### PR TITLE
fix(plugins): dedupe plugin-home package.json before install

### DIFF
--- a/src/plugins/package-manager.ts
+++ b/src/plugins/package-manager.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 
+import { normalizePluginHomeManifest } from "./plugin-home.js";
+
 export type PluginPackageManager = "bun" | "npm";
 
 export interface RunCommandOptions {
@@ -51,6 +53,10 @@ export async function installPluginPackage(input: {
 }): Promise<void> {
   const runCommand = input.runCommand ?? defaultRunCommand;
   const packageManager = input.packageManager ?? await detectPackageManager();
+  // Repair any duplicate dependency keys a prior add may have left (e.g. bun on
+  // Windows recording a package under both an npm version and a local path),
+  // which would otherwise make the package manager choke on the lockfile.
+  await normalizePluginHomeManifest(input.pluginHome);
   const spec = input.version ? `${input.packageName}@${input.version}` : input.packageName;
   if (packageManager === "bun") {
     await runCommand("bun", ["add", spec], { cwd: input.pluginHome });

--- a/src/plugins/plugin-home.ts
+++ b/src/plugins/plugin-home.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -24,6 +24,42 @@ export function resolvePluginHome(input: { home?: string; pluginHome?: string } 
   if (envOverride) return envOverride;
   const home = coerceMissing(input.home) ?? coerceMissing(process.env.HOME) ?? homedir();
   return join(home, ".weacpx", "plugins");
+}
+
+/**
+ * Collapse duplicate keys in the plugin home `package.json`.
+ *
+ * A package manager can leave the same dependency under two keys/spec-forms —
+ * notably `bun add` on Windows recording a package once as an npm version and
+ * once as an absolute local path — which is invalid JSON (duplicate key) and
+ * corrupts `bun.lock` (`InvalidPackageKey: failed to parse lockfile`). Node's
+ * `JSON.parse` tolerates duplicate keys and keeps the *last* value, so a
+ * parse → stringify round-trip physically removes the duplicates.
+ *
+ * Returns `true` when the file was rewritten (i.e. it had been changed),
+ * `false` when there was nothing to fix (clean, missing, or unparseable for
+ * some other reason — in which case the file is left untouched).
+ */
+export async function normalizePluginHomeManifest(pluginHome: string): Promise<boolean> {
+  const manifestPath = join(pluginHome, "package.json");
+  let raw: string;
+  try {
+    raw = await readFile(manifestPath, "utf8");
+  } catch {
+    return false;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Unparseable for a reason other than duplicate keys (which JSON.parse
+    // accepts). Don't clobber a manifest we can't safely understand.
+    return false;
+  }
+  const normalized = JSON.stringify(parsed, null, 2) + "\n";
+  if (normalized === raw) return false;
+  await writeFile(manifestPath, normalized, { mode: 0o600 });
+  return true;
 }
 
 export async function ensurePluginHome(pluginHome: string): Promise<void> {

--- a/tests/unit/plugins/package-manager.test.ts
+++ b/tests/unit/plugins/package-manager.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { installPluginPackage, removePluginPackage, updatePluginPackage } from "../../../src/plugins/package-manager";
 
@@ -50,6 +53,34 @@ test("updatePluginPackage without version uses bare package name", async () => {
   });
 
   expect(calls).toEqual([{ command: "bun", args: ["add", "weacpx-channel-demo"], cwd: "/tmp/weacpx-plugins" }]);
+});
+
+test("installPluginPackage repairs duplicate dependency keys before installing", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-pm-"));
+  try {
+    const manifest = join(dir, "package.json");
+    // Pre-existing corruption (a different package than the one being added).
+    await writeFile(
+      manifest,
+      '{\n  "dependencies": {\n    "@scope/feishu": "0.2.1",\n    "@scope/feishu": "/local/feishu"\n  }\n}\n',
+    );
+    const calls: unknown[] = [];
+    await installPluginPackage({
+      packageName: "@scope/yuanbao",
+      pluginHome: dir,
+      packageManager: "bun",
+      runCommand: async (command, args, options) => { calls.push({ command, args, cwd: options.cwd }); },
+    });
+
+    // Assert on the raw on-disk text: the duplicate key must be physically gone
+    // (JSON.parse would mask it, so checking the parsed object is not enough).
+    const rawAfter = await readFile(manifest, "utf8");
+    const occurrences = rawAfter.split('"@scope/feishu"').length - 1;
+    expect(occurrences).toBe(1);
+    expect(calls).toEqual([{ command: "bun", args: ["add", "@scope/yuanbao"], cwd: dir }]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("removePluginPackage runs remove in plugin home", async () => {

--- a/tests/unit/plugins/plugin-home.test.ts
+++ b/tests/unit/plugins/plugin-home.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { homedir } from "node:os";
-import { resolvePluginHome } from "../../../src/plugins/plugin-home.js";
+import { homedir, tmpdir } from "node:os";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { normalizePluginHomeManifest, resolvePluginHome } from "../../../src/plugins/plugin-home.js";
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_PLUGIN_HOME = process.env.WEACPX_PLUGIN_HOME;
@@ -66,5 +68,62 @@ describe("resolvePluginHome", () => {
   it("also treats 'null' string as missing", () => {
     process.env.HOME = "null";
     expect(resolvePluginHome()).toBe(`${homedir()}/.weacpx/plugins`);
+  });
+});
+
+describe("normalizePluginHomeManifest", () => {
+  it("collapses duplicate dependency keys (last value wins)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "weacpx-norm-"));
+    try {
+      const manifest = join(dir, "package.json");
+      // Simulates the corrupt state bun left on Windows: same package twice,
+      // once as an npm version and once as a local path.
+      await writeFile(
+        manifest,
+        '{\n  "private": true,\n  "type": "module",\n  "dependencies": {\n    "@scope/pkg": "0.2.1",\n    "@scope/pkg": "/local/path"\n  }\n}\n',
+      );
+      const changed = await normalizePluginHomeManifest(dir);
+      expect(changed).toBe(true);
+      const after = JSON.parse(await readFile(manifest, "utf8")) as { dependencies: Record<string, string> };
+      expect(Object.keys(after.dependencies)).toEqual(["@scope/pkg"]);
+      expect(after.dependencies["@scope/pkg"]).toBe("/local/path");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op for a clean manifest", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "weacpx-norm-"));
+    try {
+      const manifest = join(dir, "package.json");
+      await writeFile(
+        manifest,
+        JSON.stringify({ private: true, type: "module", dependencies: { "@scope/pkg": "0.2.1" } }, null, 2) + "\n",
+      );
+      expect(await normalizePluginHomeManifest(dir)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false when no manifest exists", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "weacpx-norm-"));
+    try {
+      expect(await normalizePluginHomeManifest(dir)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves an unparseable manifest untouched", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "weacpx-norm-"));
+    try {
+      const manifest = join(dir, "package.json");
+      await writeFile(manifest, "{ not valid json ]");
+      expect(await normalizePluginHomeManifest(dir)).toBe(false);
+      expect(await readFile(manifest, "utf8")).toBe("{ not valid json ]");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
A package manager (notably bun add on Windows recording the same package under both an npm version and a local path) can leave duplicate dependency keys in ~/.weacpx/plugins/package.json, which corrupts bun.lock (InvalidPackageKey: failed to parse lockfile). installPluginPackage now normalizes the manifest (parse->stringify collapses duplicate keys, last value wins) before invoking the package manager, repairing pre-existing corruption and preventing recurrence.

- add normalizePluginHomeManifest() in plugin-home.ts
- call it at the start of installPluginPackage (covers add + update)
- tests: dedup / clean no-op / missing / unparseable; install-path wiring