### PR TITLE
feat: 无需记忆的会话切换 (/use - 与片段模糊匹配)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -113,7 +113,11 @@ Session 是你在微信里操作的逻辑会话。每个会话绑定一个 agent
 | `/session new <alias> --agent <agent> --ws <workspace>` | 用指定别名创建会话 |
 | `/session new <alias> -a <agent> --ws <workspace>` | 指定别名创建会话的短写法 |
 | `/use <alias>` | 切换当前会话 |
+| `/use <片段>` | 按别名片段切换：精确 > 前缀 > 子串；多命中会列出候选让你再选 |
+| `/use -` | 在当前会话和上一个会话之间切换（像 shell 的 `cd -`） |
 | `/session rm <alias>` | 删除逻辑会话 |
+
+切换成功会回显当前身份，例如 `已切到 api-review · codex · backend（上一个：frontend-fix）`，不用再记别名或序号。
 
 示例：
 
@@ -123,6 +127,8 @@ Session 是你在微信里操作的逻辑会话。每个会话绑定一个 agent
 /ss new codex -d /Users/me/projects/frontend
 /session new api-review --agent codex --ws backend
 /use api-review
+/use api          # 片段匹配：唯一命中 api-review 即切换；多命中会列候选
+/use -            # 切回上一个会话
 /session rm old-review
 ```
 

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -32,6 +32,7 @@ import {
   handleSessions,
   handleSessionShortcut,
   handleSessionUse,
+  handleSessionUsePrevious,
   handleStatus,
   type SessionHandlerContext,
 } from "./handlers/session-handler";
@@ -219,6 +220,8 @@ export class CommandRouter {
           return await handleNativeSessionSelect(this.createSessionHandlerContext(undefined, perfSpan), chatKey, command.identifier, command.alias);
         case "session.use":
           return await handleSessionUse(this.createSessionHandlerContext(undefined, perfSpan), chatKey, command.alias);
+        case "session.use.previous":
+          return await handleSessionUsePrevious(this.createSessionHandlerContext(undefined, perfSpan), chatKey);
         case "mode.show":
           return await handleModeShow(this.createSessionHandlerContext(undefined, perfSpan), chatKey);
         case "mode.set":

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -14,6 +14,7 @@ import type { ChatRequestMetadata } from "../../weixin/agent/interface";
 import { buildCoordinatorPrompt } from "../../orchestration/build-coordinator-prompt";
 import { toDisplaySessionAlias, getChannelIdFromChatKey, scopeDisplayAliasToInternal, resolveSessionAliasForInput } from "../../channels/channel-scope";
 import { quoteWorkspaceNameIfNeeded } from "../workspace-name";
+import type { SessionSwitchResult } from "../../sessions/session-service";
 
 export interface SessionHandlerContext extends CommandRouterContext {
   lifecycle: SessionLifecycleOps;
@@ -257,17 +258,48 @@ async function refreshSessionTransportAgentCommandBestEffort(
   }
 }
 
+function renderSwitched(switched: SessionSwitchResult): string {
+  const base = `已切到 ${switched.alias} · ${switched.agent} · ${switched.workspace}`;
+  return switched.previousAlias ? `${base}（上一个：${switched.previousAlias}）` : base;
+}
+
 export async function handleSessionUse(
   context: SessionHandlerContext,
   chatKey: string,
-  alias: string,
+  input: string,
 ): Promise<RouterResponse> {
-  await context.sessions.useSession(chatKey, alias);
+  const result = context.sessions.resolveFuzzyAlias(chatKey, input);
+
+  if (result.kind === "none") {
+    return { text: `没有匹配「${input}」的会话。发 /sessions 看看有哪些。` };
+  }
+
+  if (result.kind === "ambiguous") {
+    const lines = result.candidates.map((candidate) => `• ${candidate.alias} · ${candidate.agent} · ${candidate.workspace}`);
+    return { text: [`「${input}」匹配到多个会话，请指定：`, ...lines].join("\n") };
+  }
+
+  const switched = await context.sessions.useSession(chatKey, result.alias);
   await context.logger.info("session.selected", "selected logical session", {
-    alias,
+    alias: switched.alias,
     chatKey,
   });
-  return { text: `已切换到会话「${alias}」` };
+  return { text: renderSwitched(switched) };
+}
+
+export async function handleSessionUsePrevious(
+  context: SessionHandlerContext,
+  chatKey: string,
+): Promise<RouterResponse> {
+  const switched = await context.sessions.usePreviousSession(chatKey);
+  if (!switched) {
+    return { text: "还没有上一个会话，发 /sessions 看看有哪些。" };
+  }
+  await context.logger.info("session.selected", "selected previous logical session", {
+    alias: switched.alias,
+    chatKey,
+  });
+  return { text: renderSwitched(switched) };
 }
 
 export async function handleModeShow(context: SessionHandlerContext, chatKey: string): Promise<RouterResponse> {

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -41,6 +41,8 @@ export const sessionHelp: HelpTopicMetadata = {
     { usage: "/session tail [N]", description: "补拉当前会话的历史输出（默认 50 行）" },
     { usage: "/session rm <alias>", description: "删除逻辑会话" },
     { usage: "/use <alias>", description: "切换当前会话" },
+    { usage: "/use <片段>", description: "按别名片段切换（精确>前缀>子串；多命中会列候选）" },
+    { usage: "/use -", description: "切回上一个会话（像 shell 的 cd -）" },
     { usage: "/session reset 或 /clear", description: "重置当前会话上下文" },
   ],
   examples: [
@@ -48,6 +50,8 @@ export const sessionHelp: HelpTopicMetadata = {
     "/ssn",
     "/ssn 1",
     "/use backend-fix",
+    "/use back",
+    "/use -",
     "/session rm old-session",
     "/session reset",
   ],

--- a/src/commands/parse-command.ts
+++ b/src/commands/parse-command.ts
@@ -53,6 +53,7 @@ export type ParsedCommand =
   | { kind: "replymode.set"; replyMode: "stream" | "final" | "verbose" }
   | { kind: "replymode.reset" }
   | { kind: "session.use"; alias: string }
+  | { kind: "session.use.previous" }
   | { kind: "session.new"; alias: string; agent: string; workspace: string }
   | { kind: "session.shortcut"; agent: string; cwd?: string; workspace?: string }
   | { kind: "session.shortcut.new"; agent: string; cwd?: string; workspace?: string }
@@ -241,6 +242,10 @@ export function parseCommand(input: string): ParsedCommand {
 
   if (command === "/config" && parts[1] === "set" && parts.length === 4) {
     return { kind: "config.set", path: parts[2] ?? "", value: parts[3] ?? "" };
+  }
+
+  if (command === "/use" && parts[1] === "-") {
+    return { kind: "session.use.previous" };
   }
 
   if (command === "/use" && parts[1]) {

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -20,6 +20,18 @@ interface SessionListItem {
   isCurrent: boolean;
 }
 
+export interface SessionSwitchResult {
+  alias: string;
+  agent: string;
+  workspace: string;
+  previousAlias?: string;
+}
+
+export type FuzzyAliasResult =
+  | { kind: "match"; alias: string }
+  | { kind: "ambiguous"; candidates: Array<{ alias: string; agent: string; workspace: string }> }
+  | { kind: "none" };
+
 interface NativeSessionAttachmentInput {
   alias: string;
   agent: string;
@@ -176,8 +188,8 @@ export class SessionService {
     return null;
   }
 
-  async useSession(chatKey: string, alias: string): Promise<void> {
-    await this.mutate(async () => {
+  async useSession(chatKey: string, alias: string): Promise<SessionSwitchResult> {
+    return await this.mutate(async () => {
       const channelId = getChannelIdFromChatKey(chatKey);
       const internalAlias = resolveSessionAliasForInput(channelId, alias, Object.keys(this.state.sessions));
       const session = this.state.sessions[internalAlias];
@@ -185,10 +197,100 @@ export class SessionService {
         throw new Error(`session "${alias}" does not exist`);
       }
 
+      const prevCtx = this.state.chat_contexts[chatKey];
+      const previousCurrent = prevCtx?.current_session;
+      const carriedPrevious =
+        previousCurrent && previousCurrent !== internalAlias ? previousCurrent : prevCtx?.previous_session;
+
       session.last_used_at = new Date().toISOString();
-      this.state.chat_contexts[chatKey] = { current_session: internalAlias };
+      this.state.chat_contexts[chatKey] = {
+        current_session: internalAlias,
+        ...(carriedPrevious ? { previous_session: carriedPrevious } : {}),
+      };
       await this.persist();
+
+      return {
+        alias: toDisplaySessionAlias(session.alias),
+        agent: session.agent,
+        workspace: session.workspace,
+        previousAlias: carriedPrevious ? toDisplaySessionAlias(carriedPrevious) : undefined,
+      };
     });
+  }
+
+  async usePreviousSession(chatKey: string): Promise<SessionSwitchResult | null> {
+    return await this.mutate(async () => {
+      const ctx = this.state.chat_contexts[chatKey];
+      const prevInternal = ctx?.previous_session;
+      if (!prevInternal) {
+        return null;
+      }
+      const prevSession = this.state.sessions[prevInternal];
+      if (!prevSession) {
+        if (ctx) {
+          delete ctx.previous_session;
+          await this.persist();
+        }
+        return null;
+      }
+
+      const currentInternal = ctx?.current_session;
+      prevSession.last_used_at = new Date().toISOString();
+      this.state.chat_contexts[chatKey] = {
+        current_session: prevInternal,
+        ...(currentInternal && currentInternal !== prevInternal ? { previous_session: currentInternal } : {}),
+      };
+      await this.persist();
+
+      return {
+        alias: toDisplaySessionAlias(prevSession.alias),
+        agent: prevSession.agent,
+        workspace: prevSession.workspace,
+        previousAlias:
+          currentInternal && currentInternal !== prevInternal ? toDisplaySessionAlias(currentInternal) : undefined,
+      };
+    });
+  }
+
+  resolveFuzzyAlias(chatKey: string, fragment: string): FuzzyAliasResult {
+    const channelId = getChannelIdFromChatKey(chatKey);
+    const frag = fragment.trim();
+    const items = Object.values(this.state.sessions)
+      .filter((session) => isSessionAliasVisibleInChannel(session.alias, channelId))
+      .map((session) => ({
+        display: toDisplaySessionAlias(session.alias),
+        agent: session.agent,
+        workspace: session.workspace,
+      }));
+
+    const toCandidate = (item: { display: string; agent: string; workspace: string }) => ({
+      alias: item.display,
+      agent: item.agent,
+      workspace: item.workspace,
+    });
+
+    const exact = items.find((item) => item.display === frag);
+    if (exact) {
+      return { kind: "match", alias: exact.display };
+    }
+
+    const prefix = items.filter((item) => item.display.startsWith(frag));
+    if (prefix.length === 1) {
+      return { kind: "match", alias: prefix[0]!.display };
+    }
+    if (prefix.length > 1) {
+      return { kind: "ambiguous", candidates: prefix.map(toCandidate) };
+    }
+
+    const substring = items.filter((item) => item.display.includes(frag));
+    if (substring.length === 1) {
+      return { kind: "match", alias: substring[0]!.display };
+    }
+    if (substring.length > 1) {
+      return { kind: "ambiguous", candidates: substring.map(toCandidate) };
+    }
+
+    return { kind: "none" };
   }
 
   async resolveAliasForChat(chatKey: string, displayAlias: string): Promise<string> {
@@ -314,6 +416,10 @@ export class SessionService {
       for (const [chatKey, ctx] of Object.entries(this.state.chat_contexts)) {
         if (ctx.current_session === alias) {
           delete this.state.chat_contexts[chatKey];
+          continue;
+        }
+        if (ctx.previous_session === alias) {
+          delete ctx.previous_session;
         }
       }
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -38,6 +38,7 @@ export interface LogicalSession {
 
 export interface ChatContextState {
   current_session: string;
+  previous_session?: string;
 }
 
 export interface AppState {

--- a/tests/unit/commands/command-router-session.test.ts
+++ b/tests/unit/commands/command-router-session.test.ts
@@ -900,7 +900,7 @@ test("/session use resolves display alias inside current channel", async () => {
 
   const response = await router.handle("feishu:default:oc_chat", "/use backend:codex");
 
-  expect(response.text).toContain("已切换到会话「backend:codex」");
+  expect(response.text).toContain("已切到 backend:codex");
   const current = await sessions.getCurrentSession("feishu:default:oc_chat");
   expect(current?.alias).toBe("feishu:backend:codex");
 });
@@ -1353,4 +1353,75 @@ test("/ssn clears stale cached native sessions after an empty list response", as
   expect(emptyReply.text).toContain("没有找到本地 Codex 会话");
   expect(selectReply.text).toContain("当前没有可用的 native 会话列表");
   expect(transport.resumeAgentSession).not.toHaveBeenCalled();
+});
+
+function buildSwitchRouter() {
+  const config = createConfig();
+  config.agents.claude = config.agents.claude ?? { driver: "claude" };
+  config.workspaces.frontend = { cwd: "/tmp/frontend" };
+  const sessions = new SessionService(config, new MemoryStateStore(), createEmptyState());
+  const transport = createTransport();
+  const router = new CommandRouter(sessions, transport, config, new MemoryConfigStore(config));
+  return { router, sessions };
+}
+
+test("/use <fragment>: unique match switches and echoes identity", async () => {
+  const { router, sessions } = buildSwitchRouter();
+  await sessions.createSession("api-review", "codex", "backend");
+  await sessions.createSession("frontend-fix", "claude", "frontend");
+  await sessions.useSession("wx:user", "api-review");
+
+  const res = await router.handle("wx:user", "/use front");
+
+  expect(res.text).toContain("已切到 frontend-fix · claude · frontend");
+  expect(res.text).toContain("（上一个：api-review）");
+});
+
+test("/use <fragment>: ambiguous lists candidates without switching", async () => {
+  const { router, sessions } = buildSwitchRouter();
+  await sessions.createSession("api-review", "codex", "backend");
+  await sessions.createSession("api-smoke", "claude", "backend");
+  await sessions.useSession("wx:user", "api-review");
+
+  const res = await router.handle("wx:user", "/use api");
+
+  expect(res.text).toContain("匹配到多个会话");
+  expect(res.text).toContain("api-review");
+  expect(res.text).toContain("api-smoke");
+  // current session unchanged
+  expect((await sessions.getCurrentSession("wx:user"))?.alias).toBe("api-review");
+});
+
+test("/use <fragment>: no match guides to /sessions", async () => {
+  const { router, sessions } = buildSwitchRouter();
+  await sessions.createSession("api-review", "codex", "backend");
+  await sessions.useSession("wx:user", "api-review");
+
+  const res = await router.handle("wx:user", "/use zzz");
+
+  expect(res.text).toContain("没有匹配「zzz」");
+  expect(res.text).toContain("/sessions");
+});
+
+test("/use -: switches back to previous with identity echo", async () => {
+  const { router, sessions } = buildSwitchRouter();
+  await sessions.createSession("api-review", "codex", "backend");
+  await sessions.createSession("frontend-fix", "claude", "frontend");
+  await sessions.useSession("wx:user", "api-review");
+  await sessions.useSession("wx:user", "frontend-fix");
+
+  const res = await router.handle("wx:user", "/use -");
+
+  expect(res.text).toContain("已切到 api-review");
+  expect((await sessions.getCurrentSession("wx:user"))?.alias).toBe("api-review");
+});
+
+test("/use -: friendly message when there is no previous", async () => {
+  const { router, sessions } = buildSwitchRouter();
+  await sessions.createSession("api-review", "codex", "backend");
+  await sessions.useSession("wx:nobody", "api-review");
+
+  const res = await router.handle("wx:nobody", "/use -");
+
+  expect(res.text).toContain("还没有上一个会话");
 });

--- a/tests/unit/commands/parse-command.test.ts
+++ b/tests/unit/commands/parse-command.test.ts
@@ -204,6 +204,17 @@ test("parses use command", () => {
   });
 });
 
+test("parses /use - as session.use.previous", () => {
+  expect(parseCommand("/use -")).toEqual({ kind: "session.use.previous" });
+});
+
+test("parses /use <fragment> as session.use without matching", () => {
+  expect(parseCommand("/use api")).toEqual({
+    kind: "session.use",
+    alias: "api",
+  });
+});
+
 test("parses workspace creation flags", () => {
   expect(parseCommand("/workspace new backend --cwd /tmp/backend")).toEqual({
     kind: "workspace.new",

--- a/tests/unit/sessions/session-service.test.ts
+++ b/tests/unit/sessions/session-service.test.ts
@@ -524,3 +524,86 @@ test("caches and expires native session lists", async () => {
   expect(state.native_session_lists["wx:user"]).toBeUndefined();
   expect(store.savedStates.at(-1)?.native_session_lists["wx:user"]).toBeUndefined();
 });
+
+function createSwitchConfig(): AppConfig {
+  const config = createConfig();
+  config.workspaces.frontend = { cwd: "/tmp/frontend" };
+  return config;
+}
+
+test("useSession records previous_session and usePreviousSession toggles", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.createSession("b", "codex", "backend");
+
+  await service.useSession("weixin:room1", "a");
+  await service.useSession("weixin:room1", "b");
+
+  const prev = await service.usePreviousSession("weixin:room1");
+  expect(prev?.alias).toBe("a");
+
+  const back = await service.usePreviousSession("weixin:room1");
+  expect(back?.alias).toBe("b");
+});
+
+test("usePreviousSession returns null when there is no previous", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.useSession("weixin:room1", "a");
+
+  expect(await service.usePreviousSession("weixin:room1")).toBeNull();
+});
+
+test("useSession returns switch info with previousAlias", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.createSession("b", "claude", "frontend");
+
+  await service.useSession("weixin:room1", "a");
+  const result = await service.useSession("weixin:room1", "b");
+
+  expect(result).toEqual({ alias: "b", agent: "claude", workspace: "frontend", previousAlias: "a" });
+});
+
+test("resolveFuzzyAlias matches exact / prefix / substring / ambiguous / none", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("api-review", "codex", "backend");
+  await service.createSession("api-smoke", "claude", "backend");
+  await service.createSession("docs", "codex", "backend");
+
+  expect(service.resolveFuzzyAlias("weixin:room1", "docs")).toEqual({ kind: "match", alias: "docs" });
+  expect(service.resolveFuzzyAlias("weixin:room1", "api-r")).toEqual({ kind: "match", alias: "api-review" });
+  expect(service.resolveFuzzyAlias("weixin:room1", "review")).toEqual({ kind: "match", alias: "api-review" });
+
+  const ambiguous = service.resolveFuzzyAlias("weixin:room1", "api");
+  expect(ambiguous.kind).toBe("ambiguous");
+  if (ambiguous.kind === "ambiguous") {
+    expect(ambiguous.candidates.map((c) => c.alias).sort()).toEqual(["api-review", "api-smoke"]);
+  }
+
+  expect(service.resolveFuzzyAlias("weixin:room1", "zzz")).toEqual({ kind: "none" });
+});
+
+test("removeSession clears dangling previous_session references", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.createSession("b", "codex", "backend");
+  await service.useSession("weixin:room1", "a");
+  await service.useSession("weixin:room1", "b");
+
+  await service.removeSession("a");
+
+  expect(await service.usePreviousSession("weixin:room1")).toBeNull();
+});
+
+test("previous_session is isolated per chat", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.createSession("b", "codex", "backend");
+  await service.useSession("weixin:room1", "a");
+  await service.useSession("weixin:room1", "b");
+  await service.useSession("weixin:room2", "a");
+
+  expect(await service.usePreviousSession("weixin:room2")).toBeNull();
+  expect((await service.usePreviousSession("weixin:room1"))?.alias).toBe("a");
+});


### PR DESCRIPTION
## 背景

多会话时用户记不住别名/序号、也常忘了「现在在哪个会话」。本 PR 朝**不依赖记忆**的方向改进会话切换。

设计/计划文档（仓库内 `docs/superpowers/` 默认被 gitignore，未入库）：
- spec：`docs/superpowers/specs/2026-05-30-memory-free-session-switching-design.md`
- plan：`docs/superpowers/plans/2026-05-30-memory-free-session-switching.md`

## 改动

- **`/use -`**：在「当前会话」与「上一个会话」之间一键切回（像 shell 的 `cd -`），每个聊天独立记录上一个会话。
- **`/use <片段>`**：按别名片段切换，优先级 精确 > 前缀 > 子串；唯一命中即切，多命中列候选（不自动切），零命中引导 `/sessions`。
- **切换回显身份**：`已切到 api-review · codex · backend（上一个：frontend-fix）`，切完立刻知道自己在哪。
- 消歧：模糊与 `-` 只挂在 `/use`（语义＝切换），`/ss <agent>`（创建/复用）语义不变。
- 状态：`ChatContextState` 新增可选 `previous_session?`（向后兼容）；`removeSession` 清理悬空引用。
- 文档：`docs/commands.md` 与 `/help session` 补充。

## 实现要点

- `parse-command.ts`：新增 `session.use.previous`。
- `session-service.ts`：`useSession` 维护 previous 并返回切换信息；新增 `usePreviousSession`、`resolveFuzzyAlias`。
- `session-handler.ts`：`handleSessionUse` 改为模糊匹配 + 身份回显；新增 `handleSessionUsePrevious`。
- `command-router.ts`：路由 `session.use.previous`。
- 不触碰消息热路径与 quota。

## 测试

- 新增/更新单测：parse（解析）、session-service（previous 记录/对调、跨 chat 隔离、模糊匹配各分支、removeSession 清理）、router 层（模糊唯一/多命中/零命中、`/use -` 切回与无上一个、身份回显）。
- `npm test`（tsc + 全部单测）✅
- `bun run build` ✅
- dry-run 端到端实测 `/use -`、`/use <片段>`、回显均符合预期 ✅