### PR TITLE
fix: codebase review batch — credential safety, session context, bridge, scheduler, Windows

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -282,6 +282,8 @@ export interface MessageChannelRuntime {
 
   start(input: ChannelStartInput): Promise<void>;
 
+  stop?(): void | Promise<void>;
+
   createConsumerLock?(options?: ConsumerLockOptions): ConsumerLock;
   configureOrchestration?(callbacks: OrchestrationDeliveryCallbacks): void;
 
@@ -314,7 +316,9 @@ Only interactive channels (WeChat QR-code login) need to run the QR code flow he
 
 ### `logout(): void`
 
-Release credentials, disconnect persistent connections, and clear in-memory sessions. **Must be reentrant** — both daemon shutdown and re-login will call it.
+**Destructive**: remove stored credentials, disconnect persistent connections, and clear in-memory sessions. It is reached only when the user explicitly runs `xacpx logout` — never as part of a normal daemon shutdown. **Must be reentrant.**
+
+One legacy exception: for channels that do **not** implement `stop()`, the daemon shutdown path falls back to `logout()`. If you rely on that fallback, `logout()` must not delete anything the user would have to re-acquire interactively (re-login, re-scan QR). New plugins should implement `stop()` and keep credential removal exclusively in `logout()`.
 
 ### `start(input: ChannelStartInput): Promise<void>`
 
@@ -328,6 +332,10 @@ Requirements:
 - Record key events for any outbound send via `input.logger`, so the user can troubleshoot with `xacpx doctor --verbose` / `app.log`.
 
 `start()` is usually a long-running promise — returning means you have wired up the callbacks, but the message loop can be asynchronous in the background.
+
+### `stop?(): void | Promise<void>`
+
+Optional, **preferred**. Non-destructive shutdown hook: on every daemon shutdown (SIGTERM / Ctrl-C and startup-error cleanup) the registry calls `stop()` when it exists and falls back to `logout()` only when it does not. Release runtime resources here — stop clients, drop `agent` / `quota` / `logger` references, clear queues — but **never touch stored credentials**: a daemon stop or restart must not force the user to log in again. Note that `abortSignal` has usually already fired by the time `stop()` runs, so it is often a small cleanup (or even a no-op).
 
 ### `createConsumerLock?(options?): ConsumerLock`
 
@@ -394,7 +402,7 @@ export interface ChannelStartInput {
 
 The `ChatAgent` interface itself is internal, but the `MessageChannelRuntime` contract only requires you to `await agent.handle(chatKey, text)` for inbound text. It returns no data; the agent calls your send methods within its own callback chain.
 
-> **Important**: Your channel must hold a reference to `agent` / `quota` / `logger` until `logout()` or `abortSignal` fires. They are not passed again after `start()` returns.
+> **Important**: Your channel must hold a reference to `agent` / `quota` / `logger` until `stop()` / `logout()` or `abortSignal` fires. They are not passed again after `start()` returns.
 
 ### 5.1 Internationalization (i18n)
 
@@ -783,10 +791,10 @@ Every plugin command accepts `--restart` / `--no-restart`, and by default asks i
    5.3 channel.start({ agent, abortSignal, quota, logger })
 6. Receive messages: channel → agent.handle(chatKey, text) → router
 7. Send messages: orchestration → channel.notifyTaskCompletion / sendCoordinatorMessage
-8. SIGTERM / SIGINT: abortSignal aborted → channel cleans up itself → channel.stopAll? → daemon exit
+8. SIGTERM / SIGINT: abortSignal aborted → channel cleans up itself → registry.stopAll: channel.stop?() (fallback: logout()) → daemon exit
 ```
 
-`logout()` is triggered only when `xacpx logout` is explicitly invoked; normal exit goes through `abortSignal`.
+Normal exit goes through `abortSignal` plus the non-destructive `stop()`; the destructive `logout()` is triggered only when `xacpx logout` is explicitly invoked — except as the shutdown fallback for legacy channels that do not implement `stop()`.
 
 ### 16.3 Module cache semantics (developer must-read)
 

--- a/docs/superpowers/plans/2026-06-10-codebase-review-fixes.md
+++ b/docs/superpowers/plans/2026-06-10-codebase-review-fixes.md
@@ -1,0 +1,56 @@
+# Codebase Review Fixes (2026-06-10)
+
+Source: full-codebase review (6 parallel review agents, top findings hand-verified).
+Branch: `worktree-fix+review-batch-2026-06`. Execution: subagent-driven development, one task at a time.
+
+## Tasks
+
+### Task 1 — Stop wiping WeChat credentials on shutdown; remove unauthenticated `/logout` chat command (P0)
+- `MessageChannelRegistry.stopAll()` (`src/channels/channel-registry.ts`) implements "stop" as `channel.logout()`. For the built-in Weixin channel this chains to `clearContextTokensForAccount()` + `clearAllWeixinAccounts()` (`src/weixin/auth/accounts.ts`), physically deleting `~/.openclaw/openclaw-weixin/accounts/*.json` on every graceful stop (SIGTERM/`xacpx stop`/startup-error cleanup in `run-console.ts`). A second instance losing the consumer lock also wipes the healthy daemon's credentials.
+- Fix: add optional non-destructive `stop()` to the channel runtime interface (`src/channels/types.ts`); `stopAll()` prefers `channel.stop?.()` and falls back to `logout()` only when `stop` is absent (plugin compat: feishu/yuanbao `logout()` is a benign client stop). `WeixinChannel.stop()` must not touch credential files. Explicit `xacpx logout` CLI keeps calling `logout()`.
+- Remove the `/logout` case from `src/weixin/messaging/slash-commands.ts` (any chat peer could wipe all bot credentials; no auth on that path). CLI logout remains the only logout surface.
+
+### Task 2 — SessionService: preserve background results; don't inherit transport agent command across agents (P0)
+- `useSession`/`usePreviousSession` (`src/sessions/session-service.ts`) rebuild the chat context object and drop `background_results`, so the switch-back replay (`takeBackgroundResult`) never fires and ● unread markers vanish. Fix: preserve existing context fields when switching.
+- `removeSession` deletes the whole chat context when removing the current session, destroying other sessions' background results and `previous_session`. Fix: prune only references to the removed alias (promote `previous_session` if available).
+- `createLogicalSession`/`resolveSession` carry the old same-alias session's `transport_agent_command`, `mode_id`, `reply_mode` onto a new session even when the agent differs → prompts go to the wrong backend. Fix: carry these over only when the agent matches.
+
+### Task 3 — Bridge transport: permissionPolicy plumbing + stdin backpressure (P0)
+- `transport.permissionPolicy` never reaches the bridge: spawn env doesn't include it and the `updatePermissionPolicy` RPC dispatch in `src/bridge/bridge-server.ts` forwards only `permissionMode`/`nonInteractivePermissions`. `BridgeRuntime` already supports it (`--permission-policy`). Fix: pass through spawn env (`bridge-env`) and the RPC dispatch; add to `SpawnedBridgeClientOptions`.
+- `AcpxBridgeClient.request` treats `stdin.write(...) === false` (backpressure) as a fatal "buffer full" error and rejects/deletes the pending entry, while the request still executes → ghost execution + lost output for >~16KB prompts. Fix: `false` is not an error; only fail on actual write errors.
+
+### Task 4 — orchestration-server: accept `parallel` in delegate parsing (P0)
+- `parseRequestDelegateRpcInput` (`src/orchestration/orchestration-server.ts`) omits `parallel` from the `requireOnlyKeys` allowlist and never copies it, so every `delegate_request`/`delegate_batch` entry that sets `parallel` fails with `ORCHESTRATION_INVALID_REQUEST`. MCP tools advertise it and the service supports it. Fix: allow + validate boolean + forward.
+
+### Task 5 — Scheduler robustness (daemon crash + validation bypass)
+- `scheduled-scheduler.ts` `tick()` is `try/finally` with no catch; a thrown `claimDueTasks()`/`markFailed()` (state save failure) escapes `void this.tick()` as an unhandled rejection → kills the daemon. Fix: catch + log.
+- `parse-later-time.ts`: overflow durations produce Invalid Date; NaN compares false against min/max so validation passes, then `toISOString()` throws a raw internal error. Fix: treat NaN as out-of-range (friendly error).
+
+### Task 6 — queue-owner-reaper: dedupe by composite key
+- `reapQueueOwners` dedupes targets by `transportSession` name only; same-named sessions in different workspaces/agents resolve to different acpx records, second is never reaped. Fix: dedupe on composite identity (agent + cwd + transportSession).
+
+### Task 7 — Plugin legacy-name handling
+- `removePlugin` (`src/plugins/plugin-cli.ts`) matches via normalized `findPlugin` but filters config by raw input name → legacy `@ganglion/weacpx-channel-*` names uninstall the package yet leave a ghost config entry. Fix: filter with normalized names.
+- `plugin-doctor.ts` `filterByName` same raw comparison → normalize.
+- `plugin-doctor.ts` orphan-channel scan iterates all channels including `enabled: false` → wrong error verdict for deliberately disabled channels. Fix: only consider enabled channels (mirror `plugin-cli.ts` `activeChannels`).
+
+### Task 8 — app-logger: logging must not take down message handling
+- `app-logger.ts` returns raw write promises; a failing log file (disk full/EACCES) rejects every `await logger.info(...)` — `ConsoleAgent.chat` and `runConsole` startup then fail. Fix: logger methods never reject (degrade gracefully; one-time stderr note is fine).
+- `rotating-file-writer.ts` `cleanupExpiredRotatedLogs` `stat()` has no ENOENT tolerance; racing deletion fails `buildApp`. Fix: tolerate ENOENT.
+
+### Task 9 — daemon status.json: atomic write
+- `daemon-status.ts` writes status.json non-atomically while the 30s heartbeat rewrites it; readers can see truncated JSON → `xacpx status` exits "indeterminate", concurrent `start` throws "status metadata is missing". Fix: tmp-file + rename in the same directory.
+
+### Task 10 — Windows spawn fixes
+- `cli-update.ts` `runCapture`/`runInherit` spawn `npm` without `shell` → fails on Windows (npm is npm.cmd). Fix: `shell: process.platform === "win32"` (pattern already used in `src/recovery/`).
+- `create-daemon-controller.ts` PowerShell launcher passes `-ArgumentList @($env:XACPX_DAEMON_ARG0, ...)`; PS 5.1 joins without quoting → install paths containing spaces break `xacpx start`. Fix: quote the arguments inside the PowerShell command.
+
+### Task 11 — Bridge ensureSession timeout
+- Bridge-side `ensureSession` has no time bound (`AcpxBridgeClient.request` never times out; `BridgeRuntime.ensureSession`/`spawnCapture` unbounded), unlike acpx-cli's `sessionInitTimeoutMs` (120s default). A hung agent init wedges the session's whole request lane until daemon restart. Fix: apply the configured/default session-init timeout to bridge ensureSession (kill the spawned acpx process on expiry, surface a clear error).
+
+## Deferred (follow-ups, not in this batch)
+- Config save rewrites the whole file (drops unknown keys, expands `~`, pins defaults) — needs a design pass on config round-tripping.
+- state.json strict parse bricks startup on one bad/old record — needs migration/quarantine design.
+- Orchestration socket auth + scheduled_list/cancel chat scoping — security design decision.
+- Group `isOwner` detection (weixin/feishu never set it) + chatType fail-open policy — cross-channel contract change.
+- Command parser quote/case handling; `/session new` alias-collision refusal; paginated final-answer parking with zero-quota heads-up; `/clear` non-native transport session leak; pairing.ts regex escape (dead code today).

--- a/docs/zh/plugin-development_zh.md
+++ b/docs/zh/plugin-development_zh.md
@@ -282,6 +282,8 @@ export interface MessageChannelRuntime {
 
   start(input: ChannelStartInput): Promise<void>;
 
+  stop?(): void | Promise<void>;
+
   createConsumerLock?(options?: ConsumerLockOptions): ConsumerLock;
   configureOrchestration?(callbacks: OrchestrationDeliveryCallbacks): void;
 
@@ -314,7 +316,9 @@ async login(): Promise<string> {
 
 ### `logout(): void`
 
-释放凭据、断开持久连接、清空内存里的会话。**必须可重入**——daemon shutdown / 重新登录都会调到。
+**破坏性操作**：删除已保存的凭据、断开持久连接、清空内存里的会话。只有用户显式执行 `xacpx logout` 才会走到这里——正常的 daemon shutdown 不会调用它。**必须可重入。**
+
+唯一的遗留例外：频道**没有**实现 `stop()` 时，daemon 关停路径会回退调用 `logout()`。如果你依赖这个回退，`logout()` 里就不能删除任何需要用户重新交互获取的东西（重新登录、重新扫码）。新插件应实现 `stop()`，并把凭据删除逻辑只放在 `logout()` 里。
 
 ### `start(input: ChannelStartInput): Promise<void>`
 
@@ -328,6 +332,10 @@ async login(): Promise<string> {
 - 任何外发都通过 `input.logger` 记录关键事件，方便用户用 `xacpx doctor --verbose` / `app.log` 排查。
 
 `start()` 通常是个长运行 promise——返回时意味着你已经 wire 好回调，但消息循环可以是后台异步。
+
+### `stop?(): void | Promise<void>`
+
+可选，**推荐实现**。非破坏性的关停钩子：每次 daemon 关停（SIGTERM / Ctrl-C 以及启动失败的 cleanup）时，registry 优先调用 `stop()`，只有它不存在时才回退到 `logout()`。在这里释放运行时资源——停掉客户端、丢弃 `agent` / `quota` / `logger` 引用、清队列——但**绝不能动磁盘上的凭据**：daemon 停止或重启不应迫使用户重新登录。注意 `stop()` 执行时 `abortSignal` 通常已经触发过，所以它往往只是一小段收尾（甚至可以是 no-op）。
 
 ### `createConsumerLock?(options?): ConsumerLock`
 
@@ -394,7 +402,7 @@ export interface ChannelStartInput {
 
 `ChatAgent` 接口本身在内部，但通过 `MessageChannelRuntime` 的契约只要求你把入站文本 `await agent.handle(chatKey, text)` 即可。返回不带数据；agent 会在自己的回调链里调你的发送方法。
 
-> **重要**：你的频道要持有一份 `agent` / `quota` / `logger` 引用直到 `logout()` 或 `abortSignal` 触发。`start()` 返回后这些不会再传一次。
+> **重要**：你的频道要持有一份 `agent` / `quota` / `logger` 引用直到 `stop()` / `logout()` 或 `abortSignal` 触发。`start()` 返回后这些不会再传一次。
 
 ### 5.1 国际化（i18n）
 
@@ -783,10 +791,10 @@ CLI 不会自动 disable 出错的插件——需要用户手工 `xacpx plugin d
    5.3 channel.start({ agent, abortSignal, quota, logger })
 6. 收消息：channel → agent.handle(chatKey, text) → router
 7. 出消息：orchestration → channel.notifyTaskCompletion / sendCoordinatorMessage
-8. SIGTERM / SIGINT：abortSignal aborted → channel 自己 cleanup → channel.stopAll? → daemon exit
+8. SIGTERM / SIGINT：abortSignal aborted → channel 自己 cleanup → registry.stopAll：channel.stop?()（回退：logout()）→ daemon exit
 ```
 
-`logout()` 只在 `xacpx logout` 显式调用时被触发；正常退出走 `abortSignal`。
+正常退出走 `abortSignal` 加非破坏性的 `stop()`；破坏性的 `logout()` 只在 `xacpx logout` 显式调用时被触发——唯一例外是没有实现 `stop()` 的遗留频道，关停时会回退到 `logout()`。
 
 ### 16.3 模块缓存语义（开发者必读）
 

--- a/src/bridge/bridge-env.ts
+++ b/src/bridge/bridge-env.ts
@@ -12,6 +12,13 @@ export function normalizeBridgeNonInteractivePermissions(
   return value === "deny" || value === "fail" ? value : "deny";
 }
 
+export function normalizeBridgePermissionPolicy(value: string | undefined): string | undefined {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+  return value;
+}
+
 export function normalizeBridgeQueueOwnerTtlSeconds(value: string | undefined): number | undefined {
   if (value === undefined) {
     return undefined;

--- a/src/bridge/bridge-env.ts
+++ b/src/bridge/bridge-env.ts
@@ -19,6 +19,14 @@ export function normalizeBridgePermissionPolicy(value: string | undefined): stri
   return value;
 }
 
+export function normalizeBridgeSessionInitTimeoutMs(value: string | undefined): number | undefined {
+  if (value === undefined || value.trim().length === 0) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export function normalizeBridgeQueueOwnerTtlSeconds(value: string | undefined): number | undefined {
   if (value === undefined) {
     return undefined;

--- a/src/bridge/bridge-main.ts
+++ b/src/bridge/bridge-main.ts
@@ -3,6 +3,7 @@ import { createInterface } from "node:readline";
 import {
   normalizeBridgeNonInteractivePermissions,
   normalizeBridgePermissionMode,
+  normalizeBridgePermissionPolicy,
   normalizeBridgeQueueOwnerTtlSeconds,
 } from "./bridge-env";
 import { BridgeServer } from "./bridge-server";
@@ -62,6 +63,7 @@ export async function runBridgeMain(): Promise<void> {
       nonInteractivePermissions: normalizeBridgeNonInteractivePermissions(
         coreEnv("BRIDGE_NON_INTERACTIVE_PERMISSIONS"),
       ),
+      permissionPolicy: normalizeBridgePermissionPolicy(coreEnv("BRIDGE_PERMISSION_POLICY")),
       queueOwnerTtlSeconds: normalizeBridgeQueueOwnerTtlSeconds(
         coreEnv("BRIDGE_QUEUE_OWNER_TTL_SECONDS"),
       ),

--- a/src/bridge/bridge-main.ts
+++ b/src/bridge/bridge-main.ts
@@ -5,6 +5,7 @@ import {
   normalizeBridgePermissionMode,
   normalizeBridgePermissionPolicy,
   normalizeBridgeQueueOwnerTtlSeconds,
+  normalizeBridgeSessionInitTimeoutMs,
 } from "./bridge-env";
 import { BridgeServer } from "./bridge-server";
 import { BridgeRuntime } from "./bridge-runtime";
@@ -66,6 +67,9 @@ export async function runBridgeMain(): Promise<void> {
       permissionPolicy: normalizeBridgePermissionPolicy(coreEnv("BRIDGE_PERMISSION_POLICY")),
       queueOwnerTtlSeconds: normalizeBridgeQueueOwnerTtlSeconds(
         coreEnv("BRIDGE_QUEUE_OWNER_TTL_SECONDS"),
+      ),
+      sessionInitTimeoutMs: normalizeBridgeSessionInitTimeoutMs(
+        coreEnv("BRIDGE_SESSION_INIT_TIMEOUT_MS"),
       ),
     }),
   );

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -5,6 +5,7 @@ import { spawn } from "node:child_process";
 
 import type { NonInteractivePermissions, PermissionMode, WechatReplyMode } from "../config/types";
 import { resolveSpawnCommand } from "../process/spawn-command";
+import { terminateProcessTree } from "../process/terminate-process-tree";
 import { getPromptText } from "../transport/prompt-output";
 import { createStructuredPromptFile } from "../transport/prompt-media";
 import { createStreamingPromptState, parseStreamingDataChunk } from "../transport/streaming-prompt";
@@ -47,8 +48,20 @@ interface CommandResult {
   stderr: string;
 }
 
+/** Mirrors the acpx-cli transport's `sessionInitTimeoutMs ?? 120_000` default. */
+const DEFAULT_SESSION_INIT_TIMEOUT_MS = 120_000;
+
+export class CommandTimeoutError extends Error {
+  constructor(readonly timeoutMs: number, command: string) {
+    super(`acpx command timed out after ${timeoutMs / 1000}s: ${command}`);
+    this.name = "CommandTimeoutError";
+  }
+}
+
 export interface CommandRunnerOptions {
   onStderrLine?: (line: string) => void;
+  /** Kill the spawned process tree and reject with CommandTimeoutError when it runs longer than this. */
+  timeoutMs?: number;
 }
 type CommandRunner = (command: string, args: string[], options?: CommandRunnerOptions) => Promise<CommandResult>;
 type SessionCreateRunner = (command: string, args: string[], cwd: string, options?: CommandRunnerOptions) => Promise<CommandResult>;
@@ -99,6 +112,8 @@ interface BridgeRuntimeOptions {
   permissionPolicy?: string;
   /** Idle TTL (seconds) passed to acpx as `--ttl` on prompt; 0 = keep alive forever. */
   queueOwnerTtlSeconds?: number;
+  /** Time bound for session-creation spawns (ensure/new/resume); defaults to 120s like acpx-cli. */
+  sessionInitTimeoutMs?: number;
 }
 
 export class BridgeRuntime {
@@ -174,11 +189,27 @@ export class BridgeRuntime {
       "--resume-session",
       input.agentSessionId,
     ], { format: "quiet" }));
-    const result = await this.runSessionCreate(spawnSpec.command, spawnSpec.args, input.cwd);
+    const timeoutMs = this.sessionInitTimeoutMs();
+    let result: CommandResult;
+    try {
+      result = await this.runSessionCreate(spawnSpec.command, spawnSpec.args, input.cwd, { timeoutMs });
+    } catch (error) {
+      if (error instanceof CommandTimeoutError) {
+        throw new Error(`session initialization timed out after ${timeoutMs / 1000}s`);
+      }
+      throw error;
+    }
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "sessions resume failed");
     }
     return {};
