### PR TITLE
fix(i18n): detect system locale on Windows via Intl fallback

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -69,7 +69,9 @@ If you want to manage WeChat/Feishu message channels, see [`docs/channel-managem
 
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| `language` | `"en"` \| `"zh"` | 否 | 选择 xacpx 运行时输出（聊天回复、CLI 输出、编排提示词等）的语言；缺省时首次启动按系统 locale（`$LANG` 等，`zh*` → 中文，否则英文）推断并写入配置；可用 `/config set language en` 修改；改后需 `xacpx restart` 生效 |
+| `language` | `"en"` \| `"zh"` | 否 | 选择 xacpx 运行时输出（聊天回复、CLI 输出、编排提示词等）的语言；缺省时按系统 locale 推断：先看 `$LC_ALL`/`$LC_MESSAGES`/`$LANG`，再回退到系统 locale（`zh*` → 中文，否则英文）；可用 `/config set language en` 修改；改后需 `xacpx restart` 生效 |
+
+> **Windows 提示**：`cmd.exe`/PowerShell 默认不设置 `LANG` 等 POSIX 环境变量，自动探测改为读取系统 locale（经 `Intl`，可识别中文 Windows）。若自动结果不准，显式设置最可靠：`/config set language zh`。
 
 ---
 

--- a/src/i18n/resolve-locale.ts
+++ b/src/i18n/resolve-locale.ts
@@ -6,11 +6,35 @@ export function isLocale(value: unknown): value is Locale {
   return typeof value === "string" && (VALID as readonly string[]).includes(value);
 }
 
+/**
+ * Best-effort cross-platform system locale (e.g. "zh-CN", "en-US").
+ *
+ * On Unix/macOS the POSIX env vars below are the source of truth, but on
+ * Windows those are unset by default — there the OS locale is only reachable
+ * via the system API, which `Intl` queries for us. Even a small-icu Node build
+ * still returns the OS locale *name* here (it only lacks formatting data), and
+ * a name is all we need for detection.
+ */
+function detectSystemLocale(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().locale || "";
+  } catch {
+    return "";
+  }
+}
+
 export function resolveLocale(
-  input: { configLanguage?: string; env?: NodeJS.ProcessEnv } = {},
+  input: { configLanguage?: string; env?: NodeJS.ProcessEnv; systemLocale?: string } = {},
 ): Locale {
   const { configLanguage, env = process.env } = input;
   if (isLocale(configLanguage)) return configLanguage;
+
+  // POSIX env (Unix/macOS, or a user who explicitly exported LANG on Windows).
   const raw = env.LC_ALL || env.LC_MESSAGES || env.LANG || "";
-  return /^zh/i.test(raw) ? "zh" : "en";
+  if (raw) return /^zh/i.test(raw) ? "zh" : "en";
+
+  // Fallback: cross-platform system locale. This is what makes auto-detection
+  // work on Windows, where the POSIX vars above are absent.
+  const systemLocale = input.systemLocale ?? detectSystemLocale();
+  return /^zh/i.test(systemLocale) ? "zh" : "en";
 }

--- a/tests/unit/i18n/resolve-locale.test.ts
+++ b/tests/unit/i18n/resolve-locale.test.ts
@@ -18,7 +18,20 @@ describe("resolveLocale", () => {
     expect(resolveLocale({ env: { LC_MESSAGES: "zh_TW.UTF-8" } })).toBe("zh");
   });
   it("defaults to en when nothing matches", () => {
-    expect(resolveLocale({ env: {} })).toBe("en");
+    expect(resolveLocale({ env: {}, systemLocale: "en-US" })).toBe("en");
+  });
+  it("falls back to the system locale when POSIX env is empty (Windows path)", () => {
+    // Windows cmd/PowerShell sets none of LC_ALL/LC_MESSAGES/LANG, so detection
+    // must come from the OS locale name (here injected; in prod from Intl).
+    expect(resolveLocale({ env: {}, systemLocale: "zh-CN" })).toBe("zh");
+    expect(resolveLocale({ env: {}, systemLocale: "en-GB" })).toBe("en");
+  });
+  it("prefers POSIX env over the system locale when both are present", () => {
+    expect(resolveLocale({ env: { LANG: "en_US.UTF-8" }, systemLocale: "zh-CN" })).toBe("en");
+    expect(resolveLocale({ env: { LANG: "zh_CN.UTF-8" }, systemLocale: "en-US" })).toBe("zh");
+  });
+  it("defaults to en when the system locale is unavailable", () => {
+    expect(resolveLocale({ env: {}, systemLocale: "" })).toBe("en");
   });
   it("isLocale guards values", () => {
     expect(isLocale("en")).toBe(true);


### PR DESCRIPTION
## Problem

Language auto-detection (`resolveLocale`) only read POSIX env vars — `LC_ALL` / `LC_MESSAGES` / `LANG`. Those are **unset by default on Windows** (`cmd.exe` / PowerShell use the system API, not POSIX env), so on a Chinese Windows machine with no explicit `config.language`, `resolveLocale` always fell through to `en`. The "auto-detect system locale" fallback was effectively Unix-only.

This affects the two entrypoints that face the OS directly: `src/main.ts:157` (daemon) and `src/cli.ts:278` (CLI). The bridge reads the already-resolved `XACPX_LANG` from its parent, so it was fine.

## Fix

Add a cross-platform fallback **after** the POSIX env check:

```
config.language  →  POSIX env (LC_ALL/LC_MESSAGES/LANG)  →  Intl system locale  →  en
```

- Uses `Intl.DateTimeFormat().resolvedOptions().locale`, which returns the OS locale **name** (e.g. `zh-CN`) on Windows via the system API. Even a small-icu Node build returns the name (it only lacks formatting data), and a name is all detection needs. The call is wrapped in try/catch → `""` on failure → `en`.
- `systemLocale` is an injectable param (defaulting to the `Intl` call), so the env-injected unit tests stay deterministic and never touch process-global state. POSIX env still wins when present, preserving existing behavior on Unix/macOS.

## Tests

`tests/unit/i18n/resolve-locale.test.ts` — added coverage for: empty POSIX env → systemLocale (Windows path), POSIX env preferred over systemLocale, and unavailable systemLocale → en. **10/10 pass**, `tsc --noEmit` clean.

## Docs

`docs/config-reference.md` — updated the `language` description and added a Windows note: auto-detection now reads the system locale via `Intl`, and `/config set language zh` is the reliable explicit override.

## Notes

The `Intl` branch is environment-dependent and can't be exercised deterministically in unit tests (only the injectable-`systemLocale` path is covered); real Windows behavior wasn't verified end-to-end, but the documented explicit override is the safety net.