### PR TITLE
fix: harden daemon startup, weixin persistence atomicity, and log permissions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -809,7 +809,14 @@ async function defaultRun(options: { firstRunOnboarding?: FirstRunOnboardingPlan
   await ensureConfigExists(runtimePaths.configPath);
   const config = await loadConfig(runtimePaths.configPath);
   const { loadConfiguredPlugins } = await import("./plugins/plugin-loader.js");
-  await loadConfiguredPlugins({ plugins: config.plugins });
+  await loadConfiguredPlugins({
+    plugins: config.plugins,
+    onPluginError: ({ name, error }) => {
+      console.error(
+        `[weacpx] skipping plugin ${name}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    },
+  });
   const { createMessageChannels } = await import("./channels/create-channel.js");
   const { MessageChannelRegistry } = await import("./channels/channel-registry.js");
   const daemonPaths = resolveDaemonPathsForCurrentConfig();

--- a/src/daemon/create-daemon-controller.ts
+++ b/src/daemon/create-daemon-controller.ts
@@ -37,8 +37,11 @@ export function createDaemonController(
     isProcessRunning: options.isProcessRunning ?? defaultIsProcessRunning,
     spawnDetached: async (spawnOptions) => {
       await mkdir(paths.runtimeDir, { recursive: true });
-      const stdoutHandle = await open(paths.stdoutLog, "a");
-      const stderrHandle = await open(paths.stderrLog, "a");
+      const stdoutHandle = await open(paths.stdoutLog, "a", 0o600);
+      const stderrHandle = await open(paths.stderrLog, "a", 0o600);
+      // open's mode only applies on creation; harden pre-existing logs too.
+      await stdoutHandle.chmod(0o600).catch(() => {});
+      await stderrHandle.chmod(0o600).catch(() => {});
 
       try {
         return await (options.spawnProcess ?? defaultSpawnProcess)(

--- a/src/daemon/daemon-controller.ts
+++ b/src/daemon/daemon-controller.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, open, readFile, rm } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type { DaemonPaths } from "./daemon-files";
@@ -100,12 +101,29 @@ export class DaemonController {
       );
     }
 
-    // Clear any stale status file before spawning so that a matching PID from a
-    // recycled process does not cause a spurious immediate return from
-    // waitForStartupMetadata.
-    await this.statusStore.clear();
-    const pid = await this.deps.spawnDetached(options);
-    await this.writePid(pid);
+    // Exclusively claim the pid file before spawning. getStatus() above already
+    // cleared any stale pid file, so a genuinely stopped daemon leaves this open;
+    // a second concurrent `start` loses the race here and aborts instead of
+    // launching a duplicate daemon.
+    const pidHandle = await this.openPidFileExclusive();
+    let pid: number;
+    try {
+      // Clear any stale status file before spawning so that a matching PID from a
+      // recycled process does not cause a spurious immediate return from
+      // waitForStartupMetadata.
+      await this.statusStore.clear();
+      pid = await this.deps.spawnDetached(options);
+      await pidHandle.write(`${pid}\n`);
+    } catch (error) {
+      // Spawn or pid write failed before the daemon could take over: drop our
+      // exclusive pid file so a retry can start cleanly.
+      await pidHandle.close().catch(() => {});
+      await rm(this.paths.pidFile, { force: true }).catch(() => {});
+      throw error;
+    }
+    await pidHandle.close();
+    // From here the daemon owns the pid file; on a startup timeout we leave it in
+    // place so `stop` can still reach a slow-but-live daemon.
     await this.waitForStartupMetadata(
       pid,
       options.firstRunOnboarding ? this.onboardingStartupTimeoutMs : this.startupTimeoutMs,
@@ -142,9 +160,18 @@ export class DaemonController {
     }
   }
 
-  private async writePid(pid: number): Promise<void> {
+  private async openPidFileExclusive(): Promise<FileHandle> {
     await mkdir(dirname(this.paths.pidFile), { recursive: true });
-    await writeFile(this.paths.pidFile, `${pid}\n`);
+    try {
+      return await open(this.paths.pidFile, "wx", 0o600);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        throw new Error(
+          `weacpx daemon pid file already exists (${this.paths.pidFile}); another start may be in progress`,
+        );
+      }
+      throw error;
+    }
   }
 
   private async clearRuntimeFiles(): Promise<void> {

--- a/src/logging/app-logger.ts
+++ b/src/logging/app-logger.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir } from "node:fs/promises";
+import { appendFile, chmod, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type { LoggingLevel } from "../config/types";
@@ -46,6 +46,7 @@ export function createNoopAppLogger(): AppLogger {
 export function createAppLogger(options: CreateAppLoggerOptions): AppLogger {
   const now = options.now ?? (() => new Date());
   let writeChain = Promise.resolve();
+  let modeEnsured = false;
 
   return {
     debug: async (event, message, context) => {
@@ -88,8 +89,15 @@ export function createAppLogger(options: CreateAppLoggerOptions): AppLogger {
 
     const line = formatLogLine(now(), level, event, message, context);
     await mkdir(dirname(options.filePath), { recursive: true });
+    if (!modeEnsured) {
+      // Harden a log file created before 0o600 was enforced. A missing file
+      // (first run) throws ENOENT and is ignored — appendFile then creates it
+      // at 0o600. Runs once per logger instance.
+      modeEnsured = true;
+      await chmod(options.filePath, 0o600).catch(() => {});
+    }
     await rotateIfNeeded(options.filePath, Buffer.byteLength(line), options.maxSizeBytes, options.maxFiles);
-    await appendFile(options.filePath, line, "utf8");
+    await appendFile(options.filePath, line, { encoding: "utf8", mode: 0o600 });
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,7 +92,12 @@ function startProgressHeartbeat(
     return undefined;
   }
 
+  let ticking = false;
   return setInterval(async () => {
+    // Skip this tick if the previous one is still running (e.g. a slow channel
+    // delivery) so heartbeat ticks cannot overlap and stack up.
+    if (ticking) return;
+    ticking = true;
     try {
       const tasks = await orchestration.listHeartbeatTasks(thresholdSeconds);
       for (const task of tasks) {
@@ -114,6 +119,8 @@ function startProgressHeartbeat(
       await logger.error("orchestration.heartbeat.check_failed", "heartbeat check failed", {
         message: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      ticking = false;
     }
   }, 60_000);
 }
@@ -699,7 +706,14 @@ export async function main(): Promise<void> {
     const startupConfig = await loadConfig(paths.configPath);
 
     const { loadConfiguredPlugins } = await import("./plugins/plugin-loader.js");
-    await loadConfiguredPlugins({ plugins: startupConfig.plugins });
+    await loadConfiguredPlugins({
+      plugins: startupConfig.plugins,
+      onPluginError: ({ name, error }) => {
+        console.error(
+          `[weacpx] skipping plugin ${name}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      },
+    });
 
     const { channelDeps } = await prepareChannelMedia(paths.configPath, startupConfig);
     const channelRegistry = new MessageChannelRegistry(createMessageChannels(startupConfig.channels, channelDeps));

--- a/src/plugins/plugin-loader.ts
+++ b/src/plugins/plugin-loader.ts
@@ -21,6 +21,13 @@ export interface LoadConfiguredPluginsInput {
    * Defaults to the value embedded in `validateWeacpxPlugin` (i.e. `readVersion()`).
    */
   currentWeacpxVersion?: string;
+  /**
+   * When provided, a plugin that fails to import or validate is reported here
+   * and skipped instead of aborting the whole load. Console startup uses this so
+   * one broken plugin cannot prevent the daemon (and healthy channels) from
+   * starting. When omitted, the first failure throws (CLI/install semantics).
+   */
+  onPluginError?: (input: { name: string; error: unknown }) => void;
 }
 
 export async function importPluginFromHome(packageName: string, pluginHome: string): Promise<unknown> {
@@ -38,21 +45,26 @@ export async function loadConfiguredPlugins(input: LoadConfiguredPluginsInput): 
   const loaded: LoadedPluginSummary[] = [];
 
   for (const config of enabled) {
-    let moduleValue: unknown;
     try {
-      moduleValue = await importPlugin(config.name, pluginHome);
+      let moduleValue: unknown;
+      try {
+        moduleValue = await importPlugin(config.name, pluginHome);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`failed to load plugin ${config.name}: ${message}`);
+      }
+      const plugin = validateWeacpxPlugin(moduleValue, config.name, {
+        ...(input.currentWeacpxVersion !== undefined ? { currentWeacpxVersion: input.currentWeacpxVersion } : {}),
+      });
+      const channels = plugin.channels ?? [];
+      for (const channel of channels) {
+        registerChannelPlugin(channel);
+      }
+      loaded.push({ name: config.name, channels: channels.map((channel) => channel.type) });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`failed to load plugin ${config.name}: ${message}`);
+      if (!input.onPluginError) throw error;
+      input.onPluginError({ name: config.name, error });
     }
-    const plugin = validateWeacpxPlugin(moduleValue, config.name, {
-      ...(input.currentWeacpxVersion !== undefined ? { currentWeacpxVersion: input.currentWeacpxVersion } : {}),
-    });
-    const channels = plugin.channels ?? [];
-    for (const channel of channels) {
-      registerChannelPlugin(channel);
-    }
-    loaded.push({ name: config.name, channels: channels.map((channel) => channel.type) });
   }
 
   return loaded;

--- a/src/util/private-file.ts
+++ b/src/util/private-file.ts
@@ -1,4 +1,5 @@
 import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 import * as lockfile from "proper-lockfile";
@@ -49,6 +50,53 @@ export async function writePrivateFileAtomic(path: string, content: string): Pro
     }
   } finally {
     await release();
+  }
+}
+
+/**
+ * Synchronous private-file write for hot-path callers that cannot await
+ * (e.g. per-message weixin credential/sync-buf/context-token persistence).
+ * Atomic via write-file-atomic's temp+rename, created at 0600 so the secret is
+ * never momentarily world-readable. No cross-process lock: weixin's per-account
+ * consumer lock already serializes the single writing daemon.
+ */
+interface WritePrivateFileSyncDeps {
+  platform?: NodeJS.Platform;
+  atomicWrite?: (path: string, content: string) => void;
+  directWrite?: (path: string, content: string) => void;
+}
+
+export function writePrivateFileSync(
+  path: string,
+  content: string,
+  deps: WritePrivateFileSyncDeps = {},
+): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const platform = deps.platform ?? process.platform;
+  const atomicWrite =
+    deps.atomicWrite ??
+    ((p, c) => writeFileAtomic.sync(p, c, { mode: PRIVATE_FILE_MODE, encoding: "utf8", fsync: true }));
+
+  try {
+    atomicWrite(path, content);
+  } catch (error) {
+    if (!isTransientWriteError(error, platform)) {
+      throw error;
+    }
+    // Windows last-ditch: AV/locking can hold the temp file and break the
+    // rename. Direct overwrite sacrifices atomicity but preserves the write,
+    // mirroring writePrivateFileAtomic's async fallback.
+    const directWrite =
+      deps.directWrite ??
+      ((p, c) => {
+        writeFileSync(p, c, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
+        try {
+          chmodSync(p, PRIVATE_FILE_MODE);
+        } catch {
+          /* best-effort */
+        }
+      });
+    directWrite(path, content);
   }
 }
 

