### PR TITLE
fix(daemon): decouple startup ready signal from the warm queue-owner sweep

### DIFF
--- a/src/daemon/daemon-controller.ts
+++ b/src/daemon/daemon-controller.ts
@@ -53,7 +53,12 @@ export class DaemonController {
   ) {
     this.statusStore = new DaemonStatusStore(paths.statusFile);
     this.startupPollIntervalMs = deps.startupPollIntervalMs ?? 50;
-    this.startupTimeoutMs = deps.startupTimeoutMs ?? 5_000;
+    // Backstop only: with the orphan sweep decoupled from the ready signal (see
+    // run-console), the daemon writes status.json within a fraction of a second. This
+    // headroom just absorbs unrelated slow-startup costs (plugin load, busy disk) without
+    // masking a genuine hang — a crashed daemon is still detected immediately via the
+    // per-poll isProcessRunning() check, independent of this timeout.
+    this.startupTimeoutMs = deps.startupTimeoutMs ?? 10_000;
     this.onboardingStartupTimeoutMs = deps.onboardingStartupTimeoutMs ?? 300_000;
     this.shutdownPollIntervalMs = deps.shutdownPollIntervalMs ?? 50;
     this.shutdownTimeoutMs = deps.shutdownTimeoutMs ?? 5_000;

--- a/src/run-console.ts
+++ b/src/run-console.ts
@@ -143,12 +143,24 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
 
     // Sweep warm acpx queue owners orphaned by a previous daemon that exited without a
     // clean shutdown (Windows `stop` force-kills the daemon via taskkill /F before
-    // dispose() can reap; crashes and reboots skip dispose entirely). Runs after the
-    // consumer lock is held — so no peer instance owns these — and before channels start
-    // serving, so it cannot kill an owner this run just launched. Best-effort.
-    await runtime.reapStaleQueueOwners();
+    // dispose() can reap; crashes and reboots skip dispose entirely). Kicked off after
+    // the consumer lock is held — so no peer instance owns these — and its target set is
+    // snapshotted synchronously here, before this run launches any owner, so it can never
+    // target a current-run owner regardless of when the bounded (~5s) sweep finishes.
+    //
+    // Deliberately NOT awaited before the ready signal: the sweep is best-effort orphan
+    // cleanup, and awaiting it used to push the daemonRuntime.start() status write past
+    // the controller's startup timeout whenever the sweep used its full budget, making
+    // `xacpx start`/`restart` falsely report "did not report ready". We join it before
+    // channels begin serving so it still finishes before any current-run owner of a
+    // stale session identity could be launched. Best-effort: never rejects.
+    const reapPromise = Promise.resolve(runtime.reapStaleQueueOwners()).catch(() => {});
 
     if (deps.beforeReady) {
+      // First-run onboarding creates a session and its warm owner; let the sweep finish
+      // first so it can never target that owner. Gated by the generous onboarding startup
+      // timeout, not the 5s default, so blocking here is safe.
+      await reapPromise;
       await deps.beforeReady(runtime);
     }
 
@@ -166,6 +178,10 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
         deps.heartbeatIntervalMs ?? 30_000,
       );
     }
+
+    // Join the orphan sweep before channels begin serving so it cannot race a current-run
+    // owner that reuses a stale session identity. By now the ready signal is already out.
+    await reapPromise;
 
     const channelStartPromise = deps.channels.startAll({
       agent: runtime.agent,

--- a/tests/unit/run-console.test.ts
+++ b/tests/unit/run-console.test.ts
@@ -139,6 +139,52 @@ test("reaps stale queue owners at startup after the consumer lock, before channe
   expect(events).toEqual(["lock:acquire", "reap", "channel:start", "lock:release"]);
 });
 
+test("reports daemon ready before the queue-owner sweep finishes, and channels wait for it", async () => {
+  const events: string[] = [];
+  let releaseReap!: () => void;
+  const reapGate = new Promise<void>((resolve) => {
+    releaseReap = resolve;
+  });
+
+  const runPromise = runConsole({ configPath: "/cfg", statePath: "/state" }, {
+    buildApp: async () => ({
+      ...createRuntime(),
+      reapStaleQueueOwners: async () => {
+        events.push("reap:start");
+        await reapGate;
+        events.push("reap:done");
+      },
+    }),
+    channels: {
+      startAll: async () => { events.push("channel:start"); },
+    },
+    daemonRuntime: {
+      start: async () => { events.push("daemon:start"); },
+      heartbeat: async () => {},
+      stop: async () => { events.push("daemon:stop"); },
+    },
+    addProcessListener: () => {},
+    removeProcessListener: () => {},
+  });
+
+  // Let startup run as far as it can while the sweep is still gated open.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  // The ready signal must be out even though the sweep has not finished...
+  expect(events).toContain("daemon:start");
+  expect(events).toContain("reap:start");
+  expect(events).not.toContain("reap:done");
+  // ...and channels must NOT begin serving until the sweep is joined.
+  expect(events).not.toContain("channel:start");
+
+  releaseReap();
+  await runPromise;
+
+  // The sweep is joined before channels serve; ready was already signalled above.
+  expect(events.indexOf("daemon:start")).toBeLessThan(events.indexOf("reap:done"));
+  expect(events.indexOf("reap:done")).toBeLessThan(events.indexOf("channel:start"));
+});
+
 test("runs afterBuild before beforeReady and channel startup", async () => {
   const events: string[] = [];
   const runtime = createRuntime();


### PR DESCRIPTION
## Problem

`xacpx restart` (and `start`) intermittently reported **`daemon did not report ready state within 5000ms`** even though the daemon came up fine a moment later.

Root cause: in `run-console.ts` the startup orphan sweep (`reapStaleQueueOwners`) was **awaited before** the daemon wrote `status.json` (the ready signal the controller polls for). The sweep is bounded at 5s and, with ~28 recorded sessions each resolved via a cold `acpx sessions show` spawn, it routinely used the full budget — pushing the ready write past the controller's `startupTimeoutMs` (5000ms). The reap budget alone equalled the entire readiness budget.

```
lock acquired → reapStaleQueueOwners (≈5s) → daemonRuntime.start() [status.json = READY] → ...
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ blocks the ready signal
```

## Fix

- **Decouple the sweep from the ready signal.** Snapshot the sweep's target set synchronously right after the consumer lock (so it can never include a current-run owner regardless of timing), then run it **without awaiting** before the ready signal.
- **Join it before channels serve**, so it still finishes before any current-run owner of a stale session identity could be launched — the invariant the old ordering guaranteed.
- **First-run onboarding** still awaits the sweep first (it creates a session/owner), but that path is gated by the generous `onboardingStartupTimeoutMs` (300s), not the 5s default.
- **Backstop:** default startup readiness timeout `5s → 10s`. With the sweep off the critical path the ready write lands sub-second; the extra headroom just absorbs unrelated slow-startup costs (plugin load, busy disk) without masking a genuine hang — a crashed daemon is still detected immediately via the per-poll `isProcessRunning()` check.

## Verification

- New regression test in `run-console.test.ts`: with a gated (slow) sweep, the daemon ready signal fires while the sweep is still running, and channels wait until it's joined. (Old code blocks before ever signalling ready.)
- Full suite green, build clean.
- **Live:** `xacpx restart` now reports success; app.log shows the ready signal at lock-acquire time and `transport.queue_owner_reap.completed` ~5s later.

Found while diagnosing a user-reported "restart errored after updating to 0.10.0". The plugin-missing / bridge errors in their logs were stale from the first post-update start; the only live defect was this readiness false-negative.