### PR TITLE
Follow-up batch: verbatim command bodies, shared bridge deadline, spec validation, lock-span fix

### DIFF
--- a/docs/superpowers/plans/2026-06-11-followup-batch.md
+++ b/docs/superpowers/plans/2026-06-11-followup-batch.md
@@ -1,0 +1,98 @@
+# Follow-up Batch (2026-06-11)
+
+Source: the deferred section of `2026-06-10-deferred-batch.md` plus review-surfaced items recorded
+in PR #22's description. Skipped as not worth fixing: the `WeixinChannel.stop()` vs in-flight
+scheduled tick race (shutdown-window cosmetics, reconciled at next start).
+Branch: `worktree-followup-batch-2026-06` (base 973c4b9 = main after PR #20/#22).
+Execution: subagent-driven development, one task at a time.
+
+## Tasks
+
+### Task F1 — Free-text command bodies keep their quotes (raw-tail extraction)
+- Bug: `tokenizeCommand` (src/commands/parse-command.ts) strips quote characters — both straight
+  (`"`/`'`, pre-existing) and curly/full-width (since the smart-quote change) — and free-text
+  bodies are rebuilt by `join(" ")` of tokens, so `/later in 2h 提醒我看"报告"` stores
+  `提醒我看报告`. Chinese IMEs emit curly quotes by default, so this silently rewrites user
+  content. Known free-text consumers: `/later` message (src/commands/handlers/later-handler.ts
+  builds the message from tokens), `/delegate` task text (parse-command.ts ~:788), `/group new`
+  title (parse-command.ts ~:189). Audit parse-command.ts for any other `join(" ")` body rebuilds.
+- Fix: free-text tails must be taken verbatim from the original input string, not re-joined from
+  tokens. Suggested design (implementer may refine): make the tokenizer record each token's source
+  start/end offsets; a free-text consumer takes `input.slice(<start of first body token>)` (trim
+  trailing whitespace) instead of joining. Structured arguments (flags, aliases, time specs) keep
+  tokenized behavior, including quoted-token support for args with spaces.
+- Tests: bodies with curly quotes, straight quotes, mixed, multiple spaces between words
+  (verbatim tail should preserve internal spacing), and the structured prefix still parsing
+  (e.g. `/later at "10:00" …` style args if supported). Existing parse tests must keep passing.
+
+### Task F2 — Bridge ensureSession: one shared deadline
+- Bug: in src/bridge/bridge-runtime.ts, `ensureSession` runs `sessions ensure` and on failure
+  `sessions new`, each spawnCapture getting a FULL `timeoutMs` budget, with an untimed
+  `sessions show` probe between — worst case ≈2× `sessionInitTimeoutMs` (+probe) before the user
+  sees the timeout error. acpx-cli's equivalent is a single end-to-end bound.
+- Fix: compute one deadline at entry (`now + timeoutMs`); every subprocess step (ensure, show
+  probe, new, any verbose-fallback retry) gets `remaining = max(deadline - now, small-floor)` as
+  its timeoutMs; on expiry surface the same EnsureSessionFailedError("session initialization
+  timed out after Ns") the per-step timeout produces today. Check `resumeAgentSession` for the
+  same pattern and bound it identically.
+- Tests: fake spawn that burns the budget in step 1 → step 2 gets only the remainder (assert via
+  captured per-call timeout values); total-elapsed bound test with injected clock if the module
+  has one (look at existing bridge-runtime tests for the spawnFn/killProcessTreeFn seams).
+
+### Task F3 — Plugin spec validation at the CLI boundary
+- Bug: a plugin spec containing `"` breaks out of the cmd.exe quote wrapper that
+  `shellSpawnPlan` (src/plugins/package-manager.ts) applies on Windows (same trust level as the
+  user's shell — no privilege boundary — but unclean), and `%VAR%` is expanded by cmd.exe even
+  inside quotes.
+- Fix: validate specs where the user hands them over (plugin add path in src/plugins/plugin-cli.ts
+  and any other entry point feeding package-manager): reject any spec containing `"` on ALL
+  platforms (double quotes are never valid in an npm package spec) with a clear error; on win32,
+  reject specs containing `%` too (npm specs may legitimately contain %-encoded URL characters in
+  tarball URLs, but on Windows they would be mangled anyway — refusing is more honest than
+  corrupting; mention the workaround of installing via npm directly). Keep error messages via the
+  existing message/i18n mechanism used by plugin CLI output (check how plugin-cli reports errors —
+  it may be plain English CLI strings, match that).
+- Tests: specs with `"` rejected everywhere; `%` rejected on win32 (platform-injectable seam if
+  needed — see how package-manager tests fake win32); normal specs (name, name@version, scoped)
+  unaffected.
+
+### Task F4 — markExecuted save failure must not record a dispatched task as FAILED
+- Bug: in src/scheduled/scheduled-scheduler.ts the dispatch try/catch wraps both the dispatch and
+  the subsequent `markExecuted`; if dispatch SUCCEEDS but `markExecuted`'s state save throws, the
+  catch calls `markFailed` — recording a successfully-dispatched task as FAILED (and `markFailed`'s
+  own save will likely fail too, already logged via scheduled.dispatch.mark_failed).
+- Fix: separate the failure domains — only dispatch errors reach `markFailed`; a `markExecuted`
+  failure is logged with its own snake_case event (e.g. `scheduled.dispatch.mark_executed_failed`)
+  and the task is left as-is (disk likely still says pending/triggering; startup reconciliation
+  handles it). Read the current code carefully — the 2026-06-10 batch already added
+  scheduled.claim/mark_failed handling; extend that structure, don't restructure it.
+- Tests: dispatch ok + markExecuted throws → markFailed NOT called, event logged; dispatch throws
+  → markFailed still called (existing behavior preserved).
+
+### Task F5 — ConfigStore: hold the file lock across read→patch→write
+- Bug: `patchRaw` (src/config/config-store.ts) reads the raw file, patches, then calls
+  `writePrivateFileAtomic` — the lock inside writePrivateFileAtomic (proper-lockfile, see
+  src/util/private-file.ts) only serializes the WRITE, so two concurrent mutations
+  (e.g. /pm set during /config set) lose one. Pre-existing window (old load→save had it too).
+- Fix: acquire the same proper-lockfile lock for the WHOLE read→patch→write span. Likely shape: a
+  `withPrivateFileLock(path, fn)` helper in src/util/private-file.ts reusing its lock options;
+  writePrivateFileAtomic gains an internal variant that skips re-locking when already held (or the
+  helper composes the existing pieces — read private-file.ts first and pick the cleanest;
+  proper-lockfile is not reentrant, so do NOT nest two lock() calls on the same path).
+- Tests: two concurrent patchRaw calls both land (run them with Promise.all against a real temp
+  file; assert both keys present). Existing config-store tests keep passing.
+
+### Task F6 — pluginRemoved success message names the normalized package
+- One-liner: src/plugins/plugin-cli.ts removal success message uses the raw user input
+  (`pluginRemoved(packageName)`) while the failure path already uses the normalized
+  `existing.name`. Use `existing.name` for consistency. Adjust/extend the existing legacy-name
+  removal test to assert the message.
+
+## Deferred (still not in this batch)
+- `WeixinChannel.stop()` vs in-flight scheduled tick: spurious task-failure log at shutdown,
+  reconciled at next start — cosmetic, not worth the surgery.
+- `replaceChannels`/`replacePlugins` write parsed (closed) entries — unknown keys inside a
+  channels[]/plugins[] entry don't survive channel/plugin CLI ops (tool-managed arrays by design).
+- MCP `scheduled_list` per-task `chatKey` output is now redundant (always the caller's own).
+- Pending-final queue front-trim (40 chunks) can make the parked-notice count overstate for
+  giant answers.

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -114,6 +114,8 @@ interface BridgeRuntimeOptions {
   queueOwnerTtlSeconds?: number;
   /** Time bound for session-creation spawns (ensure/new/resume); defaults to 120s like acpx-cli. */
   sessionInitTimeoutMs?: number;
+  /** Test seam: clock used for the shared session-init deadline. */
+  now?: () => number;
 }
 
 export class BridgeRuntime {
@@ -263,6 +265,19 @@ export class BridgeRuntime {
   ): Promise<Record<string, never>> {
     onProgress?.("spawn");
     const timeoutMs = this.sessionInitTimeoutMs();
+    // One shared deadline for every subprocess step (ensure, show probe, new,
+    // verbose-fallback retry): each step only gets the remaining budget so the
+    // whole ensure path is bounded by sessionInitTimeoutMs end-to-end, like
+    // acpx-cli. The 1ms floor makes an already-expired deadline fail fast via
+    // the normal per-spawn timeout instead of granting a fresh slice.
+    const now = this.options.now ?? Date.now;
+    const deadline = now() + timeoutMs;
+    const remainingTimeoutMs = () => Math.max(deadline - now(), 1);
+    const sessionInitTimedOutError = () =>
+      new EnsureSessionFailedError(
+        `session initialization timed out after ${timeoutMs / 1000}s`,
+        "generic",
+      );
     const onStderrLine = onProgress
       ? (line: string) => {
           const trimmed = line.replace(/\r$/, "").trimEnd();
@@ -300,10 +315,7 @@ export class BridgeRuntime {
         // killed by the runner; surface a clear, user-facing error instead of
         // blocking this session's bridge lane forever.
         if (error instanceof CommandTimeoutError) {
-          throw new EnsureSessionFailedError(
-            `session initialization timed out after ${timeoutMs / 1000}s`,
-            "generic",
-          );
+          throw sessionInitTimedOutError();
         }
         throw error;
       }
@@ -311,7 +323,7 @@ export class BridgeRuntime {
 
     const ensured = await runWithVerboseFallback(
       ["sessions", "ensure", "--name", input.name],
-      (command, args) => this.run(command, args, { onStderrLine, timeoutMs }),
+      (command, args) => this.run(command, args, { onStderrLine, timeoutMs: remainingTimeoutMs() }),
     );
     if (ensured.code === 0) {
       onProgress?.("ready");
@@ -319,7 +331,17 @@ export class BridgeRuntime {
     }
 
     const existingSpec = resolveSpawnCommand(this.command, this.buildSessionArgs(input, ["sessions", "show", input.name]));
-    const existing = await this.run(existingSpec.command, existingSpec.args);
+    const runShowProbe = async (): Promise<CommandResult> => {
+      try {
+        return await this.run(existingSpec.command, existingSpec.args, { timeoutMs: remainingTimeoutMs() });
+      } catch (error) {
+        if (error instanceof CommandTimeoutError) {
+          throw sessionInitTimedOutError();
+        }
+        throw error;
+      }
+    };
+    const existing = await runShowProbe();
     if (existing.code === 0) {
       onProgress?.("ready");
       return {};
@@ -328,7 +350,7 @@ export class BridgeRuntime {
     onProgress?.("initializing");
     const created = await runWithVerboseFallback(
       ["sessions", "new", "--name", input.name],
-      (command, args) => this.runSessionCreate(command, args, input.cwd, { onStderrLine, timeoutMs }),
+      (command, args) => this.runSessionCreate(command, args, input.cwd, { onStderrLine, timeoutMs: remainingTimeoutMs() }),
     );
 
     if (created.code === 0) {
@@ -338,7 +360,7 @@ export class BridgeRuntime {
 
     const output = created.stderr || created.stdout || "";
     if (output.includes("EPERM") && await this.repairSessionIndex()) {
-      const repaired = await this.run(existingSpec.command, existingSpec.args);
+      const repaired = await runShowProbe();
       if (repaired.code === 0) {
         onProgress?.("ready");
         return {};

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -325,6 +325,7 @@ export class CommandRouter {
           const currentSession = await this.sessions.getCurrentSession(chatKey);
           return await handleLaterCreate(
             command.tokens,
+            command.tails,
             this.scheduled,
             chatKey,
             currentSession

--- a/src/commands/handlers/later-handler.ts
+++ b/src/commands/handlers/later-handler.ts
@@ -44,6 +44,10 @@ export function handleLaterHelp(): RouterResponse {
 
 export async function handleLaterCreate(
   tokens: string[],
+  // Parallel to `tokens`: tails[i] is the verbatim input from token i to the
+  // end (quotes and internal spacing intact). The stored message must come
+  // from here so user content is never rewritten by tokenization.
+  tails: string[],
   scheduled: ScheduledRouterOps,
   chatKey: string,
   currentSession: { alias: string; agent: string; workspace: string } | null,
@@ -54,14 +58,15 @@ export async function handleLaterCreate(
   const l = t().later;
 
   // Consume any leading --bind / --temp flags (mutually exclusive).
-  let rest = tokens;
+  let restStart = 0;
   const seenFlags = new Set<string>();
   let flagMode: ScheduledSessionMode | undefined;
-  while (rest.length > 0 && (rest[0] === "--bind" || rest[0] === "--temp")) {
-    seenFlags.add(rest[0]);
-    flagMode = rest[0] === "--bind" ? "bound" : "temp";
-    rest = rest.slice(1);
+  while (restStart < tokens.length && (tokens[restStart] === "--bind" || tokens[restStart] === "--temp")) {
+    seenFlags.add(tokens[restStart] ?? "");
+    flagMode = tokens[restStart] === "--bind" ? "bound" : "temp";
+    restStart += 1;
   }
+  const rest = tokens.slice(restStart);
   if (seenFlags.size > 1) {
     return { text: l.bindAndTempMutuallyExclusive };
   }
@@ -84,7 +89,9 @@ export async function handleLaterCreate(
     return { text: renderTimeParseError(result.code, result.value) };
   }
 
-  const message = rest.slice(result.messageStartIndex).join(" ").trim();
+  // Verbatim message body: take the raw tail at the first body token instead
+  // of re-joining tokens (which would strip quotes and collapse spacing).
+  const message = (tails[restStart + result.messageStartIndex] ?? "").trim();
   if (message.startsWith("/")) {
     return {
       text: [

--- a/src/commands/parse-command.ts
+++ b/src/commands/parse-command.ts
@@ -62,7 +62,10 @@ export type ParsedCommand =
   | { kind: "session.native.select"; identifier: string; alias?: string }
   | { kind: "session.native.attach"; identifier: string; alias?: string }
   | { kind: "later.help" }
-  | { kind: "later.create"; tokens: string[] }
+  // tokens: quote-stripped values for structured parsing (flags, time spec).
+  // tails: parallel array; tails[i] is the verbatim input from token i to the
+  // end — the message body must be taken from here, never re-joined from tokens.
+  | { kind: "later.create"; tokens: string[]; tails: string[] }
   | { kind: "later.list" }
   | { kind: "later.cancel"; id: string }
   | { kind: "invalid"; text: string; recognizedCommand: string }
@@ -74,7 +77,14 @@ export function parseCommand(input: string): ParsedCommand {
     return { kind: "prompt", text: trimmed };
   }
 
-  const parts = tokenizeCommand(trimmed);
+  const tokens = tokenizeCommand(trimmed);
+  const parts = tokens.map((token) => token.value);
+  // Verbatim tail of the input starting at token `index` — quote characters
+  // and internal spacing intact. Free-text bodies (messages, task texts,
+  // titles) MUST use this; rebuilding them via parts.join(" ") silently
+  // rewrites user content (tokenization strips quotes and collapses spaces).
+  const rawTail = (index: number): string =>
+    index < tokens.length ? trimmed.slice(tokens[index]?.start ?? 0) : "";
   const command = normalizeCommand(parts[0] ?? "");
 
   if (command === "/help" && parts.length === 1) return { kind: "help" };
@@ -186,7 +196,7 @@ export function parseCommand(input: string): ParsedCommand {
   }
 
   if (command === "/group" && parts[1] === "new" && parts.length > 2) {
-    const title = parts.slice(2).join(" ");
+    const title = rawTail(2);
     if (title.trim().length > 0) {
       return { kind: "group.new", title };
     }
@@ -212,7 +222,7 @@ export function parseCommand(input: string): ParsedCommand {
       }
       break;
     }
-    const task = parts.slice(index).join(" ");
+    const task = rawTail(index);
     if (groupId.trim().length > 0 && targetAgent.trim().length > 0 && task.trim().length > 0) {
       return {
         kind: "group.delegate",
@@ -278,7 +288,7 @@ export function parseCommand(input: string): ParsedCommand {
   }
 
   if ((command === "/delegate" || command === "/dg") && parts[1]) {
-    const parsedDelegate = parseDelegateRequest(parts);
+    const parsedDelegate = parseDelegateRequest(parts, rawTail);
     if (parsedDelegate) {
       return parsedDelegate;
     }
@@ -306,7 +316,11 @@ export function parseCommand(input: string): ParsedCommand {
     if (parts[1] === "cancel" && parts[2] && parts.length === 3) {
       return { kind: "later.cancel", id: parts[2] };
     }
-    return { kind: "later.create", tokens: parts.slice(1) };
+    return {
+      kind: "later.create",
+      tokens: parts.slice(1),
+      tails: tokens.slice(1).map((_, index) => rawTail(index + 1)),
+    };
   }
 
   if (command === "/workspace" && parts[1] === "new" && parts[2]) {
@@ -664,12 +678,28 @@ const QUOTE_PAIRS: Record<string, string> = {
   "＂": "＂", // ＂ … ＂
 };
 
-function tokenizeCommand(input: string): string[] {
-  const tokens: string[] = [];
+interface CommandToken {
+  /** Token value with quote characters stripped (structured-arg semantics). */
+  value: string;
+  /**
+   * Code-unit offset of the token's first source character in the tokenized
+   * string — the opening quote itself when the token starts quoted. Lets
+   * free-text consumers slice the original input verbatim from a token.
+   */
+  start: number;
+}
+
+function tokenizeCommand(input: string): CommandToken[] {
+  const tokens: CommandToken[] = [];
   let current = "";
+  let start = -1;
   let closingQuote: string | null = null;
+  let offset = 0;
 
   for (const char of input) {
+    const charStart = offset;
+    offset += char.length;
+
     if (closingQuote) {
       if (char === closingQuote) {
         closingQuote = null;
@@ -681,23 +711,27 @@ function tokenizeCommand(input: string): string[] {
 
     const close = QUOTE_PAIRS[char];
     if (close) {
+      if (start === -1) start = charStart;
       closingQuote = close;
       continue;
     }
 
     if (/\s/.test(char)) {
       if (current.length > 0) {
-        tokens.push(current);
+        tokens.push({ value: current, start });
         current = "";
       }
+      // An empty quoted pair ("" etc.) produces no token; drop its offset too.
+      start = -1;
       continue;
     }
 
+    if (start === -1) start = charStart;
     current += char;
   }
 
   if (current.length > 0) {
-    tokens.push(current);
+    tokens.push({ value: current, start });
   }
 
   return tokens;
@@ -755,7 +789,10 @@ function parseListFilterFlags(
   return { filter, ok: true };
 }
 
-function parseDelegateRequest(parts: string[]): Extract<ParsedCommand, { kind: "delegate.request" }> | null {
+function parseDelegateRequest(
+  parts: string[],
+  rawTail: (index: number) => string,
+): Extract<ParsedCommand, { kind: "delegate.request" }> | null {
   const targetAgent = parts[1];
   if (!targetAgent) {
     return null;
@@ -785,7 +822,7 @@ function parseDelegateRequest(parts: string[]): Extract<ParsedCommand, { kind: "
     break;
   }
 
-  const task = parts.slice(index).join(" ");
+  const task = rawTail(index);
   if (task.trim().length === 0) {
     return null;
   }

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 
-import { writePrivateFileAtomic } from "../util/private-file.js";
+import { withPrivateFileLock } from "../util/private-file.js";
 
 import { loadConfig, parseConfig } from "./load-config";
 import type { AgentConfig, AppConfig, ChannelRuntimeConfig, PluginConfig } from "./types";
@@ -119,20 +119,25 @@ export class ConfigStore {
     });
   }
 
+  // The whole read→patch→write span runs under ONE file lock: locking only
+  // the write (the old shape) let two concurrent mutations read the same
+  // snapshot, so the last writer silently erased the other's change.
   private async patchRaw(mutate: (raw: RawConfig) => void): Promise<AppConfig> {
-    const { raw, existed } = await this.readRaw();
-    // For a brand-new file, seed the required sections into the WRITTEN doc so
-    // the file round-trips through load() (parseConfig requires transport/
-    // agents/workspaces to be objects). For an existing file we only patch the
-    // targeted subtree and never inject these sections.
-    const doc: RawConfig = existed ? raw : { transport: {}, agents: {}, workspaces: {} };
-    mutate(doc);
-    // Validate the patched document before it lands on disk. The required
-    // sections are backfilled for validation so a sparse existing file still
-    // parses with defaults, without pinning those defaults into the file.
-    const parsed = parseConfig({ transport: {}, agents: {}, workspaces: {}, ...doc });
-    await writePrivateFileAtomic(this.path, serializeRawConfig(doc));
-    return parsed;
+    return await withPrivateFileLock(this.path, async (writeLocked) => {
+      const { raw, existed } = await this.readRaw();
+      // For a brand-new file, seed the required sections into the WRITTEN doc so
+      // the file round-trips through load() (parseConfig requires transport/
+      // agents/workspaces to be objects). For an existing file we only patch the
+      // targeted subtree and never inject these sections.
+      const doc: RawConfig = existed ? raw : { transport: {}, agents: {}, workspaces: {} };
+      mutate(doc);
+      // Validate the patched document before it lands on disk. The required
+      // sections are backfilled for validation so a sparse existing file still
+      // parses with defaults, without pinning those defaults into the file.
+      const parsed = parseConfig({ transport: {}, agents: {}, workspaces: {}, ...doc });
+      await writeLocked(serializeRawConfig(doc));
+      return parsed;
+    });
   }
 
   private async readRaw(): Promise<{ raw: RawConfig; existed: boolean }> {

--- a/src/i18n/messages/en/plugin-cli.ts
+++ b/src/i18n/messages/en/plugin-cli.ts
@@ -7,6 +7,8 @@ export const pluginCli: PluginCliMessages = {
 
   // addPlugin
   unrecognizedArgs: (args) => `Unrecognized arguments: ${args}`,
+  pluginSpecHasDoubleQuote: (spec) => `Invalid plugin spec ${spec}: double quotes (") are never valid in an npm package spec.`,
+  pluginSpecHasPercentOnWindows: (spec) => `Invalid plugin spec ${spec}: "%" would be mangled by cmd.exe on Windows. Install the package with npm directly instead.`,
   pluginInstallFailed: (packageSpec, error) => `Plugin ${packageSpec} install failed: ${error}`,
   pluginValidateFailed: (recordedName, error) => `Plugin ${recordedName} validation failed: ${error}`,
   pluginInstalled: (recordedName) => `Plugin ${recordedName} installed`,

--- a/src/i18n/messages/zh/plugin-cli.ts
+++ b/src/i18n/messages/zh/plugin-cli.ts
@@ -7,6 +7,8 @@ export const pluginCli: PluginCliMessages = {
 
   // addPlugin
   unrecognizedArgs: (args) => `未识别的参数：${args}`,
+  pluginSpecHasDoubleQuote: (spec) => `非法插件 spec ${spec}：npm 包 spec 不允许包含双引号 (")。`,
+  pluginSpecHasPercentOnWindows: (spec) => `非法插件 spec ${spec}：Windows 上 cmd.exe 会展开 %，无法安全传递。请改用 npm 直接安装该包。`,
   pluginInstallFailed: (packageSpec, error) => `插件 ${packageSpec} 安装失败：${error}`,
   pluginValidateFailed: (recordedName, error) => `插件 ${recordedName} 校验失败：${error}`,
   pluginInstalled: (recordedName) => `插件 ${recordedName} 已安装`,

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1028,6 +1028,8 @@ export interface PluginCliMessages {
 
   // addPlugin
   unrecognizedArgs: (args: string) => string;
+  pluginSpecHasDoubleQuote: (spec: string) => string;
+  pluginSpecHasPercentOnWindows: (spec: string) => string;
   pluginInstallFailed: (packageSpec: string, error: string) => string;
   pluginValidateFailed: (recordedName: string, error: string) => string;
   pluginInstalled: (recordedName: string) => string;

--- a/src/plugins/plugin-cli.ts
+++ b/src/plugins/plugin-cli.ts
@@ -12,6 +12,30 @@ import { listKnownPlugins } from "./known-plugins.js";
 import { normalizePluginPackageName } from "./plugin-renames.js";
 import { t } from "../i18n";
 
+// User-supplied install specs reach the package manager through cmd.exe on
+// win32 (shellSpawnPlan in package-manager.ts wraps args in bare double
+// quotes), so reject what that wrapper cannot carry safely: `"` escapes the
+// wrapper (and is never valid in an npm spec anywhere), and `%VAR%` is
+// expanded by cmd.exe even inside quotes.
+export function findPluginSpecViolation(
+  spec: string,
+  platform: NodeJS.Platform,
+): "double-quote" | "percent-on-windows" | null {
+  if (spec.includes('"')) return "double-quote";
+  if (platform === "win32" && spec.includes("%")) return "percent-on-windows";
+  return null;
+}
+
+function invalidSpecMessage(specs: Array<string | undefined>, platform: NodeJS.Platform): string | null {
+  for (const spec of specs) {
+    if (!spec) continue;
+    const violation = findPluginSpecViolation(spec, platform);
+    if (violation === "double-quote") return t().pluginCli.pluginSpecHasDoubleQuote(spec);
+    if (violation === "percent-on-windows") return t().pluginCli.pluginSpecHasPercentOnWindows(spec);
+  }
+  return null;
+}
+
 export function looksLikePath(spec: string): boolean {
   return (
     spec === "." ||
@@ -86,6 +110,8 @@ export interface PluginCliDeps {
   removePackage?: (packageName: string) => Promise<void>;
   validateInstalledPlugin?: (packageName: string) => Promise<{ name: string; channels: string[] }>;
   inspectPlugins?: (input: { config: AppConfig; pluginHome: string; pluginName?: string }) => Promise<PluginDoctorIssue[]>;
+  /** Test seam: spec validation depends on the target shell (cmd.exe on win32). */
+  platform?: NodeJS.Platform;
 }
 
 export async function handlePluginCli(args: string[], deps: PluginCliDeps): Promise<number | null> {
@@ -235,6 +261,11 @@ async function addPlugin(packageSpec: string, rawArgs: string[], deps: PluginCli
     deps.print(t().pluginCli.unrecognizedArgs(flags.rest.join(" ")));
     return 1;
   }
+  const invalidSpec = invalidSpecMessage([packageSpec, flags.version], deps.platform ?? process.platform);
+  if (invalidSpec) {
+    deps.print(invalidSpec);
+    return 1;
+  }
 
   const pluginHome = deps.pluginHome ?? resolvePluginHome();
   await ensurePluginHome(pluginHome);
@@ -355,6 +386,11 @@ async function updatePlugins(args: string[], deps: PluginCliDeps): Promise<numbe
   }
   if (target === "--all" && flags.version) {
     deps.print("--all cannot be combined with --version");
+    return 1;
+  }
+  const invalidSpec = invalidSpecMessage([flags.version], deps.platform ?? process.platform);
+  if (invalidSpec) {
+    deps.print(invalidSpec);
     return 1;
   }
 

--- a/src/plugins/plugin-cli.ts
+++ b/src/plugins/plugin-cli.ts
@@ -368,7 +368,7 @@ async function removePlugin(packageName: string, rawArgs: string[], deps: Plugin
 
   config.plugins = config.plugins.filter((entry) => entry.name !== existing.name);
   await deps.savePlugins(config.plugins);
-  deps.print(t().pluginCli.pluginRemoved(packageName));
+  deps.print(t().pluginCli.pluginRemoved(existing.name));
   return await maybeRestartAfterMutation(flags.restart, deps);
 }
 

--- a/src/scheduled/scheduled-scheduler.ts
+++ b/src/scheduled/scheduled-scheduler.ts
@@ -76,7 +76,6 @@ export class ScheduledTaskScheduler {
       for (const task of dueTasks) {
         try {
           await this.dispatchWithTimeout(task);
-          await this.service.markExecuted(task.id);
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           await this.logger?.error("scheduled.dispatch.failed", "failed to dispatch scheduled task", {
@@ -98,6 +97,23 @@ export class ScheduledTaskScheduler {
               },
             );
           }
+          continue;
+        }
+        try {
+          await this.service.markExecuted(task.id);
+        } catch (markError) {
+          // The dispatch SUCCEEDED — only the bookkeeping write failed, so the
+          // task must not be recorded as failed. Leave its state alone (disk
+          // likely still says "triggering"); startup reconciliation handles
+          // the stale record.
+          await this.logger?.error(
+            "scheduled.dispatch.mark_executed_failed",
+            "markExecuted threw after a successful dispatch; leaving task state for startup reconciliation",
+            {
+              taskId: task.id,
+              message: markError instanceof Error ? markError.message : String(markError),
+            },
+          );
         }
       }
     } finally {

--- a/src/util/private-file.ts
+++ b/src/util/private-file.ts
@@ -11,7 +11,21 @@ const WRITE_RETRY_BASE_DELAY_MS = 50;
 const WRITE_RETRY_MAX_DELAY_MS = 500;
 const LOCKFILE_STALE_MS = 10_000;
 
-export async function writePrivateFileAtomic(path: string, content: string): Promise<void> {
+/**
+ * Runs `fn` while holding the file's proper-lockfile lock, so a caller can make
+ * a whole read→modify→write span atomic with respect to other xacpx-aware
+ * processes (writePrivateFileAtomic alone only serializes the write).
+ *
+ * proper-lockfile is NOT reentrant: inside `fn`, write through the provided
+ * `writeLocked` (same atomic semantics, no re-lock) — never call
+ * writePrivateFileAtomic on the same path or it will deadlock until the lock
+ * goes stale. `realpath: false` keeps locking working for a not-yet-existing
+ * target file (the lock lives at `<path>.lock`).
+ */
+export async function withPrivateFileLock<T>(
+  path: string,
+  fn: (writeLocked: (content: string) => Promise<void>) => Promise<T>,
+): Promise<T> {
   await mkdir(dirname(path), { recursive: true });
 
   const release = await lockfile.lock(path, {
@@ -27,29 +41,39 @@ export async function writePrivateFileAtomic(path: string, content: string): Pro
   });
 
   try {
-    try {
-      await retryTransientWriteErrors(
-        async () =>
-          writeFileAtomic(path, content, {
-            mode: PRIVATE_FILE_MODE,
-            encoding: "utf8",
-            fsync: true,
-          }),
-      );
-    } catch (error) {
-      if (!isTransientWriteError(error, process.platform)) {
-        throw error;
-      }
-      // Last-ditch Windows fallback: rename is exhausted (e.g. AV holds the
-      // target without FILE_SHARE_DELETE). Direct overwrite sacrifices
-      // atomicity but stays within FILE_SHARE_WRITE-friendly territory and
-      // is preferable to losing the write entirely. We still hold the
-      // proper-lockfile, so xacpx-aware processes are excluded.
-      await writeFile(path, content, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
-      await chmod(path, PRIVATE_FILE_MODE).catch(() => {});
-    }
+    return await fn((content) => writePrivateFileAtomicUnlocked(path, content));
   } finally {
     await release();
+  }
+}
+
+export async function writePrivateFileAtomic(path: string, content: string): Promise<void> {
+  await withPrivateFileLock(path, async (writeLocked) => {
+    await writeLocked(content);
+  });
+}
+
+async function writePrivateFileAtomicUnlocked(path: string, content: string): Promise<void> {
+  try {
+    await retryTransientWriteErrors(
+      async () =>
+        writeFileAtomic(path, content, {
+          mode: PRIVATE_FILE_MODE,
+          encoding: "utf8",
+          fsync: true,
+        }),
+    );
+  } catch (error) {
+    if (!isTransientWriteError(error, process.platform)) {
+      throw error;
+    }
+    // Last-ditch Windows fallback: rename is exhausted (e.g. AV holds the
+    // target without FILE_SHARE_DELETE). Direct overwrite sacrifices
+    // atomicity but stays within FILE_SHARE_WRITE-friendly territory and
+    // is preferable to losing the write entirely. We still hold the
+    // proper-lockfile, so xacpx-aware processes are excluded.
+    await writeFile(path, content, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
+    await chmod(path, PRIVATE_FILE_MODE).catch(() => {});
   }
 }
 

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 
 import {
   BridgeRuntime,
+  CommandTimeoutError,
   runStreamingPrompt,
   selectLatestAcpxSessionIndexTmp,
   spawnCapture,
@@ -333,6 +334,8 @@ test("ensureSession defaults the session init timeout to 120s and threads it int
       if (args.includes("ensure")) ensureTimeouts.push(options?.timeoutMs);
       return { code: args.includes("ensure") ? 0 : 1, stdout: "", stderr: "" };
     },
+    undefined,
+    { now: () => 0 },
   );
   await defaultedRuntime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" });
   expect(ensureTimeouts).toEqual([120_000]);
@@ -347,11 +350,114 @@ test("ensureSession defaults the session init timeout to 120s and threads it int
       createTimeouts.push(options?.timeoutMs);
       return { code: 0, stdout: "", stderr: "" };
     },
-    { sessionInitTimeoutMs: 45_000 },
+    { sessionInitTimeoutMs: 45_000, now: () => 0 },
   );
   await configuredRuntime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" });
   expect(ensureTimeouts).toEqual([120_000, 45_000]);
   expect(createTimeouts).toEqual([45_000]);
+});
+
+test("ensureSession shares one deadline: later steps only get the remaining budget", async () => {
+  let clock = 0;
+  const captured: Array<{ step: string; timeoutMs: number | undefined }> = [];
+  const runtime = new BridgeRuntime(
+    "acpx",
+    async (_command, args, options?: CommandRunnerOptions) => {
+      if (args.includes("ensure")) {
+        captured.push({ step: "ensure", timeoutMs: options?.timeoutMs });
+        clock += 80_000;
+        return { code: 1, stdout: "", stderr: "ensure failed" };
+      }
+      captured.push({ step: "show", timeoutMs: options?.timeoutMs });
+      clock += 15_000;
+      return { code: 1, stdout: "", stderr: "show failed" };
+    },
+    async (_command, _args, _cwd, options?: CommandRunnerOptions) => {
+      captured.push({ step: "new", timeoutMs: options?.timeoutMs });
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    { sessionInitTimeoutMs: 100_000, now: () => clock },
+  );
+
+  await runtime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" });
+
+  expect(captured).toEqual([
+    { step: "ensure", timeoutMs: 100_000 },
+    { step: "show", timeoutMs: 20_000 },
+    { step: "new", timeoutMs: 5_000 },
+  ]);
+});
+
+test("ensureSession floors the per-step timeout at 1ms once the deadline is spent", async () => {
+  let clock = 0;
+  const captured: Array<number | undefined> = [];
+  const runtime = new BridgeRuntime(
+    "acpx",
+    async (_command, args, options?: CommandRunnerOptions) => {
+      captured.push(options?.timeoutMs);
+      if (args.includes("ensure")) clock += 150_000; // burns past the whole budget
+      return { code: 1, stdout: "", stderr: "failed" };
+    },
+    async (_command, _args, _cwd, options?: CommandRunnerOptions) => {
+      captured.push(options?.timeoutMs);
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    { sessionInitTimeoutMs: 100_000, now: () => clock },
+  );
+
+  await runtime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" });
+
+  expect(captured).toEqual([100_000, 1, 1]);
+});
+
+test("ensureSession verbose-fallback retry draws from the same shared deadline", async () => {
+  let clock = 0;
+  const ensureTimeouts: Array<number | undefined> = [];
+  const runtime = new BridgeRuntime(
+    "acpx",
+    async (_command, args, options?: CommandRunnerOptions) => {
+      ensureTimeouts.push(options?.timeoutMs);
+      clock += 30_000;
+      if (args.includes("--verbose")) {
+        return { code: 1, stdout: "", stderr: "error: unknown option '--verbose'" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    undefined,
+    { sessionInitTimeoutMs: 100_000, now: () => clock },
+  );
+
+  await runtime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" });
+
+  expect(ensureTimeouts).toEqual([100_000, 70_000]);
+});
+
+test("ensureSession surfaces the configured total when a later step times out", async () => {
+  let clock = 0;
+  const runtime = new BridgeRuntime(
+    "acpx",
+    async (_command, args) => {
+      if (args.includes("ensure")) {
+        clock += 90_000;
+        return { code: 1, stdout: "", stderr: "ensure failed" };
+      }
+      // Show probe hangs until its (remaining) slice expires.
+      clock += 10_000;
+      throw new CommandTimeoutError(10_000, "acpx sessions show demo");
+    },
+    undefined,
+    { sessionInitTimeoutMs: 100_000, now: () => clock },
+  );
+
+  let caught: unknown;
+  try {
+    await runtime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo" });
+  } catch (error) {
+    caught = error;
+  }
+
+  expect((caught as Error).name).toBe("EnsureSessionFailedError");
+  expect((caught as Error).message).toBe("session initialization timed out after 100s");
 });
 
 test("prompt and other session commands are not subject to the session init timeout", async () => {

--- a/tests/unit/commands/command-router-later.test.ts
+++ b/tests/unit/commands/command-router-later.test.ts
@@ -120,6 +120,39 @@ test("/lt in 2h 检查 CI creates a task recording the current session as origin
   expect(call.sessionAlias).toBe("backend:codex");
 });
 
+test("/lt stores the message verbatim — quotes and internal spacing intact", async () => {
+  const state = createEmptyState();
+  state.sessions["backend:codex"] = {
+    alias: "backend:codex",
+    agent: "codex",
+    workspace: "backend",
+    transport_session: "backend:backend:codex",
+    created_at: "2026-05-23T09:00:00.000Z",
+    last_used_at: "2026-05-23T09:00:00.000Z",
+  };
+  state.chat_contexts["wx:user"] = { current_session: "backend:codex" };
+
+  const cases: Array<{ input: string; message: string }> = [
+    // Curly quotes from Chinese IMEs must not be stripped from the body.
+    { input: "/later in 2h 提醒我看“报告”", message: "提醒我看“报告”" },
+    // Straight quotes and a multi-space run survive.
+    { input: '/lt in 2h remind me to say "hello"  twice', message: 'remind me to say "hello"  twice' },
+    // A body that starts with a quoted word keeps its opening quote.
+    { input: '/lt in 2h "hello world" now', message: '"hello world" now' },
+    // A leading --temp flag is still consumed before the time spec.
+    { input: "/lt --temp in 2h 检查＂版本＂号", message: "检查＂版本＂号" },
+  ];
+
+  for (const { input, message } of cases) {
+    const scheduled = createMockScheduled();
+    const { router } = buildRouter({ scheduled, state });
+    await router.handle("wx:user", input);
+    expect(scheduled.createTask).toHaveBeenCalledTimes(1);
+    const call = (scheduled.createTask as ReturnType<typeof mock>).mock.calls[0][0] as CreateScheduledTaskInput;
+    expect(call.message).toBe(message);
+  }
+});
+
 test("/lt rejects creation when channel lacks scheduled-message support", async () => {
   const scheduled = createMockScheduled();
   const scheduledDelivery: ScheduledDeliveryCapabilityOps = {

--- a/tests/unit/commands/parse-command.test.ts
+++ b/tests/unit/commands/parse-command.test.ts
@@ -395,6 +395,53 @@ test("parses orchestration delegate commands", () => {
   });
 });
 
+test("free-text bodies keep quotes and internal spacing verbatim", () => {
+  // Curly quotes (Chinese IME default) stay in the delegate task text.
+  expect(parseCommand("/delegate claude 审查“报告”初稿")).toEqual({
+    kind: "delegate.request",
+    targetAgent: "claude",
+    task: "审查“报告”初稿",
+  });
+  // Straight quotes stay; structured flag prefix still parses.
+  expect(parseCommand('/dg claude --role reviewer remind me to say "hello"')).toEqual({
+    kind: "delegate.request",
+    targetAgent: "claude",
+    role: "reviewer",
+    task: 'remind me to say "hello"',
+  });
+  // A body that STARTS with a quoted word keeps its opening quote.
+  expect(parseCommand('/delegate claude "hello world" now')).toEqual({
+    kind: "delegate.request",
+    targetAgent: "claude",
+    task: '"hello world" now',
+  });
+  // Runs of internal spaces survive.
+  expect(parseCommand("/delegate claude keep  two   spaces")).toEqual({
+    kind: "delegate.request",
+    targetAgent: "claude",
+    task: "keep  two   spaces",
+  });
+  // Mixed straight + full-width quotes survive.
+  expect(parseCommand('/delegate claude 检查＂版本＂和 "tag"')).toEqual({
+    kind: "delegate.request",
+    targetAgent: "claude",
+    task: '检查＂版本＂和 "tag"',
+  });
+  // /group new title is verbatim.
+  expect(parseCommand("/group new “并行 评审” v2")).toEqual({
+    kind: "group.new",
+    title: "“并行 评审” v2",
+  });
+  // /group add task tail is verbatim after the --role flag.
+  expect(parseCommand('/group add g1 claude --role reviewer say "hi"  there')).toEqual({
+    kind: "group.delegate",
+    groupId: "g1",
+    targetAgent: "claude",
+    role: "reviewer",
+    task: 'say "hi"  there',
+  });
+});
+
 test("parses orchestration group commands", () => {
   expect(parseCommand("/groups")).toEqual({
     kind: "groups",
@@ -403,9 +450,10 @@ test("parses orchestration group commands", () => {
     kind: "group.new",
     title: "parallel-review",
   });
+  // The title is a free-text tail: it is stored verbatim, quotes included.
   expect(parseCommand('/group new "parallel review"')).toEqual({
     kind: "group.new",
-    title: "parallel review",
+    title: '"parallel review"',
   });
   expect(parseCommand("/group group-review")).toEqual({
     kind: "group.get",
@@ -798,6 +846,36 @@ test("parses later commands", () => {
   expect(parseCommand("/lt in 2h 检查 CI")).toEqual({
     kind: "later.create",
     tokens: ["in", "2h", "检查", "CI"],
+    tails: ["in 2h 检查 CI", "2h 检查 CI", "检查 CI", "CI"],
+  });
+});
+
+test("later.create tails keep quotes and internal spacing verbatim", () => {
+  // Curly quotes (Chinese IME default) survive in the tail even though the
+  // tokenized values strip them.
+  expect(parseCommand("/later in 2h 提醒我看“报告”")).toEqual({
+    kind: "later.create",
+    tokens: ["in", "2h", "提醒我看报告"],
+    tails: ["in 2h 提醒我看“报告”", "2h 提醒我看“报告”", "提醒我看“报告”"],
+  });
+  // Straight quotes and a multi-space run survive; a tail that starts with a
+  // quoted word keeps its opening quote.
+  expect(parseCommand('/later in 2h say "hello"  twice')).toEqual({
+    kind: "later.create",
+    tokens: ["in", "2h", "say", "hello", "twice"],
+    tails: [
+      'in 2h say "hello"  twice',
+      '2h say "hello"  twice',
+      'say "hello"  twice',
+      '"hello"  twice',
+      "twice",
+    ],
+  });
+  // Full-width quotes survive too.
+  expect(parseCommand("/lt in 2h 检查＂版本＂号")).toEqual({
+    kind: "later.create",
+    tokens: ["in", "2h", "检查版本号"],
+    tails: ["in 2h 检查＂版本＂号", "2h 检查＂版本＂号", "检查＂版本＂号"],
   });
 });
 

--- a/tests/unit/config/config-store.test.ts
+++ b/tests/unit/config/config-store.test.ts
@@ -464,3 +464,50 @@ test("writes with 2-space indent, trailing newline, and owner-only permissions",
 
   await rm(dir, { recursive: true, force: true });
 });
+
+test("concurrent patchRaw mutations all land — lock spans read→patch→write", async () => {
+  // Pre-fix, the proper-lockfile lock only covered the WRITE inside
+  // writePrivateFileAtomic: concurrent mutations all read the same snapshot
+  // and the last writer erased the others' keys (lost update).
+  const { dir, path } = await makeConfigFile({
+    transport: { type: "acpx-bridge" },
+    agents: { codex: { driver: "codex" } },
+    workspaces: {},
+  });
+  const store = new ConfigStore(path);
+
+  const names = ["w1", "w2", "w3", "w4", "w5"];
+  await Promise.all(names.map((name) => store.upsertWorkspace(name, `/repo/${name}`)));
+
+  const raw = await readRaw(path);
+  const workspaces = raw.workspaces as Record<string, { cwd: string }>;
+  expect(Object.keys(workspaces).sort()).toEqual(names);
+  for (const name of names) {
+    expect(workspaces[name]).toEqual({ cwd: `/repo/${name}` });
+  }
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("concurrent mutations from two ConfigStore instances on the same file all land", async () => {
+  // Same race across separate store instances (e.g. /pm set during /config
+  // set in two processes) — the file lock, not instance state, must serialize.
+  const { dir, path } = await makeConfigFile({
+    transport: { type: "acpx-bridge" },
+    agents: {},
+    workspaces: {},
+  });
+  const storeA = new ConfigStore(path);
+  const storeB = new ConfigStore(path);
+
+  await Promise.all([
+    storeA.upsertAgent("codex", { driver: "codex" }),
+    storeB.upsertWorkspace("backend", "/repo/backend"),
+  ]);
+
+  const raw = await readRaw(path);
+  expect((raw.agents as Record<string, unknown>).codex).toEqual({ driver: "codex" });
+  expect((raw.workspaces as Record<string, unknown>).backend).toEqual({ cwd: "/repo/backend" });
+
+  await rm(dir, { recursive: true, force: true });
+});

--- a/tests/unit/plugins/plugin-cli.test.ts
+++ b/tests/unit/plugins/plugin-cli.test.ts
@@ -268,6 +268,9 @@ test("plugin rm with legacy name removes the normalized config entry (Bug A)", a
   // npm (config gone, package orphaned) and a hard failure with bun.
   expect(harness.calls).toEqual(["remove:@ganglion/xacpx-channel-feishu"]);
   expect(validatedNames).toEqual(["@ganglion/xacpx-channel-feishu"]);
+  // The success message must name the actually removed (normalized) package,
+  // not the raw legacy input — consistent with the failure path.
+  expect(harness.lines).toContain(t().pluginCli.pluginRemoved("@ganglion/xacpx-channel-feishu"));
 });
 
 test("plugin disable and enable toggle config", async () => {

--- a/tests/unit/plugins/plugin-cli.test.ts
+++ b/tests/unit/plugins/plugin-cli.test.ts
@@ -105,6 +105,78 @@ test("plugin add installs, validates, saves config, and does not enable channel"
   expect(harness.lines).toContain(t().pluginCli.providesChannels("demo"));
 });
 
+test("plugin add rejects specs containing double quotes on all platforms", async () => {
+  for (const platform of ["linux", "darwin", "win32"] as NodeJS.Platform[]) {
+    const harness = createHarness(baseConfig());
+
+    const code = await handlePluginCli(["add", 'evil"pkg'], { ...harness.deps, platform });
+
+    expect(code).toBe(1);
+    expect(harness.calls).toEqual([]);
+    expect(harness.lines).toContain(t().pluginCli.pluginSpecHasDoubleQuote('evil"pkg'));
+  }
+});
+
+test("plugin add rejects specs containing % on win32 with an npm workaround hint", async () => {
+  const harness = createHarness(baseConfig());
+
+  const code = await handlePluginCli(["add", "pkg%PATH%"], { ...harness.deps, platform: "win32" });
+
+  expect(code).toBe(1);
+  expect(harness.calls).toEqual([]);
+  expect(harness.lines).toContain(t().pluginCli.pluginSpecHasPercentOnWindows("pkg%PATH%"));
+});
+
+test("plugin add allows specs containing % on posix", async () => {
+  const harness = createHarness(baseConfig());
+
+  const code = await handlePluginCli(["add", "https://example.com/p%20kg.tgz"], { ...harness.deps, platform: "linux" });
+
+  expect(code).toBe(0);
+  expect(harness.calls).toEqual(["install:https://example.com/p%20kg.tgz:"]);
+});
+
+test("plugin add validates the --version value like a spec", async () => {
+  const quoteHarness = createHarness(baseConfig());
+  const quoteCode = await handlePluginCli(
+    ["add", "demo", "--version", '1.0.0"'],
+    { ...quoteHarness.deps, platform: "linux" },
+  );
+  expect(quoteCode).toBe(1);
+  expect(quoteHarness.calls).toEqual([]);
+  expect(quoteHarness.lines).toContain(t().pluginCli.pluginSpecHasDoubleQuote('1.0.0"'));
+
+  const percentHarness = createHarness(baseConfig());
+  const percentCode = await handlePluginCli(
+    ["add", "demo", "--version", "%VER%"],
+    { ...percentHarness.deps, platform: "win32" },
+  );
+  expect(percentCode).toBe(1);
+  expect(percentHarness.calls).toEqual([]);
+  expect(percentHarness.lines).toContain(t().pluginCli.pluginSpecHasPercentOnWindows("%VER%"));
+});
+
+test("plugin update validates the --version value like a spec", async () => {
+  const harness = createHarness(baseConfig({ plugins: [{ name: "demo", version: "1.0.0", enabled: true }] }));
+
+  const code = await handlePluginCli(["update", "demo", "--version", "%VER%"], { ...harness.deps, platform: "win32" });
+
+  expect(code).toBe(1);
+  expect(harness.calls).toEqual([]);
+  expect(harness.lines).toContain(t().pluginCli.pluginSpecHasPercentOnWindows("%VER%"));
+});
+
+test("plugin add accepts normal npm specs on win32", async () => {
+  for (const spec of ["demo", "@scope/demo", "demo@^1.2.3", "demo@latest"]) {
+    const harness = createHarness(baseConfig());
+
+    const code = await handlePluginCli(["add", spec], { ...harness.deps, platform: "win32" });
+
+    expect(code).toBe(0);
+    expect(harness.calls).toEqual([`install:${spec}:`]);
+  }
+});
+
 test("plugin add replaces legacy weacpx package config with canonical xacpx package", async () => {
   const harness = createHarness(baseConfig({
     plugins: [{ name: "@ganglion/weacpx-channel-feishu", version: "0.2.2", enabled: true }],

--- a/tests/unit/scheduled/scheduled-scheduler.test.ts
+++ b/tests/unit/scheduled/scheduled-scheduler.test.ts
@@ -392,6 +392,99 @@ test("tick survives claimDueTasks throwing — no unhandled rejection", async ()
   expect(dispatchTask).toHaveBeenCalledTimes(0);
 });
 
+test("tick leaves a dispatched task alone when markExecuted throws — no markFailed", async () => {
+  // Dispatch SUCCEEDS, then markExecuted's state save throws. The task was
+  // delivered, so it must NOT be recorded as failed; startup reconciliation
+  // handles the stale "triggering" record.
+  const events: Array<{ event: string; context?: Record<string, unknown> }> = [];
+  const logger = {
+    debug: async () => {},
+    info: async () => {},
+    error: async (event: string, _message: string, context?: Record<string, unknown>) => {
+      events.push({ event, ...(context ? { context } : {}) });
+    },
+    cleanup: async () => {},
+    flush: async () => {},
+  };
+
+  const task = {
+    id: "ok-but-save-fails",
+    chat_key: "c",
+    session_alias: "s",
+    execute_at: "2026-05-23T09:59:00.000Z",
+    message: "delivered",
+    status: "triggering",
+    created_at: "2026-05-23T09:00:00.000Z",
+  };
+  const markFailed = mock(async () => {});
+  const service = {
+    markStartupMissed: async () => {},
+    claimDueTasks: async () => [task],
+    markExecuted: async () => {
+      throw new Error("disk full");
+    },
+    markFailed,
+  } as unknown as ScheduledTaskService;
+
+  const dispatchTask = mock(async () => {});
+  const { setIntervalFn, clearIntervalFn } = createFakeSetInterval();
+
+  const scheduler = new ScheduledTaskScheduler(service, {
+    dispatchTask,
+    setIntervalFn,
+    clearIntervalFn,
+    logger,
+  });
+
+  await expect(scheduler.tick()).resolves.toBeUndefined();
+
+  expect(dispatchTask).toHaveBeenCalledTimes(1);
+  expect(markFailed).toHaveBeenCalledTimes(0);
+  const markExecutedFailures = events.filter((entry) => entry.event === "scheduled.dispatch.mark_executed_failed");
+  expect(markExecutedFailures).toHaveLength(1);
+  expect(markExecutedFailures[0]?.context?.taskId).toBe("ok-but-save-fails");
+  expect(events.filter((entry) => entry.event === "scheduled.dispatch.failed")).toHaveLength(0);
+
+  // Ticking lock released — a later tick still runs.
+  await expect(scheduler.tick()).resolves.toBeUndefined();
+});
+
+test("tick still marks the task failed when the dispatch itself throws", async () => {
+  const task = {
+    id: "dispatch-throws",
+    chat_key: "c",
+    session_alias: "s",
+    execute_at: "2026-05-23T09:59:00.000Z",
+    message: "boom",
+    status: "triggering",
+    created_at: "2026-05-23T09:00:00.000Z",
+  };
+  const markExecuted = mock(async () => {});
+  const markFailed = mock(async () => {});
+  const service = {
+    markStartupMissed: async () => {},
+    claimDueTasks: async () => [task],
+    markExecuted,
+    markFailed,
+  } as unknown as ScheduledTaskService;
+
+  const dispatchTask = mock(async () => {
+    throw new Error("channel unavailable");
+  });
+  const { setIntervalFn, clearIntervalFn } = createFakeSetInterval();
+
+  const scheduler = new ScheduledTaskScheduler(service, {
+    dispatchTask,
+    setIntervalFn,
+    clearIntervalFn,
+  });
+
+  await expect(scheduler.tick()).resolves.toBeUndefined();
+
+  expect(markFailed).toHaveBeenCalledTimes(1);
+  expect(markExecuted).toHaveBeenCalledTimes(0);
+});
+
 test("tick survives dispatch failure AND markFailed throwing — no unhandled rejection", async () => {
   // Simulate: dispatch throws, then markFailed also throws (e.g. disk full during
   // the error-recording write). Neither error should escape tick().


### PR DESCRIPTION
Implements the follow-up list from `docs/superpowers/plans/2026-06-11-followup-batch.md` (the deferred items left after #20/#22, minus the shutdown-window cosmetic).

## Fixes

- **Free-text command bodies are stored verbatim** — `/later` messages, `/delegate` task text, and `/group new` titles no longer have straight/curly/full-width quotes stripped or internal spacing collapsed (Chinese IMEs emit curly quotes by default, so `/later in 2h 提醒我看“报告”` used to silently become `提醒我看报告`). The tokenizer now records source offsets and free-text tails slice the original input; structured args (flags, time specs, aliases) keep tokenized behavior including quoted-arg support.
- **Bridge `ensureSession` honors one deadline** — `sessions ensure`, the (previously untimed) `sessions show` probe, `sessions new`, the verbose fallback, and the EPERM-repair re-probe now share a single `sessionInitTimeoutMs` budget instead of each getting a full one (worst case was ≈2×+ the configured bound).
- **Plugin install specs are validated at the CLI boundary** — specs containing `\"` are rejected on all platforms (never valid in an npm spec; escapes the cmd.exe quote wrapper on Windows); specs containing `%` are rejected on Windows only (cmd.exe expands `%VAR%` even inside quotes) with "install via npm directly" as the suggested workaround. POSIX tarball URLs with `%20` keep working.
- **A dispatched scheduled task is never recorded as FAILED** when only the `markExecuted` state save fails — that failure now logs `scheduled.dispatch.mark_executed_failed` and leaves reconciliation to startup; dispatch failures still mark failed.
- **ConfigStore holds the file lock across read→patch→write** — two concurrent mutations (e.g. `/pm set` during `/config set`) no longer lose one update (new `withPrivateFileLock` in `private-file.ts`; `writePrivateFileAtomic` unchanged for all other callers; the new concurrency tests reproduce the lost update on pre-fix code).
- **`plugin rm` success message** names the normalized installed package, matching the failure path.

## Verification
- Subagent-driven: per-task TDD implementer + adversarial reviewer (both reviews APPROVED; fail-pre-fix verified empirically for the deadline, failure-domain, and lock-span tests).
- Full suite green (`node scripts/run-tests.mjs` rc=0), `tsc --noEmit` clean, `bun run build` clean.

## Behavior notes
- `/group new \"parallel review\"` now stores the quotes literally — one uniform rule (tails are verbatim); quoting a tail is never needed since unquoted multi-word titles work.
- Remaining deferred items are listed at the end of the plan doc (shutdown-window cosmetic, tool-managed channels[]/plugins[] entry granularity, redundant `scheduled_list` chatKey output, pending-final front-trim count edge).