### PR TITLE
feat(relay-web): cycle whimsical near-synonyms in the working HUD

### DIFF
--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -22,6 +22,24 @@ it("shows a working HUD while a live turn is active", async () => {
   expect(w.find('[data-test="turn-hud"]').text()).toContain("Working");
 });
 
+it("cycles the working verb every ~4s while the turn runs", async () => {
+  vi.useFakeTimers();
+  const start = Date.now();
+  vi.setSystemTime(start);
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  expect(w.find('[data-test="turn-hud"]').text()).toContain("Working"); // bucket 0
+  vi.advanceTimersByTime(5000); // 5s elapsed → bucket 1; also drives the 1Hz clock
+  await w.vm.$nextTick();
+  const t = w.find('[data-test="turn-hud"]').text();
+  expect(t).not.toContain("Working");
+  expect(t).toContain("Thinking");
+  vi.useRealTimers();
+});
+
 it("hides the HUD when no turn is active", () => {
   const chat = useChatStore();
   chat.select("i1", "backend");

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -16,6 +16,21 @@ const elapsed = computed(() => {
   const s = Math.max(0, Math.floor((nowMs.value - chat.liveTurn.startedAt) / 1000));
   return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
 });
+
+// Whimsical near-synonyms cycled through while a turn runs (à la Claude Code).
+// Purely cosmetic — unrelated to what the agent is actually doing. Reuses the
+// 1Hz clock above; the word changes every ~4s. "Working" stays first so the
+// HUD reads sensibly at t≈0.
+const VERBS = [
+  "Working", "Thinking", "Pondering", "Cogitating", "Reasoning", "Computing",
+  "Churning", "Crunching", "Percolating", "Noodling", "Mulling", "Brewing",
+  "Processing", "Deliberating", "Ruminating", "Synthesizing", "Wrangling", "Tinkering",
+];
+const verb = computed(() => {
+  if (!chat.liveTurn) return VERBS[0];
+  const s = Math.max(0, Math.floor((nowMs.value - chat.liveTurn.startedAt) / 1000));
+  return VERBS[Math.floor(s / 4) % VERBS.length];
+});
 const runningTools = computed(() => chat.liveTurn?.toolSteps.filter((t) => t.status === "running").length ?? 0);
 </script>
 
@@ -33,7 +48,7 @@ const runningTools = computed(() => chat.liveTurn?.toolSteps.filter((t) => t.sta
       <MessageList :messages="chat.messages" :streaming="chat.streaming" :live-turn="chat.liveTurn" />
       <div v-if="chat.busy" data-test="turn-hud" class="flex items-center gap-2 px-4 py-1 text-xs text-slate-500">
         <span class="animate-pulse">●</span>
-        <span>Working… {{ elapsed }}</span>
+        <span>{{ verb }}… {{ elapsed }}</span>
         <span v-if="runningTools > 0">· 🔧 {{ runningTools }}</span>
         <button data-test="cancel-turn" class="ml-auto text-red-500 hover:underline" @click="chat.cancel">Cancel</button>
       </div>


### PR DESCRIPTION
## Summary
- The turn HUD now rotates through a curated list of gerunds (Working, Thinking, Pondering, …) every ~4s while a turn runs, à la Claude Code.
- Purely cosmetic; reuses the existing 1Hz HUD clock (no extra timer). `Working` stays first so the HUD reads sensibly at t≈0.

## Test Plan
- [x] `chatpane` vitest: 3/3 (incl. a new test asserting the word changes from Working→Thinking after 5s)
- [x] `vue-tsc`/build clean