### PR TITLE
docs: self-hosting deployment guide for the relay hub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ There are two session concepts:
 - MCP integration (external coordinators): [`docs/external-mcp.md`](docs/external-mcp.md)
 - `xacpx doctor` diagnostics and `--fix` repairs: [`docs/doctor-command.md`](docs/doctor-command.md)
 - Control API（结构化控制面，relay 等结构化消费者入口）: [`docs/control-module.md`](docs/control-module.md)
+- Relay Hub 自托管部署/运维（operator 向）: [`docs/relay-deployment.md`](docs/relay-deployment.md)（完整图文在文档站 `guide/relay-self-hosting`）
 - Relay Hub（服务端 + 连接器）: [`docs/relay-module.md`](docs/relay-module.md)
 - Relay Web 看板模块说明: [`docs/relay-web-module.md`](docs/relay-web-module.md)
 - Code Wiki (architecture map): [`docs/code-wiki.md`](docs/code-wiki.md)

--- a/README.md
+++ b/README.md
@@ -514,6 +514,25 @@ take a look at today's API timeout issue
 
 For more filtering, aliases, and troubleshooting, see [docs/native-sessions.md](./docs/native-sessions.md).
 
+## Self-hosted relay hub (optional)
+
+If you run several xacpx instances and want to drive them all from one browser dashboard, you can self-host the **relay hub**. Each instance dials out to the hub over WebSocket and registers; you log in to a multi-tenant web dashboard and manage every instance's sessions — chat, scheduled tasks, and orchestration — from one place. Streaming agent replies render as markdown, and the layout works on mobile.
+
+> Status: the relay packages are built and audited but **not yet published to npm**, so today you deploy from a source checkout. See the full guide for the exact steps.
+
+```bash
+# Build the hub server + dashboard from a repo checkout
+git clone https://github.com/gadzan/xacpx && cd xacpx && bun install
+bun run build:relay && bun run build:relay-web
+
+# Create the first admin, then start (point --web-root at the built dashboard)
+node packages/relay/dist/cli.js init-admin --username admin --db /var/lib/xacpx-relay/relay.db
+node packages/relay/dist/cli.js start --db /var/lib/xacpx-relay/relay.db \
+  --web-root packages/relay-web/dist --host 0.0.0.0
+```
+
+Full walkthrough — pairing instances, TLS/reverse-proxy, systemd, backups, troubleshooting: **[Self-Hosting the Relay Hub](https://gadzan.github.io/xacpx/guide/relay-self-hosting)** (or [docs/relay-deployment.md](./docs/relay-deployment.md) for the terse runbook).
+
 ## Config and runtime files
 
 Default file locations:

--- a/docs/relay-deployment.md
+++ b/docs/relay-deployment.md
@@ -1,0 +1,44 @@
+# 自托管 Relay Hub — 部署运维速查
+
+> 这是面向运维者的精简 runbook。完整图文指南（架构、TLS/反向代理、systemd、备份、故障排查）见文档站点
+> **[自托管 Relay Hub](https://gadzan.github.io/xacpx/zh/guide/relay-self-hosting)**（英文版 `/guide/relay-self-hosting`）。
+> 模块内部实现见 [relay-module.md](relay-module.md) / [relay-web-module.md](relay-web-module.md)。
+
+## 现状：从源码部署
+
+`@ganglion/xacpx-relay` / `channel-relay` / `relay-protocol` / `relay-web` 四个包**尚未发布到 npm**（均 0.1.0）。
+当前从仓库 checkout 构建运行；发布后 `xacpx-relay` 命令与 `xacpx plugin add @ganglion/xacpx-channel-relay` 即一行安装。
+
+## 端到端
+
+```bash
+# 1. 构建（服务端 + 看板，看板必须单独构建，未含在 build:packages 内）
+git clone https://github.com/gadzan/xacpx && cd xacpx && bun install
+bun run build:relay         # → packages/relay/dist
+bun run build:relay-web     # → packages/relay-web/dist（不构建则没有 Web UI）
+
+# 2. 建首个管理员（不带 --password 会自动生成并只打印一次；--db 用绝对路径）
+node packages/relay/dist/cli.js init-admin --username admin --db /var/lib/xacpx-relay/relay.db
+
+# 3. 起服务（--web-root 指向已构建的看板，否则无 UI）
+node packages/relay/dist/cli.js start \
+  --db /var/lib/xacpx-relay/relay.db \
+  --web-root /opt/xacpx/packages/relay-web/dist \
+  --host 0.0.0.0 --http-port 8787 --ws-port 8788 --history-retention-days 30
+
+# 4. 发配对令牌（单次使用、--ttl-minutes 默认 10 分钟）
+node packages/relay/dist/cli.js token new --account admin --name home-pc --db /var/lib/xacpx-relay/relay.db
+
+# 5. 实例侧接入（--url 指向 8788 实例网关或其 wss:// 代理）
+xacpx channel add relay --url wss://relay.example.com --token <配对令牌> --name home-pc
+xacpx restart
+```
+
+## 关键事实
+
+- **双端口**：8787 = HTTP API + 看板 + 看板 `/ws`；8788 = 实例网关（实例在此注册）。两者分开便于分别防火墙。生产经反代终结 TLS，实例用 `wss://`。
+- **`xacpx-relay` CLI 只有三个子命令**：`start` / `init-admin` / `token new`。**没有 `stop`/`status`**——用 `Ctrl-C`/`SIGTERM`（建议 systemd/pm2/Docker 托管）。
+- **持久化**：全部在单个 SQLite 文件（`--db`）。默认 `./relay.db` 是 **cwd 相对路径**（坑），务必用绝对路径。备份即停机/静默期 `cp` 该文件。
+- **凭证**：实例首连用一次性配对令牌换长期凭证，写入 `<xacpx-home>/relay/credential.json`（0600），不进 `config.json`。
+- **自动 GC**：每小时清理超 `--history-retention-days`（默认 30，另每会话硬上限 2000 条）的缓存消息，以及过期的 web 会话/邀请/配对令牌。
+- **多租户**：账号只见自己的实例/会话；服务端盖戳身份；密钥一律哈希存储。邀请令牌在看板 Settings 页生成（单次使用）。

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
               items: [
                 { text: 'Getting Started', link: '/guide/getting-started' },
                 { text: 'Channel Management', link: '/guide/channel-management' },
+                { text: 'Self-Hosting the Relay Hub', link: '/guide/relay-self-hosting' },
                 { text: 'Scheduled Tasks', link: '/guide/scheduled-tasks' },
                 { text: 'Native Sessions', link: '/guide/native-sessions' },
                 { text: 'Group Usage', link: '/guide/group-usage' },
@@ -127,6 +128,7 @@ export default defineConfig({
               items: [
                 { text: '快速开始', link: '/zh/guide/getting-started' },
                 { text: '频道管理', link: '/zh/guide/channel-management' },
+                { text: '自托管 Relay Hub', link: '/zh/guide/relay-self-hosting' },
                 { text: '定时任务', link: '/zh/guide/scheduled-tasks' },
                 { text: '原生会话', link: '/zh/guide/native-sessions' },
                 { text: '群组使用', link: '/zh/guide/group-usage' },

--- a/packages/docs/guide/relay-self-hosting.md
+++ b/packages/docs/guide/relay-self-hosting.md
@@ -1,0 +1,257 @@
+# Self-Hosting the Relay Hub
+
+The **relay hub** is an optional, self-hosted server that turns xacpx into a multi-tenant remote-control dashboard. Your xacpx instances dial **out** to the hub over WebSocket and register; you then log in to a web dashboard from any browser and drive every instance's sessions — chat, scheduled tasks, and orchestration — from one place.
+
+This guide walks an operator from nothing to a running hub with a paired instance.
+
+::: warning Pre-release: build from source
+The relay packages (`@ganglion/xacpx-relay`, `@ganglion/xacpx-channel-relay`, `@ganglion/xacpx-relay-protocol`, `@ganglion/xacpx-relay-web`) are built and audited but **not yet published to npm**. Until they are, you deploy the hub from a checkout of the repository, as shown below. Once published, the `xacpx-relay` binary and `xacpx plugin add @ganglion/xacpx-channel-relay` become one-line installs — both paths are noted.
+:::
+
+## Architecture at a glance
+
+```
+   xacpx instance A ─┐                         ┌─ browser (account: alice)
+   xacpx instance B ─┤  WSS (dial-out)         │  HTTPS + WSS
+   xacpx instance C ─┴──────────────►  RELAY HUB  ◄───────────┘
+                       :8788 instance gateway   :8787 HTTP API + web /ws
+                                  │
+                              relay.db (SQLite)
+```
+
+- **Two ports.** The HTTP API and the dashboard's `/ws` fan-out share **8787**; the **instance** WebSocket gateway (where xacpx instances register) is **8788**. They are separate so you can firewall them independently.
+- **Multi-tenant.** Every account only ever sees its own instances and sessions; the server stamps identity on each proxied call. Secrets (passwords, pairing tokens, instance credentials, web-session cookies) are stored hashed.
+- **Source of truth stays on the instances.** The hub caches recent messages for the dashboard but does not own your sessions — the instances do.
+
+## Requirements
+
+- **Node.js ≥ 22.13** (uses the built-in `node:sqlite`) **or Bun ≥ 1.2** (uses `bun:sqlite`). No native database addon to compile.
+- A host reachable by your instances and your browser. For anything beyond localhost you want a TLS-terminating reverse proxy (see [TLS & reverse proxy](#tls-reverse-proxy)).
+- To pair instances, each instance needs the `xacpx` CLI (the normal install from [Getting Started](/guide/getting-started)).
+
+## 1. Get the server
+
+Clone the repository and build the relay server and the dashboard:
+
+```bash
+git clone https://github.com/gadzan/xacpx
+cd xacpx
+bun install
+
+# Build the hub server (compiles relay-protocol + relay to ./packages/relay/dist)
+bun run build:relay
+
+# Build the web dashboard (outputs packages/relay-web/dist)
+bun run build:relay-web
+```
+
+::: tip The dashboard build is separate
+`build:relay-web` is **not** part of `build:packages`. If you skip it you will start an API with no UI. Always build it and point `--web-root` at `packages/relay-web/dist` (step 3).
+:::
+
+The server entry point is `packages/relay/dist/cli.js`. After publish this same surface is exposed as the `xacpx-relay` binary; substitute `xacpx-relay <command>` for `node packages/relay/dist/cli.js <command>` everywhere below.
+
+## 2. Create the first admin account
+
+The hub stores everything in a single SQLite file. Pick a **stable, absolute** path for it — the default `./relay.db` is resolved relative to the current working directory, which is an easy way to end up with two different databases.
+
+```bash
+node packages/relay/dist/cli.js init-admin \
+  --username admin \
+  --db /var/lib/xacpx-relay/relay.db
+```
+
+If you omit `--password`, the hub generates one and prints it **once**:
+
+```
+admin account created: admin
+password: 3f9c1ab27de40c85
+(store it now — it is not shown again)
+```
+
+Save it in your password manager immediately.
+
+## 3. Start the server
+
+```bash
+node packages/relay/dist/cli.js start \
+  --db /var/lib/xacpx-relay/relay.db \
+  --web-root /opt/xacpx/packages/relay-web/dist \
+  --host 0.0.0.0 \
+  --http-port 8787 \
+  --ws-port 8788 \
+  --history-retention-days 30
+```
+
+On success it prints:
+
+```
+xacpx-relay listening: http :8787, instance ws :8788, db /var/lib/xacpx-relay/relay.db
+```
+
+Open `http://<host>:8787/` and log in with the admin credentials from step 2.
+
+### `start` flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--db <path>` | `./relay.db` | SQLite database file. Use an absolute path. |
+| `--http-port <n>` | `8787` | HTTP API **and** the dashboard's `/ws` fan-out. |
+| `--ws-port <n>` | `8788` | Instance gateway — where xacpx instances register. |
+| `--host <addr>` | `0.0.0.0` | Bind address. |
+| `--web-root <dir>` | _(none)_ | Directory of built dashboard assets. **Omit and no UI is served.** |
+| `--history-retention-days <n>` | `30` | Cached messages older than this are pruned hourly (also hard-capped at 2000 messages per session). |
+
+There is no `stop`/`status` subcommand — stop the hub with `Ctrl-C` / `SIGTERM` (run it under systemd, pm2, or Docker for lifecycle management).
+
+## 4. Pair an xacpx instance
+
+### Mint a pairing token (on the hub)
+
+```bash
+node packages/relay/dist/cli.js token new \
+  --account admin \
+  --name home-pc \
+  --ttl-minutes 10 \
+  --db /var/lib/xacpx-relay/relay.db
+```
+
+Output:
+
+```
+pairing token: 8e1d…(single-use, expires soon)
+expires at: 2026-06-13T12:00:00.000Z
+pair with: xacpx channel add relay --url ws://<relay-host>:<ws-port> --token <the-token>
+```
+
+The token is **single-use** and short-lived (`--ttl-minutes`, default 10).
+
+### Attach the instance
+
+On the machine running the xacpx instance, add the relay connector channel, pointing `--url` at the **instance gateway** port (8788, or your `wss://` proxy):
+
+```bash
+# After publish:
+xacpx plugin add @ganglion/xacpx-channel-relay
+xacpx channel add relay --url wss://relay.example.com --token <the-token> --name home-pc
+xacpx restart
+```
+
+`--url` must start with `ws://` or `wss://`; `--token` is the pairing token; `--name` is optional.
+
+On first connect the instance exchanges the one-shot pairing token for a long-lived credential, written (mode `0600`) to `<xacpx-home>/relay/credential.json` — **never** to `config.json` (which only keeps the url/name). Keep that file safe; it is the instance's identity.
+
+::: details Pairing the connector before it is published to npm
+`xacpx plugin add` passes its argument straight to `npm install` / `bun add`, so a local path works — but `@ganglion/xacpx-channel-relay` depends on the (also unpublished) `@ganglion/xacpx-relay-protocol`, so a bare local install will not resolve that dependency from npm. Until the packages are released, the reliable path is to run the instance from a repo checkout where the workspace already links both packages, or to pack/link both (`relay-protocol` then `channel-relay`) into the instance's plugin home. After release, the two commands above are all you need.
+:::
+
+Back in the dashboard, the instance appears in the left column with a green dot once it is online. Select a session to chat; open the task panel (right column, or the **Tasks** button on mobile) for scheduled and orchestration tasks.
+
+## TLS & reverse proxy {#tls-reverse-proxy}
+
+The hub speaks **plain** HTTP and WS. For any non-localhost deployment, terminate TLS at a reverse proxy and forward both the HTTP/web port and the instance-gateway port. Instances should then connect with `wss://`.
+
+The dashboard's live updates use a WebSocket upgrade on the **HTTP port**, so the proxy must allow upgrades on that route as well.
+
+### Caddy
+
+```text
+relay.example.com {
+    reverse_proxy 127.0.0.1:8787   # HTTP API + dashboard + dashboard /ws (Caddy proxies upgrades automatically)
+}
+
+gateway.example.com {
+    reverse_proxy 127.0.0.1:8788   # instance gateway; instances use wss://gateway.example.com
+}
+```
+
+### nginx
+
+```nginx
+# Dashboard + HTTP API (port 8787, includes the dashboard /ws upgrade)
+server {
+    listen 443 ssl;
+    server_name relay.example.com;
+    # ssl_certificate ...; ssl_certificate_key ...;
+    location / {
+        proxy_pass http://127.0.0.1:8787;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+}
+
+# Instance gateway (port 8788) — instances connect with wss://gateway.example.com
+server {
+    listen 443 ssl;
+    server_name gateway.example.com;
+    # ssl_certificate ...; ssl_certificate_key ...;
+    location / {
+        proxy_pass http://127.0.0.1:8788;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+}
+```
+
+### Which ports to expose
+
+| Port | Audience | Expose publicly? |
+|---|---|---|
+| 8787 | Browsers (dashboard + API + dashboard `/ws`) | Yes, behind TLS |
+| 8788 | xacpx instances (gateway) | Yes, behind TLS |
+| — | `relay.db` | Never — it is a local file |
+
+## Accounts, invites & maintenance
+
+- **More accounts.** An admin can generate an **invite token** from the dashboard's **Settings** page; a new operator redeems it to create their own account. Invites are single-use.
+- **More instances.** Mint another pairing token (step 4) per instance.
+- **Automatic GC.** An hourly maintenance loop prunes cached messages past `--history-retention-days` (and the 2000-per-session cap) and deletes expired web sessions, invites, and pairing tokens. No cron needed.
+
+## Persistence & backup
+
+Everything lives in the one SQLite file at `--db`. To back up, stop the hub (or snapshot during a quiet moment) and copy the file:
+
+```bash
+cp /var/lib/xacpx-relay/relay.db /backups/relay-$(date +%F).db
+```
+
+Losing it means losing accounts, instance registrations, and cached history — instances would need to be re-paired.
+
+## Running under systemd (example)
+
+```ini
+# /etc/systemd/system/xacpx-relay.service
+[Unit]
+Description=xacpx relay hub
+After=network.target
+
+[Service]
+WorkingDirectory=/opt/xacpx
+ExecStart=/usr/bin/node packages/relay/dist/cli.js start --db /var/lib/xacpx-relay/relay.db --web-root /opt/xacpx/packages/relay-web/dist --host 127.0.0.1
+Restart=on-failure
+User=xacpx
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Bind to `127.0.0.1` and let your reverse proxy face the internet.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Dashboard 404 / blank page | `--web-root` omitted or wrong | Build with `bun run build:relay-web`, point `--web-root` at `packages/relay-web/dist`. |
+| Instance never turns green | Wrong gateway URL/port, or expired token | Point `--url` at the **8788** gateway (or its `wss://` proxy); pairing tokens expire (`--ttl-minutes`) and are single-use — mint a fresh one. |
+| "two databases" / empty after restart | Default `./relay.db` is cwd-relative | Always pass an absolute `--db`. |
+| Live updates stall behind a proxy | Proxy not forwarding WebSocket upgrades on 8787 | Allow `Upgrade`/`Connection` headers on the dashboard route. |
+
+## See also
+
+- [`docs/relay-module.md`](https://github.com/gadzan/xacpx/blob/main/docs/relay-module.md) — server + connector internals.
+- [`docs/relay-web-module.md`](https://github.com/gadzan/xacpx/blob/main/docs/relay-web-module.md) — dashboard architecture.
+- Design spec: `docs/superpowers/specs/2026-06-13-relay-hub-design.md`.

--- a/packages/docs/reference/cli.md
+++ b/packages/docs/reference/cli.md
@@ -161,3 +161,21 @@ xacpx mcp-stdio --coordinator-session <session> --source-handle <handle> --works
 | `--workspace <name>` | Default workspace for delegated workers |
 
 For identity rules, `workingDirectory` semantics, the full tool list, and troubleshooting, see [External MCP Coordinator](/reference/external-mcp).
+
+## Relay hub — `xacpx-relay`
+
+A **separate** binary for [self-hosting the relay hub](/guide/relay-self-hosting) (not part of the `xacpx` CLI). It has three subcommands; until the relay packages are published to npm, invoke them as `node packages/relay/dist/cli.js <command>` from a repo checkout.
+
+```bash
+xacpx-relay init-admin --username <name> [--password <pw>] --db <path>
+xacpx-relay start --db <path> [--http-port 8787] [--ws-port 8788] [--host 0.0.0.0] [--web-root <dir>] [--history-retention-days 30]
+xacpx-relay token new --account <username> [--name <label>] [--ttl-minutes 10] --db <path>
+```
+
+| Command | Description |
+|---|---|
+| `init-admin` | Create the first admin account. Omitting `--password` prints a generated one **once**. |
+| `start` | Run the hub. `--web-root` must point at the built dashboard (`packages/relay-web/dist`) or no UI is served. No `stop`/`status` — use `SIGTERM`. |
+| `token new` | Mint a single-use, short-lived instance pairing token. |
+
+On the instance side, attach with the relay connector channel: `xacpx channel add relay --url wss://<gateway> --token <pairing-token>`. Full deployment walkthrough: [Self-Hosting the Relay Hub](/guide/relay-self-hosting).

--- a/packages/docs/zh/guide/relay-self-hosting.md
+++ b/packages/docs/zh/guide/relay-self-hosting.md
@@ -1,0 +1,257 @@
+# 自托管 Relay Hub
+
+**Relay Hub** 是一个可选的、自托管的服务端，它能把 xacpx 变成一个多租户的远程遥控看板。你的各个 xacpx 实例会通过 WebSocket **主动向外**拨号连接到 Hub 并注册；随后你即可从任意浏览器登录 Web 看板，在同一个地方驱动每个实例的会话——聊天、定时任务和编排。
+
+本指南将带运维人员从零开始，搭建一个已配对实例并正常运行的 Hub。
+
+::: warning 预发布：从源码部署
+relay 相关的包（`@ganglion/xacpx-relay`、`@ganglion/xacpx-channel-relay`、`@ganglion/xacpx-relay-protocol`、`@ganglion/xacpx-relay-web`）已构建并通过审计，但**尚未发布到 npm**。在发布之前，你需要按下文所示从仓库的检出代码部署 Hub。一旦发布，`xacpx-relay` 二进制文件以及 `xacpx plugin add @ganglion/xacpx-channel-relay` 都会变成一行命令即可安装——两种路径下文均有说明。
+:::
+
+## 架构速览
+
+```
+   xacpx instance A ─┐                         ┌─ browser (account: alice)
+   xacpx instance B ─┤  WSS (dial-out)         │  HTTPS + WSS
+   xacpx instance C ─┴──────────────►  RELAY HUB  ◄───────────┘
+                       :8788 instance gateway   :8787 HTTP API + web /ws
+                                  │
+                              relay.db (SQLite)
+```
+
+- **两个端口。** HTTP API 与看板的 `/ws` 广播共用 **8787**；**实例** WebSocket 网关（xacpx 实例在此注册）是 **8788**。两者相互独立，便于你分别配置防火墙策略。
+- **多租户。** 每个账户永远只能看到属于自己的实例和会话；服务端会在每次代理调用上打上身份标记。各类密钥（密码、配对令牌、实例凭据、Web 会话 Cookie）均以哈希形式存储。
+- **数据真相源仍在实例侧。** Hub 会为看板缓存近期消息，但它并不拥有你的会话——会话归实例所有。
+
+## 环境要求
+
+- **Node.js ≥ 22.13**（使用内置的 `node:sqlite`）**或 Bun ≥ 1.2**（使用 `bun:sqlite`）。无需编译原生数据库插件。
+- 一台可被你的实例和浏览器访问到的主机。对于 localhost 之外的任何部署，你都需要一个负责 TLS 终止的反向代理（参见 [TLS 与反向代理](#tls-reverse-proxy)）。
+- 要配对实例，每个实例都需要 `xacpx` CLI（即[快速开始](/zh/guide/getting-started)中的常规安装）。
+
+## 1. 获取服务端
+
+克隆仓库，构建 relay 服务端和看板：
+
+```bash
+git clone https://github.com/gadzan/xacpx
+cd xacpx
+bun install
+
+# Build the hub server (compiles relay-protocol + relay to ./packages/relay/dist)
+bun run build:relay
+
+# Build the web dashboard (outputs packages/relay-web/dist)
+bun run build:relay-web
+```
+
+::: tip 看板的构建是独立的
+`build:relay-web` **不**属于 `build:packages` 的一部分。如果你跳过它，启动的将是一个没有界面的 API。请务必构建它，并将 `--web-root` 指向 `packages/relay-web/dist`（步骤 3）。
+:::
+
+服务端的入口是 `packages/relay/dist/cli.js`。发布之后，同样的命令面会以 `xacpx-relay` 二进制文件的形式暴露；下文中所有 `node packages/relay/dist/cli.js <command>` 都可替换为 `xacpx-relay <command>`。
+
+## 2. 创建第一个管理员账户
+
+Hub 将所有数据存放在单个 SQLite 文件中。请为它选择一个**稳定的绝对路径**——默认的 `./relay.db` 是相对于当前工作目录解析的，很容易在不知不觉中得到两个不同的数据库。
+
+```bash
+node packages/relay/dist/cli.js init-admin \
+  --username admin \
+  --db /var/lib/xacpx-relay/relay.db
+```
+
+如果你省略 `--password`，Hub 会自动生成一个并**只打印一次**：
+
+```
+admin account created: admin
+password: 3f9c1ab27de40c85
+(store it now — it is not shown again)
+```
+
+请立即将它保存到你的密码管理器中。
+
+## 3. 启动服务端
+
+```bash
+node packages/relay/dist/cli.js start \
+  --db /var/lib/xacpx-relay/relay.db \
+  --web-root /opt/xacpx/packages/relay-web/dist \
+  --host 0.0.0.0 \
+  --http-port 8787 \
+  --ws-port 8788 \
+  --history-retention-days 30
+```
+
+成功后会打印：
+
+```
+xacpx-relay listening: http :8787, instance ws :8788, db /var/lib/xacpx-relay/relay.db
+```
+
+打开 `http://<host>:8787/`，使用步骤 2 中的管理员凭据登录。
+
+### `start` 标志
+
+| 标志 | 默认值 | 用途 |
+|---|---|---|
+| `--db <path>` | `./relay.db` | SQLite 数据库文件。请使用绝对路径。 |
+| `--http-port <n>` | `8787` | HTTP API **以及**看板的 `/ws` 广播。 |
+| `--ws-port <n>` | `8788` | 实例网关——xacpx 实例在此注册。 |
+| `--host <addr>` | `0.0.0.0` | 绑定地址。 |
+| `--web-root <dir>` | _（无）_ | 已构建的看板资源所在目录。**省略则不提供任何界面。** |
+| `--history-retention-days <n>` | `30` | 超过此天数的缓存消息会被每小时清理一次（同时硬性上限为每会话 2000 条消息）。 |
+
+没有 `stop`/`status` 子命令——请用 `Ctrl-C` / `SIGTERM` 停止 Hub（生产环境请在 systemd、pm2 或 Docker 下运行以管理生命周期）。
+
+## 4. 配对一个 xacpx 实例
+
+### 签发配对令牌（在 Hub 上）
+
+```bash
+node packages/relay/dist/cli.js token new \
+  --account admin \
+  --name home-pc \
+  --ttl-minutes 10 \
+  --db /var/lib/xacpx-relay/relay.db
+```
+
+输出：
+
+```
+pairing token: 8e1d…(single-use, expires soon)
+expires at: 2026-06-13T12:00:00.000Z
+pair with: xacpx channel add relay --url ws://<relay-host>:<ws-port> --token <the-token>
+```
+
+该令牌为**一次性使用**且短期有效（`--ttl-minutes`，默认 10 分钟）。
+
+### 挂载实例
+
+在运行 xacpx 实例的机器上，添加 relay 连接器频道，将 `--url` 指向**实例网关**端口（8788，或你的 `wss://` 代理）：
+
+```bash
+# After publish:
+xacpx plugin add @ganglion/xacpx-channel-relay
+xacpx channel add relay --url wss://relay.example.com --token <the-token> --name home-pc
+xacpx restart
+```
+
+`--url` 必须以 `ws://` 或 `wss://` 开头；`--token` 是配对令牌；`--name` 可选。
+
+首次连接时，实例会用这枚一次性配对令牌换取一个长期有效的凭据，并以 `0600` 权限写入 `<xacpx-home>/relay/credential.json`——**绝不会**写入 `config.json`（后者只保存 url/name）。请妥善保管该文件，它是实例的身份标识。
+
+::: details 在连接器发布到 npm 之前进行配对
+`xacpx plugin add` 会把它的参数直接传给 `npm install` / `bun add`，因此本地路径也可以使用——但 `@ganglion/xacpx-channel-relay` 依赖（同样未发布的）`@ganglion/xacpx-relay-protocol`，所以单纯的本地安装无法从 npm 解析出该依赖。在这些包正式发布之前，可靠的做法是：从一个 workspace 已经链接好两个包的仓库检出目录中运行实例，或者将两个包（先 `relay-protocol`，再 `channel-relay`）打包/链接到实例的插件目录中。发布之后，上面那两条命令就够了。
+:::
+
+回到看板，实例上线后会出现在左栏，并带有一个绿色圆点。选中某个会话即可聊天；打开任务面板（右栏，或移动端的 **Tasks** 按钮）可查看定时任务与编排任务。
+
+## TLS 与反向代理 {#tls-reverse-proxy}
+
+Hub 只说**明文** HTTP 和 WS。对于任何非 localhost 的部署，请在反向代理处终止 TLS，并同时转发 HTTP/web 端口和实例网关端口。实例随后应使用 `wss://` 连接。
+
+看板的实时更新会在 **HTTP 端口**上发起 WebSocket 升级，因此代理也必须在该路由上允许升级。
+
+### Caddy
+
+```text
+relay.example.com {
+    reverse_proxy 127.0.0.1:8787   # HTTP API + dashboard + dashboard /ws (Caddy proxies upgrades automatically)
+}
+
+gateway.example.com {
+    reverse_proxy 127.0.0.1:8788   # instance gateway; instances use wss://gateway.example.com
+}
+```
+
+### nginx
+
+```nginx
+# Dashboard + HTTP API (port 8787, includes the dashboard /ws upgrade)
+server {
+    listen 443 ssl;
+    server_name relay.example.com;
+    # ssl_certificate ...; ssl_certificate_key ...;
+    location / {
+        proxy_pass http://127.0.0.1:8787;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+}
+
+# Instance gateway (port 8788) — instances connect with wss://gateway.example.com
+server {
+    listen 443 ssl;
+    server_name gateway.example.com;
+    # ssl_certificate ...; ssl_certificate_key ...;
+    location / {
+        proxy_pass http://127.0.0.1:8788;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+}
+```
+
+### 应该暴露哪些端口
+
+| 端口 | 面向对象 | 是否公开暴露？ |
+|---|---|---|
+| 8787 | 浏览器（看板 + API + 看板 `/ws`） | 是，需置于 TLS 之后 |
+| 8788 | xacpx 实例（网关） | 是，需置于 TLS 之后 |
+| — | `relay.db` | 绝不——它是一个本地文件 |
+
+## 账户、邀请与维护
+
+- **添加更多账户。** 管理员可以在看板的 **Settings** 页面生成一个**邀请令牌**；新的运维人员凭它创建自己的账户。邀请为一次性使用。
+- **添加更多实例。** 为每个实例签发一个新的配对令牌（步骤 4）。
+- **自动 GC。** 一个每小时运行的维护循环会清理超过 `--history-retention-days`（以及每会话 2000 条上限）的缓存消息，并删除过期的 Web 会话、邀请和配对令牌。无需配置 cron。
+
+## 持久化与备份
+
+所有数据都存放在 `--db` 指定的那个 SQLite 文件中。备份时，停止 Hub（或在空闲时刻做快照）并复制该文件：
+
+```bash
+cp /var/lib/xacpx-relay/relay.db /backups/relay-$(date +%F).db
+```
+
+丢失它就意味着丢失所有账户、实例注册信息和缓存历史——届时实例需要重新配对。
+
+## 在 systemd 下运行（示例）
+
+```ini
+# /etc/systemd/system/xacpx-relay.service
+[Unit]
+Description=xacpx relay hub
+After=network.target
+
+[Service]
+WorkingDirectory=/opt/xacpx
+ExecStart=/usr/bin/node packages/relay/dist/cli.js start --db /var/lib/xacpx-relay/relay.db --web-root /opt/xacpx/packages/relay-web/dist --host 127.0.0.1
+Restart=on-failure
+User=xacpx
+
+[Install]
+WantedBy=multi-user.target
+```
+
+绑定到 `127.0.0.1`，让你的反向代理面向公网。
+
+## 常见问题排查
+
+| 现象 | 原因 | 解决办法 |
+|---|---|---|
+| 看板 404 / 空白页 | `--web-root` 被省略或填错 | 用 `bun run build:relay-web` 构建，并将 `--web-root` 指向 `packages/relay-web/dist`。 |
+| 实例始终不变绿 | 网关 URL/端口错误，或令牌已过期 | 将 `--url` 指向 **8788** 网关（或其 `wss://` 代理）；配对令牌会过期（`--ttl-minutes`）且一次性使用——重新签发一个。 |
+| “两个数据库” / 重启后为空 | 默认的 `./relay.db` 是相对于 cwd 的 | 始终传入绝对路径的 `--db`。 |
+| 经过代理后实时更新卡住 | 代理未在 8787 上转发 WebSocket 升级 | 在看板路由上允许 `Upgrade`/`Connection` 请求头。 |
+
+## 另请参阅
+
+- [`docs/relay-module.md`](https://github.com/gadzan/xacpx/blob/main/docs/relay-module.md) —— 服务端 + 连接器内部实现。
+- [`docs/relay-web-module.md`](https://github.com/gadzan/xacpx/blob/main/docs/relay-web-module.md) —— 看板架构。
+- 设计规范：`docs/superpowers/specs/2026-06-13-relay-hub-design.md`。

--- a/packages/docs/zh/reference/cli.md
+++ b/packages/docs/zh/reference/cli.md
@@ -161,3 +161,21 @@ xacpx mcp-stdio --coordinator-session <session> --source-handle <handle> --works
 | `--workspace <name>` | 被委派 worker 的默认工作区 |
 
 身份规则、`workingDirectory` 语义、完整工具列表和故障排查见[外部 MCP 协调器](/zh/reference/external-mcp)。
+
+## Relay hub — `xacpx-relay`
+
+[自托管 Relay Hub](/zh/guide/relay-self-hosting) 用的**独立**命令（不属于 `xacpx` CLI）。共三个子命令；在 relay 各包发布到 npm 之前，从仓库 checkout 用 `node packages/relay/dist/cli.js <命令>` 调用。
+
+```bash
+xacpx-relay init-admin --username <name> [--password <pw>] --db <path>
+xacpx-relay start --db <path> [--http-port 8787] [--ws-port 8788] [--host 0.0.0.0] [--web-root <dir>] [--history-retention-days 30]
+xacpx-relay token new --account <username> [--name <label>] [--ttl-minutes 10] --db <path>
+```
+
+| 命令 | 说明 |
+|---|---|
+| `init-admin` | 创建首个管理员账号。不带 `--password` 会**只打印一次**自动生成的密码。 |
+| `start` | 启动 hub。`--web-root` 必须指向已构建的看板（`packages/relay-web/dist`），否则不提供 UI。没有 `stop`/`status`——用 `SIGTERM`。 |
+| `token new` | 签发单次使用、短期有效的实例配对令牌。 |
+
+实例侧用 relay 连接器频道接入：`xacpx channel add relay --url wss://<gateway> --token <配对令牌>`。完整部署流程见[自托管 Relay Hub](/zh/guide/relay-self-hosting)。


### PR DESCRIPTION
## Summary

The relay hub previously had **no operator-facing deployment docs** — only Chinese developer module notes (`docs/relay-module.md` etc.) and two thin package READMEs. The root README, command reference, and config reference didn't acknowledge the relay hub at all. This adds a complete self-host guide and surfaces it everywhere an operator would look.

- **`packages/docs/guide/relay-self-hosting.md` (+ `zh/`):** the full operator walkthrough — architecture, requirements (Node ≥22.13 / Bun ≥1.2), build-from-source, `init-admin` → `start` → `token new`, instance pairing, **TLS/reverse-proxy (Caddy + nginx)**, which ports to expose, systemd unit, SQLite backup, and a troubleshooting table. Added to the VitePress guide sidebar in both locales.
- **`docs/relay-deployment.md`:** a terse repo-side runbook that links to the published guide.
- **`README.md`:** a new "Self-hosted relay hub" section with a quick-start snippet + links.
- **`reference/cli.md` (+ `zh/`):** an `xacpx-relay` CLI section (the three real subcommands).
- **`AGENTS.md`:** doc index entry.

### Honest about pre-release state
The audit confirmed the four `@ganglion/xacpx-relay*` packages are **not yet published to npm** (all 0.1.0, no publish workflow; `relay-web` is `private`). The guide leads with "build from source" as today's path and notes the one-line npm install that becomes available post-publish. It also documents the real footguns surfaced by reading the code: `build:relay-web` is separate from `build:packages` (skip it → no UI), the default `./relay.db` is cwd-relative, and there is no `stop`/`status` subcommand.

All CLI flags, ports, and the credential path were taken verbatim from `packages/relay/src/cli.ts` and `packages/channel-relay/src/`.

## Test Plan
- [x] `bun run docs:build` — VitePress build clean, **no dead links**, no warnings
- [x] Docs-only change — no source, deps, or lockfiles touched