### PR TITLE
fix(doctor): harden repair gating and align docs from PR #25 review

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: bun run build

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ xacpx doctor
 xacpx doctor --verbose
 xacpx doctor --smoke
 xacpx doctor --smoke --agent codex --workspace backend
+xacpx doctor --fix
 ```
 
 Notes:
@@ -266,6 +267,7 @@ Notes:
 - `--smoke` additionally runs a minimal real transport-level prompt check
 - `--agent` / `--workspace` only affect `--smoke`
 - Without `--smoke`, the related checks show as `SKIP`
+- `--fix` applies safe local repairs (runtime dir permissions, stale locks, invalid state records) and re-checks; state-mutating repairs are withheld while the daemon runs — see [docs/doctor-command.md](docs/doctor-command.md)
 
 ### How to use `update`
 

--- a/docs/doctor-command.md
+++ b/docs/doctor-command.md
@@ -131,5 +131,12 @@ Stop the daemon, re-run `xacpx doctor --fix`, then start it again.
 Daemon liveness is detected independently of any check output: the
 `indeterminate` state (a live daemon pid whose `status.json` is missing)
 is treated as a live daemon, so lock removal is not offered there either.
-If daemon state cannot be determined at all, doctor fails safe and treats
-the daemon as running, withholding the state-mutating repairs.
+A process that exists but cannot be signalled (`EPERM`) also counts as
+alive. If daemon state cannot be determined at all, doctor fails safe and
+treats the daemon as running, withholding the state-mutating repairs.
+
+The gate is also re-verified at apply time: if a daemon starts between
+the read-only detection pass and `--fix` applying a repair,
+`state.quarantine` refuses to run (reported as `failed` with a "stop it
+first" message) and `daemon.clear-stale-lock` re-checks each lock and
+leaves any lock alone whose owner is alive again.

--- a/docs/zh/README_zh.md
+++ b/docs/zh/README_zh.md
@@ -256,6 +256,7 @@ xacpx doctor
 xacpx doctor --verbose
 xacpx doctor --smoke
 xacpx doctor --smoke --agent codex --workspace backend
+xacpx doctor --fix
 ```
 
 说明：
@@ -264,6 +265,7 @@ xacpx doctor --smoke --agent codex --workspace backend
 - `--smoke` 会额外执行一次真实 transport 级别的最小 prompt 检查
 - `--agent` / `--workspace` 只影响 `--smoke`
 - 如果不传 `--smoke`，相关检查会显示为 `SKIP`
+- `--fix` 会执行安全的本地修复（运行时目录权限、残留锁、无效 state 记录）并重新检查；daemon 运行期间会扣留改动状态的修复，详见 [doctor-command_zh.md](doctor-command_zh.md)
 
 ### `update` 怎么用
 

