### PR TITLE
fix(relay): guard upgrade-handler path against undefined (unblocks relay-v0.2.0 publish)

### DIFF
--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -235,7 +235,7 @@ export async function startRelayServer(options: StartRelayOptions): Promise<Runn
 
   const webWss = new WebSocketServer({ noServer: true });
   httpServer.on("upgrade", (req: IncomingMessage, socket: Duplex, head: Buffer) => {
-    const path = (req.url ?? "").split("?")[0];
+    const path = (req.url ?? "").split("?")[0] ?? "";
     if (path === "/ws") {
       const token = parseCookie(req.headers.cookie ?? "")["xrelay_session"];
       const account = token ? runtime.accounts.getSessionAccount(token) : null;


### PR DESCRIPTION
The `relay-v0.2.0` publish workflow failed at `build:relay` with TS18048 `'path' is possibly 'undefined'` at the merged-gateway `/gateway/` check (`packages/relay/src/server.ts`). `(req.url ?? "").split("?")[0]` is `string | undefined` under the relay package's strict `noUncheckedIndexedAccess`; `.startsWith()` on it fails.

Root `tsc --noEmit` and `test.yml`'s `bun run build` do **not** compile the relay package's tsconfig, so this only surfaced in the publish workflow's `build:relay`. Fix: `?? ""` fallback (the array index is always present at runtime; this just satisfies the type).

Verified locally: `tsc -p packages/relay/tsconfig.json --noEmit` green, `bun run build:relay` green. Nothing was published by the failed run (relay still 0.1.0 on npm); re-tagging relay-v0.2.0 after this merges.

Follow-up (not in this PR): `test.yml` should also build the relay packages (or run `verify:publish`) so PR CI catches this class of error.