### PR TITLE
fix(update): let `update` all/interactive upgrade unpinned plugins

### DIFF
--- a/src/cli-update.ts
+++ b/src/cli-update.ts
@@ -46,7 +46,6 @@ interface UpdateTarget {
   name: string;
   currentVersion?: string;
   latestVersion?: string | null;
-  pinned?: boolean;
   // When set on the self target, this update is a rename migration to the named
   // successor package (e.g. "xacpx") rather than an in-place version bump.
   successorPackage?: string;
@@ -86,7 +85,6 @@ export async function handleUpdateCli(args: string[], deps: UpdateCliDeps): Prom
       kind: "plugin",
       name: plugin.name,
       currentVersion: plugin.version,
-      pinned: Boolean(plugin.version),
       latestVersion: await latestOf(plugin.name),
     });
   }
@@ -97,12 +95,16 @@ export async function handleUpdateCli(args: string[], deps: UpdateCliDeps): Prom
     deps.print(`${index + 1}. ${formatTarget(target)}`);
   }
 
-  const unavailable = targets.filter((target) => !target.latestVersion || (target.kind === "plugin" && !target.pinned));
+  const unavailable = targets.filter((target) => !target.latestVersion);
   if (all && unavailable.length > 0) {
     deps.print(t().cliUpdate.unavailableAborted(unavailable.map((target) => target.name).join(", ")));
     return 1;
   }
-  const candidates = targets.filter((target) => target.latestVersion && (target.kind !== "plugin" || target.pinned) && (target.successorPackage ? true : target.currentVersion !== target.latestVersion));
+  // An unpinned plugin (no recorded version) has currentVersion === undefined,
+  // so it is always considered a candidate as long as its latest version is
+  // known — `update` installs latest and pins the result, matching the
+  // behavior of `xacpx plugin update`.
+  const candidates = targets.filter((target) => target.latestVersion && (target.successorPackage ? true : target.currentVersion !== target.latestVersion));
   const selected = await selectTargets(targets, candidates, { all, explicitTarget: explicitTargets[0], deps });
   if (!selected.ok) {
     deps.print(selected.message);
@@ -211,7 +213,6 @@ async function selectTargets(
       || (entry.kind === "self" && (input.explicitTarget === "weacpx" || input.explicitTarget === entry.successorPackage)));
     if (!target) return { ok: false, message: t().cliUpdate.targetNotFound(input.explicitTarget), exitCode: 1 };
     if (!target.latestVersion) return { ok: false, message: t().cliUpdate.targetVersionUnknown(target.name), exitCode: 1 };
-    if (target.kind === "plugin" && !target.pinned) return { ok: false, message: t().cliUpdate.targetNotPinned(target.name), exitCode: 1 };
     if (!target.successorPackage && target.currentVersion === target.latestVersion) return { ok: true, targets: [] };
     return { ok: true, targets: [target] };
   }
@@ -234,7 +235,6 @@ async function selectTargets(
     }
     const target = targets[index - 1]!;
     if (!target.latestVersion) return { ok: false, message: t().cliUpdate.targetVersionUnknown(target.name), exitCode: 1 };
-    if (target.kind === "plugin" && !target.pinned) return { ok: false, message: t().cliUpdate.targetNotPinned(target.name), exitCode: 1 };
     if (!target.successorPackage && target.currentVersion === target.latestVersion) continue;
     if (!selected.includes(target)) selected.push(target);
   }