--- a/docs/zh/doctor-command_zh.md
+++ b/docs/zh/doctor-command_zh.md
@@ -1,0 +1,130 @@
+# `xacpx doctor` 命令说明
+
+`xacpx doctor` 会对本机的 xacpx 安装运行一系列**只读诊断**（config、运行时路径、
+daemon、频道、transport、插件、orchestration IPC 等）并输出报告。加上 `--fix`
+后，还会额外执行一小组安全的本地修复。
+
+## 运行方式
+
+```bash
+xacpx doctor                       # 运行所有默认检查
+xacpx doctor --verbose             # 输出更多诊断细节
+xacpx doctor --smoke               # 额外运行可选的 smoke 探测
+xacpx doctor --agent codex         # 指定 smoke 探测使用的 agent
+xacpx doctor --workspace backend   # 指定 smoke 探测使用的 workspace
+xacpx doctor --fix                 # 执行安全的本地修复，然后重新检查
+```
+
+### 退出码
+
+- `0` —— 没有检查报告 `fail`（在 `--fix` 修复并重新检查之后）。
+- `1` —— 至少有一项检查仍然是 `fail`。
+
+未知 flag（或 `--agent`/`--workspace` 缺少取值）会打印 CLI 帮助并以 `1` 退出。
+
+## 检查项
+
+检查按下面的固定顺序运行和渲染。每项检查有一个稳定的 `id`（内部用于在修复
+后重跑对应检查）和报告中展示的可读 label：
+
+| 顺序 | id                      | Label             | 验证内容 |
+|------|-------------------------|-------------------|----------|
+| 1    | `config`                | Config            | `config.json` 能加载并通过校验。 |
+| 2    | `runtime`               | Runtime           | daemon 运行时目录及其 pid/status/log 文件可用（可写或可创建）。POSIX 上还会检查运行时目录是否为私有权限（mode `0700`）。 |
+| 3    | `logs`                  | Logs              | 汇总 daemon 日志文件（`app.log`/`stdout.log`/`stderr.log` 及轮转分片）的体积，增长过大时 `warn`（单文件超 50 MB，或总量超 200 MB）；运行时目录还没有日志时 `skip`。个别文件不可读会被容忍（跳过），不会 `fail`。 |
+| 4    | `daemon`                | Daemon            | 通过 daemon controller 检查存活状态（running / stopped / indeterminate）。stopped 时还会扫描残留的 consumer-lock 文件。 |
+| 5    | `wechat`                | WeChat            | 微信（Weixin）频道处于登录状态。 |
+| 6    | `acpx`                  | acpx              | 解析到的 `acpx` 可执行文件能报告可用版本。 |
+| 7    | `bridge`                | Bridge            | acpx bridge 子进程能启动并响应。 |
+| 8    | `plugins`               | Plugins           | 已配置的插件均已安装、可加载且已启用。 |
+| 9    | `orchestration`         | Orchestration     | `state.json` 中的 orchestration 状态健康（只读 inspect，绝不会作为副作用执行隔离）。心跳新鲜度按 `orchestration.progressHeartbeatSeconds` 校验。 |
+| 10   | `orchestration-socket`  | Orchestration IPC | daemon 停止时 `skip`；只有 daemon 存活（running 或 indeterminate）时才探测 orchestration IPC 端点是否真正接受连接（只有确定性的无监听才 `fail`，可达或结果不确定时为 `pass`/`skip`）。 |
+| 11   | `smoke`                 | Smoke             | 对真实会话做端到端探测。**可选项：**不传 `--smoke` 时跳过。 |
+
+## 严重级别
+
+每项检查报告四种严重级别之一：
+
+- **pass** —— 健康。
+- **warn** —— 降级但仍可工作（例如：daemon 未运行、微信未登录、运行时目录
+  权限不是 `0700`、存在 daemon 下次启动会自动隔离的无效 state 记录）。
+- **fail** —— 已损坏；任何 fail 会让退出码非零。
+- **skip** —— 不适用或未请求（例如：未传 `--smoke` 时的 Smoke 检查，或因
+  Config 检查失败而无法运行的检查）。
+
+末尾的汇总行统计各级别数量，例如
+`Summary: PASS 5, WARN 3, FAIL 1, SKIP 2`。
+
+## Flags
+
+- `--verbose` —— 在支持的检查中输出更多诊断细节（WeChat、acpx、Bridge）。
+- `--smoke` —— 运行可选的 Smoke 检查（真实的端到端会话探测）。
+- `--agent <name>` —— 指定 Smoke 探测使用的 agent。
+- `--workspace <name>` —— 指定 Smoke 探测使用的 workspace。
+- `--fix` —— 执行安全的本地修复，然后重跑受影响的检查。
+
+## `--fix`：修复模型与安全性
+
+默认情况下 doctor 严格只读。加 `--fix` 后，doctor 会遍历各检查并执行它们
+附带的修复。修复有意保持保守：
+
+- 只有**安全且本地**的修复才会执行。会改动状态的修复受**门控**（见下文），
+  daemon 运行期间会被扣留（withheld）。
+- 被扣留的修复会以 `skipped` 加原因的形式报告，而不是被执行。
+- 修复抛错或返回失败时记录为 `failed`；一次糟糕的修复永远不会让 doctor
+  崩溃。
+- 只有至少成功应用了一项修复的检查才会被重跑，使报告反映修复后的状态。
+
+修复完成后，doctor 打印一个 `Repairs:` 区块，每项修复一行：
+
+```
+Repairs:
+- create/repair runtime dir with mode 0700: applied (runtime dir ... created/repaired with mode 0700)
+- quarantine invalid state.json records: skipped (stop the daemon first: xacpx stop)
+```
+
+**不传** `--fix` 时，存在可用修复的检查会内联标注，例如：
+
+```
+WARN Runtime: daemon runtime dir should be private (mode 0700) (fixable — run: xacpx doctor --fix)
+```
+
+### 会自动执行的修复（安全 / 本地）
+
+- `runtime.ensure-private-dir` —— 创建或修复运行时目录为 mode `0700`。
+  **不受门控**（它只调整私有运行时目录自身的权限），因此 daemon 运行时也会
+  执行。
+- `state.quarantine` —— 隔离 `state.json` 中无效/损坏的记录（丢弃坏记录、把
+  原文件备份为 `state.json.quarantine-*`，或把无法读取的文件重命名为
+  `state.json.corrupt-*`）。**门控**：要求 daemon 已停止。
+- `daemon.clear-stale-lock` —— 删除记录的 pid 确定已不存活的残留
+  `*-consumer.lock.json` 文件。**只在 daemon 已停止时提供**（running 或
+  indeterminate 的 daemon 拥有这些锁）。
+
+### 只给建议、绝不自动执行的情况
+
+以下情况只会以建议（suggestion）形式呈现，永远不会变成可执行的修复：
+
+- **插件缺失或损坏** —— 安装插件需要网络。
+- **插件被禁用** —— 重新启用是操作者的显式决定。
+- **配置无效** —— 配置修改必须由你本人慎重进行。
+- **微信未登录** —— 重新登录是交互式操作（`xacpx login`）。
+
+### daemon 停止门控
+
+会改动状态的修复（`state.quarantine`、`daemon.clear-stale-lock`）绝不能与
+存活的 daemon 竞争 —— daemon 拥有 `state.json` 和 consumer 锁。daemon 运行
+期间这些修复会被**扣留**，并以 `skipped` 加 "stop the daemon first:
+`xacpx stop`" 的原因报告。先停止 daemon，重跑 `xacpx doctor --fix`，再启动
+它。
+
+daemon 存活与否的判定独立于任何检查结果：`indeterminate` 状态（daemon pid
+存活但 `status.json` 缺失）被视为存活的 daemon，因此那种情况下也不会提供锁
+清理。进程存在但无法发送信号（`EPERM`）同样算作存活。如果完全无法确定
+daemon 状态，doctor 会按安全方向处理：视为 daemon 正在运行，扣留所有改动
+状态的修复。
+
+门控还会在执行时刻再次复核：如果在只读检测和 `--fix` 实际执行修复之间有
+daemon 启动了，`state.quarantine` 会拒绝执行（报告为 `failed`，并提示先
+停止 daemon），`daemon.clear-stale-lock` 会逐个重新核对每把锁，跳过持有者
+已重新存活的锁。

