### PR TITLE
feat(relay-web): dashboard UX borrow + read-only workspace file browser

### DIFF
--- a/docs/superpowers/plans/2026-06-15-relay-web-hapi-borrow-ux.md
+++ b/docs/superpowers/plans/2026-06-15-relay-web-hapi-borrow-ux.md
@@ -1,0 +1,74 @@
+# relay-web HAPI-borrow UX 执行计划
+
+> Spec: `docs/superpowers/specs/2026-06-15-hapi-borrow-analysis-and-spec.md`
+> 分支: `feat/relay-web-hapi-borrow-ux`（worktree）· 全部改动限 `packages/relay-web/`，零后端/协议改动。
+
+**Goal:** 借鉴 HAPI 的 4 个前端 UX 原语（会话注意力点、工具分组摘要、reasoning 流式 shimmer、FUE 首次体验），增强 relay-web 仪表盘的信息密度与可读性。
+
+**Tech:** Vue 3 `<script setup>` + Pinia + Tailwind + vitest（jsdom）。测试 `bun run --cwd packages/relay-web test -- <filter>`。
+
+---
+
+## Task 1 — FUE 原语（基础设施）
+
+**Files:**
+- Create `packages/relay-web/src/lib/use-fue.ts`
+- Create `packages/relay-web/src/lib/fue-placement.ts`
+- Create `packages/relay-web/src/components/FueDot.vue`
+- Create `packages/relay-web/src/components/FueCallout.vue`
+- Create `packages/relay-web/src/__tests__/fue.test.ts`
+
+- `use-fue.ts`：`useFue(featureId)` 返回 `{ status: Ref<'unseen'|'engaging'|'acknowledged'>, engage(), dismiss() }`。`acknowledged` 持久化到 `localStorage['xacpx.fue.v1.'+featureId]='1'`，读写 try/catch。`engage()`：`unseen→engaging`（不写存储）。`dismiss()`：→`acknowledged` + 写存储。导出 `resetFue(featureId)`（测试/调试用）。
+- `fue-placement.ts`：纯函数 `computeCalloutPlacement(anchor:{top,left,width,height}, callout:{width,height}, viewport:{width,height}, gap=8) → {top,left,placement:'above'|'below'}`：默认放 anchor 下方；下方溢出且上方更宽裕则翻到上方；`left` 以 anchor 居中后 clamp 到 [8, viewport.width-callout.width-8]。
+- `FueDot.vue`：props `{ pulsing?:boolean }`；渲染 8px sky-blue 绝对定位圆点，`pulsing` 时加 `animate-pulse`。`data-test="fue-dot"`。
+- `FueCallout.vue`：props `{ title, body, anchor?:DOMRect|null }`；emit `dismiss`。`<Teleport to="body">` 渲染卡片（标题 + 正文 + "Got it" 按钮）；`onMounted` 测量自身尺寸 + 用 `computeCalloutPlacement` 定位（anchor 缺省时居中兜底）；监听 Esc → emit dismiss；`data-test="fue-callout"`，按钮 `data-test="fue-dismiss"`。
+- 测试：状态机 3 态流转 + localStorage 持久化（acknowledged 后重建 `useFue` 直接 `acknowledged`）；`computeCalloutPlacement` 的下方/翻转/clamp 三例。
+
+## Task 2 — 工具分组摘要 + 自动折叠（增强 ToolCallPanel）
+
+**Files:**
+- Create `packages/relay-web/src/lib/tool-summary.ts`
+- Modify `packages/relay-web/src/components/ToolCallPanel.vue`
+- Modify `packages/relay-web/src/__tests__/toolcallpanel.test.ts`
+
+- `tool-summary.ts`：纯函数 `summarizeSteps(steps): { kinds: Array<{kind,icon,count}>, statuses: Array<{status,icon,count}> }`，按 `ToolStepKind`/`ToolStepStatus` 计数（图标表与组件共用，移到此文件导出 `KIND_ICON`/`STATUS_ICON`）。导出 `AUTO_COLLAPSE_THRESHOLD = 5`。
+- `ToolCallPanel.vue`：
+  - `open` 初值改为 `steps.length <= AUTO_COLLAPSE_THRESHOLD`（多步默认折叠）。
+  - 头部追加摘要 spans：`data-test="tool-summary"`，渲染 `summarizeSteps` 的 kind 计数 + `·` + status 计数（仅 count>0）。
+  - 头部挂 `FueDot`（`featureId='tool-group-collapse'`）：仅当面板默认折叠（`steps.length>THRESHOLD`）且 FUE 未 acknowledged 时显示点；点击头部展开时 `engage()`，配 `FueCallout`（标题"工具步骤已折叠"/正文"多步工具调用默认折叠，点击查看每一步"）。FUE 点与 `tool-count` 徽标互斥（未 ack 时显示点、不显示 count；ack 后反之）。
+- 测试：`summarizeSteps` 计数正确；>5 步默认折叠（无 `tool-row`）、点击头部后出现行；≤5 步默认展开；摘要 span 含正确图标计数。
+
+## Task 3 — Reasoning 流式 shimmer + 自动展开（增强 ReasoningPanel）
+
+**Files:**
+- Modify `packages/relay-web/src/components/ReasoningPanel.vue`
+- Modify `packages/relay-web/src/components/MessageList.vue`
+- Modify `packages/relay-web/src/__tests__/toolcallpanel.test.ts`（ReasoningPanel 段）
+
+- `ReasoningPanel.vue`：新增 `streaming?:boolean`。`streaming` 为真：标签文案 `Reasoning…`，标签旁渲染 shimmer 点（`data-test="reasoning-shimmer"`，`animate-pulse`），且 `open` 计算为强制真（用 `computed`：`streaming || localOpen`）。非 streaming：维持 `defaultOpen` + 用户可切换。
+- `MessageList.vue`：live reasoning 块传 `:streaming="true"`；历史块（已传 `:default-open="false"`）维持。
+- 测试：`streaming=true` 渲染 shimmer + body 可见且文案含 `…`；`streaming=false` 维持折叠/展开旧行为。
+
+## Task 4 — 会话注意力点（chat store + InstanceTree）
+
+**Files:**
+- Modify `packages/relay-web/src/stores/chat.ts`
+- Modify `packages/relay-web/src/components/InstanceTree.vue`
+- Modify `packages/relay-web/src/__tests__/chat.test.ts`
+- Modify `packages/relay-web/src/__tests__/instancetree.test.ts`
+
+- `chat.ts`：新增 `unread = ref<Set<string>>(new Set())`。
+  - `applyEvent` 的 `turn-finished`：计算 `selected`；若 **非** selected 且 `status ∈ {done,error}` → `unread.add(key)`（用新 Set 触发响应）。（selected 维持现有 flushTurn 落消息逻辑。）
+  - `select(id,alias)`：清除该 key 的 unread。
+  - `instance-status` offline 分支：顺带清除该 instance 前缀的 unread（实例离线无意义）。
+  - 暴露 `sessionAttention(instanceId, alias): 'working'|'unread'|'idle'`（working 优先：`liveTurns` 含 key → working；else unread 含 key → unread；else idle）。
+- `InstanceTree.vue`：引入 `useChatStore`；会话行点改为按 `chat.sessionAttention(inst.id, s.alias)`：`working`→amber `●`+`animate-pulse`；`unread`→sky `●`；`idle`→保留 `s.running` 兜底（运行中但事件未到时）或无点。加 `data-test="attention-dot"` + `:data-attention`。
+- 测试（chat）：非选中会话 turn-finished(done) → `sessionAttention` 返回 `unread`；`select` 后清除；working 优先于 unread；offline 清除 unread。
+- 测试（instancetree）：注入 chat store 状态后渲染对应 `data-attention`。
+
+## Task 5 — 收尾
+
+- `bun run --cwd packages/relay-web test`（全量）全绿。
+- `bun run --cwd packages/relay-web build`（`vue-tsc --noEmit` + vite build）通过。
+- 提交（精确路径，不 `git add -A`）。
+- rebuild sandbox（build relay-web → 重启 relay hub 指向新 dist，console/connector 不动）。

--- a/docs/superpowers/plans/2026-06-15-relay-web-z-client-borrow.md
+++ b/docs/superpowers/plans/2026-06-15-relay-web-z-client-borrow.md
@@ -1,0 +1,183 @@
+# relay-web 借鉴 "Z" 客户端 —— 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: 用 superpowers:subagent-driven-development 或 superpowers:executing-plans 逐任务实现。步骤用 `- [ ]` 复选框跟踪。
+>
+> 配套设计见 [`../specs/2026-06-15-z-client-borrow-design.md`](../specs/2026-06-15-z-client-borrow-design.md)。
+
+**Goal：** 把 "Z" 桌面客户端的上下文可见性与输入区控制密度借鉴进 relay-web —— composer 内联选择器、顶部上下文带、只读 Git 摘要、Ctrl+K 命令面板、工作计时与侧栏耗时徽标。
+
+**Architecture：** relay-web（Vue3+Pinia+Tailwind）经 `api.rpc` 调用 relay hub→连接器→core `ControlService`。纯前端批次只改 `packages/relay-web`；Batch A 还需协议(`relay-protocol`)+连接器(`channel-relay`)+core(`ControlService`) 三层加一对 RPC。
+
+**Tech Stack：** Vue 3 `<script setup>`、Pinia、Tailwind、vitest + @vue/test-utils；core 用 bun:test。
+
+**排序与依赖：**
+- **Batch A 依赖 `feat/session-model-selection` 先合入 core**（用其 `transport.setModel/getSessionModel`、`SessionService.setCurrentSessionModel`）。
+- **B、C、E 纯前端，无依赖，可先并行做**；C 的 Git widget 复用 B 的头部容器。
+
+测试命令：`bun run --cwd packages/relay-web test -- --run <filter>`（relay-web）、`bun test <file>`（core，逐文件）、`bun run --cwd packages/relay-web build`（含 vue-tsc）。
+
+---
+
+## Batch B —— 顶部上下文 chip 带（纯前端，先做）
+
+### Task B1：ChatPane 头部上下文 chip
+
+**Files:**
+- Modify: `packages/relay-web/src/components/ChatPane.vue`
+- Test: `packages/relay-web/src/__tests__/chatpane.test.ts`
+
+- [ ] **Step 1：失败测试** —— 选中会话后，头部渲染 `data-test="ctx-chip-workspace"`、`ctx-chip-instance`、`ctx-chip-branch`，文本含 workspace/instance/branch。先确认这些数据在 chat/instances store 里的字段名（`grep` store），断言据此写。
+- [ ] **Step 2：跑测试确认失败**（`test -- --run chatpane`）。
+- [ ] **Step 3：实现** —— 头部加一行 flex chip：workspace、`@instance`、`branch`。branch chip `@click` 切到 Files/Changes（emit 或调 store），instance chip `@click` 打开 `ManageInstanceDialog`。无数据时 chip 隐藏（`v-if`）。
+- [ ] **Step 4：跑测试通过**。
+- [ ] **Step 5：commit** `feat(relay-web): top context chips (workspace @ instance · branch)`。
+
+---
+
+## Batch C —— 只读 Git 状态摘要（纯前端，复用 fs.diff）
+
+### Task C1：files store 暴露紧凑 git 摘要
+
+**Files:**
+- Modify: `packages/relay-web/src/stores/files.ts`（已有 `changed`/`loadStatus`）
+- Test: `packages/relay-web/src/__tests__/files.test.ts`
+
+- [ ] **Step 1：失败测试** —— 加 getter/computed `statusSummary` 返回 `{ branch?, added: number, removed: number, changedCount: number }`，由 `loadStatus` 已拉的 diff 推导（`diff.files` 计数；+N/-N 若 `control.fs.diff` 结果无 stat 则以 changedCount 兜底）。先 `grep` `FsDiffResult` 字段确认有无 stat。
+- [ ] **Step 2：跑测试确认失败**。
+- [ ] **Step 3：实现** —— 在 `files.ts` 加 `statusSummary` computed；若协议无 +N/-N，仅出 `changedCount` 并在 spec 注明（不新增后端字段，保持只读复用）。
+- [ ] **Step 4：跑测试通过**。
+- [ ] **Step 5：commit** `feat(relay-web): expose compact git status summary from files store`。
+
+### Task C2：头部 Git 摘要 chip
+
+**Files:**
+- Modify: `packages/relay-web/src/components/ChatPane.vue`（接 B1 的头部）
+- Test: `packages/relay-web/src/__tests__/chatpane.test.ts`
+
+- [ ] **Step 1：失败测试** —— 头部渲染 `data-test="git-summary"`，含 `● <branch>` 与改动计数；`@click` 切到 Files/Changes。
+- [ ] **Step 2：失败 → 实现 → 通过**（紧凑只读 chip；点击 `rightTab='files'` + `files.tab='changes'`）。
+- [ ] **Step 3：commit** `feat(relay-web): read-only git summary chip in header`。
+
+---
+
+## Batch E —— 细节打磨（纯前端，低风险，可并行）
+
+### Task E1：工作计时（已工作 Ns）
+
+**Files:**
+- Modify: 状态 HUD 组件（`grep` `working`/turn-status 找到具体文件，可能在 `ChatPane.vue`/`MessageList.vue`）
+- Test: 对应 `__tests__`
+
+- [ ] **Step 1：失败测试** —— busy 时渲染 `data-test="work-elapsed"`，文本随秒递增（用注入的 `now`/计时器，测试里 mock 定时器）。
+- [ ] **Step 2：失败 → 实现** —— busy 起点记 `startedAt`，`setInterval` 每秒更新 `已工作 Ns`；停止时清理。
+- [ ] **Step 3：通过 → commit** `feat(relay-web): elapsed working timer in status hud`。
+
+### Task E2：reasoning 折叠头时长
+
+**Files:**
+- Modify: `packages/relay-web/src/components/ReasoningPanel.vue`
+- Test: `packages/relay-web/src/__tests__/`（reasoning 相关）
+
+- [ ] **Step 1** 先 `grep` ReasoningPanel 是否已有 duration 数据位；无则从 reasoning 段的起止时间推导（或在 store 记 `reasoningStartedAt/EndedAt`）。
+- [ ] **Step 2：失败测试** —— 折叠头渲染 `持续 Ns`（`data-test="reasoning-duration"`）。
+- [ ] **Step 3：失败 → 实现 → 通过 → commit** `feat(relay-web): reasoning duration label`。
+
+### Task E3：侧栏会话耗时徽标 + 空态
+
+**Files:**
+- Modify: `packages/relay-web/src/components/InstanceTree.vue`
+- Test: `packages/relay-web/src/__tests__/instancetree.test.ts`
+
+- [ ] **Step 1：失败测试** —— 运行中会话渲染 `data-test="session-elapsed"` 相对时长徽标；instance 无会话时渲染 `暂无会话` 空态。
+- [ ] **Step 2：失败 → 实现**（相对时长用已有 lastActivity/startedAt；空态文案）。
+- [ ] **Step 3：通过 → commit** `feat(relay-web): session elapsed badges + empty state in tree`。
+
+### Task E4：警告/需授权 callout
+
+**Files:**
+- Modify: `packages/relay-web/src/components/MessageList.vue`（消息渲染分支）；复用 `FueCallout.vue`
+- Test: `packages/relay-web/src/__tests__/messagelist.test.ts`
+
+- [ ] **Step 1：失败测试** —— 标记为 warning/需授权的消息渲染成 `data-test="msg-callout"`（带 ⚠️ 样式）。先确认消息模型里如何标识这类消息（`grep` 消息 kind/type）。
+- [ ] **Step 2：失败 → 实现 → 通过 → commit** `feat(relay-web): render warning/permission messages as callouts`。
+
+---
+
+## Batch D —— Ctrl+K 命令面板（纯前端）
+
+### Task D1：CommandPalette 组件
+
+**Files:**
+- Create: `packages/relay-web/src/components/CommandPalette.vue`
+- Modify: `packages/relay-web/src/views/DashboardView.vue`（挂载 + 全局快捷键）
+- Test: `packages/relay-web/src/__tests__/commandpalette.test.ts`
+
+- [ ] **Step 1：失败测试** —— `Cmd/Ctrl+K` 打开面板（`data-test="command-palette"`）；输入过滤跨 instance/session 与 `/command` 目录（复用 `lib/command-catalog.ts`）；回车选中会话→`chat.select`，选中命令→填充 composer。
+- [ ] **Step 2：跑测试确认失败**。
+- [ ] **Step 3：实现** —— 组件：搜索框 + 分组结果（Sessions / Commands）；键盘上下选择 + 回车；Esc 关闭。`DashboardView` 注册 `keydown` 监听（`Cmd/Ctrl+K`，`preventDefault`），打开/关闭。
+- [ ] **Step 4：跑测试通过**。
+- [ ] **Step 5：commit** `feat(relay-web): Ctrl/Cmd+K command palette (sessions + commands)`。
+
+---
+
+## Batch A —— composer 内联选择器（依赖 model-selection 先合入 core）
+
+> 前置：`feat/session-model-selection` 已合入 core（含 `transport.setModel/getSessionModel`、`SessionService.setCurrentSessionModel`）。否则本批 RPC 无可调用的底座。
+
+### Task A1：core ControlService 暴露 model get/set
+
+**Files:**
+- Modify: `src/control/control-service.ts`
+- Test: `tests/unit/control/control-service-model.test.ts`
+
+- [ ] **Step 1：失败测试**（bun:test）—— `controlService.getSessionModel(chatKey)` 返回 `{ current?, available[] }`；`setSessionModel(chatKey, id)` 调 transport.setModel + `SessionService.setCurrentSessionModel`。
+- [ ] **Step 2：跑测试确认失败** `bun test tests/unit/control/control-service-model.test.ts`。
+- [ ] **Step 3：实现** —— 解析当前会话（仿现有 ControlService 方法），调 `getSessionModel/setModel` + 持久化。transport 方法为 optional，缺失时返回 `{ available: [] }` 兜底。
+- [ ] **Step 4：通过**。
+- [ ] **Step 5：commit** `feat(control): expose session model get/set on ControlService`。
+
+### Task A2：协议 + 连接器 RPC
+
+**Files:**
+- Modify: `packages/relay-protocol/src/messages.ts`（`MSG.sessionModelGet/Set` + payload/result）
+- Modify: `packages/channel-relay/src/control-bridge.ts`（两个 case，仿 `fs.*`）
+- Test: 连接器 bridge 单测（仿现有 fs case 测试）
+
+- [ ] **Step 1：失败测试** —— bridge 收到 `control.session.model.get/set` 调对应 ControlService 方法；缺 workspace/会话时 `bad-request`。
+- [ ] **Step 2：失败 → 实现** —— 协议加类型（**用 tsc 构建 relay-protocol dist**，见 [[reference_bun_barrel_empty_export]] 记忆：桶文件需 tsc）；bridge switch 加 case。
+- [ ] **Step 3：通过 → commit** `feat(relay): control.session.model get/set RPC`。
+
+### Task A3：relay-web 模型选择器 chip
+
+**Files:**
+- Create: `packages/relay-web/src/stores/session-controls.ts`（model/permission 状态 + actions）
+- Modify: `packages/relay-web/src/components/PromptInput.vue`
+- Test: `packages/relay-web/src/__tests__/promptinput.test.ts` + `session-controls.test.ts`
+
+- [ ] **Step 1：失败测试**（store）—— `loadModel(instanceId, alias)` 调 `api.rpc(..., "control.session.model.get")` 填 `current/available`；`setModel(id)` 调 set 并乐观更新；`isErrorPayload` 兜底。
+- [ ] **Step 2：失败测试**（组件）—— composer 底部渲染 `data-test="model-chip"`，点开列 `available` 选择，选中调 `setModel`；无 available 时 chip 显示当前/隐藏。
+- [ ] **Step 3：跑测试确认失败**。
+- [ ] **Step 4：实现** —— store + PromptInput 底部一行 chip（model）；mock `api.rpc`。
+- [ ] **Step 5：通过 → commit** `feat(relay-web): model selector chip in composer`。
+
+### Task A4：composer 权限模式 chip + 工作计时
+
+**Files:**
+- Modify: `packages/relay-web/src/components/PromptInput.vue`、`stores/session-controls.ts`
+- Test: `promptinput.test.ts`
+
+- [ ] **Step 1：失败测试** —— 渲染 `data-test="permission-chip"`（读/写权限模式，复用 permission 命令语义的 RPC，或先只读显示）；busy 时显示 `work-elapsed`（与 E1 合流，避免重复实现——E1 若已做则此处只接线）。
+- [ ] **Step 2：失败 → 实现 → 通过 → commit** `feat(relay-web): permission + working-timer chips in composer`。
+
+---
+
+## 收尾
+- 全部完成后跑 `bun run --cwd packages/relay-web build`（vue-tsc）+ 受影响 core 文件逐个 `bun test`，再用 review 子代理过一遍（仿 model-selection 那批）。
+- 沙箱热部署预览（hub `--web-root` 直指 worktree dist，rebuild 即生效）。
+
+## 自检清单
+- [ ] Git widget 严格只读，无任何写 git 入口
+- [ ] Batch A 仅在 model-selection 合入后开工
+- [ ] relay-protocol 用 tsc 构建（桶文件 tree-shake 坑）
+- [ ] 纯前端批次 mock `api.rpc`；勿整目录 bun test
+- [ ] 新组件 data-test 齐全，vue-tsc 干净

--- a/docs/superpowers/specs/2026-06-15-hapi-borrow-analysis-and-spec.md
+++ b/docs/superpowers/specs/2026-06-15-hapi-borrow-analysis-and-spec.md
@@ -102,6 +102,27 @@ HAPI 与 xacpx 强同域：本地包裹 AI coding agent（Claude Code / Codex / 
 
 完整九大 surface 穷尽枚举见本次第二份 subagent 内参（含每项 file:line / 概念vs字面移植 / effort / 是否需后端）。
 
+## 5c. Pass 3 — 工作空间文件浏览器 + git diff（用户点名要做，原 defer 项 H）
+
+借鉴 hapi 的"远程查看实例机器上工作空间文件 + 内容 + git diff"。契合 relay 拓扑：connector 跑在用户机器上，本就能访问 workspace 磁盘。**全栈**实现（core → connector → protocol → relay-web），hub 无需改动（`control.fs.*` 走既有 `control.` 前缀白名单，且非 chat-scoped）。
+
+**安全模型（关键，刻意与 hapi 的 fail-open 相反）**：`src/control/workspace-fs.ts`
+- **默认拒绝**：只接受已配置的 workspace 名，绝不接受任意绝对路径（`path-must-be-relative`）。
+- **realpath 容器化**：目标经 symlink 解析后必须仍在 symlink-解析后的 workspace root 内，`..` 和 symlink 都逃不出去（`path-escapes-workspace`）。已端到端验证：`../../../etc/passwd` 与 symlink 逃逸均被拒。
+- **只读**：无写方法；git 走 `execFile`(参数数组、绝不 shell)跑只读子命令，路径无法注入命令。
+- **有界**：目录条目 2000、文件 256 KiB、diff 512 KiB 上限；NUL 字节判定 binary 且不回传内容。
+- `~` 展开（配置常用 `~`/`~/path`）。
+
+**分层**：
+- protocol：`MSG.fs{List,Read,Diff}` = `control.fs.{list,read,diff}` + `Fs{List,Read,Diff}Payload/Result` + `FsEntryDto`/`FsDiffFileDto`。
+- core：`WorkspaceFs`（上述安全逻辑）+ `ControlService.{listDirectory,readWorkspaceFile,workspaceGitDiff}`，经 `xacpx/plugin-api` 暴露给 connector。
+- connector：`control-bridge.ts` 三个 case 转发。
+- relay-web：`stores/files.ts` + `FilesPanel.vue`（workspace 下拉 + 懒加载目录树 + 面包屑 + 文件查看器[truncated/binary 徽标] + Changes 标签的 git status 文件列表 + 着色 unified diff）；右栏 Tasks|Files 切换；`instances.loadWorkspaces`。
+
+**测试**：`tests/unit/control/workspace-fs.test.ts`（容器化/逃逸/symlink/binary/git diff/~，10 例，真实临时目录 + git）；`packages/relay-web/src/__tests__/files.test.ts`（store 逻辑 + 错误 payload，4 例）。端到端经真实 relay 验证（list/read/diff/home-~/两类安全拒绝）。
+
+**v1 已知边界（后续可加）**：无文件搜索（`rg --files`）、无 staged/unstaged 分离视图、diff 仅 `git diff HEAD`（fallback `git diff`）、无文件写、无 syntax 高亮（复用纯文本 + diff 着色）。
+
 ## 6. 验收
 
 - `bun run --cwd packages/relay-web test` 全绿（新增各 feature 的 vitest）。

--- a/docs/superpowers/specs/2026-06-15-hapi-borrow-analysis-and-spec.md
+++ b/docs/superpowers/specs/2026-06-15-hapi-borrow-analysis-and-spec.md
@@ -77,6 +77,31 @@ HAPI 与 xacpx 强同域：本地包裹 AI coding agent（Claude Code / Codex / 
 - **doctor 增项**：HAPI doctor 反而缺 acpx 解析/版本检查（xacpx 已有）；无新增可借。
 - **terminal/files（H）**：契合 relay 拓扑但需 connector 侧 PTY/fs + realpath 容器化安全模型（HAPI 自身实现 fail-open 且可绕过，**不可照抄**）。大型独立项目。
 
