### PR TITLE
fix: clean up orphaned warm queue-owner process trees

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ import { AcpxBridgeTransport } from "./transport/acpx-bridge/acpx-bridge-transpo
 import { AcpxCliTransport } from "./transport/acpx-cli/acpx-cli-transport";
 import type { ResolvedSession, SessionTransport } from "./transport/types";
 import { reapQueueOwners } from "./transport/queue-owner-reaper";
-import { workerBindingReapTargets } from "./transport/collect-reap-targets";
+import { collectReapTargets } from "./transport/collect-reap-targets";
 import type { MessageChannelRuntime, CoordinatorMessageInput } from "./channels/types.js";
 import { MessageChannelRegistry } from "./channels/channel-registry.js";
 import { RuntimeMediaStore } from "./channels/media-store.js";
@@ -77,6 +77,13 @@ export interface AppRuntime {
     service: ScheduledTaskService;
     scheduler: ScheduledTaskScheduler;
   };
+  /**
+   * Terminate warm acpx queue owners orphaned by a previous daemon that exited
+   * without a clean shutdown (Windows `stop` force-kills via taskkill /F, crashes,
+   * machine reboot). Run once at startup before serving: this daemon has not launched
+   * any owners yet, so every owner recorded for a known session is stale. Best-effort.
+   */
+  reapStaleQueueOwners: () => Promise<void>;
   dispose: () => Promise<void>;
 }
 
@@ -722,6 +729,40 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
     logger,
   });
 
+  // Terminate warm acpx queue owners for our sessions. At shutdown this stops them
+  // lingering until their --ttl expires (or forever, when ttl=0). At startup it sweeps
+  // owners orphaned by a previous daemon that died without a clean shutdown (Windows
+  // `stop` force-kills via taskkill /F, crashes, reboots) — safe because this daemon has
+  // not launched any owners yet, so every recorded owner is stale. Best-effort and
+  // bounded: failures/timeouts just leave owners to expire on TTL.
+  const reapWarmQueueOwners = async (phase: "startup" | "shutdown"): Promise<void> => {
+    try {
+      const targets = collectReapTargets(sessions, state.orchestration, config);
+      if (targets.length === 0) {
+        return;
+      }
+      const { terminated, attempted } = await reapQueueOwners(acpxCommand, targets, {
+        onError: (target, error) => {
+          void logger.info("transport.queue_owner_reap.failed", "failed to reap queue owner", {
+            phase,
+            transport_session: target.transportSession,
+            error: error instanceof Error ? error.message : String(error),
+          }).catch(() => {});
+        },
+      });
+      await logger.info("transport.queue_owner_reap.completed", "reaped warm queue owners", {
+        phase,
+        terminated,
+        attempted,
+      }).catch(() => {});
+    } catch (err) {
+      await logger.error("transport.queue_owner_reap.error", "queue owner reap failed", {
+        phase,
+        error: err instanceof Error ? err.message : String(err),
+      }).catch(() => {});
+    }
+  };
+
   return {
     agent,
     router,
@@ -742,45 +783,14 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
       service: scheduledService,
       scheduler: scheduledScheduler,
     },