--- a/packages/docs/reference/cli.md
+++ b/packages/docs/reference/cli.md
@@ -9,7 +9,7 @@ xacpx login | logout | run | start | status | stop | restart
 xacpx update [--all | <name>]
 xacpx channel | ch  list | show | add | rm | enable | disable  [--account <id>]
 xacpx plugin  list | add | update | remove | enable | disable | doctor | known
-xacpx doctor [--verbose] [--smoke] [--agent <a>] [--workspace <w>]
+xacpx doctor [--verbose] [--smoke] [--agent <a>] [--workspace <w>] [--fix]
 xacpx version
 xacpx agent | agents  list | add | rm | templates
 xacpx workspace | ws  list | add [name] [--raw] | rm <name>
@@ -95,12 +95,14 @@ xacpx doctor
 xacpx doctor --verbose
 xacpx doctor --smoke
 xacpx doctor --smoke --agent codex --workspace backend
+xacpx doctor --fix
 ```
 
 - `--verbose` expands the details of each check.
 - `--smoke` additionally runs a minimal real transport-level prompt check.
 - `--agent` / `--workspace` only affect `--smoke`.
 - Without `--smoke`, the related checks show as `SKIP`.
+- `--fix` applies safe local repairs (runtime dir permissions, stale consumer locks, invalid state records) and re-runs the affected checks. Repairs that mutate state are withheld while the daemon runs ("stop the daemon first").
 
 ## Workspaces — `xacpx workspace`
 

--- a/packages/docs/zh/reference/cli.md
+++ b/packages/docs/zh/reference/cli.md
@@ -9,7 +9,7 @@ xacpx login | logout | run | start | status | stop | restart
 xacpx update [--all | <name>]
 xacpx channel | ch  list | show | add | rm | enable | disable  [--account <id>]
 xacpx plugin  list | add | update | remove | enable | disable | doctor | known
-xacpx doctor [--verbose] [--smoke] [--agent <a>] [--workspace <w>]
+xacpx doctor [--verbose] [--smoke] [--agent <a>] [--workspace <w>] [--fix]
 xacpx version
 xacpx agent | agents  list | add | rm | templates
 xacpx workspace | ws  list | add [name] [--raw] | rm <name>
@@ -95,12 +95,14 @@ xacpx doctor
 xacpx doctor --verbose
 xacpx doctor --smoke
 xacpx doctor --smoke --agent codex --workspace backend
+xacpx doctor --fix
 ```
 
 - `--verbose` 会展开每项检查的细节。
 - `--smoke` 会额外执行一次真实 transport 级别的最小 prompt 检查。
 - `--agent` / `--workspace` 只影响 `--smoke`。
 - 如果不传 `--smoke`，相关检查会显示为 `SKIP`。