+## 5b. Pass 2 — 交互设计扩展（第一轮过于保守，补做）
+
+第一轮只取了 4 项偏"展示"的借鉴；经第二份**穷尽式交互设计内参**（hapi web 的 composer/thread/optimistic/transient/navigation/micro-interaction/density/markdown 九大 surface 全量枚举）复盘，补做以下**纯前端、可预览**的交互设计借鉴：
+
+| 借鉴点 | hapi 出处 | 落地 |
+|---|---|---|
+| **Composer slash 自动补全 popover** + 键位优先级阶梯 | `HappyComposer.tsx:405-498` 1.1/1.2（被内参称为"用户觉得欠缺的中心项"） | `lib/command-catalog.ts`（curated 静态目录，后续可 RPC 驱动）+ `PromptInput.vue`：`/`前缀建议、↑↓选择、Tab/Enter 补全、点击补全 |
+| **Esc 优先级**（先关 popover，再停 turn） | 1.2 #5/#6 | Esc：有 popover→先关；否则 busy→cancel |
+| **IME 合成保护**（CJK 关键修正） | 1.2 #1 | `e.isComposing` 时不拦截——中文回车确认候选不误发 |
+| **Send/Stop 按钮形变** + busy 时仍可输入 | 1.4 / 1.5 | 显式 Send；busy→Stop（emit cancel）；textarea busy 时不禁用（可预编排 + Esc 停） |
+| **↑/↓ 历史回溯**（shell 式） | 1.2 | 光标在行首时 ↑ 召回上一条已发送 |
+| **每会话草稿持久化** | 1.9 | `lib/composer-drafts.ts`（sessionStorage，按 instance+session key），切会话/刷新保留半成稿 |
+| **粘到底部 + "↓ Latest" 浮标** | 2.1 / auto-scroll | `MessageList.vue`：在底部才跟随；滚上去出现跳转浮标 |
+| **复制按钮**（消息 hover + execCommand 兜底） | 6.4 | `CopyButton.vue`，agent 消息悬浮显示 |
+| **Diff +N/−N 统计徽标** | 8.8 | `ToolDetail.vue` diff 头部统计 |
+| **循环"工作中"近义词**（vibing words） | 2a | `ChatPane.vue`（与未合并 PR #34 同源，本批次内联以保预览完整） |
+
+**仍 deferred（带 effort/原因，源自穷尽内参；多数需后端/协议或属大型独立项）**：
+- 需后端/协议：optimistic 消息生命周期（queued bar / 状态徽标 / 取消·编辑·重试，需 localId 回显 + `messages-consumed`/`message-cancelled` SSE，surface 3）、附件粘贴上传（1.6）、通知点击 deep-link `data.url`（5.4）、schedule-send UI（1.11，xacpx 有 /later 后端）。
+- 大型纯前端独立项：暗色主题 + 通用 `usePersistedPref` 偏好体系（7.\*，M/L 跨切面）、Shiki 语法高亮 + CodeBlock 折叠（8.1/8.2）、tap-to-expand-dialog 详情弹层（6.1）、会话大纲跳转 + 滚动锚点保持（2.2/2.4）、长按上下文菜单（6.5）、图片查看器（6.7）。
+- 小项后续：transient 三横幅（offline/syncing/reconnecting，4.1）+ syncing 状态机（4.2）、骨架屏（2.3）、空状态双 CTA（4.4）、live per-tool elapsed timer（6.2）、TodoWrite/plan checklist（8.9，依赖数据）、settings popover（1.7，依赖 model/effort 是否暴露）、haptics（1.10）、Shift+Tab 权限模式循环（1.3，依赖权限模式 UI）。
+- 两个"移植时要修正、别照抄"：空状态要 gate 在 `!isLoading`（hapi 加载中也显示空态）；SW 通知点击加 `clients.matchAll`+focus 防重复开标签。
+
+完整九大 surface 穷尽枚举见本次第二份 subagent 内参（含每项 file:line / 概念vs字面移植 / effort / 是否需后端）。
+
 ## 6. 验收
 
 - `bun run --cwd packages/relay-web test` 全绿（新增各 feature 的 vitest）。

--- a/docs/superpowers/specs/2026-06-15-hapi-borrow-analysis-and-spec.md
+++ b/docs/superpowers/specs/2026-06-15-hapi-borrow-analysis-and-spec.md
@@ -1,0 +1,84 @@
+# HAPI 竞品分析 & relay-web 借鉴改进 Spec
+
+> 日期: 2026-06-15 · 分支: `feat/relay-web-hapi-borrow-ux`
+> 竞品源码: `/Users/maijiazhen/projects/hapi`（HAPI v0.20.2，Bun monorepo: cli/ hub/ web/ shared/）
+
+## 1. 竞品定位
+
+HAPI 与 xacpx 强同域：本地包裹 AI coding agent（Claude Code / Codex / Gemini / Cursor / OpenCode）→ hub（Socket.IO + SSE + SQLite + Telegram bot + E2E relay）→ React PWA 远程控制。核心卖点：**Seamless Handoff / Native First / AFK Without Stopping**。
+
+与 xacpx 的根本差异：HAPI 包裹**本地交互式终端** agent，可在终端 ↔ web 之间无损切换同一会话；xacpx 不包裹本地 TTY，而是经 chat channel（微信/飞书/元宝）→ relay → acpx 会话驱动。因此 HAPI 一整类"本地↔远程切换"机制（双 launcher、双击空格夺回、JSONL transcript file-tail）**不适用** xacpx —— 概念（稳定 session-id 作为句柄、多前端 attach）可借，机制不可移植。
+
+## 2. 可借鉴清单（5 份 subagent 内参综合）
+
+| # | 借鉴点 | 价值 | 可行性 | 可在 sandbox 预览 | 裁决 |
+|---|--------|------|--------|------------------|------|
+| A | **会话列表语义化注意力指示**（HAPI `sessionAttention.ts`：permission>input>background>unread 优先级点） | 高（"哪个会话需要我"） | 高（纯 Pinia 分类器，数据已存在于 chat store `liveTurns`） | ✅ | **做** |
+| B | **工具调用分组/摘要 anti-spam**（HAPI `toolGroups.ts`：连续例行工具折叠成带计数摘要） | 高（多工具回合密度） | 高（增强现有 `ToolCallPanel`） | ✅ | **做** |
+| C | **Reasoning 流式自动展开 + shimmer 点，完成收起**（HAPI `reasoning.tsx`） | 中（打磨） | 高（增强 `ReasoningPanel`） | ✅ | **做** |
+| D | **FUE 首次体验原语**（HAPI `use-fue.ts` + `Fue.tsx`，其 AGENTS.md 头号推荐，近乎逐字可移植到 Vue `<Teleport>`） | 中（特性发现） | 高（小、纯前端） | ✅ | **做**（精简版，挂到 B 的摘要头作为载体） |
+| E | per-tool 渲染注册表 + inline diff | 中 | relay-web `ToolDetail.vue` 已具 diff/read/command/search/text/fields | 部分已有 | 暂缓 |
+| F | context-budget 计量条 + 阈值变色 | 中 | **不可行**：控制事件流无 token 用量数据 | ✗ | 不做 |
+| G | 远程权限审批（allow/deny） | 高 | 需 acpx escalation；已有独立未启动 plan（`2026-06-12-chat-permission-approval-v1.md`）；chat-only 无 web UI；大 | 弱 | 本批次不做（见 §5） |
+| H | web 终端 / 文件浏览器 | 高 | 大型：需 connector PTY/fs RPC + 安全模型（realpath 容器化） | ✗（多 session） | 不做 |
+| I | PWA + visibility-gated web push | 中 | 需 SW + VAPID 基建 | 部分 | 不做（本批次） |
+| J | voice assistant | 低-中 | 大型、React-SDK 强耦合 | ✗ | 不做 |
+| K | hub 后端加固（time-based stale-keepalive 拒绝、localId 幂等插入、versioned helper） | 中 | 可行但**不可预览**、价值低可见性 | 后端 | 本批次不做 |
+
+**本批次只做 A/B/C/D**：四者构成一个内聚主题——"更密、更聪明、更易读的 relay-web 仪表盘"，全部纯 Vue/Pinia/Tailwind，**零** acpx/协议/connector 改动，可 `build` + 重启 hub 立即预览，每项可 vitest 单测。其余项要么超范围/不可预览/不可行，记录在案供后续。
+
+## 3. 现状基线（xacpx，已核对源码）
+
+- `stores/chat.ts`：`liveTurns: Record<"<instanceId>\0<alias>", LiveTurn>` 已**全局**跟踪所有会话的活跃回合（`ensureTurn` 对任意 turn-started 建条目，turn-finished `flushTurn` 清除）。`flushTurn` 仅在 `selected` 时把内容落成消息。→ **A 的数据已就绪**。
+- `components/ToolCallPanel.vue`：单一可折叠面板，`open=true` 默认全展开列所有行，头部仅 `🔧 Tool calls (N)`。→ **B 增强此处**。
+- `components/ReasoningPanel.vue`：`defaultOpen` prop（live=true / 历史=false），无流式态/shimmer。→ **C 增强此处**。
+- `components/InstanceTree.vue`：会话行 `s.running` 时显示静态 `●`（amber）。`SessionDto = {alias,agent,workspace,transportSession,running}`，**无 unread 字段**。→ **A 用 chat store 的实时态替代/增强**。
+- 无 FUE 原语。
+
+## 4. 详细设计
+
+### Feature A — 会话注意力指示
+**数据**：扩展 `chat` store（它已消费全局事件流）：
+- 新增 `unread: ref<Set<string>>`（key = `<instanceId>\0<alias>`）。
+- `applyEvent` 的 `turn-finished` 分支：若该 key **非当前选中**且 `status ∈ {done,error}`，`unread.add(key)`。
+- `select(id,alias)`：清除新选中 key 的 unread。
+- 暴露 `sessionAttention(instanceId, alias): "working" | "unread" | "idle"`：
+  - `working`：`liveTurns` 含该 key（实时，比 `SessionDto.running` 更即时）。
+  - `unread`：`unread` 含该 key。
+  - 否则 `idle`。
+- 暴露 `instanceHasAttention(instanceId): boolean`（任一子会话 working/unread）→ 折叠的实例头也能显示卷起指示。
+
+**渲染**：`InstanceTree.vue` 会话行点：`working` → amber `●` + `animate-pulse`；`unread` → sky-blue `●`（静态）；`idle` → 无点（或保留 `running` 兜底）。`offline`（`!inst.online`）实例头点维持灰色。`data-test="attention-dot"` + `data-attention` 属性供测试。
+
+### Feature B — 工具分组摘要 + 自动折叠
+增强 `ToolCallPanel.vue`：
+- 头部追加**按 kind/status 的计数摘要**：例如 `📖3 💻2 ✏️1 · ✅5 ⏳1`（仅显示计数 >0 的项）。纯函数 `summarizeSteps(steps): {kind, status}` 计数，可单测。
+- **自动折叠**：`steps.length > THRESHOLD(=5)` 时 `open` 初始为 `false`（默认折叠，避免长墙），≤5 维持展开。用户可点开。
+- 展开后逐行不变（保留现有 per-step 行 + ToolDetail）。
+- 头部摘要旁挂 Feature D 的 FUE 点（首次提示"工具步骤已折叠，点击展开"）。
+
+### Feature C — Reasoning 流式 shimmer + 自动展开
+增强 `ReasoningPanel.vue`：
+- 新增 `streaming?: boolean` prop。`MessageList.vue` 对 **live** reasoning 传 `:streaming="true"`，历史传 `false`。
+- `streaming` 时：标签显示 `Reasoning…` + 一个脉冲 shimmer 点（`animate-pulse` 小圆点），且强制 `open`（忽略用户折叠，直到流结束）。
+- 非 streaming：维持 `defaultOpen` 行为（历史默认折叠）。
+
+### Feature D — FUE 原语（精简 Vue 移植）
+- `lib/use-fue.ts`：`useFue(featureId)` → `{ status, engage, dismiss }`，三态 `unseen → engaging → acknowledged`，localStorage `xacpx.fue.v1.<featureId>`，try/catch 容错（隐私模式），**无自动超时**（仅显式 "Got it"）。纯逻辑，可单测。
+- `lib/fue-placement.ts`：`computeCalloutPlacement(anchorRect, calloutSize, viewport)` 纯函数——上下翻转 + 水平 clamp，可单测。
+- `components/FueDot.vue`：8px 绝对定位圆点，`unseen` 时 `animate-pulse`。
+- `components/FueCallout.vue`：`<Teleport to="body">` 弹出框（标题 + 正文 + "Got it"），用 placement 函数定位，Esc/点击 "Got it" 关闭。
+- 互斥规则：FUE 点与任何特性计数徽标互斥（onboarding 信号优先），载体处遵守。
+
+## 5. 明确不做 & 后续（记录）
+
+- **权限审批（G）**：已有 `docs/superpowers/plans/2026-06-12-chat-permission-approval-v1.md`（未启动，chat-text only）。HAPI 模型（synced `requests` map + parked promise + RPC 解锁 + AFK visibility gate + 富答案 allow-once/for-session/mode-on-approve）价值高但需 acpx escalation 能力 + 跨 connector/协议/web 多层改动，属独立中型项目，不在"可预览小批次"内。后续若做，relay-web 侧可移植 HAPI `PermissionFooter` 按钮集 + danger tone。
+- **后端加固（K）**：time-based stale-keepalive 拒绝、localId 幂等插入、`updateVersionedField` 通用乐观并发 helper——价值真实但不可预览，建议独立 PR 配后端单测。
+- **doctor 增项**：HAPI doctor 反而缺 acpx 解析/版本检查（xacpx 已有）；无新增可借。
+- **terminal/files（H）**：契合 relay 拓扑但需 connector 侧 PTY/fs + realpath 容器化安全模型（HAPI 自身实现 fail-open 且可绕过，**不可照抄**）。大型独立项目。
+
+## 6. 验收
+
+- `bun run --cwd packages/relay-web test` 全绿（新增各 feature 的 vitest）。
+- `bun run --cwd packages/relay-web build`（含 `vue-tsc --noEmit`）通过。
+- sandbox 重建后：仪表盘会话列表出现实时 working/unread 点；多工具回合工具面板折叠并显示计数摘要；live reasoning 流式 shimmer；首次见到折叠工具面板有 FUE 引导点。

--- a/docs/superpowers/specs/2026-06-15-z-client-borrow-design.md
+++ b/docs/superpowers/specs/2026-06-15-z-client-borrow-design.md
@@ -1,0 +1,73 @@
+# relay-web 借鉴 "Z" 桌面客户端 —— 分析与设计
+
+> 来源：一张 "Z" 桌面编码 agent 客户端截图（GLM-5.2 模型选择器、Git 工具面板、工作区→任务树、composer 内联选择器）。本文是借鉴分析 + 设计决策，配套实现计划见 [`../plans/2026-06-15-relay-web-z-client-borrow.md`](../plans/2026-06-15-relay-web-z-client-borrow.md)。
+>
+> 这批工作延续既有的 [hapi-borrow](./2026-06-15-hapi-borrow-analysis-and-spec.md) 看板改进，目标仍是 `packages/relay-web`。
+>
+> 注意：交互细节部分由静态截图推断；落地时以实际行为为准。
+
+## 1. 动机
+
+relay-web 当前 composer 只有 textarea + Send/Stop + 斜杠命令补全（`PromptInput.vue`），看板顶部没有上下文带，没有全局搜索。"Z" 客户端在"上下文可见性"和"输入区控制密度"上做得更好，且其 composer 的**模型 / 权限 / 强度三选择器**正好与刚在 core 落地的 model-selection 特性（`feat/session-model-selection` 分支）闭环。
+
+## 2. 源界面元素清单（四区）
+
+1. **顶部上下文带**：任务标题 + chip 串 `仓库@主机 · 分支 · …溢出`；右侧面板开关/窗口控制。每个 chip 既显示状态又是入口。
+2. **左侧栏**：固定动作（新建/搜索 Ctrl+K/技能）+ `工作区` 分组（过滤/搜索/归档）+ 两级树（工作区→任务，活动任务高亮 + 耗时徽标 `1分` + 空态 `暂无任务`）+ 底部账户/设置。
+3. **中部对话流**：用户气泡右对齐；`已工作 59 秒 ⌄` 工作计时折叠；`思考过程 持续了几秒 ⌄` 带时长的 reasoning 折叠；工具聚合 `已探索 2 文件 ⌄`；`⚠️ 暂停一下` 警告 callout + 风险列表；右下浮动回到底部。
+4. **右侧 Git 工具面板**：`更改 +3 -3` · `分支` · `提交 …`，面板可全屏。
+5. **底部 composer**：占位 + `+` 附件 + 三内联 chip（`完全访问` 权限 / `GLM-5.2` 模型 / `最高` 强度）+ 同步指示 + 发送。
+
+## 3. 决策矩阵
+
+| # | 借鉴点 | relay-web 现状 | 决定 | 价值/可行性 |
+|---|---|---|---|---|
+| 1 | composer 内联选择器（模型/权限/工作计时） | 仅 textarea+Send/Stop（`PromptInput.vue`） | **借鉴** | ★★★ / ★★（需 1 条新 relay RPC；依赖 model-selection 分支） |
+| 2 | 顶部上下文 chip 带（workspace@instance·branch） | 无顶部带 | **借鉴** | ★★★ / ★★★ 纯前端 |
+| 3 | Git 状态摘要 widget（只读 `● branch · +N -N`） | 有 Files/Changes 只读 diff，无紧凑摘要 | **借鉴（只读）** | ★★ / ★★★ |
+| 4 | Ctrl+K 命令面板 / 全局搜索 | 无 | **借鉴** | ★★★ / ★★ 纯前端 |
+| 5 | 工作计时 + reasoning 时长 | 有 working-verb 状态，不显示耗时 | **借鉴** | ★★ / ★★★ |
+| 6 | 侧栏会话耗时徽标 + 空态文案 | 有 attention 圆点，无耗时徽标/空态 | **借鉴** | ★★ / ★★★ |
+| 7 | 警告/需授权 callout 样式 | 普通文本 | **借鉴** | ★★ / ★★★（复用 `FueCallout.vue`） |
+| 8 | 面板全屏/折叠 chrome | 右面板仅 Tasks/Files 切 | **延后** | ★ / ★★ |
+| 9 | 从 Web 直接 `提交`/写 git | — | **拒绝** | 破坏只读+容器化安全边界 |
+| 10 | 桌面窗口 chrome（标题栏/最小化） | — | **拒绝** | Web 不适用 |
+| 11 | `技能` 顶级入口 | 无技能体系 | **拒绝** | 无对应能力，价值低 |
+
+## 4. 设计
+
+### 4.1 安全边界（不可协商）
+文件浏览器那批刻意做成**默认只读 + realpath 容器化**。本批的 Git widget **只读**：仅展示 `branch + 改动统计`，数据复用已有 `control.fs.diff`（`MSG.fsDiff`）。**绝不**从 Web 暴露 commit/push/写 git。
+
+### 4.2 Batch A —— composer 内联选择器（最高协同）
+- **UI**：`PromptInput.vue` 底部增加一行 chip：模型（点开列 `availableModels` 选择）、权限模式、工作计时（busy 时显示 `已工作 Ns`）。
+- **数据通路**：新增 relay 控制 RPC，与现有 `fs.*` 同构：
+  - `control.session.model.get` → 返回 `{ current?, available[] }`
+  - `control.session.model.set` → 切换并持久化
+  - `control.session.permission.get/set`（复用现有 permission 命令语义）
+  - 协议：`packages/relay-protocol/src/messages.ts` 加 `MSG`/payload/result；连接器 `packages/channel-relay/src/control-bridge.ts` 加 case，调用 core `ControlService`。
+  - core `ControlService`（`src/control/control-service.ts`）新增方法，转调 `feat/session-model-selection` 已落地的 `transport.getSessionModel` / `SessionService.setCurrentSessionModel` / `transport.setModel`。
+- **依赖**：**Batch A 依赖 `feat/session-model-selection` 先合入 core**（transport 的 `setModel/getSessionModel` 在那条分支）。B/C/E 无此依赖，可并行先做。
+
+### 4.3 Batch B —— 顶部上下文 chip 带（纯前端）
+- `ChatPane.vue` 头部加一行 chip：`workspace @ instance · branch`，chip 可点（branch→切到 Files/Changes，instance→`ManageInstanceDialog`）。数据来自 instance/session 元数据（已在 store）。
+
+### 4.4 Batch C —— Git 状态摘要 widget（只读）
+- 头部或 Files 标签顶部紧凑 `● <branch> · +N -N`，源自 `control.fs.diff` 的 files/stat（已有）。点击展开 Changes 标签。
+
+### 4.5 Batch D —— Ctrl+K 命令面板（纯前端）
+- 新组件 `CommandPalette.vue`：`Cmd/Ctrl+K` 唤起，跨 instance/session 模糊搜索 + `/command` 目录（复用 `lib/command-catalog.ts`）。回车跳转会话或填充命令。
+
+### 4.6 Batch E —— 细节打磨（纯前端，低风险）
+- 状态 HUD/`MessageList`：busy 显示 `已工作 Ns`；`ReasoningPanel.vue` 折叠头加 `持续 Ns`（若无时长数据位则补一个）。
+- `InstanceTree.vue`：会话加最近活动耗时徽标 + `暂无会话` 空态。
+- 把"需授权/警告"类 agent 消息渲染为 callout（复用 `FueCallout.vue` 样式骨架）。
+
+## 5. 范围与排序
+- 独立可上线批次：A（需先合 model-selection）、B、C、E 纯前端可并行；Git widget(C 4.4) 复用 B 的头部。
+- 不在本 spec：面板全屏 chrome（延后）、任何写 git（拒绝）、技能体系（拒绝）。
+
+## 6. 测试策略
+- 纯前端批次：vitest + @vue/test-utils 组件测试（沿用现有 `__tests__/` 模式），mock `api.rpc`。
+- Batch A 的 RPC：core 侧 `bun test` 单文件（ControlService + 连接器 bridge case），relay-web 侧 mock rpc。
+- 全程 `bun run --cwd packages/relay-web build`(含 vue-tsc) + 受影响文件逐个 `bun test`（勿整目录）。

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -2,6 +2,9 @@ import {
   MSG,
   errorPayload,
   type CommandExecutePayload,
+  type FsDiffPayload,
+  type FsListPayload,
+  type FsReadPayload,
   type OrchestrationCancelPayload,
   type OrchestrationGetPayload,
   type OrchestrationTaskDto,
@@ -152,6 +155,21 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
     case MSG.orchestrationCancel: {
       const input = payload as OrchestrationCancelPayload;
       return orchestrationTaskToDto(await control.cancelOrchestrationTask({ taskId: input.taskId }));
+    }
+    case MSG.fsList: {
+      const input = payload as FsListPayload;
+      if (!input.workspace) return errorPayload("bad-request", "workspace is required");
+      return await control.listDirectory(input.workspace, input.path); // DirListing ≅ FsListResult
+    }
+    case MSG.fsRead: {
+      const input = payload as FsReadPayload;
+      if (!input.workspace || !input.path) return errorPayload("bad-request", "workspace and path are required");
+      return await control.readWorkspaceFile(input.workspace, input.path); // FileContent ≅ FsReadResult
+    }
+    case MSG.fsDiff: {
+      const input = payload as FsDiffPayload;
+      if (!input.workspace) return errorPayload("bad-request", "workspace is required");
+      return await control.workspaceGitDiff(input.workspace, input.path); // WorkspaceDiff ≅ FsDiffResult
     }
     default:
       return errorPayload("unknown-type", `unsupported rpc type: ${envelope.type}`);

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -5,6 +5,7 @@ import {
   type FsDiffPayload,
   type FsListPayload,
   type FsReadPayload,
+  type FsSearchPayload,
   type OrchestrationCancelPayload,
   type OrchestrationGetPayload,
   type OrchestrationTaskDto,
@@ -170,6 +171,11 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
       const input = payload as FsDiffPayload;
       if (!input.workspace) return errorPayload("bad-request", "workspace is required");
       return await control.workspaceGitDiff(input.workspace, input.path); // WorkspaceDiff ≅ FsDiffResult
+    }
+    case MSG.fsSearch: {
+      const input = payload as FsSearchPayload;
+      if (!input.workspace) return errorPayload("bad-request", "workspace is required");
+      return await control.searchWorkspace(input.workspace, input.query ?? ""); // SearchResult ≅ FsSearchResult
     }
     default:
       return errorPayload("unknown-type", `unsupported rpc type: ${envelope.type}`);

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -27,6 +27,21 @@ export interface WorkspaceDto {
   description?: string;
 }
 
+/** A single entry in a workspace directory listing (read-only file browser). */
+export interface FsEntryDto {
+  name: string;
+  type: "dir" | "file";
+  /** File size in bytes; omitted for directories. */
+  size?: number;
+}
+
+/** A changed file in a workspace's git working tree. `status` is the porcelain XY
+ *  code (e.g. " M", "A ", "??", "D "). */
+export interface FsDiffFileDto {
+  path: string;
+  status: string;
+}
+
 // Keep in sync with ScheduledTaskStatus in src/scheduled/scheduled-types.ts
 export type ScheduledTaskStatusDto =
   | "pending"

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -1,4 +1,4 @@
-import type { AgentCatalogEntryDto, AgentDto, ControlEventDto, OrchestrationTaskDto, ScheduledTaskDto, SessionDto, WorkspaceDto } from "./dtos.js";
+import type { AgentCatalogEntryDto, AgentDto, ControlEventDto, FsDiffFileDto, FsEntryDto, OrchestrationTaskDto, ScheduledTaskDto, SessionDto, WorkspaceDto } from "./dtos.js";
 
 // Instance <-> relay message types. Convention: chatKey for relay-driven chats
 // is `relay:<accountId>`; the relay server stamps chatKey/senderId/isOwner on
@@ -27,6 +27,9 @@ export const MSG = {
   orchestrationList: "control.orchestration.list",
   orchestrationGet: "control.orchestration.get",
   orchestrationCancel: "control.orchestration.cancel",
+  fsList: "control.fs.list",
+  fsRead: "control.fs.read",
+  fsDiff: "control.fs.diff",
 } as const;
 
 export type MessageType = (typeof MSG)[keyof typeof MSG];
@@ -196,3 +199,47 @@ export interface OrchestrationCancelPayload {
   taskId: string;
 }
 export type OrchestrationCancelResult = OrchestrationTaskDto;
+
+// --- workspace file browser (read-only, scoped to a configured workspace root) ---
+export interface FsListPayload {
+  /** Configured workspace name. */
+  workspace: string;
+  /** Directory path relative to the workspace root; defaults to the root. */
+  path?: string;
+}
+export interface FsListResult {
+  workspace: string;
+  /** Normalized path relative to the workspace root ("" = root). */
+  path: string;
+  entries: FsEntryDto[];
+}
+export interface FsReadPayload {
+  workspace: string;
+  /** File path relative to the workspace root. */
+  path: string;
+}
+export interface FsReadResult {
+  workspace: string;
+  path: string;
+  /** UTF-8 content (possibly truncated). Empty when `binary` is true. */
+  content: string;
+  /** Total file size in bytes. */
+  size: number;
+  /** True when the file exceeded the read cap and `content` is a prefix. */
+  truncated: boolean;
+  /** True when the file looks binary; `content` is then empty. */
+  binary: boolean;
+}
+export interface FsDiffPayload {
+  workspace: string;
+  /** Optional file path (relative) to scope the diff; defaults to the whole tree. */
+  path?: string;
+}
+export interface FsDiffResult {
+  workspace: string;
+  /** Changed files from `git status` (includes untracked). */
+  files: FsDiffFileDto[];
+  /** Unified diff text vs HEAD (possibly truncated). */
+  diff: string;
+  truncated: boolean;
+}

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -30,6 +30,7 @@ export const MSG = {
   fsList: "control.fs.list",
   fsRead: "control.fs.read",
   fsDiff: "control.fs.diff",
+  fsSearch: "control.fs.search",
 } as const;
 
 export type MessageType = (typeof MSG)[keyof typeof MSG];
@@ -241,5 +242,18 @@ export interface FsDiffResult {
   files: FsDiffFileDto[];
   /** Unified diff text vs HEAD (possibly truncated). */
   diff: string;
+  truncated: boolean;
+}
+export interface FsSearchPayload {
+  workspace: string;
+  /** Case-insensitive substring matched against each file's relative path. */
+  query: string;
+}
+export interface FsSearchResult {
+  workspace: string;
+  query: string;
+  /** Matching file paths relative to the workspace root. */
+  matches: string[];
+  /** True when the result cap was hit. */
   truncated: boolean;
 }

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -250,3 +250,38 @@ test("PromptInput disables its textarea when busy", () => {
   const wrapper = mount(PromptInput, { props: { busy: true } });
   expect((wrapper.find("textarea").element as HTMLTextAreaElement).disabled).toBe(true);
 });
+
+test("a finished turn on an unviewed session becomes unread, and select clears it", () => {
+  const store = useChatStore();
+  store.select("i1", "backend"); // viewing backend, not frontend
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "frontend", ok: true } } as never);
+  expect(store.sessionAttention("i1", "frontend")).toBe("unread");
+  expect(store.sessionAttention("i1", "backend")).toBe("idle"); // viewed → no unread
+  store.select("i1", "frontend");
+  expect(store.sessionAttention("i1", "frontend")).toBe("idle");
+});
+
+test("working (a live turn) outranks unread", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "frontend", ok: true } } as never);
+  expect(store.sessionAttention("i1", "frontend")).toBe("unread");
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "frontend" } } as never);
+  expect(store.sessionAttention("i1", "frontend")).toBe("working");
+});
+
+test("an instance going offline clears its unread signals", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "frontend", ok: true } } as never);
+  expect(store.sessionAttention("i1", "frontend")).toBe("unread");
+  store.applyEvent({ kind: "instance-status", instanceId: "i1", online: false } as never);
+  expect(store.sessionAttention("i1", "frontend")).toBe("idle");
+});
+
+test("a cancelled turn on an unviewed session does NOT mark unread", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "frontend", ok: false, cancelled: true } } as never);
+  expect(store.sessionAttention("i1", "frontend")).toBe("idle");
+});

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -246,9 +246,21 @@ test("a cancelled finish marks the turn stopped, not errored", () => {
   expect(store.messages.at(-1)).toMatchObject({ status: "cancelled", text: "partial" });
 });
 