--- a/src/i18n/messages/en/cli-update.ts
+++ b/src/i18n/messages/en/cli-update.ts
@@ -36,8 +36,6 @@ export const cliUpdate: CliUpdateMessages = {
   // selectTargets — no target found
   targetNotFound: (name) => `Update target not found: ${name}`,
   targetVersionUnknown: (name) => `${name}: cannot check latest version; skipped.`,
-  targetNotPinned: (name) =>
-    `${name} has no recorded version; use \`xacpx plugin update ${name}\` or specify a version explicitly.`,
 
   // selectTargets — non-interactive multi-target
   multiTargetNonInteractive: "Installed plugins detected; in non-interactive mode use `xacpx update --all` or `xacpx update <name>`.",

--- a/src/i18n/messages/zh/cli-update.ts
+++ b/src/i18n/messages/zh/cli-update.ts
@@ -36,8 +36,6 @@ export const cliUpdate: CliUpdateMessages = {
   // selectTargets — no target found
   targetNotFound: (name) => `没有找到更新项：${name}`,
   targetVersionUnknown: (name) => `${name} 无法检查最新版本，已跳过。`,
-  targetNotPinned: (name) =>
-    `${name} 未记录当前版本；请先使用 \`xacpx plugin update ${name}\` 或显式选择版本。`,
 
   // selectTargets — non-interactive multi-target
   multiTargetNonInteractive: "检测到已安装插件；非交互模式请使用 `xacpx update --all` 或 `xacpx update <name>`。",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -940,7 +940,6 @@ export interface CliUpdateMessages {
   // selectTargets — no target found
   targetNotFound: (name: string) => string;
   targetVersionUnknown: (name: string) => string;
-  targetNotPinned: (name: string) => string;
 
   // selectTargets — non-interactive multi-target
   multiTargetNonInteractive: string;

--- a/tests/unit/cli-update.test.ts
+++ b/tests/unit/cli-update.test.ts
@@ -307,26 +307,51 @@ test("implicit rename migration requires confirmation in interactive mode", asyn
   expect(lines.some((line) => line === t().cliUpdate.renameCancelled("xacpx"))).toBe(true);
 });
 
-test("update --all refuses unpinned plugins because current version is unknown", async () => {
+test("update --all updates unpinned plugins to latest and pins the result", async () => {
   setLocale("zh");
   const updated: string[] = [];
-  const lines: string[] = [];
+  let saved: AppConfig | null = null;
   const code = await handleUpdateCli(["--all"], {
     loadConfig: async () => config([{ name: "p1", enabled: true }]),
-    saveConfig: async () => {},
+    saveConfig: async (next) => { saved = next; },
     readCurrentVersion: () => "0.8.0",
     packageName: "xacpx",
-    print: (line) => lines.push(line),
+    print: () => {},
     isInteractive: () => false,
     promptText: async () => "",
-    // self (xacpx) is at latest so it is neither a candidate nor unavailable;
-    // the unpinned plugin p1 is what gets refused.
+    // self (xacpx) is at latest; the unpinned plugin p1 still gets updated.
     getLatestVersion: async (name) => name === "xacpx" ? "0.8.0" : "9.0.0",
     updateSelf: async (name) => { updated.push(name); },
     updatePlugin: async ({ packageName }) => { updated.push(packageName); },
+    validatePlugin: async () => {},
   });
 
-  expect(code).toBe(1);
-  expect(updated).toEqual([]);
-  expect(lines).toContain(t().cliUpdate.unavailableAborted("p1"));
+  expect(code).toBe(0);
+  expect(updated).toEqual(["p1"]);
+  // After updating, the previously-unpinned plugin is pinned to the new version.
+  expect(saved?.plugins[0]?.version).toBe("9.0.0");
+});
+
+test("interactive 'a' updates unpinned plugins (the reported regression)", async () => {
+  setLocale("en");
+  const updated: string[] = [];
+  let saved: AppConfig | null = null;
+  const code = await handleUpdateCli([], {
+    loadConfig: async () => config([{ name: "p1", enabled: true }]),
+    saveConfig: async (next) => { saved = next; },
+    readCurrentVersion: () => "0.9.1",
+    packageName: "xacpx",
+    print: () => {},
+    isInteractive: () => true,
+    // selectionPrompt -> "a" (all); self-update confirm -> "y".
+    promptText: async (message) => message.includes("[y/N]") ? "y" : "a",
+    getLatestVersion: async (name) => name === "xacpx" ? "0.9.2" : "0.5.0",
+    updateSelf: async (name) => { updated.push(name); },
+    updatePlugin: async ({ packageName }) => { updated.push(packageName); },
+    validatePlugin: async () => {},
+  });
+
+  expect(code).toBe(0);
+  expect(updated).toEqual(["xacpx", "p1"]);
+  expect(saved?.plugins[0]?.version).toBe("0.5.0");
 });


### PR DESCRIPTION
## Problem

`xacpx update` only treated **version-pinned** plugins (those with a `version` in config) as upgrade candidates. An unpinned plugin entry like:

```json
{ "name": "@ganglion/xacpx-channel-feishu", "enabled": true }
```

was silently skipped when the user picked `a`/all at the interactive prompt — even though it was listed with a target version (`unpinned -> 0.5.0`), implying it was selectable. Meanwhile the explicit `xacpx update --all` flag *aborted loudly* on the same input, an inconsistent split between the two paths. The separate `xacpx plugin update <name>` command *would* update it, so the restriction only existed on this one path.

## Fix

- Drop the `pinned` requirement from candidate selection: any plugin with a resolvable latest version is now an upgrade candidate, installed to latest and **pinned to the result** in config — matching `xacpx plugin update` behavior.
- The unavailable-abort path now triggers only when the latest version genuinely can't be checked.
- Remove the now-dead `targetNotPinned` message (en/zh/types) and the unused `pinned` field on `UpdateTarget`.

## Tests

- Rewrote the old "`--all` refuses unpinned plugins" test to assert it now **upgrades and pins** the result.
- Added a regression test reproducing the exact reported scenario: interactive `a` (all) → core + previously-unpinned plugin both upgrade.
- `npx tsc --noEmit` clean; `cli-update` + `plugin-cli` + `i18n` suites green.