--- a/src/weixin/auth/accounts.ts
+++ b/src/weixin/auth/accounts.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { ensureDirSync } from "../storage/ensure-dir.js";
 import { resolveStateDir } from "../storage/state-dir.js";
 import { logger } from "../util/logger.js";
+import { writePrivateFileSync } from "../../util/private-file.js";
 
 export const DEFAULT_BASE_URL = "https://ilinkai.weixin.qq.com";
 export const CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c";
@@ -177,9 +178,6 @@ export function saveWeixinAccount(
   accountId: string,
   update: { token?: string; baseUrl?: string; userId?: string },
 ): void {
-  const dir = resolveAccountsDir();
-  ensureDirSync(dir);
-
   const existing = loadWeixinAccount(accountId) ?? {};
 
   const token = update.token?.trim() || existing.token;
@@ -195,13 +193,7 @@ export function saveWeixinAccount(
     ...(userId ? { userId } : {}),
   };
 
-  const filePath = resolveAccountPath(accountId);
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
-  try {
-    fs.chmodSync(filePath, 0o600);
-  } catch {
-    // best-effort
-  }
+  writePrivateFileSync(resolveAccountPath(accountId), JSON.stringify(data, null, 2));
 }
 
 /** Remove account data file. */

--- a/src/weixin/messaging/inbound.ts
+++ b/src/weixin/messaging/inbound.ts
@@ -7,6 +7,7 @@ import { generateId } from "../util/random.js";
 import type { WeixinMessage, MessageItem } from "../api/types.js";
 import { MessageItemType } from "../api/types.js";
 import { resolveStateDir } from "../storage/state-dir.js";