-test("PromptInput disables its textarea when busy", () => {
+test("PromptInput stays composable while busy but shows Stop and blocks send", async () => {
   const wrapper = mount(PromptInput, { props: { busy: true } });
-  expect((wrapper.find("textarea").element as HTMLTextAreaElement).disabled).toBe(true);
+  // Textarea is intentionally enabled while busy (pre-compose / Esc-to-stop).
+  expect((wrapper.find("textarea").element as HTMLTextAreaElement).disabled).toBe(false);
+  expect(wrapper.find('[data-test="composer-stop"]').exists()).toBe(true);
+  await wrapper.find("textarea").setValue("queued while busy");
+  await wrapper.find("textarea").trigger("keydown", { key: "Enter" });
+  expect(wrapper.emitted("send")).toBeFalsy(); // submit no-ops while busy
+});
+
+test("PromptInput Stop button and Esc-while-busy emit cancel", async () => {
+  const wrapper = mount(PromptInput, { props: { busy: true } });
+  await wrapper.find('[data-test="composer-stop"]').trigger("click");
+  await wrapper.find("textarea").trigger("keydown", { key: "Escape" });
+  expect(wrapper.emitted("cancel")?.length).toBe(2);
 });
 
 test("a finished turn on an unviewed session becomes unread, and select clears it", () => {

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -9,8 +9,39 @@ vi.mock("../api/client", () => ({
 
 import ChatPane from "../components/ChatPane.vue";
 import { useChatStore } from "../stores/chat";
+import { useInstancesStore } from "../stores/instances";
 
 beforeEach(() => setActivePinia(createPinia()));
+
+function seedInstance() {
+  const instances = useInstancesStore();
+  instances.instances.push({
+    id: "i1", name: "prod-box", online: true, lastSeenAt: null,
+    sessions: [{ alias: "backend", agent: "codex", workspace: "gaia" }],
+    agents: [], workspaces: [], agentCatalog: [],
+  } as never);
+}
+
+it("renders workspace, instance and agent context chips for the current session", async () => {
+  seedInstance();
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  expect(w.find('[data-test="ctx-chip-workspace"]').text()).toContain("gaia");
+  expect(w.find('[data-test="ctx-chip-instance"]').text()).toContain("prod-box");
+  expect(w.find('[data-test="ctx-chip-agent"]').text()).toContain("codex");
+});
+
+it("clicking the workspace chip emits show-files", async () => {
+  seedInstance();
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  await w.find('[data-test="ctx-chip-workspace"]').trigger("click");
+  expect(w.emitted("show-files")).toBeTruthy();
+});
 
 it("shows a working HUD while a live turn is active", async () => {
   const chat = useChatStore();

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -10,6 +10,7 @@ vi.mock("../api/client", () => ({
 import ChatPane from "../components/ChatPane.vue";
 import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
+import { useFilesStore } from "../stores/files";
 
 beforeEach(() => setActivePinia(createPinia()));
 
@@ -40,6 +41,25 @@ it("clicking the workspace chip emits show-files", async () => {
   const w = mount(ChatPane);
   await w.vm.$nextTick();
   await w.find('[data-test="ctx-chip-workspace"]').trigger("click");
+  expect(w.emitted("show-files")).toBeTruthy();
+});
+
+it("renders a git summary chip and clicking it opens the Changes tab", async () => {
+  seedInstance();
+  const chat = useChatStore();
+  const files = useFilesStore();
+  chat.select("i1", "backend");
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  // Set after mount so the immediate watch (which clears it via the mocked rpc)
+  // doesn't overwrite our fixture.
+  files.gitSummary = { workspace: "gaia", changedCount: 3 };
+  await w.vm.$nextTick();
+  const chip = w.find('[data-test="git-summary"]');
+  expect(chip.exists()).toBe(true);
+  expect(chip.text()).toContain("3 changed");
+  await chip.trigger("click");
+  expect(files.tab).toBe("changes");
   expect(w.emitted("show-files")).toBeTruthy();
 });
 

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -28,3 +28,20 @@ it("hides the HUD when no turn is active", () => {
   const w = mount(ChatPane);
   expect(w.find('[data-test="turn-hud"]').exists()).toBe(false);
 });
+
+it("cycles the working verb every ~4s while the turn runs", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  expect(w.find('[data-test="turn-hud"]').text()).toContain("Working"); // bucket 0
+  vi.advanceTimersByTime(5000); // 5s → bucket 1, also drives the 1Hz clock
+  await w.vm.$nextTick();
+  const t = w.find('[data-test="turn-hud"]').text();
+  expect(t).not.toContain("Working");
+  expect(t).toContain("Thinking");
+  vi.useRealTimers();
+});

--- a/packages/relay-web/src/__tests__/commandpalette.test.ts
+++ b/packages/relay-web/src/__tests__/commandpalette.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import CommandPalette from "../components/CommandPalette.vue";
+import { useInstancesStore } from "../stores/instances";
+
+function seed() {
+  const instances = useInstancesStore();
+  instances.instances = [
+    { id: "i1", name: "prod-box", online: true, lastSeenAt: null, agents: [], workspaces: [], agentCatalog: [],
+      sessions: [{ alias: "backend", agent: "codex", workspace: "gaia" }, { alias: "frontend", agent: "claude", workspace: "web" }] },
+  ] as never;
+}
+
+describe("CommandPalette", () => {
+  beforeEach(() => { setActivePinia(createPinia()); seed(); });
+
+  it("lists sessions and commands, sessions first", () => {
+    const w = mount(CommandPalette);
+    const rows = w.findAll('[data-test="palette-row"]');
+    expect(rows.length).toBeGreaterThan(2);
+    expect(rows[0].text()).toContain("backend");
+    expect(w.text()).toContain("/status"); // a command from the catalog
+  });
+
+  it("filters by the query across label and subtitle", async () => {
+    const w = mount(CommandPalette);
+    await w.find('[data-test="palette-input"]').setValue("frontend");
+    const rows = w.findAll('[data-test="palette-row"]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain("frontend");
+  });
+
+  it("emits select-session when a session row is chosen", async () => {
+    const w = mount(CommandPalette);
+    await w.find('[data-test="palette-input"]').setValue("backend");
+    await w.find('[data-test="palette-row"]').trigger("click");
+    expect(w.emitted("select-session")?.[0]).toEqual(["i1", "backend"]);
+    expect(w.emitted("close")).toBeTruthy();
+  });
+
+  it("emits pick-command when a command row is chosen", async () => {
+    const w = mount(CommandPalette);
+    await w.find('[data-test="palette-input"]').setValue("/status");
+    await w.find('[data-test="palette-row"]').trigger("click");
+    expect(w.emitted("pick-command")?.[0]).toEqual(["/status"]);
+  });
+
+  it("Enter selects the active row, Escape closes", async () => {
+    const w = mount(CommandPalette);
+    const input = w.find('[data-test="palette-input"]');
+    await input.setValue("frontend");
+    await input.trigger("keydown", { key: "Enter" });
+    expect(w.emitted("select-session")?.[0]).toEqual(["i1", "frontend"]);
+    await input.trigger("keydown", { key: "Escape" });
+    expect(w.emitted("close")).toBeTruthy();
+  });
+
+  it("ArrowDown moves the active row", async () => {
+    const w = mount(CommandPalette);
+    const input = w.find('[data-test="palette-input"]');
+    await input.trigger("keydown", { key: "ArrowDown" });
+    await input.trigger("keydown", { key: "Enter" });
+    // second session row is "frontend"
+    expect(w.emitted("select-session")?.[0]).toEqual(["i1", "frontend"]);
+  });
+});

--- a/packages/relay-web/src/__tests__/copybutton.test.ts
+++ b/packages/relay-web/src/__tests__/copybutton.test.ts
@@ -1,0 +1,17 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import CopyButton from "../components/CopyButton.vue";
+
+describe("CopyButton", () => {
+  it("writes text to the clipboard and shows a transient confirmation", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const w = mount(CopyButton, { props: { text: "hello world" } });
+    expect(w.text()).toContain("⧉");
+    await w.find('[data-test="copy-button"]').trigger("click");
+    await Promise.resolve();
+    expect(writeText).toHaveBeenCalledWith("hello world");
+    await w.vm.$nextTick();
+    expect(w.text()).toContain("✓");
+  });
+});

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -110,6 +110,28 @@ describe("files store", () => {
     expect(s.error).toBe(""); // browsing stays clean — no error surfaced
   });
 
+  it("loadGitSummary stores a changed-file count for a workspace", async () => {
+    const s = useFilesStore();
+    rpc.mockResolvedValueOnce({ workspace: "ws", files: [{ path: "a.ts", status: " M" }, { path: "b.ts", status: "??" }], diff: "", truncated: false });
+    await s.loadGitSummary("i1", "ws");
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.diff", { workspace: "ws" });
+    expect(s.gitSummary).toEqual({ workspace: "ws", changedCount: 2 });
+  });
+
+  it("loadGitSummary picks up a branch when the backend provides one", async () => {
+    const s = useFilesStore();
+    rpc.mockResolvedValueOnce({ workspace: "ws", branch: "main", files: [], diff: "", truncated: false });
+    await s.loadGitSummary("i1", "ws");
+    expect(s.gitSummary).toEqual({ workspace: "ws", changedCount: 0, branch: "main" });
+  });
+
+  it("loadGitSummary clears the summary for a non-git workspace (error payload)", async () => {
+    const s = useFilesStore();
+    rpc.mockResolvedValueOnce({ error: { code: "internal", message: "not-a-git-repo" } });
+    await s.loadGitSummary("i1", "ws");
+    expect(s.gitSummary).toBeNull();
+  });
+
   it("surfaces an instance-side error payload as an error string", async () => {
     rpc.mockResolvedValueOnce({ error: { code: "internal", message: "path-escapes-workspace" } });
     const s = useFilesStore();

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -89,6 +89,27 @@ describe("files store", () => {
     expect(s.results).toEqual([]);
   });
 
+  it("loadStatus populates the changed map from a whole-tree diff", async () => {
+    const s = useFilesStore();
+    s.instanceId = "i1";
+    s.workspace = "ws";
+    rpc.mockResolvedValueOnce({ workspace: "ws", files: [{ path: "src/a.ts", status: " M" }, { path: "new.ts", status: "??" }], diff: "", truncated: false });
+    await s.loadStatus();
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.diff", { workspace: "ws" });
+    expect(s.changed).toEqual({ "src/a.ts": " M", "new.ts": "??" });
+  });
+
+  it("loadStatus clears the changed map quietly for a non-git workspace (no error)", async () => {
+    const s = useFilesStore();
+    s.instanceId = "i1";
+    s.workspace = "ws";
+    s.changed = { stale: "M" };
+    rpc.mockResolvedValueOnce({ error: { code: "internal", message: "not-a-git-repo" } });
+    await s.loadStatus();
+    expect(s.changed).toEqual({});
+    expect(s.error).toBe(""); // browsing stays clean — no error surfaced
+  });
+
   it("surfaces an instance-side error payload as an error string", async () => {
     rpc.mockResolvedValueOnce({ error: { code: "internal", message: "path-escapes-workspace" } });
     const s = useFilesStore();

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -1,0 +1,60 @@
+import { setActivePinia, createPinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpc = vi.fn();
+vi.mock("../api/client", () => ({
+  ApiError: class extends Error { constructor(public code: string, public status: number) { super(code); } },
+  api: { rpc: (id: string, type: string, payload?: unknown) => rpc(id, type, payload) },
+}));
+
+import { useFilesStore } from "../stores/files";
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  rpc.mockReset();
+});
+
+describe("files store", () => {
+  it("selects a workspace and lists the root", async () => {
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [
+      { name: "src", type: "dir" },
+      { name: "README.md", type: "file", size: 10 },
+    ] });
+    const s = useFilesStore();
+    await s.selectWorkspace("i1", "ws");
+    expect(rpc).toHaveBeenCalledWith("i1", "control.fs.list", { workspace: "ws", path: "" });
+    expect(s.entries.map((e) => e.name)).toEqual(["src", "README.md"]);
+  });
+
+  it("descends into a directory and opens a file", async () => {
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [] });
+    const s = useFilesStore();
+    await s.selectWorkspace("i1", "ws");
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "src", entries: [{ name: "a.ts", type: "file", size: 5 }] });
+    await s.open({ name: "src", type: "dir" });
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.list", { workspace: "ws", path: "src" });
+    expect(s.path).toBe("src");
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "src/a.ts", content: "export const a = 1;", size: 19, truncated: false, binary: false });
+    await s.open({ name: "a.ts", type: "file", size: 5 });
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.read", { workspace: "ws", path: "src/a.ts" });
+    expect(s.file?.content).toContain("export const a");
+  });
+
+  it("loads a git diff into the changes view", async () => {
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [] });
+    const s = useFilesStore();
+    await s.selectWorkspace("i1", "ws");
+    rpc.mockResolvedValueOnce({ workspace: "ws", files: [{ path: "f.txt", status: " M" }], diff: "@@ -1 +1,2 @@\n one\n+two", truncated: false });
+    await s.loadDiff();
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.diff", { workspace: "ws" });
+    expect(s.diff?.files[0].path).toBe("f.txt");
+    expect(s.diff?.diff).toContain("+two");
+  });
+
+  it("surfaces an instance-side error payload as an error string", async () => {
+    rpc.mockResolvedValueOnce({ error: { code: "internal", message: "path-escapes-workspace" } });
+    const s = useFilesStore();
+    await s.selectWorkspace("i1", "ws");
+    expect(s.error).toBe("path-escapes-workspace");
+  });
+});

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -51,6 +51,44 @@ describe("files store", () => {
     expect(s.diff?.diff).toContain("+two");
   });
 
+  it("searches files by name and opens a result", async () => {
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [] });
+    const s = useFilesStore();
+    await s.selectWorkspace("i1", "ws");
+    rpc.mockResolvedValueOnce({ workspace: "ws", query: "a.ts", matches: ["src/a.ts"], truncated: false });
+    await s.search("a.ts");
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.search", { workspace: "ws", query: "a.ts" });
+    expect(s.results).toEqual(["src/a.ts"]);
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false });
+    await s.openFile("src/a.ts");
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.read", { workspace: "ws", path: "src/a.ts" });
+    expect(s.file?.path).toBe("src/a.ts");
+  });
+
+  it("loads a per-file diff and tracks the selected path", async () => {
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [] });
+    const s = useFilesStore();
+    await s.selectWorkspace("i1", "ws");
+    rpc.mockResolvedValueOnce({ workspace: "ws", files: [{ path: "f.txt", status: " M" }], diff: "@@\n+x", truncated: false });
+    await s.loadDiff("f.txt");
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.diff", { workspace: "ws", path: "f.txt" });
+    expect(s.diffPath).toBe("f.txt");
+    rpc.mockResolvedValueOnce({ workspace: "ws", files: [], diff: "", truncated: false });
+    await s.loadDiff();
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.diff", { workspace: "ws" });
+    expect(s.diffPath).toBe(null);
+  });
+
+  it("an empty search query clears results without an rpc", async () => {
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [] });
+    const s = useFilesStore();
+    await s.selectWorkspace("i1", "ws");
+    rpc.mockReset();
+    await s.search("   ");
+    expect(rpc).not.toHaveBeenCalled();
+    expect(s.results).toEqual([]);
+  });
+
   it("surfaces an instance-side error payload as an error string", async () => {
     rpc.mockResolvedValueOnce({ error: { code: "internal", message: "path-escapes-workspace" } });
     const s = useFilesStore();

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -43,6 +43,25 @@ describe("FilesPanel file viewer", () => {
     expect((navigator.clipboard.writeText as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith("hello");
   });
 
+  it("badges directory entries with git status", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    files.path = "";
+    files.entries = [
+      { name: "src", type: "dir" },
+      { name: "clean.ts", type: "file", size: 1 },
+      { name: "new.ts", type: "file", size: 1 },
+    ];
+    files.changed = { "src/a.ts": " M", "new.ts": "??" };
+    await w.vm.$nextTick();
+    const badges = w.findAll('[data-test="fs-status"]');
+    // src (dir, nested change) + new.ts (untracked) badge; clean.ts has none.
+    expect(badges.length).toBe(2);
+    const texts = badges.map((b) => b.text());
+    expect(texts).toContain("•"); // src directory contains a change
+    expect(texts).toContain("U"); // new.ts is untracked
+  });
+
   it("hides the gutter and copy button for a binary file", async () => {
     const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
     const files = useFilesStore();

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -1,0 +1,55 @@
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpc = vi.fn().mockResolvedValue({ workspaces: [], entries: [], path: "" });
+vi.mock("../api/client", () => ({
+  ApiError: class extends Error {},
+  api: { rpc: (...a: unknown[]) => rpc(...a) },
+}));
+
+import FilesPanel from "../components/FilesPanel.vue";
+import { useFilesStore } from "../stores/files";
+
+let pinia: ReturnType<typeof createPinia>;
+beforeEach(() => {
+  pinia = createPinia();
+  setActivePinia(pinia);
+  rpc.mockClear();
+  Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+});
+
+describe("FilesPanel file viewer", () => {
+  it("renders a numbered gutter with one row per line", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    files.file = { workspace: "ws", path: "src/a.ts", content: "one\ntwo\nthree", size: 13, truncated: false, binary: false };
+    await w.vm.$nextTick();
+    const lines = w.findAll('[data-test="file-line"]');
+    expect(lines.length).toBe(3);
+    expect(lines[0].text()).toContain("1");
+    expect(lines[0].text()).toContain("one");
+    expect(lines[2].text()).toContain("3");
+    expect(lines[2].text()).toContain("three");
+  });
+
+  it("offers a copy button that copies the file content", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    files.file = { workspace: "ws", path: "src/a.ts", content: "hello", size: 5, truncated: false, binary: false };
+    await w.vm.$nextTick();
+    await w.find('[data-test="copy-button"]').trigger("click");
+    await Promise.resolve();
+    expect((navigator.clipboard.writeText as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith("hello");
+  });
+
+  it("hides the gutter and copy button for a binary file", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    files.file = { workspace: "ws", path: "bin.dat", content: "", size: 4, truncated: false, binary: true };
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="file-body"]').exists()).toBe(false);
+    expect(w.find('[data-test="copy-button"]').exists()).toBe(false);
+    expect(w.text()).toContain("Binary file not shown");
+  });
+});

--- a/packages/relay-web/src/__tests__/fue.test.ts
+++ b/packages/relay-web/src/__tests__/fue.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { useFue, resetFue } from "../lib/use-fue";
+import { computeCalloutPlacement } from "../lib/fue-placement";
+import FueCallout from "../components/FueCallout.vue";
+
+describe("useFue state machine", () => {
+  beforeEach(() => resetFue("feat-x"));
+
+  it("starts unseen, engages, then acknowledges and persists", () => {
+    const a = useFue("feat-x");
+    expect(a.status.value).toBe("unseen");
+    a.engage();
+    expect(a.status.value).toBe("engaging");
+    a.dismiss();
+    expect(a.status.value).toBe("acknowledged");
+    // A fresh instance reads the persisted acknowledgement.
+    const b = useFue("feat-x");
+    expect(b.status.value).toBe("acknowledged");
+  });
+
+  it("engage is a no-op once acknowledged", () => {
+    const a = useFue("feat-x");
+    a.dismiss();
+    a.engage();
+    expect(a.status.value).toBe("acknowledged");
+  });
+
+  it("resetFue clears the acknowledgement", () => {
+    useFue("feat-x").dismiss();
+    resetFue("feat-x");
+    expect(useFue("feat-x").status.value).toBe("unseen");
+  });
+});
+
+describe("computeCalloutPlacement", () => {
+  const vp = { width: 1000, height: 800 };
+  const callout = { width: 256, height: 100 };
+
+  it("places below the anchor by default", () => {
+    const p = computeCalloutPlacement({ top: 100, left: 400, width: 40, height: 20 }, callout, vp);
+    expect(p.placement).toBe("below");
+    expect(p.top).toBe(100 + 20 + 8);
+  });
+
+  it("flips above when below overflows and above has more room", () => {
+    const p = computeCalloutPlacement({ top: 760, left: 400, width: 40, height: 20 }, callout, vp);
+    expect(p.placement).toBe("above");
+    expect(p.top).toBe(760 - 100 - 8);
+  });
+
+  it("clamps the horizontal position into the viewport", () => {
+    const nearRight = computeCalloutPlacement({ top: 100, left: 980, width: 40, height: 20 }, callout, vp);
+    expect(nearRight.left).toBe(vp.width - callout.width - 8); // 736
+    const nearLeft = computeCalloutPlacement({ top: 100, left: 0, width: 10, height: 20 }, callout, vp);
+    expect(nearLeft.left).toBe(8);
+  });
+});
+
+describe("FueCallout component", () => {
+  it("renders title/body and emits dismiss on Got it", async () => {
+    const w = mount(FueCallout, { props: { title: "Hi", body: "There", anchor: null } });
+    // Teleported to body — query the document, not the wrapper subtree.
+    const el = document.querySelector('[data-test="fue-callout"]');
+    expect(el?.textContent).toContain("Hi");
+    expect(el?.textContent).toContain("There");
+    const btn = document.querySelector('[data-test="fue-dismiss"]') as HTMLButtonElement;
+    btn.click();
+    await w.vm.$nextTick();
+    expect(w.emitted("dismiss")).toBeTruthy();
+    w.unmount();
+  });
+});

--- a/packages/relay-web/src/__tests__/instances.test.ts
+++ b/packages/relay-web/src/__tests__/instances.test.ts
@@ -15,7 +15,7 @@ test("loadInstances populates the list with online flags", async () => {
 
 test("applyEvent instance-status toggles online without refetch", () => {
   const store = useInstancesStore();
-  store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], agents: [], workspaces: [], agentCatalog: [] }];
+  store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];
   store.applyEvent({ kind: "instance-status", instanceId: "i1", online: false });
   expect(store.instances[0]?.online).toBe(false);
 });
@@ -25,9 +25,40 @@ test("loadSessions caches sessions under the instance", async () => {
     result: { sessions: [{ alias: "backend", agent: "claude", workspace: "/w", transportSession: "t", running: false }] },
   }), { status: 200 })));
   const store = useInstancesStore();
-  store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], agents: [], workspaces: [], agentCatalog: [] }];
+  store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];
   await store.loadSessions("i1");
   expect(store.instances[0]?.sessions.map((s) => s.alias)).toEqual(["backend"]);
