### PR TITLE
ci(test): build all packages so package-level type errors are caught at PR time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,9 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Build
-        run: bun run build
+      # Build ALL workspace packages, not just the root. Each package's own
+      # tsconfig (e.g. the relay stack's stricter noUncheckedIndexedAccess) is
+      # only compiled by its `build:*` script — `bun run build` alone misses
+      # them, so package-level type/build errors used to surface only at publish.
+      - name: Build (all packages)
+        run: bun run build:packages


### PR DESCRIPTION
## Why
`relay-v0.2.0` failed to publish on a strict-tsconfig type error (`server.ts` `path` possibly undefined) that PR CI never caught: `test.yml`'s Build step ran `bun run build` (root `cli.ts`/`bridge`/`plugin-api` only). The relay stack's own `tsconfig`s — with stricter `noUncheckedIndexedAccess` — are compiled only by their `build:*` scripts (via `tsc -p packages/<pkg>/tsconfig.json`), which run in the **publish** workflow, not here. So package-level type/build breakage surfaced only at release.

## Change
Build step: `bun run build` → `bun run build:packages`, which compiles every workspace package (root + channel-yuanbao + channel-feishu + relay-protocol + relay + channel-relay, including the embedded relay-web vite/vue-tsc build). Now a relay-package type error fails the PR instead of the release.

## Verified
`bun run build:packages` runs clean locally on this branch (exit 0). CI on this PR exercises the new step.

Cost: slightly longer CI (adds the channel + relay-stack + relay-web builds). Acceptable for catching release-blocking errors pre-merge.