+import { writePrivateFileSync } from "../../util/private-file.js";
 
 // ---------------------------------------------------------------------------
 // Context token store (in-memory cache + per-account disk persistence)
@@ -43,8 +44,7 @@ function persistContextTokens(accountId: string): void {
   }
   const filePath = resolveContextTokenFilePath(accountId);
   try {
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, JSON.stringify(tokens), "utf-8");
+    writePrivateFileSync(filePath, JSON.stringify(tokens));
   } catch (err) {
     logger.warn(`persistContextTokens: failed to write ${filePath}: ${String(err)}`);
   }

--- a/src/weixin/storage/sync-buf.ts
+++ b/src/weixin/storage/sync-buf.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { deriveRawAccountId } from "../auth/accounts.js";
+import { writePrivateFileSync } from "../../util/private-file.js";
 
-import { ensureDirSync } from "./ensure-dir.js";
 import { resolveStateDir } from "./state-dir.js";
 
 function resolveAccountsDir(): string {
@@ -76,7 +76,5 @@ export function loadGetUpdatesBuf(filePath: string): string | undefined {
  * Persist get_updates_buf. Creates parent dir if needed.
  */
 export function saveGetUpdatesBuf(filePath: string, getUpdatesBuf: string): void {
-  const dir = path.dirname(filePath);
-  ensureDirSync(dir);
-  fs.writeFileSync(filePath, JSON.stringify({ get_updates_buf: getUpdatesBuf }, null, 0), "utf-8");
+  writePrivateFileSync(filePath, JSON.stringify({ get_updates_buf: getUpdatesBuf }, null, 0));
 }

--- a/tests/unit/daemon/daemon-controller.test.ts
+++ b/tests/unit/daemon/daemon-controller.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -176,6 +176,55 @@ test("start waits for daemon status metadata before returning", async () => {
   });
   expect(checks).toBeGreaterThan(0);
   await expect(statusStore.load()).resolves.toMatchObject({ pid: 44444 });
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("start refuses to overwrite an existing pid file it did not create", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
+  let spawned = false;
+  const controller = createController(dir, {
+    isProcessRunning: () => false,
+    spawnDetached: async () => {
+      spawned = true;
+      return 12321;
+    },
+  });
+  // A pid file whose contents do not parse as a live pid: getStatus treats the
+  // daemon as stopped without clearing the file, so start() must not clobber it.
+  await writeFile(join(dir, "daemon.pid"), "not-a-pid\n");
+
+  await expect(controller.start()).rejects.toThrow(/pid file already exists/);
+  expect(spawned).toBe(false);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("start creates the pid file with owner-only permissions", async () => {
+  if (process.platform === "win32") return;
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
+  const statusStore = new DaemonStatusStore(join(dir, "status.json"));
+  const controller = createController(dir, {
+    isProcessRunning: (pid) => pid === 13579,
+    spawnDetached: async () => 13579,
+    onStartupPoll: async () => {
+      await statusStore.save({
+        pid: 13579,
+        started_at: "2026-03-26T00:00:00.000Z",
+        heartbeat_at: "2026-03-26T00:00:00.000Z",
+        config_path: "/cfg",
+        state_path: "/state",
+        app_log: "/app",
+        stdout_log: "/out",
+        stderr_log: "/err",
+      });
+    },
+  });
+
+  await expect(controller.start()).resolves.toEqual({ state: "started", pid: 13579 });
+  const { mode } = await stat(join(dir, "daemon.pid"));
+  expect(mode & 0o777).toBe(0o600);
+  await expect(readFile(join(dir, "daemon.pid"), "utf8")).resolves.toBe("13579\n");
 
   await rm(dir, { recursive: true, force: true });
 });

--- a/tests/unit/logging/app-logger.test.ts
+++ b/tests/unit/logging/app-logger.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -23,6 +23,47 @@ test("writes structured log lines at or above the configured level", async () =>
   expect(content).toContain("INFO command.completed");
   expect(content).toContain('durationMs=42');
   expect(content).not.toContain("DEBUG command.parsed");
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("creates the app log file with owner-only permissions", async () => {
+  if (process.platform === "win32") return;
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-app-logger-"));
+  const appLog = join(dir, "app.log");
+  const logger = createAppLogger({
+    filePath: appLog,
+    level: "info",
+    maxSizeBytes: 1024,
+    maxFiles: 3,
+    retentionDays: 7,
+  });
+
+  await logger.info("command.completed", "command finished");
+
+  const { mode } = await stat(appLog);
+  expect(mode & 0o777).toBe(0o600);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("hardens a pre-existing world-readable log file to 0600 on first write", async () => {
+  if (process.platform === "win32") return;
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-app-logger-"));
+  const appLog = join(dir, "app.log");
+  await writeFile(appLog, "pre-existing line\n");
+  await chmod(appLog, 0o644);
+
+  const logger = createAppLogger({
+    filePath: appLog,
+    level: "info",
+    maxSizeBytes: 1_000_000,
+    maxFiles: 3,
+    retentionDays: 7,
+  });
+  await logger.info("command.completed", "command finished");
+
+  expect((await stat(appLog)).mode & 0o777).toBe(0o600);
 
   await rm(dir, { recursive: true, force: true });
 });

--- a/tests/unit/plugins/plugin-loader.test.ts
+++ b/tests/unit/plugins/plugin-loader.test.ts
@@ -34,6 +34,37 @@ test("loadConfiguredPlugins wraps import errors with package name", async () => 
   })).rejects.toThrow("failed to load plugin missing-plugin: Cannot find package");
 });
 
+test("loadConfiguredPlugins skips a failing plugin and continues when onPluginError is provided", async () => {
+  const errors: { name: string; message: string }[] = [];
+
+  const loaded = await loadConfiguredPlugins({
+    plugins: [
+      { name: "broken-plugin", enabled: true },
+      { name: "ok-plugin", enabled: true },
+    ],
+    currentWeacpxVersion: "0.3.3",
+    importPlugin: async (name) => {
+      if (name === "broken-plugin") throw new Error("boom");
+      return { default: { apiVersion: 1, name: "ok-plugin", channels: [] } };
+    },
+    onPluginError: ({ name, error }) => {
+      errors.push({ name, message: error instanceof Error ? error.message : String(error) });
+    },
+  });
+
+  expect(loaded).toEqual([{ name: "ok-plugin", channels: [] }]);
+  expect(errors).toEqual([
+    { name: "broken-plugin", message: "failed to load plugin broken-plugin: boom" },
+  ]);
+});
+
+test("loadConfiguredPlugins still throws on plugin failure when no onPluginError is provided", async () => {
+  await expect(loadConfiguredPlugins({
+    plugins: [{ name: "broken-plugin", enabled: true }],
+    importPlugin: async () => { throw new Error("boom"); },
+  })).rejects.toThrow("failed to load plugin broken-plugin: boom");
+});
+
 test("loadConfiguredPlugins surfaces upgrade-weacpx hint when plugin requires newer core", async () => {
   await expect(loadConfiguredPlugins({
     plugins: [{ name: "future-plugin", enabled: true }],

--- a/tests/unit/util/private-file.test.ts
+++ b/tests/unit/util/private-file.test.ts
@@ -1,6 +1,56 @@
 import { expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-import { __privateFileForTests } from "../../../src/util/private-file";
+import { __privateFileForTests, writePrivateFileSync } from "../../../src/util/private-file";
+
+function transientError(code: string): NodeJS.ErrnoException {
+  const err = new Error("locked") as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+test("writePrivateFileSync falls back to a direct write on a transient windows error", () => {
+  const dir = mkdtempSync(join(tmpdir(), "weacpx-private-file-"));
+  const target = join(dir, "nested", "secret.json");
+  let directCalls = 0;
+
+  writePrivateFileSync(target, "payload", {
+    platform: "win32",
+    atomicWrite: () => {
+      throw transientError("EPERM");
+    },
+    directWrite: (p, c) => {
+      directCalls += 1;
+      writeFileSync(p, c);
+    },
+  });
+
+  expect(directCalls).toBe(1);
+  expect(readFileSync(target, "utf8")).toBe("payload");
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("writePrivateFileSync rethrows a non-transient error without falling back", () => {
+  const dir = mkdtempSync(join(tmpdir(), "weacpx-private-file-"));
+  let directCalls = 0;
+
+  expect(() =>
+    writePrivateFileSync(join(dir, "secret.json"), "payload", {
+      platform: "linux",
+      atomicWrite: () => {
+        throw transientError("EPERM"); // transient code, but non-win32 → not transient
+      },
+      directWrite: () => {
+        directCalls += 1;
+      },
+    }),
+  ).toThrow("locked");
+
+  expect(directCalls).toBe(0);
+  rmSync(dir, { recursive: true, force: true });
+});
 
 test("windows atomic write retries transient EPERM long enough before failing", async () => {
   let attempts = 0;

--- a/tests/unit/weixin/accounts.test.ts
+++ b/tests/unit/weixin/accounts.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 import { expect, test } from "bun:test";
 
-import { clearAllWeixinAccounts, listWeixinAccountIds, registerWeixinAccountId } from "../../../src/weixin/auth/accounts";
+import { clearAllWeixinAccounts, listWeixinAccountIds, loadWeixinAccount, registerWeixinAccountId, saveWeixinAccount } from "../../../src/weixin/auth/accounts";
 
 async function withTempStateDir<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
   const stateDir = await mkdtemp(path.join(tmpdir(), "weacpx-openclaw-"));
@@ -53,6 +53,18 @@ test("registerWeixinAccountId tolerates EPERM when the state directory already e
   });
 });
 
+
+test("saveWeixinAccount writes the credential file with owner-only permissions", async () => {
+  if (process.platform === "win32") return;
+  await withTempStateDir(async (stateDir) => {
+    const accountId = "e33867cf4ec7-im-bot";
+    saveWeixinAccount(accountId, { token: "secret-token", baseUrl: "https://example.com" });
+
+    const accountFile = path.join(stateDir, "openclaw-weixin", "accounts", `${accountId}.json`);
+    expect(fs.statSync(accountFile).mode & 0o777).toBe(0o600);
+    expect(loadWeixinAccount(accountId)?.token).toBe("secret-token");
+  });
+});
 
 test("clearAllWeixinAccounts clears credential files even when the account index is empty", async () => {
   await withTempStateDir(async (stateDir) => {

--- a/tests/unit/weixin/messaging/inbound-persistence.test.ts
+++ b/tests/unit/weixin/messaging/inbound-persistence.test.ts
@@ -76,6 +76,12 @@ describe("contextToken disk persistence", () => {
     expect(getContextToken(restoredId, "user-2")).toBe("tok-222");
   });
 
+  it("setContextToken writes the persistence file with owner-only permissions", () => {
+    if (process.platform === "win32") return;
+    setContextToken("acct-perm", "user-1", "tok-perm");
+    expect(fs.statSync(tokenFilePath("acct-perm")).mode & 0o777).toBe(0o600);
+  });
+
   it("clearContextTokensForAccount removes memory + disk entries", () => {
     setContextToken("acct-B1", "user-1", "tok-xyz");
     expect(getContextToken("acct-B1", "user-1")).toBe("tok-xyz");

--- a/tests/unit/weixin/sync-buf.test.ts
+++ b/tests/unit/weixin/sync-buf.test.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, expect, test } from "bun:test";
+
+import { getSyncBufFilePath, loadGetUpdatesBuf, saveGetUpdatesBuf } from "../../../src/weixin/storage/sync-buf";
+
+let prevStateDir: string | undefined;
+let stateDir: string;
+
+beforeEach(() => {
+  prevStateDir = process.env.OPENCLAW_STATE_DIR;
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "weacpx-syncbuf-"));
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  if (prevStateDir === undefined) delete process.env.OPENCLAW_STATE_DIR;
+  else process.env.OPENCLAW_STATE_DIR = prevStateDir;
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+test("saveGetUpdatesBuf round-trips and writes the file with owner-only permissions", () => {
+  const filePath = getSyncBufFilePath("acct-sync");
+  saveGetUpdatesBuf(filePath, "cursor-123");
+
+  expect(loadGetUpdatesBuf(filePath)).toBe("cursor-123");
+  if (process.platform !== "win32") {
+    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+  }
+});


### PR DESCRIPTION
## Summary

Hardening pass from a full-project bug/vulnerability review. Three independent, low-risk fixes, one per commit:

**`fix(daemon)`: startup robustness** (`cfe19e5`)
- `loadConfiguredPlugins` gains an optional `onPluginError` callback — a broken/incompatible npm plugin is now logged and skipped instead of aborting daemon startup (and orchestration IPC + healthy channels). Default throw semantics preserved when the callback is omitted (CLI/install paths unchanged).
- Single-flight guard on the progress heartbeat (`startProgressHeartbeat`) so a slow tick can't overlap and stack with the next interval.
- `DaemonController.start` claims the pid file exclusively (`open(..., "wx", 0o600)`) before spawning — a racing `weacpx start` now loses with `EEXIST` instead of launching a duplicate daemon; the lock is dropped on spawn/write failure. Removed the old plain-`writeFile` `writePid`.

**`fix(weixin)`: atomic 0600 persistence** (`ca70b60`)
- New `writePrivateFileSync` helper (write-file-atomic temp+rename, mode `0600`, fsync, with a Windows AV direct-write fallback mirroring the async `writePrivateFileAtomic`).
- Used in `saveWeixinAccount`, `saveGetUpdatesBuf`, and `persistContextTokens` — removes the `writeFileSync`-then-`chmod` world-readable window on credentials and the non-atomic writes that could leave a corrupt file on crash.

**`fix(logging)`: 0600 log files** (`6ff3b9b`)
- `appendFile` (app log) and the daemon `stdout`/`stderr` opens pass mode `0600`. Because mode only applies on creation, a pre-existing log is also chmod'd once on first write/open so logs created before this change are hardened too.

## Review

These changes came out of a full-project review, triaged into batches by severity × fix-cost × real-world likelihood. Several initially-flagged findings were verified and **dropped** as already-handled or not worth changing (e.g. the weixin-login-kills-orchestration concern is already decoupled via the daemon's `best-effort` channel-startup policy; bridge pending-request cleanup already handled on exit/error; session alias creation is already mutex-serialized).

Each batch was then independently reviewed (OpenAI `opencode` + a separate read-only review agent). All three came back sound; two completeness refinements surfaced and were folded in:
- the `writePrivateFileSync` Windows AV fallback (above), and
- the one-time chmod of pre-existing logs (above).

## Test plan

- `npx tsc --noEmit` — clean
- `npm test` — **1902 pass / 0 fail** (includes typecheck; +10 tests added across the three batches: plugin isolation, exclusive-pid + 0600, atomic-write 0600 round-trips, Windows-fallback DI, pre-existing-log chmod)

Note: no VERSION bump / CHANGELOG entry here — weacpx versioning is owned by the `release-to-github` flow (package.json + tags), so that's deferred to release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