+});
+
+test("loadInstances eagerly loads sessions for online instances", async () => {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo) => {
+    const url = typeof input === "string" ? input : String(input);
+    const body = url.includes("/rpc")
+      ? { result: { sessions: [{ alias: "backend", agent: "claude", workspace: "/w", transportSession: "t", running: false }] } }
+      : { instances: [{ id: "i1", name: "pc", online: true, lastSeenAt: null }, { id: "i2", name: "off", online: false, lastSeenAt: null }] };
+    return new Response(JSON.stringify(body), { status: 200 });
+  }));
+  const store = useInstancesStore();
+  await store.loadInstances();
+  // Wait a microtask turn for the fire-and-forget loadSessions to settle.
+  await new Promise((r) => setTimeout(r, 0));
+  expect(store.byId("i1")!.sessions.map((s) => s.alias)).toEqual(["backend"]);
+  expect(store.byId("i1")!.sessionsLoaded).toBe(true);
+  // The offline instance is left untouched (no eager fetch).
+  expect(store.byId("i2")!.sessionsLoaded).toBe(false);
+  vi.unstubAllGlobals();
+});
+
+test("applyEvent instance-status loads sessions when an instance comes online", async () => {
+  const store = useInstancesStore();
+  store.instances = [{ id: "i1", name: "pc", online: false, lastSeenAt: null, sessions: [], sessionsLoaded: false, agents: [], workspaces: [], agentCatalog: [] }];
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [{ alias: "backend", agent: "claude", workspace: "/w", transportSession: "t", running: false }] });
+  store.applyEvent({ kind: "instance-status", instanceId: "i1", online: true });
+  await new Promise((r) => setTimeout(r, 0));
+  expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.list");
+  expect(store.byId("i1")!.sessionsLoaded).toBe(true);
+  vi.restoreAllMocks();
 });
 
 describe("createSession timeout handling", () => {
@@ -35,7 +66,7 @@ describe("createSession timeout handling", () => {
 
   function seed() {
     const store = useInstancesStore();
-    store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], agents: [], workspaces: [], agentCatalog: [] }];
+    store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];
     return store;
   }
 
