### PR TITLE
fix(docs): stop hero phone mockup overlapping copy on mobile

### DIFF
--- a/packages/docs/.vitepress/theme/style.css
+++ b/packages/docs/.vitepress/theme/style.css
@@ -1462,6 +1462,23 @@
 /* =========================================================================
    Responsive
    ========================================================================= */
+/* Stacked hero (< 960px). The default theme gives .image order:1 (above the
+   copy), a fixed-height container (320/392px), and negative margins — all
+   tuned for the tiny decorative image-src, not our full-height phone. That
+   makes the phone overflow its box and sit on top of the hero text. Reset to
+   normal flow and drop the phone below the copy. */
+@media (max-width: 959px) {
+  .VPHome .VPHero .image {
+    order: 2;
+    margin: 12px 0 0;
+  }
+  .VPHome .VPHero .image-container {
+    width: 100%;
+    height: auto;
+    transform: none;
+  }
+}
+
 @media (max-width: 640px) {
   .install-cmd { max-width: 100%; }
   .phone { width: 240px; }


### PR DESCRIPTION
## Problem

On the docs homepage, at mobile/tablet widths (< 960px) the hero phone mockup rendered **centered at the top, overlapping the headline and tagline** instead of stacking below the copy.

## Root cause

The home hero uses VitePress's default `home` layout, which expects a small decorative `image-src`. Below 960px the default theme gives `.image`:

- `order: 1` → renders **above** the hero copy
- a fixed-height container (`320px` / `392px`)
- negative margins (`-76px -24px -48px`)

Our custom `ChatMockup` is a full-height phone (~570px tall), so it overflowed that fixed box and the negative margins pulled the copy up underneath it.

## Fix

A `@media (max-width: 959px)` block scoped to the home hero that:

- resets `.image` to `order: 2` with a normal top margin (phone now stacks **below** the copy)
- lets `.image-container` size to its content (`width: 100%; height: auto`)

Desktop (≥ 960px) is untouched.

## Verification

Screenshotted the live dev server at three widths:

| Width | Result |
|-------|--------|
| 390px (mobile) | Headline at top, phone below — no overlap ✅ |
| 768px (tablet) | Same clean stack ✅ |
| 1280px (desktop) | Unchanged side-by-side layout ✅ |