+  }
+
+  private sessionInitTimeoutMs(): number {
+    const value = this.options.sessionInitTimeoutMs;
+    return typeof value === "number" && Number.isFinite(value) && value > 0
+      ? value
+      : DEFAULT_SESSION_INIT_TIMEOUT_MS;
   }
 
   async hasSession(input: {
@@ -231,6 +262,7 @@ export class BridgeRuntime {
     onProgress?: (progress: EnsureSessionProgress) => void,
   ): Promise<Record<string, never>> {
     onProgress?.("spawn");
+    const timeoutMs = this.sessionInitTimeoutMs();
     const onStderrLine = onProgress
       ? (line: string) => {
           const trimmed = line.replace(/\r$/, "").trimEnd();
@@ -243,30 +275,43 @@ export class BridgeRuntime {
       tailArgs: string[],
       runner: (command: string, args: string[]) => Promise<CommandResult>,
     ): Promise<CommandResult> => {
-      const useVerbose = this.acpxVerboseSupported !== false;
-      const spec = resolveSpawnCommand(
-        this.command,
-        this.buildSessionArgs(input, tailArgs, { verbose: useVerbose }),
-      );
-      const result = await runner(spec.command, spec.args);
-      if (result.code === 0) {
-        if (useVerbose) this.acpxVerboseSupported = true;
-        return result;
-      }
-      if (useVerbose && isUnknownVerboseOption(result.stderr, result.stdout)) {
-        this.acpxVerboseSupported = false;
-        const retrySpec = resolveSpawnCommand(
+      try {
+        const useVerbose = this.acpxVerboseSupported !== false;
+        const spec = resolveSpawnCommand(
           this.command,
-          this.buildSessionArgs(input, tailArgs, { verbose: false }),
+          this.buildSessionArgs(input, tailArgs, { verbose: useVerbose }),
         );
-        return await runner(retrySpec.command, retrySpec.args);
+        const result = await runner(spec.command, spec.args);
+        if (result.code === 0) {
+          if (useVerbose) this.acpxVerboseSupported = true;
+          return result;
+        }
+        if (useVerbose && isUnknownVerboseOption(result.stderr, result.stdout)) {
+          this.acpxVerboseSupported = false;
+          const retrySpec = resolveSpawnCommand(
+            this.command,
+            this.buildSessionArgs(input, tailArgs, { verbose: false }),
+          );
+          return await runner(retrySpec.command, retrySpec.args);
+        }
+        return result;
+      } catch (error) {
+        // Agent init hung (auth prompt, network stall): the spawn was already
+        // killed by the runner; surface a clear, user-facing error instead of
+        // blocking this session's bridge lane forever.
+        if (error instanceof CommandTimeoutError) {
+          throw new EnsureSessionFailedError(
+            `session initialization timed out after ${timeoutMs / 1000}s`,
+            "generic",
+          );
+        }
+        throw error;
       }
-      return result;
     };
 
     const ensured = await runWithVerboseFallback(
       ["sessions", "ensure", "--name", input.name],
-      (command, args) => this.run(command, args, { onStderrLine }),
+      (command, args) => this.run(command, args, { onStderrLine, timeoutMs }),
     );
     if (ensured.code === 0) {
       onProgress?.("ready");
@@ -283,7 +328,7 @@ export class BridgeRuntime {
     onProgress?.("initializing");
     const created = await runWithVerboseFallback(
       ["sessions", "new", "--name", input.name],
-      (command, args) => this.runSessionCreate(command, args, input.cwd, { onStderrLine }),
+      (command, args) => this.runSessionCreate(command, args, input.cwd, { onStderrLine, timeoutMs }),
     );
 
     if (created.code === 0) {
@@ -570,18 +615,39 @@ export class BridgeRuntime {
   }
 }
 
-function spawnCapture(
+export interface SpawnCaptureOptions extends CommandRunnerOptions {
+  cwd?: string;
+  /** Test seam: replaces node:child_process spawn. */
+  spawnFn?: typeof spawn;
+  /** Test seam: replaces terminateProcessTree for timeout kills. */
+  killProcessTreeFn?: (pid: number) => Promise<void>;
+}
+
+export function spawnCapture(
   command: string,
   args: string[],
-  options?: { cwd?: string; onStderrLine?: (line: string) => void },
+  options?: SpawnCaptureOptions,
 ): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd: options?.cwd, stdio: ["ignore", "pipe", "pipe"] });
+    const spawnFn = options?.spawnFn ?? spawn;
+    const child = spawnFn(command, args, { cwd: options?.cwd, stdio: ["ignore", "pipe", "pipe"] });
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     let stdout = "";
     let stderr = "";
     let stderrTail = "";
+
+    const timeoutId =
+      typeof options?.timeoutMs === "number" && Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
+        ? setTimeout(() => {
+            // Same kill semantics as the acpx-cli transport's timed-out runner:
+            // tear down the whole spawned tree so no orphan keeps holding the lane.
+            const kill = options.killProcessTreeFn
+              ?? ((pid: number) => terminateProcessTree(pid, { detachedProcessGroup: false }));
+            void kill(child.pid ?? 0);
+            reject(new CommandTimeoutError(options.timeoutMs!, [command, ...args].join(" ")));
+          }, options.timeoutMs)
+        : undefined;
 
     child.stdout.on("data", (chunk) => {
       stdout += String(chunk);
@@ -599,8 +665,12 @@ function spawnCapture(
         options.onStderrLine(line);
       }
     });
-    child.on("error", reject);
+    child.on("error", (error) => {
+      if (timeoutId) clearTimeout(timeoutId);
+      reject(error);
+    });
     child.on("close", (code) => {
+      if (timeoutId) clearTimeout(timeoutId);
       if (options?.onStderrLine && stderrTail.length > 0) {
         options.onStderrLine(stderrTail);
       }
@@ -709,7 +779,7 @@ async function shellSessionCreateRunner(
   cwd: string,
   options?: CommandRunnerOptions,
 ): Promise<CommandResult> {
-  return await spawnCapture(command, args, { cwd, onStderrLine: options?.onStderrLine });
+  return await spawnCapture(command, args, { ...options, cwd });
 }
 
 export function selectLatestAcpxSessionIndexTmp(files: string[]): string | null {

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -126,6 +126,7 @@ export class BridgeServer {
         return await this.runtime.updatePermissionPolicy({
           permissionMode: requirePermissionMode(params, "permissionMode"),
           nonInteractivePermissions: requireNonInteractivePermissions(params, "nonInteractivePermissions"),
+          permissionPolicy: asOptionalString(params.permissionPolicy),
         });
       case "hasSession":
         return await this.runtime.hasSession({

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -46,15 +46,25 @@ export class MessageChannelRegistry {
    * non-destructive `stop()` and falls back to `logout()` only for channels
    * that predate `stop()` (published plugins whose logout is a benign client
    * stop). Never an intentional credential wipe — that is `xacpx logout`.
+   *
+   * Like startAll, channels are isolated from each other: one throwing
+   * channel must not skip teardown of the rest. The first error is rethrown
+   * afterwards so the run-console cleanup sequence still records it.
    */
   async stopAll(): Promise<void> {
+    let firstError: unknown;
     for (const channel of this.channels.values()) {
-      if (channel.stop) {
-        await channel.stop();
-      } else {
-        channel.logout();
+      try {
+        if (channel.stop) {
+          await channel.stop();
+        } else {
+          channel.logout();
+        }
+      } catch (error) {
+        firstError ??= error;
       }
     }
+    if (firstError !== undefined) throw firstError;
   }
 
   getByChatKey(chatKey: string): MessageChannelRuntime | null {

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -41,9 +41,19 @@ export class MessageChannelRegistry {
     }
   }
 
-  stopAll(): void {
+  /**
+   * Shutdown path (signal handlers, startup-error cleanup). Prefers the
+   * non-destructive `stop()` and falls back to `logout()` only for channels
+   * that predate `stop()` (published plugins whose logout is a benign client
+   * stop). Never an intentional credential wipe — that is `xacpx logout`.
+   */
+  async stopAll(): Promise<void> {
     for (const channel of this.channels.values()) {
-      channel.logout();
+      if (channel.stop) {
+        await channel.stop();
+      } else {
+        channel.logout();
+      }
     }
   }
 

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -114,9 +114,21 @@ export interface MessageChannelRuntime {
 
   isLoggedIn(): boolean;
   login(): Promise<string>;
+  /**
+   * Destructive credential removal. Reached only via the explicit
+   * `xacpx logout` CLI path — never as part of a normal shutdown.
+   */
   logout(): void;
 
   start(input: ChannelStartInput): Promise<void>;
+
+  /**
+   * Non-destructive shutdown: release runtime resources without touching
+   * stored credentials. Optional for compatibility with already-published
+   * plugin channels; when absent, the registry falls back to `logout()`
+   * (which for those plugins is a benign client stop).
+   */
+  stop?(): void | Promise<void>;
 
   createConsumerLock?(options?: ConsumerLockOptions): ConsumerLock;
 

--- a/src/channels/weixin-channel.ts
+++ b/src/channels/weixin-channel.ts
@@ -70,6 +70,8 @@ export class WeixinChannel implements MessageChannelRuntime {
     this.agent = null;
     this.quota = null;
     this.logger = null;
+    this.markDelivered = null;
+    this.markFailed = null;
   }
 
   createConsumerLock(options?: ConsumerLockOptions): ConsumerLock {

--- a/src/channels/weixin-channel.ts
+++ b/src/channels/weixin-channel.ts
@@ -59,6 +59,19 @@ export class WeixinChannel implements MessageChannelRuntime {
     weixinLogout();
   }
 
+  /**
+   * Non-destructive shutdown. The monitor loop is already stopped via the
+   * abort signal passed to start(); this only drops runtime references and
+   * MUST NOT touch the credential files on disk (a graceful daemon stop or
+   * restart must not force a QR re-login). Destructive credential removal
+   * happens only through logout() (the explicit `xacpx logout` CLI path).
+   */
+  stop(): void {
+    this.agent = null;
+    this.quota = null;
+    this.logger = null;
+  }
+
   createConsumerLock(options?: ConsumerLockOptions): ConsumerLock {
     return createWeixinConsumerLock({
       ...(options?.lockFilePath ? { lockFilePath: options.lockFilePath } : {}),

--- a/src/cli-update.ts
+++ b/src/cli-update.ts
@@ -316,9 +316,19 @@ function compareSemver(a: string, b: string): number {
   return left.prerelease ? -1 : 1;
 }
 
+// runCapture/runInherit are only ever used to run package managers (npm/bun).
+// On Windows those resolve to .cmd shims, which Node refuses to spawn without
+// a shell since the batch-file security change (EINVAL), so spawn with
+// `shell: true` there — same pattern as src/recovery/auto-install-optional-dep.ts.
+// With a shell, args are not re-quoted, but everything passed here is an npm
+// package name/spec or a fixed flag (no spaces or shell metacharacters), so
+// this is safe. Do NOT reuse these helpers for commands whose args may
+// contain spaces (e.g. paths) without adding quoting.
+const spawnUsesShell = (): boolean => process.platform === "win32";
+
 async function runCapture(command: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"], shell: spawnUsesShell() });
     let stdout = "";
     let stderr = "";
     child.stdout.setEncoding("utf8");
@@ -332,7 +342,7 @@ async function runCapture(command: string, args: string[]): Promise<{ code: numb
 
 async function runInherit(command: string, args: string[]): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, { stdio: "inherit" });
+    const child = spawn(command, args, { stdio: "inherit", shell: spawnUsesShell() });
     child.on("error", reject);
     child.on("exit", (code) => {
       if (code === 0) resolve();

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -555,7 +555,14 @@ export async function handleSessionRemove(
   }
 
   const sharedAliasCount = context.sessions.countAliasesSharingTransport(session.transportSession, internalAlias);
+  const wasCurrentInThisChat = context.sessions.peekCurrentSessionAlias(chatKey) === internalAlias;
   const { wasActive } = await context.sessions.removeSession(internalAlias);
+  // removeSession promotes previous_session to current_session; if that
+  // happened for this chat, the next plain message routes to the promoted
+  // session, so the reply must name it instead of claiming a cleared context.
+  const promotedAlias = wasCurrentInThisChat
+    ? context.sessions.peekCurrentSessionAlias(chatKey) || undefined
+    : undefined;
 
   let orchestrationPurgeWarning: string | undefined;
   if (context.orchestration) {
@@ -596,7 +603,11 @@ export async function handleSessionRemove(
   const s = t().session;
   const lines = [s.sessionRemoved(alias)];
   if (wasActive) {
-    lines.push(s.sessionRemovedWasActive);
+    lines.push(
+      promotedAlias
+        ? s.sessionRemovedWasActivePromoted(toDisplaySessionAlias(promotedAlias))
+        : s.sessionRemovedWasActive,
+    );
   }
   if (!shouldTeardownTransport) {
     lines.push(s.sessionTransportShared(session.transportSession, sharedAliasCount));

--- a/src/daemon/create-daemon-controller.ts
+++ b/src/daemon/create-daemon-controller.ts
@@ -120,10 +120,24 @@ function buildSpawnRequest(
 }
 
 function buildWindowsLauncherScript(): string {
+  // Invariant: each -ArgumentList element must reach the child process as ONE
+  // argv entry even when it contains spaces. Windows PowerShell 5.1 builds the
+  // child command line by joining -ArgumentList elements with spaces WITHOUT
+  // quoting them, so a cli.js path like `C:\Users\John Doe\...\cli.js` would
+  // split into multiple argv entries (node then exits MODULE_NOT_FOUND).
+  // Wrap each element in explicit double quotes here, in PowerShell, where no
+  // further escaping layer applies (the script travels via -EncodedCommand and
+  // the values via env vars). Windows paths cannot contain `"`, and neither
+  // value ends with a trailing backslash (arg0 ends in cli.js, arg1 is "run"),
+  // so plain surrounding quotes are sufficient. -FilePath, -WorkingDirectory
+  // and -RedirectStandard* bind their variable as a single parameter value and
+  // need no quoting.
   const script = [
     "$env:XACPX_DAEMON_RUN = '1'",
+    `$arg0 = '"' + $env:XACPX_DAEMON_ARG0 + '"'`,
+    `$arg1 = '"' + $env:XACPX_DAEMON_ARG1 + '"'`,
     "$process = Start-Process -FilePath $env:XACPX_DAEMON_COMMAND `",
-    "  -ArgumentList @($env:XACPX_DAEMON_ARG0, $env:XACPX_DAEMON_ARG1) `",
+    "  -ArgumentList @($arg0, $arg1) `",
     "  -WorkingDirectory $env:XACPX_DAEMON_CWD `",
     "  -RedirectStandardOutput $env:XACPX_DAEMON_STDOUT `",
     "  -RedirectStandardError $env:XACPX_DAEMON_STDERR `",

--- a/src/daemon/daemon-status.ts
+++ b/src/daemon/daemon-status.ts
@@ -1,5 +1,7 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import { dirname } from "node:path";
+
+import writeFileAtomic from "write-file-atomic";
 
 export interface DaemonStatus {
   pid: number;
@@ -35,7 +37,7 @@ export class DaemonStatusStore {
 
   async save(status: DaemonStatus): Promise<void> {
     await mkdir(dirname(this.path), { recursive: true });
-    await writeFile(this.path, JSON.stringify(status, null, 2));
+    await writeFileAtomic(this.path, JSON.stringify(status, null, 2), { encoding: "utf8" });
   }
 
   async clear(): Promise<void> {

--- a/src/i18n/messages/en/session.ts
+++ b/src/i18n/messages/en/session.ts
@@ -77,6 +77,8 @@ export const session: SessionMessages = {
   sessionRemoved: (alias) => `Session "${alias}" removed.`,
   sessionRemovedWasActive:
     "This was the active session. Its chat context has been cleared.",
+  sessionRemovedWasActivePromoted: (alias) =>
+    `This was the active session. Switched back to the previous session "${alias}".`,
   sessionTransportShared: (transportSession, count) =>
     `Note: backend session "${transportSession}" is still referenced by ${count} other session(s) and was not closed.`,
   sessionOrchestrationPurgeFailed: (warning) =>

--- a/src/i18n/messages/en/weixin.ts
+++ b/src/i18n/messages/en/weixin.ts
@@ -14,12 +14,6 @@ export const weixin: WeixinMessages = {
   // /clear
   sessionCleared: "✅ Session cleared. Starting a fresh conversation.",
 
-  // /logout — no accounts
-  noAccountsLoggedIn: "No accounts are currently logged in.",
-
-  // /logout — success
-  logoutSuccess: "✅ Logged out. All account credentials cleared.",
-
   // handleSlashCommand — command execution error
   commandFailed: (detail: string) => `❌ Command failed: ${detail}`,
 };

--- a/src/i18n/messages/zh/session.ts
+++ b/src/i18n/messages/zh/session.ts
@@ -70,6 +70,8 @@ export const session: SessionMessages = {
   sessionBlockedByTasksHint: "使用 /tasks 查看任务列表，或 /task cancel <id> 取消任务。",
   sessionRemoved: (alias) => `已删除会话「${alias}」。`,
   sessionRemovedWasActive: "该会话是当前活跃会话，已自动清除相关聊天上下文。",
+  sessionRemovedWasActivePromoted: (alias) =>
+    `该会话是当前活跃会话，已切换回上一个会话「${alias}」。`,
   sessionTransportShared: (transportSession, count) =>
     `提示：后端会话「${transportSession}」仍被其他 ${count} 个会话引用，未关闭。`,
   sessionOrchestrationPurgeFailed: (warning) =>

--- a/src/i18n/messages/zh/weixin.ts
+++ b/src/i18n/messages/zh/weixin.ts
@@ -14,12 +14,6 @@ export const weixin: WeixinMessages = {
   // /clear
   sessionCleared: "✅ 会话已清除，重新开始对话",
 
-  // /logout — no accounts
-  noAccountsLoggedIn: "当前没有已登录的账号",
-
-  // /logout — success
-  logoutSuccess: "✅ 已退出登录，清除所有账号凭证",
-
   // handleSlashCommand — command execution error
   commandFailed: (detail: string) => `❌ 指令执行失败: ${detail}`,
 };

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -63,6 +63,7 @@ export interface SessionMessages {
   sessionBlockedByTasksHint: string;
   sessionRemoved: (alias: string) => string;
   sessionRemovedWasActive: string;
+  sessionRemovedWasActivePromoted: (alias: string) => string;
   sessionTransportShared: (transportSession: string, count: number) => string;
   sessionOrchestrationPurgeFailed: (warning: string) => string;
   sessionTransportTeardownFailed: (warning: string) => string;

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1197,12 +1197,6 @@ export interface WeixinMessages {
   // /clear
   sessionCleared: string;
 
-  // /logout — no accounts
-  noAccountsLoggedIn: string;
-
-  // /logout — success
-  logoutSuccess: string;
-
   // handleSlashCommand — command execution error
   commandFailed: (detail: string) => string;
 }

--- a/src/logging/app-logger.ts
+++ b/src/logging/app-logger.ts
@@ -48,7 +48,9 @@ export function createAppLogger(options: CreateAppLoggerOptions): AppLogger {
   let writeChain = Promise.resolve();
   let modeEnsured = false;
   // Latch: emit at most one console.error when the log file becomes unwritable.
-  // Reset if a subsequent write succeeds (file may have been restored).
+  // Reset only when an append actually succeeds (file may have been restored) —
+  // level-filtered no-op writes must NOT reset it, or interleaved below-level
+  // calls would turn the one-time notice into per-failure spam.
   let writeErrorLatched = false;
 
   return {
@@ -84,26 +86,20 @@ export function createAppLogger(options: CreateAppLoggerOptions): AppLogger {
     // The resolved promise handed back to the caller must never reject.
     // We catch write errors internally and degrade gracefully (emit a
     // one-time operator notice, then silently drop further failures).
+    // Invariant: every promise assigned to writeChain has its rejection
+    // handled below, so the chain head never rejects (no .catch needed).
     const writePromise = writeChain
-      .catch(() => {})
       .then(() => writeLog(level, event, message, context))
-      .then(
-        () => {
-          // A successful write clears the latch so the next failure is
-          // visible again (e.g. disk temporarily full then freed).
-          writeErrorLatched = false;
-        },
-        (error: unknown) => {
-          if (!writeErrorLatched) {
-            writeErrorLatched = true;
-            console.error(
-              "[xacpx] app-logger: log file write failed — further write errors will be suppressed.",
-              error instanceof Error ? error.message : String(error),
-            );
-          }
-          // Swallow the error: callers must not be affected by log I/O failures.
-        },
-      );
+      .catch((error: unknown) => {
+        if (!writeErrorLatched) {
+          writeErrorLatched = true;
+          console.error(
+            "[xacpx] app-logger: log file write failed — further write errors will be suppressed.",
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+        // Swallow the error: callers must not be affected by log I/O failures.
+      });
     writeChain = writePromise;
     return writePromise;
   }
@@ -129,6 +125,9 @@ export function createAppLogger(options: CreateAppLoggerOptions): AppLogger {
     }
     await rotateIfNeeded(options.filePath, Buffer.byteLength(line), options.maxSizeBytes, options.maxFiles);
     await appendFile(options.filePath, line, { encoding: "utf8", mode: 0o600 });
+    // A real append succeeded — clear the latch so the next failure is
+    // visible again (e.g. disk temporarily full then freed).
+    writeErrorLatched = false;
   }
 }
 

--- a/src/logging/app-logger.ts
+++ b/src/logging/app-logger.ts
@@ -47,6 +47,9 @@ export function createAppLogger(options: CreateAppLoggerOptions): AppLogger {
   const now = options.now ?? (() => new Date());
   let writeChain = Promise.resolve();
   let modeEnsured = false;
+  // Latch: emit at most one console.error when the log file becomes unwritable.
+  // Reset if a subsequent write succeeds (file may have been restored).
+  let writeErrorLatched = false;
 
   return {
     debug: async (event, message, context) => {
@@ -59,7 +62,13 @@ export function createAppLogger(options: CreateAppLoggerOptions): AppLogger {
       await enqueueWrite("error", event, message, context);
     },
     cleanup: async () => {
-      await cleanupExpiredRotatedLogs(options.filePath, options.retentionDays, now);
+      try {
+        await cleanupExpiredRotatedLogs(options.filePath, options.retentionDays, now);
+      } catch {
+        // Cleanup failures must not abort the daemon. The rotating writer
+        // already tolerates ENOENT; other transient errors (EACCES, etc.)
+        // are silenced here so startup continues unaffected.
+      }
     },
     flush: async () => {
       await writeChain;
@@ -72,7 +81,29 @@ export function createAppLogger(options: CreateAppLoggerOptions): AppLogger {
     message: string,
     context: LogContext = {},
   ): Promise<void> {
-    const writePromise = writeChain.catch(() => {}).then(() => writeLog(level, event, message, context));
+    // The resolved promise handed back to the caller must never reject.
+    // We catch write errors internally and degrade gracefully (emit a
+    // one-time operator notice, then silently drop further failures).
+    const writePromise = writeChain
+      .catch(() => {})
+      .then(() => writeLog(level, event, message, context))
+      .then(
+        () => {
+          // A successful write clears the latch so the next failure is
+          // visible again (e.g. disk temporarily full then freed).
+          writeErrorLatched = false;
+        },
+        (error: unknown) => {
+          if (!writeErrorLatched) {
+            writeErrorLatched = true;
+            console.error(
+              "[xacpx] app-logger: log file write failed — further write errors will be suppressed.",
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+          // Swallow the error: callers must not be affected by log I/O failures.
+        },
+      );
     writeChain = writePromise;
     return writePromise;
   }

--- a/src/logging/rotating-file-writer.ts
+++ b/src/logging/rotating-file-writer.ts
@@ -69,7 +69,17 @@ export async function cleanupExpiredRotatedLogs(
     }
 
     const candidate = join(parentDir, file);
-    const details = await stat(candidate);
+    let details;
+    try {
+      details = await stat(candidate);
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        // File was removed between readdir and stat (race with another process
+        // or manual deletion) — skip silently.
+        continue;
+      }
+      throw error;
+    }
     if (details.mtime.getTime() < cutoff) {
       await rm(candidate, { force: true });
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -219,6 +219,9 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
                 bridgeEntryPath: resolveBridgeEntryPath(),
                 permissionMode: config.transport.permissionMode,
                 nonInteractivePermissions: config.transport.nonInteractivePermissions,
+                ...(typeof config.transport.permissionPolicy === "string"
+                  ? { permissionPolicy: config.transport.permissionPolicy }
+                  : {}),
                 ...(typeof config.transport.queueOwnerTtlSeconds === "number"
                   ? { queueOwnerTtlSeconds: config.transport.queueOwnerTtlSeconds }
                   : {}),

--- a/src/main.ts
+++ b/src/main.ts
@@ -225,6 +225,9 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
                 ...(typeof config.transport.queueOwnerTtlSeconds === "number"
                   ? { queueOwnerTtlSeconds: config.transport.queueOwnerTtlSeconds }
                   : {}),
+                ...(typeof config.transport.sessionInitTimeoutMs === "number"
+                  ? { sessionInitTimeoutMs: config.transport.sessionInitTimeoutMs }
+                  : {}),
               }),
             ),
           ))

--- a/src/orchestration/orchestration-server.ts
+++ b/src/orchestration/orchestration-server.ts
@@ -320,10 +320,11 @@ export class OrchestrationServer {
   }
 
   private parseRequestDelegateRpcInput(params: Record<string, unknown>): RequestDelegateRpcInput {
-    requireOnlyKeys(params, ["sourceHandle", "targetAgent", "task", "cwd", "role", "groupId"], "params");
+    requireOnlyKeys(params, ["sourceHandle", "targetAgent", "task", "cwd", "role", "groupId", "parallel"], "params");
     const cwd = requireOptionalString(params, "cwd");
     const role = requireOptionalString(params, "role");
     const groupId = requireOptionalString(params, "groupId");
+    const parallel = requireOptionalBoolean(params, "parallel");
     return {
       sourceHandle: requireString(params, "sourceHandle"),
       targetAgent: requireString(params, "targetAgent"),
@@ -331,6 +332,7 @@ export class OrchestrationServer {
       ...(cwd !== undefined ? { cwd } : {}),
       ...(role !== undefined ? { role } : {}),
       ...(groupId !== undefined ? { groupId } : {}),
+      ...(parallel !== undefined ? { parallel } : {}),
     };
   }
 

--- a/src/plugins/package-manager.ts
+++ b/src/plugins/package-manager.ts
@@ -13,9 +13,28 @@ export interface RunCommandOptions {
 
 export type RunCommand = (command: string, args: string[], options: RunCommandOptions) => Promise<void>;
 
+// defaultRunCommand/silentRun only ever run package managers (npm/bun). On
+// Windows those resolve to .cmd shims, which Node refuses to spawn without a
+// shell since the batch-file security change (EINVAL), so spawn through a
+// shell there — same pattern as src/cli-update.ts and src/recovery/*. Going
+// through cmd.exe means cmd metacharacters in args would be interpreted, and
+// unlike cli-update the specs here may carry semver range characters from the
+// owner-writable config (e.g. "pkg@^1.2.0" — `^` is cmd's escape char), so on
+// the shell path each arg is additionally wrapped in double quotes, inside
+// which cmd treats ^ & < > | literally. Args are npm package names/specs and
+// fixed flags — they never contain `"` or spaces themselves. The cwd (plugin
+// home, which CAN contain spaces) is passed as a spawn option, not through
+// the command line, so it needs no quoting. Do NOT reuse these helpers for
+// commands whose args may contain quotes or spaces.
+function shellSpawnPlan(args: string[]): { shell: boolean; args: string[] } {
+  const shell = process.platform === "win32";
+  return { shell, args: shell ? args.map((arg) => `"${arg}"`) : args };
+}
+
 async function defaultRunCommand(command: string, args: string[], options: RunCommandOptions): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, { cwd: options.cwd, stdio: "inherit" });
+    const plan = shellSpawnPlan(args);
+    const child = spawn(command, plan.args, { cwd: options.cwd, stdio: "inherit", shell: plan.shell });
     child.on("error", reject);
     child.on("exit", (code) => {
       if (code === 0) resolve();
@@ -26,7 +45,8 @@ async function defaultRunCommand(command: string, args: string[], options: RunCo
 
 async function silentRun(command: string, args: string[], options: RunCommandOptions): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, { cwd: options.cwd, stdio: "ignore" });
+    const plan = shellSpawnPlan(args);
+    const child = spawn(command, plan.args, { cwd: options.cwd, stdio: "ignore", shell: plan.shell });
     child.on("error", reject);
     child.on("exit", (code) => {
       if (code === 0) resolve();

--- a/src/plugins/plugin-cli.ts
+++ b/src/plugins/plugin-cli.ts
@@ -315,7 +315,10 @@ async function removePlugin(packageName: string, rawArgs: string[], deps: Plugin
 
   const pluginHome = deps.pluginHome ?? resolvePluginHome();
   const validate = deps.validateInstalledPlugin ?? ((name: string) => validateInstalledPluginDefault(name, pluginHome));
-  const guard = await dependencyGuard(packageName, config, validate);
+  // Guard and uninstall must target the installed (normalized) package name,
+  // not the raw user input: a legacy alias makes `npm uninstall` a silent
+  // no-op (orphan package) and `bun remove` a hard failure.
+  const guard = await dependencyGuard(existing.name, config, validate);
   if (!guard.allow) {
     if (guard.reason) deps.print(guard.reason);
     return 1;
@@ -325,9 +328,9 @@ async function removePlugin(packageName: string, rawArgs: string[], deps: Plugin
     await removePluginPackage({ packageName: name, pluginHome });
   });
   try {
-    await remove(packageName);
+    await remove(existing.name);
   } catch (error) {
-    deps.print(t().pluginCli.pluginUninstallFailed(packageName, describeError(error)));
+    deps.print(t().pluginCli.pluginUninstallFailed(existing.name, describeError(error)));
     return 1;
   }
 

--- a/src/plugins/plugin-cli.ts
+++ b/src/plugins/plugin-cli.ts
@@ -331,7 +331,7 @@ async function removePlugin(packageName: string, rawArgs: string[], deps: Plugin
     return 1;
   }
 
-  config.plugins = config.plugins.filter((entry) => entry.name !== packageName);
+  config.plugins = config.plugins.filter((entry) => entry.name !== existing.name);
   await deps.saveConfig(config);
   deps.print(t().pluginCli.pluginRemoved(packageName));
   return await maybeRestartAfterMutation(flags.restart, deps);

--- a/src/plugins/plugin-doctor.ts
+++ b/src/plugins/plugin-doctor.ts
@@ -6,6 +6,7 @@ import { listKnownChannelIds } from "../channels/channel-scope.js";
 import { importPluginFromHome } from "./plugin-loader.js";
 import { validateWeacpxPlugin } from "./validate-plugin.js";
 import { findKnownPluginByChannel } from "./known-plugins.js";
+import { normalizePluginPackageName } from "./plugin-renames.js";
 
 function suggestedPluginPackageForChannel(type: string): string {
   return findKnownPluginByChannel(type)?.packageName ?? `<npm-package-that-provides-${type}>`;
@@ -54,9 +55,9 @@ export async function inspectPlugins(input: InspectPluginsInput): Promise<Plugin
 
   const importPlugin = input.importPlugin ?? importPluginFromHome;
   const allConfigured = input.config.plugins;
-  const filterByName = input.pluginName ?? null;
+  const filterByName = input.pluginName ? normalizePluginPackageName(input.pluginName) : null;
 
-  if (filterByName && !allConfigured.some((plugin) => plugin.name === filterByName)) {
+  if (filterByName && !allConfigured.some((plugin) => normalizePluginPackageName(plugin.name) === filterByName)) {
     return [{ level: "error", plugin: filterByName, message: `plugin is not configured; run xacpx plugin add ${filterByName}` }];
   }
 
@@ -110,6 +111,7 @@ export async function inspectPlugins(input: InspectPluginsInput): Promise<Plugin
 
   const builtInChannelTypes = new Set(listKnownChannelIds());
   for (const channel of input.config.channels) {
+    if (channel.enabled === false) continue;
     if (builtInChannelTypes.has(channel.type)) continue;
     const provider = channelProviders.get(channel.type);
     if (!provider) {

--- a/src/scheduled/parse-later-time.ts
+++ b/src/scheduled/parse-later-time.ts
@@ -133,7 +133,9 @@ function validateResult(
   if (pastTodayValue) return { ok: false, code: "past_today_time", value: pastTodayValue };
   if (tokens.slice(messageStartIndex).join(" ").trim().length === 0) return { ok: false, code: "missing_message" };
   const delta = executeAt.getTime() - now.getTime();
+  // NaN delta (e.g. astronomically large digit counts overflow the Date range)
+  // must be treated as out-of-range, not silently accepted with an Invalid Date.
+  if (isNaN(delta) || delta > LATER_MAX_DELAY_MS) return { ok: false, code: "out_of_range" };
   if (delta < LATER_MIN_DELAY_MS) return { ok: false, code: "too_soon" };
-  if (delta > LATER_MAX_DELAY_MS) return { ok: false, code: "out_of_range" };
   return { ok: true, executeAt, messageStartIndex };
 }

--- a/src/scheduled/scheduled-scheduler.ts
+++ b/src/scheduled/scheduled-scheduler.ts
@@ -60,7 +60,19 @@ export class ScheduledTaskScheduler {
     if (this.ticking) return;
     this.ticking = true;
     try {
-      const dueTasks = await this.service.claimDueTasks();
+      let dueTasks: ScheduledTaskRecord[];
+      try {
+        dueTasks = await this.service.claimDueTasks();
+      } catch (claimError) {
+        // A transient state-store failure (disk full, EBUSY, EPERM, …) must
+        // never kill the daemon — skip this tick and wait for the next interval.
+        await this.logger?.error(
+          "scheduled.claim.failed",
+          "claimDueTasks threw; skipping tick",
+          { message: claimError instanceof Error ? claimError.message : String(claimError) },
+        );
+        return;
+      }
       for (const task of dueTasks) {
         try {
           await this.dispatchWithTimeout(task);
@@ -71,7 +83,21 @@ export class ScheduledTaskScheduler {
             taskId: task.id,
             message,
           });
-          await this.service.markFailed(task.id, error);
+          try {
+            await this.service.markFailed(task.id, error);
+          } catch (markError) {
+            // markFailed itself may throw if the store write fails.  Swallow so
+            // one bad task's error-recording write cannot escape tick() and
+            // crash the daemon or prevent subsequent tasks from being processed.
+            await this.logger?.error(
+              "scheduled.markFailed.failed",
+              "markFailed threw; task state may be stale",
+              {
+                taskId: task.id,
+                message: markError instanceof Error ? markError.message : String(markError),
+              },
+            );
+          }
         }
       }
     } finally {

--- a/src/scheduled/scheduled-scheduler.ts
+++ b/src/scheduled/scheduled-scheduler.ts
@@ -90,7 +90,7 @@ export class ScheduledTaskScheduler {
             // one bad task's error-recording write cannot escape tick() and
             // crash the daemon or prevent subsequent tasks from being processed.
             await this.logger?.error(
-              "scheduled.markFailed.failed",
+              "scheduled.dispatch.mark_failed",
               "markFailed threw; task state may be stale",
               {
                 taskId: task.id,

--- a/src/scheduled/scheduled-service.ts
+++ b/src/scheduled/scheduled-service.ts
@@ -118,7 +118,19 @@ export class ScheduledTaskService {
         task.triggered_at = at;
         this.claimedInThisSession.add(task.id);
       }
-      await this.save();
+      try {
+        await this.save();
+      } catch (error) {
+        // Roll back the claim: a task left "triggering" in memory drops out of
+        // listPending and would silently never fire until a daemon restart.
+        // Restoring "pending" lets the next scheduler tick retry the claim.
+        for (const task of due) {
+          task.status = "pending";
+          delete task.triggered_at;
+          this.claimedInThisSession.delete(task.id);
+        }
+        throw error;
+      }
       return due.map((task) => ({ ...task }));
     });
   }

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -4,7 +4,7 @@ import { t } from "../i18n/index.js";
 import { AsyncMutex } from "../orchestration/async-mutex";
 import { stableCoordinatorSession } from "../orchestration/coordinator-identity";
 import type { StateStore } from "../state/state-store";
-import type { AppState, BackgroundResult, LogicalSession } from "../state/types";
+import type { AppState, BackgroundResult, ChatContextState, LogicalSession } from "../state/types";
 import type { AgentSession, ResolvedSession } from "../transport/types";
 import {
   buildDefaultTransportSession,
@@ -109,13 +109,17 @@ export class SessionService {
 
   resolveSession(alias: string, agent: string, workspace: string, transportSession: string): ResolvedSession {
     this.validateSession(alias, agent, workspace);
+    const existing = this.state.sessions[alias];
+    // A cached transport agent command is only valid for the same agent; never
+    // reuse it across agents (e.g. alias recreated with --agent claude after codex).
+    const sameAgentExisting = existing && existing.agent === agent ? existing : undefined;
     return this.toResolvedSession({
       alias,
       agent,
       workspace,
       transport_session: transportSession,
-      transport_agent_command: this.state.sessions[alias]?.transport_agent_command,
-      created_at: this.state.sessions[alias]?.created_at ?? new Date().toISOString(),
+      transport_agent_command: sameAgentExisting?.transport_agent_command,
+      created_at: existing?.created_at ?? new Date().toISOString(),
       last_used_at: new Date().toISOString(),
     });
   }
@@ -233,10 +237,15 @@ export class SessionService {
         previousCurrent && previousCurrent !== internalAlias ? previousCurrent : prevCtx?.previous_session;
 
       session.last_used_at = new Date().toISOString();
-      this.state.chat_contexts[chatKey] = {
-        current_session: internalAlias,
-        ...(carriedPrevious ? { previous_session: carriedPrevious } : {}),
-      };
+      // Spread the previous context so unread background_results (and any other
+      // per-chat state) survive the switch; only current/previous change.
+      const nextCtx: ChatContextState = { ...prevCtx, current_session: internalAlias };
+      if (carriedPrevious) {
+        nextCtx.previous_session = carriedPrevious;
+      } else {
+        delete nextCtx.previous_session;
+      }
+      this.state.chat_contexts[chatKey] = nextCtx;
       await this.persist();
 
       return {
@@ -266,10 +275,14 @@ export class SessionService {
 
       const currentInternal = ctx?.current_session;
       prevSession.last_used_at = new Date().toISOString();
-      this.state.chat_contexts[chatKey] = {
-        current_session: prevInternal,
-        ...(currentInternal && currentInternal !== prevInternal ? { previous_session: currentInternal } : {}),
-      };
+      // Preserve background_results and other per-chat state on toggle.
+      const nextCtx: ChatContextState = { ...ctx, current_session: prevInternal };
+      if (currentInternal && currentInternal !== prevInternal) {
+        nextCtx.previous_session = currentInternal;
+      } else {
+        delete nextCtx.previous_session;
+      }
+      this.state.chat_contexts[chatKey] = nextCtx;
       await this.persist();
 
       return {
@@ -477,12 +490,27 @@ export class SessionService {
       delete this.state.sessions[alias];
 
       for (const [chatKey, ctx] of Object.entries(this.state.chat_contexts)) {
-        if (ctx.current_session === alias) {
-          delete this.state.chat_contexts[chatKey];
-          continue;
-        }
+        // Prune only references to the removed alias; keep the rest of the
+        // chat context (other aliases' background_results, previous_session).
         if (ctx.previous_session === alias) {
           delete ctx.previous_session;
+        }
+        if (ctx.current_session === alias) {
+          if (ctx.previous_session) {
+            ctx.current_session = ctx.previous_session;
+            delete ctx.previous_session;
+          } else {
+            ctx.current_session = "";
+          }
+        }
+        if (ctx.background_results && alias in ctx.background_results) {
+          delete ctx.background_results[alias];
+          if (Object.keys(ctx.background_results).length === 0) {
+            delete ctx.background_results;
+          }
+        }
+        if (!ctx.current_session && !ctx.previous_session && !ctx.background_results) {
+          delete this.state.chat_contexts[chatKey];
         }
       }
 
@@ -631,6 +659,11 @@ export class SessionService {
         throw new Error(`transport session "${transportSession}" conflicts with an external coordinator`);
       }
       const existingSession = this.state.sessions[alias];
+      // Per-agent settings (cached transport command, mode, reply mode) are only
+      // carried over when the alias is recreated with the same agent. A different
+      // agent must start clean, otherwise prompts would go to the old agent binary.
+      const sameAgentExisting =
+        existingSession && existingSession.agent === agent ? existingSession : undefined;
       const now = new Date(this.now()).toISOString();
       const normalizedTransportAgentCommand = transportAgentCommand?.trim();
       const session: LogicalSession = {
@@ -645,11 +678,11 @@ export class SessionService {
         attached_at: native ? now : undefined,
         ...(normalizedTransportAgentCommand
           ? { transport_agent_command: normalizedTransportAgentCommand }
-          : existingSession?.transport_agent_command
-            ? { transport_agent_command: existingSession.transport_agent_command }
+          : sameAgentExisting?.transport_agent_command
+            ? { transport_agent_command: sameAgentExisting.transport_agent_command }
             : {}),
-        mode_id: existingSession?.mode_id,
-        reply_mode: existingSession?.reply_mode,
+        mode_id: sameAgentExisting?.mode_id,
+        reply_mode: sameAgentExisting?.reply_mode,
         created_at: existingSession?.created_at ?? now,
         last_used_at: now,
       };

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -86,23 +86,38 @@ export class SessionService {
 
   /**
    * All currently-known logical sessions resolved to transport sessions, deduped by
-   * transport session. Sessions whose agent or workspace is no longer registered are
-   * skipped (toResolvedSession would throw). Used by shutdown cleanup to reap warm
-   * acpx queue owners; never throws.
+   * the composite identity acpx keys its session records on (agent + agent command +
+   * cwd + transport session name). Two aliases sharing a transport-session *name*
+   * but differing in agent/cwd (possible via /session attach) resolve to different
+   * acpx records with their own warm queue owners, so both must survive. Sessions
+   * whose agent or workspace is no longer registered are skipped (toResolvedSession
+   * would throw). Used by startup/shutdown cleanup to reap warm acpx queue owners;
+   * never throws.
    */
   listAllResolvedSessions(): ResolvedSession[] {
     const seen = new Set<string>();
     const resolved: ResolvedSession[] = [];
     for (const session of Object.values(this.state.sessions)) {
-      if (seen.has(session.transport_session)) {
-        continue;
-      }
-      seen.add(session.transport_session);
+      let candidate: ResolvedSession;
       try {
-        resolved.push(this.toResolvedSession(session));
+        candidate = this.toResolvedSession(session);
       } catch {
         // Agent/workspace de-registered since this session was created — skip it.
+        continue;
       }
+      // Same composite key as reapQueueOwners/defaultResolveRecordId; JSON.stringify
+      // so cwd values with arbitrary characters cannot collide.
+      const key = JSON.stringify([
+        candidate.agent,
+        candidate.agentCommand ?? null,
+        candidate.cwd,
+        candidate.transportSession,
+      ]);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      resolved.push(candidate);
     }
     return resolved;
   }

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -15,7 +15,10 @@ import { terminateProcessTree } from "../../process/terminate-process-tree";
 import type { ToolUseEvent } from "../../channels/types.js";
 import { getLocale } from "../../i18n";
 
-type WriteLine = (line: string) => boolean | void;
+// `boolean | void` return mirrors Writable.write: `false` only signals
+// backpressure (the line is still queued and delivered), never failure.
+// Real write failures are reported through the optional callback.
+type WriteLine = (line: string, onWriteError?: (error?: Error | null) => void) => boolean | void;
 
 export type BridgeEvent =
   | { type: "prompt.segment"; text: string }
@@ -57,18 +60,21 @@ export class AcpxBridgeClient {
       });
 
       try {
-        const didWrite = this.writeLine(
+        // A `false` return only signals backpressure (the line is still
+        // queued and delivered), so it is deliberately ignored here. Only a
+        // real write error — reported via the callback — fails the request.
+        this.writeLine(
           encodeBridgeRequest({
             id,
             method,
             params,
           }),
+          (error) => {
+            if (error && this.pending.delete(id)) {
+              reject(error);
+            }
+          },
         );
-
-        if (didWrite === false) {
-          this.pending.delete(id);
-          reject(new Error("bridge write buffer is full"));
-        }
       } catch (error) {
         this.pending.delete(id);
         reject(error);
@@ -173,7 +179,25 @@ interface SpawnedBridgeClientOptions {
   cwd?: string;
   permissionMode?: string;
   nonInteractivePermissions?: string;
+  permissionPolicy?: string;
   queueOwnerTtlSeconds?: number;
+}
+
+export function buildBridgeSpawnEnv(
+  options: SpawnedBridgeClientOptions = {},
+): Record<string, string> {
+  return {
+    XACPX_LANG: getLocale(),
+    XACPX_BRIDGE_ACPX_COMMAND: options.acpxCommand ?? "acpx",
+    XACPX_BRIDGE_PERMISSION_MODE: options.permissionMode ?? "approve-all",
+    XACPX_BRIDGE_NON_INTERACTIVE_PERMISSIONS: options.nonInteractivePermissions ?? "deny",
+    ...(typeof options.permissionPolicy === "string" && options.permissionPolicy.trim().length > 0
+      ? { XACPX_BRIDGE_PERMISSION_POLICY: options.permissionPolicy }
+      : {}),
+    ...(typeof options.queueOwnerTtlSeconds === "number" && Number.isFinite(options.queueOwnerTtlSeconds)
+      ? { XACPX_BRIDGE_QUEUE_OWNER_TTL_SECONDS: String(options.queueOwnerTtlSeconds) }
+      : {}),
+  };
 }
 
 export function buildBridgeSpawnSpec(options: {
@@ -206,18 +230,14 @@ export async function spawnAcpxBridgeClient(
     cwd: options.cwd ?? process.cwd(),
     env: {
       ...process.env,
-      XACPX_LANG: getLocale(),
-      XACPX_BRIDGE_ACPX_COMMAND: options.acpxCommand ?? "acpx",
-      XACPX_BRIDGE_PERMISSION_MODE: options.permissionMode ?? "approve-all",
-      XACPX_BRIDGE_NON_INTERACTIVE_PERMISSIONS: options.nonInteractivePermissions ?? "deny",
-      ...(typeof options.queueOwnerTtlSeconds === "number" && Number.isFinite(options.queueOwnerTtlSeconds)
-        ? { XACPX_BRIDGE_QUEUE_OWNER_TTL_SECONDS: String(options.queueOwnerTtlSeconds) }
-        : {}),
+      ...buildBridgeSpawnEnv(options),
     },
     stdio: ["pipe", "pipe", "inherit"],
   });
 
-  const client = new AcpxBridgeClient((line) => child.stdin.write(line)) as ManagedBridgeClient;
+  const client = new AcpxBridgeClient(
+    (line, onWriteError) => child.stdin.write(line, onWriteError),
+  ) as ManagedBridgeClient;
   const output = createInterface({
     input: child.stdout,
     crlfDelay: Infinity,

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -181,6 +181,7 @@ interface SpawnedBridgeClientOptions {
   nonInteractivePermissions?: string;
   permissionPolicy?: string;
   queueOwnerTtlSeconds?: number;
+  sessionInitTimeoutMs?: number;
 }
 
 export function buildBridgeSpawnEnv(
@@ -196,6 +197,11 @@ export function buildBridgeSpawnEnv(
       : {}),
     ...(typeof options.queueOwnerTtlSeconds === "number" && Number.isFinite(options.queueOwnerTtlSeconds)
       ? { XACPX_BRIDGE_QUEUE_OWNER_TTL_SECONDS: String(options.queueOwnerTtlSeconds) }
+      : {}),
+    ...(typeof options.sessionInitTimeoutMs === "number"
+      && Number.isFinite(options.sessionInitTimeoutMs)
+      && options.sessionInitTimeoutMs > 0
+      ? { XACPX_BRIDGE_SESSION_INIT_TIMEOUT_MS: String(options.sessionInitTimeoutMs) }
       : {}),
   };
 }

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -241,9 +241,38 @@ export async function spawnAcpxBridgeClient(
     stdio: ["pipe", "pipe", "inherit"],
   });
 
+  const client = manageBridgeChild(child);
+  await client.waitUntilReady();
+  return client;
+}
+
+/**
+ * Minimal child-process surface needed by manageBridgeChild; lets tests drive a
+ * fake child without spawning a real bridge process.
+ */
+export interface BridgeChildProcess {
+  pid?: number | undefined;
+  stdin: {
+    write(chunk: string, callback?: (error?: Error | null) => void): boolean;
+    end(): void;
+    on(event: "error", listener: (error: Error) => void): unknown;
+  };
+  stdout: NodeJS.ReadableStream;
+  on(event: "exit" | "error", listener: (...args: never[]) => void): unknown;
+}
+
+/** Wire a spawned bridge child process into a managed bridge client. */
+export function manageBridgeChild(child: BridgeChildProcess): ManagedBridgeClient {
   const client = new AcpxBridgeClient(
     (line, onWriteError) => child.stdin.write(line, onWriteError),
   ) as ManagedBridgeClient;
+
+  // Per Node stream semantics a failed stdin write is reported through the
+  // write callback (which rejects the pending request) AND as an 'error' event
+  // on the stream. Without a listener that event becomes an uncaught exception
+  // that kills the daemon; bridge death itself is handled by the 'exit' handler.
+  child.stdin.on("error", () => {});
+
   const output = createInterface({
     input: child.stdout,
     crlfDelay: Infinity,
@@ -257,7 +286,7 @@ export async function spawnAcpxBridgeClient(
     output.close();
     client.handleExit(new Error("bridge process exited before responding"));
   });
-  child.on("error", (error) => {
+  child.on("error", (error: Error) => {
     client.handleExit(error);
   });
 
@@ -273,7 +302,6 @@ export async function spawnAcpxBridgeClient(
     }
   };
 
-  await client.waitUntilReady();
   return client;
 }
 

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -258,7 +258,8 @@ export interface BridgeChildProcess {
     on(event: "error", listener: (error: Error) => void): unknown;
   };
   stdout: NodeJS.ReadableStream;
-  on(event: "exit" | "error", listener: (...args: never[]) => void): unknown;
+  on(event: "exit", listener: () => void): unknown;
+  on(event: "error", listener: (error: Error) => void): unknown;
 }
 
 /** Wire a spawned bridge child process into a managed bridge client. */

--- a/src/transport/queue-owner-reaper.ts
+++ b/src/transport/queue-owner-reaper.ts
@@ -47,13 +47,17 @@ export async function reapQueueOwners(
   const timeoutMs = deps.timeoutMs ?? 5_000;
 
   // Several aliases can share one transport session; the queue owner is per
-  // session record, so dedup by name to avoid redundant resolves/kills.
+  // session record, so dedup by composite identity to avoid redundant resolves/kills.
+  // Two targets that share a session *name* but differ in cwd or agent resolve to
+  // different acpx records (different queue owners) and must both be reaped.
+  // Use JSON.stringify so cwd values with arbitrary characters cannot collide.
   const seen = new Set<string>();
   const unique = targets.filter((target) => {
-    if (seen.has(target.transportSession)) {
+    const key = JSON.stringify([target.agent, target.agentCommand ?? null, target.cwd, target.transportSession]);
+    if (seen.has(key)) {
       return false;
     }
-    seen.add(target.transportSession);
+    seen.add(key);
     return true;
   });
 

--- a/src/weixin/messaging/slash-commands.ts
+++ b/src/weixin/messaging/slash-commands.ts
@@ -5,10 +5,11 @@
  * - /echo <message>         直接回复消息（不经过 AI），并附带通道耗时统计
  * - /toggle-debug           开关 debug 模式，启用后每条 AI 回复追加全链路耗时
  * - /clear                  清除当前会话，重新开始对话
- * - /logout                 清除已保存的登录凭证
+ *
+ * 注意：聊天侧不提供 /logout —— 任何能给 bot 发消息的用户都不应有清除
+ * 凭证的权限；退出登录只能通过 CLI（`xacpx logout`）。
  */
 import type { WeixinApiOptions } from "../api/api.js";
-import { clearAllWeixinAccounts, listWeixinAccountIds } from "../auth/accounts.js";
 import { logger } from "../util/logger.js";
 import { t } from "../../i18n/index.js";
 
@@ -204,15 +205,6 @@ export async function handleSlashCommand(
         // send it now. If pending is empty, this remains a pure no-op (no
         // reply burned on an ack).
         await drainPendingFinalForJx(ctx);
-        return { handled: true };
-      }
-      case "/logout": {
-        if (listWeixinAccountIds().length === 0) {
-          await sendReply(ctx, t().weixin.noAccountsLoggedIn);
-          return { handled: true };
-        }
-        clearAllWeixinAccounts();
-        await sendReply(ctx, t().weixin.logoutSuccess);
         return { handled: true };
       }
       default:

--- a/src/weixin/monitor/monitor.ts
+++ b/src/weixin/monitor/monitor.ts
@@ -93,7 +93,7 @@ function shouldFetchTypingConfig(textBody: string): boolean {
   //
   // /clear is deliberately NOT listed here: resetting/recreating a session can
   // take noticeable time, so handleWeixinMessageTurn wraps /clear with typing.
-  return !["/cancel", "/stop", "/jx", "/echo", "/toggle-debug", "/logout"].includes(command);
+  return !["/cancel", "/stop", "/jx", "/echo", "/toggle-debug"].includes(command);
 }
 
 /**

--- a/tests/unit/bridge/bridge-env.test.ts
+++ b/tests/unit/bridge/bridge-env.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeBridgePermissionMode,
   normalizeBridgePermissionPolicy,
   normalizeBridgeQueueOwnerTtlSeconds,
+  normalizeBridgeSessionInitTimeoutMs,
 } from "../../../src/bridge/bridge-env";
 
 test("accepts deny for bridge non-interactive permissions", () => {
@@ -29,6 +30,17 @@ test("normalizes bridge permission policy, dropping blank or missing values", ()
   expect(normalizeBridgePermissionPolicy(undefined)).toBeUndefined();
   expect(normalizeBridgePermissionPolicy("")).toBeUndefined();
   expect(normalizeBridgePermissionPolicy("   ")).toBeUndefined();
+});
+
+test("normalizes bridge session init timeout ms, dropping blank, zero, negative, or garbage values", () => {
+  expect(normalizeBridgeSessionInitTimeoutMs("120000")).toBe(120000);
+  expect(normalizeBridgeSessionInitTimeoutMs("50")).toBe(50);
+  expect(normalizeBridgeSessionInitTimeoutMs(undefined)).toBeUndefined();
+  expect(normalizeBridgeSessionInitTimeoutMs("")).toBeUndefined();
+  expect(normalizeBridgeSessionInitTimeoutMs("   ")).toBeUndefined();
+  expect(normalizeBridgeSessionInitTimeoutMs("garbage")).toBeUndefined();
+  expect(normalizeBridgeSessionInitTimeoutMs("0")).toBeUndefined();
+  expect(normalizeBridgeSessionInitTimeoutMs("-100")).toBeUndefined();
 });
 
 test("normalizes bridge queue owner ttl seconds, preserving 0 and dropping invalid input", () => {

--- a/tests/unit/bridge/bridge-env.test.ts
+++ b/tests/unit/bridge/bridge-env.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import {
   normalizeBridgeNonInteractivePermissions,
   normalizeBridgePermissionMode,
+  normalizeBridgePermissionPolicy,
   normalizeBridgeQueueOwnerTtlSeconds,
 } from "../../../src/bridge/bridge-env";
 
@@ -19,6 +20,15 @@ test("normalizes bridge permission mode with approve-all fallback", () => {
   expect(normalizeBridgePermissionMode("approve-reads")).toBe("approve-reads");
   expect(normalizeBridgePermissionMode("deny-all")).toBe("deny-all");
   expect(normalizeBridgePermissionMode("bogus")).toBe("approve-all");
+});
+
+test("normalizes bridge permission policy, dropping blank or missing values", () => {
+  expect(normalizeBridgePermissionPolicy("C:/policies/weacpx-policy.json")).toBe(
+    "C:/policies/weacpx-policy.json",
+  );
+  expect(normalizeBridgePermissionPolicy(undefined)).toBeUndefined();
+  expect(normalizeBridgePermissionPolicy("")).toBeUndefined();
+  expect(normalizeBridgePermissionPolicy("   ")).toBeUndefined();
 });
 
 test("normalizes bridge queue owner ttl seconds, preserving 0 and dropping invalid input", () => {

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -4,7 +4,9 @@ import {
   BridgeRuntime,
   runStreamingPrompt,
   selectLatestAcpxSessionIndexTmp,
+  spawnCapture,
   tryRepairAcpxSessionIndex,
+  type CommandRunnerOptions,
 } from "../../../src/bridge/bridge-runtime";
 import type { AcpxQueueOwnerLauncher } from "../../../src/transport/acpx-queue-owner-launcher";
 
@@ -256,6 +258,118 @@ test("ensureSession retries after EPERM repair succeeds", async () => {
     name: "demo",
   })).resolves.toEqual({});
   expect(repairCalls).toBe(1);
+});
+
+// ── session init timeout tests ───────────────────────────────────────────────
+
+interface FakeSpawnChildOptions {
+  pid: number;
+  /** When set, fire the close handler with this exit code on the next tick. */
+  closeWithCode?: number;
+}
+
+function makeFakeSpawnChild(options: FakeSpawnChildOptions) {
+  return {
+    pid: options.pid,
+    stdout: { setEncoding: () => {}, on: () => {} },
+    stderr: { setEncoding: () => {}, on: () => {} },
+    on: (event: string, handler: (code: number | null) => void) => {
+      if (event === "close" && options.closeWithCode !== undefined) {
+        setTimeout(() => handler(options.closeWithCode!), 0);
+      }
+    },
+  };
+}
+
+function makeTimeoutTestRuntime(childOptions: FakeSpawnChildOptions, sessionInitTimeoutMs: number) {
+  const killed: number[] = [];
+  const spawnFn = (() => makeFakeSpawnChild(childOptions)) as never;
+  const killProcessTreeFn = async (pid: number) => {
+    killed.push(pid);
+  };
+  const runtime = new BridgeRuntime(
+    "acpx",
+    (command, args, options?: CommandRunnerOptions) =>
+      spawnCapture(command, args, { ...options, spawnFn, killProcessTreeFn }),
+    (command, args, cwd, options?: CommandRunnerOptions) =>
+      spawnCapture(command, args, { ...options, cwd, spawnFn, killProcessTreeFn }),
+    { sessionInitTimeoutMs },
+  );
+  return { runtime, killed };
+}
+
+test("ensureSession kills the hung acpx spawn and rejects once the session init timeout expires", async () => {
+  // The fake child never emits "close" — equivalent to acpx hanging on agent init.
+  const { runtime, killed } = makeTimeoutTestRuntime({ pid: 4242 }, 50);
+
+  let caught: unknown;
+  try {
+    await runtime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" });
+  } catch (error) {
+    caught = error;
+  }
+
+  expect((caught as Error).message).toBe("session initialization timed out after 0.05s");
+  expect((caught as { kind?: string }).kind).toBe("generic");
+  expect(killed).toEqual([4242]);
+});
+
+test("ensureSession completes within the session init timeout and never fires the kill timer", async () => {
+  const { runtime, killed } = makeTimeoutTestRuntime({ pid: 1111, closeWithCode: 0 }, 30);
+
+  await expect(runtime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" })).resolves.toEqual({});
+
+  // If the timer were left dangling it would fire here and kill pid 1111.
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  expect(killed).toEqual([]);
+});
+
+test("ensureSession defaults the session init timeout to 120s and threads it into ensure and create spawns", async () => {
+  const ensureTimeouts: Array<number | undefined> = [];
+  const createTimeouts: Array<number | undefined> = [];
+  const defaultedRuntime = new BridgeRuntime(
+    "acpx",
+    async (_command, args, options?: CommandRunnerOptions) => {
+      if (args.includes("ensure")) ensureTimeouts.push(options?.timeoutMs);
+      return { code: args.includes("ensure") ? 0 : 1, stdout: "", stderr: "" };
+    },
+  );
+  await defaultedRuntime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" });
+  expect(ensureTimeouts).toEqual([120_000]);
+
+  const configuredRuntime = new BridgeRuntime(
+    "acpx",
+    async (_command, args, options?: CommandRunnerOptions) => {
+      if (args.includes("ensure")) ensureTimeouts.push(options?.timeoutMs);
+      return { code: 1, stdout: "", stderr: "boom" };
+    },
+    async (_command, _args, _cwd, options?: CommandRunnerOptions) => {
+      createTimeouts.push(options?.timeoutMs);
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    { sessionInitTimeoutMs: 45_000 },
+  );
+  await configuredRuntime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" });
+  expect(ensureTimeouts).toEqual([120_000, 45_000]);
+  expect(createTimeouts).toEqual([45_000]);
+});
+
+test("prompt and other session commands are not subject to the session init timeout", async () => {
+  const timeouts: Array<number | undefined> = [];
+  const runtime = new BridgeRuntime(
+    "acpx",
+    async (_command, _args, options?: CommandRunnerOptions) => {
+      timeouts.push(options?.timeoutMs);
+      return { code: 0, stdout: "agent reply", stderr: "" };
+    },
+    undefined,
+    { sessionInitTimeoutMs: 50 },
+  );
+
+  await runtime.prompt({ agent: "codex", cwd: "/repo", name: "demo", text: "hello" });
+  await runtime.hasSession({ agent: "codex", cwd: "/repo", name: "demo" });
+
+  expect(timeouts).toEqual([undefined, undefined]);
 });
 
 test("prompt starts queue owner with orchestration MCP identity", async () => {

--- a/tests/unit/bridge/bridge-server.test.ts
+++ b/tests/unit/bridge/bridge-server.test.ts
@@ -1487,6 +1487,92 @@ test("bridge-server serializes structured missing_optional_dep error", async () 
   expect(parsed.error.data.package).toBe("opencode-windows-x64");
 });
 
+test("forwards permissionPolicy through the updatePermissionPolicy dispatch", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const runtime = {
+    updatePermissionPolicy: async (policy: Record<string, unknown>) => {
+      calls.push(policy);
+      return {};
+    },
+  } as unknown as BridgeRuntime;
+  const server = new BridgeServer(runtime);
+
+  await expect(server.handleLine(JSON.stringify({
+    id: "policy-fwd",
+    method: "updatePermissionPolicy",
+    params: {
+      permissionMode: "approve-reads",
+      nonInteractivePermissions: "deny",
+      permissionPolicy: "C:/policies/weacpx-policy.json",
+    },
+  }))).resolves.toBe('{"id":"policy-fwd","ok":true,"result":{}}\n');
+
+  expect(calls).toEqual([
+    {
+      permissionMode: "approve-reads",
+      nonInteractivePermissions: "deny",
+      permissionPolicy: "C:/policies/weacpx-policy.json",
+    },
+  ]);
+});
+
+test("clears permissionPolicy when the updatePermissionPolicy request omits it", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const runtime = {
+    updatePermissionPolicy: async (policy: Record<string, unknown>) => {
+      calls.push(policy);
+      return {};
+    },
+  } as unknown as BridgeRuntime;
+  const server = new BridgeServer(runtime);
+
+  await expect(server.handleLine(JSON.stringify({
+    id: "policy-clear",
+    method: "updatePermissionPolicy",
+    params: {
+      permissionMode: "approve-all",
+      nonInteractivePermissions: "deny",
+    },
+  }))).resolves.toBe('{"id":"policy-clear","ok":true,"result":{}}\n');
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]?.permissionPolicy).toBeUndefined();
+});
+
+test("applies a permissionPolicy received over ndjson to later runtime commands", async () => {
+  const calls: string[][] = [];
+  const runtime = new BridgeRuntime(
+    "acpx",
+    async (_command, args) => {
+      calls.push(args);
+      return { code: 0, stdout: "ok", stderr: "" };
+    },
+  );
+  const server = new BridgeServer(runtime);
+
+  await server.handleLine(JSON.stringify({
+    id: "policy-apply",
+    method: "updatePermissionPolicy",
+    params: {
+      permissionMode: "approve-all",
+      nonInteractivePermissions: "deny",
+      permissionPolicy: "C:/policies/weacpx-policy.json",
+    },
+  }));
+  await runtime.prompt({
+    agent: "codex",
+    cwd: "/repo",
+    name: "demo",
+    text: "hello",
+  });
+
+  expect(calls).toHaveLength(1);
+  const args = calls[0]!;
+  const flagIndex = args.indexOf("--permission-policy");
+  expect(flagIndex).toBeGreaterThan(-1);
+  expect(args[flagIndex + 1]).toBe("C:/policies/weacpx-policy.json");
+});
+
 test("updates bridge runtime permission policy for later commands", async () => {
   const calls: string[][] = [];
   const runtime = new BridgeRuntime(

--- a/tests/unit/channels/channel-registry.test.ts
+++ b/tests/unit/channels/channel-registry.test.ts
@@ -208,6 +208,47 @@ test("stopAll mixes stop() and logout() per channel capability", async () => {
   expect(events).toEqual(["weixin:stop", "feishu:logout"]);
 });
 
+test("stopAll keeps tearing down remaining channels when one throws, then rethrows", async () => {
+  const events: string[] = [];
+  const throwing: MessageChannelRuntime = {
+    ...fakeChannel("weixin", events),
+    stop: () => {
+      throw new Error("stop-boom");
+    },
+  };
+  const healthy: MessageChannelRuntime = {
+    ...fakeChannel("feishu", events),
+    stop: () => {
+      events.push("feishu:stop");
+    },
+  };
+  const registry = new MessageChannelRegistry([throwing, healthy]);
+
+  await expect(registry.stopAll()).rejects.toThrow("stop-boom");
+  // The second channel must still be stopped despite the first one throwing.
+  expect(events).toContain("feishu:stop");
+});
+
+test("stopAll isolates a throwing logout() fallback as well", async () => {
+  const events: string[] = [];
+  const legacyThrowing: MessageChannelRuntime = {
+    ...fakeChannel("weixin", events),
+    logout: () => {
+      throw new Error("logout-boom");
+    },
+  };
+  const healthy: MessageChannelRuntime = {
+    ...fakeChannel("feishu", events),
+    stop: () => {
+      events.push("feishu:stop");
+    },
+  };
+  const registry = new MessageChannelRegistry([legacyThrowing, healthy]);
+
+  await expect(registry.stopAll()).rejects.toThrow("logout-boom");
+  expect(events).toContain("feishu:stop");
+});
+
 test("routes legacy chat keys to weixin and prefixed keys to matching channel", async () => {
   const events: string[] = [];
   const registry = new MessageChannelRegistry([fakeChannel("weixin", events), fakeChannel("feishu", events)]);

--- a/tests/unit/channels/channel-registry.test.ts
+++ b/tests/unit/channels/channel-registry.test.ts
@@ -158,14 +158,54 @@ test("startAll rejects when ALL channels fail", async () => {
   expect(logErrors.length).toBeGreaterThanOrEqual(2);
 });
 
-test("starts and stops all channels", async () => {
+test("stopAll falls back to logout() only for channels without stop()", async () => {
   const events: string[] = [];
   const registry = new MessageChannelRegistry([fakeChannel("weixin", events), fakeChannel("feishu", events)]);
 
   await registry.startAll(startInput);
-  registry.stopAll();
+  await registry.stopAll();
 
   expect(events).toEqual(["weixin:start", "feishu:start", "weixin:logout", "feishu:logout"]);
+});
+
+test("stopAll prefers non-destructive stop() over logout()", async () => {
+  const events: string[] = [];
+  const withStop: MessageChannelRuntime = {
+    ...fakeChannel("weixin", events),
+    stop: () => {
+      events.push("weixin:stop");
+    },
+  };
+  const withAsyncStop: MessageChannelRuntime = {
+    ...fakeChannel("feishu", events),
+    stop: async () => {
+      events.push("feishu:stop");
+    },
+  };
+  const registry = new MessageChannelRegistry([withStop, withAsyncStop]);
+
+  await registry.startAll(startInput);
+  await registry.stopAll();
+
+  expect(events).toEqual(["weixin:start", "feishu:start", "weixin:stop", "feishu:stop"]);
+  expect(events).not.toContain("weixin:logout");
+  expect(events).not.toContain("feishu:logout");
+});
+
+test("stopAll mixes stop() and logout() per channel capability", async () => {
+  const events: string[] = [];
+  const withStop: MessageChannelRuntime = {
+    ...fakeChannel("weixin", events),
+    stop: () => {
+      events.push("weixin:stop");
+    },
+  };
+  const legacy = fakeChannel("feishu", events); // plugin without stop()
+  const registry = new MessageChannelRegistry([withStop, legacy]);
+
+  await registry.stopAll();
+
+  expect(events).toEqual(["weixin:stop", "feishu:logout"]);
 });
 
 test("routes legacy chat keys to weixin and prefixed keys to matching channel", async () => {

--- a/tests/unit/channels/weixin-channel.test.ts
+++ b/tests/unit/channels/weixin-channel.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { createMessageChannel } from "../../../src/channels/create-channel.js";
 
 test("createMessageChannel('weixin') returns a channel with id 'weixin'", () => {
@@ -71,6 +74,39 @@ test("sendCoordinatorMessage throws before start is called", async () => {
       text: "hello",
     }),
   ).rejects.toThrow("WeixinChannel.start() must be called before orchestration delivery");
+});
+
+test("stop() is non-destructive: keeps account credentials; logout() still clears them", async () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "xacpx-weixin-stop-"));
+  const prevStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  try {
+    const { saveWeixinAccount, registerWeixinAccountId, listWeixinAccountIds } = await import(
+      "../../../src/weixin/auth/accounts.js"
+    );
+    saveWeixinAccount("acct-1", { token: "tok-1", baseUrl: "https://example.com" });
+    registerWeixinAccountId("acct-1");
+    expect(listWeixinAccountIds()).toEqual(["acct-1"]);
+    const accountFile = path.join(stateDir, "openclaw-weixin", "accounts", "acct-1.json");
+    expect(fs.existsSync(accountFile)).toBe(true);
+
+    const channel = createMessageChannel("weixin");
+    expect(typeof channel.stop).toBe("function");
+
+    // Graceful shutdown path: must not delete credentials from disk.
+    await channel.stop!();
+    expect(fs.existsSync(accountFile)).toBe(true);
+    expect(listWeixinAccountIds()).toEqual(["acct-1"]);
+
+    // Explicit logout (xacpx logout) remains the destructive surface.
+    channel.logout();
+    expect(fs.existsSync(accountFile)).toBe(false);
+    expect(listWeixinAccountIds()).toEqual([]);
+  } finally {
+    if (prevStateDir === undefined) delete process.env.OPENCLAW_STATE_DIR;
+    else process.env.OPENCLAW_STATE_DIR = prevStateDir;
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
 });
 
 test("createConsumerLock returns a lock with acquire and release methods", () => {

--- a/tests/unit/cli-update-windows-spawn.test.ts
+++ b/tests/unit/cli-update-windows-spawn.test.ts
@@ -1,0 +1,121 @@
+// Pins the Windows spawn behavior of `xacpx update`: npm/bun resolve to .cmd
+// shims on win32, and since Node's batch-file security change spawning them
+// without `shell: true` fails (EINVAL/ENOENT). These tests mock
+// node:child_process and assert on the options runCapture/runInherit pass to
+// spawn. This file must run in isolation (bun test <this file>) because it
+// mocks a builtin module.
+import { expect, test, mock } from "bun:test";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+interface RecordedSpawn {
+  command: string;
+  args: string[];
+  options: Record<string, unknown>;
+}
+
+const spawnCalls: RecordedSpawn[] = [];
+let nextStdout = "";
+
+mock.module("node:child_process", () => ({
+  spawn: (command: string, args: string[], options: Record<string, unknown>) => {
+    spawnCalls.push({ command, args, options });
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    setTimeout(() => {
+      child.stdout.end(nextStdout);
+      child.emit("exit", 0);
+      child.emit("close", 0);
+    }, 0);
+    return child;
+  },
+}));
+
+const { getLatestNpmVersion, handleUpdateCli } = await import("../../src/cli-update");
+
+async function withPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T>): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(process, "platform")!;
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(process, "platform", original);
+  }
+}
+
+test("runCapture spawns npm with shell: true on win32", async () => {
+  spawnCalls.length = 0;
+  nextStdout = '"1.2.3"';
+
+  const version = await withPlatform("win32", async () => await getLatestNpmVersion("xacpx"));
+
+  expect(version).toBe("1.2.3");
+  expect(spawnCalls).toHaveLength(1);
+  expect(spawnCalls[0]!.command).toBe("npm");
+  expect(spawnCalls[0]!.args).toEqual(["view", "xacpx", "version", "--json"]);
+  expect(spawnCalls[0]!.options.shell).toBe(true);
+});
+
+test("runCapture spawns npm without a shell on posix", async () => {
+  spawnCalls.length = 0;
+  nextStdout = '"1.2.3"';
+
+  const version = await withPlatform("linux", async () => await getLatestNpmVersion("xacpx"));
+
+  expect(version).toBe("1.2.3");
+  expect(spawnCalls).toHaveLength(1);
+  expect(spawnCalls[0]!.options.shell).toBe(false);
+});
+
+test("self-update via runInherit spawns npm with shell: true on win32", async () => {
+  spawnCalls.length = 0;
+  nextStdout = "";
+  delete process.env.XACPX_PACKAGE_MANAGER;
+  delete process.env.WEACPX_PACKAGE_MANAGER;
+
+  const printed: string[] = [];
+  const exitCode = await withPlatform("win32", async () => await handleUpdateCli(["xacpx"], {
+    loadConfig: async () => ({}) as never,
+    saveConfig: async () => {},
+    readCurrentVersion: () => "0.0.1",
+    print: (line) => { printed.push(line); },
+    isInteractive: () => false,
+    promptText: async () => "",
+    packageName: "xacpx",
+    getLatestVersion: async (name) => (name === "xacpx" ? "9.9.9" : null),
+    // updateSelf deliberately NOT injected: exercise the default npm path.
+  }));
+
+  expect(exitCode).toBe(0);
+  expect(spawnCalls).toHaveLength(1);
+  expect(spawnCalls[0]!.command).toBe("npm");
+  expect(spawnCalls[0]!.args).toEqual(["install", "-g", "xacpx"]);
+  expect(spawnCalls[0]!.options.shell).toBe(true);
+  expect(spawnCalls[0]!.options.stdio).toBe("inherit");
+});
+
+test("self-update via runInherit spawns npm without a shell on posix", async () => {
+  spawnCalls.length = 0;
+  nextStdout = "";
+  delete process.env.XACPX_PACKAGE_MANAGER;
+  delete process.env.WEACPX_PACKAGE_MANAGER;
+
+  const exitCode = await withPlatform("darwin", async () => await handleUpdateCli(["xacpx"], {
+    loadConfig: async () => ({}) as never,
+    saveConfig: async () => {},
+    readCurrentVersion: () => "0.0.1",
+    print: () => {},
+    isInteractive: () => false,
+    promptText: async () => "",
+    packageName: "xacpx",
+    getLatestVersion: async (name) => (name === "xacpx" ? "9.9.9" : null),
+  }));
+
+  expect(exitCode).toBe(0);
+  expect(spawnCalls).toHaveLength(1);
+  expect(spawnCalls[0]!.options.shell).toBe(false);
+});

--- a/tests/unit/commands/command-router-interaction.test.ts
+++ b/tests/unit/commands/command-router-interaction.test.ts
@@ -1505,6 +1505,41 @@ test("removes a session and clears its chat context", async () => {
   expect(statusReply.text).toContain("other");
 });
 
+test("removing the current session names the promoted previous session in the reply", async () => {
+  const config = createConfig();
+  const sessions = new SessionService(config, new MemoryStateStore(), createEmptyState());
+  const transport = createTransport();
+  const router = new CommandRouter(sessions, transport, config);
+
+  await router.handle("wx:user", "/session new main --agent codex --ws backend");
+  await router.handle("wx:user", "/session new other --agent codex --ws backend");
+
+  // current=other, previous=main → removing "other" promotes "main".
+  const reply = await router.handle("wx:user", "/session rm other");
+
+  expect(reply.text).toContain("已删除会话「other」");
+  // The next plain message routes to the promoted session — the reply must say
+  // so instead of claiming the chat context was cleared.
+  expect(reply.text).toContain("已切换回上一个会话「main」");
+  expect(reply.text).not.toContain("已自动清除");
+  const statusReply = await router.handle("wx:user", "/status");
+  expect(statusReply.text).toContain("main");
+});
+
+test("removing the current session without a previous one still reports a cleared context", async () => {
+  const config = createConfig();
+  const sessions = new SessionService(config, new MemoryStateStore(), createEmptyState());
+  const transport = createTransport();
+  const router = new CommandRouter(sessions, transport, config);
+
+  await router.handle("wx:user", "/session new main --agent codex --ws backend");
+  const reply = await router.handle("wx:user", "/session rm main");
+
+  expect(reply.text).toContain("已删除会话「main」");
+  expect(reply.text).toContain("已自动清除相关聊天上下文");
+  expect(reply.text).not.toContain("已切换回上一个会话");
+});
+
 test("tears down the transport session when removing a logical session", async () => {
   const config = createConfig();
   const sessions = new SessionService(config, new MemoryStateStore(), createEmptyState());

--- a/tests/unit/daemon/create-daemon-controller.test.ts
+++ b/tests/unit/daemon/create-daemon-controller.test.ts
@@ -141,6 +141,53 @@ test("uses a hidden powershell launcher when spawning the daemon on win32", asyn
   await rm(runtimeDir, { recursive: true, force: true });
 });
 
+test("quotes Start-Process arguments so install paths with spaces survive on win32", async () => {
+  const runtimeDir = await mkdtemp(join(tmpdir(), "weacpx-daemon-factory-"));
+  const paths = createPaths(runtimeDir);
+  const spawnCalls: Array<{
+    command: string;
+    args: string[];
+    options: Record<string, unknown>;
+  }> = [];
+
+  const controller = createDaemonController(paths, {
+    processExecPath: "C:\\Program Files\\nodejs\\node.exe",
+    cliEntryPath: "C:\\Users\\John Doe\\AppData\\Roaming\\npm\\node_modules\\xacpx\\dist\\cli.js",
+    cwd: "C:\\Users\\John Doe\\project",
+    env: {},
+    platform: "win32",
+    spawnProcess: async ({ command, args, options }) => {
+      spawnCalls.push({ command, args, options });
+      await writeReadyStatus(paths.statusFile, 87654);
+      return 87654;
+    },
+    isProcessRunning: (pid) => pid === 87654,
+    terminateProcess: async () => {},
+  });
+
+  await controller.start();
+
+  // Paths with spaces travel verbatim through env vars (never through the
+  // command line of the powershell process itself).
+  const env = (spawnCalls[0]!.options as { env: Record<string, string> }).env;
+  expect(env.XACPX_DAEMON_COMMAND).toBe("C:\\Program Files\\nodejs\\node.exe");
+  expect(env.XACPX_DAEMON_ARG0).toBe("C:\\Users\\John Doe\\AppData\\Roaming\\npm\\node_modules\\xacpx\\dist\\cli.js");
+  expect(env.XACPX_DAEMON_ARG1).toBe("run");
+
+  const encodedIndex = spawnCalls[0]!.args.indexOf("-EncodedCommand") + 1;
+  const launcherScript = Buffer.from(spawnCalls[0]!.args[encodedIndex]!, "base64").toString("utf16le");
+  // Windows PowerShell 5.1's Start-Process joins -ArgumentList elements with
+  // spaces WITHOUT quoting them, so each element must carry its own embedded
+  // double quotes to reach the child as a single argv entry. Pin the exact
+  // quoting construction so it cannot regress to bare $env: references.
+  expect(launcherScript).toContain(`$arg0 = '"' + $env:XACPX_DAEMON_ARG0 + '"'`);
+  expect(launcherScript).toContain(`$arg1 = '"' + $env:XACPX_DAEMON_ARG1 + '"'`);
+  expect(launcherScript).toContain("-ArgumentList @($arg0, $arg1)");
+  expect(launcherScript).not.toContain("-ArgumentList @($env:XACPX_DAEMON_ARG0");
+
+  await rm(runtimeDir, { recursive: true, force: true });
+});
+
 test("returns as soon as the hidden windows launcher prints a pid", async () => {
   const runtimeDir = await mkdtemp(join(tmpdir(), "weacpx-daemon-factory-"));
   const paths = createPaths(runtimeDir);

--- a/tests/unit/daemon/daemon-status.test.ts
+++ b/tests/unit/daemon/daemon-status.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -51,6 +51,55 @@ test("clears the daemon status file", async () => {
 
   await store.clear();
   await expect(store.load()).resolves.toBeNull();
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("leaves no stray tmp files after save", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-status-"));
+  const store = new DaemonStatusStore(join(dir, "status.json"));
+
+  await store.save({
+    pid: 99,
+    started_at: "2026-03-26T00:00:00.000Z",
+    heartbeat_at: "2026-03-26T00:00:00.000Z",
+    config_path: "/cfg",
+    state_path: "/state",
+    app_log: "/a.log",
+    stdout_log: "/o.log",
+    stderr_log: "/e.log",
+  });
+
+  const entries = await readdir(dir);
+  expect(entries).toEqual(["status.json"]);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("overwrites existing status.json atomically", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-status-"));
+  const store = new DaemonStatusStore(join(dir, "status.json"));
+
+  const first: DaemonStatus = {
+    pid: 1,
+    started_at: "2026-01-01T00:00:00.000Z",
+    heartbeat_at: "2026-01-01T00:00:00.000Z",
+    config_path: "/cfg",
+    state_path: "/state",
+    app_log: "/a.log",
+    stdout_log: "/o.log",
+    stderr_log: "/e.log",
+  };
+  const second: DaemonStatus = { ...first, pid: 2, heartbeat_at: "2026-01-01T00:05:00.000Z" };
+
+  await store.save(first);
+  await store.save(second);
+
+  await expect(store.load()).resolves.toEqual(second);
+
+  // Only status.json should be present — no stray tmp from second write
+  const entries = await readdir(dir);
+  expect(entries).toEqual(["status.json"]);
 
   await rm(dir, { recursive: true, force: true });
 });

--- a/tests/unit/logging/app-logger.test.ts
+++ b/tests/unit/logging/app-logger.test.ts
@@ -1,9 +1,10 @@
-import { expect, test } from "bun:test";
+import { expect, test, mock, spyOn, beforeEach, afterEach } from "bun:test";
 import { chmod, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { createAppLogger } from "../../../src/logging/app-logger";
+import * as rotatingFileWriter from "../../../src/logging/rotating-file-writer";
 
 test("writes structured log lines at or above the configured level", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-app-logger-"));
@@ -122,5 +123,93 @@ test("cleans expired rotated logs while keeping fresh files", async () => {
   await expect(stat(freshLog)).resolves.toBeDefined();
   await expect(stat(staleLog)).rejects.toThrow();
 
+  await rm(dir, { recursive: true, force: true });
+});
+
+// --- Bug A: write failures must not reject logger public methods ---
+
+test("logger.info resolves (does not reject) when appendFile rejects", async () => {
+  const fsPromises = await import("node:fs/promises");
+  const appendFileSpy = spyOn(fsPromises, "appendFile").mockRejectedValueOnce(
+    new Error("ENOSPC: no space left on device"),
+  );
+
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-app-logger-mock-"));
+  const appLog = join(dir, "app.log");
+  const logger = createAppLogger({
+    filePath: appLog,
+    level: "info",
+    maxSizeBytes: 1024,
+    maxFiles: 3,
+    retentionDays: 7,
+  });
+
+  let threw = false;
+  try {
+    await logger.info("test.event", "should not throw even when disk full");
+  } catch {
+    threw = true;
+  }
+  expect(threw).toBe(false);
+
+  appendFileSpy.mockRestore();
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("logger emits a one-time console.error note on write failure, not per-call spam", async () => {
+  // Set up temp dir BEFORE mocking so fs operations for dir creation succeed.
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-app-logger-once-"));
+  const appLog = join(dir, "app.log");
+  const logger = createAppLogger({
+    filePath: appLog,
+    level: "info",
+    maxSizeBytes: 1024,
+    maxFiles: 3,
+    retentionDays: 7,
+  });
+
+  // Now activate mocks — only affects calls made during logger.info invocations.
+  const fsPromises = await import("node:fs/promises");
+  const appendFileSpy = spyOn(fsPromises, "appendFile").mockRejectedValue(
+    new Error("ENOSPC: no space left on device"),
+  );
+  const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+  // Call 5 times — should only emit one console.error
+  for (let i = 0; i < 5; i++) {
+    await logger.info("test.event", "repeated failure");
+  }
+
+  expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+  appendFileSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("logger.cleanup() resolves even when cleanupExpiredRotatedLogs throws", async () => {
+  const cleanupSpy = spyOn(rotatingFileWriter, "cleanupExpiredRotatedLogs").mockRejectedValueOnce(
+    new Error("EACCES: permission denied"),
+  );
+
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-app-logger-cleanup-"));
+  const appLog = join(dir, "app.log");
+  const logger = createAppLogger({
+    filePath: appLog,
+    level: "info",
+    maxSizeBytes: 1024,
+    maxFiles: 3,
+    retentionDays: 7,
+  });
+
+  let threw = false;
+  try {
+    await logger.cleanup();
+  } catch {
+    threw = true;
+  }
+  expect(threw).toBe(false);
+
+  cleanupSpy.mockRestore();
   await rm(dir, { recursive: true, force: true });
 });

--- a/tests/unit/logging/app-logger.test.ts
+++ b/tests/unit/logging/app-logger.test.ts
@@ -187,6 +187,39 @@ test("logger emits a one-time console.error note on write failure, not per-call 
   await rm(dir, { recursive: true, force: true });
 });
 
+test("level-filtered no-op writes do not reset the one-time error latch", async () => {
+  // Regression: debug calls at info level early-return without touching disk;
+  // they resolve through the success path and must NOT reset the latch, or a
+  // persistently broken disk with interleaved debug calls would emit one
+  // console.error per failing write instead of one per burst.
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-app-logger-latch-"));
+  const appLog = join(dir, "app.log");
+  const logger = createAppLogger({
+    filePath: appLog,
+    level: "info",
+    maxSizeBytes: 1024,
+    maxFiles: 3,
+    retentionDays: 7,
+  });
+
+  const fsPromises = await import("node:fs/promises");
+  const appendFileSpy = spyOn(fsPromises, "appendFile").mockRejectedValue(
+    new Error("ENOSPC: no space left on device"),
+  );
+  const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+  for (let i = 0; i < 3; i++) {
+    await logger.info("test.event", "failing write");
+    await logger.debug("test.noop", "below level — never touches disk");
+  }
+
+  expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+  appendFileSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+  await rm(dir, { recursive: true, force: true });
+});
+
 test("logger.cleanup() resolves even when cleanupExpiredRotatedLogs throws", async () => {
   const cleanupSpy = spyOn(rotatingFileWriter, "cleanupExpiredRotatedLogs").mockRejectedValueOnce(
     new Error("EACCES: permission denied"),

--- a/tests/unit/logging/rotating-file-writer.test.ts
+++ b/tests/unit/logging/rotating-file-writer.test.ts
@@ -55,26 +55,12 @@ test("cleanupExpiredRotatedLogs deletes rotated files older than retentionDays",
 
 // --- Bug B: candidate disappearing between readdir and stat must not reject ---
 
-test("cleanupExpiredRotatedLogs resolves and processes remaining candidates when one file is removed before stat", async () => {
-  // Verifies the ENOENT-tolerance fix: when a rotated file is deleted between
-  // readdir and stat (race with another process / manual deletion), cleanup must
-  // not throw and must still process the remaining candidates.
-  //
-  // We simulate the race by wrapping cleanupExpiredRotatedLogs in a variant that
-  // deletes a candidate immediately after readdir completes but before stat is
-  // called. We achieve the observable effect by creating both files, then deleting
-  // one right before the function call — on a fast system, readdir inside the
-  // function won't see the deleted file, so we cannot rely on that. Instead we
-  // pass a custom `stat` wrapper by refactoring the test to call the internal
-  // helper with an injected fs — but since the function is not parameterised on fs,
-  // we test via real filesystem: create .1 and .2, delete .1, then call cleanup.
-  // readdir won't list .1 (it's already gone), so no ENOENT path is hit — but the
-  // test still proves cleanup works correctly when candidates are missing.
-  //
-  // The precise ENOENT-during-stat scenario is validated by a second sub-test
-  // that wraps the module with a monkey-patched stat that injects ENOENT for
-  // one specific path, verifying the loop continues to process remaining files.
-
+test("cleanupExpiredRotatedLogs tolerates ENOENT from stat mid-iteration and still processes other candidates", async () => {
+  // Simulates the race where a rotated file is removed between readdir and stat
+  // (concurrent cleanup in another process, manual deletion). Both candidates
+  // exist on disk so readdir lists them; the spy then makes stat throw ENOENT
+  // for candidate1 only. Cleanup must skip it without rejecting and continue
+  // on to delete the stale candidate2.
   const dir = await mkdtemp(join(tmpdir(), "weacpx-rfw-race-"));
   const logFile = join(dir, "test.log");
   const candidate1 = join(dir, "test.log.1");
@@ -88,8 +74,23 @@ test("cleanupExpiredRotatedLogs resolves and processes remaining candidates when
   await utimes(candidate1, eightDaysAgo, eightDaysAgo);
   await utimes(candidate2, eightDaysAgo, eightDaysAgo);
 
-  // Delete one file before calling cleanup — simulates external removal.
-  await rm(candidate1, { force: true });
+  const fsPromises = await import("node:fs/promises");
+  // Capture the real stat BEFORE spying — the mock must call through to the
+  // original, not the spied binding (that would recurse infinitely).
+  const realStat = fsPromises.stat;
+  const statSpy = spyOn(fsPromises, "stat").mockImplementation(((
+    path: Parameters<typeof realStat>[0],
+    ...args: unknown[]
+  ) => {
+    if (typeof path === "string" && path === candidate1) {
+      return Promise.reject(
+        Object.assign(new Error("ENOENT: no such file or directory (simulated race)"), {
+          code: "ENOENT",
+        }),
+      );
+    }
+    return (realStat as (...a: unknown[]) => Promise<unknown>)(path, ...args);
+  }) as typeof realStat);
 
   let threw = false;
   try {
@@ -97,10 +98,13 @@ test("cleanupExpiredRotatedLogs resolves and processes remaining candidates when
   } catch {
     threw = true;
   }
+  statSpy.mockRestore();
 
   expect(threw).toBe(false);
-  // candidate2 was stale and still present — should be cleaned up.
   const files = await readdir(dir);
+  // candidate1 was skipped (stat "raced") so it remains on disk untouched.
+  expect(files).toContain("test.log.1");
+  // candidate2 was stale and statted fine — it must still have been deleted.
   expect(files).not.toContain("test.log.2");
 
   await rm(dir, { recursive: true, force: true });

--- a/tests/unit/logging/rotating-file-writer.test.ts
+++ b/tests/unit/logging/rotating-file-writer.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, test, spyOn } from "bun:test";
 import { appendFile, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -49,6 +49,59 @@ test("cleanupExpiredRotatedLogs deletes rotated files older than retentionDays",
 
   const files = await readdir(dir);
   expect(files).toEqual(["test.log.1"]);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+// --- Bug B: candidate disappearing between readdir and stat must not reject ---
+
+test("cleanupExpiredRotatedLogs resolves and processes remaining candidates when one file is removed before stat", async () => {
+  // Verifies the ENOENT-tolerance fix: when a rotated file is deleted between
+  // readdir and stat (race with another process / manual deletion), cleanup must
+  // not throw and must still process the remaining candidates.
+  //
+  // We simulate the race by wrapping cleanupExpiredRotatedLogs in a variant that
+  // deletes a candidate immediately after readdir completes but before stat is
+  // called. We achieve the observable effect by creating both files, then deleting
+  // one right before the function call — on a fast system, readdir inside the
+  // function won't see the deleted file, so we cannot rely on that. Instead we
+  // pass a custom `stat` wrapper by refactoring the test to call the internal
+  // helper with an injected fs — but since the function is not parameterised on fs,
+  // we test via real filesystem: create .1 and .2, delete .1, then call cleanup.
+  // readdir won't list .1 (it's already gone), so no ENOENT path is hit — but the
+  // test still proves cleanup works correctly when candidates are missing.
+  //
+  // The precise ENOENT-during-stat scenario is validated by a second sub-test
+  // that wraps the module with a monkey-patched stat that injects ENOENT for
+  // one specific path, verifying the loop continues to process remaining files.
+
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-rfw-race-"));
+  const logFile = join(dir, "test.log");
+  const candidate1 = join(dir, "test.log.1");
+  const candidate2 = join(dir, "test.log.2");
+  await writeFile(candidate1, "stale-1");
+  await writeFile(candidate2, "stale-2");
+
+  const now = new Date("2026-05-15T00:00:00Z");
+  const eightDaysAgo = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000);
+  const { utimes } = await import("node:fs/promises");
+  await utimes(candidate1, eightDaysAgo, eightDaysAgo);
+  await utimes(candidate2, eightDaysAgo, eightDaysAgo);
+
+  // Delete one file before calling cleanup — simulates external removal.
+  await rm(candidate1, { force: true });
+
+  let threw = false;
+  try {
+    await cleanupExpiredRotatedLogs(logFile, 7, () => now);
+  } catch {
+    threw = true;
+  }
+
+  expect(threw).toBe(false);
+  // candidate2 was stale and still present — should be cleaned up.
+  const files = await readdir(dir);
+  expect(files).not.toContain("test.log.2");
 
   await rm(dir, { recursive: true, force: true });
 });

--- a/tests/unit/orchestration/orchestration-server.test.ts
+++ b/tests/unit/orchestration/orchestration-server.test.ts
@@ -69,6 +69,123 @@ function makeServerHandlers(overrides: Partial<Record<string, unknown>> = {}) {
 
 
 
+test("delegate.request accepts parallel:true and passes it to the handler", async () => {
+  const endpoint = resolveOrchestrationEndpoint("/tmp/weacpx-orch-server-test");
+  const requestDelegate = mock(async (input: Record<string, unknown>) => ({
+    taskId: "task-1",
+    status: "needs_confirmation",
+    input,
+  }));
+  const server = new OrchestrationServer(endpoint, makeServerHandlers({ requestDelegate }));
+
+  const response = JSON.parse(
+    await server.handleLine(JSON.stringify({
+      id: "req-parallel-true",
+      method: "delegate.request",
+      params: {
+        sourceHandle: "backend:main",
+        targetAgent: "claude",
+        task: "review",
+        parallel: true,
+      },
+    })),
+  );
+
+  expect(response).toMatchObject({ id: "req-parallel-true", ok: true });
+  expect(requestDelegate).toHaveBeenCalledWith({
+    sourceHandle: "backend:main",
+    targetAgent: "claude",
+    task: "review",
+    parallel: true,
+  });
+});
+
+test("delegate.request accepts parallel:false and passes it to the handler", async () => {
+  const endpoint = resolveOrchestrationEndpoint("/tmp/weacpx-orch-server-test");
+  const requestDelegate = mock(async (input: Record<string, unknown>) => ({
+    taskId: "task-2",
+    status: "needs_confirmation",
+    input,
+  }));
+  const server = new OrchestrationServer(endpoint, makeServerHandlers({ requestDelegate }));
+
+  const response = JSON.parse(
+    await server.handleLine(JSON.stringify({
+      id: "req-parallel-false",
+      method: "delegate.request",
+      params: {
+        sourceHandle: "backend:main",
+        targetAgent: "claude",
+        task: "review",
+        parallel: false,
+      },
+    })),
+  );
+
+  expect(response).toMatchObject({ id: "req-parallel-false", ok: true });
+  expect(requestDelegate).toHaveBeenCalledWith({
+    sourceHandle: "backend:main",
+    targetAgent: "claude",
+    task: "review",
+    parallel: false,
+  });
+});
+
+test("delegate.request without parallel omits the field from handler input", async () => {
+  const endpoint = resolveOrchestrationEndpoint("/tmp/weacpx-orch-server-test");
+  const requestDelegate = mock(async (input: Record<string, unknown>) => ({
+    taskId: "task-3",
+    status: "needs_confirmation",
+    input,
+  }));
+  const server = new OrchestrationServer(endpoint, makeServerHandlers({ requestDelegate }));
+
+  const response = JSON.parse(
+    await server.handleLine(JSON.stringify({
+      id: "req-no-parallel",
+      method: "delegate.request",
+      params: {
+        sourceHandle: "backend:main",
+        targetAgent: "claude",
+        task: "review",
+      },
+    })),
+  );
+
+  expect(response).toMatchObject({ id: "req-no-parallel", ok: true });
+  const calledWith = (requestDelegate.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+  expect(calledWith).not.toHaveProperty("parallel");
+});
+
+test("delegate.request rejects non-boolean parallel value", async () => {
+  const endpoint = resolveOrchestrationEndpoint("/tmp/weacpx-orch-server-test");
+  const requestDelegate = mock(async () => ({ taskId: "task-1", status: "needs_confirmation" }));
+  const server = new OrchestrationServer(endpoint, makeServerHandlers({ requestDelegate }));
+
+  for (const parallel of ["yes", 1, "true", null, []]) {
+    const response = JSON.parse(
+      await server.handleLine(JSON.stringify({
+        id: "req-bad-parallel",
+        method: "delegate.request",
+        params: {
+          sourceHandle: "backend:main",
+          targetAgent: "claude",
+          task: "review",
+          parallel,
+        },
+      })),
+    );
+
+    expect(response).toMatchObject({
+      id: "req-bad-parallel",
+      ok: false,
+      error: { code: "ORCHESTRATION_INVALID_REQUEST" },
+    });
+  }
+
+  expect(requestDelegate).not.toHaveBeenCalled();
+});
+
 test("forwards task watch RPC to handlers", async () => {
   const endpoint = resolveOrchestrationEndpoint("/tmp/weacpx-orch-server-test");
   const watchTask = mock(async (input: Record<string, unknown>) => ({

--- a/tests/unit/plugins/package-manager-windows-spawn.test.ts
+++ b/tests/unit/plugins/package-manager-windows-spawn.test.ts
@@ -1,0 +1,142 @@
+// Pins the Windows spawn behavior of the plugin package-manager helpers:
+// npm/bun resolve to .cmd shims on win32, and since Node's batch-file
+// security change spawning them without `shell: true` fails (EINVAL/ENOENT)
+// — breaking `xacpx plugin add/update/rm` and silently degrading the
+// `bun --version` probe to npm. On the shell path each arg must also be
+// double-quoted so cmd.exe metacharacters in semver ranges (e.g. the `^` in
+// "pkg@^1.2.0", cmd's escape char) survive to the package manager. These
+// tests mock node:child_process and assert on the spawn options/args. This
+// file must run in isolation (bun test <this file>) because it mocks a
+// builtin module.
+import { expect, test, mock } from "bun:test";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+interface RecordedSpawn {
+  command: string;
+  args: string[];
+  options: Record<string, unknown>;
+}
+
+const spawnCalls: RecordedSpawn[] = [];
+
+mock.module("node:child_process", () => ({
+  spawn: (command: string, args: string[], options: Record<string, unknown>) => {
+    spawnCalls.push({ command, args, options });
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    setTimeout(() => {
+      child.stdout.end();
+      child.emit("exit", 0);
+      child.emit("close", 0);
+    }, 0);
+    return child;
+  },
+}));
+
+const { detectPackageManager, installPluginPackage, removePluginPackage } = await import("../../../src/plugins/package-manager");
+
+async function withPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T>): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(process, "platform")!;
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(process, "platform", original);
+  }
+}
+
+// pluginHome never has to exist for these tests: the manifest normalization
+// tolerates a missing package.json and the spawn itself is mocked.
+const pluginHome = "/tmp/xacpx-plugin-home-spawn-test";
+
+test("installPluginPackage spawns npm via shell with quoted args on win32", async () => {
+  spawnCalls.length = 0;
+
+  await withPlatform("win32", async () => {
+    await installPluginPackage({
+      packageName: "weacpx-channel-demo",
+      version: "^1.2.0",
+      pluginHome,
+      packageManager: "npm",
+      // runCommand deliberately NOT injected: exercise the default spawn path.
+    });
+  });
+
+  expect(spawnCalls).toHaveLength(1);
+  expect(spawnCalls[0]!.command).toBe("npm");
+  // Quoting keeps the `^` in the range from being eaten by cmd.exe.
+  expect(spawnCalls[0]!.args).toEqual(['"install"', '"weacpx-channel-demo@^1.2.0"']);
+  expect(spawnCalls[0]!.options.shell).toBe(true);
+  expect(spawnCalls[0]!.options.cwd).toBe(pluginHome);
+  expect(spawnCalls[0]!.options.stdio).toBe("inherit");
+});
+
+test("installPluginPackage spawns npm without a shell and unquoted on posix", async () => {
+  spawnCalls.length = 0;
+
+  await withPlatform("linux", async () => {
+    await installPluginPackage({
+      packageName: "weacpx-channel-demo",
+      version: "^1.2.0",
+      pluginHome,
+      packageManager: "npm",
+    });
+  });
+
+  expect(spawnCalls).toHaveLength(1);
+  expect(spawnCalls[0]!.command).toBe("npm");
+  expect(spawnCalls[0]!.args).toEqual(["install", "weacpx-channel-demo@^1.2.0"]);
+  expect(spawnCalls[0]!.options.shell).toBe(false);
+});
+
+test("removePluginPackage spawns npm via shell with quoted args on win32", async () => {
+  spawnCalls.length = 0;
+
+  await withPlatform("win32", async () => {
+    await removePluginPackage({
+      packageName: "weacpx-channel-demo",
+      pluginHome,
+      packageManager: "npm",
+    });
+  });
+
+  expect(spawnCalls).toHaveLength(1);
+  expect(spawnCalls[0]!.command).toBe("npm");
+  expect(spawnCalls[0]!.args).toEqual(['"uninstall"', '"weacpx-channel-demo"']);
+  expect(spawnCalls[0]!.options.shell).toBe(true);
+});
+
+test("detectPackageManager probes bun via shell on win32", async () => {
+  spawnCalls.length = 0;
+  delete process.env.XACPX_PACKAGE_MANAGER;
+  delete process.env.WEACPX_PACKAGE_MANAGER;
+
+  const manager = await withPlatform("win32", async () => await detectPackageManager());
+
+  // The mocked probe exits 0, so a shell-spawned `bun --version` must be
+  // detected as bun instead of silently falling back to npm.
+  expect(manager).toBe("bun");
+  expect(spawnCalls).toHaveLength(1);
+  expect(spawnCalls[0]!.command).toBe("bun");
+  expect(spawnCalls[0]!.args).toEqual(['"--version"']);
+  expect(spawnCalls[0]!.options.shell).toBe(true);
+  expect(spawnCalls[0]!.options.stdio).toBe("ignore");
+});
+
+test("detectPackageManager probes bun without a shell on posix", async () => {
+  spawnCalls.length = 0;
+  delete process.env.XACPX_PACKAGE_MANAGER;
+  delete process.env.WEACPX_PACKAGE_MANAGER;
+
+  const manager = await withPlatform("darwin", async () => await detectPackageManager());
+
+  expect(manager).toBe("bun");
+  expect(spawnCalls).toHaveLength(1);
+  expect(spawnCalls[0]!.args).toEqual(["--version"]);
+  expect(spawnCalls[0]!.options.shell).toBe(false);
+});

--- a/tests/unit/plugins/plugin-cli.test.ts
+++ b/tests/unit/plugins/plugin-cli.test.ts
@@ -173,6 +173,20 @@ test("plugin rm removes plugin config and package", async () => {
   expect(harness.getConfig().plugins).toEqual([]);
 });
 
+test("plugin rm with legacy name removes the normalized config entry (Bug A)", async () => {
+  // Config stores the normalized name; user passes the legacy name.
+  const harness = createHarness(baseConfig({
+    plugins: [{ name: "@ganglion/xacpx-channel-feishu", enabled: true }],
+  }));
+  harness.summaries.set("@ganglion/xacpx-channel-feishu", { name: "@ganglion/xacpx-channel-feishu", channels: [] });
+
+  const code = await handlePluginCli(["rm", "@ganglion/weacpx-channel-feishu"], harness.deps);
+
+  expect(code).toBe(0);
+  // The normalized config entry must be gone — not just the raw legacy-name entry.
+  expect(harness.getConfig().plugins).toEqual([]);
+});
+
 test("plugin disable and enable toggle config", async () => {
   const harness = createHarness(baseConfig({ plugins: [{ name: "xacpx-channel-demo", enabled: true }] }));
 

--- a/tests/unit/plugins/plugin-cli.test.ts
+++ b/tests/unit/plugins/plugin-cli.test.ts
@@ -179,12 +179,23 @@ test("plugin rm with legacy name removes the normalized config entry (Bug A)", a
     plugins: [{ name: "@ganglion/xacpx-channel-feishu", enabled: true }],
   }));
   harness.summaries.set("@ganglion/xacpx-channel-feishu", { name: "@ganglion/xacpx-channel-feishu", channels: [] });
+  const validatedNames: string[] = [];
+  const validate = harness.deps.validateInstalledPlugin;
+  harness.deps.validateInstalledPlugin = async (packageName: string) => {
+    validatedNames.push(packageName);
+    return await validate(packageName);
+  };
 
   const code = await handlePluginCli(["rm", "@ganglion/weacpx-channel-feishu"], harness.deps);
 
   expect(code).toBe(0);
   // The normalized config entry must be gone — not just the raw legacy-name entry.
   expect(harness.getConfig().plugins).toEqual([]);
+  // The uninstall and the dependency guard must target the actually installed
+  // (normalized) package: uninstalling the legacy name is a silent no-op with
+  // npm (config gone, package orphaned) and a hard failure with bun.
+  expect(harness.calls).toEqual(["remove:@ganglion/xacpx-channel-feishu"]);
+  expect(validatedNames).toEqual(["@ganglion/xacpx-channel-feishu"]);
 });
 
 test("plugin disable and enable toggle config", async () => {

--- a/tests/unit/plugins/plugin-doctor.test.ts
+++ b/tests/unit/plugins/plugin-doctor.test.ts
@@ -211,3 +211,71 @@ test("doctor errors when configured channel provider plugin is disabled", async 
     await rm(pluginHome, { recursive: true, force: true });
   }
 });
+
+test("doctor with legacy pluginName filter finds the configured plugin (Bug B)", async () => {
+  const pluginHome = await createPluginHome({ "@ganglion/xacpx-channel-feishu": "1.0.0" });
+  try {
+    const issues = await inspectPlugins({
+      pluginHome,
+      // config stores the normalized name
+      config: baseConfig({ plugins: [{ name: "@ganglion/xacpx-channel-feishu", enabled: true }] }),
+      // user passes the legacy name as filter
+      pluginName: "@ganglion/weacpx-channel-feishu",
+      importPlugin: async () => ({ default: { apiVersion: 1, name: "@ganglion/xacpx-channel-feishu", channels: [] } }),
+    });
+
+    // Should NOT return "plugin is not configured" error
+    expect(issues.some((issue) => issue.message.includes("plugin is not configured"))).toBe(false);
+    // Should find the plugin and report it as valid
+    expect(issues.some((issue) => issue.level === "ok")).toBe(true);
+  } finally {
+    await rm(pluginHome, { recursive: true, force: true });
+  }
+});
+
+test("doctor does not flag a disabled channel as orphan (Bug C)", async () => {
+  const pluginHome = await createPluginHome();
+  try {
+    const issues = await inspectPlugins({
+      pluginHome,
+      config: baseConfig({
+        plugins: [],
+        channels: [
+          { id: "weixin", type: "weixin", enabled: true },
+          // feishu channel intentionally disabled — no plugin needed
+          { id: "feishu", type: "feishu", enabled: false },
+        ],
+      }),
+      importPlugin: async () => ({ default: { apiVersion: 1, channels: [] } }),
+    });
+
+    // disabled channel must NOT produce an orphan error
+    expect(issues.some((issue) => issue.message.includes("channel feishu is configured"))).toBe(false);
+  } finally {
+    await rm(pluginHome, { recursive: true, force: true });
+  }
+});
+
+test("doctor still flags an enabled channel with no provider as error (Bug C regression)", async () => {
+  const pluginHome = await createPluginHome();
+  try {
+    const issues = await inspectPlugins({
+      pluginHome,
+      config: baseConfig({
+        plugins: [],
+        channels: [
+          { id: "weixin", type: "weixin", enabled: true },
+          { id: "feishu", type: "feishu", enabled: true },
+        ],
+      }),
+      importPlugin: async () => ({ default: { apiVersion: 1, channels: [] } }),
+    });
+
+    expect(issues).toContainEqual(expect.objectContaining({
+      level: "error",
+      message: expect.stringContaining("channel feishu is configured but no enabled plugin provides it"),
+    }));
+  } finally {
+    await rm(pluginHome, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/scheduled/parse-later-time.test.ts
+++ b/tests/unit/scheduled/parse-later-time.test.ts
@@ -112,7 +112,9 @@ test("parses various weekday names", () => {
   expect(r4.executeAt.getDay()).toBe(0);
 });
 
-// ---- Bug B: Invalid Date from huge digit count ----
+// Overflow guard: durations large enough to overflow the Date range produce a
+// NaN timestamp; validation must reject them as out_of_range, never return
+// ok:true with an Invalid Date (which throws downstream on toISOString()).
 
 test("rejects astronomically large day count (overflow → Invalid Date)", () => {
   // 99999999999999d overflows Date range → getTime() is NaN.

--- a/tests/unit/scheduled/parse-later-time.test.ts
+++ b/tests/unit/scheduled/parse-later-time.test.ts
@@ -111,3 +111,25 @@ test("parses various weekday names", () => {
   const r4 = ok(["周天", "12:00", "x"]);
   expect(r4.executeAt.getDay()).toBe(0);
 });
+
+// ---- Bug B: Invalid Date from huge digit count ----
+
+test("rejects astronomically large day count (overflow → Invalid Date)", () => {
+  // 99999999999999d overflows Date range → getTime() is NaN.
+  // Must return ok:false with out_of_range, not ok:true with an Invalid Date.
+  const result = parseLaterTime(["in", "99999999999999d", "继续"], now);
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.code).toBe("out_of_range");
+});
+
+test("rejects astronomically large hour count (overflow → Invalid Date)", () => {
+  const result = parseLaterTime(["in", "999999999999h", "继续"], now);
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.code).toBe("out_of_range");
+});
+
+test("normal 5m duration still works after NaN guard", () => {
+  // Sanity-check that the guard does not break ordinary inputs.
+  const result = parseLaterTime(["in", "5m", "继续"], now);
+  expect(result.ok).toBe(true);
+});

--- a/tests/unit/scheduled/scheduled-scheduler.test.ts
+++ b/tests/unit/scheduled/scheduled-scheduler.test.ts
@@ -356,3 +356,82 @@ test("tick does not wedge when a dispatch ignores its abort signal", async () =>
 
   expect(state.scheduled_tasks.stuck?.status).toBe("failed");
 });
+
+// ---- Bug A robustness tests ----
+
+test("tick survives claimDueTasks throwing — no unhandled rejection", async () => {
+  // Build a fake service whose claimDueTasks always throws.
+  // If tick() lets the error escape as an unhandled rejection, bun:test detects
+  // it and fails the file.  The await below would also throw if tick() rethrows.
+  const throwingService = {
+    markStartupMissed: async () => {},
+    claimDueTasks: async (): Promise<never> => {
+      throw new Error("state-store EBUSY");
+    },
+    markExecuted: async () => {},
+    markFailed: async () => {},
+  } as unknown as ScheduledTaskService;
+
+  const dispatchTask = mock(async () => {});
+  const { setIntervalFn, clearIntervalFn } = createFakeSetInterval();
+
+  const scheduler = new ScheduledTaskScheduler(throwingService, {
+    dispatchTask,
+    setIntervalFn,
+    clearIntervalFn,
+  });
+
+  // tick() must not throw (the daemon must survive a transient store error).
+  await expect(scheduler.tick()).resolves.toBeUndefined();
+
+  // A second tick must also execute (the ticking lock must have been released).
+  await expect(scheduler.tick()).resolves.toBeUndefined();
+
+  // dispatchTask was never reached because claimDueTasks threw before it.
+  expect(dispatchTask).toHaveBeenCalledTimes(0);
+});
+
+test("tick survives dispatch failure AND markFailed throwing — no unhandled rejection", async () => {
+  // Simulate: dispatch throws, then markFailed also throws (e.g. disk full during
+  // the error-recording write). Neither error should escape tick().
+  const state = createEmptyState();
+  state.scheduled_tasks.fail2 = {
+    id: "fail2",
+    chat_key: "c",
+    session_alias: "s",
+    execute_at: "2026-05-23T09:59:00.000Z",
+    message: "will fail",
+    status: "pending",
+    created_at: "2026-05-23T09:00:00.000Z",
+  };
+
+  const saveCalls: number[] = [];
+  const store = {
+    saves: 0,
+    async save(): Promise<void> {
+      saveCalls.push(Date.now());
+      // First save (claimDueTasks) succeeds; second save (markFailed) throws.
+      if (saveCalls.length >= 2) throw new Error("disk full");
+    },
+  };
+  const service = new ScheduledTaskService(state, store, {
+    now: () => new Date("2026-05-23T10:00:00.000Z"),
+  });
+
+  const dispatchTask = mock(async () => {
+    throw new Error("channel unavailable");
+  });
+  const { setIntervalFn, clearIntervalFn } = createFakeSetInterval();
+
+  const scheduler = new ScheduledTaskScheduler(service, {
+    dispatchTask,
+    setIntervalFn,
+    clearIntervalFn,
+  });
+
+  // Must not throw even though markFailed's save also throws.
+  await expect(scheduler.tick()).resolves.toBeUndefined();
+
+  // Subsequent tick must still work (ticking lock released).
+  await expect(scheduler.tick()).resolves.toBeUndefined();
+});

--- a/tests/unit/scheduled/scheduled-scheduler.test.ts
+++ b/tests/unit/scheduled/scheduled-scheduler.test.ts
@@ -357,7 +357,8 @@ test("tick does not wedge when a dispatch ignores its abort signal", async () =>
   expect(state.scheduled_tasks.stuck?.status).toBe("failed");
 });
 
-// ---- Bug A robustness tests ----
+// tick() resilience: state-store errors must never escape tick() — an escaped
+// rejection from the interval callback would terminate the daemon process.
 
 test("tick survives claimDueTasks throwing — no unhandled rejection", async () => {
   // Build a fake service whose claimDueTasks always throws.
@@ -407,7 +408,6 @@ test("tick survives dispatch failure AND markFailed throwing — no unhandled re
 
   const saveCalls: number[] = [];
   const store = {
-    saves: 0,
     async save(): Promise<void> {
       saveCalls.push(Date.now());
       // First save (claimDueTasks) succeeds; second save (markFailed) throws.

--- a/tests/unit/scheduled/scheduled-service.test.ts
+++ b/tests/unit/scheduled/scheduled-service.test.ts
@@ -77,6 +77,34 @@ test("claims due tasks and marks old pending tasks missed", async () => {
   expect(state.scheduled_tasks.due1?.status).toBe("triggering");
 });
 
+test("rolls back the in-memory claim when save fails so the next tick can retry", async () => {
+  const state = createEmptyState();
+  state.scheduled_tasks.due1 = {
+    id: "due1", chat_key: "c", session_alias: "s", execute_at: "2026-05-23T09:59:00.000Z", message: "due", status: "pending", created_at: "2026-05-23T09:00:00.000Z",
+  };
+  let failNextSave = true;
+  const store = {
+    save: async (_s: AppState): Promise<void> => {
+      if (failNextSave) {
+        failNextSave = false;
+        throw new Error("disk full");
+      }
+    },
+  };
+  const service = new ScheduledTaskService(state, store, { now: () => new Date("2026-05-23T10:00:00.000Z") });
+
+  await expect(service.claimDueTasks()).rejects.toThrow("disk full");
+  // Without rollback the task stays "triggering" in memory, disappears from
+  // listPending, and silently never fires until a daemon restart.
+  expect(state.scheduled_tasks.due1?.status).toBe("pending");
+  expect(state.scheduled_tasks.due1?.triggered_at).toBeUndefined();
+  expect(service.listPending().map((task) => task.id)).toEqual(["due1"]);
+
+  // The next tick retries and claims the task normally.
+  expect((await service.claimDueTasks()).map((task) => task.id)).toEqual(["due1"]);
+  expect(state.scheduled_tasks.due1?.status).toBe("triggering");
+});
+
 test("scheduled writes serialize with the shared state mutex so an interleaved clone-save cannot drop a task", async () => {
   const mutex = new AsyncMutex();
   const state = createEmptyState();

--- a/tests/unit/sessions/session-service.test.ts
+++ b/tests/unit/sessions/session-service.test.ts
@@ -636,6 +636,154 @@ test("setBackgroundResult overwrites a prior unread result for the same alias", 
   expect(taken?.status).toBe("error");
 });
 
+test("useSession preserves unread background results across switches", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.createSession("b", "codex", "backend");
+  const chatKey = "weixin:acc:user";
+
+  await service.useSession(chatKey, "a");
+  await service.setBackgroundResult(chatKey, "a", {
+    text: "task a finished", status: "done", finished_at: "2026-06-10T01:00:00.000Z",
+  });
+  await service.useSession(chatKey, "b");
+  expect(service.listBackgroundResultAliases(chatKey)).toEqual(["a"]);
+  await service.useSession(chatKey, "a");
+
+  const taken = await service.takeBackgroundResult(chatKey, "a");
+  expect(taken?.text).toBe("task a finished");
+});
+
+test("usePreviousSession preserves unread background results", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.createSession("b", "codex", "backend");
+  const chatKey = "weixin:acc:user";
+
+  await service.useSession(chatKey, "a");
+  await service.useSession(chatKey, "b");
+  await service.setBackgroundResult(chatKey, "a", {
+    text: "task a finished", status: "done", finished_at: "2026-06-10T01:00:00.000Z",
+  });
+
+  const prev = await service.usePreviousSession(chatKey);
+  expect(prev?.alias).toBe("a");
+  const taken = await service.takeBackgroundResult(chatKey, "a");
+  expect(taken?.text).toBe("task a finished");
+});
+
+test("removeSession of current session keeps other aliases' background results and promotes previous_session", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.createSession("b", "codex", "backend");
+  const chatKey = "weixin:acc:user";
+
+  await service.useSession(chatKey, "a");
+  await service.useSession(chatKey, "b"); // current=b, previous=a
+  await service.setBackgroundResult(chatKey, "a", {
+    text: "task a finished", status: "done", finished_at: "2026-06-10T01:00:00.000Z",
+  });
+
+  await service.removeSession("b");
+
+  // previous_session promoted to current; a's background result survives.
+  await expect(service.getCurrentSession(chatKey)).resolves.toMatchObject({ alias: "a" });
+  const taken = await service.takeBackgroundResult(chatKey, "a");
+  expect(taken?.text).toBe("task a finished");
+});
+
+test("removeSession drops only the removed alias's background result", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.createSession("b", "codex", "backend");
+  const chatKey = "weixin:acc:user";
+
+  await service.useSession(chatKey, "b");
+  await service.setBackgroundResult(chatKey, "a", {
+    text: "task a finished", status: "done", finished_at: "2026-06-10T01:00:00.000Z",
+  });
+  await service.setBackgroundResult(chatKey, "b", {
+    text: "task b finished", status: "done", finished_at: "2026-06-10T01:00:00.000Z",
+  });
+
+  await service.removeSession("b");
+
+  expect(await service.takeBackgroundResult(chatKey, "b")).toBeNull();
+  expect((await service.takeBackgroundResult(chatKey, "a"))?.text).toBe("task a finished");
+});
+
+test("removeSession of current session without previous clears the current marker", async () => {
+  const service = new SessionService(createSwitchConfig(), new MemoryStateStore(), createEmptyState());
+  await service.createSession("a", "codex", "backend");
+  await service.createSession("b", "codex", "backend");
+  const chatKey = "weixin:acc:user";
+
+  await service.useSession(chatKey, "a");
+  await service.setBackgroundResult(chatKey, "b", {
+    text: "task b finished", status: "done", finished_at: "2026-06-10T01:00:00.000Z",
+  });
+
+  await service.removeSession("a");
+
+  expect(await service.getCurrentSession(chatKey)).toBeNull();
+  expect((await service.takeBackgroundResult(chatKey, "b"))?.text).toBe("task b finished");
+});
+
+test("recreating an alias with a different agent does not inherit transport agent command, mode, or reply mode", async () => {
+  const store = new MemoryStateStore();
+  const state = createEmptyState();
+  const service = new SessionService(createConfig(), store, state);
+  const chatKey = "weixin:acc:user";
+
+  await service.createSession("foo", "codex", "backend");
+  await service.useSession(chatKey, "foo");
+  await service.setSessionTransportAgentCommand("foo", "npx @zed-industries/codex-acp@^0.9.5");
+  await service.setCurrentSessionMode(chatKey, "plan");
+  await service.setCurrentSessionReplyMode(chatKey, "final");
+
+  const recreated = await service.createSession("foo", "claude", "backend");
+
+  expect(recreated.agentCommand).toBeUndefined();
+  expect(recreated.modeId).toBeUndefined();
+  expect(recreated.replyMode).toBeUndefined();
+  expect(state.sessions.foo?.transport_agent_command).toBeUndefined();
+  expect(state.sessions.foo?.mode_id).toBeUndefined();
+  expect(state.sessions.foo?.reply_mode).toBeUndefined();
+});
+
+test("recreating an alias with the same agent still inherits transport agent command, mode, and reply mode", async () => {
+  const store = new MemoryStateStore();
+  const state = createEmptyState();
+  const service = new SessionService(createConfig(), store, state);
+  const chatKey = "weixin:acc:user";
+
+  await service.createSession("foo", "codex", "backend");
+  await service.useSession(chatKey, "foo");
+  await service.setSessionTransportAgentCommand("foo", "npx @zed-industries/codex-acp@^0.9.5");
+  await service.setCurrentSessionMode(chatKey, "plan");
+  await service.setCurrentSessionReplyMode(chatKey, "final");
+
+  const recreated = await service.createSession("foo", "codex", "backend");
+
+  expect(recreated.agentCommand).toBe("npx @zed-industries/codex-acp@^0.9.5");
+  expect(recreated.modeId).toBe("plan");
+  expect(recreated.replyMode).toBe("final");
+});
+
+test("resolveSession does not reuse a cached transport agent command from a different agent", async () => {
+  const store = new MemoryStateStore();
+  const service = new SessionService(createConfig(), store, createEmptyState());
+
+  await service.createSession("foo", "codex", "backend");
+  await service.setSessionTransportAgentCommand("foo", "npx @zed-industries/codex-acp@^0.9.5");
+
+  const crossAgent = service.resolveSession("foo", "claude", "backend", "backend:foo");
+  expect(crossAgent.agentCommand).toBeUndefined();
+
+  const sameAgent = service.resolveSession("foo", "codex", "backend", "backend:foo");
+  expect(sameAgent.agentCommand).toBe("npx @zed-industries/codex-acp@^0.9.5");
+});
+
 test("peekCurrentSessionAlias returns the current internal alias without mutating", async () => {
   const store = new MemoryStateStore();
   const service = new SessionService(createConfig(), store, createEmptyState());

--- a/tests/unit/sessions/session-service.test.ts
+++ b/tests/unit/sessions/session-service.test.ts
@@ -381,22 +381,31 @@ test("resolves display alias to internal alias per channel", async () => {
   expect(await service.resolveAliasForChat("feishu:default:oc_chat", "backend:codex")).toBe("feishu:backend:codex");
 });
 
-test("listAllResolvedSessions resolves all sessions, dedups by transport session, and skips de-registered ones", async () => {
+test("listAllResolvedSessions resolves all sessions, dedups by composite identity, and skips de-registered ones", async () => {
+  const config = createConfig();
+  config.workspaces.frontend = { cwd: "/tmp/frontend" };
   const state = createEmptyState();
   const baseTimes = { created_at: "2026-05-03T00:00:00.000Z", last_used_at: "2026-05-03T00:00:00.000Z" };
   state.sessions["api-fix"] = { alias: "api-fix", agent: "codex", workspace: "backend", transport_session: "backend:api-fix", ...baseTimes };
   state.sessions["docs"] = { alias: "docs", agent: "claude", workspace: "backend", transport_session: "backend:docs", ...baseTimes };
   // Second alias bound to the same transport session as api-fix → must dedup.
   state.sessions["api-fix-mirror"] = { alias: "api-fix-mirror", agent: "codex", workspace: "backend", transport_session: "backend:api-fix", ...baseTimes };
+  // Same transport-session NAME but a different workspace (possible via
+  // /session attach) resolves to a different acpx record with its own warm
+  // queue owner → must NOT collapse with backend's api-fix.
+  state.sessions["api-fix-frontend"] = { alias: "api-fix-frontend", agent: "codex", workspace: "frontend", transport_session: "backend:api-fix", ...baseTimes };
   // Workspace de-registered after the session was created → must be skipped (no throw).
   state.sessions["orphan"] = { alias: "orphan", agent: "codex", workspace: "ghost-workspace", transport_session: "ghost-workspace:orphan", ...baseTimes };
-  const service = new SessionService(createConfig(), new MemoryStateStore(), state);
+  const service = new SessionService(config, new MemoryStateStore(), state);
 
   const resolved = service.listAllResolvedSessions();
-  const transportSessions = resolved.map((s) => s.transportSession).sort();
+  const identities = resolved.map((s) => `${s.transportSession}@${s.cwd}`).sort();
 
-  expect(transportSessions).toEqual(["backend:api-fix", "backend:docs"]);
-  expect(resolved.every((s) => s.cwd === "/tmp/backend")).toBe(true);
+  expect(identities).toEqual([
+    "backend:api-fix@/tmp/backend",
+    "backend:api-fix@/tmp/frontend",
+    "backend:docs@/tmp/backend",
+  ]);
 });
 
 test("stores native metadata when attaching a native session", async () => {

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
@@ -5,7 +5,10 @@ import {
   buildBridgeSpawnEnv,
   buildBridgeSpawnSpec,
 } from "../../../../src/transport/acpx-bridge/acpx-bridge-client";
-import { normalizeBridgePermissionPolicy } from "../../../../src/bridge/bridge-env";
+import {
+  normalizeBridgePermissionPolicy,
+  normalizeBridgeSessionInitTimeoutMs,
+} from "../../../../src/bridge/bridge-env";
 import { encodeBridgeRequest } from "../../../../src/transport/acpx-bridge/acpx-bridge-protocol";
 import { PromptCommandError } from "../../../../src/transport/prompt-output";
 import { MissingOptionalDepError } from "../../../../src/recovery/errors";
@@ -172,6 +175,23 @@ test("includes the permission policy in the bridge spawn env and round-trips it"
   expect(normalizeBridgePermissionPolicy(env.XACPX_BRIDGE_PERMISSION_POLICY)).toBe(
     "C:/policies/weacpx-policy.json",
   );
+});
+
+test("includes the session init timeout in the bridge spawn env and round-trips it", () => {
+  const env = buildBridgeSpawnEnv({ sessionInitTimeoutMs: 120_000 });
+
+  expect(env.XACPX_BRIDGE_SESSION_INIT_TIMEOUT_MS).toBe("120000");
+  expect(normalizeBridgeSessionInitTimeoutMs(env.XACPX_BRIDGE_SESSION_INIT_TIMEOUT_MS)).toBe(120_000);
+});
+
+test("omits the session init timeout from the bridge spawn env when unset or invalid", () => {
+  expect("XACPX_BRIDGE_SESSION_INIT_TIMEOUT_MS" in buildBridgeSpawnEnv({})).toBe(false);
+  expect(
+    "XACPX_BRIDGE_SESSION_INIT_TIMEOUT_MS" in buildBridgeSpawnEnv({ sessionInitTimeoutMs: Number.NaN }),
+  ).toBe(false);
+  expect(
+    "XACPX_BRIDGE_SESSION_INIT_TIMEOUT_MS" in buildBridgeSpawnEnv({ sessionInitTimeoutMs: 0 }),
+  ).toBe(false);
 });
 
 test("omits the permission policy from the bridge spawn env when unset", () => {

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import {
   AcpxBridgeClient,
+  buildBridgeSpawnEnv,
   buildBridgeSpawnSpec,
 } from "../../../../src/transport/acpx-bridge/acpx-bridge-client";
+import { normalizeBridgePermissionPolicy } from "../../../../src/bridge/bridge-env";
 import { encodeBridgeRequest } from "../../../../src/transport/acpx-bridge/acpx-bridge-protocol";
 import { PromptCommandError } from "../../../../src/transport/prompt-output";
 import { MissingOptionalDepError } from "../../../../src/recovery/errors";
@@ -125,15 +127,60 @@ test("rejects new requests after the bridge exits", async () => {
   await expect(client.request("ping", {})).rejects.toThrow("bridge exited");
 });
 
-test("rejects requests when the writer signals backpressure", async () => {
+test("keeps the request pending when the writer signals backpressure (write returned false)", async () => {
+  // Writable.write returning false means "queued above the high-water mark" —
+  // the line is still delivered, so the request must NOT fail.
   const writes: string[] = [];
   const client = new AcpxBridgeClient((line) => {
     writes.push(line);
     return false;
   });
 
-  await expect(client.request("ping", {})).rejects.toThrow("bridge write buffer is full");
+  const pending = client.request("ping", {});
+  client.handleLine('{"id":"1","ok":true,"result":{}}');
+
+  await expect(pending).resolves.toEqual({});
   expect(writes).toEqual(['{"id":"1","method":"ping","params":{}}\n']);
+});
+
+test("rejects the request when the write callback reports a real write error", async () => {
+  const client = new AcpxBridgeClient((_line, onWriteError) => {
+    onWriteError?.(new Error("write EPIPE"));
+    return false;
+  });
+
+  await expect(client.request("ping", {})).rejects.toThrow("write EPIPE");
+});
+
+test("a late write-callback error after the response resolved is ignored", async () => {
+  let reportError: ((error?: Error | null) => void) | undefined;
+  const client = new AcpxBridgeClient((_line, onWriteError) => {
+    reportError = onWriteError;
+  });
+
+  const pending = client.request("ping", {});
+  client.handleLine('{"id":"1","ok":true,"result":{}}');
+  await expect(pending).resolves.toEqual({});
+
+  expect(() => reportError?.(new Error("write EPIPE"))).not.toThrow();
+});
+
+test("includes the permission policy in the bridge spawn env and round-trips it", () => {
+  const env = buildBridgeSpawnEnv({ permissionPolicy: "C:/policies/weacpx-policy.json" });
+
+  expect(env.XACPX_BRIDGE_PERMISSION_POLICY).toBe("C:/policies/weacpx-policy.json");
+  expect(normalizeBridgePermissionPolicy(env.XACPX_BRIDGE_PERMISSION_POLICY)).toBe(
+    "C:/policies/weacpx-policy.json",
+  );
+});
+
+test("omits the permission policy from the bridge spawn env when unset", () => {
+  const env = buildBridgeSpawnEnv({});
+
+  expect("XACPX_BRIDGE_PERMISSION_POLICY" in env).toBe(false);
+  expect(env.XACPX_BRIDGE_PERMISSION_MODE).toBe("approve-all");
+  expect(env.XACPX_BRIDGE_NON_INTERACTIVE_PERMISSIONS).toBe("deny");
+  expect(env.XACPX_BRIDGE_ACPX_COMMAND).toBe("acpx");
 });
 
 describe("AcpxBridgeClient", () => {

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 
 import {
   AcpxBridgeClient,
   buildBridgeSpawnEnv,
   buildBridgeSpawnSpec,
+  manageBridgeChild,
 } from "../../../../src/transport/acpx-bridge/acpx-bridge-client";
 import {
   normalizeBridgePermissionPolicy,
@@ -166,6 +169,24 @@ test("a late write-callback error after the response resolved is ignored", async
   await expect(pending).resolves.toEqual({});
 
   expect(() => reportError?.(new Error("write EPIPE"))).not.toThrow();
+});
+
+test("survives an 'error' event on the bridge stdin and keeps serving requests", async () => {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const child = Object.assign(new EventEmitter(), { stdin, stdout, pid: 12345 });
+
+  const client = manageBridgeChild(child);
+
+  // Per Node stream semantics a failed write is reported through the write
+  // callback AND as an 'error' event on the stream. Without a listener the
+  // event becomes an uncaught exception that kills the daemon.
+  expect(() => stdin.emit("error", new Error("write EPIPE"))).not.toThrow();
+
+  // The client must keep functioning after the stdin error.
+  const pending = client.request("ping", {});
+  stdout.write('{"id":"1","ok":true,"result":{}}\n');
+  await expect(pending).resolves.toEqual({});
 });
 
 test("includes the permission policy in the bridge spawn env and round-trips it", () => {

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
@@ -229,11 +229,13 @@ test("proxies permission policy updates through the bridge client", async () => 
   await transport.updatePermissionPolicy?.({
     permissionMode: "approve-reads",
     nonInteractivePermissions: "deny",
+    permissionPolicy: "C:/policies/weacpx-policy.json",
   });
 
   expect(request).toHaveBeenCalledWith("updatePermissionPolicy", {
     permissionMode: "approve-reads",
     nonInteractivePermissions: "deny",
+    permissionPolicy: "C:/policies/weacpx-policy.json",
   });
 });
 

--- a/tests/unit/transport/queue-owner-reaper.test.ts
+++ b/tests/unit/transport/queue-owner-reaper.test.ts
@@ -38,6 +38,74 @@ test("deduplicates targets that share a transport session", async () => {
   expect(resolved.sort()).toEqual(["backend:api", "backend:docs"]);
 });
 
+test("reaps BOTH targets when session name is the same but cwd differs", async () => {
+  const terminated: string[] = [];
+  // Two logical sessions share the name "backend:main" but live in different workspaces.
+  // They map to different acpx records and must both be reaped.
+  const result = await reapQueueOwners(
+    "acpx",
+    [
+      { agent: "codex", cwd: "/workspace/alpha", transportSession: "backend:main" },
+      { agent: "codex", cwd: "/workspace/beta", transportSession: "backend:main" },
+    ],
+    {
+      resolveRecordId: async (_cmd, t) => `record-${t.transportSession}-${t.cwd}`,
+      terminate: async (recordId) => {
+        terminated.push(recordId);
+      },
+    },
+  );
+
+  expect(terminated.sort()).toEqual([
+    "record-backend:main-/workspace/alpha",
+    "record-backend:main-/workspace/beta",
+  ]);
+  expect(result.terminated).toBe(2);
+  expect(result.attempted).toBe(2);
+});
+
+test("reaps BOTH targets when session name is the same but agent differs", async () => {
+  const terminated: string[] = [];
+  const result = await reapQueueOwners(
+    "acpx",
+    [
+      { agent: "codex", cwd: "/workspace/proj", transportSession: "main" },
+      { agent: "opus", cwd: "/workspace/proj", transportSession: "main" },
+    ],
+    {
+      resolveRecordId: async (_cmd, t) => `record-${t.transportSession}-${t.agent}`,
+      terminate: async (recordId) => {
+        terminated.push(recordId);
+      },
+    },
+  );
+
+  expect(terminated.sort()).toEqual(["record-main-codex", "record-main-opus"]);
+  expect(result.terminated).toBe(2);
+});
+
+test("still deduplicates truly identical targets (same name + same cwd + same agent)", async () => {
+  const resolved: string[] = [];
+  await reapQueueOwners(
+    "acpx",
+    [
+      { agent: "codex", cwd: "/workspace/alpha", transportSession: "backend:main" },
+      { agent: "codex", cwd: "/workspace/alpha", transportSession: "backend:main" },
+      { agent: "codex", cwd: "/workspace/beta", transportSession: "backend:main" },
+    ],
+    {
+      resolveRecordId: async (_cmd, t) => {
+        resolved.push(`${t.transportSession}|${t.cwd}`);
+        return `record-${t.transportSession}-${t.cwd}`;
+      },
+      terminate: async () => {},
+    },
+  );
+
+  // The alpha duplicate collapses; beta is distinct → 2 resolves total.
+  expect(resolved.sort()).toEqual(["backend:main|/workspace/alpha", "backend:main|/workspace/beta"]);
+});
+
 test("skips targets whose record id resolves to null", async () => {
   const terminated: string[] = [];
   const result = await reapQueueOwners("acpx", [target("backend:api"), target("backend:docs")], {

--- a/tests/unit/weixin/monitor.test.ts
+++ b/tests/unit/weixin/monitor.test.ts
@@ -154,9 +154,9 @@ describe("v1.4: monitor drops pending final on non-/jx inbound", () => {
     expect(echo.configCalls).toEqual([]);
     expect(echo.typingTickets).toEqual([""]);
 
-    const logout = await runOneInbound("/logout");
-    expect(logout.configCalls).toEqual([]);
-    expect(logout.typingTickets).toEqual([""]);
+    const jx = await runOneInbound("/jx");
+    expect(jx.configCalls).toEqual([]);
+    expect(jx.typingTickets).toEqual([""]);
   });
 });
 

--- a/tests/unit/weixin/slash-commands.test.ts
+++ b/tests/unit/weixin/slash-commands.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeEach, afterAll } from "bun:test";
 
-import { drainPendingFinalForJx } from "../../../src/weixin/messaging/slash-commands";
+import { drainPendingFinalForJx, handleSlashCommand } from "../../../src/weixin/messaging/slash-commands";
 import type { PendingFinalChunk } from "../../../src/weixin/messaging/quota-manager";
 import type { SlashCommandContext } from "../../../src/weixin/messaging/slash-commands";
 import { setLocale } from "../../../src/i18n";
@@ -25,6 +25,16 @@ function baseCtx(overrides: Partial<SlashCommandContext> = {}): SlashCommandCont
     ...overrides,
   };
 }
+
+describe("/logout chat command removal", () => {
+  test("/logout is no longer handled (no unauthenticated credential wipe)", async () => {
+    // Must fall through as an unknown command: any chat peer could previously
+    // trigger clearAllWeixinAccounts() with zero authorization. CLI `xacpx
+    // logout` is the only remaining logout surface.
+    const result = await handleSlashCommand("/logout", baseCtx(), Date.now());
+    expect(result.handled).toBe(false);
+  });
+});
 
 describe("v1.4: /jx drains pending final pages", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Fixes from a full-codebase review (6 parallel review agents; top findings hand-verified). Plan: `docs/superpowers/plans/2026-06-10-codebase-review-fixes.md`. Each task went through implementer + spec review + code-quality review.

**P0**
- **Credential safety**: graceful shutdown no longer wipes WeChat credentials — `stopAll()` now prefers a new non-destructive `stop()` channel hook (`logout()` stays CLI-only, legacy fallback for plugins without `stop()`); removed the unauthenticated chat `/logout` command that let any chat peer delete all bot credentials.
- **Session switching**: `/use` and `/session rm` no longer destroy unread background results — the switch-back replay and ● unread markers work again; `/session new` with an existing alias no longer inherits the old agent's transport command (prompts went to the wrong backend).
- **Bridge transport**: `transport.permissionPolicy` now actually reaches acpx (spawn env + RPC update path); stdin backpressure is no longer misread as a write failure (>16KB prompts caused ghost execution with lost output); session init is now bounded by `sessionInitTimeoutMs` (120s default) instead of wedging the session lane forever.
- **Orchestration**: `delegate_request`/`delegate_batch` `parallel` flag is accepted instead of failing with `ORCHESTRATION_INVALID_REQUEST`.

**Robustness**
- Scheduler `tick()` errors can no longer kill the daemon (unhandled rejection); `/later` durations that overflow the Date range fail validation as `out_of_range` instead of throwing internal errors.
- Logger write failures no longer crash message handling or startup (never-rejecting log calls, one-time stderr latch, ENOENT-tolerant rotated-log cleanup).
- `status.json` written atomically (tmp+rename) — no more truncated reads racing the heartbeat.
- Queue-owner reaper dedupes by composite identity (agent+command+cwd+session), so same-named sessions in different workspaces are all reaped.
- `plugin rm`/`plugin doctor` normalize legacy `@ganglion/weacpx-channel-*` names (no more ghost config entries); doctor no longer flags deliberately disabled channels.

**Windows**
- `xacpx update` and `xacpx plugin add/update/rm` spawn npm/bun via shell (npm.cmd EINVAL), with cmd.exe-safe arg quoting for semver ranges.
- Daemon PowerShell launcher quotes its arguments — `xacpx start` works when the install path contains spaces.

Behavior note for release notes: removing the current session now promotes `previous_session` to current instead of clearing the chat context.

## Test Plan
- [x] `npm test` — typecheck + all 229 unit test files, 0 failures (~60 new test cases, TDD red→green per fix)
- [x] `bun run build` — cli.js + bridge/bridge-main.js + plugin-api.js emitted
- [x] Per-task spec-compliance + code-quality reviews, plus a whole-batch final review (cross-task interactions: shutdown ordering, bridge spawn env, chat-context state shape)