@@ -83,7 +114,7 @@ describe("agent catalog + management actions", () => {
 
   test("loadAgentCatalog stores the catalog on the instance", async () => {
     const store = useInstancesStore();
-    store.instances = [{ id: "i1", name: "n", online: true, lastSeenAt: null, sessions: [], agents: [], workspaces: [], agentCatalog: [] }];
+    store.instances = [{ id: "i1", name: "n", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];
     const { api } = await import("../api/client");
     vi.spyOn(api, "rpc").mockResolvedValue({ agents: [{ driver: "gemini", configured: false, installed: "unknown" }] });
     await store.loadAgentCatalog("i1");
@@ -93,7 +124,7 @@ describe("agent catalog + management actions", () => {
 
   test("createAgent refreshes once (single catalog fetch, no double)", async () => {
     const store = useInstancesStore();
-    store.instances = [{ id: "i1", name: "n", online: true, lastSeenAt: null, sessions: [], agents: [], workspaces: [], agentCatalog: [] }];
+    store.instances = [{ id: "i1", name: "n", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];
     const { api } = await import("../api/client");
     const rpc = vi.spyOn(api, "rpc").mockImplementation(async (_id: string, type: string) => {
       if (type === "control.agents.list") return { agents: [] } as never;
@@ -111,7 +142,7 @@ describe("agent catalog + management actions", () => {
 
   test("removeAgent surfaces an instance-side error payload", async () => {
     const store = useInstancesStore();
-    store.instances = [{ id: "i1", name: "n", online: true, lastSeenAt: null, sessions: [], agents: [], workspaces: [], agentCatalog: [] }];
+    store.instances = [{ id: "i1", name: "n", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];
     const { api } = await import("../api/client");
     vi.spyOn(api, "rpc").mockResolvedValue({ error: { code: "internal", message: 'agent "codex" is in use by an existing session' } });
     await expect(store.removeAgent("i1", "codex")).rejects.toThrow(/in use/);
@@ -126,8 +157,8 @@ test("InstanceTree renders an online dot per instance", () => {
   setActivePinia(createPinia());
   const store = useInstancesStore();
   store.instances = [
-    { id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], agents: [], workspaces: [], agentCatalog: [] },
-    { id: "i2", name: "srv", online: false, lastSeenAt: null, sessions: [], agents: [], workspaces: [], agentCatalog: [] },
+    { id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] },
+    { id: "i2", name: "srv", online: false, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] },
   ];
   const wrapper = mount(InstanceTree);
   const dots = wrapper.findAll('[data-test="online-dot"]');

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -3,6 +3,7 @@ import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import InstanceTree from "../components/InstanceTree.vue";
 import { useInstancesStore } from "../stores/instances";
+import { useChatStore } from "../stores/chat";
 
 const instance = (sessions: unknown[] = []) => ({
   id: "i1", name: "pc", online: true, lastSeenAt: null, sessions, agents: [], workspaces: [],
@@ -32,5 +33,33 @@ describe("InstanceTree session management", () => {
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
     await w.find('[data-test="delete-session"]').trigger("click");
     expect(remove).toHaveBeenCalledWith("i1", "backend");
+  });
+
+  it("mounts with an empty chat store and shows no attention dot for idle sessions", () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="attention-dot"]').exists()).toBe(false);
+  });
+
+  it("renders a working dot when the chat store reports a live turn", () => {
+    const instances = useInstancesStore();
+    instances.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    const chat = useChatStore();
+    chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const dot = w.find('[data-test="attention-dot"]');
+    expect(dot.exists()).toBe(true);
+    expect(dot.attributes("data-attention")).toBe("working");
+  });
+
+  it("renders an unread dot for a finished, unviewed session", () => {
+    const instances = useInstancesStore();
+    instances.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    const chat = useChatStore();
+    chat.select("i1", "other"); // not viewing backend
+    chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "backend", ok: true } } as never);
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="attention-dot"]').attributes("data-attention")).toBe("unread");
   });
 });

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -5,8 +5,8 @@ import InstanceTree from "../components/InstanceTree.vue";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 
-const instance = (sessions: unknown[] = []) => ({
-  id: "i1", name: "pc", online: true, lastSeenAt: null, sessions, agents: [], workspaces: [],
+const instance = (sessions: unknown[] = [], sessionsLoaded = true) => ({
+  id: "i1", name: "pc", online: true, lastSeenAt: null, sessions, sessionsLoaded, agents: [], workspaces: [],
 });
 
 describe("InstanceTree session management", () => {
@@ -63,11 +63,19 @@ describe("InstanceTree session management", () => {
     expect(w.find('[data-test="attention-dot"]').attributes("data-attention")).toBe("unread");
   });
 
-  it("shows an empty-state row for an instance with no sessions", () => {
+  it("shows an empty-state row only once sessions have loaded", () => {
     const store = useInstancesStore();
-    store.instances = [instance([])] as never;
+    store.instances = [instance([], true)] as never;
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
     expect(w.find('[data-test="no-sessions"]').exists()).toBe(true);
+  });
+
+  it("shows a loading row (not the empty state) before sessions have loaded", () => {
+    const store = useInstancesStore();
+    store.instances = [instance([], false)] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="sessions-loading"]').exists()).toBe(true);
+    expect(w.find('[data-test="no-sessions"]').exists()).toBe(false);
   });
 
   it("renders an elapsed badge for a working session", () => {

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -62,4 +62,29 @@ describe("InstanceTree session management", () => {
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
     expect(w.find('[data-test="attention-dot"]').attributes("data-attention")).toBe("unread");
   });
+
+  it("shows an empty-state row for an instance with no sessions", () => {
+    const store = useInstancesStore();
+    store.instances = [instance([])] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="no-sessions"]').exists()).toBe(true);
+  });
+
+  it("renders an elapsed badge for a working session", () => {
+    const instances = useInstancesStore();
+    instances.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    const chat = useChatStore();
+    chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const badge = w.find('[data-test="session-elapsed"]');
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toMatch(/^\d+[smh]$/);
+  });
+
+  it("shows no elapsed badge for an idle session", () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="session-elapsed"]').exists()).toBe(false);
+  });
 });

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -56,6 +56,16 @@ describe("MessageList", () => {
     });
     expect(wrapper.find('[data-test="msg-failed"]').exists()).toBe(true);
   });
+
+  it("offers a copy button on agent messages and hides jump-latest while pinned", () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [msg({ direction: "out", text: "copy me" })], streaming: "", liveTurn: null },
+    });
+    expect(wrapper.find('[data-test="copy-button"]').exists()).toBe(true);
+    // atBottom defaults true → the jump-latest affordance is hidden (v-show).
+    const jump = wrapper.find('[data-test="jump-latest"]');
+    expect(jump.exists() && jump.isVisible()).toBe(false);
+  });
 });
 
 it("renders persisted tool steps under a completed out message", () => {

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -1,0 +1,79 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import PromptInput from "../components/PromptInput.vue";
+import { suggestCommands } from "../lib/command-catalog";
+
+describe("suggestCommands", () => {
+  it("suggests by first-token prefix", () => {
+    expect(suggestCommands("/s").map((c) => c.name)).toContain("/session");
+    expect(suggestCommands("/s").map((c) => c.name)).toContain("/status");
+    expect(suggestCommands("/s").map((c) => c.name)).toContain("/ssn");
+  });
+  it("stops once an argument (space) begins", () => {
+    expect(suggestCommands("/session new")).toEqual([]);
+  });
+  it("returns [] for non-slash input and exact complete matches", () => {
+    expect(suggestCommands("hello")).toEqual([]);
+    expect(suggestCommands("/status")).toEqual([]); // exact, nothing left to suggest
+  });
+});
+
+describe("PromptInput composer", () => {
+  it("shows a suggestion popover for a slash prefix and Tab completes it", async () => {
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("/se");
+    expect(w.find('[data-test="cmd-suggestions"]').exists()).toBe(true);
+    expect(w.find('[data-test="cmd-suggestions"]').text()).toContain("/session");
+    await ta.trigger("keydown", { key: "Tab" });
+    expect((ta.element as HTMLTextAreaElement).value).toBe("/session ");
+    expect(w.find('[data-test="cmd-suggestions"]').exists()).toBe(false);
+  });
+
+  it("Esc dismisses the popover before anything else", async () => {
+    const w = mount(PromptInput);
+    await w.find("textarea").setValue("/se");
+    expect(w.find('[data-test="cmd-suggestions"]').exists()).toBe(true);
+    await w.find("textarea").trigger("keydown", { key: "Escape" });
+    expect(w.find('[data-test="cmd-suggestions"]').exists()).toBe(false);
+  });
+
+  it("Enter sends a plain message and records it in history for ↑ recall", async () => {
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("hello there");
+    await ta.trigger("keydown", { key: "Enter" });
+    expect(w.emitted("send")?.[0]).toEqual(["hello there"]);
+    expect((ta.element as HTMLTextAreaElement).value).toBe(""); // cleared
+    // Caret at start of an empty field → ArrowUp recalls the last sent line.
+    await ta.trigger("keydown", { key: "ArrowUp" });
+    expect((ta.element as HTMLTextAreaElement).value).toBe("hello there");
+  });
+
+  it("does not send while a suggestion is active (Enter accepts instead)", async () => {
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("/sta");
+    await ta.trigger("keydown", { key: "Enter" });
+    expect(w.emitted("send")).toBeFalsy();
+    expect((ta.element as HTMLTextAreaElement).value).toBe("/status ");
+  });
+
+  it("ignores Enter mid-IME-composition (CJK input)", async () => {
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("你好");
+    await ta.trigger("keydown", { key: "Enter", isComposing: true });
+    expect(w.emitted("send")).toBeFalsy(); // composition confirm, not submit
+  });
+
+  it("persists a per-session draft and restores it when the key returns", async () => {
+    sessionStorage.clear();
+    const w = mount(PromptInput, { props: { draftKey: "k1" } });
+    await w.find("textarea").setValue("half-typed");
+    await w.setProps({ draftKey: "k2" }); // switch session → draft stashed, k2 empty
+    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("");
+    await w.setProps({ draftKey: "k1" }); // back → restored
+    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("half-typed");
+  });
+});

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -1,7 +1,11 @@
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
 import PromptInput from "../components/PromptInput.vue";
 import { suggestCommands } from "../lib/command-catalog";
+
+// PromptInput now uses the composer store, which needs an active pinia.
+beforeEach(() => setActivePinia(createPinia()));
 
 describe("suggestCommands", () => {
   it("suggests by first-token prefix", () => {
@@ -75,5 +79,18 @@ describe("PromptInput composer", () => {
     expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("");
     await w.setProps({ draftKey: "k1" }); // back → restored
     expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("half-typed");
+  });
+
+  it("inserts text from a composer store request targeting this session", async () => {
+    const { useComposerStore } = await import("../stores/composer");
+    const composer = useComposerStore();
+    const w = mount(PromptInput, { props: { draftKey: "ins-key" } });
+    composer.requestInsert("ins-key", "/status");
+    await w.vm.$nextTick();
+    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("/status");
+    // a request for a different session is ignored
+    composer.requestInsert("other", "/help");
+    await w.vm.$nextTick();
+    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("/status");
   });
 });

--- a/packages/relay-web/src/__tests__/toolcallpanel.test.ts
+++ b/packages/relay-web/src/__tests__/toolcallpanel.test.ts
@@ -1,13 +1,18 @@
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import ToolCallPanel from "../components/ToolCallPanel.vue";
 import ReasoningPanel from "../components/ReasoningPanel.vue";
 import type { ToolStepDto } from "@ganglion/xacpx-relay-protocol";
+import { summarizeSteps } from "../lib/tool-summary";
+import { resetFue } from "../lib/use-fue";
 
 const steps: ToolStepDto[] = [
   { toolCallId: "t1", toolName: "Bash", kind: "execute", status: "success", title: "npm test", durationMs: 400, detail: { type: "command", command: "npm test", output: "passed" } },
   { toolCallId: "t2", toolName: "Read", kind: "read", status: "running", title: "a.ts" },
 ];
+
+const manySteps = (n: number): ToolStepDto[] =>
+  Array.from({ length: n }, (_, i) => ({ toolCallId: `t${i}`, toolName: "Read", kind: "read" as const, status: "success" as const, title: `f${i}.ts` }));
 
 describe("ToolCallPanel", () => {
   it("shows a count and one row per step", () => {
@@ -29,6 +34,52 @@ describe("ToolCallPanel", () => {
     expect(rows[0].text()).toContain("✅");
     expect(rows[1].text()).toContain("⏳");
   });
+
+  it("renders a kind/status summary in the header", () => {
+    const w = mount(ToolCallPanel, { props: { steps } });
+    const sum = w.find('[data-test="tool-summary"]').text();
+    expect(sum).toContain("💻1"); // one execute
+    expect(sum).toContain("📖1"); // one read
+    expect(sum).toContain("✅1"); // one success
+    expect(sum).toContain("⏳1"); // one running
+  });
+});
+
+describe("ToolCallPanel auto-collapse", () => {
+  beforeEach(() => resetFue("tool-group-collapse"));
+
+  it("collapses a many-step panel by default and expands on header click", async () => {
+    const w = mount(ToolCallPanel, { props: { steps: manySteps(8) } });
+    expect(w.findAll('[data-test="tool-row"]').length).toBe(0); // collapsed
+    expect(w.find('[data-test="fue-dot"]').exists()).toBe(true); // FUE nudge replaces the count
+    await w.find("button").trigger("click");
+    expect(w.findAll('[data-test="tool-row"]').length).toBe(8);
+  });
+
+  it("keeps a short panel expanded and shows the count (no FUE dot)", () => {
+    const w = mount(ToolCallPanel, { props: { steps } });
+    expect(w.findAll('[data-test="tool-row"]').length).toBe(2);
+    expect(w.find('[data-test="fue-dot"]').exists()).toBe(false);
+    expect(w.find('[data-test="tool-count"]').text()).toContain("2");
+  });
+});
+
+describe("summarizeSteps", () => {
+  it("counts by kind and status in stable order", () => {
+    const sum = summarizeSteps(steps);
+    expect(sum.kinds).toEqual([
+      { icon: "📖", count: 1 },
+      { icon: "💻", count: 1 },
+    ]);
+    expect(sum.statuses).toEqual([
+      { icon: "⏳", count: 1 },
+      { icon: "✅", count: 1 },
+    ]);
+  });
+
+  it("aggregates repeated kinds", () => {
+    expect(summarizeSteps(manySteps(4)).kinds).toEqual([{ icon: "📖", count: 4 }]);
+  });
 });
 
 describe("ReasoningPanel", () => {
@@ -36,5 +87,21 @@ describe("ReasoningPanel", () => {
     const w = mount(ReasoningPanel, { props: { reasoning: "step by step" } });
     expect(w.text()).toContain("Reasoning");
     expect(w.find('[data-test="reasoning-body"]').text()).toContain("step by step");
+  });
+
+  it("shows a shimmer and stays open while streaming", () => {
+    const w = mount(ReasoningPanel, { props: { reasoning: "thinking", streaming: true, defaultOpen: false } });
+    expect(w.find('[data-test="reasoning-shimmer"]').exists()).toBe(true);
+    expect(w.text()).toContain("Reasoning…");
+    // Forced open despite defaultOpen=false.
+    expect(w.find('[data-test="reasoning-body"]').exists()).toBe(true);
+  });
+
+  it("respects defaultOpen and the toggle when not streaming", async () => {
+    const w = mount(ReasoningPanel, { props: { reasoning: "done", defaultOpen: false } });
+    expect(w.find('[data-test="reasoning-shimmer"]').exists()).toBe(false);
+    expect(w.find('[data-test="reasoning-body"]').exists()).toBe(false);
+    await w.find("button").trigger("click");
+    expect(w.find('[data-test="reasoning-body"]').exists()).toBe(true);
   });
 });

--- a/packages/relay-web/src/__tests__/tooldetail.test.ts
+++ b/packages/relay-web/src/__tests__/tooldetail.test.ts
@@ -14,6 +14,13 @@ describe("ToolDetail", () => {
     expect(w.find('[data-test="diff-add"]').text()).toContain("const a = 2");
   });
 
+  it("shows +N/−N stat badges for a diff", () => {
+    const w = render({ type: "diff", path: "src/x.ts", oldText: "a\nb", newText: "a\nb\nc\nd" });
+    const stats = w.find('[data-test="diff-stats"]').text();
+    expect(stats).toContain("+4"); // 4 non-empty added lines
+    expect(stats).toContain("−2"); // 2 non-empty removed lines
+  });
+
   it("renders a command with a terminal output block and exit code", () => {
     const w = render({ type: "command", command: "npm test", output: "12 passed", exitCode: 0 });
     expect(w.find('[data-test="cmd-command"]').text()).toContain("npm test");

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -1,10 +1,22 @@
 <script setup lang="ts">
 import { computed, onUnmounted, ref } from "vue";
 import { useChatStore } from "../stores/chat";
+import { useInstancesStore } from "../stores/instances";
 import MessageList from "./MessageList.vue";
 import PromptInput from "./PromptInput.vue";
 
+const emit = defineEmits<{ (e: "show-files"): void }>();
+
 const chat = useChatStore();
+const instances = useInstancesStore();
+
+// Context for the header chips: the current session's workspace/agent plus the
+// instance name. Branch is intentionally absent — the protocol carries no git
+// branch yet (deferred to the read-only git summary batch).
+const instance = computed(() => (chat.instanceId ? instances.byId(chat.instanceId) : undefined));
+const currentSession = computed(() =>
+  instance.value?.sessions.find((s) => s.alias === chat.sessionAlias),
+);
 
 // Live elapsed clock for the active turn HUD.
 const nowMs = ref(Date.now());
@@ -39,7 +51,16 @@ const verb = computed(() => {
       Select a session
     </div>
     <template v-else>
-      <div class="border-b px-4 py-2 text-sm font-medium">{{ chat.sessionAlias }}</div>
+      <div class="border-b px-4 py-2">
+        <div class="text-sm font-medium">{{ chat.sessionAlias }}</div>
+        <div v-if="currentSession || instance" class="mt-1 flex flex-wrap items-center gap-1 text-xs text-slate-500">
+          <button v-if="currentSession?.workspace" data-test="ctx-chip-workspace"
+                  class="rounded bg-slate-100 px-1.5 py-0.5 hover:bg-slate-200" title="Browse files"
+                  @click="emit('show-files')">📁 {{ currentSession.workspace }}</button>
+          <span v-if="instance?.name" data-test="ctx-chip-instance" class="rounded bg-slate-100 px-1.5 py-0.5">@ {{ instance.name }}</span>
+          <span v-if="currentSession?.agent" data-test="ctx-chip-agent" class="rounded bg-slate-100 px-1.5 py-0.5">🤖 {{ currentSession.agent }}</span>
+        </div>
+      </div>
       <div v-if="chat.error" data-test="chat-error" class="bg-red-50 px-4 py-1 text-xs text-red-700">
         {{ chat.error }}
         <button class="ml-2 underline" @click="chat.error = ''">dismiss</button>

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -17,6 +17,20 @@ const elapsed = computed(() => {
   return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
 });
 const runningTools = computed(() => chat.liveTurn?.toolSteps.filter((t) => t.status === "running").length ?? 0);
+
+// Whimsical near-synonyms cycled through while a turn runs (à la Claude Code / HAPI's
+// "vibing messages"). Purely cosmetic; reuses the 1Hz clock, rotating every ~4s on a
+// calm interval rather than re-rolling every frame. "Working" stays first for t≈0.
+const VERBS = [
+  "Working", "Thinking", "Pondering", "Cogitating", "Reasoning", "Computing",
+  "Churning", "Crunching", "Percolating", "Noodling", "Mulling", "Brewing",
+  "Processing", "Deliberating", "Ruminating", "Synthesizing", "Wrangling", "Tinkering",
+];
+const verb = computed(() => {
+  if (!chat.liveTurn) return VERBS[0];
+  const s = Math.max(0, Math.floor((nowMs.value - chat.liveTurn.startedAt) / 1000));
+  return VERBS[Math.floor(s / 4) % VERBS.length];
+});
 </script>
 
 <template>
@@ -33,11 +47,11 @@ const runningTools = computed(() => chat.liveTurn?.toolSteps.filter((t) => t.sta
       <MessageList :messages="chat.messages" :streaming="chat.streaming" :live-turn="chat.liveTurn" />
       <div v-if="chat.busy" data-test="turn-hud" class="flex items-center gap-2 px-4 py-1 text-xs text-slate-500">
         <span class="animate-pulse">●</span>
-        <span>Working… {{ elapsed }}</span>
+        <span>{{ verb }}… {{ elapsed }}</span>
         <span v-if="runningTools > 0">· 🔧 {{ runningTools }}</span>
         <button data-test="cancel-turn" class="ml-auto text-red-500 hover:underline" @click="chat.cancel">Cancel</button>
       </div>
-      <PromptInput :busy="chat.busy" @send="chat.send" />
+      <PromptInput :busy="chat.busy" :draft-key="`${chat.instanceId}\0${chat.sessionAlias}`" @send="chat.send" @cancel="chat.cancel" />
     </template>
   </div>
 </template>

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, onUnmounted, ref } from "vue";
+import { computed, onUnmounted, ref, watch } from "vue";
 import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
+import { useFilesStore } from "../stores/files";
 import MessageList from "./MessageList.vue";
 import PromptInput from "./PromptInput.vue";
 
@@ -9,13 +10,25 @@ const emit = defineEmits<{ (e: "show-files"): void }>();
 
 const chat = useChatStore();
 const instances = useInstancesStore();
+const files = useFilesStore();
 
 // Context for the header chips: the current session's workspace/agent plus the
-// instance name. Branch is intentionally absent — the protocol carries no git
-// branch yet (deferred to the read-only git summary batch).
+// instance name. Branch comes from the read-only git summary (undefined until the
+// backend ever adds it to the diff result).
 const instance = computed(() => (chat.instanceId ? instances.byId(chat.instanceId) : undefined));
 const currentSession = computed(() =>
   instance.value?.sessions.find((s) => s.alias === chat.sessionAlias),
+);
+
+// Keep a read-only git summary loaded for the current session's workspace so the
+// header chip reflects changes without the user opening the Files panel first.
+watch(
+  () => [chat.instanceId, currentSession.value?.workspace] as const,
+  ([id, ws]) => {
+    if (id && ws) void files.loadGitSummary(id, ws);
+    else files.gitSummary = null;
+  },
+  { immediate: true },
 );
 
 // Live elapsed clock for the active turn HUD.
@@ -59,6 +72,13 @@ const verb = computed(() => {
                   @click="emit('show-files')">📁 {{ currentSession.workspace }}</button>
           <span v-if="instance?.name" data-test="ctx-chip-instance" class="rounded bg-slate-100 px-1.5 py-0.5">@ {{ instance.name }}</span>
           <span v-if="currentSession?.agent" data-test="ctx-chip-agent" class="rounded bg-slate-100 px-1.5 py-0.5">🤖 {{ currentSession.agent }}</span>
+          <button v-if="files.gitSummary" data-test="git-summary"
+                  class="rounded bg-slate-100 px-1.5 py-0.5 hover:bg-slate-200" title="View changes"
+                  @click="files.tab = 'changes'; emit('show-files')">
+            <span class="text-sky-500">●</span>
+            <span v-if="files.gitSummary.branch"> {{ files.gitSummary.branch }} ·</span>
+            {{ files.gitSummary.changedCount }} changed
+          </button>
         </div>
       </div>
       <div v-if="chat.error" data-test="chat-error" class="bg-red-50 px-4 py-1 text-xs text-red-700">

--- a/packages/relay-web/src/components/CommandPalette.vue
+++ b/packages/relay-web/src/components/CommandPalette.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref } from "vue";
+import { useInstancesStore } from "../stores/instances";
+import { COMMAND_CATALOG } from "../lib/command-catalog";
+
+const emit = defineEmits<{
+  close: [];
+  "select-session": [instanceId: string, alias: string];
+  "pick-command": [name: string];
+}>();
+
+const instances = useInstancesStore();
+const query = ref("");
+const input = ref<HTMLInputElement | null>(null);
+const active = ref(0);
+
+interface Row {
+  kind: "session" | "command";
+  label: string;
+  sub: string;
+  instanceId?: string;
+  alias?: string;
+  name?: string;
+}
+
+// All sessions across instances, flattened to palette rows.
+const sessionRows = computed<Row[]>(() =>
+  instances.instances.flatMap((inst) =>
+    inst.sessions.map((s) => ({
+      kind: "session" as const,
+      label: s.alias,
+      sub: `${inst.name} · ${s.agent}`,
+      instanceId: inst.id,
+      alias: s.alias,
+    })),
+  ),
+);
+
+const commandRows = computed<Row[]>(() =>
+  COMMAND_CATALOG.map((c) => ({ kind: "command" as const, label: c.name, sub: c.hint, name: c.name })),
+);
+
+function matches(row: Row, q: string): boolean {
+  if (!q) return true;
+  const hay = `${row.label} ${row.sub}`.toLowerCase();
+  return hay.includes(q.toLowerCase());
+}
+
+// Combined, filtered, sessions first (navigation is the primary use).
+const rows = computed<Row[]>(() => {
+  const q = query.value.trim();
+  return [...sessionRows.value, ...commandRows.value].filter((r) => matches(r, q));
+});
+
+function clampActive() {
+  if (active.value >= rows.value.length) active.value = Math.max(0, rows.value.length - 1);
+}
+
+function choose(row: Row) {
+  if (row.kind === "session" && row.instanceId && row.alias) emit("select-session", row.instanceId, row.alias);
+  else if (row.kind === "command" && row.name) emit("pick-command", row.name);
+  emit("close");
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape") { emit("close"); return; }
+  if (e.key === "ArrowDown") { e.preventDefault(); active.value = Math.min(active.value + 1, rows.value.length - 1); }
+  else if (e.key === "ArrowUp") { e.preventDefault(); active.value = Math.max(active.value - 1, 0); }
+  else if (e.key === "Enter") { e.preventDefault(); const r = rows.value[active.value]; if (r) choose(r); }
+}
+
+onMounted(() => void nextTick(() => input.value?.focus()));
+</script>
+
+<template>
+  <div class="fixed inset-0 z-50 flex items-start justify-center bg-black/30 pt-24" data-test="command-palette" @click.self="emit('close')">
+    <div class="w-full max-w-lg overflow-hidden rounded-lg bg-white shadow-xl">
+      <input ref="input" v-model="query" data-test="palette-input"
+             placeholder="Jump to a session or pick a command…"
+             class="w-full border-b px-4 py-3 text-sm outline-none"
+             @input="active = 0; clampActive()" @keydown="onKeydown" />
+      <ul class="max-h-80 overflow-y-auto py-1 text-sm">
+        <li v-for="(r, i) in rows" :key="`${r.kind}:${r.label}:${i}`">
+          <button data-test="palette-row" class="flex w-full items-center gap-2 px-4 py-1.5 text-left"
+                  :class="i === active ? 'bg-sky-50' : 'hover:bg-slate-50'"
+                  @mouseenter="active = i" @click="choose(r)">
+            <span>{{ r.kind === "session" ? "💬" : "⌘" }}</span>
+            <span class="font-medium text-slate-700">{{ r.label }}</span>
+            <span class="truncate text-xs text-slate-400">{{ r.sub }}</span>
+          </button>
+        </li>
+        <li v-if="!rows.length" class="px-4 py-3 text-xs text-slate-400">no matches</li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/packages/relay-web/src/components/CopyButton.vue
+++ b/packages/relay-web/src/components/CopyButton.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const props = defineProps<{ text: string }>();
+const copied = ref(false);
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+async function copy(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(props.text);
+  } catch {
+    // Fallback for insecure contexts / older engines.
+    const ta = document.createElement("textarea");
+    ta.value = props.text;
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      document.execCommand("copy");
+    } catch {
+      /* give up silently */
+    }
+    document.body.removeChild(ta);
+  }
+  copied.value = true;
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => (copied.value = false), 1200);
+}
+</script>
+
+<template>
+  <button
+    data-test="copy-button"
+    type="button"
+    :title="copied ? 'Copied' : 'Copy'"
+    class="rounded p-1 text-xs leading-none text-slate-400 hover:bg-slate-200 hover:text-slate-600"
+    @click.stop="copy"
+  >
+    {{ copied ? "✓" : "⧉" }}
+  </button>
+</template>

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useFilesStore } from "../stores/files";
 import { useInstancesStore } from "../stores/instances";
 
@@ -9,6 +9,18 @@ const instances = useInstancesStore();
 
 const workspaces = computed(() => (props.instanceId ? instances.byId(props.instanceId)?.workspaces ?? [] : []));
 const crumbs = computed(() => (files.path ? files.path.split("/") : []));
+
+// Debounced file-name search.
+const searchInput = ref("");
+let searchTimer: ReturnType<typeof setTimeout> | null = null;
+function onSearchInput() {
+  if (searchTimer) clearTimeout(searchTimer);
+  searchTimer = setTimeout(() => void files.search(searchInput.value), 250);
+}
+function clearSearch() {
+  searchInput.value = "";
+  void files.search("");
+}
 
 // Format a byte size compactly.
 function fmtSize(n?: number): string {
@@ -31,6 +43,7 @@ watch(
   () => props.instanceId,
   async (id) => {
     files.reset();
+    searchInput.value = "";
     if (!id) return;
     files.instanceId = id;
     await instances.loadWorkspaces(id).catch(() => {});
@@ -49,6 +62,7 @@ watch(
 
 function onWorkspaceChange(e: Event) {
   const name = (e.target as HTMLSelectElement).value;
+  searchInput.value = "";
   if (props.instanceId) void files.selectWorkspace(props.instanceId, name);
 }
 </script>
@@ -74,8 +88,29 @@ function onWorkspaceChange(e: Event) {
 
       <!-- Files tab -->
       <div v-if="files.tab === 'files'" class="min-h-0 flex-1 overflow-y-auto">
-        <!-- breadcrumb -->
-        <div class="flex flex-wrap items-center gap-1 border-b px-2 py-1 text-xs text-slate-500">
+        <!-- search -->
+        <div class="flex items-center gap-1 border-b px-2 py-1">
+          <input v-model="searchInput" data-test="fs-search" placeholder="Search files by name…"
+                 class="min-w-0 flex-1 rounded border px-2 py-1 text-xs" @input="onSearchInput" />
+          <button v-if="searchInput" class="text-xs text-slate-400 hover:text-slate-700" @click="clearSearch">✕</button>
+        </div>
+
+        <!-- search results -->
+        <div v-if="files.query.trim()" data-test="fs-results">
+          <ul>
+            <li v-for="m in files.results" :key="m">
+              <button data-test="fs-result" class="flex w-full items-center gap-2 px-3 py-1 text-left hover:bg-slate-50" @click="files.openFile(m)">
+                <span>📄</span><span class="truncate font-mono text-xs text-slate-600">{{ m }}</span>
+              </button>
+            </li>
+            <li v-if="!files.results.length && !files.searching" class="px-3 py-2 text-xs text-slate-400">no matches</li>
+          </ul>
+          <div v-if="files.searchTruncated" class="px-3 py-1 text-xs text-amber-600">showing first 200 matches</div>
+          <div v-if="files.file" class="border-t" />
+        </div>
+
+        <!-- breadcrumb (hidden while searching) -->
+        <div v-if="!files.query.trim()" class="flex flex-wrap items-center gap-1 border-b px-2 py-1 text-xs text-slate-500">
           <button class="hover:underline" @click="files.up(-1)">{{ files.workspace ?? "root" }}</button>
           <template v-for="(c, i) in crumbs" :key="i">
             <span>/</span><button class="hover:underline" @click="files.up(i)">{{ c }}</button>
@@ -96,7 +131,7 @@ function onWorkspaceChange(e: Event) {
         </div>
 
         <!-- directory listing -->
-        <ul v-else>
+        <ul v-else-if="!files.query.trim()">
           <li v-for="e in files.entries" :key="e.name">
             <button data-test="fs-entry" class="flex w-full items-center gap-2 px-3 py-1 text-left hover:bg-slate-50" @click="files.open(e)">
               <span>{{ e.type === "dir" ? "📁" : "📄" }}</span>
@@ -111,10 +146,17 @@ function onWorkspaceChange(e: Event) {
       <!-- Changes (git diff) tab -->
       <div v-else class="min-h-0 flex-1 overflow-y-auto">
         <div v-if="files.diff">
+          <div v-if="files.diffPath" class="flex items-center gap-2 border-b bg-sky-50 px-3 py-1 text-xs">
+            <span class="truncate font-mono text-slate-700">{{ files.diffPath }}</span>
+            <button data-test="diff-all" class="ml-auto text-sky-600 hover:underline" @click="files.loadDiff()">← all files</button>
+          </div>
           <ul class="border-b text-xs">
-            <li v-for="f in files.diff.files" :key="f.path" data-test="diff-file" class="flex items-center gap-2 px-3 py-1">
-              <span class="w-6 font-mono text-slate-400">{{ f.status.trim() || "··" }}</span>
-              <span class="truncate font-mono text-slate-700">{{ f.path }}</span>
+            <li v-for="f in files.diff.files" :key="f.path">
+              <button data-test="diff-file" class="flex w-full items-center gap-2 px-3 py-1 text-left hover:bg-slate-50"
+                      :class="files.diffPath === f.path ? 'bg-sky-50' : ''" @click="files.loadDiff(f.path)">
+                <span class="w-6 font-mono text-slate-400">{{ f.status.trim() || "··" }}</span>
+                <span class="truncate font-mono text-slate-700">{{ f.path }}</span>
+              </button>
             </li>
             <li v-if="!files.diff.files.length" class="px-3 py-2 text-slate-400">no changes</li>
           </ul>

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -39,6 +39,29 @@ function fmtSize(n?: number): string {
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
   return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
+// Git-status badge for a directory entry, derived from the quietly-loaded status map.
+// Files show their own porcelain code; directories show a dot if they contain changes.
+function entryRel(name: string): string {
+  return files.path ? `${files.path}/${name}` : name;
+}
+function statusBadge(code: string): { label: string; cls: string } {
+  const c = code.trim();
+  if (c.includes("?")) return { label: "U", cls: "text-amber-600" }; // untracked
+  if (c.includes("A")) return { label: "A", cls: "text-green-600" };
+  if (c.includes("D")) return { label: "D", cls: "text-red-600" };
+  if (c.includes("R")) return { label: "R", cls: "text-violet-600" };
+  if (c.includes("M")) return { label: "M", cls: "text-sky-600" };
+  return { label: c[0] ?? "•", cls: "text-slate-500" };
+}
+function entryStatus(e: { name: string; type: string }): { label: string; cls: string } | null {
+  const rel = entryRel(e.name);
+  if (e.type === "file") {
+    const code = files.changed[rel];
+    return code ? statusBadge(code) : null;
+  }
+  const prefix = `${rel}/`;
+  return Object.keys(files.changed).some((p) => p.startsWith(prefix)) ? { label: "•", cls: "text-sky-500" } : null;
+}
 function diffLineClass(line: string): string {
   if (line.startsWith("+") && !line.startsWith("+++")) return "text-green-600";
   if (line.startsWith("-") && !line.startsWith("---")) return "text-red-600";
@@ -154,7 +177,9 @@ function onWorkspaceChange(e: Event) {
             <button data-test="fs-entry" class="flex w-full items-center gap-2 px-3 py-1 text-left hover:bg-slate-50" @click="files.open(e)">
               <span>{{ e.type === "dir" ? "📁" : "📄" }}</span>
               <span class="truncate" :class="e.type === 'dir' ? 'text-slate-700' : 'text-slate-600'">{{ e.name }}</span>
-              <span v-if="e.type === 'file'" class="ml-auto text-xs text-slate-400">{{ fmtSize(e.size) }}</span>
+              <span v-if="entryStatus(e)" data-test="fs-status" class="ml-auto w-4 text-center font-mono text-xs font-bold" :class="entryStatus(e)!.cls"
+                    :title="files.changed[entryRel(e.name)] || 'contains changes'">{{ entryStatus(e)!.label }}</span>
+              <span v-if="e.type === 'file'" class="text-xs text-slate-400" :class="entryStatus(e) ? 'ml-1' : 'ml-auto'">{{ fmtSize(e.size) }}</span>
             </button>
           </li>
           <li v-if="!files.entries.length && !files.loading" class="px-3 py-2 text-xs text-slate-400">empty directory</li>

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed, watch } from "vue";
+import { useFilesStore } from "../stores/files";
+import { useInstancesStore } from "../stores/instances";
+
+const props = defineProps<{ instanceId: string | null }>();
+const files = useFilesStore();
+const instances = useInstancesStore();
+
+const workspaces = computed(() => (props.instanceId ? instances.byId(props.instanceId)?.workspaces ?? [] : []));
+const crumbs = computed(() => (files.path ? files.path.split("/") : []));
+
+// Format a byte size compactly.
+function fmtSize(n?: number): string {
+  if (n === undefined) return "";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+function diffLineClass(line: string): string {
+  if (line.startsWith("+") && !line.startsWith("+++")) return "text-green-600";
+  if (line.startsWith("-") && !line.startsWith("---")) return "text-red-600";
+  if (line.startsWith("@@")) return "text-sky-600";
+  if (line.startsWith("diff ") || line.startsWith("index ")) return "text-slate-400";
+  return "text-slate-600";
+}
+
+// When the selected instance changes, reset and load its workspaces, auto-selecting
+// the first so the panel is immediately useful.
+watch(
+  () => props.instanceId,
+  async (id) => {
+    files.reset();
+    if (!id) return;
+    files.instanceId = id;
+    await instances.loadWorkspaces(id).catch(() => {});
+    const first = instances.byId(id)?.workspaces?.[0];
+    if (first) void files.selectWorkspace(id, first.name);
+  },
+  { immediate: true },
+);
+
+watch(
+  () => files.tab,
+  (t) => {
+    if (t === "changes" && !files.diff) void files.loadDiff();
+  },
+);
+
+function onWorkspaceChange(e: Event) {
+  const name = (e.target as HTMLSelectElement).value;
+  if (props.instanceId) void files.selectWorkspace(props.instanceId, name);
+}
+</script>
+
+<template>
+  <div class="flex h-full flex-col text-sm">
+    <div v-if="!instanceId" class="flex flex-1 items-center justify-center p-4 text-center text-xs text-slate-400">
+      Select a session to browse its workspace
+    </div>
+    <template v-else>
+      <div class="flex items-center gap-2 border-b p-2">
+        <select data-test="ws-select" class="min-w-0 flex-1 rounded border px-2 py-1 text-xs" :value="files.workspace ?? ''" @change="onWorkspaceChange">
+          <option v-if="!workspaces.length" value="">no workspaces</option>
+          <option v-for="w in workspaces" :key="w.name" :value="w.name">{{ w.name }}</option>
+        </select>
+        <div class="flex shrink-0 overflow-hidden rounded border text-xs">
+          <button data-test="tab-files" class="px-2 py-1" :class="files.tab === 'files' ? 'bg-sky-500 text-white' : 'text-slate-500'" @click="files.tab = 'files'">Files</button>
+          <button data-test="tab-changes" class="px-2 py-1" :class="files.tab === 'changes' ? 'bg-sky-500 text-white' : 'text-slate-500'" @click="files.tab = 'changes'">Changes</button>
+        </div>
+      </div>
+
+      <div v-if="files.error" data-test="files-error" class="bg-red-50 px-2 py-1 text-xs text-red-700">{{ files.error }}</div>
+
+      <!-- Files tab -->
+      <div v-if="files.tab === 'files'" class="min-h-0 flex-1 overflow-y-auto">
+        <!-- breadcrumb -->
+        <div class="flex flex-wrap items-center gap-1 border-b px-2 py-1 text-xs text-slate-500">
+          <button class="hover:underline" @click="files.up(-1)">{{ files.workspace ?? "root" }}</button>
+          <template v-for="(c, i) in crumbs" :key="i">
+            <span>/</span><button class="hover:underline" @click="files.up(i)">{{ c }}</button>
+          </template>
+        </div>
+
+        <!-- file viewer -->
+        <div v-if="files.file" data-test="file-viewer">
+          <div class="flex items-center gap-2 border-b bg-slate-50 px-2 py-1 text-xs">
+            <span class="truncate font-mono text-slate-700">{{ files.file.path }}</span>
+            <span class="text-slate-400">{{ fmtSize(files.file.size) }}</span>
+            <span v-if="files.file.truncated" class="rounded bg-amber-100 px-1 text-amber-700">truncated</span>
+            <span v-if="files.file.binary" class="rounded bg-slate-200 px-1 text-slate-600">binary</span>
+            <button class="ml-auto text-slate-400 hover:text-slate-700" @click="files.file = null">✕</button>
+          </div>
+          <pre v-if="!files.file.binary" class="overflow-x-auto p-2 font-mono text-xs leading-snug text-slate-700 whitespace-pre">{{ files.file.content }}</pre>
+          <div v-else class="p-3 text-xs text-slate-400">Binary file not shown.</div>
+        </div>
+
+        <!-- directory listing -->
+        <ul v-else>
+          <li v-for="e in files.entries" :key="e.name">
+            <button data-test="fs-entry" class="flex w-full items-center gap-2 px-3 py-1 text-left hover:bg-slate-50" @click="files.open(e)">
+              <span>{{ e.type === "dir" ? "📁" : "📄" }}</span>
+              <span class="truncate" :class="e.type === 'dir' ? 'text-slate-700' : 'text-slate-600'">{{ e.name }}</span>
+              <span v-if="e.type === 'file'" class="ml-auto text-xs text-slate-400">{{ fmtSize(e.size) }}</span>
+            </button>
+          </li>
+          <li v-if="!files.entries.length && !files.loading" class="px-3 py-2 text-xs text-slate-400">empty directory</li>
+        </ul>
+      </div>
+
+      <!-- Changes (git diff) tab -->
+      <div v-else class="min-h-0 flex-1 overflow-y-auto">
+        <div v-if="files.diff">
+          <ul class="border-b text-xs">
+            <li v-for="f in files.diff.files" :key="f.path" data-test="diff-file" class="flex items-center gap-2 px-3 py-1">
+              <span class="w-6 font-mono text-slate-400">{{ f.status.trim() || "··" }}</span>
+              <span class="truncate font-mono text-slate-700">{{ f.path }}</span>
+            </li>
+            <li v-if="!files.diff.files.length" class="px-3 py-2 text-slate-400">no changes</li>
+          </ul>
+          <pre v-if="files.diff.diff" data-test="diff-body" class="overflow-x-auto p-2 font-mono text-xs leading-snug whitespace-pre"><span v-for="(l, i) in files.diff.diff.split('\n')" :key="i" class="block" :class="diffLineClass(l)">{{ l }}</span></pre>
+          <div v-if="files.diff.truncated" class="px-3 py-1 text-xs text-amber-600">diff truncated</div>
+        </div>
+        <div v-else-if="!files.loading" class="p-3 text-xs text-slate-400">no diff loaded</div>
+      </div>
+
+      <div v-if="files.loading" class="border-t px-3 py-1 text-xs text-slate-400">loading…</div>
+    </template>
+  </div>
+</template>

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from "vue";
 import { useFilesStore } from "../stores/files";
 import { useInstancesStore } from "../stores/instances";
+import CopyButton from "./CopyButton.vue";
 
 const props = defineProps<{ instanceId: string | null }>();
 const files = useFilesStore();
@@ -9,6 +10,15 @@ const instances = useInstancesStore();
 
 const workspaces = computed(() => (props.instanceId ? instances.byId(props.instanceId)?.workspaces ?? [] : []));
 const crumbs = computed(() => (files.path ? files.path.split("/") : []));
+
+// Line-numbered gutter for the file viewer. Above this many lines we fall back to a
+// plain <pre> so we don't emit tens of thousands of DOM nodes for a large file.
+const LINE_GUTTER_LIMIT = 5000;
+const fileLines = computed(() => {
+  const f = files.file;
+  if (!f || f.binary) return [];
+  return f.content.split("\n");
+});
 
 // Debounced file-name search.
 const searchInput = ref("");
@@ -124,9 +134,17 @@ function onWorkspaceChange(e: Event) {
             <span class="text-slate-400">{{ fmtSize(files.file.size) }}</span>
             <span v-if="files.file.truncated" class="rounded bg-amber-100 px-1 text-amber-700">truncated</span>
             <span v-if="files.file.binary" class="rounded bg-slate-200 px-1 text-slate-600">binary</span>
-            <button class="ml-auto text-slate-400 hover:text-slate-700" @click="files.file = null">✕</button>
+            <CopyButton v-if="!files.file.binary" :text="files.file.content" class="ml-auto" />
+            <button class="text-slate-400 hover:text-slate-700" @click="files.file = null">✕</button>
           </div>
-          <pre v-if="!files.file.binary" class="overflow-x-auto p-2 font-mono text-xs leading-snug text-slate-700 whitespace-pre">{{ files.file.content }}</pre>
+          <!-- numbered gutter for reasonable files; plain <pre> as a fallback for huge ones -->
+          <div v-if="!files.file.binary && fileLines.length <= LINE_GUTTER_LIMIT" data-test="file-body" class="overflow-x-auto font-mono text-xs leading-snug">
+            <div v-for="(l, i) in fileLines" :key="i" data-test="file-line" class="flex">
+              <span class="sticky left-0 w-12 shrink-0 select-none border-r bg-slate-50 px-2 text-right text-slate-300 tabular-nums">{{ i + 1 }}</span>
+              <span class="whitespace-pre px-3 text-slate-700">{{ l || " " }}</span>
+            </div>
+          </div>
+          <pre v-else-if="!files.file.binary" class="overflow-x-auto p-2 font-mono text-xs leading-snug text-slate-700 whitespace-pre">{{ files.file.content }}</pre>
           <div v-else class="p-3 text-xs text-slate-400">Binary file not shown.</div>
         </div>
 

--- a/packages/relay-web/src/components/FueCallout.vue
+++ b/packages/relay-web/src/components/FueCallout.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import { computeCalloutPlacement, type Rect } from "../lib/fue-placement";
+
+const props = defineProps<{ title: string; body: string; anchor?: Rect | null }>();
+const emit = defineEmits<{ dismiss: [] }>();
+
+const card = ref<HTMLElement | null>(null);
+const style = ref<Record<string, string>>({ visibility: "hidden" });
+
+function reposition(): void {
+  const el = card.value;
+  if (!el) return;
+  const size = { width: el.offsetWidth || 256, height: el.offsetHeight || 96 };
+  const viewport = { width: window.innerWidth, height: window.innerHeight };
+  if (props.anchor) {
+    const p = computeCalloutPlacement(props.anchor, size, viewport);
+    style.value = { top: `${p.top}px`, left: `${p.left}px`, visibility: "visible" };
+  } else {
+    // No anchor — center in the viewport as a fallback.
+    style.value = {
+      top: `${Math.max(8, viewport.height / 2 - size.height / 2)}px`,
+      left: `${Math.max(8, viewport.width / 2 - size.width / 2)}px`,
+      visibility: "visible",
+    };
+  }
+}
+
+function onKey(e: KeyboardEvent): void {
+  if (e.key === "Escape") emit("dismiss");
+}
+
+onMounted(() => {
+  reposition();
+  window.addEventListener("keydown", onKey);
+  window.addEventListener("resize", reposition);
+});
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onKey);
+  window.removeEventListener("resize", reposition);
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      ref="card"
+      data-test="fue-callout"
+      class="fixed z-50 w-64 rounded-lg border border-slate-200 bg-white p-3 text-sm shadow-lg"
+      :style="style"
+      role="dialog"
+    >
+      <p class="font-medium text-slate-800">{{ title }}</p>
+      <p class="mt-1 text-xs text-slate-500">{{ body }}</p>
+      <div class="mt-2 flex justify-end">
+        <button
+          data-test="fue-dismiss"
+          type="button"
+          class="rounded bg-sky-500 px-2 py-1 text-xs font-medium text-white hover:bg-sky-600"
+          @click="emit('dismiss')"
+        >
+          Got it
+        </button>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/packages/relay-web/src/components/FueDot.vue
+++ b/packages/relay-web/src/components/FueDot.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+// A small onboarding badge that sits on a `position:relative` affordance. Pulses
+// while the feature is unseen, then settles to a static dot once the user engages.
+withDefaults(defineProps<{ pulsing?: boolean }>(), { pulsing: true });
+</script>
+
+<template>
+  <span
+    data-test="fue-dot"
+    class="inline-block h-2 w-2 rounded-full bg-sky-500"
+    :class="pulsing ? 'animate-pulse' : ''"
+    aria-hidden="true"
+  />
+</template>

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -56,7 +56,10 @@ function remove(id: string, alias: string) {
           </button>
           <button data-test="delete-session" class="text-xs text-red-400 hover:underline" @click.stop="remove(inst.id, s.alias)">delete</button>
         </li>
-        <li v-if="!inst.sessions.length" data-test="no-sessions" class="px-6 py-1 text-xs text-slate-400">no sessions yet</li>
+        <li v-if="inst.online && !inst.sessionsLoaded && !inst.sessions.length" data-test="sessions-loading"
+            class="px-6 py-1 text-xs text-slate-400">loading…</li>
+        <li v-else-if="inst.sessionsLoaded && !inst.sessions.length" data-test="no-sessions"
+            class="px-6 py-1 text-xs text-slate-400">no sessions yet</li>
       </ul>
       <div class="flex items-center gap-3 px-6 py-1.5">
         <button data-test="new-session" class="text-left text-xs font-medium text-slate-500 hover:text-slate-800"

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { onUnmounted, ref } from "vue";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import NewSessionDialog from "./NewSessionDialog.vue";
@@ -10,6 +10,21 @@ const chat = useChatStore();
 const emit = defineEmits<{ select: [instanceId: string, alias: string] }>();
 const dialogFor = ref<{ id: string; name: string } | null>(null);
 const manageFor = ref<{ id: string; name: string } | null>(null);
+
+// 1Hz clock so working-session elapsed badges tick.
+const nowMs = ref(Date.now());
+const timer = setInterval(() => { nowMs.value = Date.now(); }, 1000);
+onUnmounted(() => clearInterval(timer));
+
+// Compact elapsed label (e.g. "12s", "3m", "1h") for a working session, or "".
+function elapsedLabel(instanceId: string, alias: string): string {
+  const since = chat.runningSince(instanceId, alias);
+  if (since === null) return "";
+  const s = Math.max(0, Math.floor((nowMs.value - since) / 1000));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  return `${Math.floor(s / 3600)}h`;
+}
 
 async function toggle(id: string) {
   await store.loadSessions(id).catch(() => {});
@@ -36,9 +51,12 @@ function remove(id: string, alias: string) {
                   class="text-sky-500">●</span>
             <span v-else-if="s.running" data-test="attention-dot" data-attention="running" class="text-amber-500">●</span>
             {{ s.alias }} <span class="text-slate-400">({{ s.agent }})</span>
+            <span v-if="elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
+                  class="ml-auto tabular-nums text-xs text-amber-500">{{ elapsedLabel(inst.id, s.alias) }}</span>
           </button>
           <button data-test="delete-session" class="text-xs text-red-400 hover:underline" @click.stop="remove(inst.id, s.alias)">delete</button>
         </li>
+        <li v-if="!inst.sessions.length" data-test="no-sessions" class="px-6 py-1 text-xs text-slate-400">no sessions yet</li>
       </ul>
       <div class="flex items-center gap-3 px-6 py-1.5">
         <button data-test="new-session" class="text-left text-xs font-medium text-slate-500 hover:text-slate-800"

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useInstancesStore } from "../stores/instances";
+import { useChatStore } from "../stores/chat";
 import NewSessionDialog from "./NewSessionDialog.vue";
 import ManageInstanceDialog from "./ManageInstanceDialog.vue";
 
 const store = useInstancesStore();
+const chat = useChatStore();
 const emit = defineEmits<{ select: [instanceId: string, alias: string] }>();
 const dialogFor = ref<{ id: string; name: string } | null>(null);
 const manageFor = ref<{ id: string; name: string } | null>(null);
@@ -28,7 +30,11 @@ function remove(id: string, alias: string) {
         <li v-for="s in inst.sessions" :key="s.alias" class="flex items-center justify-between pr-2">
           <button class="flex flex-1 items-center gap-2 px-6 py-1 text-left text-sm hover:bg-slate-50"
                   @click="emit('select', inst.id, s.alias)">
-            <span v-if="s.running" class="text-amber-500">●</span>
+            <span v-if="chat.sessionAttention(inst.id, s.alias) === 'working'" data-test="attention-dot" data-attention="working"
+                  class="text-amber-500 animate-pulse">●</span>
+            <span v-else-if="chat.sessionAttention(inst.id, s.alias) === 'unread'" data-test="attention-dot" data-attention="unread"
+                  class="text-sky-500">●</span>
+            <span v-else-if="s.running" data-test="attention-dot" data-attention="running" class="text-amber-500">●</span>
             {{ s.alias }} <span class="text-slate-400">({{ s.agent }})</span>
           </button>
           <button data-test="delete-session" class="text-xs text-red-400 hover:underline" @click.stop="remove(inst.id, s.alias)">delete</button>

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -25,7 +25,7 @@ defineProps<{ messages: ChatMessage[]; streaming: string; liveTurn: LiveTurn | n
     <div v-if="streaming || liveTurn?.toolSteps.length || liveTurn?.reasoning" class="flex justify-start">
       <div data-test="msg-streaming" class="max-w-[80%] rounded-lg bg-slate-100 px-3 py-2 opacity-90">
         <ToolCallPanel v-if="liveTurn?.toolSteps.length" :steps="liveTurn.toolSteps" />
-        <ReasoningPanel v-if="liveTurn?.reasoning" :reasoning="liveTurn.reasoning" />
+        <ReasoningPanel v-if="liveTurn?.reasoning" :reasoning="liveTurn.reasoning" :streaming="true" />
         <StreamMarkdown v-if="streaming" :text="streaming" :streaming="true" />
       </div>
     </div>

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -1,33 +1,78 @@
 <script setup lang="ts">
+import { nextTick, ref, watch } from "vue";
 import type { ChatMessage, LiveTurn } from "../stores/chat";
 import StreamMarkdown from "./StreamMarkdown.vue";
 import ToolCallPanel from "./ToolCallPanel.vue";
 import ReasoningPanel from "./ReasoningPanel.vue";
-defineProps<{ messages: ChatMessage[]; streaming: string; liveTurn: LiveTurn | null }>();
+import CopyButton from "./CopyButton.vue";
+
+const props = defineProps<{ messages: ChatMessage[]; streaming: string; liveTurn: LiveTurn | null }>();
+
+// Stick-to-bottom: keep the newest content in view while the user is at the bottom,
+// but don't yank them down if they've scrolled up to read history. A "jump to latest"
+// affordance appears whenever we're detached from the bottom.
+const scroller = ref<HTMLElement | null>(null);
+const atBottom = ref(true);
+const THRESHOLD = 48; // px from bottom still counts as "at bottom"
+
+function onScroll(): void {
+  const el = scroller.value;
+  if (!el) return;
+  atBottom.value = el.scrollHeight - el.scrollTop - el.clientHeight <= THRESHOLD;
+}
+
+function scrollToBottom(smooth = false): void {
+  const el = scroller.value;
+  if (!el) return;
+  if (typeof el.scrollTo === "function") el.scrollTo({ top: el.scrollHeight, behavior: smooth ? "smooth" : "auto" });
+  else el.scrollTop = el.scrollHeight; // jsdom / older engines
+  atBottom.value = true;
+}
+
+// New messages / streaming chunks / tool steps: follow only if already pinned to bottom.
+watch(
+  () => [props.messages.length, props.streaming, props.liveTurn?.toolSteps.length, props.liveTurn?.reasoning],
+  () => {
+    if (atBottom.value) void nextTick(() => scrollToBottom(false));
+  },
+);
 </script>
 
 <template>
-  <div class="flex-1 space-y-2 overflow-y-auto p-4">
-    <div v-for="(m, i) in messages" :key="i" class="flex" :class="m.direction === 'in' ? 'justify-end' : 'justify-start'">
-      <pre v-if="m.direction === 'in'" data-test="msg-in"
-           class="max-w-[80%] whitespace-pre-wrap rounded-lg bg-slate-800 px-3 py-2 text-sm text-white"
-           :class="m.failed ? 'ring-1 ring-red-400' : ''">{{ m.text }}<span v-if="m.failed" data-test="msg-failed" class="ml-2 text-xs text-red-400">failed</span></pre>
-      <div v-else data-test="msg-out"
-           class="max-w-[80%] rounded-lg bg-slate-100 px-3 py-2"
-           :class="m.failed ? 'ring-1 ring-red-400' : ''">
-        <ToolCallPanel v-if="m.structured?.toolSteps?.length" :steps="m.structured.toolSteps" />
-        <ReasoningPanel v-if="m.structured?.reasoning" :reasoning="m.structured.reasoning" :default-open="false" />
-        <StreamMarkdown :text="m.text" />
-        <span v-if="m.status === 'cancelled'" data-test="msg-cancelled" class="text-xs text-amber-600">⏹ Stopped</span>
-        <span v-if="m.failed" data-test="msg-failed" class="text-xs text-red-400">failed</span>
+  <div class="relative flex-1 overflow-hidden">
+    <div ref="scroller" data-test="msg-scroller" class="h-full space-y-2 overflow-y-auto p-4" @scroll="onScroll">
+      <div v-for="(m, i) in messages" :key="i" class="group flex" :class="m.direction === 'in' ? 'justify-end' : 'justify-start'">
+        <pre v-if="m.direction === 'in'" data-test="msg-in"
+             class="max-w-[80%] whitespace-pre-wrap rounded-lg bg-slate-800 px-3 py-2 text-sm text-white"
+             :class="m.failed ? 'ring-1 ring-red-400' : ''">{{ m.text }}<span v-if="m.failed" data-test="msg-failed" class="ml-2 text-xs text-red-400">failed</span></pre>
+        <div v-else data-test="msg-out"
+             class="relative max-w-[80%] rounded-lg bg-slate-100 px-3 py-2"
+             :class="m.failed ? 'ring-1 ring-red-400' : ''">
+          <ToolCallPanel v-if="m.structured?.toolSteps?.length" :steps="m.structured.toolSteps" />
+          <ReasoningPanel v-if="m.structured?.reasoning" :reasoning="m.structured.reasoning" :default-open="false" />
+          <StreamMarkdown :text="m.text" />
+          <span v-if="m.status === 'cancelled'" data-test="msg-cancelled" class="text-xs text-amber-600">⏹ Stopped</span>
+          <span v-if="m.failed" data-test="msg-failed" class="text-xs text-red-400">failed</span>
+          <CopyButton v-if="m.text" :text="m.text" class="absolute right-1 top-1 opacity-0 transition-opacity group-hover:opacity-100" />
+        </div>
+      </div>
+      <div v-if="streaming || liveTurn?.toolSteps.length || liveTurn?.reasoning" class="flex justify-start">
+        <div data-test="msg-streaming" class="max-w-[80%] rounded-lg bg-slate-100 px-3 py-2 opacity-90">
+          <ToolCallPanel v-if="liveTurn?.toolSteps.length" :steps="liveTurn.toolSteps" />
+          <ReasoningPanel v-if="liveTurn?.reasoning" :reasoning="liveTurn.reasoning" :streaming="true" />
+          <StreamMarkdown v-if="streaming" :text="streaming" :streaming="true" />
+        </div>
       </div>
     </div>
-    <div v-if="streaming || liveTurn?.toolSteps.length || liveTurn?.reasoning" class="flex justify-start">
-      <div data-test="msg-streaming" class="max-w-[80%] rounded-lg bg-slate-100 px-3 py-2 opacity-90">
-        <ToolCallPanel v-if="liveTurn?.toolSteps.length" :steps="liveTurn.toolSteps" />
-        <ReasoningPanel v-if="liveTurn?.reasoning" :reasoning="liveTurn.reasoning" :streaming="true" />
-        <StreamMarkdown v-if="streaming" :text="streaming" :streaming="true" />
-      </div>
-    </div>
+
+    <button
+      v-show="!atBottom"
+      data-test="jump-latest"
+      type="button"
+      class="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-600 shadow hover:bg-slate-50"
+      @click="scrollToBottom(true)"
+    >
+      ↓ Latest
+    </button>
   </div>
 </template>

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -1,22 +1,128 @@
 <script setup lang="ts">
-import { ref } from "vue";
-const props = defineProps<{ busy?: boolean }>();
-const emit = defineEmits<{ send: [text: string] }>();
-const text = ref("");
+import { computed, nextTick, ref, watch } from "vue";
+import { suggestCommands } from "../lib/command-catalog";
+import { loadDraft, saveDraft } from "../lib/composer-drafts";
+
+const props = defineProps<{ busy?: boolean; draftKey?: string }>();
+const emit = defineEmits<{ send: [text: string]; cancel: [] }>();
+
+const text = ref(loadDraft(props.draftKey ?? ""));
+const textarea = ref<HTMLTextAreaElement | null>(null);
+
+// Persist the draft per session and restore on switch: when the key changes, stash the
+// current text under the previous key, then load the incoming session's draft.
+watch(text, (t) => saveDraft(props.draftKey ?? "", t));
+watch(
+  () => props.draftKey,
+  (next, prev) => {
+    if (prev) saveDraft(prev, text.value);
+    text.value = loadDraft(next ?? "");
+  },
+);
+
+// Sent-message history (↑/↓ recall, à la a shell prompt).
+const history = ref<string[]>([]);
+let historyIdx = -1; // -1 = editing a fresh line
+
+// Slash-command autocomplete popover.
+const suggestions = computed(() => suggestCommands(text.value));
+const showSuggestions = ref(false);
+const activeIdx = ref(0);
+function refreshSuggestions() {
+  showSuggestions.value = suggestions.value.length > 0;
+  activeIdx.value = 0;
+}
+
 function submit() {
   if (props.busy) return;
   const value = text.value.trim();
   if (!value) return;
   emit("send", value);
+  if (history.value[history.value.length - 1] !== value) history.value.push(value);
+  historyIdx = -1;
   text.value = "";
+  showSuggestions.value = false;
+}
+
+function acceptSuggestion(i = activeIdx.value) {
+  const s = suggestions.value[i];
+  if (!s) return;
+  text.value = s.name + " ";
+  showSuggestions.value = false;
+  void nextTick(() => textarea.value?.focus());
+}
+
+function recallHistory(dir: -1 | 1) {
+  if (history.value.length === 0) return;
+  if (dir === -1) {
+    historyIdx = historyIdx === -1 ? history.value.length - 1 : Math.max(0, historyIdx - 1);
+  } else {
+    if (historyIdx === -1) return;
+    historyIdx = historyIdx + 1;
+    if (historyIdx >= history.value.length) { historyIdx = -1; text.value = ""; return; }
+  }
+  text.value = history.value[historyIdx];
+}
+
+function onKeydown(e: KeyboardEvent) {
+  // IME guard: never intercept keys mid-composition (CJK input) — Enter here confirms
+  // the candidate, it must not submit. `isComposing` covers all input engines.
+  if (e.isComposing) return;
+  if (e.key === "Escape") {
+    if (showSuggestions.value) { showSuggestions.value = false; e.preventDefault(); return; }
+    if (props.busy) { emit("cancel"); e.preventDefault(); }
+    return;
+  }
+  if (showSuggestions.value) {
+    if (e.key === "ArrowDown") { activeIdx.value = (activeIdx.value + 1) % suggestions.value.length; e.preventDefault(); return; }
+    if (e.key === "ArrowUp") { activeIdx.value = (activeIdx.value - 1 + suggestions.value.length) % suggestions.value.length; e.preventDefault(); return; }
+    if (e.key === "Tab") { acceptSuggestion(); e.preventDefault(); return; }
+    if (e.key === "Enter" && !e.shiftKey) { acceptSuggestion(); e.preventDefault(); return; }
+  }
+  // Plain Enter submits; Shift+Enter inserts a newline (default behavior).
+  if (e.key === "Enter" && !e.shiftKey) { submit(); e.preventDefault(); return; }
+  // History recall only when not navigating a popover and the caret sits at the start.
+  const caretAtStart = (textarea.value?.selectionStart ?? 0) === 0 && (textarea.value?.selectionEnd ?? 0) === 0;
+  if (e.key === "ArrowUp" && caretAtStart) { recallHistory(-1); e.preventDefault(); return; }
+  if (e.key === "ArrowDown" && historyIdx !== -1 && caretAtStart) { recallHistory(1); e.preventDefault(); return; }
+}
+
+function onInput() {
+  historyIdx = -1;
+  refreshSuggestions();
 }
 </script>
 
 <template>
-  <form class="border-t p-3" @submit.prevent="submit">
-    <textarea v-model="text" rows="2" :disabled="busy"
-              class="w-full resize-none rounded border px-3 py-2 text-sm disabled:bg-slate-100 disabled:text-slate-400"
-              :placeholder="busy ? 'Agent is working…' : 'Message, or /command'"
-              @keydown.enter.exact.prevent="submit" />
+  <form class="relative border-t p-3" @submit.prevent="submit">
+    <!-- Suggestion popover, anchored above the input. -->
+    <ul v-if="showSuggestions" data-test="cmd-suggestions"
+        class="absolute bottom-full left-3 right-3 mb-1 max-h-48 overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg">
+      <li v-for="(s, i) in suggestions" :key="s.name">
+        <button type="button" data-test="cmd-suggestion"
+                class="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-sm"
+                :class="i === activeIdx ? 'bg-sky-50' : 'hover:bg-slate-50'"
+                @mousedown.prevent="acceptSuggestion(i)">
+          <span class="font-mono font-medium text-slate-700">{{ s.name }}</span>
+          <span class="truncate text-xs text-slate-400">{{ s.hint }}</span>
+        </button>
+      </li>
+    </ul>
+
+    <div class="flex items-end gap-2">
+      <!-- Stays enabled while busy so you can pre-compose the next message and press
+           Esc to stop; submit() itself no-ops while busy. -->
+      <textarea ref="textarea" v-model="text" rows="2"
+                class="w-full resize-none rounded border px-3 py-2 text-sm"
+                :placeholder="busy ? 'Agent is working… (Esc to stop)' : 'Message, or /command'"
+                @input="onInput"
+                @keydown="onKeydown"
+                @blur="showSuggestions = false" />
+      <button v-if="busy" type="button" data-test="composer-stop"
+              class="shrink-0 rounded bg-red-500 px-3 py-2 text-sm font-medium text-white hover:bg-red-600"
+              @click="emit('cancel')">Stop</button>
+      <button v-else type="submit" data-test="composer-send" :disabled="!text.trim()"
+              class="shrink-0 rounded bg-sky-500 px-3 py-2 text-sm font-medium text-white hover:bg-sky-600 disabled:bg-slate-200 disabled:text-slate-400">Send</button>
+    </div>
   </form>
 </template>

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -2,10 +2,12 @@
 import { computed, nextTick, ref, watch } from "vue";
 import { suggestCommands } from "../lib/command-catalog";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
+import { useComposerStore } from "../stores/composer";
 
 const props = defineProps<{ busy?: boolean; draftKey?: string }>();
 const emit = defineEmits<{ send: [text: string]; cancel: [] }>();
 
+const composer = useComposerStore();
 const text = ref(loadDraft(props.draftKey ?? ""));
 const textarea = ref<HTMLTextAreaElement | null>(null);
 
@@ -17,6 +19,16 @@ watch(
   (next, prev) => {
     if (prev) saveDraft(prev, text.value);
     text.value = loadDraft(next ?? "");
+  },
+);
+
+// External insert requests (e.g. command palette) targeted at this session.
+watch(
+  () => composer.insertRequest,
+  (req) => {
+    if (!req || req.key !== (props.draftKey ?? "")) return;
+    text.value = text.value.trim() ? `${text.value.trimEnd()} ${req.text}` : req.text;
+    void nextTick(() => textarea.value?.focus());
   },
 );
 

--- a/packages/relay-web/src/components/ReasoningPanel.vue
+++ b/packages/relay-web/src/components/ReasoningPanel.vue
@@ -1,14 +1,22 @@
 <script setup lang="ts">
-import { ref } from "vue";
-const props = withDefaults(defineProps<{ reasoning: string; defaultOpen?: boolean }>(), { defaultOpen: true });
-const open = ref(props.defaultOpen ?? true);
+import { computed, ref } from "vue";
+const props = withDefaults(defineProps<{ reasoning: string; defaultOpen?: boolean; streaming?: boolean }>(), {
+  defaultOpen: true,
+  streaming: false,
+});
+// While the reasoning is still streaming we force the panel open (and ignore the
+// user's toggle) so the live thought is visible; once it settles, the user's own
+// open/closed preference takes over. Historical panels are never streaming.
+const localOpen = ref(props.defaultOpen ?? true);
+const open = computed(() => props.streaming || localOpen.value);
 </script>
 
 <template>
   <div class="mt-1 rounded border border-slate-200 text-xs">
-    <button type="button" class="flex w-full items-center gap-1 px-2 py-1 text-left text-slate-600" @click="open = !open">
+    <button type="button" class="flex w-full items-center gap-1 px-2 py-1 text-left text-slate-600" @click="localOpen = !localOpen">
       <span>{{ open ? "▾" : "▸" }}</span>
-      <span>🧠 Reasoning</span>
+      <span>🧠 {{ streaming ? "Reasoning…" : "Reasoning" }}</span>
+      <span v-if="streaming" data-test="reasoning-shimmer" class="ml-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-slate-400" aria-hidden="true" />
     </button>
     <p v-if="open" data-test="reasoning-body" class="whitespace-pre-wrap px-2 pb-2 text-slate-600">{{ reasoning }}</p>
   </div>

--- a/packages/relay-web/src/components/ToolCallPanel.vue
+++ b/packages/relay-web/src/components/ToolCallPanel.vue
@@ -1,19 +1,42 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import type { ToolStepDto } from "@ganglion/xacpx-relay-protocol";
 import ToolDetail from "./ToolDetail.vue";
+import FueDot from "./FueDot.vue";
+import FueCallout from "./FueCallout.vue";
+import { useFue } from "../lib/use-fue";
+import type { Rect } from "../lib/fue-placement";
+import { AUTO_COLLAPSE_THRESHOLD, KIND_ICON, STATUS_ICON, summarizeSteps } from "../lib/tool-summary";
 
-defineProps<{ steps: ToolStepDto[] }>();
+const props = defineProps<{ steps: ToolStepDto[] }>();
 
-const open = ref(true);
+// Long tool runs collapse by default so they don't bury the reply; short ones stay open.
+const open = ref(props.steps.length <= AUTO_COLLAPSE_THRESHOLD);
 const expanded = ref<Set<string>>(new Set());
 function toggleRow(id: string) {
   if (expanded.value.has(id)) expanded.value.delete(id); else expanded.value.add(id);
   expanded.value = new Set(expanded.value);
 }
 
-const STATUS_ICON: Record<string, string> = { running: "⏳", success: "✅", error: "❌" };
-const KIND_ICON: Record<string, string> = { read: "📖", search: "🔍", execute: "💻", edit: "✏️", think: "🧠", other: "🔧" };
+const summary = computed(() => summarizeSteps(props.steps));
+
+// First-User-Experience: the first time a user meets an auto-collapsed panel, nudge
+// them that it expands. The dot replaces the count badge until acknowledged.
+const fue = useFue("tool-group-collapse");
+const collapsible = computed(() => props.steps.length > AUTO_COLLAPSE_THRESHOLD);
+const showFueDot = computed(() => collapsible.value && fue.status.value !== "acknowledged");
+const header = ref<HTMLElement | null>(null);
+const anchor = ref<Rect | null>(null);
+
+function onHeaderClick() {
+  open.value = !open.value;
+  if (showFueDot.value) {
+    const r = header.value?.getBoundingClientRect();
+    if (r) anchor.value = { top: r.top, left: r.left, width: r.width, height: r.height };
+    fue.engage();
+  }
+}
+
 function fmtDuration(ms?: number): string {
   if (ms === undefined) return "";
   return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
@@ -22,11 +45,24 @@ function fmtDuration(ms?: number): string {
 
 <template>
   <div class="mt-1 rounded border border-slate-200 text-xs">
-    <button type="button" class="flex w-full items-center gap-1 px-2 py-1 text-left text-slate-600" @click="open = !open">
+    <button ref="header" type="button" class="flex w-full items-center gap-1 px-2 py-1 text-left text-slate-600" @click="onHeaderClick">
       <span>{{ open ? "▾" : "▸" }}</span>
       <span>🔧 Tool calls</span>
-      <span data-test="tool-count" class="text-slate-400">({{ steps.length }})</span>
+      <FueDot v-if="showFueDot" :pulsing="fue.status.value === 'unseen'" />
+      <span v-else data-test="tool-count" class="text-slate-400">({{ steps.length }})</span>
+      <span data-test="tool-summary" class="ml-1 flex items-center gap-1 text-slate-400">
+        <span v-for="k in summary.kinds" :key="'k' + k.icon">{{ k.icon }}{{ k.count }}</span>
+        <span v-if="summary.statuses.length" class="text-slate-300">·</span>
+        <span v-for="st in summary.statuses" :key="'s' + st.icon">{{ st.icon }}{{ st.count }}</span>
+      </span>
     </button>
+    <FueCallout
+      v-if="fue.status.value === 'engaging'"
+      :title="'Tool steps collapsed'"
+      :body="'Multi-step tool runs are collapsed by default to keep replies readable. Click the header to expand and inspect each step.'"
+      :anchor="anchor"
+      @dismiss="fue.dismiss()"
+    />
     <ul v-if="open" class="divide-y divide-slate-100">
       <li v-for="s in steps" :key="s.toolCallId">
         <button type="button" data-test="tool-row" class="flex w-full items-center gap-2 px-2 py-1 text-left hover:bg-slate-50" @click="toggleRow(s.toolCallId)">

--- a/packages/relay-web/src/components/ToolDetail.vue
+++ b/packages/relay-web/src/components/ToolDetail.vue
@@ -9,12 +9,23 @@ const diffLines = computed(() => {
   if (props.detail.type !== "diff") return { del: [] as string[], add: [] as string[] };
   return { del: props.detail.oldText.split("\n"), add: props.detail.newText.split("\n") };
 });
+// Non-empty changed-line counts for the +N/−N stat badges.
+const diffStats = computed(() => ({
+  add: diffLines.value.add.filter((l) => l.length > 0).length,
+  del: diffLines.value.del.filter((l) => l.length > 0).length,
+}));
 </script>
 
 <template>
   <div class="mt-1 space-y-1 text-xs">
     <template v-if="detail.type === 'diff'">
-      <div class="font-mono text-slate-500">📄 {{ detail.path }}</div>
+      <div class="flex items-center gap-2 font-mono text-slate-500">
+        <span>📄 {{ detail.path }}</span>
+        <span data-test="diff-stats" class="ml-auto flex items-center gap-1 text-[10px]">
+          <span v-if="diffStats.add" class="rounded bg-green-100 px-1 text-green-700">+{{ diffStats.add }}</span>
+          <span v-if="diffStats.del" class="rounded bg-red-100 px-1 text-red-700">−{{ diffStats.del }}</span>
+        </span>
+      </div>
       <div class="overflow-x-auto rounded bg-slate-50 p-2 font-mono">
         <div v-for="(l, i) in diffLines.del" :key="'d' + i" data-test="diff-del" class="whitespace-pre text-red-600">- {{ l }}</div>
         <div v-for="(l, i) in diffLines.add" :key="'a' + i" data-test="diff-add" class="whitespace-pre text-green-600">+ {{ l }}</div>

--- a/packages/relay-web/src/lib/command-catalog.ts
+++ b/packages/relay-web/src/lib/command-catalog.ts
@@ -1,0 +1,38 @@
+/** Curated catalog of top-level slash commands for the composer's autocomplete.
+ *
+ *  xacpx is a slash-command-driven console, so surfacing the command surface inline
+ *  (à la HAPI's composer suggestion popover) is a large interaction win for the web
+ *  dashboard. This is a deliberately STATIC, hand-maintained subset of the most-used
+ *  top-level commands; a future enhancement could drive it from a control RPC
+ *  (the connector already owns a command-hints catalog) instead of hardcoding. */
+export interface CommandEntry {
+  name: string; // includes the leading slash, e.g. "/session"
+  hint: string; // short one-line description
+}
+
+export const COMMAND_CATALOG: CommandEntry[] = [
+  { name: "/status", hint: "Show the current session status" },
+  { name: "/session", hint: "Manage logical sessions (new/attach/rm/reset/tail)" },
+  { name: "/use", hint: "Switch the active session in place" },
+  { name: "/agent", hint: "Manage configured agents (add/list/rm)" },
+  { name: "/workspace", hint: "Manage configured workspaces" },
+  { name: "/permission", hint: "Inspect or set the permission policy" },
+  { name: "/later", hint: "Schedule a prompt to run later" },
+  { name: "/config", hint: "Inspect or edit configuration" },
+  { name: "/ssn", hint: "List/select native acpx sessions" },
+  { name: "/reset", hint: "Reset the current session's transport state" },
+  { name: "/tail", hint: "Tail recent session output" },
+  { name: "/help", hint: "List available commands" },
+];
+
+/** Suggestions for the first token of a slash command. Returns [] unless the input is
+ *  a single `/word` token (no space yet) — once arguments begin, autocomplete steps
+ *  out of the way. An exact, complete match also returns [] (nothing left to suggest). */
+export function suggestCommands(input: string): CommandEntry[] {
+  if (!input.startsWith("/")) return [];
+  if (/\s/.test(input)) return []; // arguments started — stop suggesting
+  const q = input.toLowerCase();
+  const matches = COMMAND_CATALOG.filter((c) => c.name.toLowerCase().startsWith(q));
+  if (matches.length === 1 && matches[0].name.toLowerCase() === q) return [];
+  return matches;
+}

--- a/packages/relay-web/src/lib/composer-drafts.ts
+++ b/packages/relay-web/src/lib/composer-drafts.ts
@@ -1,0 +1,37 @@
+/** Per-session composer draft persistence (borrowed from HAPI's composer-drafts).
+ *  A half-typed message survives switching sessions or reloading the tab. Stored in
+ *  sessionStorage (deliberately tab-scoped — dies with the tab) keyed by the
+ *  instance+session key. Empty text removes the key so the store doesn't grow. */
+const KEY = "xacpx.composer-drafts.v1";
+
+type Drafts = Record<string, string>;
+
+function read(): Drafts {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as Drafts) : {};
+  } catch {
+    return {};
+  }
+}
+
+function write(drafts: Drafts): void {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify(drafts));
+  } catch {
+    /* storage full / disabled — drafts are best-effort */
+  }
+}
+
+export function loadDraft(draftKey: string): string {
+  if (!draftKey) return "";
+  return read()[draftKey] ?? "";
+}
+
+export function saveDraft(draftKey: string, text: string): void {
+  if (!draftKey) return;
+  const drafts = read();
+  if (text) drafts[draftKey] = text;
+  else delete drafts[draftKey];
+  write(drafts);
+}

--- a/packages/relay-web/src/lib/fue-placement.ts
+++ b/packages/relay-web/src/lib/fue-placement.ts
@@ -1,0 +1,49 @@
+/** Pure placement math for `FueCallout` (borrowed from HAPI's
+ *  `computeFueCalloutPlacement`). Kept DOM-free so it is unit-testable without a
+ *  layout engine. Places the callout below the anchor by default; flips above when
+ *  below would overflow the viewport and there is more room above; clamps the
+ *  horizontal position into the viewport with an 8px margin. */
+export interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+export interface Placement {
+  top: number;
+  left: number;
+  placement: "above" | "below";
+}
+
+const MARGIN = 8;
+
+export function computeCalloutPlacement(anchor: Rect, callout: Size, viewport: Viewport, gap = MARGIN): Placement {
+  const belowTop = anchor.top + anchor.height + gap;
+  const aboveTop = anchor.top - callout.height - gap;
+  const roomBelow = viewport.height - (anchor.top + anchor.height);
+  const roomAbove = anchor.top;
+
+  // Flip above only when below overflows AND above has more room.
+  const overflowsBelow = belowTop + callout.height > viewport.height - MARGIN;
+  const flip = overflowsBelow && roomAbove > roomBelow;
+  const placement: "above" | "below" = flip ? "above" : "below";
+  const top = placement === "above" ? Math.max(MARGIN, aboveTop) : belowTop;
+
+  // Center under the anchor, then clamp horizontally into the viewport.
+  const centered = anchor.left + anchor.width / 2 - callout.width / 2;
+  const maxLeft = Math.max(MARGIN, viewport.width - callout.width - MARGIN);
+  const left = Math.min(Math.max(MARGIN, centered), maxLeft);
+
+  return { top, left, placement };
+}

--- a/packages/relay-web/src/lib/tool-summary.ts
+++ b/packages/relay-web/src/lib/tool-summary.ts
@@ -1,0 +1,48 @@
+import type { ToolStepDto, ToolStepKind, ToolStepStatus } from "@ganglion/xacpx-relay-protocol";
+
+/** Shared icon tables + a pure step-summarizer for ToolCallPanel. Borrowed from
+ *  HAPI's tool-group summary idea (`toolGroups.ts`): instead of an endless wall of
+ *  rows, the panel header shows an at-a-glance count of steps by kind and status. */
+export const KIND_ICON: Record<ToolStepKind, string> = {
+  read: "📖",
+  search: "🔍",
+  execute: "💻",
+  edit: "✏️",
+  think: "🧠",
+  other: "🔧",
+};
+
+export const STATUS_ICON: Record<ToolStepStatus, string> = {
+  running: "⏳",
+  success: "✅",
+  error: "❌",
+};
+
+const KIND_ORDER: ToolStepKind[] = ["read", "search", "execute", "edit", "think", "other"];
+const STATUS_ORDER: ToolStepStatus[] = ["running", "success", "error"];
+
+/** Many-step panels collapse by default so a long tool run doesn't bury the reply. */
+export const AUTO_COLLAPSE_THRESHOLD = 5;
+
+export interface SummaryEntry {
+  icon: string;
+  count: number;
+}
+
+export interface StepSummary {
+  kinds: SummaryEntry[];
+  statuses: SummaryEntry[];
+}
+
+export function summarizeSteps(steps: ToolStepDto[]): StepSummary {
+  const kindCounts = new Map<ToolStepKind, number>();
+  const statusCounts = new Map<ToolStepStatus, number>();
+  for (const s of steps) {
+    kindCounts.set(s.kind, (kindCounts.get(s.kind) ?? 0) + 1);
+    statusCounts.set(s.status, (statusCounts.get(s.status) ?? 0) + 1);
+  }
+  return {
+    kinds: KIND_ORDER.filter((k) => kindCounts.has(k)).map((k) => ({ icon: KIND_ICON[k], count: kindCounts.get(k)! })),
+    statuses: STATUS_ORDER.filter((s) => statusCounts.has(s)).map((s) => ({ icon: STATUS_ICON[s], count: statusCounts.get(s)! })),
+  };
+}

--- a/packages/relay-web/src/lib/use-fue.ts
+++ b/packages/relay-web/src/lib/use-fue.ts
@@ -1,0 +1,63 @@
+import { ref, type Ref } from "vue";
+
+/** First-User-Experience primitive (borrowed from HAPI's `use-fue.ts`).
+ *
+ *  A per-feature, localStorage-backed onboarding state machine so existing users
+ *  discover a new affordance without a permanent always-visible UI block. Three
+ *  states: `unseen` (never engaged) → `engaging` (user just touched the affordance,
+ *  show a one-time callout) → `acknowledged` (dismissed, never show again). There is
+ *  NO auto-timeout by design — the user dismisses explicitly.
+ *
+ *  Call `useFue(featureId)` ONCE per affordance and pass `status` down to `FueDot`;
+ *  separate `useFue` instances for the same id do not share reactive state. */
+export type FueStatus = "unseen" | "engaging" | "acknowledged";
+
+const STORAGE_PREFIX = "xacpx.fue.v1.";
+
+function read(featureId: string): boolean {
+  try {
+    return localStorage.getItem(STORAGE_PREFIX + featureId) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function persist(featureId: string): void {
+  try {
+    localStorage.setItem(STORAGE_PREFIX + featureId, "1");
+  } catch {
+    /* private mode / storage disabled — degrade to in-memory only */
+  }
+}
+
+export interface Fue {
+  status: Ref<FueStatus>;
+  /** The user touched the affordance: surface the callout (only from `unseen`). */
+  engage(): void;
+  /** The user dismissed the callout: never show it again. */
+  dismiss(): void;
+}
+
+export function useFue(featureId: string): Fue {
+  const status = ref<FueStatus>(read(featureId) ? "acknowledged" : "unseen");
+
+  function engage(): void {
+    if (status.value === "unseen") status.value = "engaging";
+  }
+
+  function dismiss(): void {
+    status.value = "acknowledged";
+    persist(featureId);
+  }
+
+  return { status, engage, dismiss };
+}
+
+/** Test/debug helper: forget a feature's acknowledgement. */
+export function resetFue(featureId: string): void {
+  try {
+    localStorage.removeItem(STORAGE_PREFIX + featureId);
+  } catch {
+    /* ignore */
+  }
+}

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -23,7 +23,19 @@ export const useChatStore = defineStore("chat", () => {
   const sessionAlias = ref<string | null>(null);
   const messages = ref<ChatMessage[]>([]);
   const liveTurns = ref<Record<string, LiveTurn>>({});
+  // Sessions whose turn finished while NOT being viewed — drives the "unread" attention
+  // dot in the session list. Reassigned (never mutated in place) so the Set stays reactive.
+  const unread = ref<Set<string>>(new Set());
   const bufKey = (instanceId: string, alias: string) => `${instanceId}\0${alias}`;
+
+  /** Which attention signal a session should show in the list. `working` (a live turn)
+   *  outranks `unread` (a finished-but-unviewed result); otherwise `idle`. */
+  function sessionAttention(instId: string, alias: string): "working" | "unread" | "idle" {
+    const k = bufKey(instId, alias);
+    if (liveTurns.value[k]) return "working";
+    if (unread.value.has(k)) return "unread";
+    return "idle";
+  }
 
   const selectedKey = computed(() =>
     instanceId.value && sessionAlias.value ? bufKey(instanceId.value, sessionAlias.value) : null,
@@ -77,6 +89,13 @@ export const useChatStore = defineStore("chat", () => {
     sessionAlias.value = alias;
     messages.value = [];
     error.value = "";
+    // Viewing a session clears its unread signal.
+    const k = bufKey(id, alias);
+    if (unread.value.has(k)) {
+      const next = new Set(unread.value);
+      next.delete(k);
+      unread.value = next;
+    }
   }
 
   async function loadHistory(): Promise<void> {
@@ -91,6 +110,8 @@ export const useChatStore = defineStore("chat", () => {
     if (event.kind === "instance-status" && !event.online) {
       const prefix = `${event.instanceId}\0`;
       for (const k of Object.keys(liveTurns.value)) if (k.startsWith(prefix)) delete liveTurns.value[k];
+      const next = new Set([...unread.value].filter((k) => !k.startsWith(prefix)));
+      if (next.size !== unread.value.size) unread.value = next;
       return;
     }
     if (event.kind !== "control-event") return;
@@ -109,7 +130,15 @@ export const useChatStore = defineStore("chat", () => {
       ensureTurn(bufKey(event.instanceId, e.sessionAlias)).reasoning += e.chunk;
     } else if (e.type === "turn-finished") {
       const status: TurnStatus = e.cancelled ? "cancelled" : e.ok ? "done" : "error";
+      const selected = event.instanceId === instanceId.value && e.sessionAlias === sessionAlias.value;
       flushTurn(event.instanceId, e.sessionAlias, status, e.errorMessage);
+      // A result that landed in a session the user isn't viewing earns an unread dot.
+      if (!selected && (status === "done" || status === "error")) {
+        const k = bufKey(event.instanceId, e.sessionAlias);
+        const next = new Set(unread.value);
+        next.add(k);
+        unread.value = next;
+      }
     }
   }
 
@@ -157,5 +186,5 @@ export const useChatStore = defineStore("chat", () => {
     }
   }
 
-  return { instanceId, sessionAlias, messages, streaming, liveTurn, busy, sending, error, select, loadHistory, applyEvent, send, cancel };
+  return { instanceId, sessionAlias, messages, streaming, liveTurn, busy, unread, sessionAttention, sending, error, select, loadHistory, applyEvent, send, cancel };
 });

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -37,6 +37,11 @@ export const useChatStore = defineStore("chat", () => {
     return "idle";
   }
 
+  /** Epoch ms when the session's live turn began, or null if it isn't working. */
+  function runningSince(instId: string, alias: string): number | null {
+    return liveTurns.value[bufKey(instId, alias)]?.startedAt ?? null;
+  }
+
   const selectedKey = computed(() =>
     instanceId.value && sessionAlias.value ? bufKey(instanceId.value, sessionAlias.value) : null,
   );
@@ -186,5 +191,5 @@ export const useChatStore = defineStore("chat", () => {
     }
   }
 
-  return { instanceId, sessionAlias, messages, streaming, liveTurn, busy, unread, sessionAttention, sending, error, select, loadHistory, applyEvent, send, cancel };
+  return { instanceId, sessionAlias, messages, streaming, liveTurn, busy, unread, sessionAttention, runningSince, sending, error, select, loadHistory, applyEvent, send, cancel };
 });

--- a/packages/relay-web/src/stores/composer.ts
+++ b/packages/relay-web/src/stores/composer.ts
@@ -1,0 +1,14 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+/** A tiny reactive bridge so non-composer UI (e.g. the command palette) can push
+ *  text into a session's composer. The bumping `seq` makes repeated inserts of the
+ *  same text still trigger the watcher in PromptInput. */
+export const useComposerStore = defineStore("composer", () => {
+  const insertRequest = ref<{ key: string; text: string; seq: number } | null>(null);
+  let seq = 0;
+  function requestInsert(key: string, text: string): void {
+    insertRequest.value = { key, text, seq: ++seq };
+  }
+  return { insertRequest, requestInsert };
+});

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -25,6 +25,9 @@ export const useFilesStore = defineStore("files", () => {
   const diffPath = ref<string | null>(null); // null = whole-tree diff
   const tab = ref<"files" | "changes">("files");
   const changed = ref<Record<string, string>>({}); // relPath -> git porcelain status, for Files-tab badges
+  // Standalone read-only summary for the header chip — independent of the browsed
+  // workspace above, so showing it never disturbs file-browser navigation state.
+  const gitSummary = ref<{ workspace: string; changedCount: number; branch?: string } | null>(null);
   const query = ref("");
   const results = ref<string[]>([]);
   const searchTruncated = ref(false);
@@ -74,6 +77,27 @@ export const useFilesStore = defineStore("files", () => {
       changed.value = map;
     } catch {
       changed.value = {};
+    }
+  }
+
+  /** Read-only git summary for a session's workspace (header chip). Quiet: a
+   *  non-git workspace just clears the summary. `branch` is populated only if the
+   *  backend ever adds it to the diff result; today it stays undefined. */
+  async function loadGitSummary(id: string, ws: string): Promise<void> {
+    if (!id || !ws) {
+      gitSummary.value = null;
+      return;
+    }
+    try {
+      const r = await api.rpc<FsDiffResult>(id, "control.fs.diff", { workspace: ws });
+      if (isErrorPayload(r)) {
+        gitSummary.value = null;
+        return;
+      }
+      const branch = typeof (r as { branch?: unknown }).branch === "string" ? (r as { branch?: string }).branch : undefined;
+      gitSummary.value = { workspace: ws, changedCount: r.files.length, ...(branch ? { branch } : {}) };
+    } catch {
+      gitSummary.value = null;
     }
   }
 
@@ -165,5 +189,5 @@ export const useFilesStore = defineStore("files", () => {
     }
   }
 
-  return { instanceId, workspace, path, entries, file, diff, diffPath, changed, tab, query, results, searchTruncated, searching, loading, error, reset, selectWorkspace, list, open, openFile, up, search, loadDiff, loadStatus };
+  return { instanceId, workspace, path, entries, file, diff, diffPath, changed, gitSummary, tab, query, results, searchTruncated, searching, loading, error, reset, selectWorkspace, list, open, openFile, up, search, loadDiff, loadStatus, loadGitSummary };
 });

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -24,6 +24,7 @@ export const useFilesStore = defineStore("files", () => {
   const diff = ref<FsDiffResult | null>(null);
   const diffPath = ref<string | null>(null); // null = whole-tree diff
   const tab = ref<"files" | "changes">("files");
+  const changed = ref<Record<string, string>>({}); // relPath -> git porcelain status, for Files-tab badges
   const query = ref("");
   const results = ref<string[]>([]);
   const searchTruncated = ref(false);
@@ -38,6 +39,7 @@ export const useFilesStore = defineStore("files", () => {
     file.value = null;
     diff.value = null;
     diffPath.value = null;
+    changed.value = {};
     query.value = "";
     results.value = [];
     error.value = "";
@@ -49,9 +51,30 @@ export const useFilesStore = defineStore("files", () => {
     file.value = null;
     diff.value = null;
     diffPath.value = null;
+    changed.value = {};
     query.value = "";
     results.value = [];
     await list("");
+    void loadStatus();
+  }
+
+  /** Quietly fetch git status for badge annotation. Failures (e.g. a non-git
+   *  workspace) clear the badges without surfacing an error, so plain browsing
+   *  stays clean — the Changes tab's loadDiff() is what surfaces git errors. */
+  async function loadStatus(): Promise<void> {
+    if (!instanceId.value || !workspace.value) return;
+    try {
+      const r = await api.rpc<FsDiffResult>(instanceId.value, "control.fs.diff", { workspace: workspace.value });
+      if (isErrorPayload(r)) {
+        changed.value = {};
+        return;
+      }
+      const map: Record<string, string> = {};
+      for (const f of r.files) map[f.path] = f.status;
+      changed.value = map;
+    } catch {
+      changed.value = {};
+    }
   }
 
   async function list(dir: string): Promise<void> {
@@ -142,5 +165,5 @@ export const useFilesStore = defineStore("files", () => {
     }
   }
 
-  return { instanceId, workspace, path, entries, file, diff, diffPath, tab, query, results, searchTruncated, searching, loading, error, reset, selectWorkspace, list, open, openFile, up, search, loadDiff };
+  return { instanceId, workspace, path, entries, file, diff, diffPath, changed, tab, query, results, searchTruncated, searching, loading, error, reset, selectWorkspace, list, open, openFile, up, search, loadDiff, loadStatus };
 });

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -6,6 +6,7 @@ import {
   type FsEntryDto,
   type FsListResult,
   type FsReadResult,
+  type FsSearchResult,
 } from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
 
@@ -21,7 +22,12 @@ export const useFilesStore = defineStore("files", () => {
   const entries = ref<FsEntryDto[]>([]);
   const file = ref<FsReadResult | null>(null);
   const diff = ref<FsDiffResult | null>(null);
+  const diffPath = ref<string | null>(null); // null = whole-tree diff
   const tab = ref<"files" | "changes">("files");
+  const query = ref("");
+  const results = ref<string[]>([]);
+  const searchTruncated = ref(false);
+  const searching = ref(false);
   const loading = ref(false);
   const error = ref("");
 
@@ -31,6 +37,9 @@ export const useFilesStore = defineStore("files", () => {
     entries.value = [];
     file.value = null;
     diff.value = null;
+    diffPath.value = null;
+    query.value = "";
+    results.value = [];
     error.value = "";
   }
 
@@ -39,6 +48,9 @@ export const useFilesStore = defineStore("files", () => {
     workspace.value = ws;
     file.value = null;
     diff.value = null;
+    diffPath.value = null;
+    query.value = "";
+    results.value = [];
     await list("");
   }
 
@@ -74,18 +86,54 @@ export const useFilesStore = defineStore("files", () => {
     }
   }
 
+  /** Open a file by its full path relative to the workspace root (search results). */
+  async function openFile(relPath: string): Promise<void> {
+    if (!instanceId.value || !workspace.value) return;
+    loading.value = true;
+    error.value = "";
+    try {
+      file.value = unwrap(await api.rpc<FsReadResult>(instanceId.value, "control.fs.read", { workspace: workspace.value, path: relPath }));
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "read-failed";
+    } finally {
+      loading.value = false;
+    }
+  }
+
   /** Navigate to an ancestor by breadcrumb index (-1 = root). */
   function up(toIndex: number): void {
     const segs = path.value ? path.value.split("/") : [];
     void list(segs.slice(0, toIndex + 1).join("/"));
   }
 
-  async function loadDiff(): Promise<void> {
+  async function search(q: string): Promise<void> {
+    query.value = q;
+    if (!instanceId.value || !workspace.value || !q.trim()) {
+      results.value = [];
+      searchTruncated.value = false;
+      return;
+    }
+    searching.value = true;
+    error.value = "";
+    try {
+      const r = unwrap(await api.rpc<FsSearchResult>(instanceId.value, "control.fs.search", { workspace: workspace.value, query: q }));
+      results.value = r.matches;
+      searchTruncated.value = r.truncated;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "search-failed";
+    } finally {
+      searching.value = false;
+    }
+  }
+
+  /** Load the git diff for the whole tree (path omitted) or one file. */
+  async function loadDiff(filePath?: string): Promise<void> {
     if (!instanceId.value || !workspace.value) return;
     loading.value = true;
     error.value = "";
+    diffPath.value = filePath ?? null;
     try {
-      diff.value = unwrap(await api.rpc<FsDiffResult>(instanceId.value, "control.fs.diff", { workspace: workspace.value }));
+      diff.value = unwrap(await api.rpc<FsDiffResult>(instanceId.value, "control.fs.diff", { workspace: workspace.value, ...(filePath ? { path: filePath } : {}) }));
     } catch (e) {
       error.value = e instanceof Error ? e.message : "diff-failed";
       diff.value = null;
@@ -94,5 +142,5 @@ export const useFilesStore = defineStore("files", () => {
     }
   }
 
-  return { instanceId, workspace, path, entries, file, diff, tab, loading, error, reset, selectWorkspace, list, open, up, loadDiff };
+  return { instanceId, workspace, path, entries, file, diff, diffPath, tab, query, results, searchTruncated, searching, loading, error, reset, selectWorkspace, list, open, openFile, up, search, loadDiff };
 });

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -1,0 +1,98 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import {
+  isErrorPayload,
+  type FsDiffResult,
+  type FsEntryDto,
+  type FsListResult,
+  type FsReadResult,
+} from "@ganglion/xacpx-relay-protocol";
+import { api } from "../api/client";
+
+function unwrap<T>(result: T | { error: { code: string; message: string } }): T {
+  if (isErrorPayload(result)) throw new Error(result.error.message || result.error.code);
+  return result;
+}
+
+export const useFilesStore = defineStore("files", () => {
+  const instanceId = ref<string | null>(null);
+  const workspace = ref<string | null>(null);
+  const path = ref(""); // current directory, relative to the workspace root
+  const entries = ref<FsEntryDto[]>([]);
+  const file = ref<FsReadResult | null>(null);
+  const diff = ref<FsDiffResult | null>(null);
+  const tab = ref<"files" | "changes">("files");
+  const loading = ref(false);
+  const error = ref("");
+
+  function reset(): void {
+    workspace.value = null;
+    path.value = "";
+    entries.value = [];
+    file.value = null;
+    diff.value = null;
+    error.value = "";
+  }
+
+  async function selectWorkspace(id: string, ws: string): Promise<void> {
+    instanceId.value = id;
+    workspace.value = ws;
+    file.value = null;
+    diff.value = null;
+    await list("");
+  }
+
+  async function list(dir: string): Promise<void> {
+    if (!instanceId.value || !workspace.value) return;
+    loading.value = true;
+    error.value = "";
+    file.value = null;
+    try {
+      const r = unwrap(await api.rpc<FsListResult>(instanceId.value, "control.fs.list", { workspace: workspace.value, path: dir }));
+      path.value = r.path;
+      entries.value = r.entries;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "list-failed";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /** Descend into a child dir or open a file, relative to the current path. */
+  async function open(entry: FsEntryDto): Promise<void> {
+    const child = path.value ? `${path.value}/${entry.name}` : entry.name;
+    if (entry.type === "dir") return list(child);
+    if (!instanceId.value || !workspace.value) return;
+    loading.value = true;
+    error.value = "";
+    try {
+      file.value = unwrap(await api.rpc<FsReadResult>(instanceId.value, "control.fs.read", { workspace: workspace.value, path: child }));
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "read-failed";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /** Navigate to an ancestor by breadcrumb index (-1 = root). */
+  function up(toIndex: number): void {
+    const segs = path.value ? path.value.split("/") : [];
+    void list(segs.slice(0, toIndex + 1).join("/"));
+  }
+
+  async function loadDiff(): Promise<void> {
+    if (!instanceId.value || !workspace.value) return;
+    loading.value = true;
+    error.value = "";
+    try {
+      diff.value = unwrap(await api.rpc<FsDiffResult>(instanceId.value, "control.fs.diff", { workspace: workspace.value }));
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "diff-failed";
+      diff.value = null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  return { instanceId, workspace, path, entries, file, diff, tab, loading, error, reset, selectWorkspace, list, open, up, loadDiff };
+});

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -39,6 +39,14 @@ export const useInstancesStore = defineStore("instances", () => {
     if (inst) inst.sessions = sessions;
   }
 
+  // Just the workspaces (for the file browser) — lighter than loadFormOptions, which
+  // also pulls agents + the driver catalog.
+  async function loadWorkspaces(instanceId: string): Promise<void> {
+    const { workspaces } = await api.rpc<{ workspaces: WorkspaceDto[] }>(instanceId, "control.workspaces.list");
+    const inst = byId(instanceId);
+    if (inst) inst.workspaces = workspaces;
+  }
+
   // Pull the instance's configured agents + workspaces to drive the create-session
   // form's dropdowns. Called when the dialog opens.
   async function loadFormOptions(instanceId: string): Promise<void> {
@@ -122,5 +130,5 @@ export const useInstancesStore = defineStore("instances", () => {
     return instances.value.find((i) => i.id === id);
   }
 
-  return { instances, loadInstances, loadSessions, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, removeSession, applyEvent, byId };
+  return { instances, loadInstances, loadSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, removeSession, applyEvent, byId };
 });

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -17,6 +17,9 @@ export interface InstanceView {
   online: boolean;
   lastSeenAt: string | null;
   sessions: SessionDto[];
+  // Distinguishes "sessions never fetched" from "fetched and genuinely empty" so the
+  // sidebar only shows the "no sessions yet" empty row once a list has actually loaded.
+  sessionsLoaded: boolean;
   agents: AgentDto[];
   workspaces: WorkspaceDto[];
   agentCatalog: AgentCatalogEntryDto[];
@@ -26,17 +29,26 @@ export const useInstancesStore = defineStore("instances", () => {
   const instances = ref<InstanceView[]>([]);
 
   async function loadInstances(): Promise<void> {
-    const { instances: rows } = await api.get<{ instances: Array<Omit<InstanceView, "sessions" | "agents" | "workspaces" | "agentCatalog">> }>("/api/instances");
+    const { instances: rows } = await api.get<{ instances: Array<Omit<InstanceView, "sessions" | "sessionsLoaded" | "agents" | "workspaces" | "agentCatalog">> }>("/api/instances");
     instances.value = rows.map((r) => {
       const prev = byId(r.id);
-      return { ...r, sessions: prev?.sessions ?? [], agents: prev?.agents ?? [], workspaces: prev?.workspaces ?? [], agentCatalog: prev?.agentCatalog ?? [] };
+      return { ...r, sessions: prev?.sessions ?? [], sessionsLoaded: prev?.sessionsLoaded ?? false, agents: prev?.agents ?? [], workspaces: prev?.workspaces ?? [], agentCatalog: prev?.agentCatalog ?? [] };
     });
+    // Eagerly populate the session list for every online instance so the sidebar shows
+    // them without the user having to click the instance first. Fire-and-forget: a slow
+    // or failing instance must not block the rest of the dashboard from rendering.
+    for (const inst of instances.value) {
+      if (inst.online && !inst.sessionsLoaded) void loadSessions(inst.id).catch(() => {});
+    }
   }
 
   async function loadSessions(instanceId: string): Promise<void> {
     const { sessions } = await api.rpc<{ sessions: SessionDto[] }>(instanceId, "control.sessions.list");
     const inst = byId(instanceId);
-    if (inst) inst.sessions = sessions;
+    if (inst) {
+      inst.sessions = sessions;
+      inst.sessionsLoaded = true;
+    }
   }
 
   // Just the workspaces (for the file browser) — lighter than loadFormOptions, which
@@ -120,7 +132,12 @@ export const useInstancesStore = defineStore("instances", () => {
   function applyEvent(event: WebServerEvent): void {
     if (event.kind === "instance-status") {
       const inst = byId(event.instanceId);
-      if (inst) inst.online = event.online;
+      if (inst) {
+        inst.online = event.online;
+        // An instance that just came online may not have had its sessions fetched yet
+        // (it was offline at the initial snapshot) — pull them now so the sidebar fills in.
+        if (event.online && !inst.sessionsLoaded) void loadSessions(event.instanceId).catch(() => {});
+      }
     } else if (event.kind === "control-event" && event.event.type === "sessions-changed") {
       void loadSessions(event.instanceId).catch(() => {});
     }

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -11,6 +11,7 @@ import { useConnectionStore } from "../stores/connection";
 import InstanceTree from "../components/InstanceTree.vue";
 import ChatPane from "../components/ChatPane.vue";
 import TaskPanel from "../components/TaskPanel.vue";
+import FilesPanel from "../components/FilesPanel.vue";
 import NoticeToast from "../components/NoticeToast.vue";
 import ConnectionBadge from "../components/ConnectionBadge.vue";
 
@@ -27,6 +28,7 @@ let disconnect: (() => void) | null = null;
 // these flags are visually irrelevant because the lg: classes override the transform.
 const leftOpen = ref(false);
 const rightOpen = ref(false);
+const rightTab = ref<"tasks" | "files">("tasks");
 function closeDrawers() {
   leftOpen.value = false;
   rightOpen.value = false;
@@ -115,11 +117,16 @@ onUnmounted(() => disconnect?.());
       <div data-test="column" data-drawer="right"
            class="fixed inset-y-0 right-0 z-40 w-72 max-w-[85%] shrink-0 transform overflow-y-auto border-l bg-white shadow-lg transition-transform lg:static lg:z-auto lg:max-w-none lg:translate-x-0 lg:transform-none lg:shadow-none"
            :class="rightOpen ? 'translate-x-0' : 'translate-x-full'">
-        <div class="flex items-center justify-end border-b p-2 lg:hidden">
+        <div class="flex items-center gap-1 border-b p-2">
+          <div class="flex overflow-hidden rounded border text-xs">
+            <button data-test="right-tab-tasks" class="px-2 py-1" :class="rightTab === 'tasks' ? 'bg-sky-500 text-white' : 'text-slate-500'" @click="rightTab = 'tasks'">Tasks</button>
+            <button data-test="right-tab-files" class="px-2 py-1" :class="rightTab === 'files' ? 'bg-sky-500 text-white' : 'text-slate-500'" @click="rightTab = 'files'">Files</button>
+          </div>
           <button data-test="close-tasks" aria-label="Close tasks"
-                  class="text-slate-400 hover:text-slate-600" @click="rightOpen = false">✕</button>
+                  class="ml-auto text-slate-400 hover:text-slate-600 lg:hidden" @click="rightOpen = false">✕</button>
         </div>
-        <TaskPanel />
+        <TaskPanel v-if="rightTab === 'tasks'" />
+        <FilesPanel v-else :instance-id="chat.instanceId" />
       </div>
     </div>
     <NoticeToast />

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -14,9 +14,12 @@ import TaskPanel from "../components/TaskPanel.vue";
 import FilesPanel from "../components/FilesPanel.vue";
 import NoticeToast from "../components/NoticeToast.vue";
 import ConnectionBadge from "../components/ConnectionBadge.vue";
+import CommandPalette from "../components/CommandPalette.vue";
+import { useComposerStore } from "../stores/composer";
 
 const instances = useInstancesStore();
 const chat = useChatStore();
+const composer = useComposerStore();
 const tasks = useTasksStore();
 const notices = useNoticesStore();
 const conn = useConnectionStore();
@@ -32,6 +35,16 @@ const rightTab = ref<"tasks" | "files">("tasks");
 function closeDrawers() {
   leftOpen.value = false;
   rightOpen.value = false;
+}
+
+// Cmd/Ctrl+K command palette.
+const paletteOpen = ref(false);
+const composerKey = () => `${chat.instanceId}\0${chat.sessionAlias}`;
+function onGlobalKey(e: KeyboardEvent) {
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+    e.preventDefault();
+    paletteOpen.value = !paletteOpen.value;
+  }
 }
 
 async function onLogout() {
@@ -63,6 +76,7 @@ function onStatus(online: boolean) {
 }
 
 onMounted(async () => {
+  window.addEventListener("keydown", onGlobalKey);
   await instances.loadInstances();
   disconnect = connectEvents((event) => {
     instances.applyEvent(event);
@@ -72,7 +86,10 @@ onMounted(async () => {
   }, onStatus);
 });
 
-onUnmounted(() => disconnect?.());
+onUnmounted(() => {
+  window.removeEventListener("keydown", onGlobalKey);
+  disconnect?.();
+});
 </script>
 
 <template>
@@ -130,5 +147,9 @@ onUnmounted(() => disconnect?.());
       </div>
     </div>
     <NoticeToast />
+    <CommandPalette v-if="paletteOpen"
+                    @close="paletteOpen = false"
+                    @select-session="(id, alias) => { onSelect(id, alias); paletteOpen = false; }"
+                    @pick-command="(name) => { composer.requestInsert(composerKey(), name); paletteOpen = false; }" />
   </div>
 </template>

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -110,7 +110,7 @@ onUnmounted(() => disconnect?.());
 
       <!-- Center: chat, always full width of the remaining space. -->
       <div data-test="column" class="flex flex-1 flex-col">
-        <ChatPane />
+        <ChatPane @show-files="rightTab = 'files'" />
       </div>
 
       <!-- Right: tasks. Off-canvas drawer < lg, static column ≥ lg. -->

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -20,7 +20,7 @@ import {
 } from "../channels/channel-scope";
 import type { ControlEventBus } from "./control-event-bus";
 import type { AgentCatalogEntry } from "../config/agent-catalog";
-import { WorkspaceFs, type DirListing, type FileContent, type WorkspaceDiff } from "./workspace-fs";
+import { WorkspaceFs, type DirListing, type FileContent, type SearchResult, type WorkspaceDiff } from "./workspace-fs";
 
 export interface ControlSessionInfo {
   alias: string;
@@ -115,6 +115,10 @@ export class ControlService {
 
   workspaceGitDiff(workspace: string, path?: string): Promise<WorkspaceDiff> {
     return this.workspaceFs.gitDiff(workspace, path);
+  }
+
+  searchWorkspace(workspace: string, query: string): Promise<SearchResult> {
+    return this.workspaceFs.search(workspace, query);
   }
 
   get events(): ControlEventBus {

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -20,6 +20,7 @@ import {
 } from "../channels/channel-scope";
 import type { ControlEventBus } from "./control-event-bus";
 import type { AgentCatalogEntry } from "../config/agent-catalog";
+import { WorkspaceFs, type DirListing, type FileContent, type WorkspaceDiff } from "./workspace-fs";
 
 export interface ControlSessionInfo {
   alias: string;
@@ -97,6 +98,24 @@ export interface ControlExecuteCommandInput {
 // connector first). Holds no state of its own beyond in-flight turn tracking.
 export class ControlService {
   constructor(private readonly deps: ControlServiceDeps) {}
+
+  // Read-only workspace file browser, scoped to configured workspace roots. Lazily
+  // reads the live workspace list so newly-created workspaces are immediately browsable.
+  private readonly workspaceFs = new WorkspaceFs(() =>
+    this.deps.workspaces.list().map((w) => ({ name: w.name, cwd: w.cwd })),
+  );
+
+  listDirectory(workspace: string, path?: string): Promise<DirListing> {
+    return this.workspaceFs.listDirectory(workspace, path);
+  }
+
+  readWorkspaceFile(workspace: string, path: string): Promise<FileContent> {
+    return this.workspaceFs.readFile(workspace, path);
+  }
+
+  workspaceGitDiff(workspace: string, path?: string): Promise<WorkspaceDiff> {
+    return this.workspaceFs.gitDiff(workspace, path);
+  }
 
   get events(): ControlEventBus {
     return this.deps.events;

--- a/src/control/workspace-fs.ts
+++ b/src/control/workspace-fs.ts
@@ -27,6 +27,9 @@ const MAX_ENTRIES = 2000;
 const FILE_READ_CAP = 256 * 1024; // 256 KiB
 const DIFF_CAP = 512 * 1024; // 512 KiB
 const GIT_MAX_BUFFER = 32 * 1024 * 1024;
+const SEARCH_MAX_RESULTS = 200;
+const SEARCH_MAX_SCAN = 20000; // directory entries visited before giving up
+const SEARCH_SKIP_DIRS = new Set([".git", "node_modules"]);
 
 export interface FsEntry {
   name: string;
@@ -49,6 +52,12 @@ export interface FileContent {
 export interface DiffFile {
   path: string;
   status: string;
+}
+export interface SearchResult {
+  workspace: string;
+  query: string;
+  matches: string[];
+  truncated: boolean;
 }
 export interface WorkspaceDiff {
   workspace: string;
@@ -133,6 +142,45 @@ export class WorkspaceFs {
     } finally {
       await fh.close();
     }
+  }
+
+  /** Find files whose relative path contains `query` (case-insensitive). Walks the
+   *  tree breadth-first, skipping `.git`/`node_modules` and never following symlinks
+   *  (so it stays contained), bounded by a scan budget and a result cap. */
+  async search(workspace: string, query: string): Promise<SearchResult> {
+    const { root } = await this.resolve(workspace, undefined);
+    const needle = query.trim().toLowerCase();
+    const matches: string[] = [];
+    if (!needle) return { workspace, query, matches, truncated: false };
+
+    let scanned = 0;
+    let truncated = false;
+    const queue: string[] = [root];
+    while (queue.length) {
+      const dir = queue.shift()!;
+      let dirents;
+      try {
+        dirents = await readdir(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const d of dirents) {
+        if (++scanned > SEARCH_MAX_SCAN) { truncated = true; break; }
+        if (d.isSymbolicLink()) continue; // never follow symlinks — keeps us contained
+        if (d.isDirectory()) {
+          if (!SEARCH_SKIP_DIRS.has(d.name)) queue.push(resolve(dir, d.name));
+        } else if (d.isFile()) {
+          const rel = relative(root, resolve(dir, d.name)).split(sep).join("/");
+          if (rel.toLowerCase().includes(needle)) {
+            matches.push(rel);
+            if (matches.length >= SEARCH_MAX_RESULTS) { truncated = true; break; }
+          }
+        }
+      }
+      if (truncated) break;
+    }
+    matches.sort();
+    return { workspace, query, matches, truncated };
   }
 
   async gitDiff(workspace: string, relPath?: string): Promise<WorkspaceDiff> {

--- a/src/control/workspace-fs.ts
+++ b/src/control/workspace-fs.ts
@@ -1,0 +1,178 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { homedir } from "node:os";
+import { readdir, realpath, stat, open } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+/** Expand a leading `~` to the home directory (workspace cwds are often configured
+ *  as `~` or `~/path`). */
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/") || p.startsWith("~" + sep)) return resolve(homedir(), p.slice(2));
+  return p;
+}
+
+// Read-only browser over a configured workspace's files + git diff, for the relay
+// web dashboard. Security model (deliberately the OPPOSITE of HAPI's fail-open one):
+//   - default-deny: an unknown workspace name is rejected, never an absolute path.
+//   - realpath containment: the target is symlink-resolved and must stay inside the
+//     symlink-resolved workspace root, so neither `..` nor a symlink can escape.
+//   - read-only: no method writes; git runs read-only subcommands via execFile
+//     (argument array, never a shell) so a path cannot inject a command.
+//   - bounded: entry counts, file size, and diff size are all capped.
+
+const MAX_ENTRIES = 2000;
+const FILE_READ_CAP = 256 * 1024; // 256 KiB
+const DIFF_CAP = 512 * 1024; // 512 KiB
+const GIT_MAX_BUFFER = 32 * 1024 * 1024;
+
+export interface FsEntry {
+  name: string;
+  type: "dir" | "file";
+  size?: number;
+}
+export interface DirListing {
+  workspace: string;
+  path: string;
+  entries: FsEntry[];
+}
+export interface FileContent {
+  workspace: string;
+  path: string;
+  content: string;
+  size: number;
+  truncated: boolean;
+  binary: boolean;
+}
+export interface DiffFile {
+  path: string;
+  status: string;
+}
+export interface WorkspaceDiff {
+  workspace: string;
+  files: DiffFile[];
+  diff: string;
+  truncated: boolean;
+}
+
+export interface WorkspaceRef {
+  name: string;
+  cwd: string;
+}
+
+export class WorkspaceFs {
+  constructor(private readonly listWorkspaces: () => WorkspaceRef[]) {}
+
+  /** Resolve `relPath` within a named workspace, symlink-safe and contained. Throws
+   *  on unknown workspace, missing target, or any path that escapes the root. */
+  private async resolve(workspace: string, relPath: string | undefined): Promise<{ root: string; abs: string; rel: string }> {
+    const ref = this.listWorkspaces().find((w) => w.name === workspace);
+    if (!ref) throw new Error("unknown-workspace");
+    if (relPath && isAbsolute(relPath)) throw new Error("path-must-be-relative");
+
+    let root: string;
+    try {
+      root = await realpath(expandHome(ref.cwd));
+    } catch {
+      throw new Error("workspace-root-missing");
+    }
+    const requested = resolve(root, relPath ?? ".");
+    let abs: string;
+    try {
+      abs = await realpath(requested);
+    } catch {
+      throw new Error("not-found");
+    }
+    if (abs !== root && !abs.startsWith(root + sep)) throw new Error("path-escapes-workspace");
+    const rel = abs === root ? "" : relative(root, abs).split(sep).join("/");
+    return { root, abs, rel };
+  }
+
+  async listDirectory(workspace: string, relPath?: string): Promise<DirListing> {
+    const { abs, rel } = await this.resolve(workspace, relPath);
+    const dirents = await readdir(abs, { withFileTypes: true });
+    const entries: FsEntry[] = [];
+    for (const d of dirents.slice(0, MAX_ENTRIES)) {
+      if (d.isDirectory()) {
+        entries.push({ name: d.name, type: "dir" });
+      } else if (d.isFile()) {
+        let size: number | undefined;
+        try {
+          size = (await stat(resolve(abs, d.name))).size;
+        } catch {
+          size = undefined;
+        }
+        entries.push({ name: d.name, type: "file", size });
+      }
+      // symlinks / sockets / devices are skipped (not browsable read targets)
+    }
+    entries.sort((a, b) => (a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name)));
+    return { workspace, path: rel, entries };
+  }
+
+  async readFile(workspace: string, relPath: string): Promise<FileContent> {
+    const { abs, rel } = await this.resolve(workspace, relPath);
+    const info = await stat(abs);
+    if (!info.isFile()) throw new Error("not-a-file");
+    const fh = await open(abs, "r");
+    try {
+      const buf = Buffer.alloc(Math.min(info.size, FILE_READ_CAP));
+      const { bytesRead } = await fh.read(buf, 0, buf.length, 0);
+      const slice = buf.subarray(0, bytesRead);
+      const binary = slice.includes(0); // NUL byte ⇒ treat as binary
+      return {
+        workspace,
+        path: rel,
+        content: binary ? "" : slice.toString("utf8"),
+        size: info.size,
+        truncated: info.size > FILE_READ_CAP,
+        binary,
+      };
+    } finally {
+      await fh.close();
+    }
+  }
+
+  async gitDiff(workspace: string, relPath?: string): Promise<WorkspaceDiff> {
+    const { root, rel } = await this.resolve(workspace, relPath);
+    try {
+      await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { maxBuffer: GIT_MAX_BUFFER });
+    } catch {
+      throw new Error("not-a-git-repo");
+    }
+
+    // Changed-file list (includes untracked as "??").
+    const files: DiffFile[] = [];
+    try {
+      const { stdout } = await execFileAsync("git", ["-C", root, "status", "--porcelain"], { maxBuffer: GIT_MAX_BUFFER });
+      for (const line of stdout.split("\n")) {
+        if (!line) continue;
+        const status = line.slice(0, 2);
+        let path = line.slice(3);
+        const arrow = path.indexOf(" -> "); // renamed: "old -> new"
+        if (arrow >= 0) path = path.slice(arrow + 4);
+        files.push({ path, status });
+      }
+    } catch {
+      /* status failed — leave files empty, still try the diff */
+    }
+
+    // Unified diff vs HEAD (staged + unstaged for tracked files). Fall back to a
+    // working-tree diff in a fresh repo with no commit yet.
+    const diffArgs = (base: string[]) => ["-C", root, ...base, ...(rel ? ["--", rel] : [])];
+    let diff = "";
+    try {
+      diff = (await execFileAsync("git", diffArgs(["diff", "HEAD"]), { maxBuffer: GIT_MAX_BUFFER })).stdout;
+    } catch {
+      try {
+        diff = (await execFileAsync("git", diffArgs(["diff"]), { maxBuffer: GIT_MAX_BUFFER })).stdout;
+      } catch {
+        diff = "";
+      }
+    }
+    const truncated = diff.length > DIFF_CAP;
+    return { workspace, files, diff: truncated ? diff.slice(0, DIFF_CAP) : diff, truncated };
+  }
+}

--- a/tests/unit/control/workspace-fs.test.ts
+++ b/tests/unit/control/workspace-fs.test.ts
@@ -79,6 +79,25 @@ describe("WorkspaceFs listing & reading", () => {
   });
 });
 
+describe("WorkspaceFs search", () => {
+  test("finds files by case-insensitive path substring", async () => {
+    const r = await fs.search("ws", "A.TS");
+    expect(r.matches).toContain("src/a.ts");
+    expect(r.truncated).toBe(false);
+  });
+
+  test("returns no matches for an empty or unmatched query", async () => {
+    expect((await fs.search("ws", "")).matches).toEqual([]);
+    expect((await fs.search("ws", "zzz-nope")).matches).toEqual([]);
+  });
+
+  test("does not follow a symlink that escapes the root", async () => {
+    // `escape` points outside; its `secret.txt` must never appear in results.
+    const r = await fs.search("ws", "secret");
+    expect(r.matches).toEqual([]);
+  });
+});
+
 describe("WorkspaceFs git diff", () => {
   test("throws on a non-git workspace", async () => {
     await expect(fs.gitDiff("ws")).rejects.toThrow("not-a-git-repo");

--- a/tests/unit/control/workspace-fs.test.ts
+++ b/tests/unit/control/workspace-fs.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkspaceFs } from "../../../src/control/workspace-fs";
+
+let root: string;
+let outside: string;
+let fs: WorkspaceFs;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "wsfs-"));
+  outside = mkdtempSync(join(tmpdir(), "wsfs-out-"));
+  writeFileSync(join(outside, "secret.txt"), "TOP SECRET");
+  mkdirSync(join(root, "src"));
+  writeFileSync(join(root, "README.md"), "# hello\n");
+  writeFileSync(join(root, "src", "a.ts"), "export const a = 1;\n");
+  writeFileSync(join(root, "bin.dat"), Buffer.from([0x00, 0x01, 0x02, 0x00]));
+  symlinkSync(outside, join(root, "escape")); // symlink pointing outside the root
+  fs = new WorkspaceFs(() => [{ name: "ws", cwd: root }]);
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
+});
+
+describe("WorkspaceFs containment", () => {
+  test("rejects an unknown workspace", async () => {
+    await expect(fs.listDirectory("nope")).rejects.toThrow("unknown-workspace");
+  });
+
+  test("rejects an absolute path", async () => {
+    await expect(fs.readFile("ws", "/etc/passwd")).rejects.toThrow("path-must-be-relative");
+  });
+
+  test("rejects a .. traversal escape", async () => {
+    await expect(fs.listDirectory("ws", "../")).rejects.toThrow(/escapes-workspace|not-found/);
+  });
+
+  test("rejects a symlink that escapes the root", async () => {
+    await expect(fs.listDirectory("ws", "escape")).rejects.toThrow("path-escapes-workspace");
+    await expect(fs.readFile("ws", "escape/secret.txt")).rejects.toThrow("path-escapes-workspace");
+  });
+});
+
+describe("WorkspaceFs listing & reading", () => {
+  test("lists the root with directories first", async () => {
+    const { entries, path } = await fs.listDirectory("ws");
+    expect(path).toBe("");
+    const names = entries.map((e) => e.name);
+    expect(names).toContain("src");
+    expect(names).toContain("README.md");
+    expect(entries[0].type).toBe("dir"); // dirs sort first
+  });
+
+  test("reads a text file", async () => {
+    const r = await fs.readFile("ws", "src/a.ts");
+    expect(r.content).toContain("export const a = 1");
+    expect(r.binary).toBe(false);
+    expect(r.truncated).toBe(false);
+  });
+
+  test("flags a binary file and omits its content", async () => {
+    const r = await fs.readFile("ws", "bin.dat");
+    expect(r.binary).toBe(true);
+    expect(r.content).toBe("");
+  });
+
+  test("expands a leading ~ in the workspace cwd", async () => {
+    // HOME is set per test run; point a workspace at "~" and confirm it resolves.
+    const home = process.env.HOME ?? "";
+    const homeFs = new WorkspaceFs(() => [{ name: "h", cwd: "~" }]);
+    const { entries } = await homeFs.listDirectory("h");
+    // Resolves to the real home dir without throwing; listing is whatever HOME holds.
+    expect(Array.isArray(entries)).toBe(true);
+    expect(home.length).toBeGreaterThan(0);
+  });
+});
+
+describe("WorkspaceFs git diff", () => {
+  test("throws on a non-git workspace", async () => {
+    await expect(fs.gitDiff("ws")).rejects.toThrow("not-a-git-repo");
+  });
+
+  test("reports changed files and a unified diff", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "wsfs-git-"));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+    git("init", "-q");
+    git("config", "user.email", "t@t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "f.txt"), "one\n");
+    git("add", "."); git("commit", "-qm", "init");
+    writeFileSync(join(repo, "f.txt"), "one\ntwo\n"); // modify
+    writeFileSync(join(repo, "new.txt"), "fresh\n"); // untracked
+    const gfs = new WorkspaceFs(() => [{ name: "g", cwd: repo }]);
+    const d = await gfs.gitDiff("g");
+    expect(d.files.map((f) => f.path)).toContain("f.txt");
+    expect(d.files.some((f) => f.path === "new.txt" && f.status.includes("?"))).toBe(true);
+    expect(d.diff).toContain("+two");
+    rmSync(repo, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
A batch of relay-web dashboard improvements borrowed from HAPI and a "Z" desktop agent client, plus a read-only workspace file browser that spans the relay (protocol → connector → core). All additive; the web surface stays **read-only** by design.

### Workspace file browser (read-only, sandboxed)
- New core `WorkspaceFs` (`src/control/workspace-fs.ts`): default-deny, realpath containment (symlink-resolved target must stay inside the symlink-resolved root), read-only, git via `execFile` (array args, no shell), bounded caps, `~` expansion.
- `control.fs.list/read/diff/search` RPCs (protocol + connector bridge + `ControlService`).
- relay-web `FilesPanel`: directory browse, file viewer with **line numbers + copy**, file-name **search**, whole-tree & **per-file git diff**, **git-status badges** in the listing.

### HAPI-borrow dashboard UX
- Attention dots, tool-call summary, reasoning shimmer, first-use-experience hints.
- Composer/scroll/copy refinements, diff stats.

### "Z" client borrow (Batches B/C/E/D — see `docs/superpowers/`)
- **B** Top context chips: `📁 workspace · @ instance · 🤖 agent`; workspace chip jumps to Files.
- **C** Read-only git summary chip (`● N changed`) in the chat header, reusing `control.fs.diff`.
- **E** Sidebar session elapsed badges + empty state.
- **D** `Cmd/Ctrl+K` command palette: fuzzy-search sessions across instances + the slash-command catalog, keyboard nav, command picks fill the composer.

Deferred (documented, no clean data source yet): branch in the git chip (protocol carries no git branch), reasoning-duration label (no reasoning start/end timestamps), warning callouts (no structured warning message kind).

## Test Plan
- [x] relay-web: **179 pass / 0 fail** (vitest) + `vue-tsc` build clean
- [x] core file browser: `workspace-fs` **13 pass / 0 fail**; `npx tsc --noEmit` clean
- [x] Verified end-to-end through the live relay sandbox (list/read/diff/search, security rejections, context chips, git summary, palette)
- Spec + plan docs under `docs/superpowers/{specs,plans}/2026-06-15-*`