+    reapStaleQueueOwners: () => reapWarmQueueOwners("startup"),
     dispose: async () => {
       scheduledScheduler.stop();
       if (progressHeartbeatInterval !== undefined) {
         clearInterval(progressHeartbeatInterval);
       }
       await Promise.allSettled([...pendingWorkerDispatches]);
-      // Terminate warm acpx queue owners for our sessions so they don't linger
-      // until their --ttl expires (or forever, when ttl=0) after the daemon exits.
-      // Best-effort and bounded: failures/timeouts just leave owners to expire on TTL.
-      try {
-        const targets = [
-          ...sessions.listAllResolvedSessions().map((session) => ({
-            agent: session.agent,
-            ...(session.agentCommand ? { agentCommand: session.agentCommand } : {}),
-            cwd: session.cwd,
-            transportSession: session.transportSession,
-          })),
-          // Orchestration worker sessions also spawn warm owners (with the same TTL).
-          ...workerBindingReapTargets(state.orchestration, config),
-        ];
-        if (targets.length > 0) {
-          const { terminated, attempted } = await reapQueueOwners(acpxCommand, targets, {
-            onError: (target, error) => {
-              void logger.info("transport.queue_owner_reap.failed", "failed to reap queue owner on shutdown", {
-                transport_session: target.transportSession,
-                error: error instanceof Error ? error.message : String(error),
-              }).catch(() => {});
-            },
-          });
-          await logger.info("transport.queue_owner_reap.completed", "reaped warm queue owners on shutdown", {
-            terminated,
-            attempted,
-          }).catch(() => {});
-        }
-      } catch (err) {
-        await logger.error("transport.queue_owner_reap.error", "queue owner reap failed during shutdown", {
-          error: err instanceof Error ? err.message : String(err),
-        }).catch(() => {});
-      }
+      await reapWarmQueueOwners("shutdown");
       await debouncedStateStore.dispose();
       if ("dispose" in transport && typeof transport.dispose === "function") {
         await transport.dispose();

--- a/src/mcp/xacpx-mcp-server.ts
+++ b/src/mcp/xacpx-mcp-server.ts
@@ -24,6 +24,7 @@ import { coreEnv } from "../runtime/core-env";
 import type { OrchestrationIpcEndpoint } from "../orchestration/orchestration-ipc";
 import type { OrchestrationTaskRecord } from "../orchestration/orchestration-types";
 import { resolveDefaultOrchestrationEndpoint } from "./resolve-endpoint";
+import { canConnectToEndpoint } from "../orchestration/endpoint-probe";
 import { buildXacpxMcpToolRegistry } from "./xacpx-mcp-tools";
 import { createOrchestrationTransport, type XacpxMcpTransport } from "./xacpx-mcp-transport";
 
@@ -718,6 +719,20 @@ export interface McpStdioShutdownHookOptions {
   parentCheckIntervalMs?: number;
   signalSource?: McpShutdownSignalSource;
   isProcessRunning?: (pid: number) => boolean;
+  /**
+   * Liveness probe for the orchestration daemon this bridge proxies to. Returns
+   * false ONLY when the endpoint definitively has no listener (ECONNREFUSED /
+   * ENOENT); a successful connect or any ambiguous error returns true. The bridge
+   * is useless once the daemon is gone, so a sustained run of false results means
+   * it should exit. Targets the daemon directly — unlike the parent-pid poll,
+   * which on Windows watches the cmd/.cmd shim wrapper (alive as long as the
+   * bridge itself), so it can never fire there.
+   */
+  probeEndpoint?: () => Promise<boolean>;
+  endpointCheckIntervalMs?: number;
+  /** Consecutive no-listener probes required before shutting down. Conservative
+   * debounce against transient blips: a live daemon resets the counter. */
+  endpointFailureThreshold?: number;
   setIntervalFn?: (callback: () => void, ms: number) => McpIntervalHandle;
   clearIntervalFn?: (handle: McpIntervalHandle) => void;
   onDiagnostic?: (event: string, context?: Record<string, unknown>) => void;
@@ -730,7 +745,9 @@ export function installMcpStdioShutdownHooks(options: McpStdioShutdownHookOption
   const setIntervalFn = options.setIntervalFn ?? ((callback, ms) => setInterval(callback, ms));
   const clearIntervalFn = options.clearIntervalFn ?? ((handle) => clearInterval(handle));
   const parentPid = options.parentPid ?? process.ppid;
-  const parentCheckIntervalMs = options.parentCheckIntervalMs ?? parseParentCheckIntervalMs(coreEnv("MCP_PARENT_CHECK_INTERVAL_MS"));
+  const parentCheckIntervalMs = options.parentCheckIntervalMs ?? parseIntervalMs(coreEnv("MCP_PARENT_CHECK_INTERVAL_MS"), 5_000);
+  const endpointCheckIntervalMs = options.endpointCheckIntervalMs ?? parseIntervalMs(coreEnv("MCP_ENDPOINT_CHECK_INTERVAL_MS"), 10_000);
+  const endpointFailureThreshold = options.endpointFailureThreshold ?? 3;
 
   let disposed = false;
   let triggered = false;
@@ -773,6 +790,37 @@ export function installMcpStdioShutdownHooks(options: McpStdioShutdownHookOption
     parentTimer.unref?.();
   }
 
+  let endpointTimer: McpIntervalHandle | undefined;
+  const probeEndpoint = options.probeEndpoint;
+  if (probeEndpoint && endpointCheckIntervalMs > 0 && endpointFailureThreshold > 0) {
+    let consecutiveDead = 0;
+    let probing = false;
+    const runEndpointCheck = async (): Promise<void> => {
+      // Skip while shutting down, or if a prior probe is still in flight (a slow
+      // connect must not let checks pile up or fire concurrently).
+      if (disposed || triggered || probing) return;
+      probing = true;
+      try {
+        if (await probeEndpoint()) {
+          consecutiveDead = 0;
+          return;
+        }
+        consecutiveDead += 1;
+        if (consecutiveDead >= endpointFailureThreshold) {
+          triggerShutdown("daemon_endpoint_dead", { consecutiveFailures: consecutiveDead });
+        }
+      } catch {
+        // Probe threw unexpectedly: treat as inconclusive (neither a live daemon
+        // nor a definitive no-listener), so it can never by itself cause a
+        // shutdown. The counter is left unchanged.
+      } finally {
+        probing = false;
+      }
+    };
+    endpointTimer = setIntervalFn(runEndpointCheck, endpointCheckIntervalMs);
+    endpointTimer.unref?.();
+  }
+
   return () => {
     if (disposed) return;
     disposed = true;
@@ -786,13 +834,16 @@ export function installMcpStdioShutdownHooks(options: McpStdioShutdownHookOption
     if (parentTimer) {
       clearIntervalFn(parentTimer);
     }
+    if (endpointTimer) {
+      clearIntervalFn(endpointTimer);
+    }
   };
 }
 
-function parseParentCheckIntervalMs(raw: string | undefined): number {
-  if (raw === undefined || raw.trim().length === 0) return 5_000;
+function parseIntervalMs(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim().length === 0) return fallback;
   const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5_000;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
 function errorContext(error: unknown): Record<string, unknown> {
@@ -823,9 +874,8 @@ export async function runXacpxMcpServer(options: {
   availableAgents?: string[];
   onDiagnostic?: (event: string, context?: Record<string, unknown>) => void;
 }): Promise<void> {
-  const transport = options.transport ?? createOrchestrationTransport(
-    options.endpoint ?? resolveDefaultOrchestrationEndpoint(process.env, process.platform),
-  );
+  const endpoint = options.endpoint ?? resolveDefaultOrchestrationEndpoint(process.env, process.platform);
+  const transport = options.transport ?? createOrchestrationTransport(endpoint);
   const server = createXacpxMcpServer({
     transport,
     ...(options.coordinatorSession ? { coordinatorSession: options.coordinatorSession } : {}),
@@ -864,6 +914,7 @@ export async function runXacpxMcpServer(options: {
     stdin,
     stdout,
     shutdown,
+    probeEndpoint: () => canConnectToEndpoint(endpoint.path, 4_000),
     onDiagnostic: options.onDiagnostic,
   });
 

--- a/src/orchestration/endpoint-probe.ts
+++ b/src/orchestration/endpoint-probe.ts
@@ -1,0 +1,50 @@
+import { createConnection } from "node:net";
+
+/**
+ * Liveness probe for an orchestration IPC endpoint (a unix socket or Windows
+ * named pipe path). Returns false ONLY when the endpoint definitively has no
+ * listener — `ECONNREFUSED` (nothing accepting / stale socket file) or `ENOENT`
+ * (pipe/socket path gone). A successful connect, or any other / ambiguous error
+ * (including a timeout), returns true. This conservative bias means a busy or
+ * transiently-unreachable daemon is reported alive, so callers that act on a
+ * false result (e.g. self-terminating) do not misfire on a blip.
+ *
+ * The probe sends no bytes: it connects and immediately closes, which the
+ * orchestration server tolerates as an empty connection.
+ */
+export async function canConnectToEndpoint(path: string, timeoutMs?: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const socket = createConnection(path);
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (result: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      socket.destroy();
+      resolve(result);
+    };
+
+    if (timeoutMs !== undefined && timeoutMs > 0) {
+      // A connect that neither resolves nor errors within the budget is treated
+      // as inconclusive (alive), never as a no-listener.
+      timer = setTimeout(() => finish(true), timeoutMs);
+      timer.unref?.();
+    }
+
+    socket.once("connect", () => finish(true));
+    socket.once("error", (error) => {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ECONNREFUSED") {
+        finish(false);
+        return;
+      }
+      finish(true);
+    });
+  });
+}

--- a/src/orchestration/orchestration-server.ts
+++ b/src/orchestration/orchestration-server.ts
@@ -1,5 +1,5 @@
 import { rm } from "node:fs/promises";
-import { createConnection, createServer, type Server, type Socket } from "node:net";
+import { createServer, type Server, type Socket } from "node:net";
 
 import {
   encodeOrchestrationRpcResponse,
@@ -23,6 +23,7 @@ import {
   MAX_TASK_WATCH_TIMEOUT_MS,
 } from "./task-watch-timeouts";
 import { sameCoordinatorSession } from "./coordinator-identity";
+import { canConnectToEndpoint } from "./endpoint-probe";
 import type { ScheduledCreateFromRouteInput } from "../scheduled/scheduled-route-create";
 import type {
   ScheduledCancelFromRouteInput,
@@ -632,33 +633,6 @@ function requireTaskQuestions(
       taskId: requireString(entry as Record<string, unknown>, "taskId"),
       questionId: requireString(entry as Record<string, unknown>, "questionId"),
     };
-  });
-}
-
-async function canConnectToEndpoint(path: string): Promise<boolean> {
-  return await new Promise<boolean>((resolve) => {
-    const socket = createConnection(path);
-    let settled = false;
-
-    const finish = (result: boolean) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      socket.destroy();
-      resolve(result);
-    };
-
-    socket.once("connect", () => finish(true));
-    socket.once("error", (error) => {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "ENOENT" || code === "ECONNREFUSED") {
-        finish(false);
-        return;
-      }
-
-      finish(true);
-    });
   });
 }
 

--- a/src/run-console.ts
+++ b/src/run-console.ts
@@ -141,6 +141,13 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
       }
     }
 
+    // Sweep warm acpx queue owners orphaned by a previous daemon that exited without a
+    // clean shutdown (Windows `stop` force-kills the daemon via taskkill /F before
+    // dispose() can reap; crashes and reboots skip dispose entirely). Runs after the
+    // consumer lock is held — so no peer instance owns these — and before channels start
+    // serving, so it cannot kill an owner this run just launched. Best-effort.
+    await runtime.reapStaleQueueOwners();
+
     if (deps.beforeReady) {
       await deps.beforeReady(runtime);
     }

--- a/src/transport/collect-reap-targets.ts
+++ b/src/transport/collect-reap-targets.ts
@@ -1,7 +1,32 @@
 import { resolveAgentCommand } from "../config/resolve-agent-command";
 import type { AppConfig } from "../config/types";
 import type { OrchestrationState } from "../orchestration/orchestration-types";
+import type { ResolvedSession } from "./types";
 import type { ReapTarget } from "./queue-owner-reaper";
+
+/**
+ * Full reap-target set for a daemon: every known logical (user) session plus the
+ * orchestration worker sessions. Both spawn warm acpx queue owners honoring `--ttl`,
+ * so both must be swept at shutdown (so they don't linger) and at startup (so owners
+ * orphaned by a previously crashed/force-killed daemon get cleaned up). Sessions whose
+ * agent/workspace are de-registered are already filtered by listAllResolvedSessions and
+ * workerBindingReapTargets respectively.
+ */
+export function collectReapTargets(
+  sessions: { listAllResolvedSessions(): ResolvedSession[] },
+  orchestration: OrchestrationState,
+  config: AppConfig,
+): ReapTarget[] {
+  return [
+    ...sessions.listAllResolvedSessions().map((session) => ({
+      agent: session.agent,
+      ...(session.agentCommand ? { agentCommand: session.agentCommand } : {}),
+      cwd: session.cwd,
+      transportSession: session.transportSession,
+    })),
+    ...workerBindingReapTargets(orchestration, config),
+  ];
+}
 
 /**
  * Reap targets for orchestration worker sessions. These are acpx sessions xacpx

--- a/tests/unit/mcp/xacpx-mcp-server.test.ts
+++ b/tests/unit/mcp/xacpx-mcp-server.test.ts
@@ -1044,6 +1044,84 @@ test("MCP stdio shutdown hooks poll parent process liveness", () => {
   expect(cleared).toBe(true);
 });
 
+test("MCP stdio endpoint watchdog shuts down after consecutive no-listener probes", async () => {
+  const stdin = new EventEmitter();
+  const stdout = new EventEmitter();
+  const signals = new EventEmitter();
+  let intervalCallback: (() => void | Promise<void>) | undefined;
+  let cleared = false;
+  const intervalHandle = { unref() {} } as ReturnType<typeof setInterval>;
+  let calls = 0;
+  const diagnostics: unknown[] = [];
+
+  const cleanup = installMcpStdioShutdownHooks({
+    stdin,
+    stdout,
+    platform: "win32",
+    parentPid: 0,
+    signalSource: signals as never,
+    probeEndpoint: async () => false,
+    endpointCheckIntervalMs: 10,
+    endpointFailureThreshold: 3,
+    setIntervalFn: (callback) => {
+      intervalCallback = callback;
+      return intervalHandle;
+    },
+    clearIntervalFn: (handle) => {
+      expect(handle).toBe(intervalHandle);
+      cleared = true;
+    },
+    onDiagnostic: (event, context) => diagnostics.push({ event, context }),
+    shutdown: () => { calls += 1; },
+  });
+
+  expect(intervalCallback).toBeDefined();
+  await intervalCallback!();
+  expect(calls).toBe(0);
+  await intervalCallback!();
+  expect(calls).toBe(0);
+  await intervalCallback!();
+  expect(calls).toBe(1);
+  expect(diagnostics).toEqual([
+    { event: "mcp.stdio.shutdown", context: { reason: "daemon_endpoint_dead", consecutiveFailures: 3 } },
+  ]);
+  cleanup();
+  expect(cleared).toBe(true);
+});
+
+test("MCP stdio endpoint watchdog resets its counter when a probe reaches the daemon", async () => {
+  const stdin = new EventEmitter();
+  const stdout = new EventEmitter();
+  const signals = new EventEmitter();
+  let intervalCallback: (() => void | Promise<void>) | undefined;
+  let calls = 0;
+
+  // dead, dead, ALIVE, dead, dead — never 3 consecutive failures, so no shutdown.
+  const results = [false, false, true, false, false];
+  let index = 0;
+
+  installMcpStdioShutdownHooks({
+    stdin,
+    stdout,
+    platform: "win32",
+    parentPid: 0,
+    signalSource: signals as never,
+    probeEndpoint: async () => results[index++]!,
+    endpointCheckIntervalMs: 10,
+    endpointFailureThreshold: 3,
+    setIntervalFn: (callback) => {
+      intervalCallback = callback;
+      return { unref() {} } as ReturnType<typeof setInterval>;
+    },
+    shutdown: () => { calls += 1; },
+  });
+
+  for (let i = 0; i < results.length; i += 1) {
+    await intervalCallback!();
+  }
+  expect(calls).toBe(0);
+});
+
 test("task_watch native MCP task surfaces the watch result and is purged once consumed", async () => {
   const baseTask: OrchestrationTaskRecord = {
     taskId: "task-1",

--- a/tests/unit/run-console-consumer-lock.test.ts
+++ b/tests/unit/run-console-consumer-lock.test.ts
@@ -31,6 +31,7 @@ test("acquires and releases the weixin consumer lock around sdk.start", async ()
         configStore: {} as never,
         scheduled: createScheduledRuntime(),
         logger: createNoopAppLogger(),
+        reapStaleQueueOwners: async () => {},
         dispose: async () => {
           events.push("dispose");
         },
@@ -72,6 +73,7 @@ test("releases the weixin consumer lock when sdk.start fails", async () => {
           configStore: {} as never,
           scheduled: createScheduledRuntime(),
           logger: createNoopAppLogger(),
+          reapStaleQueueOwners: async () => {},
           dispose: async () => {
             events.push("dispose");
           },
@@ -114,6 +116,7 @@ test("does not release the lock if acquisition fails before startup", async () =
           configStore: {} as never,
           scheduled: createScheduledRuntime(),
           logger: createNoopAppLogger(),
+          reapStaleQueueOwners: async () => {},
           dispose: async () => {
             events.push("dispose");
           },
@@ -166,6 +169,7 @@ test("logs active lock holder diagnostics when another consumer already owns the
             cleanup: async () => {},
             flush: async () => {},
           },
+          reapStaleQueueOwners: async () => {},
           dispose: async () => {},
         }),
         channels: {

--- a/tests/unit/run-console.test.ts
+++ b/tests/unit/run-console.test.ts
@@ -30,6 +30,7 @@ function createRuntime() {
       },
       endpoint: {} as never,
     },
+    reapStaleQueueOwners: async () => {},
     dispose: async () => {},
   };
 }
@@ -67,6 +68,7 @@ test("registers and clears the heartbeat timer across daemon lifecycle", async (
             reconcileParallelSlots: async () => {},
           },
         },
+        reapStaleQueueOwners: async () => {},
         dispose: async () => {
           events.push("dispose");
         },
@@ -113,6 +115,28 @@ test("registers and clears the heartbeat timer across daemon lifecycle", async (
   ]);
   expect(intervalDelays).toEqual([5_000]);
   expect(clearedTimers).toEqual(["timer-5000"]);
+});
+
+test("reaps stale queue owners at startup after the consumer lock, before channels start", async () => {
+  const events: string[] = [];
+
+  await runConsole({ configPath: "/cfg", statePath: "/state" }, {
+    buildApp: async () => ({
+      ...createRuntime(),
+      reapStaleQueueOwners: async () => { events.push("reap"); },
+    }),
+    consumerLock: {
+      acquire: async () => { events.push("lock:acquire"); },
+      release: async () => { events.push("lock:release"); },
+    } as never,
+    channels: {
+      startAll: async () => { events.push("channel:start"); },
+    },
+    addProcessListener: () => {},
+    removeProcessListener: () => {},
+  });
+
+  expect(events).toEqual(["lock:acquire", "reap", "channel:start", "lock:release"]);
 });
 
 test("runs afterBuild before beforeReady and channel startup", async () => {
@@ -233,6 +257,7 @@ test("best-effort channel startup keeps running when all channels fail until shu
             reconcileParallelSlots: async () => {},
           },
         },
+        reapStaleQueueOwners: async () => {},
         dispose: async () => {
           events.push("dispose");
         },
@@ -317,6 +342,7 @@ test("require-one channel startup still rejects when all channels fail", async (
               reconcileParallelSlots: async () => {},
             },
           },
+          reapStaleQueueOwners: async () => {},
           dispose: async () => {
             events.push("dispose");
           },
@@ -414,6 +440,7 @@ test("disposes runtime when loading the sdk fails before startup", async () => {
               reconcileParallelSlots: async () => {},
             },
           },
+          reapStaleQueueOwners: async () => {},
           dispose: async () => {
             events.push("dispose");
           },
@@ -456,6 +483,7 @@ test("swallows heartbeat failures inside the timer callback", async () => {
             reconcileParallelSlots: async () => {},
           },
         },
+        reapStaleQueueOwners: async () => {},
         dispose: async () => {},
       }),
       channels: {
@@ -507,6 +535,7 @@ test("does not register gc interval in foreground mode", async () => {
             reconcileParallelSlots: async () => {},
           },
         },
+        reapStaleQueueOwners: async () => {},
         dispose: async () => {},
       }),
       channels: {
@@ -554,6 +583,7 @@ test("still stops daemon runtime when dispose fails", async () => {
               reconcileParallelSlots: async () => {},
             },
           },
+          reapStaleQueueOwners: async () => {},
           dispose: async () => {
             events.push("dispose");
             throw new Error("dispose failed");
@@ -611,6 +641,7 @@ test("handles SIGINT by aborting the sdk start and running cleanup", async () =>
             reconcileParallelSlots: async () => {},
           },
         },
+        reapStaleQueueOwners: async () => {},
         dispose: async () => {
           events.push("dispose");
         },

--- a/tests/unit/transport/collect-reap-targets.test.ts
+++ b/tests/unit/transport/collect-reap-targets.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
 
-import { workerBindingReapTargets } from "../../../src/transport/collect-reap-targets";
+import { collectReapTargets, workerBindingReapTargets } from "../../../src/transport/collect-reap-targets";
 import type { AppConfig } from "../../../src/config/types";
+import type { ResolvedSession } from "../../../src/transport/types";
 import { createEmptyState } from "../../../src/state/types";
 
 function createConfig(): AppConfig {
@@ -65,6 +66,45 @@ test("falls back to workspace cwd when the binding has no explicit cwd", () => {
   const targets = workerBindingReapTargets(state.orchestration, createConfig());
 
   expect(targets).toEqual([
+    { agent: "codex", cwd: "/tmp/backend", transportSession: "backend:codex:wk" },
+  ]);
+});
+
+function resolvedSession(over: Partial<ResolvedSession> & Pick<ResolvedSession, "agent" | "cwd" | "transportSession">): ResolvedSession {
+  return {
+    alias: over.transportSession,
+    workspace: "backend",
+    ...over,
+  } as ResolvedSession;
+}
+
+test("collectReapTargets combines logical sessions and worker bindings", () => {
+  const state = createEmptyState();
+  state.orchestration.workerBindings["backend:codex:wk"] = {
+    sourceHandle: "h1",
+    coordinatorSession: "backend:main",
+    workspace: "backend",
+    cwd: "/tmp/backend",
+    targetAgent: "codex",
+  };
+
+  const sessions = {
+    listAllResolvedSessions: (): ResolvedSession[] => [
+      resolvedSession({ agent: "codex", cwd: "/tmp/a", transportSession: "wx:alice" }),
+      resolvedSession({
+        agent: "opencode",
+        agentCommand: "npx -y opencode-ai acp",
+        cwd: "/tmp/b",
+        transportSession: "wx:bob",
+      }),
+    ],
+  };
+
+  const targets = collectReapTargets(sessions, state.orchestration, createConfig());
+
+  expect(targets).toEqual([
+    { agent: "codex", cwd: "/tmp/a", transportSession: "wx:alice" },
+    { agent: "opencode", agentCommand: "npx -y opencode-ai acp", cwd: "/tmp/b", transportSession: "wx:bob" },
     { agent: "codex", cwd: "/tmp/backend", transportSession: "backend:codex:wk" },
   ]);
 });


### PR DESCRIPTION
## Problem

Warm `acpx __queue-owner` process trees (owner → agent → `xacpx mcp-stdio` bridges) leak as orphans when a daemon exits without a clean shutdown, accumulating across restarts and holding memory. Surfaced by a process audit on a Windows machine showing multiple orphaned owner trees under a dead daemon.

Two root causes combine:

1. **Reap only runs in the daemon's graceful `dispose()`.** On Windows `xacpx stop` force-kills the daemon via `taskkill /T /F` before `dispose()` can reap, and the detached owner breaks away from the tree; crashes/reboots skip `dispose()` entirely.
2. **No startup sweep.** Orphans left by a previously-dead daemon are only cleared lazily when that exact session is prompted again, or when the owner's `--ttl` expires (never, when `ttl=0`).

## Changes

**Commit 1 — `fix(daemon): reap orphaned warm queue owners at startup`**
- Runs after the consumer lock is acquired (no peer instance owns the owners) and before channels start serving (cannot kill an owner this run just launched). The daemon hasn't launched any owners yet, so every owner recorded for a known session is stale.
- Extracts `collectReapTargets()` (logical sessions + worker bindings), shared between the new startup reap and the existing shutdown reap via `AppRuntime.reapStaleQueueOwners()`.

**Commit 2 — `fix(mcp): terminate stdio bridge when the orchestration endpoint is gone`**
- The bridge's parent-death watchdog polls `process.ppid`, but on Windows the bridge is launched via a `cmd`/`.cmd` shim that lives as long as the bridge itself, so it never fires. Adds an endpoint-liveness watchdog that targets the daemon directly.
- `OrchestrationClient` connects per-RPC (no standing connection), so this polls: every 10s it probes the endpoint and shuts down only after **3 consecutive definitive no-listener results** (`ECONNREFUSED`/`ENOENT`). A successful connect resets the counter; any ambiguous error/timeout is treated as alive, so a busy or briefly-restarting daemon doesn't trip it. Tunable via `MCP_ENDPOINT_CHECK_INTERVAL_MS`.
- Extracts `canConnectToEndpoint()` into a lightweight `endpoint-probe` module (reused by `orchestration-server`) so the bridge doesn't pull in the full server.

## Scope / limitations

The endpoint watchdog only reclaims the **bridge** leaves; the dominant memory (queue-owner + agent) is reclaimed by the startup reap on next start, or by TTL. The deepest fix — having `acpx __queue-owner` self-terminate when its daemon dies — lives in the upstream `acpx` repo and is intentionally **not** attempted here.

## Testing

- TDD throughout (red → green) for `collectReapTargets`, the startup-reap wiring/ordering in `run-console`, and the endpoint watchdog (consecutive-failure threshold + counter reset).
- `npm test` (typecheck + full unit suite) passes; `bun run build` passes.
- Not reproducible on macOS (Windows-specific); verified via unit tests.