+- `--fix` 会执行安全的本地修复（运行时目录权限、残留 consumer 锁、无效 state 记录）并重跑受影响的检查。会改动状态的修复在 daemon 运行期间会被扣留（提示先 stop daemon）。
 
 ## 工作区 —— `xacpx workspace`
 

--- a/src/daemon/daemon-files.ts
+++ b/src/daemon/daemon-files.ts
@@ -43,16 +43,17 @@ export function resolveDaemonOrchestrationSocketPath(
 }
 
 /**
- * Liveness probe via signal 0: returns true when the pid can be signalled,
- * false when process.kill throws. Note this treats any throw (including EPERM,
- * which actually means the process exists but is owned by another user) as "not
- * alive"; matches the behaviour of the other isProcessRunning copies.
+ * Liveness probe via signal 0: returns true when the pid can be signalled.
+ * EPERM also reads as ALIVE — it means the signal was denied but the process
+ * exists (typically owned by another user). Doctor uses this to gate
+ * state-mutating repairs, where the unsafe direction is reporting a live
+ * process as dead; only a definitive "no such process" (ESRCH) reads as dead.
  */
 export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
   }
 }

--- a/src/doctor/checks/daemon-check.ts
+++ b/src/doctor/checks/daemon-check.ts
@@ -157,6 +157,9 @@ interface StaleConsumerLockDeps {
  * a missing dir, no matching files, unreadable locks, or live-pid locks all
  * yield no fix. When at least one stale lock exists, returns a repair whose
  * run() removes every stale lock found (and only those) and names them.
+ * run() re-verifies each lock is still readable-and-stale before removing it:
+ * a daemon may have started (rewriting a lock with a live pid) between the
+ * read-only detection pass and --fix applying the repair.
  */
 async function detectStaleConsumerLockFix(
   runtimeDir: string,
@@ -183,12 +186,24 @@ async function detectStaleConsumerLockFix(
     id: "daemon.clear-stale-lock",
     title: "remove stale consumer lock(s)",
     run: async () => {
+      const removed: string[] = [];
+      let skipped = 0;
       for (const lockPath of stalePaths) {
+        const lock = await deps.readConsumerLock(lockPath);
+        if (!lock || deps.isProcessRunning(lock.pid)) {
+          skipped += 1;
+          continue;
+        }
         await deps.removeConsumerLock(lockPath);
+        removed.push(lockPath);
       }
+      const skippedNote = skipped > 0 ? `; left ${skipped} no-longer-stale lock(s) alone` : "";
       return {
         ok: true,
-        message: `removed ${stalePaths.length} stale consumer lock(s): ${stalePaths.join(", ")}`,
+        message:
+          removed.length > 0
+            ? `removed ${removed.length} stale consumer lock(s): ${removed.join(", ")}${skippedNote}`
+            : `no locks removed${skippedNote}`,
       };
     },
   };

--- a/src/doctor/checks/logs-check.ts
+++ b/src/doctor/checks/logs-check.ts
@@ -44,20 +44,26 @@ export async function checkLogs(options: LogsCheckOptions = {}): Promise<DoctorC
   const singleFileWarnBytes = options.singleFileWarnBytes ?? DEFAULT_SINGLE_FILE_WARN_BYTES;
   const totalWarnBytes = options.totalWarnBytes ?? DEFAULT_TOTAL_WARN_BYTES;
 
-  // A missing runtime dir means the daemon has never written logs here.
+  // A missing runtime dir means the daemon has never written logs here. Any
+  // other obstacle (unreadable dir, path is not a directory) is a Runtime-check
+  // problem; skip without claiming the logs do not exist.
   let entries: string[];
   try {
     const dirStat = await probe.stat(paths.runtimeDir);
     if (!dirStat.isDirectory()) {
-      return skip(paths.runtimeDir);
+      return skip("runtime log directory could not be read", [
+        `runtimeDir: ${paths.runtimeDir} (exists but is not a directory)`,
+      ]);
     }
     entries = await probe.readdir(paths.runtimeDir);
   } catch (error) {
     if (isMissingPathError(error)) {
-      return skip(paths.runtimeDir);
+      return skip("no runtime logs yet", [`runtimeDir: ${paths.runtimeDir} (missing)`]);
     }
-    // An unreadable runtime dir is surfaced by the Runtime check; do not crash here.
-    return skip(paths.runtimeDir);
+    return skip("runtime log directory could not be read", [
+      `runtimeDir: ${paths.runtimeDir}`,
+      `error: ${formatError(error)}`,
+    ]);
   }
 
   // Enumerate the base daemon logs plus every rotation sibling: a file in the
@@ -119,13 +125,13 @@ export async function checkLogs(options: LogsCheckOptions = {}): Promise<DoctorC
   };
 }
 
