### PR TITLE
feat(doctor): repair mode (--fix), plugin/channel health, and new coverage checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ There are two session concepts:
 - Daemon subsystem notes: [`docs/daemon-module.md`](docs/daemon-module.md)
 - Commands module notes: [`docs/commands-module.md`](docs/commands-module.md)
 - MCP integration (external coordinators): [`docs/external-mcp.md`](docs/external-mcp.md)
+- `xacpx doctor` diagnostics and `--fix` repairs: [`docs/doctor-command.md`](docs/doctor-command.md)
 - Code Wiki (architecture map): [`docs/code-wiki.md`](docs/code-wiki.md)
 
 ## Package Manager
@@ -133,6 +134,7 @@ Uses **Bun** for development scripts and builds. Dependencies are in `package.js
 - 配置文件详解 [docs/config-reference.md](docs/config-reference.md)
 - `/config` 命令说明 [docs/config-command.md](docs/config-command.md)
 - `/later` 定时任务命令说明 [docs/later-command.md](docs/later-command.md)
+- `xacpx doctor` 命令说明 [docs/doctor-command.md](docs/doctor-command.md)
 - `src/commands` 模块说明 [commands-module.md](docs/commands-module.md)
 - `src/daemon` 模块说明 [daemon-module.md](docs/daemon-module.md)
 - 计划文档 [superpower/plans](docs/superpowers/plans/)

--- a/docs/doctor-command.md
+++ b/docs/doctor-command.md
@@ -1,0 +1,135 @@
+# `xacpx doctor`
+
+`xacpx doctor` runs a series of read-only diagnostics against your local
+xacpx installation (config, runtime paths, daemon, channels, transport,
+plugins, and the orchestration IPC surface) and prints a report. With
+`--fix` it can additionally apply a small set of safe, local repairs.
+
+## Running it
+
+```bash
+xacpx doctor                       # run all default checks
+xacpx doctor --verbose             # include extra diagnostic detail
+xacpx doctor --smoke               # also run the opt-in smoke probe
+xacpx doctor --agent codex         # pin the agent used by the smoke probe
+xacpx doctor --workspace backend   # pin the workspace used by the smoke probe
+xacpx doctor --fix                 # apply safe local repairs, then re-check
+```
+
+### Exit code
+
+- `0` — no check reports `fail` (after any `--fix` repairs and re-checks).
+- `1` — at least one check still reports `fail`.
+
+Unknown flags (or `--agent`/`--workspace` without a value) print the CLI
+help and exit with `1`.
+
+## Checks
+
+Checks run and render in this fixed order. Each check has a stable `id`
+(used internally to re-run a check after a repair) and a human-readable
+label shown in the report:
+
+| Order | id                      | Label             | What it verifies |
+|-------|-------------------------|-------------------|------------------|
+| 1     | `config`                | Config            | `config.json` loads and validates. |
+| 2     | `runtime`               | Runtime           | The daemon runtime dir and its pid/status/log files are usable (writable or creatable). On POSIX it also checks the runtime dir is private (mode `0700`). |
+| 3     | `logs`                  | Logs              | The runtime log files exist and are readable. |
+| 4     | `daemon`                | Daemon            | Daemon liveness via the daemon controller (running / stopped / indeterminate). Also scans for stale consumer-lock files when stopped. |
+| 5     | `wechat`                | WeChat            | The WeChat (Weixin) channel is logged in. |
+| 6     | `acpx`                  | acpx              | The resolved `acpx` binary reports a usable version. |
+| 7     | `bridge`                | Bridge            | The acpx bridge subprocess starts and responds. |
+| 8     | `plugins`               | Plugins           | Configured plugins are installed, loadable, and enabled. |
+| 9     | `orchestration`         | Orchestration     | Orchestration state in `state.json` is healthy (inspected read-only; never quarantined as a side effect). Heartbeat freshness is checked against `orchestration.progressHeartbeatSeconds`. |
+| 10    | `orchestration-socket`  | Orchestration IPC | The orchestration IPC socket is present and live. |
+| 11    | `smoke`                 | Smoke             | End-to-end probe of a real session. **Opt-in:** skipped unless `--smoke` is passed. |
+
+## Severities
+
+Every check reports one of four severities:
+
+- **pass** — healthy.
+- **warn** — degraded but still working (for example: daemon not running,
+  WeChat logged out, runtime dir mode not `0700`, invalid state records
+  that the daemon would quarantine at next startup).
+- **fail** — broken; a failing check drives a non-zero exit code.
+- **skip** — not applicable or not requested (for example: Smoke without
+  `--smoke`, or a check that cannot run because the Config check failed).
+
+A summary line tallies the counts, e.g.
+`Summary: PASS 5, WARN 3, FAIL 1, SKIP 2`.
+
+## Flags
+
+- `--verbose` — include extra diagnostic detail in checks that support it
+  (WeChat, acpx, Bridge).
+- `--smoke` — run the opt-in Smoke check (a real end-to-end session probe).
+- `--agent <name>` — pin the agent the Smoke probe uses.
+- `--workspace <name>` — pin the workspace the Smoke probe uses.
+- `--fix` — apply safe local repairs, then re-run the affected checks.
+
+## `--fix`: the repair model and safety
+
+By default, doctor is strictly read-only. Under `--fix`, doctor walks the
+checks and runs the repairs each one attached. Repairs are deliberately
+conservative:
+
+- A repair runs only if it is **safe and local**. State-mutating repairs
+  are **gated** (see below) and are withheld while a daemon is running.
+- A withheld repair is reported as `skipped` with the reason instead of
+  running.
+- If a repair throws or returns failure, it is recorded as `failed`;
+  a bad repair can never crash doctor.
+- Only checks that had at least one repair successfully applied are
+  re-run, so the report reflects the post-repair state.
+
+After repairs, doctor prints a `Repairs:` section, one line per repair:
+
+```
+Repairs:
+- create/repair runtime dir with mode 0700: applied (runtime dir ... created/repaired with mode 0700)
+- quarantine invalid state.json records: skipped (stop the daemon first: xacpx stop)
+```
+
+When `--fix` is **not** passed, a check that has a repair available is
+flagged inline, e.g.:
+
+```
+WARN Runtime: daemon runtime dir should be private (mode 0700) (fixable — run: xacpx doctor --fix)
+```
+
+### What auto-applies (safe / local)
+
+- `runtime.ensure-private-dir` — create or repair the runtime dir with
+  mode `0700`. **Ungated** (it only adjusts the private runtime dir's own
+  permissions), so it applies even while the daemon runs.
+- `state.quarantine` — quarantine invalid/corrupt records in `state.json`
+  (drop bad records, back the original up as `state.json.quarantine-*`, or
+  rename an unreadable file to `state.json.corrupt-*`). **Gated** on the
+  daemon being stopped.
+- `daemon.clear-stale-lock` — remove stale `*-consumer.lock.json` files
+  whose recorded pid is definitively not running. Offered **only when the
+  daemon is stopped** (a running or indeterminate daemon owns the lock).
+
+### What stays a suggestion only (never auto-applied)
+
+These conditions are surfaced as suggestions, never as runnable repairs:
+
+- **Missing or broken plugin** — installing a plugin needs network access.
+- **Disabled plugin** — re-enabling is an explicit operator decision.
+- **Invalid config** — config edits must be made deliberately by you.
+- **WeChat logged out** — re-login is interactive (`xacpx login`).
+
+### Daemon-stopped gating
+
+State-mutating repairs (`state.quarantine`, `daemon.clear-stale-lock`)
+must never race a live daemon, which owns `state.json` and the consumer
+locks. While the daemon is running, those repairs are **withheld** and
+reported as `skipped` with a "stop the daemon first: `xacpx stop`" reason.
+Stop the daemon, re-run `xacpx doctor --fix`, then start it again.
+
+Daemon liveness is detected independently of any check output: the
+`indeterminate` state (a live daemon pid whose `status.json` is missing)
+is treated as a live daemon, so lock removal is not offered there either.
+If daemon state cannot be determined at all, doctor fails safe and treats
+the daemon as running, withholding the state-mutating repairs.

--- a/docs/doctor-command.md
+++ b/docs/doctor-command.md
@@ -34,14 +34,14 @@ label shown in the report:
 |-------|-------------------------|-------------------|------------------|
 | 1     | `config`                | Config            | `config.json` loads and validates. |
 | 2     | `runtime`               | Runtime           | The daemon runtime dir and its pid/status/log files are usable (writable or creatable). On POSIX it also checks the runtime dir is private (mode `0700`). |
-| 3     | `logs`                  | Logs              | The runtime log files exist and are readable. |
+| 3     | `logs`                  | Logs              | Sums the sizes of the daemon log files (`app.log`/`stdout.log`/`stderr.log` plus rotation siblings) and `warn`s on growth (a single file over 50 MB, or all combined over 200 MB); `skip` when the runtime dir has no logs yet. Unreadable individual files are tolerated (skipped), not failed. |
 | 4     | `daemon`                | Daemon            | Daemon liveness via the daemon controller (running / stopped / indeterminate). Also scans for stale consumer-lock files when stopped. |
 | 5     | `wechat`                | WeChat            | The WeChat (Weixin) channel is logged in. |
 | 6     | `acpx`                  | acpx              | The resolved `acpx` binary reports a usable version. |
 | 7     | `bridge`                | Bridge            | The acpx bridge subprocess starts and responds. |
 | 8     | `plugins`               | Plugins           | Configured plugins are installed, loadable, and enabled. |
 | 9     | `orchestration`         | Orchestration     | Orchestration state in `state.json` is healthy (inspected read-only; never quarantined as a side effect). Heartbeat freshness is checked against `orchestration.progressHeartbeatSeconds`. |
-| 10    | `orchestration-socket`  | Orchestration IPC | The orchestration IPC socket is present and live. |
+| 10    | `orchestration-socket`  | Orchestration IPC | `skip`s when the daemon is stopped; only when the daemon is live (running or indeterminate) does it probe whether the orchestration IPC endpoint actually accepts connections (`fail` only on a definitive no-listener, `pass`/`skip` on reachable or ambiguous). |
 | 11    | `smoke`                 | Smoke             | End-to-end probe of a real session. **Opt-in:** skipped unless `--smoke` is passed. |
 
 ## Severities

--- a/docs/superpowers/plans/2026-06-11-doctor-enhancements.md
+++ b/docs/superpowers/plans/2026-06-11-doctor-enhancements.md
@@ -1,0 +1,184 @@
+# Plan: `xacpx doctor` enhancements — repair mode, plugin/channel health, more coverage
+
+Date: 2026-06-11
+Status: proposed (awaiting approval)
+
+## Motivation
+
+`xacpx doctor` today is **diagnose-only**: 8 read-only checks (Config, Runtime, Daemon,
+WeChat, Acpx, Bridge, Orchestration, Smoke) emitting `severity + summary + details +
+suggestions`, rendered to the terminal, exit 1 on any FAIL. Two concrete gaps surfaced
+in practice:
+
+1. **No repair.** Even trivially-fixable conditions (runtime dir perms, stale lock/pid
+   files, quarantinable `state.json` records) require the user to act manually.
+2. **No plugin/channel health.** A channel-plugin that fails to load — e.g. the feishu
+   `failed to import plugin: Cannot find module '@ganglion/xacpx-channel-feishu'` seen
+   right after a core update — is **not** caught by `xacpx doctor`. That logic exists, but
+   only behind a *separate* `xacpx plugin doctor` (`inspectPlugins`).
+
+Approved directions (user, 2026-06-11): **(1) `--fix` repair mode**, **(2) fold in
+plugin/channel health**, **(3) more coverage**. (`--json` output explicitly out of scope.)
+
+## Design principles
+
+- **Detect and repair stay separate.** Checks remain pure/read-only and never mutate as a
+  side effect (the Orchestration check already deliberately uses `StateStore.inspect()`,
+  not `load()`). Repairs run only under an explicit `--fix`.
+- **`--fix` is conservative.** A fix auto-applies only if it is **local, non-destructive,
+  and needs no network**. Anything requiring the network (plugin (re)install), user intent
+  (a malformed config value), or interaction (WeChat re-login) stays a **suggestion**,
+  never an auto-fix.
+- **State-mutating fixes are gated on the daemon being stopped.** Quarantining `state.json`
+  records or removing a consumer lock while the daemon is live would race it. When the
+  daemon is running, such a fix is *withheld* with a "stop the daemon first" note.
+- English output only (matches existing doctor strings; no CJK so the i18n guard is
+  unaffected).
+
+---
+
+## Task A1 — Repair framework (types + runner)
+
+**Files:** `src/doctor/doctor-types.ts`, `src/doctor/doctor.ts`, `src/doctor/render-doctor.ts`
+
+Extend the result shape with optional, typed, *lazily-executed* fixes:
+
+```ts
+export interface DoctorFixOutcome { ok: boolean; message: string; }
+export interface DoctorFix {
+  id: string;                 // stable, e.g. "runtime.repair-perms"
+  title: string;              // human: "create runtime dir with mode 0700"
+  /** Withheld (not run) under --fix with this reason set; rendered as a note. */
+  withheld?: string;          // e.g. "stop the daemon first: xacpx stop"
+  run: () => Promise<DoctorFixOutcome>;
+}
+export interface DoctorCheckResult { /* ...existing... */ fixes?: DoctorFix[]; }
+export interface DoctorRunOptions { /* ...existing... */ fix?: boolean; }
+```
+
+Runner (`runDoctor`):
+1. Run all checks read-only (unchanged).
+2. If `options.fix`: for each check result in order, for each `fix` whose `withheld` is
+   unset, `await fix.run()` and record `{ checkId, fixId, title, outcome }`. Withheld
+   fixes are recorded as skipped-with-reason. Swallow/normalise thrown errors into
+   `{ ok: false, message }` (a failing repair must never crash doctor).
+3. After applying, **re-run the affected checks** (those that had an applied fix) to show
+   post-fix state; replace their results in the report.
+4. Return `report` (with a new `repairs: DoctorRepairOutcome[]`) + rendered output. Exit
+   code: still `1` if any FAIL remains *after* repairs.
+
+Render:
+- Without `--fix`: a check carrying fixes shows `(fixable — run: xacpx doctor --fix)`.
+- With `--fix`: append a `Repairs:` section listing each applied fix and `ok`/`failed`/
+  `skipped: <reason>`, then the (re-checked) summary line.
+
+**Tests:** `tests/unit/doctor/doctor.test.ts` (extend) — fixes only run under `--fix`;
+withheld fixes are not run; affected checks are re-run after fixing; a throwing fix is
+captured, not propagated; exit code reflects post-repair severity.
+
+## Task A2 — Attach safe fixes to existing checks
+
+Wire concrete, in-scope fixes onto the checks that detect a fixable condition. Each fix
+reuses an existing primitive — no new repair logic invented.
+
+- **Runtime** (`runtime-check.ts`): when the runtime dir is missing or its mode is not
+  `0700`, attach `runtime.ensure-private-dir` → `ensurePrivateRuntimeDir(runtimeDir)`
+  (create + chmod-repair; already exists). Local, safe, ungated.
+- **Daemon** (`daemon-check.ts`): when a **stale** consumer lock or pid/status file is
+  owned by a **dead** pid (and no live daemon), attach `daemon.clear-stale-runtime` →
+  remove the stale lock / clear stale pid+status (reuse controller stale-clearing +
+  targeted lock removal). Gated: `withheld` when a daemon is currently running.
+- **Orchestration** (`doctor.ts` `defaultCheckOrchestrationHealth`): when the inspection
+  reports droppable/corrupt `state.json`, attach `state.quarantine` → `new
+  StateStore(statePath).load()` (performs the documented quarantine/backup/rename). Gated:
+  `withheld` when a daemon is running (it would do this itself at next start).
+
+Explicitly **suggestion-only** (no auto-fix): invalid config value (Config), missing or
+broken plugin package (needs `xacpx plugin add` → network), disabled plugin (behaviour
+change), WeChat logged out (interactive).
+
+**Tests:** per-check unit tests assert the fix is attached only on the fixable condition,
+is withheld when the daemon runs, and that `run()` invokes the injected primitive.
+
+## Task B1 — Plugin/channel health check (fold-in)
+
+**Files:** new `src/doctor/checks/plugin-check.ts`; wire into `src/doctor/doctor.ts`.
+
+Wrap the existing `inspectPlugins`:
+```ts
+inspectPlugins({
+  config,
+  pluginHome: resolvePluginHome({ home }),
+  currentXacpxVersion: XACPX_CORE_VERSION,
+})
+```
+Map issues → one `DoctorCheckResult` id `"plugins"`, label `"Plugins"`:
+- any `error` → `fail`; else any `warn` → `warn`; else `pass` (or `skip` if no plugins
+  configured).
+- `details` = each issue message; `suggestions` = the `xacpx plugin …` hints already
+  embedded in the messages (deduped).
+- If config fails to load, `skip` with a pointer to the Config check (mirror
+  Orchestration's behaviour). Reuse the shared `loadConfig`.
+
+Insert in `runDoctor` after Bridge, before Orchestration. This is the check that would
+have caught the feishu import failure.
+
+Suggestion-only fix (network): `error` "package not installed / failed to import" →
+suggest `xacpx plugin add <pkg> && xacpx restart` (no auto-run).
+
+**Tests:** `tests/unit/doctor/checks/plugin-check.test.ts` — error/warn/ok/skip mapping
+from injected `inspectPlugins`; import-failure surfaces as `fail` with the package name.
+
+## Task C1 — Orchestration socket liveness check
+
+**Files:** new `src/doctor/checks/orchestration-socket-check.ts`; wire into `doctor.ts`.
+
+When the daemon reports **running**, confirm the orchestration IPC endpoint actually
+accepts connections (catches a daemon whose heartbeat is fresh but whose orchestration
+server is dead). Reuse `resolveOrchestrationEndpoint` + the existing `endpoint-probe.ts`
+(definitive-no-listener semantics). Result:
+- daemon not running → `skip` ("daemon stopped").
+- endpoint reachable → `pass`.
+- definitive no-listener → `fail` ("daemon is running but orchestration IPC is not
+  accepting connections"), suggest `xacpx restart`.
+- ambiguous/other → `warn` with the detail.
+
+**Tests:** `tests/unit/doctor/checks/orchestration-socket-check.test.ts` — skip when
+stopped; pass/fail/warn from an injected probe.
+
+## Task C2 — Log/disk growth health check
+
+**Files:** new `src/doctor/checks/logs-check.ts`; wire into `doctor.ts`.
+
+Sum the sizes of `app.log` / `stdout.log` / `stderr.log` (and rotation siblings) in the
+runtime dir. `warn` if any single file exceeds a threshold (default 50 MB) or the total
+exceeds 200 MB — a signal that rotation isn't keeping up or disk pressure is building.
+`pass` otherwise; `skip` if the runtime dir doesn't exist yet. Read-only; thresholds are
+constants with an injectable override for tests. No auto-fix (suggest checking rotation /
+disk), since truncating logs is destructive.
+
+**Tests:** `tests/unit/doctor/checks/logs-check.test.ts` — pass under threshold, warn over
+(single-file and total), skip when missing.
+
+## Task D1 — CLI flag + docs
+
+- `src/cli.ts` `parseDoctorArgs`: add `--fix` → `options.fix = true`.
+- New `docs/doctor-command.md`: the check matrix, severities, `--fix` safety model (what
+  auto-applies vs stays a suggestion, daemon-stopped gating), and the new checks. Link it
+  from `AGENTS.md` "Docs to rely on" and `README` if doctor is referenced there.
+
+## Out of scope / deferred
+
+- `--json` machine-readable output (user deselected).
+- **Warm queue-owner orphan scan.** Detecting *leaked* warm `acpx __queue-owner` process
+  trees needs acpx-side process scanning whose identity model is fuzzy from the xacpx
+  side; the existing startup reap already cleans these. Revisit only if a concrete,
+  low-false-positive signal emerges. (Related: `attempted=28` startup reap cost.)
+- Auto-running plugin (re)install or config rewrites under `--fix` (network / intent).
+
+## Execution
+
+Subagent-driven-development in an isolated worktree: per-task implementer (TDD, per-file
+tests via `bun test ./tests/unit/<file>`) → spec + code-quality review → fix loop; final
+whole-batch review; full `npm test` + `bun run build`; PR to `main`. No release unless
+asked.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1346,6 +1346,9 @@ function parseDoctorArgs(args: string[]): { ok: true; options: DoctorRunOptions 
       case "--smoke":
         options.smoke = true;
         break;
+      case "--fix":
+        options.fix = true;
+        break;
       case "--agent": {
         const value = args[index + 1];
         if (!value || value.startsWith("--")) {

--- a/src/daemon/daemon-files.ts
+++ b/src/daemon/daemon-files.ts
@@ -43,9 +43,10 @@ export function resolveDaemonOrchestrationSocketPath(
 }
 
 /**
- * Liveness probe via signal 0: succeeds when the pid exists (and is signalable),
- * throws otherwise. EPERM still means the process exists, so only a thrown
- * error is treated as "not alive".
+ * Liveness probe via signal 0: returns true when the pid can be signalled,
+ * false when process.kill throws. Note this treats any throw (including EPERM,
+ * which actually means the process exists but is owned by another user) as "not
+ * alive"; matches the behaviour of the other isProcessRunning copies.
  */
 export function isProcessAlive(pid: number): boolean {
   try {

--- a/src/daemon/daemon-files.ts
+++ b/src/daemon/daemon-files.ts
@@ -41,3 +41,17 @@ export function resolveDaemonOrchestrationSocketPath(
 ): string {
   return resolveOrchestrationEndpoint(runtimeDir, platform).path;
 }
+
+/**
+ * Liveness probe via signal 0: succeeds when the pid exists (and is signalable),
+ * throws otherwise. EPERM still means the process exists, so only a thrown
+ * error is treated as "not alive".
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/doctor/checks/daemon-check.ts
+++ b/src/doctor/checks/daemon-check.ts
@@ -44,13 +44,15 @@ export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<Doc
 
   try {
     const status = await controller.getStatus();
-    // A stale consumer lock can only be safely cleared when no daemon owns it.
-    // When the daemon is running it owns the lock, so we never offer a removal
-    // there (no staleness is possible).
+    // A stale consumer lock can only be safely cleared when there is genuinely
+    // no live daemon. Only "stopped" qualifies: "running" obviously owns the
+    // lock, and "indeterminate" is also a LIVE pid (getStatus reports it only
+    // after confirming the daemon process is alive but status.json is missing),
+    // so removing the lock there would race a live daemon.
     const staleLockFix =
-      status.state === "running"
-        ? undefined
-        : await detectStaleConsumerLockFix(paths.runtimeDir, isProcessRunning, readConsumerLock, removeConsumerLock);
+      status.state === "stopped"
+        ? await detectStaleConsumerLockFix(paths.runtimeDir, isProcessRunning, readConsumerLock, removeConsumerLock)
+        : undefined;
     switch (status.state) {
       case "running":
         return {
@@ -79,13 +81,14 @@ export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<Doc
           },
         };
       case "indeterminate":
+        // indeterminate = a LIVE daemon pid (status.json missing). Never offer
+        // a lock removal here; it would race the live daemon.
         return {
           id: "daemon",
           label: "Daemon",
           severity: "fail",
           summary: "daemon status is indeterminate",
           details: [`pid: ${status.pid}`, `reason: ${status.reason}`],
-          ...(staleLockFix ? { fixes: [staleLockFix] } : {}),
           metadata: {
             paths,
             status,

--- a/src/doctor/checks/daemon-check.ts
+++ b/src/doctor/checks/daemon-check.ts
@@ -1,9 +1,13 @@
+import { readFile, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { createDaemonController } from "../../daemon/create-daemon-controller";
 import { resolveDaemonPaths, resolveRuntimeDirFromConfigPath, type DaemonPaths } from "../../daemon/daemon-files";
-import type { DoctorCheckResult } from "../doctor-types";
+import type { DoctorCheckResult, DoctorFix } from "../doctor-types";
+
+const CONSUMER_LOCK_FILENAME = "weixin-consumer.lock.json";
 
 export interface DaemonCheckOptions {
   home?: string;
@@ -14,6 +18,10 @@ export interface DaemonCheckOptions {
   cliEntryPath?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  /** Injected so stale-lock detection never reads the real filesystem in tests. */
+  readConsumerLock?: (path: string) => Promise<{ pid: number } | null>;
+  /** Injected so the attached repair never touches the real filesystem in tests. */
+  removeConsumerLock?: (path: string) => Promise<void>;
 }
 
 export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<DoctorCheckResult> {
@@ -23,16 +31,26 @@ export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<Doc
     home,
     ...(runtimeDir ? { runtimeDir } : {}),
   });
+  const isProcessRunning = options.isProcessRunning ?? defaultIsProcessRunning;
+  const readConsumerLock = options.readConsumerLock ?? defaultReadConsumerLock;
+  const removeConsumerLock = options.removeConsumerLock ?? defaultRemoveConsumerLock;
   const controller = createDaemonController(paths, {
     processExecPath: options.processExecPath ?? process.execPath,
     cliEntryPath: options.cliEntryPath ?? resolveCliEntryPath(),
     cwd: options.cwd ?? process.cwd(),
     env: options.env ?? process.env,
-    isProcessRunning: options.isProcessRunning ?? defaultIsProcessRunning,
+    isProcessRunning,
   });
 
   try {
     const status = await controller.getStatus();
+    // A stale consumer lock can only be safely cleared when no daemon owns it.
+    // When the daemon is running it owns the lock, so we never offer a removal
+    // there (no staleness is possible).
+    const staleLockFix =
+      status.state === "running"
+        ? undefined
+        : await detectStaleConsumerLockFix(paths.runtimeDir, isProcessRunning, readConsumerLock, removeConsumerLock);
     switch (status.state) {
       case "running":
         return {
@@ -54,6 +72,7 @@ export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<Doc
           summary: status.stale ? "daemon was stopped and stale runtime files were cleared" : "daemon is not running",
           details: status.stale ? ["stale runtime files were cleared"] : undefined,
           suggestions: ["run: xacpx start"],
+          ...(staleLockFix ? { fixes: [staleLockFix] } : {}),
           metadata: {
             paths,
             status,
@@ -66,6 +85,7 @@ export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<Doc
           severity: "fail",
           summary: "daemon status is indeterminate",
           details: [`pid: ${status.pid}`, `reason: ${status.reason}`],
+          ...(staleLockFix ? { fixes: [staleLockFix] } : {}),
           metadata: {
             paths,
             status,
@@ -100,6 +120,48 @@ export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<Doc
       },
     };
   }
+}
+
+/**
+ * Detect a STALE Weixin consumer lock: the lock file exists and its recorded
+ * pid is definitively NOT running. Conservative — a lock that is missing,
+ * unreadable, or owned by a live pid yields no fix. Returns the removal repair
+ * when (and only when) staleness is certain.
+ */
+async function detectStaleConsumerLockFix(
+  runtimeDir: string,
+  isProcessRunning: (pid: number) => boolean,
+  readConsumerLock: (path: string) => Promise<{ pid: number } | null>,
+  removeConsumerLock: (path: string) => Promise<void>,
+): Promise<DoctorFix | undefined> {
+  const lockPath = join(runtimeDir, CONSUMER_LOCK_FILENAME);
+  const lock = await readConsumerLock(lockPath);
+  if (!lock || isProcessRunning(lock.pid)) {
+    return undefined;
+  }
+
+  return {
+    id: "daemon.clear-stale-lock",
+    title: "remove stale weixin consumer lock",
+    run: async () => {
+      await removeConsumerLock(lockPath);
+      return { ok: true, message: `removed stale consumer lock ${lockPath} (owner pid ${lock.pid} not running)` };
+    },
+  };
+}
+
+async function defaultReadConsumerLock(path: string): Promise<{ pid: number } | null> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as { pid?: unknown };
+    return typeof parsed.pid === "number" ? { pid: parsed.pid } : null;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultRemoveConsumerLock(path: string): Promise<void> {
+  await rm(path, { force: true });
 }
 
 function defaultIsProcessRunning(pid: number): boolean {

--- a/src/doctor/checks/daemon-check.ts
+++ b/src/doctor/checks/daemon-check.ts
@@ -1,13 +1,24 @@
-import { readFile, rm } from "node:fs/promises";
+import { readdir, readFile, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { createDaemonController } from "../../daemon/create-daemon-controller";
-import { resolveDaemonPaths, resolveRuntimeDirFromConfigPath, type DaemonPaths } from "../../daemon/daemon-files";
+import {
+  isProcessAlive,
+  resolveDaemonPaths,
+  resolveRuntimeDirFromConfigPath,
+  type DaemonPaths,
+} from "../../daemon/daemon-files";
 import type { DoctorCheckResult, DoctorFix } from "../doctor-types";
 
-const CONSUMER_LOCK_FILENAME = "weixin-consumer.lock.json";
+/**
+ * Consumer lock files are named "<channel-id>-consumer.lock.json" (see cli.ts:
+ * the first registered channel's id is the prefix). Match channel-agnostically
+ * so a Feishu-first install ("feishu-consumer.lock.json") is covered, not just
+ * Weixin.
+ */
+const CONSUMER_LOCK_SUFFIX = "-consumer.lock.json";
 
 export interface DaemonCheckOptions {
   home?: string;
@@ -18,6 +29,8 @@ export interface DaemonCheckOptions {
   cliEntryPath?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  /** Injected so stale-lock detection never reads the real filesystem in tests. */
+  listConsumerLocks?: (runtimeDir: string) => Promise<string[]>;
   /** Injected so stale-lock detection never reads the real filesystem in tests. */
   readConsumerLock?: (path: string) => Promise<{ pid: number } | null>;
   /** Injected so the attached repair never touches the real filesystem in tests. */
@@ -31,7 +44,8 @@ export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<Doc
     home,
     ...(runtimeDir ? { runtimeDir } : {}),
   });
-  const isProcessRunning = options.isProcessRunning ?? defaultIsProcessRunning;
+  const isProcessRunning = options.isProcessRunning ?? isProcessAlive;
+  const listConsumerLocks = options.listConsumerLocks ?? defaultListConsumerLocks;
   const readConsumerLock = options.readConsumerLock ?? defaultReadConsumerLock;
   const removeConsumerLock = options.removeConsumerLock ?? defaultRemoveConsumerLock;
   const controller = createDaemonController(paths, {
@@ -51,7 +65,12 @@ export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<Doc
     // so removing the lock there would race a live daemon.
     const staleLockFix =
       status.state === "stopped"
-        ? await detectStaleConsumerLockFix(paths.runtimeDir, isProcessRunning, readConsumerLock, removeConsumerLock)
+        ? await detectStaleConsumerLockFix(paths.runtimeDir, {
+            isProcessRunning,
+            listConsumerLocks,
+            readConsumerLock,
+            removeConsumerLock,
+          })
         : undefined;
     switch (status.state) {
       case "running":
@@ -125,32 +144,63 @@ export async function checkDaemon(options: DaemonCheckOptions = {}): Promise<Doc
   }
 }
 
+interface StaleConsumerLockDeps {
+  isProcessRunning: (pid: number) => boolean;
+  listConsumerLocks: (runtimeDir: string) => Promise<string[]>;
+  readConsumerLock: (path: string) => Promise<{ pid: number } | null>;
+  removeConsumerLock: (path: string) => Promise<void>;
+}
+
 /**
- * Detect a STALE Weixin consumer lock: the lock file exists and its recorded
- * pid is definitively NOT running. Conservative — a lock that is missing,
- * unreadable, or owned by a live pid yields no fix. Returns the removal repair
- * when (and only when) staleness is certain.
+ * Detect STALE consumer locks: any "<channel>-consumer.lock.json" in the
+ * runtime dir whose recorded pid is definitively NOT running. Conservative —
+ * a missing dir, no matching files, unreadable locks, or live-pid locks all
+ * yield no fix. When at least one stale lock exists, returns a repair whose
+ * run() removes every stale lock found (and only those) and names them.
  */
 async function detectStaleConsumerLockFix(
   runtimeDir: string,
-  isProcessRunning: (pid: number) => boolean,
-  readConsumerLock: (path: string) => Promise<{ pid: number } | null>,
-  removeConsumerLock: (path: string) => Promise<void>,
+  deps: StaleConsumerLockDeps,
 ): Promise<DoctorFix | undefined> {
-  const lockPath = join(runtimeDir, CONSUMER_LOCK_FILENAME);
-  const lock = await readConsumerLock(lockPath);
-  if (!lock || isProcessRunning(lock.pid)) {
+  const lockFiles = await deps.listConsumerLocks(runtimeDir);
+  const stalePaths: string[] = [];
+  for (const fileName of lockFiles) {
+    if (!fileName.endsWith(CONSUMER_LOCK_SUFFIX)) {
+      continue;
+    }
+    const lockPath = join(runtimeDir, fileName);
+    const lock = await deps.readConsumerLock(lockPath);
+    if (lock && !deps.isProcessRunning(lock.pid)) {
+      stalePaths.push(lockPath);
+    }
+  }
+
+  if (stalePaths.length === 0) {
     return undefined;
   }
 
   return {
     id: "daemon.clear-stale-lock",
-    title: "remove stale weixin consumer lock",
+    title: "remove stale consumer lock(s)",
     run: async () => {
-      await removeConsumerLock(lockPath);
-      return { ok: true, message: `removed stale consumer lock ${lockPath} (owner pid ${lock.pid} not running)` };
+      for (const lockPath of stalePaths) {
+        await deps.removeConsumerLock(lockPath);
+      }
+      return {
+        ok: true,
+        message: `removed ${stalePaths.length} stale consumer lock(s): ${stalePaths.join(", ")}`,
+      };
     },
   };
+}
+
+async function defaultListConsumerLocks(runtimeDir: string): Promise<string[]> {
+  try {
+    return await readdir(runtimeDir);
+  } catch {
+    // Missing/unreadable runtime dir => nothing to scan.
+    return [];
+  }
 }
 
 async function defaultReadConsumerLock(path: string): Promise<{ pid: number } | null> {
@@ -165,15 +215,6 @@ async function defaultReadConsumerLock(path: string): Promise<{ pid: number } | 
 
 async function defaultRemoveConsumerLock(path: string): Promise<void> {
   await rm(path, { force: true });
-}
-
-function defaultIsProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function resolveCliEntryPath(): string {

--- a/src/doctor/checks/logs-check.ts
+++ b/src/doctor/checks/logs-check.ts
@@ -1,0 +1,181 @@
+import { stat, readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { homedir } from "node:os";
+
+import { resolveDaemonPaths, resolveRuntimeDirFromConfigPath, type DaemonPaths } from "../../daemon/daemon-files";
+import type { DoctorCheckResult } from "../doctor-types";
+
+/** A single log file over this size (bytes) trips a warn on its own. */
+const DEFAULT_SINGLE_FILE_WARN_BYTES = 50 * 1024 * 1024;
+/** The combined size of all log files (base + rotation siblings) over this trips a warn. */
+const DEFAULT_TOTAL_WARN_BYTES = 200 * 1024 * 1024;
+
+export interface LogsCheckOptions {
+  home?: string;
+  resolveDaemonPaths?: (options: { home: string; runtimeDir?: string }) => DaemonPaths;
+  configPath?: string;
+  probe?: LogsFsProbe;
+  /** A single log file larger than this (bytes) warns. */
+  singleFileWarnBytes?: number;
+  /** The total across all log files larger than this (bytes) warns. */
+  totalWarnBytes?: number;
+}
+
+/** Injected fs seam so tests never touch the real filesystem. */
+export interface LogsFsProbe {
+  stat(path: string): Promise<{ isDirectory(): boolean; size: number }>;
+  readdir(path: string): Promise<string[]>;
+}
+
+interface LogFileSize {
+  name: string;
+  path: string;
+  size: number;
+}
+
+export async function checkLogs(options: LogsCheckOptions = {}): Promise<DoctorCheckResult> {
+  const home = options.home ?? process.env.HOME ?? homedir();
+  const runtimeDir = options.configPath ? resolveRuntimeDirFromConfigPath(options.configPath) : undefined;
+  const paths = (options.resolveDaemonPaths ?? resolveDaemonPaths)({
+    home,
+    ...(runtimeDir ? { runtimeDir } : {}),
+  });
+  const probe = options.probe ?? createLogsFsProbe();
+  const singleFileWarnBytes = options.singleFileWarnBytes ?? DEFAULT_SINGLE_FILE_WARN_BYTES;
+  const totalWarnBytes = options.totalWarnBytes ?? DEFAULT_TOTAL_WARN_BYTES;
+
+  // A missing runtime dir means the daemon has never written logs here.
+  let entries: string[];
+  try {
+    const dirStat = await probe.stat(paths.runtimeDir);
+    if (!dirStat.isDirectory()) {
+      return skip(paths.runtimeDir);
+    }
+    entries = await probe.readdir(paths.runtimeDir);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return skip(paths.runtimeDir);
+    }
+    // An unreadable runtime dir is surfaced by the Runtime check; do not crash here.
+    return skip(paths.runtimeDir);
+  }
+
+  // Enumerate the base daemon logs plus every rotation sibling: a file in the
+  // runtime dir named "<base>" or "<base>.<N>" where N is a positive integer
+  // (mirrors rotating-file-writer's "<base>.1", "<base>.2", … naming).
+  const baseNames = [basename(paths.appLog), basename(paths.stdoutLog), basename(paths.stderrLog)];
+  const tracked = new Set(baseNames);
+  const matched = entries.filter((entry) => isTrackedLogName(entry, tracked));
+
+  const files: LogFileSize[] = [];
+  for (const name of matched) {
+    const path = join(paths.runtimeDir, name);
+    try {
+      const fileStat = await probe.stat(path);
+      if (fileStat.isDirectory()) {
+        continue;
+      }
+      files.push({ name, path, size: fileStat.size });
+    } catch {
+      // Tolerate a file that is missing/unreadable/vanished between readdir and
+      // stat: skip it rather than failing the whole check.
+      continue;
+    }
+  }
+
+  const total = files.reduce((sum, file) => sum + file.size, 0);
+  const largestSingle = files.reduce((max, file) => Math.max(max, file.size), 0);
+  const overSingle = files.some((file) => file.size > singleFileWarnBytes);
+  const overTotal = total > totalWarnBytes;
+
+  const sorted = [...files].sort((a, b) => b.size - a.size);
+  const details = [
+    ...sorted.map((file) => `${file.name}: ${formatBytes(file.size)}`),
+    `total: ${formatBytes(total)}`,
+  ];
+
+  if (overSingle || overTotal) {
+    const reason = overSingle
+      ? `largest single log is ${formatBytes(largestSingle)}`
+      : `total is ${formatBytes(total)}`;
+    return {
+      id: "logs",
+      label: "Logs",
+      severity: "warn",
+      summary: `log growth high: ${reason} (total ${formatBytes(total)})`,
+      details,
+      suggestions: [
+        "logs are large; check disk space and that log rotation is configured (logging.maxSizeBytes / maxFiles)",
+      ],
+    };
+  }
+
+  return {
+    id: "logs",
+    label: "Logs",
+    severity: "pass",
+    summary: `logs total ${formatBytes(total)}`,
+    details,
+  };
+}
+
+function skip(runtimeDir: string): DoctorCheckResult {
+  return {
+    id: "logs",
+    label: "Logs",
+    severity: "skip",
+    summary: "no runtime logs yet",
+    details: [`runtimeDir: ${runtimeDir} (missing)`],
+  };
+}
+
+/**
+ * True when `name` is a base daemon log, or a rotation sibling "<base>.<N>"
+ * where N is a positive integer.
+ */
+function isTrackedLogName(name: string, baseNames: Set<string>): boolean {
+  if (baseNames.has(name)) {
+    return true;
+  }
+  for (const base of baseNames) {
+    const prefix = `${base}.`;
+    if (name.startsWith(prefix)) {
+      const suffix = name.slice(prefix.length);
+      if (/^\d+$/.test(suffix) && Number(suffix) > 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
+}
+
+function createLogsFsProbe(): LogsFsProbe {
+  return {
+    stat: async (path) => await stat(path),
+    readdir: async (path) => await readdir(path),
+  };
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    ((error as NodeJS.ErrnoException).code === "ENOENT" ||
+      (error as NodeJS.ErrnoException).code === "ENOTDIR")
+  );
+}

--- a/src/doctor/checks/orchestration-socket-check.ts
+++ b/src/doctor/checks/orchestration-socket-check.ts
@@ -1,0 +1,138 @@
+import { homedir } from "node:os";
+
+import { createDaemonController } from "../../daemon/create-daemon-controller";
+import {
+  isProcessAlive,
+  resolveDaemonPaths,
+  resolveRuntimeDirFromConfigPath,
+  type DaemonPaths,
+} from "../../daemon/daemon-files";
+import { canConnectToEndpoint } from "../../orchestration/endpoint-probe";
+import {
+  resolveOrchestrationEndpoint,
+  type OrchestrationIpcEndpoint,
+} from "../../orchestration/orchestration-ipc";
+import type { DoctorCheckResult } from "../doctor-types";
+
+/**
+ * Minimal view of the daemon lifecycle states this check cares about. Mirrors
+ * DaemonController.getStatus() but kept narrow so the seam can be injected in
+ * tests without constructing a real controller. "running" and "indeterminate"
+ * are both LIVE daemons (getStatus reports "indeterminate" only after confirming
+ * the pid is alive); "stopped" is the only non-live state.
+ */
+export type DaemonStatusSummary =
+  | { state: "stopped" }
+  | { state: "running"; pid: number }
+  | { state: "indeterminate"; pid: number }
+  | { state: string; pid?: number };
+
+export interface OrchestrationSocketCheckOptions {
+  home?: string;
+  configPath?: string;
+  resolveDaemonPaths?: (options: { home: string; runtimeDir?: string }) => DaemonPaths;
+  /** Daemon liveness seam. Injected so tests never touch real processes. */
+  getDaemonStatus?: (paths: DaemonPaths) => Promise<DaemonStatusSummary>;
+  resolveOrchestrationEndpoint?: (runtimeDir: string) => OrchestrationIpcEndpoint;
+  /** IPC liveness probe seam. Injected so tests never open a real socket. */
+  canConnectToEndpoint?: (path: string) => Promise<boolean>;
+  processExecPath?: string;
+  cliEntryPath?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  isProcessRunning?: (pid: number) => boolean;
+}
+
+/**
+ * Confirm the orchestration IPC endpoint is actually accepting connections when
+ * the daemon is running. This catches the case where the daemon process is alive
+ * (fresh heartbeat) but its orchestration server has died, leaving MCP
+ * coordinators unable to reach it.
+ *
+ * The check is meaningful only for a LIVE daemon, so a stopped daemon yields a
+ * skip. A live daemon (running or indeterminate) is probed.
+ */
+export async function checkOrchestrationSocket(
+  options: OrchestrationSocketCheckOptions = {},
+): Promise<DoctorCheckResult> {
+  const home = options.home ?? process.env.HOME ?? homedir();
+  const runtimeDir = options.configPath ? resolveRuntimeDirFromConfigPath(options.configPath) : undefined;
+  const paths = (options.resolveDaemonPaths ?? resolveDaemonPaths)({
+    home,
+    ...(runtimeDir ? { runtimeDir } : {}),
+  });
+  const getDaemonStatus = options.getDaemonStatus ?? ((p) => defaultGetDaemonStatus(p, options));
+  const probe = options.canConnectToEndpoint ?? canConnectToEndpoint;
+  const resolveEndpoint = options.resolveOrchestrationEndpoint ?? ((dir) => resolveOrchestrationEndpoint(dir));
+
+  let status: DaemonStatusSummary;
+  try {
+    status = await getDaemonStatus(paths);
+  } catch (error) {
+    return {
+      id: "orchestration-socket",
+      label: "Orchestration IPC",
+      severity: "skip",
+      summary: "daemon status could not be read",
+      details: [`runtime dir: ${paths.runtimeDir}`, `error: ${formatError(error)}`],
+    };
+  }
+
+  // Only a stopped daemon is non-live. "running" and "indeterminate" are both
+  // live pids, so the orchestration endpoint should be reachable.
+  if (status.state === "stopped") {
+    return {
+      id: "orchestration-socket",
+      label: "Orchestration IPC",
+      severity: "skip",
+      summary: "daemon stopped",
+    };
+  }
+
+  const endpoint = resolveEndpoint(paths.runtimeDir);
+  const reachable = await probe(endpoint.path);
+
+  // The probe is conservative: it returns false ONLY when the endpoint
+  // definitively has no listener (ECONNREFUSED/ENOENT). A successful connect OR
+  // any ambiguous result (timeout / other error) returns true. So "pass" also
+  // covers the ambiguous/busy-server case, which guarantees we never falsely
+  // fail a daemon that is merely slow or transiently unreachable.
+  if (reachable) {
+    return {
+      id: "orchestration-socket",
+      label: "Orchestration IPC",
+      severity: "pass",
+      summary: "orchestration IPC is accepting connections",
+      details: [`endpoint: ${endpoint.path}`],
+    };
+  }
+
+  return {
+    id: "orchestration-socket",
+    label: "Orchestration IPC",
+    severity: "fail",
+    summary: "daemon is running but orchestration IPC is not accepting connections",
+    details: [`endpoint: ${endpoint.path}`],
+    // Restart is a user action (it stops and respawns the daemon), so this is a
+    // suggestion only — no automated DoctorFix is attached.
+    suggestions: ["run: xacpx restart"],
+  };
+}
+
+async function defaultGetDaemonStatus(
+  paths: DaemonPaths,
+  options: OrchestrationSocketCheckOptions,
+): Promise<DaemonStatusSummary> {
+  const controller = createDaemonController(paths, {
+    processExecPath: options.processExecPath ?? process.execPath,
+    cliEntryPath: options.cliEntryPath ?? process.argv[1] ?? "",
+    cwd: options.cwd ?? process.cwd(),
+    env: options.env ?? process.env,
+    isProcessRunning: options.isProcessRunning ?? isProcessAlive,
+  });
+  return await controller.getStatus();
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/doctor/checks/orchestration-socket-check.ts
+++ b/src/doctor/checks/orchestration-socket-check.ts
@@ -89,8 +89,25 @@ export async function checkOrchestrationSocket(
     };
   }
 
-  const endpoint = resolveEndpoint(paths.runtimeDir);
-  const reachable = await probe(endpoint.path);
+  let endpoint: OrchestrationIpcEndpoint;
+  let reachable: boolean;
+  try {
+    endpoint = resolveEndpoint(paths.runtimeDir);
+    reachable = await probe(endpoint.path);
+  } catch (error) {
+    // The real probe never rejects (it resolves true on any ambiguous error),
+    // but guard the whole resolve+probe body anyway so an injected or future
+    // probe that throws can never crash doctor (runDoctor's runner loop does not
+    // wrap run()). Mirror the getStatus guard: skip rather than fail, since a
+    // probe error means we could not establish liveness, not that the IPC is down.
+    return {
+      id: "orchestration-socket",
+      label: "Orchestration IPC",
+      severity: "skip",
+      summary: "orchestration IPC liveness could not be probed",
+      details: [`runtime dir: ${paths.runtimeDir}`, `error: ${formatError(error)}`],
+    };
+  }
 
   // The probe is conservative: it returns false ONLY when the endpoint
   // definitively has no listener (ECONNREFUSED/ENOENT). A successful connect OR

--- a/src/doctor/checks/plugin-check.ts
+++ b/src/doctor/checks/plugin-check.ts
@@ -1,0 +1,154 @@
+import { loadConfig as defaultLoadConfig } from "../../config/load-config";
+import type { AppConfig } from "../../config/types";
+import { listKnownChannelIds } from "../../channels/channel-scope";
+import { resolveRuntimePaths as defaultResolveRuntimePaths, type RuntimePaths } from "../../main";
+import {
+  inspectPlugins as defaultInspectPlugins,
+  type InspectPluginsInput,
+  type PluginDoctorIssue,
+} from "../../plugins/plugin-doctor";
+import { resolvePluginHome as defaultResolvePluginHome } from "../../plugins/plugin-home";
+import { XACPX_CORE_VERSION } from "../../version";
+import type { DoctorCheckResult } from "../doctor-types";
+
+export interface PluginCheckOptions {
+  /** Home dir used to resolve the plugin home; mirrors the rest of doctor. */
+  home?: string;
+  resolveRuntimePaths?: () => RuntimePaths;
+  loadConfig?: (configPath: string) => Promise<AppConfig>;
+  resolvePluginHome?: (input: { home?: string }) => string;
+  inspectPlugins?: (input: InspectPluginsInput) => Promise<PluginDoctorIssue[]>;
+  /** Injected for tests; defaults to the running core version. */
+  currentXacpxVersion?: string;
+}
+
+/**
+ * Fold the existing plugin/channel health logic (`inspectPlugins`, previously
+ * only reachable via `xacpx plugin doctor`) into `xacpx doctor`. This is the
+ * check that catches a channel plugin that fails to load after a core update
+ * (e.g. `failed to import plugin: Cannot find module ...`).
+ *
+ * Read-only: plugin (re)install needs the network, so this check never attaches
+ * a fix — it only surfaces actionable `xacpx plugin ...` suggestions.
+ */
+export async function checkPlugins(options: PluginCheckOptions = {}): Promise<DoctorCheckResult> {
+  const runtimePaths = (options.resolveRuntimePaths ?? defaultResolveRuntimePaths)();
+
+  let config: AppConfig;
+  try {
+    config = await (options.loadConfig ?? defaultLoadConfig)(runtimePaths.configPath);
+  } catch (error) {
+    return {
+      id: "plugins",
+      label: "Plugins",
+      severity: "skip",
+      summary: "plugin check skipped because configuration could not be loaded",
+      details: [`config path: ${runtimePaths.configPath}`, `error: ${formatError(error)}`],
+      suggestions: ["fix the Config check first, then run: xacpx doctor"],
+    };
+  }
+
+  if (!hasPluginSurface(config)) {
+    return {
+      id: "plugins",
+      label: "Plugins",
+      severity: "skip",
+      summary: "no plugins configured",
+    };
+  }
+
+  const pluginHome = (options.resolvePluginHome ?? defaultResolvePluginHome)({ home: options.home });
+  const inspect = options.inspectPlugins ?? defaultInspectPlugins;
+  const issues = await inspect({
+    config,
+    pluginHome,
+    currentXacpxVersion: options.currentXacpxVersion ?? XACPX_CORE_VERSION,
+  });
+
+  const errorCount = issues.filter((issue) => issue.level === "error").length;
+  const warnCount = issues.filter((issue) => issue.level === "warn").length;
+  const severity = errorCount > 0 ? "fail" : warnCount > 0 ? "warn" : "pass";
+  const problemCount = errorCount + warnCount;
+
+  return {
+    id: "plugins",
+    label: "Plugins",
+    severity,
+    summary:
+      problemCount > 0
+        ? `${problemCount} plugin issue(s)`
+        : "all plugins healthy",
+    details: issues.map(formatIssueDetail),
+    suggestions: collectSuggestions(issues),
+    metadata: { pluginHome, issues },
+  };
+}
+
+/**
+ * True when there is anything for the plugin check to inspect: at least one
+ * configured plugin, or at least one enabled channel whose type is not a
+ * built-in (i.e. a plugin-provided channel). Otherwise the check skips.
+ */
+function hasPluginSurface(config: AppConfig): boolean {
+  if ((config.plugins ?? []).length > 0) {
+    return true;
+  }
+  const builtInChannelTypes = new Set(listKnownChannelIds());
+  return (config.channels ?? []).some(
+    (channel) => channel.enabled !== false && !builtInChannelTypes.has(channel.type),
+  );
+}
+
+function formatIssueDetail(issue: PluginDoctorIssue): string {
+  return issue.plugin ? `${issue.plugin}: ${issue.message}` : issue.message;
+}
+
+/**
+ * Build a deduped, actionable suggestion list. Common errors (package not
+ * installed / failed to import) get an explicit add+restart hint keyed by the
+ * affected package; other messages that already embed an `xacpx plugin ...`
+ * remediation hint are surfaced verbatim.
+ */
+function collectSuggestions(issues: PluginDoctorIssue[]): string[] {
+  const suggestions: string[] = [];
+  const seen = new Set<string>();
+  const push = (suggestion: string) => {
+    if (!seen.has(suggestion)) {
+      seen.add(suggestion);
+      suggestions.push(suggestion);
+    }
+  };
+
+  for (const issue of issues) {
+    if (issue.level === "ok") {
+      continue;
+    }
+    if (
+      issue.plugin &&
+      (issue.message.startsWith("package not installed") ||
+        issue.message.startsWith("failed to import plugin"))
+    ) {
+      push(`run: xacpx plugin add ${issue.plugin} && xacpx restart`);
+      continue;
+    }
+    const embedded = extractPluginCommand(issue.message);
+    if (embedded) {
+      push(`run: ${embedded}`);
+    }
+  }
+
+  return suggestions;
+}
+
+/**
+ * Pull the first `xacpx plugin ...` remediation command embedded in a message
+ * (the issue strings already carry these). Returns null when none is present.
+ */
+function extractPluginCommand(message: string): string | null {
+  const match = message.match(/xacpx plugin [^;]+/);
+  return match ? match[0].trim() : null;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/doctor/checks/plugin-check.ts
+++ b/src/doctor/checks/plugin-check.ts
@@ -59,11 +59,25 @@ export async function checkPlugins(options: PluginCheckOptions = {}): Promise<Do
 
   const pluginHome = (options.resolvePluginHome ?? defaultResolvePluginHome)({ home: options.home });
   const inspect = options.inspectPlugins ?? defaultInspectPlugins;
-  const issues = await inspect({
-    config,
-    pluginHome,
-    currentXacpxVersion: options.currentXacpxVersion ?? XACPX_CORE_VERSION,
-  });
+
+  let issues: PluginDoctorIssue[];
+  try {
+    issues = await inspect({
+      config,
+      pluginHome,
+      currentXacpxVersion: options.currentXacpxVersion ?? XACPX_CORE_VERSION,
+    });
+  } catch (error) {
+    // A throw here must never crash runDoctor — degrade to a fail, mirroring
+    // the orchestration sibling's inspect guard.
+    return {
+      id: "plugins",
+      label: "Plugins",
+      severity: "fail",
+      summary: "plugin health check failed",
+      details: [`plugin home: ${pluginHome}`, `error: ${formatError(error)}`],
+    };
+  }
 
   const errorCount = issues.filter((issue) => issue.level === "error").length;
   const warnCount = issues.filter((issue) => issue.level === "warn").length;
@@ -78,9 +92,11 @@ export async function checkPlugins(options: PluginCheckOptions = {}): Promise<Do
       problemCount > 0
         ? `${problemCount} plugin issue(s)`
         : "all plugins healthy",
-    details: issues.map(formatIssueDetail),
+    // Match the sibling checks' altitude: only surface the problems, not the
+    // healthy plugins (the summary already says "all plugins healthy").
+    details: issues.filter((issue) => issue.level !== "ok").map(formatIssueDetail),
     suggestions: collectSuggestions(issues),
-    metadata: { pluginHome, issues },
+    metadata: { pluginHome, errorCount, warnCount },
   };
 }
 
@@ -104,49 +120,23 @@ function formatIssueDetail(issue: PluginDoctorIssue): string {
 }
 
 /**
- * Build a deduped, actionable suggestion list. Common errors (package not
- * installed / failed to import) get an explicit add+restart hint keyed by the
- * affected package; other messages that already embed an `xacpx plugin ...`
- * remediation hint are surfaced verbatim.
+ * Collect the structured `suggestion` remediation commands the issues already
+ * carry (deduped, in order). The precise command is set at the source in
+ * `inspectPlugins`, so there is no message parsing here.
  */
 function collectSuggestions(issues: PluginDoctorIssue[]): string[] {
   const suggestions: string[] = [];
   const seen = new Set<string>();
-  const push = (suggestion: string) => {
-    if (!seen.has(suggestion)) {
-      seen.add(suggestion);
-      suggestions.push(suggestion);
-    }
-  };
 
   for (const issue of issues) {
-    if (issue.level === "ok") {
-      continue;
-    }
-    if (
-      issue.plugin &&
-      (issue.message.startsWith("package not installed") ||
-        issue.message.startsWith("failed to import plugin"))
-    ) {
-      push(`run: xacpx plugin add ${issue.plugin} && xacpx restart`);
-      continue;
-    }
-    const embedded = extractPluginCommand(issue.message);
-    if (embedded) {
-      push(`run: ${embedded}`);
+    const suggestion = issue.suggestion;
+    if (suggestion && !seen.has(suggestion)) {
+      seen.add(suggestion);
+      suggestions.push(`run: ${suggestion}`);
     }
   }
 
   return suggestions;
-}
-
-/**
- * Pull the first `xacpx plugin ...` remediation command embedded in a message
- * (the issue strings already carry these). Returns null when none is present.
- */
-function extractPluginCommand(message: string): string | null {
-  const match = message.match(/xacpx plugin [^;]+/);
-  return match ? match[0].trim() : null;
 }
 
 function formatError(error: unknown): string {

--- a/src/doctor/checks/runtime-check.ts
+++ b/src/doctor/checks/runtime-check.ts
@@ -4,9 +4,12 @@ import { dirname } from "node:path";
 import { homedir } from "node:os";
 
 import { resolveDaemonPaths, resolveRuntimeDirFromConfigPath, type DaemonPaths } from "../../daemon/daemon-files";
-import type { DoctorCheckResult } from "../doctor-types";
+import { ensurePrivateRuntimeDir } from "../../daemon/private-runtime-dir";
+import type { DoctorCheckResult, DoctorFix } from "../doctor-types";
 
 const DIRECTORY_USABLE = constants.W_OK | constants.X_OK;
+/** The runtime dir must be user-private (0700); see ensurePrivateRuntimeDir. */
+const PRIVATE_DIR_MODE = 0o700;
 
 export interface RuntimeCheckOptions {
   home?: string;
@@ -14,6 +17,8 @@ export interface RuntimeCheckOptions {
   configPath?: string;
   probe?: RuntimeFsProbe;
   platform?: NodeJS.Platform;
+  /** Injected so the attached repair never touches the real filesystem in tests. */
+  ensurePrivateRuntimeDir?: (runtimeDir: string) => Promise<void>;
 }
 
 export async function checkRuntime(options: RuntimeCheckOptions = {}): Promise<DoctorCheckResult> {
@@ -45,6 +50,26 @@ export async function checkRuntime(options: RuntimeCheckOptions = {}): Promise<D
     };
   }
 
+  // The dir is usable, but it may still need privacy hardening: a missing dir
+  // (about to be created) or — on POSIX — a present dir whose mode has group/
+  // other bits set. Both are repaired by ensurePrivateRuntimeDir (create +
+  // chmod 0700). This downgrades an otherwise-passing dir to a warn so the
+  // world-readable orchestration socket directory is surfaced and fixable.
+  const privacy = await inspectRuntimeDirPrivacy(paths.runtimeDir, probe, platform);
+  if (privacy.needsRepair) {
+    return {
+      id: "runtime",
+      label: "Runtime",
+      severity: "warn",
+      summary: "daemon runtime dir should be private (mode 0700)",
+      details: [...checks.map((check) => check.detail), privacy.detail],
+      fixes: [createEnsurePrivateDirFix(paths.runtimeDir, options.ensurePrivateRuntimeDir)],
+      metadata: {
+        paths,
+      },
+    };
+  }
+
   return {
     id: "runtime",
     label: "Runtime",
@@ -55,6 +80,73 @@ export async function checkRuntime(options: RuntimeCheckOptions = {}): Promise<D
       paths,
     },
   };
+}
+
+interface RuntimeDirPrivacy {
+  needsRepair: boolean;
+  detail: string;
+}
+
+/**
+ * Decide whether the runtime dir warrants the ensure-private-dir repair. On
+ * win32 POSIX modes do not apply (mirror ensurePrivateRuntimeDir's own no-op),
+ * so privacy is never flagged there. Otherwise: a missing dir needs creating
+ * (with mode 0700), and a present dir whose mode (mask 0o777) is not exactly
+ * 0700 needs a chmod repair. A stat that reports no mode (older probes) is
+ * treated as fine — only definitive wrong bits trigger the fix.
+ */
+async function inspectRuntimeDirPrivacy(
+  runtimeDir: string,
+  probe: RuntimeFsProbe,
+  platform: NodeJS.Platform,
+): Promise<RuntimeDirPrivacy> {
+  if (platform === "win32") {
+    return { needsRepair: false, detail: "" };
+  }
+
+  try {
+    const stats = await probe.stat(runtimeDir);
+    if (typeof stats.mode !== "number") {
+      return { needsRepair: false, detail: "" };
+    }
+    const mode = stats.mode & 0o777;
+    if (mode === PRIVATE_DIR_MODE) {
+      return { needsRepair: false, detail: "" };
+    }
+    return {
+      needsRepair: true,
+      detail: `runtimeDir: ${runtimeDir} (mode ${formatMode(mode)} is not 0700; group/other access should be removed)`,
+    };
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return {
+        needsRepair: true,
+        detail: `runtimeDir: ${runtimeDir} (missing; will be created with mode 0700)`,
+      };
+    }
+    // An unreadable dir is already a usability failure handled above; do not
+    // double-report it here.
+    return { needsRepair: false, detail: "" };
+  }
+}
+
+function createEnsurePrivateDirFix(
+  runtimeDir: string,
+  ensureImpl?: (runtimeDir: string) => Promise<void>,
+): DoctorFix {
+  const ensure = ensureImpl ?? ((dir: string) => ensurePrivateRuntimeDir(dir));
+  return {
+    id: "runtime.ensure-private-dir",
+    title: "create/repair runtime dir with mode 0700",
+    run: async () => {
+      await ensure(runtimeDir);
+      return { ok: true, message: `runtime dir ${runtimeDir} created/repaired with mode 0700` };
+    },
+  };
+}
+
+function formatMode(mode: number): string {
+  return `0${(mode & 0o777).toString(8)}`;
 }
 
 interface PathCheckResult {
@@ -69,6 +161,8 @@ interface RuntimeFsProbe {
 
 interface RuntimePathStat {
   isDirectory(): boolean;
+  /** POSIX permission bits, when the probe supplies them (used for privacy checks). */
+  mode?: number;
 }
 
 function createRuntimeFsProbe(): RuntimeFsProbe {

--- a/src/doctor/doctor-types.ts
+++ b/src/doctor/doctor-types.ts
@@ -1,5 +1,20 @@
 export type DoctorSeverity = "pass" | "warn" | "fail" | "skip";
 
+export interface DoctorFixOutcome {
+  ok: boolean;
+  message: string;
+}
+
+export interface DoctorFix {
+  /** Stable identifier, e.g. "runtime.repair-perms". */
+  id: string;
+  /** Human-readable title, e.g. "create runtime dir with mode 0700". */
+  title: string;
+  /** When set, the fix is NOT run under --fix; this reason is rendered instead. */
+  withheld?: string;
+  run: () => Promise<DoctorFixOutcome>;
+}
+
 export interface DoctorCheckResult {
   id: string;
   label: string;
@@ -8,6 +23,7 @@ export interface DoctorCheckResult {
   details?: string[];
   suggestions?: string[];
   metadata?: Record<string, unknown>;
+  fixes?: DoctorFix[];
 }
 
 export interface DoctorRunOptions {
@@ -15,8 +31,19 @@ export interface DoctorRunOptions {
   smoke?: boolean;
   agent?: string;
   workspace?: string;
+  fix?: boolean;
+}
+
+export interface DoctorRepairOutcome {
+  checkId: string;
+  fixId: string;
+  title: string;
+  status: "applied" | "failed" | "skipped";
+  /** Outcome message, or the withheld reason for a skipped fix. */
+  message: string;
 }
 
 export interface DoctorReport {
   checks: DoctorCheckResult[];
+  repairs?: DoctorRepairOutcome[];
 }

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -5,6 +5,8 @@ import { coreHomeDir } from "../runtime/core-home";
 import { coreEnv } from "../runtime/core-env";
 import { loadConfig } from "../config/load-config";
 import type { AppConfig } from "../config/types";
+import { createDaemonController } from "../daemon/create-daemon-controller";
+import { resolveDaemonPaths, resolveRuntimeDirFromConfigPath } from "../daemon/daemon-files";
 import { resolveRuntimePaths, type RuntimePaths } from "../main";
 import { StateStore, type StateLoadReport } from "../state/state-store";
 import { checkAcpx } from "./checks/acpx-check";
@@ -17,6 +19,7 @@ import { checkSmoke } from "./checks/smoke-check";
 import { checkWechat } from "./checks/wechat-check";
 import type {
   DoctorCheckResult,
+  DoctorFix,
   DoctorFixOutcome,
   DoctorReport,
   DoctorRepairOutcome,
@@ -42,6 +45,12 @@ interface DoctorDeps {
   checkBridge?: typeof checkBridge;
   checkOrchestrationHealth?: () => Promise<DoctorCheckResult>;
   checkSmoke?: (options: DoctorRunOptions) => Promise<DoctorCheckResult>;
+  /**
+   * Whether a daemon currently owns the runtime. Injected so the state-mutating
+   * orchestration repair can be gated (withheld) without touching real
+   * processes in tests.
+   */
+  isDaemonRunning?: () => Promise<boolean>;
   renderDoctor?: typeof renderDoctor;
 }
 
@@ -109,6 +118,7 @@ export async function runDoctor(options: DoctorRunOptions = {}, deps: DoctorDeps
         (deps.checkOrchestrationHealth ?? (() => defaultCheckOrchestrationHealth({
           runtimePaths,
           loadConfig: sharedLoadConfig,
+          isDaemonRunning: deps.isDaemonRunning ?? (() => defaultIsDaemonRunning(home, runtimePaths)),
         })))(),
     },
     {
@@ -262,6 +272,7 @@ function createSmokeSkipResult(summary: string): DoctorCheckResult {
 async function defaultCheckOrchestrationHealth(deps: {
   runtimePaths: RuntimePaths;
   loadConfig: (configPath: string) => Promise<AppConfig>;
+  isDaemonRunning: () => Promise<boolean>;
 }): Promise<DoctorCheckResult> {
   let config: AppConfig;
   try {
@@ -288,7 +299,11 @@ async function defaultCheckOrchestrationHealth(deps: {
       now: () => new Date(),
       heartbeatThresholdSeconds: config.orchestration.progressHeartbeatSeconds,
     });
-    return applyStateInspectionReport(result, inspection.report, deps.runtimePaths.statePath);
+    // Determine daemon liveness only when a fix would actually be offered (the
+    // inspection found something to quarantine), to avoid a needless status read
+    // on the healthy path.
+    const daemonRunning = inspection.report ? await deps.isDaemonRunning() : false;
+    return applyStateInspectionReport(result, inspection.report, deps.runtimePaths.statePath, daemonRunning);
   } catch (error) {
     return {
       id: "orchestration",
@@ -311,6 +326,7 @@ function applyStateInspectionReport(
   result: DoctorCheckResult,
   report: StateLoadReport | null,
   statePath: string,
+  daemonRunning: boolean,
 ): DoctorCheckResult {
   if (!report) {
     return result;
@@ -340,7 +356,68 @@ function applyStateInspectionReport(
         ? "back up the state file before the next daemon start if you want to attempt manual recovery"
         : "the daemon backs the original file up as state.json.quarantine-* before dropping these records",
     ],
+    fixes: [createStateQuarantineFix(statePath, daemonRunning)],
   };
+}
+
+/**
+ * Quarantine repair for invalid/corrupt state.json. run() drives the documented
+ * StateStore.load() path (drop bad records, back the original up as
+ * .quarantine-* / rename a corrupt file to .corrupt-*). Gated: while the daemon
+ * is running it owns state.json and performs this itself at the next start, so
+ * the fix is withheld rather than racing it.
+ */
+function createStateQuarantineFix(statePath: string, daemonRunning: boolean): DoctorFix {
+  return {
+    id: "state.quarantine",
+    title: "quarantine invalid state.json records",
+    ...(daemonRunning ? { withheld: "stop the daemon first: xacpx stop" } : {}),
+    run: async () => {
+      const store = new StateStore(statePath);
+      await store.load();
+      const report = store.lastLoadReport;
+      if (!report) {
+        return { ok: true, message: "state.json was already valid; nothing to quarantine" };
+      }
+      if (report.corruptPath) {
+        return { ok: true, message: `state.json was unreadable; renamed to ${report.corruptPath} and reset` };
+      }
+      const backup = report.quarantinePath ? ` (original backed up to ${report.quarantinePath})` : "";
+      return {
+        ok: true,
+        message: `quarantined ${report.dropped.length} invalid state.json record(s)${backup}`,
+      };
+    },
+  };
+}
+
+async function defaultIsDaemonRunning(home: string, runtimePaths: RuntimePaths): Promise<boolean> {
+  try {
+    const paths = resolveDaemonPaths({
+      home,
+      runtimeDir: resolveRuntimeDirFromConfigPath(runtimePaths.configPath),
+    });
+    const controller = createDaemonController(paths, {
+      processExecPath: process.execPath,
+      cliEntryPath: process.argv[1] ?? "",
+      cwd: process.cwd(),
+      env: process.env,
+      isProcessRunning: (pid: number) => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    });
+    const status = await controller.getStatus();
+    return status.state === "running";
+  } catch {
+    // If we cannot determine daemon state, do NOT mutate: treat as running so
+    // the state-mutating fix is withheld (fail-safe).
+    return true;
+  }
 }
 
 function formatError(error: unknown): string {

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -15,7 +15,13 @@ import { checkOrchestrationHealth } from "./checks/orchestration-health";
 import { checkRuntime } from "./checks/runtime-check";
 import { checkSmoke } from "./checks/smoke-check";
 import { checkWechat } from "./checks/wechat-check";
-import type { DoctorCheckResult, DoctorReport, DoctorRunOptions } from "./doctor-types";
+import type {
+  DoctorCheckResult,
+  DoctorFixOutcome,
+  DoctorReport,
+  DoctorRepairOutcome,
+  DoctorRunOptions,
+} from "./doctor-types";
 import { renderDoctor } from "./render-doctor";
 
 export interface DoctorRunResult {
@@ -44,60 +50,102 @@ export async function runDoctor(options: DoctorRunOptions = {}, deps: DoctorDeps
   const runtimePaths = resolveDoctorRuntimePaths(home, deps.resolveRuntimePaths);
   const sharedLoadConfig = createSharedLoadConfig(runtimePaths, deps.loadConfig ?? loadConfig);
 
-  const checks: DoctorCheckResult[] = [];
-  checks.push(
-    await (deps.checkConfig ?? checkConfig)({
-      loadConfig: sharedLoadConfig,
-      resolveRuntimePaths: () => runtimePaths,
-    }),
-  );
-  checks.push(
-    await (deps.checkRuntime ?? checkRuntime)({
-      home,
-      configPath: runtimePaths.configPath,
-    }),
-  );
-  checks.push(
-    await (deps.checkDaemon ?? checkDaemon)({
-      home,
-      configPath: runtimePaths.configPath,
-    }),
-  );
-  checks.push(
-    await (deps.checkWechat ?? checkWechat)({
-      verbose: options.verbose,
-    }),
-  );
-  checks.push(
-    await (deps.checkAcpx ?? checkAcpx)({
-      verbose: options.verbose,
-      loadConfig: sharedLoadConfig,
-      resolveRuntimePaths: () => runtimePaths,
-    }),
-  );
-  checks.push(
-    await (deps.checkBridge ?? checkBridge)({
-      verbose: options.verbose,
-      loadConfig: sharedLoadConfig,
-      resolveRuntimePaths: () => runtimePaths,
-    }),
-  );
-  checks.push(
-    await (deps.checkOrchestrationHealth ?? (() => defaultCheckOrchestrationHealth({
-      runtimePaths,
-      loadConfig: sharedLoadConfig,
-    })))(),
-  );
-  checks.push(
-    options.smoke === true
-      ? await (deps.checkSmoke ?? ((runOptions) => defaultCheckSmoke(runOptions, {
-          resolveRuntimePaths: () => runtimePaths,
+  // Each runner produces one check result; keeping the wiring in a single place
+  // lets the repair pass re-invoke a check by id without duplicating dependency
+  // setup. The array order is the rendered/report order.
+  const runners: Array<{ id: string; run: () => Promise<DoctorCheckResult> }> = [
+    {
+      id: "config",
+      run: () =>
+        (deps.checkConfig ?? checkConfig)({
           loadConfig: sharedLoadConfig,
-        })))(options)
-      : createSmokeSkipResult("smoke probe not requested"),
-  );
+          resolveRuntimePaths: () => runtimePaths,
+        }),
+    },
+    {
+      id: "runtime",
+      run: () =>
+        (deps.checkRuntime ?? checkRuntime)({
+          home,
+          configPath: runtimePaths.configPath,
+        }),
+    },
+    {
+      id: "daemon",
+      run: () =>
+        (deps.checkDaemon ?? checkDaemon)({
+          home,
+          configPath: runtimePaths.configPath,
+        }),
+    },
+    {
+      id: "wechat",
+      run: () =>
+        (deps.checkWechat ?? checkWechat)({
+          verbose: options.verbose,
+        }),
+    },
+    {
+      id: "acpx",
+      run: () =>
+        (deps.checkAcpx ?? checkAcpx)({
+          verbose: options.verbose,
+          loadConfig: sharedLoadConfig,
+          resolveRuntimePaths: () => runtimePaths,
+        }),
+    },
+    {
+      id: "bridge",
+      run: () =>
+        (deps.checkBridge ?? checkBridge)({
+          verbose: options.verbose,
+          loadConfig: sharedLoadConfig,
+          resolveRuntimePaths: () => runtimePaths,
+        }),
+    },
+    {
+      id: "orchestration",
+      run: () =>
+        (deps.checkOrchestrationHealth ?? (() => defaultCheckOrchestrationHealth({
+          runtimePaths,
+          loadConfig: sharedLoadConfig,
+        })))(),
+    },
+    {
+      id: "smoke",
+      run: () =>
+        options.smoke === true
+          ? (deps.checkSmoke ?? ((runOptions) => defaultCheckSmoke(runOptions, {
+              resolveRuntimePaths: () => runtimePaths,
+              loadConfig: sharedLoadConfig,
+            })))(options)
+          : Promise.resolve(createSmokeSkipResult("smoke probe not requested")),
+    },
+  ];
+
+  const runnersById = new Map(runners.map((runner) => [runner.id, runner.run] as const));
+
+  const checks: DoctorCheckResult[] = [];
+  for (const runner of runners) {
+    checks.push(await runner.run());
+  }
 
   const report: DoctorReport = { checks };
+
+  if (options.fix === true) {
+    const { repairs, repairedCheckIds } = await applyRepairs(checks);
+    report.repairs = repairs;
+
+    for (const checkId of repairedCheckIds) {
+      const index = checks.findIndex((check) => check.id === checkId);
+      const rerun = runnersById.get(checkId);
+      if (index === -1 || !rerun) {
+        continue;
+      }
+      checks[index] = await rerun();
+    }
+  }
+
   const output = (deps.renderDoctor ?? renderDoctor)(report, options);
 
   return {
@@ -105,6 +153,56 @@ export async function runDoctor(options: DoctorRunOptions = {}, deps: DoctorDeps
     output,
     exitCode: checks.some((check) => check.severity === "fail") ? 1 : 0,
   };
+}
+
+/**
+ * Run the attached fixes for the read-only checks under --fix. Withheld fixes
+ * are recorded as skipped (never run). A failing or throwing fix is normalised
+ * into a "failed" outcome so a bad repair can never crash doctor. Returns the
+ * collected outcomes plus the set of check ids that had at least one applied
+ * fix (those, and only those, are re-run to reflect post-repair state).
+ */
+async function applyRepairs(
+  checks: DoctorCheckResult[],
+): Promise<{ repairs: DoctorRepairOutcome[]; repairedCheckIds: string[] }> {
+  const repairs: DoctorRepairOutcome[] = [];
+  const repairedCheckIds: string[] = [];
+
+  for (const check of checks) {
+    for (const fix of check.fixes ?? []) {
+      if (fix.withheld !== undefined) {
+        repairs.push({
+          checkId: check.id,
+          fixId: fix.id,
+          title: fix.title,
+          status: "skipped",
+          message: fix.withheld,
+        });
+        continue;
+      }
+
+      let outcome: DoctorFixOutcome;
+      try {
+        outcome = await fix.run();
+      } catch (error) {
+        outcome = { ok: false, message: formatError(error) };
+      }
+
+      repairs.push({
+        checkId: check.id,
+        fixId: fix.id,
+        title: fix.title,
+        status: outcome.ok ? "applied" : "failed",
+        message: outcome.message,
+      });
+
+      if (outcome.ok && !repairedCheckIds.includes(check.id)) {
+        repairedCheckIds.push(check.id);
+      }
+    }
+  }
+
+  return { repairs, repairedCheckIds };
 }
 
 function resolveDoctorRuntimePaths(home: string, resolver?: () => RuntimePaths): RuntimePaths {

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -13,6 +13,7 @@ import { checkAcpx } from "./checks/acpx-check";
 import { checkBridge } from "./checks/bridge-check";
 import { checkConfig } from "./checks/config-check";
 import { checkDaemon } from "./checks/daemon-check";
+import { checkLogs } from "./checks/logs-check";
 import { checkOrchestrationHealth } from "./checks/orchestration-health";
 import { checkOrchestrationSocket } from "./checks/orchestration-socket-check";
 import { checkPlugins } from "./checks/plugin-check";
@@ -42,6 +43,7 @@ interface DoctorDeps {
   checkConfig?: typeof checkConfig;
   checkRuntime?: typeof checkRuntime;
   checkDaemon?: typeof checkDaemon;
+  checkLogs?: typeof checkLogs;
   checkWechat?: typeof checkWechat;
   checkAcpx?: typeof checkAcpx;
   checkBridge?: typeof checkBridge;
@@ -79,6 +81,14 @@ export async function runDoctor(options: DoctorRunOptions = {}, deps: DoctorDeps
       id: "runtime",
       run: () =>
         (deps.checkRuntime ?? checkRuntime)({
+          home,
+          configPath: runtimePaths.configPath,
+        }),
+    },
+    {
+      id: "logs",
+      run: () =>
+        (deps.checkLogs ?? checkLogs)({
           home,
           configPath: runtimePaths.configPath,
         }),

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -57,6 +57,12 @@ interface DoctorDeps {
    * processes in tests.
    */
   isDaemonRunning?: () => Promise<boolean>;
+  /**
+   * Raw daemon status getter used by the DEFAULT liveness mapping. Injected so
+   * the running/indeterminate -> "live" gating can be exercised without real
+   * processes; ignored when {@link isDaemonRunning} is supplied directly.
+   */
+  getDaemonStatus?: () => Promise<{ state: string }>;
   renderDoctor?: typeof renderDoctor;
 }
 
@@ -141,7 +147,8 @@ export async function runDoctor(options: DoctorRunOptions = {}, deps: DoctorDeps
         (deps.checkOrchestrationHealth ?? (() => defaultCheckOrchestrationHealth({
           runtimePaths,
           loadConfig: sharedLoadConfig,
-          isDaemonRunning: deps.isDaemonRunning ?? (() => defaultIsDaemonRunning(home, runtimePaths)),
+          isDaemonRunning:
+            deps.isDaemonRunning ?? (() => defaultIsDaemonRunning(home, runtimePaths, deps.getDaemonStatus)),
         })))(),
     },
     {
@@ -422,26 +429,39 @@ function createStateQuarantineFix(statePath: string, daemonRunning: boolean): Do
   };
 }
 
-async function defaultIsDaemonRunning(home: string, runtimePaths: RuntimePaths): Promise<boolean> {
+async function defaultIsDaemonRunning(
+  home: string,
+  runtimePaths: RuntimePaths,
+  getDaemonStatus: () => Promise<{ state: string }> = () => defaultGetDaemonStatus(home, runtimePaths),
+): Promise<boolean> {
   try {
-    const paths = resolveDaemonPaths({
-      home,
-      runtimeDir: resolveRuntimeDirFromConfigPath(runtimePaths.configPath),
-    });
-    const controller = createDaemonController(paths, {
-      processExecPath: process.execPath,
-      cliEntryPath: process.argv[1] ?? "",
-      cwd: process.cwd(),
-      env: process.env,
-      isProcessRunning: isProcessAlive,
-    });
-    const status = await controller.getStatus();
-    return status.state === "running";
+    const status = await getDaemonStatus();
+    // Both "running" AND "indeterminate" mean a LIVE daemon pid:
+    // getStatus() only reports "indeterminate" after confirming the process is
+    // alive (status.json missing). The state-mutating quarantine must be gated
+    // (withheld) in both cases, or --fix would rename/rewrite state.json out
+    // from under a live daemon.
+    return status.state === "running" || status.state === "indeterminate";
   } catch {
     // If we cannot determine daemon state, do NOT mutate: treat as running so
     // the state-mutating fix is withheld (fail-safe).
     return true;
   }
+}
+
+async function defaultGetDaemonStatus(home: string, runtimePaths: RuntimePaths): Promise<{ state: string }> {
+  const paths = resolveDaemonPaths({
+    home,
+    runtimeDir: resolveRuntimeDirFromConfigPath(runtimePaths.configPath),
+  });
+  const controller = createDaemonController(paths, {
+    processExecPath: process.execPath,
+    cliEntryPath: process.argv[1] ?? "",
+    cwd: process.cwd(),
+    env: process.env,
+    isProcessRunning: isProcessAlive,
+  });
+  return await controller.getStatus();
 }
 
 function formatError(error: unknown): string {

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -14,6 +14,7 @@ import { checkBridge } from "./checks/bridge-check";
 import { checkConfig } from "./checks/config-check";
 import { checkDaemon } from "./checks/daemon-check";
 import { checkOrchestrationHealth } from "./checks/orchestration-health";
+import { checkPlugins } from "./checks/plugin-check";
 import { checkRuntime } from "./checks/runtime-check";
 import { checkSmoke } from "./checks/smoke-check";
 import { checkWechat } from "./checks/wechat-check";
@@ -43,6 +44,7 @@ interface DoctorDeps {
   checkWechat?: typeof checkWechat;
   checkAcpx?: typeof checkAcpx;
   checkBridge?: typeof checkBridge;
+  checkPlugins?: typeof checkPlugins;
   checkOrchestrationHealth?: () => Promise<DoctorCheckResult>;
   checkSmoke?: (options: DoctorRunOptions) => Promise<DoctorCheckResult>;
   /**
@@ -108,6 +110,15 @@ export async function runDoctor(options: DoctorRunOptions = {}, deps: DoctorDeps
       run: () =>
         (deps.checkBridge ?? checkBridge)({
           verbose: options.verbose,
+          loadConfig: sharedLoadConfig,
+          resolveRuntimePaths: () => runtimePaths,
+        }),
+    },
+    {
+      id: "plugins",
+      run: () =>
+        (deps.checkPlugins ?? checkPlugins)({
+          home,
           loadConfig: sharedLoadConfig,
           resolveRuntimePaths: () => runtimePaths,
         }),

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -6,7 +6,7 @@ import { coreEnv } from "../runtime/core-env";
 import { loadConfig } from "../config/load-config";
 import type { AppConfig } from "../config/types";
 import { createDaemonController } from "../daemon/create-daemon-controller";
-import { resolveDaemonPaths, resolveRuntimeDirFromConfigPath } from "../daemon/daemon-files";
+import { isProcessAlive, resolveDaemonPaths, resolveRuntimeDirFromConfigPath } from "../daemon/daemon-files";
 import { resolveRuntimePaths, type RuntimePaths } from "../main";
 import { StateStore, type StateLoadReport } from "../state/state-store";
 import { checkAcpx } from "./checks/acpx-check";
@@ -402,14 +402,7 @@ async function defaultIsDaemonRunning(home: string, runtimePaths: RuntimePaths):
       cliEntryPath: process.argv[1] ?? "",
       cwd: process.cwd(),
       env: process.env,
-      isProcessRunning: (pid: number) => {
-        try {
-          process.kill(pid, 0);
-          return true;
-        } catch {
-          return false;
-        }
-      },
+      isProcessRunning: isProcessAlive,
     });
     const status = await controller.getStatus();
     return status.state === "running";

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -14,6 +14,7 @@ import { checkBridge } from "./checks/bridge-check";
 import { checkConfig } from "./checks/config-check";
 import { checkDaemon } from "./checks/daemon-check";
 import { checkOrchestrationHealth } from "./checks/orchestration-health";
+import { checkOrchestrationSocket } from "./checks/orchestration-socket-check";
 import { checkPlugins } from "./checks/plugin-check";
 import { checkRuntime } from "./checks/runtime-check";
 import { checkSmoke } from "./checks/smoke-check";
@@ -46,6 +47,7 @@ interface DoctorDeps {
   checkBridge?: typeof checkBridge;
   checkPlugins?: typeof checkPlugins;
   checkOrchestrationHealth?: () => Promise<DoctorCheckResult>;
+  checkOrchestrationSocket?: typeof checkOrchestrationSocket;
   checkSmoke?: (options: DoctorRunOptions) => Promise<DoctorCheckResult>;
   /**
    * Whether a daemon currently owns the runtime. Injected so the state-mutating
@@ -131,6 +133,14 @@ export async function runDoctor(options: DoctorRunOptions = {}, deps: DoctorDeps
           loadConfig: sharedLoadConfig,
           isDaemonRunning: deps.isDaemonRunning ?? (() => defaultIsDaemonRunning(home, runtimePaths)),
         })))(),
+    },
+    {
+      id: "orchestration-socket",
+      run: () =>
+        (deps.checkOrchestrationSocket ?? checkOrchestrationSocket)({
+          home,
+          configPath: runtimePaths.configPath,
+        }),
     },
     {
       id: "smoke",

--- a/src/doctor/render-doctor.ts
+++ b/src/doctor/render-doctor.ts
@@ -8,54 +8,75 @@ const SEVERITY_LABELS: Record<DoctorSeverity, string> = {
 };
 
 export function renderDoctor(report: DoctorReport, options: DoctorRunOptions = {}): string[] {
-  return options.verbose ? renderVerboseDoctor(report) : renderDefaultDoctor(report);
+  const fixMode = options.fix === true;
+  return options.verbose
+    ? renderVerboseDoctor(report, fixMode)
+    : renderDefaultDoctor(report, fixMode);
 }
 
-function renderDefaultDoctor(report: DoctorReport): string[] {
+function renderDefaultDoctor(report: DoctorReport, fixMode: boolean): string[] {
   const lines: string[] = [];
 
   for (const check of report.checks) {
-    lines.push(renderCheckLine(check));
+    lines.push(renderCheckLine(check, fixMode));
   }
 
+  appendRepairs(lines, report, fixMode);
   lines.push(renderSummaryLine(report.checks));
-
-  const suggestions = collectSuggestions(report.checks);
-  if (suggestions.length > 0) {
-    lines.push("Next steps:");
-    for (const suggestion of suggestions) {
-      lines.push(`- ${suggestion}`);
-    }
-  }
+  appendNextSteps(lines, report.checks);
 
   return lines;
 }
 
-function renderVerboseDoctor(report: DoctorReport): string[] {
+function renderVerboseDoctor(report: DoctorReport, fixMode: boolean): string[] {
   const lines: string[] = [];
 
   for (const check of report.checks) {
-    lines.push(renderCheckLine(check));
+    lines.push(renderCheckLine(check, fixMode));
     for (const detail of check.details ?? []) {
       lines.push(`  detail: ${detail}`);
     }
   }
 
+  appendRepairs(lines, report, fixMode);
   lines.push(renderSummaryLine(report.checks));
+  appendNextSteps(lines, report.checks);
 
-  const suggestions = collectSuggestions(report.checks);
+  return lines;
+}
+
+function appendNextSteps(lines: string[], checks: DoctorCheckResult[]): void {
+  const suggestions = collectSuggestions(checks);
   if (suggestions.length > 0) {
     lines.push("Next steps:");
     for (const suggestion of suggestions) {
       lines.push(`- ${suggestion}`);
     }
   }
-
-  return lines;
 }
 
-function renderCheckLine(check: DoctorCheckResult): string {
-  return `${SEVERITY_LABELS[check.severity]} ${check.label}: ${check.summary}`;
+function appendRepairs(lines: string[], report: DoctorReport, fixMode: boolean): void {
+  if (!fixMode) {
+    return;
+  }
+
+  const repairs = report.repairs ?? [];
+  if (repairs.length === 0) {
+    return;
+  }
+
+  lines.push("Repairs:");
+  for (const repair of repairs) {
+    lines.push(`- ${repair.title}: ${repair.status} (${repair.message})`);
+  }
+}
+
+function renderCheckLine(check: DoctorCheckResult, fixMode: boolean): string {
+  const base = `${SEVERITY_LABELS[check.severity]} ${check.label}: ${check.summary}`;
+  if (!fixMode && (check.fixes?.length ?? 0) > 0) {
+    return `${base} (fixable — run: xacpx doctor --fix)`;
+  }
+  return base;
 }
 
 function renderSummaryLine(checks: DoctorCheckResult[]): string {

--- a/src/plugins/plugin-doctor.ts
+++ b/src/plugins/plugin-doctor.ts
@@ -18,6 +18,13 @@ export interface PluginDoctorIssue {
   level: PluginDoctorLevel;
   plugin?: string;
   message: string;
+  /**
+   * Precise remediation command for this issue (e.g.
+   * `xacpx plugin add <name> && xacpx restart`). Populated at the error/warn
+   * site where the exact target is known, so consumers (e.g. `xacpx doctor`)
+   * surface actionable suggestions without parsing the human-readable message.
+   */
+  suggestion?: string;
 }
 
 export interface InspectPluginsInput {
@@ -69,7 +76,7 @@ export async function inspectPlugins(input: InspectPluginsInput): Promise<Plugin
 
   for (const configPlugin of allConfigured) {
     if (!(configPlugin.name in dependencies)) {
-      pushIfRelevant({ level: "error", plugin: configPlugin.name, message: `package not installed in plugin home; run xacpx plugin add ${configPlugin.name}` });
+      pushIfRelevant({ level: "error", plugin: configPlugin.name, message: `package not installed in plugin home; run xacpx plugin add ${configPlugin.name}`, suggestion: `xacpx plugin add ${configPlugin.name} && xacpx restart` });
       continue;
     }
 
@@ -78,7 +85,7 @@ export async function inspectPlugins(input: InspectPluginsInput): Promise<Plugin
       moduleValue = await importPlugin(configPlugin.name, input.pluginHome);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      pushIfRelevant({ level: "error", plugin: configPlugin.name, message: `failed to import plugin: ${message}` });
+      pushIfRelevant({ level: "error", plugin: configPlugin.name, message: `failed to import plugin: ${message}`, suggestion: `xacpx plugin add ${configPlugin.name} && xacpx restart` });
       continue;
     }
 
@@ -102,6 +109,7 @@ export async function inspectPlugins(input: InspectPluginsInput): Promise<Plugin
         message: configPlugin.enabled
           ? `plugin is installed and valid; channels: ${channelTypes.length > 0 ? channelTypes.join(", ") : "none"}`
           : `plugin is installed and valid but disabled; run xacpx plugin enable ${configPlugin.name}`,
+        ...(configPlugin.enabled ? {} : { suggestion: `xacpx plugin enable ${configPlugin.name}` }),
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -116,9 +124,11 @@ export async function inspectPlugins(input: InspectPluginsInput): Promise<Plugin
     const provider = channelProviders.get(channel.type);
     if (!provider) {
       if (!filterByName) {
+        const suggestedPackage = suggestedPluginPackageForChannel(channel.type);
         issues.push({
           level: "error",
-          message: `channel ${channel.type} is configured but no enabled plugin provides it; run xacpx plugin add ${suggestedPluginPackageForChannel(channel.type)} or another plugin that provides type "${channel.type}"`,
+          message: `channel ${channel.type} is configured but no enabled plugin provides it; run xacpx plugin add ${suggestedPackage} or another plugin that provides type "${channel.type}"`,
+          suggestion: `xacpx plugin add ${suggestedPackage}`,
         });
       }
       continue;
@@ -128,6 +138,7 @@ export async function inspectPlugins(input: InspectPluginsInput): Promise<Plugin
         level: "error",
         plugin: provider.plugin,
         message: `channel ${channel.type} is configured but provider plugin is disabled; run xacpx plugin enable ${provider.plugin}`,
+        suggestion: `xacpx plugin enable ${provider.plugin}`,
       });
     }
   }

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -429,6 +429,36 @@ test("passes doctor options through unchanged", async () => {
   ]);
 });
 
+test("passes the --fix flag through to doctor", async () => {
+  const received: Array<Record<string, unknown>> = [];
+
+  await expect(
+    runCli(["doctor", "--fix"], {
+      doctor: async (options) => {
+        received.push(options);
+        return 0;
+      },
+    }),
+  ).resolves.toBe(0);
+
+  expect(received).toEqual([{ fix: true }]);
+});
+
+test("combines --fix with --verbose and --smoke", async () => {
+  const received: Array<Record<string, unknown>> = [];
+
+  await expect(
+    runCli(["doctor", "--fix", "--verbose", "--smoke"], {
+      doctor: async (options) => {
+        received.push(options);
+        return 0;
+      },
+    }),
+  ).resolves.toBe(0);
+
+  expect(received).toEqual([{ fix: true, verbose: true, smoke: true }]);
+});
+
 test("adds a workspace from the current directory with basename as default name", async () => {
   setLocale("zh");
   await withTempHome(async (home) => {

--- a/tests/unit/doctor/checks/daemon-check.test.ts
+++ b/tests/unit/doctor/checks/daemon-check.test.ts
@@ -1,0 +1,137 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { expect, test } from "bun:test";
+
+import { checkDaemon } from "../../../../src/doctor/checks/daemon-check";
+import { DaemonStatusStore } from "../../../../src/daemon/daemon-status";
+
+async function createTempHome(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "xacpx-daemon-check-"));
+}
+
+function lockPath(runtimeDir: string): string {
+  return join(runtimeDir, "weixin-consumer.lock.json");
+}
+
+async function writeLock(runtimeDir: string, pid: number): Promise<void> {
+  await mkdir(runtimeDir, { recursive: true });
+  await writeFile(
+    lockPath(runtimeDir),
+    JSON.stringify({
+      pid,
+      mode: "daemon",
+      startedAt: "2026-06-11T00:00:00.000Z",
+      configPath: "/cfg",
+      statePath: "/state",
+    }),
+    "utf8",
+  );
+}
+
+test("daemon check attaches clear-stale-lock fix when the lock pid is dead and no daemon runs", async () => {
+  const home = await createTempHome();
+  const runtimeDir = join(home, ".xacpx", "runtime");
+  const stalePid = 99999;
+
+  try {
+    await writeLock(runtimeDir, stalePid);
+
+    const removed: string[] = [];
+    const result = await checkDaemon({
+      home,
+      // daemon stopped (no pid file); lock pid is not running
+      isProcessRunning: () => false,
+      removeConsumerLock: async (path) => {
+        removed.push(path);
+      },
+    });
+
+    const fix = result.fixes?.find((entry) => entry.id === "daemon.clear-stale-lock");
+    expect(fix).toBeDefined();
+    expect(fix?.withheld).toBeUndefined();
+
+    const outcome = await fix!.run();
+    expect(outcome.ok).toBe(true);
+    expect(removed).toEqual([lockPath(runtimeDir)]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("daemon check does not attach the lock fix when the lock pid is alive", async () => {
+  const home = await createTempHome();
+  const runtimeDir = join(home, ".xacpx", "runtime");
+  const livePid = 4242;
+
+  try {
+    await writeLock(runtimeDir, livePid);
+
+    const result = await checkDaemon({
+      home,
+      // The lock owner is alive; the daemon pid file is absent so the daemon
+      // itself reads as stopped, but the lock is NOT stale.
+      isProcessRunning: (pid) => pid === livePid,
+    });
+
+    expect(result.fixes?.some((entry) => entry.id === "daemon.clear-stale-lock") ?? false).toBe(false);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("daemon check does not attach the lock fix when the daemon is running", async () => {
+  const home = await createTempHome();
+  const runtimeDir = join(home, ".weacpx", "runtime");
+  const daemonPid = 12345;
+  const stalePid = 99999;
+
+  try {
+    await mkdir(runtimeDir, { recursive: true });
+    await writeFile(join(runtimeDir, "daemon.pid"), `${daemonPid}\n`, "utf8");
+    await new DaemonStatusStore(join(runtimeDir, "status.json")).save({
+      pid: daemonPid,
+      started_at: "2026-06-11T00:00:00.000Z",
+      heartbeat_at: "2026-06-11T00:01:00.000Z",
+      config_path: "/cfg",
+      state_path: "/state",
+      app_log: "/app",
+      stdout_log: "/out",
+      stderr_log: "/err",
+    });
+    await writeLock(runtimeDir, stalePid);
+
+    const removed: string[] = [];
+    const result = await checkDaemon({
+      home,
+      // daemon pid alive, lock pid dead
+      isProcessRunning: (pid) => pid === daemonPid,
+      removeConsumerLock: async (path) => {
+        removed.push(path);
+      },
+    });
+
+    expect(result.severity).toBe("pass");
+    expect(result.fixes?.some((entry) => entry.id === "daemon.clear-stale-lock") ?? false).toBe(false);
+    expect(removed).toEqual([]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("daemon check ignores a missing consumer lock", async () => {
+  const home = await createTempHome();
+
+  try {
+    const result = await checkDaemon({
+      home,
+      isProcessRunning: () => false,
+    });
+
+    expect(result.fixes?.some((entry) => entry.id === "daemon.clear-stale-lock") ?? false).toBe(false);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/doctor/checks/daemon-check.test.ts
+++ b/tests/unit/doctor/checks/daemon-check.test.ts
@@ -135,3 +135,36 @@ test("daemon check ignores a missing consumer lock", async () => {
     await rm(home, { recursive: true, force: true });
   }
 });
+
+test("daemon check does not attach the lock fix when status is indeterminate (live daemon pid)", async () => {
+  const home = await createTempHome();
+  const runtimeDir = join(home, ".weacpx", "runtime");
+  const daemonPid = 12345;
+  const stalePid = 99999;
+
+  try {
+    // pid file present but status.json absent => getStatus() reports
+    // "indeterminate" ONLY after confirming the pid is alive. That is a LIVE
+    // daemon, so a stale lock must not be removed.
+    await mkdir(runtimeDir, { recursive: true });
+    await writeFile(join(runtimeDir, "daemon.pid"), `${daemonPid}\n`, "utf8");
+    await writeLock(runtimeDir, stalePid);
+
+    const removed: string[] = [];
+    const result = await checkDaemon({
+      home,
+      // daemon pid alive (indeterminate), lock pid dead
+      isProcessRunning: (pid) => pid === daemonPid,
+      removeConsumerLock: async (path) => {
+        removed.push(path);
+      },
+    });
+
+    expect(result.severity).toBe("fail");
+    expect(result.summary).toContain("indeterminate");
+    expect(result.fixes?.some((entry) => entry.id === "daemon.clear-stale-lock") ?? false).toBe(false);
+    expect(removed).toEqual([]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/doctor/checks/daemon-check.test.ts
+++ b/tests/unit/doctor/checks/daemon-check.test.ts
@@ -12,14 +12,14 @@ async function createTempHome(): Promise<string> {
   return await mkdtemp(join(tmpdir(), "xacpx-daemon-check-"));
 }
 
-function lockPath(runtimeDir: string): string {
-  return join(runtimeDir, "weixin-consumer.lock.json");
+function lockPath(runtimeDir: string, channel = "weixin"): string {
+  return join(runtimeDir, `${channel}-consumer.lock.json`);
 }
 
-async function writeLock(runtimeDir: string, pid: number): Promise<void> {
+async function writeLock(runtimeDir: string, pid: number, channel = "weixin"): Promise<void> {
   await mkdir(runtimeDir, { recursive: true });
   await writeFile(
-    lockPath(runtimeDir),
+    lockPath(runtimeDir, channel),
     JSON.stringify({
       pid,
       mode: "daemon",
@@ -84,7 +84,7 @@ test("daemon check does not attach the lock fix when the lock pid is alive", asy
 
 test("daemon check does not attach the lock fix when the daemon is running", async () => {
   const home = await createTempHome();
-  const runtimeDir = join(home, ".weacpx", "runtime");
+  const runtimeDir = join(home, ".xacpx", "runtime");
   const daemonPid = 12345;
   const stalePid = 99999;
 
@@ -136,9 +136,89 @@ test("daemon check ignores a missing consumer lock", async () => {
   }
 });
 
+test("daemon check detects a stale non-weixin (feishu) consumer lock", async () => {
+  const home = await createTempHome();
+  const runtimeDir = join(home, ".xacpx", "runtime");
+  const stalePid = 99999;
+
+  try {
+    await writeLock(runtimeDir, stalePid, "feishu");
+
+    const removed: string[] = [];
+    const result = await checkDaemon({
+      home,
+      isProcessRunning: () => false,
+      removeConsumerLock: async (path) => {
+        removed.push(path);
+      },
+    });
+
+    const fix = result.fixes?.find((entry) => entry.id === "daemon.clear-stale-lock");
+    expect(fix).toBeDefined();
+
+    const outcome = await fix!.run();
+    expect(outcome.ok).toBe(true);
+    expect(removed).toEqual([lockPath(runtimeDir, "feishu")]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("daemon check removes only the dead-pid lock when multiple consumer locks exist", async () => {
+  const home = await createTempHome();
+  const runtimeDir = join(home, ".xacpx", "runtime");
+  const livePid = 4242;
+  const stalePid = 99999;
+
+  try {
+    await writeLock(runtimeDir, livePid, "weixin");
+    await writeLock(runtimeDir, stalePid, "feishu");
+
+    const removed: string[] = [];
+    const result = await checkDaemon({
+      home,
+      // Only the feishu owner is dead.
+      isProcessRunning: (pid) => pid === livePid,
+      removeConsumerLock: async (path) => {
+        removed.push(path);
+      },
+    });
+
+    const fix = result.fixes?.find((entry) => entry.id === "daemon.clear-stale-lock");
+    expect(fix).toBeDefined();
+
+    const outcome = await fix!.run();
+    expect(outcome.ok).toBe(true);
+    // The live weixin lock is left alone; only the stale feishu lock is removed.
+    expect(removed).toEqual([lockPath(runtimeDir, "feishu")]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("daemon check attaches no lock fix when all consumer locks have live pids", async () => {
+  const home = await createTempHome();
+  const runtimeDir = join(home, ".xacpx", "runtime");
+  const livePid = 4242;
+
+  try {
+    await writeLock(runtimeDir, livePid, "weixin");
+    await writeLock(runtimeDir, livePid, "feishu");
+
+    const result = await checkDaemon({
+      home,
+      isProcessRunning: (pid) => pid === livePid,
+    });
+
+    expect(result.fixes?.some((entry) => entry.id === "daemon.clear-stale-lock") ?? false).toBe(false);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
 test("daemon check does not attach the lock fix when status is indeterminate (live daemon pid)", async () => {
   const home = await createTempHome();
-  const runtimeDir = join(home, ".weacpx", "runtime");
+  const runtimeDir = join(home, ".xacpx", "runtime");
   const daemonPid = 12345;
   const stalePid = 99999;
 

--- a/tests/unit/doctor/checks/logs-check.test.ts
+++ b/tests/unit/doctor/checks/logs-check.test.ts
@@ -1,0 +1,184 @@
+import { join } from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { checkLogs } from "../../../../src/doctor/checks/logs-check";
+
+const MB = 1024 * 1024;
+
+interface ProbeOptions {
+  /** runtime dirs that exist. */
+  directories: string[];
+  /** path -> on-disk size in bytes. Presence implies the file exists. */
+  sizes?: Record<string, number>;
+  /** files that throw when stat'd (e.g. unreadable / vanished). */
+  unreadable?: string[];
+}
+
+function createLogsProbe(options: ProbeOptions): {
+  stat: (path: string) => Promise<{ isDirectory: () => boolean; size: number }>;
+  readdir: (path: string) => Promise<string[]>;
+} {
+  const directories = new Set(options.directories);
+  const sizes = options.sizes ?? {};
+  const unreadable = new Set(options.unreadable ?? []);
+
+  return {
+    async stat(path: string) {
+      if (directories.has(path)) {
+        return { isDirectory: () => true, size: 0 };
+      }
+      if (unreadable.has(path)) {
+        throw createErrno("EACCES", path);
+      }
+      const size = sizes[path];
+      if (size === undefined) {
+        throw createErrno("ENOENT", path);
+      }
+      return { isDirectory: () => false, size };
+    },
+    async readdir(path: string) {
+      if (!directories.has(path)) {
+        throw createErrno("ENOENT", path);
+      }
+      // Return entries that live directly under this dir (base names only).
+      const prefix = `${path}/`;
+      const names = new Set<string>();
+      for (const candidate of [...Object.keys(sizes), ...(options.unreadable ?? [])]) {
+        if (candidate.startsWith(prefix)) {
+          names.add(candidate.slice(prefix.length));
+        }
+      }
+      return [...names];
+    },
+  };
+}
+
+function createErrno(code: string, path: string): NodeJS.ErrnoException {
+  const error = new Error(`${code}: ${path}`) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+function runtimeDirOf(home: string): string {
+  return join(home, ".xacpx", "runtime");
+}
+
+test("logs check skips when the runtime dir does not exist", async () => {
+  const home = "/home/user";
+  const probe = createLogsProbe({ directories: [] });
+
+  const result = await checkLogs({ home, probe });
+
+  expect(result.id).toBe("logs");
+  expect(result.severity).toBe("skip");
+  expect(result.summary.toLowerCase()).toContain("no runtime logs");
+});
+
+test("logs check passes when all files are under threshold and reports the total", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createLogsProbe({
+    directories: [runtimeDir],
+    sizes: {
+      [join(runtimeDir, "app.log")]: 1 * MB,
+      [join(runtimeDir, "stdout.log")]: 2 * MB,
+      [join(runtimeDir, "stderr.log")]: 3 * MB,
+    },
+  });
+
+  const result = await checkLogs({ home, probe });
+
+  expect(result.severity).toBe("pass");
+  expect(result.summary).toContain("6");
+  expect(result.details?.join("\n") ?? "").toContain("app.log");
+});
+
+test("logs check warns when a single log file exceeds the single-file threshold", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createLogsProbe({
+    directories: [runtimeDir],
+    sizes: {
+      [join(runtimeDir, "app.log")]: 60 * MB,
+      [join(runtimeDir, "stdout.log")]: 1 * MB,
+    },
+  });
+
+  const result = await checkLogs({
+    home,
+    probe,
+    singleFileWarnBytes: 50 * MB,
+    totalWarnBytes: 200 * MB,
+  });
+
+  expect(result.severity).toBe("warn");
+  expect(result.suggestions?.join("\n") ?? "").toContain("rotation");
+});
+
+test("logs check warns when the total exceeds the total threshold even with no single file over", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createLogsProbe({
+    directories: [runtimeDir],
+    sizes: {
+      [join(runtimeDir, "app.log")]: 40 * MB,
+      [join(runtimeDir, "stdout.log")]: 40 * MB,
+      [join(runtimeDir, "stderr.log")]: 40 * MB,
+    },
+  });
+
+  const result = await checkLogs({
+    home,
+    probe,
+    singleFileWarnBytes: 50 * MB,
+    totalWarnBytes: 100 * MB,
+  });
+
+  expect(result.severity).toBe("warn");
+});
+
+test("logs check counts rotation siblings toward the total", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createLogsProbe({
+    directories: [runtimeDir],
+    sizes: {
+      [join(runtimeDir, "app.log")]: 10 * MB,
+      [join(runtimeDir, "app.log.1")]: 10 * MB,
+      [join(runtimeDir, "app.log.2")]: 10 * MB,
+    },
+  });
+
+  const result = await checkLogs({
+    home,
+    probe,
+    singleFileWarnBytes: 50 * MB,
+    totalWarnBytes: 25 * MB,
+  });
+
+  // 30 MB total > 25 MB threshold thanks to the two rotation siblings.
+  expect(result.severity).toBe("warn");
+  const details = result.details?.join("\n") ?? "";
+  expect(details).toContain("app.log.1");
+  expect(details).toContain("app.log.2");
+});
+
+test("logs check tolerates an unreadable individual file and still sums the rest", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createLogsProbe({
+    directories: [runtimeDir],
+    sizes: {
+      [join(runtimeDir, "app.log")]: 5 * MB,
+      [join(runtimeDir, "stderr.log")]: 5 * MB,
+    },
+    unreadable: [join(runtimeDir, "stdout.log")],
+  });
+
+  const result = await checkLogs({ home, probe });
+
+  expect(result.severity).toBe("pass");
+  // 10 MB summed from the two readable files; the unreadable one is skipped.
+  expect(result.summary).toContain("10");
+});

--- a/tests/unit/doctor/checks/orchestration-socket-check.test.ts
+++ b/tests/unit/doctor/checks/orchestration-socket-check.test.ts
@@ -1,0 +1,119 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { expect, test } from "bun:test";
+
+import { checkOrchestrationSocket } from "../../../../src/doctor/checks/orchestration-socket-check";
+
+async function createTempHome(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "xacpx-orch-socket-check-"));
+}
+
+test("orchestration socket check skips and never probes when the daemon is stopped", async () => {
+  const home = await createTempHome();
+  let probed = false;
+
+  try {
+    const result = await checkOrchestrationSocket({
+      home,
+      getDaemonStatus: async () => ({ state: "stopped" }),
+      canConnectToEndpoint: async () => {
+        probed = true;
+        return true;
+      },
+    });
+
+    expect(result.id).toBe("orchestration-socket");
+    expect(result.severity).toBe("skip");
+    expect(result.summary).toContain("daemon stopped");
+    expect(probed).toBe(false);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("orchestration socket check passes when the daemon is running and the endpoint accepts connections", async () => {
+  const home = await createTempHome();
+
+  try {
+    const result = await checkOrchestrationSocket({
+      home,
+      getDaemonStatus: async () => ({ state: "running", pid: 4242 }),
+      canConnectToEndpoint: async () => true,
+    });
+
+    expect(result.severity).toBe("pass");
+    expect(result.summary).toContain("accepting connections");
+    expect(result.fixes ?? []).toEqual([]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("orchestration socket check fails with endpoint path and a restart suggestion when there is definitively no listener", async () => {
+  const home = await createTempHome();
+  let probedPath: string | undefined;
+
+  try {
+    const result = await checkOrchestrationSocket({
+      home,
+      getDaemonStatus: async () => ({ state: "running", pid: 4242 }),
+      canConnectToEndpoint: async (path) => {
+        probedPath = path;
+        return false;
+      },
+    });
+
+    expect(result.severity).toBe("fail");
+    expect(result.summary).toContain("not accepting connections");
+    expect(result.suggestions ?? []).toContain("run: xacpx restart");
+    expect(result.details?.join("\n") ?? "").toContain(probedPath!);
+    // restart is a user action; no automated fix is attached.
+    expect(result.fixes ?? []).toEqual([]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("orchestration socket check treats an indeterminate daemon as a live daemon and probes it", async () => {
+  const home = await createTempHome();
+  let probed = false;
+
+  try {
+    const result = await checkOrchestrationSocket({
+      home,
+      getDaemonStatus: async () => ({ state: "indeterminate", pid: 4242 }),
+      canConnectToEndpoint: async () => {
+        probed = true;
+        return true;
+      },
+    });
+
+    expect(probed).toBe(true);
+    expect(result.severity).toBe("pass");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("orchestration socket check resolves the endpoint from the runtime dir and probes that path", async () => {
+  const home = await createTempHome();
+  let probedPath: string | undefined;
+
+  try {
+    await checkOrchestrationSocket({
+      home,
+      getDaemonStatus: async () => ({ state: "running", pid: 4242 }),
+      resolveOrchestrationEndpoint: (runtimeDir) => ({ kind: "unix", path: join(runtimeDir, "custom.sock") }),
+      canConnectToEndpoint: async (path) => {
+        probedPath = path;
+        return true;
+      },
+    });
+
+    expect(probedPath?.endsWith("custom.sock")).toBe(true);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/doctor/checks/orchestration-socket-check.test.ts
+++ b/tests/unit/doctor/checks/orchestration-socket-check.test.ts
@@ -117,3 +117,48 @@ test("orchestration socket check resolves the endpoint from the runtime dir and 
     await rm(home, { recursive: true, force: true });
   }
 });
+
+test("orchestration socket check skips with the error in details when the daemon status read throws", async () => {
+  const home = await createTempHome();
+  let probed = false;
+
+  try {
+    const result = await checkOrchestrationSocket({
+      home,
+      getDaemonStatus: async () => {
+        throw new Error("status read exploded");
+      },
+      canConnectToEndpoint: async () => {
+        probed = true;
+        return true;
+      },
+    });
+
+    expect(result.severity).toBe("skip");
+    expect(result.summary).toContain("could not be read");
+    expect(result.details?.join("\n") ?? "").toContain("status read exploded");
+    expect(probed).toBe(false);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("orchestration socket check skips without crashing when the probe throws", async () => {
+  const home = await createTempHome();
+
+  try {
+    const result = await checkOrchestrationSocket({
+      home,
+      getDaemonStatus: async () => ({ state: "running", pid: 4242 }),
+      canConnectToEndpoint: async () => {
+        throw new Error("probe exploded");
+      },
+    });
+
+    expect(result.severity).toBe("skip");
+    expect(result.summary).toContain("could not be probed");
+    expect(result.details?.join("\n") ?? "").toContain("probe exploded");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/doctor/checks/plugin-check.test.ts
+++ b/tests/unit/doctor/checks/plugin-check.test.ts
@@ -60,6 +60,12 @@ test("checkPlugins fails when any issue is an error", async () => {
 
   expect(result.severity).toBe("fail");
   expect(result.summary).toContain("issue");
+  // metadata is trimmed: counts + pluginHome only, never the raw issues array
+  expect(result.metadata).toEqual({ pluginHome: "/home/.xacpx/plugins", errorCount: 1, warnCount: 0 });
+  // duplicate-provider error carries no suggestion
+  expect(result.suggestions).toEqual([]);
+  // ok issues are not listed in details
+  expect(result.details?.join("\n") ?? "").not.toContain("a: ok");
 });
 
 test("checkPlugins surfaces an import failure as fail with the package name and an actionable suggestion", async () => {
@@ -69,6 +75,7 @@ test("checkPlugins surfaces an import failure as fail with the package name and 
         level: "error",
         plugin: "@ganglion/xacpx-channel-feishu",
         message: "failed to import plugin: Cannot find module '@ganglion/xacpx-channel-feishu'",
+        suggestion: "xacpx plugin add @ganglion/xacpx-channel-feishu && xacpx restart",
       },
     ]),
   );
@@ -76,7 +83,24 @@ test("checkPlugins surfaces an import failure as fail with the package name and 
   expect(result.severity).toBe("fail");
   expect(result.details?.join("\n") ?? "").toContain("@ganglion/xacpx-channel-feishu");
   const suggestions = result.suggestions ?? [];
-  expect(suggestions.some((s) => s.includes("xacpx plugin add @ganglion/xacpx-channel-feishu"))).toBe(true);
+  expect(suggestions).toContain("run: xacpx plugin add @ganglion/xacpx-channel-feishu && xacpx restart");
+});
+
+test("checkPlugins degrades to fail without throwing when inspectPlugins throws", async () => {
+  const result = await checkPlugins({
+    home: "/home",
+    loadConfig: async () => makeConfig(),
+    resolveRuntimePaths: () => ({ configPath: CONFIG_PATH, statePath: "/home/.xacpx/state.json" }),
+    resolvePluginHome: () => "/home/.xacpx/plugins",
+    inspectPlugins: async () => {
+      throw new Error("inspect exploded");
+    },
+    currentXacpxVersion: "9.9.9",
+  });
+
+  expect(result.severity).toBe("fail");
+  expect(result.summary).toContain("plugin health check failed");
+  expect(result.details?.join("\n") ?? "").toContain("inspect exploded");
 });
 
 test("checkPlugins skips when config cannot be loaded and points at the Config check", async () => {
@@ -122,7 +146,7 @@ test("checkPlugins inspects when a plugin-provided channel is configured even wi
     resolveRuntimePaths: () => ({ configPath: CONFIG_PATH, statePath: "/home/.xacpx/state.json" }),
     resolvePluginHome: () => "/home/.xacpx/plugins",
     inspectPlugins: async () => [
-      { level: "error", message: "channel feishu is configured but no enabled plugin provides it; run xacpx plugin add @ganglion/xacpx-channel-feishu" },
+      { level: "error", message: "channel feishu is configured but no enabled plugin provides it; run xacpx plugin add @ganglion/xacpx-channel-feishu", suggestion: "xacpx plugin add @ganglion/xacpx-channel-feishu" },
     ],
     currentXacpxVersion: "9.9.9",
   });
@@ -130,17 +154,38 @@ test("checkPlugins inspects when a plugin-provided channel is configured even wi
   expect(result.severity).toBe("fail");
 });
 
+test("checkPlugins surfaces a clean channel-not-provided suggestion with no mangled tail", async () => {
+  const result = await checkPlugins({
+    home: "/home",
+    loadConfig: async () => makeConfig({ plugins: [], channels: [{ id: "feishu", type: "feishu", enabled: true }] }),
+    resolveRuntimePaths: () => ({ configPath: CONFIG_PATH, statePath: "/home/.xacpx/state.json" }),
+    resolvePluginHome: () => "/home/.xacpx/plugins",
+    inspectPlugins: async () => [
+      {
+        level: "error",
+        message: "channel feishu is configured but no enabled plugin provides it; run xacpx plugin add @ganglion/xacpx-channel-feishu or another plugin that provides type \"feishu\"",
+        suggestion: "xacpx plugin add @ganglion/xacpx-channel-feishu",
+      },
+    ],
+    currentXacpxVersion: "9.9.9",
+  });
+
+  expect(result.suggestions).toContain("run: xacpx plugin add @ganglion/xacpx-channel-feishu");
+  expect((result.suggestions ?? []).join("\n")).not.toContain("or another plugin");
+});
+
 test("checkPlugins dedups suggestions", async () => {
   const result = await checkPlugins(
     baseDeps([
-      { level: "error", plugin: "a", message: "package not installed in plugin home; run xacpx plugin add a" },
-      { level: "error", plugin: "a", message: "failed to import plugin: Cannot find module 'a'" },
+      { level: "error", plugin: "a", message: "package not installed in plugin home; run xacpx plugin add a", suggestion: "xacpx plugin add a && xacpx restart" },
+      { level: "error", plugin: "a", message: "failed to import plugin: Cannot find module 'a'", suggestion: "xacpx plugin add a && xacpx restart" },
     ]),
   );
 
   const suggestions = result.suggestions ?? [];
   const unique = new Set(suggestions);
   expect(unique.size).toBe(suggestions.length);
+  expect(suggestions).toEqual(["run: xacpx plugin add a && xacpx restart"]);
 });
 
 test("checkPlugins passes currentXacpxVersion and resolved plugin home to inspectPlugins", async () => {

--- a/tests/unit/doctor/checks/plugin-check.test.ts
+++ b/tests/unit/doctor/checks/plugin-check.test.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "bun:test";
+
+import { checkPlugins } from "../../../../src/doctor/checks/plugin-check";
+import type { AppConfig } from "../../../../src/config/types";
+import type { PluginDoctorIssue } from "../../../../src/plugins/plugin-doctor";
+
+const CONFIG_PATH = "/home/.xacpx/config.json";
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    plugins: [{ name: "@ganglion/xacpx-channel-feishu", enabled: true }],
+    channels: [],
+    ...overrides,
+  } as AppConfig;
+}
+
+function baseDeps(issues: PluginDoctorIssue[], config: AppConfig = makeConfig()) {
+  return {
+    home: "/home",
+    loadConfig: async () => config,
+    resolveRuntimePaths: () => ({ configPath: CONFIG_PATH, statePath: "/home/.xacpx/state.json" }),
+    resolvePluginHome: () => "/home/.xacpx/plugins",
+    inspectPlugins: async () => issues,
+    currentXacpxVersion: "9.9.9",
+  };
+}
+
+test("checkPlugins passes when every issue is ok", async () => {
+  const result = await checkPlugins(
+    baseDeps([
+      { level: "ok", plugin: "@ganglion/xacpx-channel-feishu", message: "plugin is installed and valid; channels: feishu" },
+    ]),
+  );
+
+  expect(result.id).toBe("plugins");
+  expect(result.label).toBe("Plugins");
+  expect(result.severity).toBe("pass");
+  expect(result.summary).toContain("healthy");
+});
+
+test("checkPlugins warns when an ok issue is mixed with a warn", async () => {
+  const result = await checkPlugins(
+    baseDeps([
+      { level: "ok", plugin: "a", message: "plugin is installed and valid; channels: x" },
+      { level: "warn", plugin: "b", message: "plugin is installed and valid but disabled; run xacpx plugin enable b" },
+    ]),
+  );
+
+  expect(result.severity).toBe("warn");
+  expect(result.details?.join("\n") ?? "").toContain("b: plugin is installed and valid but disabled");
+});
+
+test("checkPlugins fails when any issue is an error", async () => {
+  const result = await checkPlugins(
+    baseDeps([
+      { level: "ok", plugin: "a", message: "ok" },
+      { level: "error", plugin: "b", message: "channel type x is already provided by a" },
+    ]),
+  );
+
+  expect(result.severity).toBe("fail");
+  expect(result.summary).toContain("issue");
+});
+
+test("checkPlugins surfaces an import failure as fail with the package name and an actionable suggestion", async () => {
+  const result = await checkPlugins(
+    baseDeps([
+      {
+        level: "error",
+        plugin: "@ganglion/xacpx-channel-feishu",
+        message: "failed to import plugin: Cannot find module '@ganglion/xacpx-channel-feishu'",
+      },
+    ]),
+  );
+
+  expect(result.severity).toBe("fail");
+  expect(result.details?.join("\n") ?? "").toContain("@ganglion/xacpx-channel-feishu");
+  const suggestions = result.suggestions ?? [];
+  expect(suggestions.some((s) => s.includes("xacpx plugin add @ganglion/xacpx-channel-feishu"))).toBe(true);
+});
+
+test("checkPlugins skips when config cannot be loaded and points at the Config check", async () => {
+  const result = await checkPlugins({
+    home: "/home",
+    loadConfig: async () => {
+      throw new Error("ENOENT: config.json");
+    },
+    resolveRuntimePaths: () => ({ configPath: CONFIG_PATH, statePath: "/home/.xacpx/state.json" }),
+    resolvePluginHome: () => "/home/.xacpx/plugins",
+    inspectPlugins: async () => [],
+    currentXacpxVersion: "9.9.9",
+  });
+
+  expect(result.severity).toBe("skip");
+  expect(result.summary).toContain("configuration could not be loaded");
+  expect((result.suggestions ?? []).join("\n")).toContain("Config check");
+});
+
+test("checkPlugins skips when no plugins and no plugin-provided channels are configured", async () => {
+  let inspected = false;
+  const result = await checkPlugins({
+    home: "/home",
+    loadConfig: async () => makeConfig({ plugins: [], channels: [{ id: "weixin", type: "weixin", enabled: true }] }),
+    resolveRuntimePaths: () => ({ configPath: CONFIG_PATH, statePath: "/home/.xacpx/state.json" }),
+    resolvePluginHome: () => "/home/.xacpx/plugins",
+    inspectPlugins: async () => {
+      inspected = true;
+      return [];
+    },
+    currentXacpxVersion: "9.9.9",
+  });
+
+  expect(result.severity).toBe("skip");
+  expect(result.summary).toContain("no plugins configured");
+  expect(inspected).toBe(false);
+});
+
+test("checkPlugins inspects when a plugin-provided channel is configured even with no plugins array", async () => {
+  const result = await checkPlugins({
+    home: "/home",
+    loadConfig: async () => makeConfig({ plugins: [], channels: [{ id: "feishu", type: "feishu", enabled: true }] }),
+    resolveRuntimePaths: () => ({ configPath: CONFIG_PATH, statePath: "/home/.xacpx/state.json" }),
+    resolvePluginHome: () => "/home/.xacpx/plugins",
+    inspectPlugins: async () => [
+      { level: "error", message: "channel feishu is configured but no enabled plugin provides it; run xacpx plugin add @ganglion/xacpx-channel-feishu" },
+    ],
+    currentXacpxVersion: "9.9.9",
+  });
+
+  expect(result.severity).toBe("fail");
+});
+
+test("checkPlugins dedups suggestions", async () => {
+  const result = await checkPlugins(
+    baseDeps([
+      { level: "error", plugin: "a", message: "package not installed in plugin home; run xacpx plugin add a" },
+      { level: "error", plugin: "a", message: "failed to import plugin: Cannot find module 'a'" },
+    ]),
+  );
+
+  const suggestions = result.suggestions ?? [];
+  const unique = new Set(suggestions);
+  expect(unique.size).toBe(suggestions.length);
+});
+
+test("checkPlugins passes currentXacpxVersion and resolved plugin home to inspectPlugins", async () => {
+  let seen: { pluginHome?: string; currentXacpxVersion?: string } = {};
+  await checkPlugins({
+    home: "/home",
+    loadConfig: async () => makeConfig(),
+    resolveRuntimePaths: () => ({ configPath: CONFIG_PATH, statePath: "/home/.xacpx/state.json" }),
+    resolvePluginHome: (input) => {
+      expect(input).toMatchObject({ home: "/home" });
+      return "/resolved/plugins";
+    },
+    inspectPlugins: async (input) => {
+      seen = { pluginHome: input.pluginHome, currentXacpxVersion: input.currentXacpxVersion };
+      return [{ level: "ok", plugin: "@ganglion/xacpx-channel-feishu", message: "ok" }];
+    },
+    currentXacpxVersion: "1.2.3",
+  });
+
+  expect(seen.pluginHome).toBe("/resolved/plugins");
+  expect(seen.currentXacpxVersion).toBe("1.2.3");
+});

--- a/tests/unit/doctor/checks/runtime-check.test.ts
+++ b/tests/unit/doctor/checks/runtime-check.test.ts
@@ -1,0 +1,164 @@
+import { constants } from "node:fs";
+import { join } from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { checkRuntime } from "../../../../src/doctor/checks/runtime-check";
+
+const DIRECTORY_USABLE = constants.W_OK | constants.X_OK;
+
+interface ProbeOptions {
+  directories: string[];
+  /** path -> POSIX mode (mask 0o777) returned by stat for that directory. */
+  modes?: Record<string, number>;
+  deniedAccess?: string[];
+}
+
+function createRuntimeProbe(options: ProbeOptions): {
+  probe: {
+    stat: (path: string) => Promise<{ isDirectory: () => boolean; mode?: number }>;
+    access: (path: string, mode: number) => Promise<void>;
+  };
+} {
+  const directories = new Set(options.directories);
+  const deniedAccess = new Set(options.deniedAccess ?? []);
+  const modes = options.modes ?? {};
+
+  return {
+    probe: {
+      async stat(path: string) {
+        if (directories.has(path)) {
+          const mode = modes[path];
+          return {
+            isDirectory: () => true,
+            ...(mode === undefined ? {} : { mode }),
+          };
+        }
+        throw createErrno("ENOENT", path);
+      },
+      async access(path: string, mode: number) {
+        if (!directories.has(path) || deniedAccess.has(path)) {
+          throw createErrno("EACCES", path);
+        }
+      },
+    },
+  };
+}
+
+function createErrno(code: string, path: string): NodeJS.ErrnoException {
+  const error = new Error(`${code}: ${path}`) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+function runtimeDirOf(home: string): string {
+  return join(home, ".xacpx", "runtime");
+}
+
+test("runtime check warns and attaches a fix when the runtime dir has group/other bits set", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createRuntimeProbe({
+    directories: [home, runtimeDir],
+    modes: { [runtimeDir]: 0o755 },
+  });
+
+  const ensureCalls: string[] = [];
+  const result = await checkRuntime({
+    home,
+    probe: probe.probe,
+    platform: "linux",
+    ensurePrivateRuntimeDir: async (dir) => {
+      ensureCalls.push(dir);
+    },
+  });
+
+  expect(result.severity).toBe("warn");
+  const fix = result.fixes?.find((entry) => entry.id === "runtime.ensure-private-dir");
+  expect(fix).toBeDefined();
+  expect(fix?.withheld).toBeUndefined();
+
+  const outcome = await fix!.run();
+  expect(outcome.ok).toBe(true);
+  expect(outcome.message).toContain(runtimeDir);
+  expect(ensureCalls).toEqual([runtimeDir]);
+});
+
+test("runtime check attaches the ensure-private-dir fix when the runtime dir is missing", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  // Parent exists and is writable so the dir is still creatable (check passes),
+  // but the dir itself is absent, so the repair primitive should be offered.
+  const probe = createRuntimeProbe({
+    directories: [home, join(home, ".xacpx")],
+  });
+
+  const ensureCalls: string[] = [];
+  const result = await checkRuntime({
+    home,
+    probe: probe.probe,
+    platform: "linux",
+    ensurePrivateRuntimeDir: async (dir) => {
+      ensureCalls.push(dir);
+    },
+  });
+
+  const fix = result.fixes?.find((entry) => entry.id === "runtime.ensure-private-dir");
+  expect(fix).toBeDefined();
+
+  await fix!.run();
+  expect(ensureCalls).toEqual([runtimeDir]);
+});
+
+test("runtime check does not attach a perms fix when the runtime dir is already 0700", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createRuntimeProbe({
+    directories: [home, runtimeDir],
+    modes: { [runtimeDir]: 0o700 },
+  });
+
+  const result = await checkRuntime({
+    home,
+    probe: probe.probe,
+    platform: "linux",
+  });
+
+  expect(result.severity).toBe("pass");
+  expect(result.fixes ?? []).toEqual([]);
+});
+
+test("runtime check does not attach a perms fix on win32 even with wide bits", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createRuntimeProbe({
+    directories: [home, runtimeDir],
+    modes: { [runtimeDir]: 0o777 },
+  });
+
+  const result = await checkRuntime({
+    home,
+    probe: probe.probe,
+    platform: "win32",
+  });
+
+  expect(result.fixes ?? []).toEqual([]);
+});
+
+test("runtime check still fails (no perms fix) when a critical path is not usable", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createRuntimeProbe({
+    directories: [home, runtimeDir],
+    modes: { [runtimeDir]: 0o755 },
+    deniedAccess: [runtimeDir],
+  });
+
+  const result = await checkRuntime({
+    home,
+    probe: probe.probe,
+    platform: "linux",
+  });
+
+  expect(result.severity).toBe("fail");
+});

--- a/tests/unit/doctor/doctor.test.ts
+++ b/tests/unit/doctor/doctor.test.ts
@@ -1417,3 +1417,57 @@ test("orchestration check attaches no state.quarantine fix when state.json is va
     await rm(home, { recursive: true, force: true });
   }
 });
+
+test("default daemon-liveness mapping withholds the quarantine fix for an indeterminate (live) daemon", async () => {
+  const home = await createTempHome();
+  const rootDir = join(home, ".xacpx");
+  const statePath = join(rootDir, "state.json");
+  const original = JSON.stringify({ sessions: { bad: { alias: "bad" } }, chat_contexts: {} });
+
+  try {
+    await mkdir(rootDir, { recursive: true });
+    await writeFile(statePath, original, "utf8");
+
+    // Exercise the DEFAULT liveness mapping (not the isDaemonRunning boolean):
+    // an "indeterminate" status is a LIVE daemon, so the fix must be withheld.
+    const result = await runDoctor(
+      {},
+      { home, ...createStateDoctorStubs(), getDaemonStatus: async () => ({ state: "indeterminate" }) },
+    );
+
+    const orchestration = result.report.checks.find((check) => check.id === "orchestration");
+    const fix = orchestration?.fixes?.find((entry) => entry.id === "state.quarantine");
+    expect(fix).toBeDefined();
+    expect(fix?.withheld).toBe("stop the daemon first: xacpx stop");
+
+    // The check must not mutate state.json while a live daemon owns it.
+    expect(await readFile(statePath, "utf8")).toBe(original);
+    expect(await readdir(rootDir)).toEqual(["state.json"]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("default daemon-liveness mapping allows the quarantine fix for a stopped daemon", async () => {
+  const home = await createTempHome();
+  const rootDir = join(home, ".xacpx");
+  const statePath = join(rootDir, "state.json");
+  const original = JSON.stringify({ sessions: { bad: { alias: "bad" } }, chat_contexts: {} });
+
+  try {
+    await mkdir(rootDir, { recursive: true });
+    await writeFile(statePath, original, "utf8");
+
+    const result = await runDoctor(
+      {},
+      { home, ...createStateDoctorStubs(), getDaemonStatus: async () => ({ state: "stopped" }) },
+    );
+
+    const orchestration = result.report.checks.find((check) => check.id === "orchestration");
+    const fix = orchestration?.fixes?.find((entry) => entry.id === "state.quarantine");
+    expect(fix).toBeDefined();
+    expect(fix?.withheld).toBeUndefined();
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/doctor/doctor.test.ts
+++ b/tests/unit/doctor/doctor.test.ts
@@ -515,10 +515,21 @@ test("doctor orchestrator runs baseline checks in stable order and records smoke
       checkBridge: createCheck("bridge"),
       checkPlugins: createCheck("plugins") as never,
       checkOrchestrationHealth: createCheck("orchestration"),
+      checkOrchestrationSocket: createCheck("orchestration-socket") as never,
     },
   );
 
-  expect(calls).toEqual(["config", "runtime", "daemon", "wechat", "acpx", "bridge", "plugins", "orchestration"]);
+  expect(calls).toEqual([
+    "config",
+    "runtime",
+    "daemon",
+    "wechat",
+    "acpx",
+    "bridge",
+    "plugins",
+    "orchestration",
+    "orchestration-socket",
+  ]);
   expect(result.report.checks.map((check) => check.id)).toEqual([
     "config",
     "runtime",
@@ -528,6 +539,7 @@ test("doctor orchestrator runs baseline checks in stable order and records smoke
     "bridge",
     "plugins",
     "orchestration",
+    "orchestration-socket",
     "smoke",
   ]);
   expect(result.report.checks.at(-1)).toMatchObject({
@@ -643,11 +655,12 @@ test("doctor orchestrator returns exit code 1 when any check fails", async () =>
       checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "skip", summary: "skip" }),
       checkPlugins: async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" }),
       checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }),
+      checkOrchestrationSocket: (async () => ({ id: "orchestration-socket", label: "Orchestration IPC", severity: "skip", summary: "skip" })) as never,
     },
   );
 
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain("Summary: PASS 4, WARN 1, FAIL 1, SKIP 3");
+  expect(result.output).toContain("Summary: PASS 4, WARN 1, FAIL 1, SKIP 4");
 });
 
 test("doctor orchestrator returns exit code 0 when report only contains pass warn and skip", async () => {
@@ -662,11 +675,12 @@ test("doctor orchestrator returns exit code 0 when report only contains pass war
       checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "skip", summary: "skip" }),
       checkPlugins: async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" }),
       checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }),
+      checkOrchestrationSocket: (async () => ({ id: "orchestration-socket", label: "Orchestration IPC", severity: "skip", summary: "skip" })) as never,
     },
   );
 
   expect(result.exitCode).toBe(0);
-  expect(result.output).toContain("Summary: PASS 5, WARN 1, FAIL 0, SKIP 3");
+  expect(result.output).toContain("Summary: PASS 5, WARN 1, FAIL 0, SKIP 4");
 });
 
 test("runDoctor includes the orchestration-health check result", async () => {
@@ -723,6 +737,39 @@ test("runDoctor places the plugins check between bridge and orchestration and ho
   });
 });
 
+test("runDoctor places the orchestration-socket check after orchestration and before smoke and honors the override", async () => {
+  let called = false;
+  const result = await runDoctor(
+    {},
+    {
+      checkConfig: async () => ({ id: "config", label: "Config", severity: "pass", summary: "ok" }),
+      checkRuntime: async () => ({ id: "runtime", label: "Runtime", severity: "pass", summary: "ok" }),
+      checkDaemon: async () => ({ id: "daemon", label: "Daemon", severity: "pass", summary: "ok" }),
+      checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }),
+      checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }),
+      checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "pass", summary: "ok" }),
+      checkPlugins: (async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" })) as never,
+      checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }),
+      checkOrchestrationSocket: (async () => {
+        called = true;
+        return { id: "orchestration-socket", label: "Orchestration IPC", severity: "fail", summary: "ipc down" };
+      }) as never,
+    },
+  );
+
+  expect(called).toBe(true);
+  const ids = result.report.checks.map((check) => check.id);
+  const orchestrationIndex = ids.indexOf("orchestration");
+  const socketIndex = ids.indexOf("orchestration-socket");
+  const smokeIndex = ids.indexOf("smoke");
+  expect(socketIndex).toBe(orchestrationIndex + 1);
+  expect(smokeIndex).toBe(socketIndex + 1);
+  expect(result.report.checks.find((check) => check.id === "orchestration-socket")).toMatchObject({
+    severity: "fail",
+    summary: "ipc down",
+  });
+});
+
 test("runDoctor skips orchestration-health instead of throwing when config cannot be loaded", async () => {
   const home = await createTempHome();
   const configPath = join(home, ".weacpx", "config.json");
@@ -762,6 +809,7 @@ function createStateDoctorStubs() {
     checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkPlugins: (async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" })) as never,
+    checkOrchestrationSocket: (async () => ({ id: "orchestration-socket", label: "Orchestration IPC", severity: "skip", summary: "skip" })) as never,
     loadConfig: async () => ({ orchestration: { progressHeartbeatSeconds: 300 } }) as never,
   };
 }
@@ -826,6 +874,7 @@ function createFixDoctorStubs() {
     checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkPlugins: (async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" })) as never,
     checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkOrchestrationSocket: (async () => ({ id: "orchestration-socket", label: "Orchestration IPC", severity: "skip", summary: "skip" })) as never,
   };
 }
 

--- a/tests/unit/doctor/doctor.test.ts
+++ b/tests/unit/doctor/doctor.test.ts
@@ -509,6 +509,7 @@ test("doctor orchestrator runs baseline checks in stable order and records smoke
     {
       checkConfig: createCheck("config"),
       checkRuntime: createCheck("runtime"),
+      checkLogs: createCheck("logs") as never,
       checkDaemon: createCheck("daemon"),
       checkWechat: createCheck("wechat"),
       checkAcpx: createCheck("acpx"),
@@ -522,6 +523,7 @@ test("doctor orchestrator runs baseline checks in stable order and records smoke
   expect(calls).toEqual([
     "config",
     "runtime",
+    "logs",
     "daemon",
     "wechat",
     "acpx",
@@ -533,6 +535,7 @@ test("doctor orchestrator runs baseline checks in stable order and records smoke
   expect(result.report.checks.map((check) => check.id)).toEqual([
     "config",
     "runtime",
+    "logs",
     "daemon",
     "wechat",
     "acpx",
@@ -545,6 +548,40 @@ test("doctor orchestrator runs baseline checks in stable order and records smoke
   expect(result.report.checks.at(-1)).toMatchObject({
     id: "smoke",
     severity: "skip",
+  });
+});
+
+test("runDoctor places the logs check after runtime and before daemon and honors the checkLogs override", async () => {
+  let called = false;
+  const result = await runDoctor(
+    {},
+    {
+      checkConfig: async () => ({ id: "config", label: "Config", severity: "pass", summary: "ok" }),
+      checkRuntime: async () => ({ id: "runtime", label: "Runtime", severity: "pass", summary: "ok" }),
+      checkLogs: (async () => {
+        called = true;
+        return { id: "logs", label: "Logs", severity: "warn", summary: "log growth high" };
+      }) as never,
+      checkDaemon: async () => ({ id: "daemon", label: "Daemon", severity: "pass", summary: "ok" }),
+      checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }),
+      checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }),
+      checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "pass", summary: "ok" }),
+      checkPlugins: (async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" })) as never,
+      checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }),
+      checkOrchestrationSocket: (async () => ({ id: "orchestration-socket", label: "Orchestration IPC", severity: "skip", summary: "skip" })) as never,
+    },
+  );
+
+  expect(called).toBe(true);
+  const ids = result.report.checks.map((check) => check.id);
+  const runtimeIndex = ids.indexOf("runtime");
+  const logsIndex = ids.indexOf("logs");
+  const daemonIndex = ids.indexOf("daemon");
+  expect(logsIndex).toBe(runtimeIndex + 1);
+  expect(daemonIndex).toBe(logsIndex + 1);
+  expect(result.report.checks.find((check) => check.id === "logs")).toMatchObject({
+    severity: "warn",
+    summary: "log growth high",
   });
 });
 
@@ -649,6 +686,7 @@ test("doctor orchestrator returns exit code 1 when any check fails", async () =>
     {
       checkConfig: async () => ({ id: "config", label: "Config", severity: "pass", summary: "ok" }),
       checkRuntime: async () => ({ id: "runtime", label: "Runtime", severity: "fail", summary: "broken" }),
+      checkLogs: (async () => ({ id: "logs", label: "Logs", severity: "skip", summary: "skip" })) as never,
       checkDaemon: async () => ({ id: "daemon", label: "Daemon", severity: "warn", summary: "warn" }),
       checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }),
       checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }),
@@ -660,7 +698,7 @@ test("doctor orchestrator returns exit code 1 when any check fails", async () =>
   );
 
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain("Summary: PASS 4, WARN 1, FAIL 1, SKIP 4");
+  expect(result.output).toContain("Summary: PASS 4, WARN 1, FAIL 1, SKIP 5");
 });
 
 test("doctor orchestrator returns exit code 0 when report only contains pass warn and skip", async () => {
@@ -669,6 +707,7 @@ test("doctor orchestrator returns exit code 0 when report only contains pass war
     {
       checkConfig: async () => ({ id: "config", label: "Config", severity: "pass", summary: "ok" }),
       checkRuntime: async () => ({ id: "runtime", label: "Runtime", severity: "warn", summary: "warn" }),
+      checkLogs: (async () => ({ id: "logs", label: "Logs", severity: "skip", summary: "skip" })) as never,
       checkDaemon: async () => ({ id: "daemon", label: "Daemon", severity: "pass", summary: "ok" }),
       checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }),
       checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }),
@@ -680,7 +719,7 @@ test("doctor orchestrator returns exit code 0 when report only contains pass war
   );
 
   expect(result.exitCode).toBe(0);
-  expect(result.output).toContain("Summary: PASS 5, WARN 1, FAIL 0, SKIP 4");
+  expect(result.output).toContain("Summary: PASS 5, WARN 1, FAIL 0, SKIP 5");
 });
 
 test("runDoctor includes the orchestration-health check result", async () => {
@@ -804,6 +843,7 @@ function createStateDoctorStubs() {
   return {
     checkConfig: async () => ({ id: "config", label: "Config", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkRuntime: async () => ({ id: "runtime", label: "Runtime", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkLogs: (async () => ({ id: "logs", label: "Logs", severity: "skip", summary: "skip" })) as never,
     checkDaemon: async () => ({ id: "daemon", label: "Daemon", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }) as DoctorCheckResult,
@@ -868,6 +908,7 @@ function createFixDoctorStubs() {
   return {
     checkConfig: async () => ({ id: "config", label: "Config", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkRuntime: async () => ({ id: "runtime", label: "Runtime", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkLogs: (async () => ({ id: "logs", label: "Logs", severity: "skip", summary: "skip" })) as never,
     checkDaemon: async () => ({ id: "daemon", label: "Daemon", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }) as DoctorCheckResult,

--- a/tests/unit/doctor/doctor.test.ts
+++ b/tests/unit/doctor/doctor.test.ts
@@ -1209,3 +1209,83 @@ test("doctor index main runs orchestrator and prints rendered output", async () 
     console.log = restore;
   }
 });
+
+test("orchestration check attaches state.quarantine fix when daemon is stopped and a state record is invalid", async () => {
+  const home = await createTempHome();
+  const rootDir = join(home, ".xacpx");
+  const statePath = join(rootDir, "state.json");
+  const original = JSON.stringify({ sessions: { bad: { alias: "bad" } }, chat_contexts: {} });
+
+  try {
+    await mkdir(rootDir, { recursive: true });
+    await writeFile(statePath, original, "utf8");
+
+    const result = await runDoctor(
+      {},
+      { home, ...createStateDoctorStubs(), isDaemonRunning: async () => false },
+    );
+
+    const orchestration = result.report.checks.find((check) => check.id === "orchestration");
+    const fix = orchestration?.fixes?.find((entry) => entry.id === "state.quarantine");
+    expect(fix).toBeDefined();
+    expect(fix?.withheld).toBeUndefined();
+
+    // run() performs the real quarantine via StateStore.load(): records dropped,
+    // original backed up, state.json rewritten on the next save cycle.
+    const outcome = await fix!.run();
+    expect(outcome.ok).toBe(true);
+    const backups = (await readdir(rootDir)).filter((name) => name.includes("quarantine"));
+    expect(backups.length).toBeGreaterThan(0);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("orchestration check withholds state.quarantine fix and does not mutate when the daemon is running", async () => {
+  const home = await createTempHome();
+  const rootDir = join(home, ".xacpx");
+  const statePath = join(rootDir, "state.json");
+  const original = JSON.stringify({ sessions: { bad: { alias: "bad" } }, chat_contexts: {} });
+
+  try {
+    await mkdir(rootDir, { recursive: true });
+    await writeFile(statePath, original, "utf8");
+
+    const result = await runDoctor(
+      {},
+      { home, ...createStateDoctorStubs(), isDaemonRunning: async () => true },
+    );
+
+    const orchestration = result.report.checks.find((check) => check.id === "orchestration");
+    const fix = orchestration?.fixes?.find((entry) => entry.id === "state.quarantine");
+    expect(fix).toBeDefined();
+    expect(fix?.withheld).toBe("stop the daemon first: xacpx stop");
+
+    // Detection alone must never mutate; the running daemon owns state.json.
+    expect(await readFile(statePath, "utf8")).toBe(original);
+    expect(await readdir(rootDir)).toEqual(["state.json"]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("orchestration check attaches no state.quarantine fix when state.json is valid", async () => {
+  const home = await createTempHome();
+  const rootDir = join(home, ".xacpx");
+  const statePath = join(rootDir, "state.json");
+
+  try {
+    await mkdir(rootDir, { recursive: true });
+    await writeFile(statePath, JSON.stringify({ sessions: {}, chat_contexts: {} }), "utf8");
+
+    const result = await runDoctor(
+      {},
+      { home, ...createStateDoctorStubs(), isDaemonRunning: async () => false },
+    );
+
+    const orchestration = result.report.checks.find((check) => check.id === "orchestration");
+    expect(orchestration?.fixes?.some((entry) => entry.id === "state.quarantine") ?? false).toBe(false);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/doctor/doctor.test.ts
+++ b/tests/unit/doctor/doctor.test.ts
@@ -513,11 +513,12 @@ test("doctor orchestrator runs baseline checks in stable order and records smoke
       checkWechat: createCheck("wechat"),
       checkAcpx: createCheck("acpx"),
       checkBridge: createCheck("bridge"),
+      checkPlugins: createCheck("plugins") as never,
       checkOrchestrationHealth: createCheck("orchestration"),
     },
   );
 
-  expect(calls).toEqual(["config", "runtime", "daemon", "wechat", "acpx", "bridge", "orchestration"]);
+  expect(calls).toEqual(["config", "runtime", "daemon", "wechat", "acpx", "bridge", "plugins", "orchestration"]);
   expect(result.report.checks.map((check) => check.id)).toEqual([
     "config",
     "runtime",
@@ -525,6 +526,7 @@ test("doctor orchestrator runs baseline checks in stable order and records smoke
     "wechat",
     "acpx",
     "bridge",
+    "plugins",
     "orchestration",
     "smoke",
   ]);
@@ -639,12 +641,13 @@ test("doctor orchestrator returns exit code 1 when any check fails", async () =>
       checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }),
       checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }),
       checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "skip", summary: "skip" }),
+      checkPlugins: async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" }),
       checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }),
     },
   );
 
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain("Summary: PASS 4, WARN 1, FAIL 1, SKIP 2");
+  expect(result.output).toContain("Summary: PASS 4, WARN 1, FAIL 1, SKIP 3");
 });
 
 test("doctor orchestrator returns exit code 0 when report only contains pass warn and skip", async () => {
@@ -657,12 +660,13 @@ test("doctor orchestrator returns exit code 0 when report only contains pass war
       checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }),
       checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }),
       checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "skip", summary: "skip" }),
+      checkPlugins: async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" }),
       checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }),
     },
   );
 
   expect(result.exitCode).toBe(0);
-  expect(result.output).toContain("Summary: PASS 5, WARN 1, FAIL 0, SKIP 2");
+  expect(result.output).toContain("Summary: PASS 5, WARN 1, FAIL 0, SKIP 3");
 });
 
 test("runDoctor includes the orchestration-health check result", async () => {
@@ -685,6 +689,38 @@ test("runDoctor includes the orchestration-health check result", async () => {
 
   expect(called).toBe(true);
   expect(result.report.checks.some((c) => c.id === "orchestration")).toBe(true);
+});
+
+test("runDoctor places the plugins check between bridge and orchestration and honors the checkPlugins override", async () => {
+  let called = false;
+  const result = await runDoctor(
+    {},
+    {
+      checkConfig: async () => ({ id: "config", label: "Config", severity: "pass", summary: "ok" }),
+      checkRuntime: async () => ({ id: "runtime", label: "Runtime", severity: "pass", summary: "ok" }),
+      checkDaemon: async () => ({ id: "daemon", label: "Daemon", severity: "pass", summary: "ok" }),
+      checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }),
+      checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }),
+      checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "pass", summary: "ok" }),
+      checkPlugins: (async () => {
+        called = true;
+        return { id: "plugins", label: "Plugins", severity: "warn", summary: "1 plugin issue(s)" };
+      }) as never,
+      checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }),
+    },
+  );
+
+  expect(called).toBe(true);
+  const ids = result.report.checks.map((check) => check.id);
+  const bridgeIndex = ids.indexOf("bridge");
+  const pluginsIndex = ids.indexOf("plugins");
+  const orchestrationIndex = ids.indexOf("orchestration");
+  expect(pluginsIndex).toBe(bridgeIndex + 1);
+  expect(orchestrationIndex).toBe(pluginsIndex + 1);
+  expect(result.report.checks.find((check) => check.id === "plugins")).toMatchObject({
+    severity: "warn",
+    summary: "1 plugin issue(s)",
+  });
 });
 
 test("runDoctor skips orchestration-health instead of throwing when config cannot be loaded", async () => {
@@ -725,6 +761,7 @@ function createStateDoctorStubs() {
     checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkPlugins: (async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" })) as never,
     loadConfig: async () => ({ orchestration: { progressHeartbeatSeconds: 300 } }) as never,
   };
 }
@@ -787,6 +824,7 @@ function createFixDoctorStubs() {
     checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }) as DoctorCheckResult,
     checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkPlugins: (async () => ({ id: "plugins", label: "Plugins", severity: "skip", summary: "skip" })) as never,
     checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }) as DoctorCheckResult,
   };
 }

--- a/tests/unit/doctor/doctor.test.ts
+++ b/tests/unit/doctor/doctor.test.ts
@@ -779,6 +779,408 @@ test("doctor warns on an unreadable state.json without renaming it", async () =>
   }
 });
 
+function createFixDoctorStubs() {
+  return {
+    checkConfig: async () => ({ id: "config", label: "Config", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkRuntime: async () => ({ id: "runtime", label: "Runtime", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkDaemon: async () => ({ id: "daemon", label: "Daemon", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkWechat: async () => ({ id: "wechat", label: "WeChat", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkAcpx: async () => ({ id: "acpx", label: "acpx", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkBridge: async () => ({ id: "bridge", label: "Bridge", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+    checkOrchestrationHealth: async () => ({ id: "orchestration", label: "Orchestration", severity: "pass", summary: "ok" }) as DoctorCheckResult,
+  };
+}
+
+test("doctor does not run fixes unless options.fix is true", async () => {
+  let ran = false;
+  const result = await runDoctor(
+    {},
+    {
+      ...createFixDoctorStubs(),
+      checkRuntime: async () => ({
+        id: "runtime",
+        label: "Runtime",
+        severity: "fail",
+        summary: "broken",
+        fixes: [
+          {
+            id: "runtime.repair",
+            title: "repair runtime",
+            run: async () => {
+              ran = true;
+              return { ok: true, message: "repaired" };
+            },
+          },
+        ],
+      }),
+    },
+  );
+
+  expect(ran).toBe(false);
+  expect(result.report.repairs ?? []).toEqual([]);
+  expect(result.exitCode).toBe(1);
+});
+
+test("doctor records a withheld fix as skipped and never invokes run()", async () => {
+  let ran = false;
+  const result = await runDoctor(
+    { fix: true },
+    {
+      ...createFixDoctorStubs(),
+      checkDaemon: async () => ({
+        id: "daemon",
+        label: "Daemon",
+        severity: "warn",
+        summary: "stale",
+        fixes: [
+          {
+            id: "daemon.clear",
+            title: "clear stale runtime",
+            withheld: "stop the daemon first: xacpx stop",
+            run: async () => {
+              ran = true;
+              return { ok: true, message: "cleared" };
+            },
+          },
+        ],
+      }),
+    },
+  );
+
+  expect(ran).toBe(false);
+  expect(result.report.repairs).toEqual([
+    {
+      checkId: "daemon",
+      fixId: "daemon.clear",
+      title: "clear stale runtime",
+      status: "skipped",
+      message: "stop the daemon first: xacpx stop",
+    },
+  ]);
+});
+
+test("doctor applies a fix and re-runs only the affected check", async () => {
+  let runtimeCalls = 0;
+  let daemonCalls = 0;
+
+  const result = await runDoctor(
+    { fix: true },
+    {
+      ...createFixDoctorStubs(),
+      checkRuntime: async () => {
+        runtimeCalls += 1;
+        if (runtimeCalls === 1) {
+          return {
+            id: "runtime",
+            label: "Runtime",
+            severity: "fail",
+            summary: "broken",
+            fixes: [
+              {
+                id: "runtime.repair",
+                title: "repair runtime",
+                run: async () => ({ ok: true, message: "repaired" }),
+              },
+            ],
+          };
+        }
+        return { id: "runtime", label: "Runtime", severity: "pass", summary: "fixed" };
+      },
+      checkDaemon: async () => {
+        daemonCalls += 1;
+        return { id: "daemon", label: "Daemon", severity: "pass", summary: "ok" };
+      },
+    },
+  );
+
+  expect(runtimeCalls).toBe(2);
+  expect(daemonCalls).toBe(1);
+  const runtime = result.report.checks.find((check) => check.id === "runtime");
+  expect(runtime).toMatchObject({ severity: "pass", summary: "fixed" });
+  expect(result.report.repairs).toEqual([
+    {
+      checkId: "runtime",
+      fixId: "runtime.repair",
+      title: "repair runtime",
+      status: "applied",
+      message: "repaired",
+    },
+  ]);
+  expect(result.exitCode).toBe(0);
+});
+
+test("doctor captures a throwing fix as failed without crashing", async () => {
+  let runtimeCalls = 0;
+  const result = await runDoctor(
+    { fix: true },
+    {
+      ...createFixDoctorStubs(),
+      checkRuntime: async () => {
+        runtimeCalls += 1;
+        return {
+          id: "runtime",
+          label: "Runtime",
+          severity: "fail",
+          summary: "broken",
+          fixes: [
+            {
+              id: "runtime.repair",
+              title: "repair runtime",
+              run: async () => {
+                throw new Error("boom");
+              },
+            },
+          ],
+        };
+      },
+    },
+  );
+
+  // a failed (not applied) fix does not trigger a re-run
+  expect(runtimeCalls).toBe(1);
+  expect(result.report.repairs).toEqual([
+    {
+      checkId: "runtime",
+      fixId: "runtime.repair",
+      title: "repair runtime",
+      status: "failed",
+      message: "boom",
+    },
+  ]);
+  expect(result.exitCode).toBe(1);
+});
+
+test("doctor records an outcome with ok false as failed", async () => {
+  const result = await runDoctor(
+    { fix: true },
+    {
+      ...createFixDoctorStubs(),
+      checkRuntime: async () => ({
+        id: "runtime",
+        label: "Runtime",
+        severity: "fail",
+        summary: "broken",
+        fixes: [
+          {
+            id: "runtime.repair",
+            title: "repair runtime",
+            run: async () => ({ ok: false, message: "could not repair" }),
+          },
+        ],
+      }),
+    },
+  );
+
+  expect(result.report.repairs).toEqual([
+    {
+      checkId: "runtime",
+      fixId: "runtime.repair",
+      title: "repair runtime",
+      status: "failed",
+      message: "could not repair",
+    },
+  ]);
+  expect(result.exitCode).toBe(1);
+});
+
+test("doctor handles a mixed fixes array: skips the withheld one and applies the runnable one", async () => {
+  let runtimeCalls = 0;
+  let withheldRan = false;
+
+  const result = await runDoctor(
+    { fix: true },
+    {
+      ...createFixDoctorStubs(),
+      checkRuntime: async () => {
+        runtimeCalls += 1;
+        if (runtimeCalls === 1) {
+          return {
+            id: "runtime",
+            label: "Runtime",
+            severity: "fail",
+            summary: "broken",
+            fixes: [
+              {
+                id: "runtime.withheld",
+                title: "withheld fix",
+                withheld: "stop the daemon first",
+                run: async () => {
+                  withheldRan = true;
+                  return { ok: true, message: "should not run" };
+                },
+              },
+              {
+                id: "runtime.repair",
+                title: "repair runtime",
+                run: async () => ({ ok: true, message: "repaired" }),
+              },
+            ],
+          };
+        }
+        return { id: "runtime", label: "Runtime", severity: "pass", summary: "fixed" };
+      },
+    },
+  );
+
+  expect(withheldRan).toBe(false);
+  // re-run exactly once despite two fixes on the check
+  expect(runtimeCalls).toBe(2);
+  expect(result.report.repairs).toEqual([
+    {
+      checkId: "runtime",
+      fixId: "runtime.withheld",
+      title: "withheld fix",
+      status: "skipped",
+      message: "stop the daemon first",
+    },
+    {
+      checkId: "runtime",
+      fixId: "runtime.repair",
+      title: "repair runtime",
+      status: "applied",
+      message: "repaired",
+    },
+  ]);
+  expect(result.report.checks.find((check) => check.id === "runtime")).toMatchObject({
+    severity: "pass",
+    summary: "fixed",
+  });
+  expect(result.exitCode).toBe(0);
+});
+
+test("doctor re-runs every check that applied a fix", async () => {
+  let runtimeCalls = 0;
+  let daemonCalls = 0;
+
+  const result = await runDoctor(
+    { fix: true },
+    {
+      ...createFixDoctorStubs(),
+      checkRuntime: async () => {
+        runtimeCalls += 1;
+        if (runtimeCalls === 1) {
+          return {
+            id: "runtime",
+            label: "Runtime",
+            severity: "fail",
+            summary: "broken",
+            fixes: [
+              {
+                id: "runtime.repair",
+                title: "repair runtime",
+                run: async () => ({ ok: true, message: "runtime repaired" }),
+              },
+            ],
+          };
+        }
+        return { id: "runtime", label: "Runtime", severity: "pass", summary: "runtime fixed" };
+      },
+      checkDaemon: async () => {
+        daemonCalls += 1;
+        if (daemonCalls === 1) {
+          return {
+            id: "daemon",
+            label: "Daemon",
+            severity: "warn",
+            summary: "stale",
+            fixes: [
+              {
+                id: "daemon.clear",
+                title: "clear stale runtime",
+                run: async () => ({ ok: true, message: "daemon cleared" }),
+              },
+            ],
+          };
+        }
+        return { id: "daemon", label: "Daemon", severity: "pass", summary: "daemon fixed" };
+      },
+    },
+  );
+
+  expect(runtimeCalls).toBe(2);
+  expect(daemonCalls).toBe(2);
+  expect(result.report.checks.find((check) => check.id === "runtime")).toMatchObject({
+    severity: "pass",
+    summary: "runtime fixed",
+  });
+  expect(result.report.checks.find((check) => check.id === "daemon")).toMatchObject({
+    severity: "pass",
+    summary: "daemon fixed",
+  });
+  expect(result.report.repairs).toEqual([
+    {
+      checkId: "runtime",
+      fixId: "runtime.repair",
+      title: "repair runtime",
+      status: "applied",
+      message: "runtime repaired",
+    },
+    {
+      checkId: "daemon",
+      fixId: "daemon.clear",
+      title: "clear stale runtime",
+      status: "applied",
+      message: "daemon cleared",
+    },
+  ]);
+  expect(result.exitCode).toBe(0);
+});
+
+test("doctor re-runs a check exactly once even when it applies two fixes", async () => {
+  let runtimeCalls = 0;
+
+  const result = await runDoctor(
+    { fix: true },
+    {
+      ...createFixDoctorStubs(),
+      checkRuntime: async () => {
+        runtimeCalls += 1;
+        if (runtimeCalls === 1) {
+          return {
+            id: "runtime",
+            label: "Runtime",
+            severity: "fail",
+            summary: "broken",
+            fixes: [
+              {
+                id: "runtime.repair-a",
+                title: "repair runtime a",
+                run: async () => ({ ok: true, message: "repaired a" }),
+              },
+              {
+                id: "runtime.repair-b",
+                title: "repair runtime b",
+                run: async () => ({ ok: true, message: "repaired b" }),
+              },
+            ],
+          };
+        }
+        return { id: "runtime", label: "Runtime", severity: "pass", summary: "fixed" };
+      },
+    },
+  );
+
+  // both fixes applied, but the dedup keeps the re-run to a single invocation
+  expect(runtimeCalls).toBe(2);
+  expect(result.report.repairs).toEqual([
+    {
+      checkId: "runtime",
+      fixId: "runtime.repair-a",
+      title: "repair runtime a",
+      status: "applied",
+      message: "repaired a",
+    },
+    {
+      checkId: "runtime",
+      fixId: "runtime.repair-b",
+      title: "repair runtime b",
+      status: "applied",
+      message: "repaired b",
+    },
+  ]);
+  expect(result.exitCode).toBe(0);
+});
+
 test("doctor index main runs orchestrator and prints rendered output", async () => {
   const lines: string[] = [];
   const restore = console.log;

--- a/tests/unit/doctor/render-doctor.test.ts
+++ b/tests/unit/doctor/render-doctor.test.ts
@@ -97,6 +97,95 @@ test("keeps suggestion ordering stable while deduplicating repeats", () => {
   ]);
 });
 
+test("marks fixable checks without --fix", () => {
+  const report: DoctorReport = {
+    checks: [
+      {
+        id: "runtime",
+        label: "Runtime",
+        severity: "fail",
+        summary: "runtime dir is not private",
+        fixes: [
+          {
+            id: "runtime.repair",
+            title: "repair runtime perms",
+            run: async () => ({ ok: true, message: "done" }),
+          },
+        ],
+      },
+    ],
+  };
+
+  expect(renderDoctor(report)).toEqual([
+    "FAIL Runtime: runtime dir is not private (fixable — run: xacpx doctor --fix)",
+    "Summary: PASS 0, WARN 0, FAIL 1, SKIP 0",
+  ]);
+});
+
+test("renders the repairs section under --fix", () => {
+  const report: DoctorReport = {
+    checks: [
+      {
+        id: "runtime",
+        label: "Runtime",
+        severity: "pass",
+        summary: "runtime dir is private",
+      },
+    ],
+    repairs: [
+      {
+        checkId: "runtime",
+        fixId: "runtime.repair",
+        title: "repair runtime perms",
+        status: "applied",
+        message: "created runtime dir",
+      },
+      {
+        checkId: "daemon",
+        fixId: "daemon.clear",
+        title: "clear stale runtime",
+        status: "skipped",
+        message: "stop the daemon first",
+      },
+      {
+        checkId: "orchestration",
+        fixId: "state.quarantine",
+        title: "quarantine state",
+        status: "failed",
+        message: "permission denied",
+      },
+    ],
+  };
+
+  expect(renderDoctor(report, { fix: true })).toEqual([
+    "PASS Runtime: runtime dir is private",
+    "Repairs:",
+    "- repair runtime perms: applied (created runtime dir)",
+    "- clear stale runtime: skipped (stop the daemon first)",
+    "- quarantine state: failed (permission denied)",
+    "Summary: PASS 1, WARN 0, FAIL 0, SKIP 0",
+  ]);
+});
+
+test("omits the repairs section under --fix when there were no repairs", () => {
+  const report: DoctorReport = {
+    checks: [
+      {
+        id: "config",
+        label: "Config",
+        severity: "pass",
+        summary: "configuration file found",
+      },
+    ],
+    repairs: [],
+  };
+
+  expect(renderDoctor(report, { fix: true })).toEqual([
+    "PASS Config: configuration file found",
+    "Summary: PASS 1, WARN 0, FAIL 0, SKIP 0",
+  ]);
+});
+
 test("includes detail lines in verbose mode", () => {
   const report: DoctorReport = {
     checks: [

--- a/tests/unit/plugins/plugin-doctor.test.ts
+++ b/tests/unit/plugins/plugin-doctor.test.ts
@@ -57,7 +57,7 @@ test("doctor reports missing dependency error", async () => {
       importPlugin: async () => ({ default: { apiVersion: 1, name: "weacpx-channel-demo", channels: [] } }),
     });
 
-    expect(issues).toContainEqual({ level: "error", plugin: "weacpx-channel-demo", message: "package not installed in plugin home; run xacpx plugin add weacpx-channel-demo" });
+    expect(issues).toContainEqual({ level: "error", plugin: "weacpx-channel-demo", message: "package not installed in plugin home; run xacpx plugin add weacpx-channel-demo", suggestion: "xacpx plugin add weacpx-channel-demo && xacpx restart" });
   } finally {
     await rm(pluginHome, { recursive: true, force: true });
   }
@@ -71,7 +71,7 @@ test("doctor reports import and validation failures", async () => {
       config: baseConfig({ plugins: [{ name: "weacpx-channel-demo", enabled: true }] }),
       importPlugin: async () => { throw new Error("module not found"); },
     });
-    expect(importIssues).toContainEqual({ level: "error", plugin: "weacpx-channel-demo", message: "failed to import plugin: module not found" });
+    expect(importIssues).toContainEqual({ level: "error", plugin: "weacpx-channel-demo", message: "failed to import plugin: module not found", suggestion: "xacpx plugin add weacpx-channel-demo && xacpx restart" });
 
     const validationIssues = await inspectPlugins({
       pluginHome,
@@ -114,7 +114,7 @@ test("doctor reports error when configured channel has no provider plugin", asyn
       importPlugin: async () => ({ default: { apiVersion: 1, channels: [] } }),
     });
 
-    expect(issues).toContainEqual({ level: "error", message: "channel yuanbao is configured but no enabled plugin provides it; run xacpx plugin add @ganglion/xacpx-channel-yuanbao or another plugin that provides type \"yuanbao\"" });
+    expect(issues).toContainEqual({ level: "error", message: "channel yuanbao is configured but no enabled plugin provides it; run xacpx plugin add @ganglion/xacpx-channel-yuanbao or another plugin that provides type \"yuanbao\"", suggestion: "xacpx plugin add @ganglion/xacpx-channel-yuanbao" });
   } finally {
     await rm(pluginHome, { recursive: true, force: true });
   }
@@ -206,7 +206,7 @@ test("doctor errors when configured channel provider plugin is disabled", async 
       importPlugin: async () => ({ default: { apiVersion: 1, name: "weacpx-channel-demo", channels: [{ type: "demo", factory: () => ({ id: "demo", start: async () => {}, stop: async () => {} }) }] } }),
     });
 
-    expect(issues).toContainEqual({ level: "error", plugin: "weacpx-channel-demo", message: "channel demo is configured but provider plugin is disabled; run xacpx plugin enable weacpx-channel-demo" });
+    expect(issues).toContainEqual({ level: "error", plugin: "weacpx-channel-demo", message: "channel demo is configured but provider plugin is disabled; run xacpx plugin enable weacpx-channel-demo", suggestion: "xacpx plugin enable weacpx-channel-demo" });
   } finally {
     await rm(pluginHome, { recursive: true, force: true });
   }


### PR DESCRIPTION
Enhances `xacpx doctor` along three approved directions. Diagnose-only → can also self-repair, now catches plugin/channel breakage, and adds IPC + log/disk coverage. Plan: `docs/superpowers/plans/2026-06-11-doctor-enhancements.md`.

## A — `--fix` repair mode
- New lazily-executed `DoctorFix` framework: checks attach typed fixes that run **only under `--fix`**, then the affected checks are re-run and a `Repairs:` section is rendered. Exit code reflects the post-repair state. A throwing fix is captured, never crashes doctor.
- **Auto-applied (safe/local, no network):**
  - `runtime.ensure-private-dir` — create/repair the runtime dir to mode `0700` (ungated).
  - `state.quarantine` — quarantine invalid `state.json` records via `StateStore.load()` (**gated**).
  - `daemon.clear-stale-lock` — remove stale `*-consumer.lock.json` whose pid is dead (**gated**, channel-agnostic scan).
- **Gating:** state-mutating fixes are **withheld while the daemon is live** — and "live" correctly includes the `indeterminate` status (pid alive, status.json missing), not just `running`. Unknown status fails safe (withhold). A crashed daemon is detected independently.
- **Suggestion-only (never auto):** invalid config, missing/broken plugin (needs `plugin add` → network), disabled plugin, WeChat re-login.

## B — plugin/channel health (folded in)
- New `Plugins` check wraps `inspectPlugins` and is wired into `xacpx doctor` (between Bridge and Orchestration). Catches the exact failure seen after a core update: a channel plugin that **fails to import** (`Cannot find module …`), plus package-not-installed, peer-version skew, duplicate providers, and disabled providers.
- Remediation is now **structured at the source**: `PluginDoctorIssue.suggestion?` carries the precise `xacpx plugin …` command (no more prose/regex scraping). The `inspect` call is guarded so a throw degrades to a `fail`, not a crash.

## C — new coverage checks
- **Orchestration IPC** liveness: when the daemon is live, probe the orchestration endpoint; a definitive no-listener → `fail` (heartbeat-fresh but IPC-dead), else `pass`/`skip`. Probe and status both guarded.
- **Logs**: sum daemon log + rotation-sibling sizes; `warn` on growth (single >50 MB / total >200 MB); tolerates unreadable files; suggestion-only (no destructive truncation).

## D — CLI + docs
- `--fix` flag added to `parseDoctorArgs`.
- New `docs/doctor-command.md` (check matrix, severities, flags, `--fix` safety/gating model), linked from `AGENTS.md`.

## Quality
- Built per task via TDD subagents with spec + code-quality review each, plus a final whole-batch review (which caught the `indeterminate` gating gap, now fixed).
- Full suite green (`npm test`, per-file), `npx tsc --noEmit` clean, `bun run build` clean.

No release; this just lands on `main`.