-function skip(runtimeDir: string): DoctorCheckResult {
+function skip(summary: string, details: string[]): DoctorCheckResult {
   return {
     id: "logs",
     label: "Logs",
     severity: "skip",
-    summary: "no runtime logs yet",
-    details: [`runtimeDir: ${runtimeDir} (missing)`],
+    summary,
+    details,
   };
 }
 
@@ -168,6 +174,10 @@ function createLogsFsProbe(): LogsFsProbe {
     stat: async (path) => await stat(path),
     readdir: async (path) => await readdir(path),
   };
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isMissingPathError(error: unknown): boolean {

--- a/src/doctor/checks/orchestration-socket-check.ts
+++ b/src/doctor/checks/orchestration-socket-check.ts
@@ -22,10 +22,8 @@ import type { DoctorCheckResult } from "../doctor-types";
  * the pid is alive); "stopped" is the only non-live state.
  */
 export type DaemonStatusSummary =
-  | { state: "stopped" }
-  | { state: "running"; pid: number }
-  | { state: "indeterminate"; pid: number }
-  | { state: string; pid?: number };
+  | { state: "stopped"; stale?: boolean }
+  | { state: "running" | "indeterminate" | "already-running"; pid: number };
 
 export interface OrchestrationSocketCheckOptions {
   home?: string;

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -341,7 +341,13 @@ async function defaultCheckOrchestrationHealth(deps: {
     // inspection found something to quarantine), to avoid a needless status read
     // on the healthy path.
     const daemonRunning = inspection.report ? await deps.isDaemonRunning() : false;
-    return applyStateInspectionReport(result, inspection.report, deps.runtimePaths.statePath, daemonRunning);
+    return applyStateInspectionReport(
+      result,
+      inspection.report,
+      deps.runtimePaths.statePath,
+      daemonRunning,
+      deps.isDaemonRunning,
+    );
   } catch (error) {
     return {
       id: "orchestration",
@@ -365,6 +371,7 @@ function applyStateInspectionReport(
   report: StateLoadReport | null,
   statePath: string,
   daemonRunning: boolean,
+  isDaemonRunning: () => Promise<boolean>,
 ): DoctorCheckResult {
   if (!report) {
     return result;
@@ -394,7 +401,7 @@ function applyStateInspectionReport(
         ? "back up the state file before the next daemon start if you want to attempt manual recovery"
         : "the daemon backs the original file up as state.json.quarantine-* before dropping these records",
     ],
-    fixes: [createStateQuarantineFix(statePath, daemonRunning)],
+    fixes: [createStateQuarantineFix(statePath, daemonRunning, isDaemonRunning)],
   };
 }
 
@@ -403,14 +410,26 @@ function applyStateInspectionReport(
  * StateStore.load() path (drop bad records, back the original up as
  * .quarantine-* / rename a corrupt file to .corrupt-*). Gated: while the daemon
  * is running it owns state.json and performs this itself at the next start, so
- * the fix is withheld rather than racing it.
+ * the fix is withheld rather than racing it. The gate is re-verified inside
+ * run() because a daemon may start between the read-only detection pass and
+ * --fix applying the repair.
  */
-function createStateQuarantineFix(statePath: string, daemonRunning: boolean): DoctorFix {
+function createStateQuarantineFix(
+  statePath: string,
+  daemonRunning: boolean,
+  isDaemonRunning: () => Promise<boolean>,
+): DoctorFix {
   return {
     id: "state.quarantine",
     title: "quarantine invalid state.json records",
     ...(daemonRunning ? { withheld: "stop the daemon first: xacpx stop" } : {}),
     run: async () => {
+      if (await isDaemonRunning()) {
+        return {
+          ok: false,
+          message: "a daemon started since detection; stop it first: xacpx stop",
+        };
+      }
       const store = new StateStore(statePath);
       await store.load();
       const report = store.lastLoadReport;

--- a/tests/unit/daemon/daemon-files.test.ts
+++ b/tests/unit/daemon/daemon-files.test.ts
@@ -1,7 +1,13 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 
-import { resolveDaemonPaths } from "../../../src/daemon/daemon-files";
+import { isProcessAlive, resolveDaemonPaths } from "../../../src/daemon/daemon-files";
+
+function killError(code: string): NodeJS.ErrnoException {
+  const error = new Error(`kill failed: ${code}`) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
 
 test("resolves runtime files under ~/.xacpx/runtime by default", () => {
   expect(
@@ -32,4 +38,33 @@ test("allows overriding the runtime directory", () => {
     stderrLog: join("/tmp/weacpx-runtime", "stderr.log"),
     appLog: join("/tmp/weacpx-runtime", "app.log"),
   });
+});
+
+test("isProcessAlive reports the current process as alive", () => {
+  expect(isProcessAlive(process.pid)).toBe(true);
+});
+
+test("isProcessAlive treats ESRCH (no such process) as dead", () => {
+  const spy = spyOn(process, "kill").mockImplementation(() => {
+    throw killError("ESRCH");
+  });
+  try {
+    expect(isProcessAlive(99999)).toBe(false);
+  } finally {
+    spy.mockRestore();
+  }
+});
+
+test("isProcessAlive treats EPERM (exists, signal denied) as ALIVE", () => {
+  // EPERM means the process exists but is owned by another user. Doctor gates
+  // state-mutating repairs on liveness, so an existing process must never read
+  // as dead.
+  const spy = spyOn(process, "kill").mockImplementation(() => {
+    throw killError("EPERM");
+  });
+  try {
+    expect(isProcessAlive(1)).toBe(true);
+  } finally {
+    spy.mockRestore();
+  }
 });

--- a/tests/unit/doctor/checks/daemon-check.test.ts
+++ b/tests/unit/doctor/checks/daemon-check.test.ts
@@ -248,3 +248,36 @@ test("daemon check does not attach the lock fix when status is indeterminate (li
     await rm(home, { recursive: true, force: true });
   }
 });
+
+test("clear-stale-lock run() re-verifies and leaves a lock alone when its pid became live after detection", async () => {
+  const home = await createTempHome();
+  const runtimeDir = join(home, ".xacpx", "runtime");
+  const pid = 4242;
+
+  try {
+    await writeLock(runtimeDir, pid);
+
+    // Dead at detection time, alive by the time the fix runs — the TOCTOU
+    // window where a daemon/channel restarted and re-owned the lock.
+    let alive = false;
+    const removed: string[] = [];
+    const result = await checkDaemon({
+      home,
+      isProcessRunning: () => alive,
+      removeConsumerLock: async (path) => {
+        removed.push(path);
+      },
+    });
+
+    const fix = result.fixes?.find((entry) => entry.id === "daemon.clear-stale-lock");
+    expect(fix).toBeDefined();
+
+    alive = true;
+    const outcome = await fix!.run();
+    expect(outcome.ok).toBe(true);
+    expect(outcome.message).toContain("no locks removed");
+    expect(removed).toEqual([]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/doctor/checks/logs-check.test.ts
+++ b/tests/unit/doctor/checks/logs-check.test.ts
@@ -182,3 +182,20 @@ test("logs check tolerates an unreadable individual file and still sums the rest
   // 10 MB summed from the two readable files; the unreadable one is skipped.
   expect(result.summary).toContain("10");
 });
+
+test("logs check skips with a could-not-read summary (not 'no logs') when the runtime dir is unreadable", async () => {
+  const home = "/home/user";
+  const runtimeDir = runtimeDirOf(home);
+  const probe = createLogsProbe({
+    directories: [],
+    // The runtime dir itself stats with EACCES — present but unreadable.
+    unreadable: [runtimeDir],
+  });
+
+  const result = await checkLogs({ home, probe });
+
+  expect(result.severity).toBe("skip");
+  expect(result.summary).toContain("could not be read");
+  expect(result.summary.toLowerCase()).not.toContain("no runtime logs");
+  expect(result.details?.join("\n") ?? "").toContain("EACCES");
+});

--- a/tests/unit/doctor/doctor.test.ts
+++ b/tests/unit/doctor/doctor.test.ts
@@ -1471,3 +1471,39 @@ test("default daemon-liveness mapping allows the quarantine fix for a stopped da
     await rm(home, { recursive: true, force: true });
   }
 });
+
+test("state.quarantine run() re-verifies liveness and refuses when a daemon started after detection", async () => {
+  const home = await createTempHome();
+  const rootDir = join(home, ".xacpx");
+  const statePath = join(rootDir, "state.json");
+  const original = JSON.stringify({ sessions: { bad: { alias: "bad" } }, chat_contexts: {} });
+
+  try {
+    await mkdir(rootDir, { recursive: true });
+    await writeFile(statePath, original, "utf8");
+
+    // Daemon is stopped at detection time (fix attached, not withheld), but has
+    // started by the time the fix is applied — the TOCTOU window.
+    let liveness = false;
+    const result = await runDoctor(
+      {},
+      { home, ...createStateDoctorStubs(), isDaemonRunning: async () => liveness },
+    );
+
+    const orchestration = result.report.checks.find((check) => check.id === "orchestration");
+    const fix = orchestration?.fixes?.find((entry) => entry.id === "state.quarantine");
+    expect(fix).toBeDefined();
+    expect(fix?.withheld).toBeUndefined();
+
+    liveness = true;
+    const outcome = await fix!.run();
+    expect(outcome.ok).toBe(false);
+    expect(outcome.message).toContain("xacpx stop");
+
+    // The refused repair must not have touched state.json.
+    expect(await readFile(statePath, "utf8")).toBe(original);
+    expect(await readdir(rootDir)).toEqual(["state.json"]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Follow-ups from the post-merge review of #25. All items were Minor; none blocked the merge.

## Code fixes

- **`isProcessAlive` treats EPERM as ALIVE** (`src/daemon/daemon-files.ts`). EPERM means the process exists but cannot be signalled (typically another user's). Doctor gates state-mutating repairs on liveness, where the unsafe direction is reading a live process as dead — only a definitive ESRCH reads as dead now.
- **Close the detect→apply TOCTOU window.** A daemon can start between the read-only detection pass and `--fix` applying a repair:
  - `state.quarantine` re-verifies daemon liveness inside `run()` and refuses (reported `failed`, "stop it first") instead of mutating `state.json` under a live daemon.
  - `daemon.clear-stale-lock` re-reads each lock at apply time and leaves any lock alone whose owner pid is alive again.
- **Logs check messaging**: an unreadable runtime dir no longer skips with "no runtime logs yet"; it skips with a could-not-read summary and the underlying error.
- **`DaemonStatusSummary` tightened**: dropped the catch-all union member that defeated the discriminated states.

## CI

The repo ran **no tests on PRs at all** (only docs deploys and tag-triggered publishes). Added `.github/workflows/test.yml` (pull_request + push to main) mirroring the publish job's setup: `npm ci`, `npm test`, `bun run build`. This PR should be the first to get a green check from it.

## Docs / i18n alignment

- Added the missing Chinese translation **`docs/zh/doctor-command_zh.md`** (every other `docs/*.md` already had a `_zh` mirror).
- Added `--fix` to the doctor sections in `README.md`, `docs/zh/README_zh.md`, and the VitePress CLI reference (en + zh), which still documented only `--verbose/--smoke/--agent/--workspace`.
- Documented the EPERM rule and apply-time re-verification in `docs/doctor-command.md`.

Doctor's terminal output itself stays English-only by design (matches the existing doctor strings; the i18n catalogs only carry the CLI help one-liner and the orchestration suggestions, both unchanged).

## Testing

- `npm test` (per-file runner): exit 0, no failing files.
- `bun run build`: clean.
- New unit tests: EPERM/ESRCH/self-pid mapping for `isProcessAlive`; TOCTOU refusal for `state.quarantine`; apply-time re-verification for `daemon.clear-stale-lock`; unreadable-dir messaging for the logs check.