### PR TITLE
fix(relay): add shebang to the xacpx-relay bin (publish 0.2.1)

### DIFF
--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": ["xacpx", "relay", "hub"],

--- a/packages/relay/src/cli.ts
+++ b/packages/relay/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";

--- a/scripts/verify-publish.mjs
+++ b/scripts/verify-publish.mjs
@@ -119,6 +119,20 @@ async function verifyPackage(repoRoot, pkg, failures, runDryRun) {
     }
   }
 
+  // Every `bin` target must start with a `#!` shebang, or running the installed
+  // command directly (not via `node <file>`) fails with a shell syntax error.
+  const binEntries = typeof packageJson.bin === "string"
+    ? [packageJson.bin]
+    : Object.values(packageJson.bin ?? {});
+  for (const binRel of binEntries) {
+    const binPath = join(packageRoot, binRel);
+    if (!existsSync(binPath)) continue; // missing-file is already reported via requiredFiles
+    const firstLine = (await readFile(binPath, "utf8")).split("\n", 1)[0] ?? "";
+    if (!firstLine.startsWith("#!")) {
+      failures.push(`${pkg.id}: bin ${binRel} is missing a shebang (first line: ${JSON.stringify(firstLine.slice(0, 40))}). Add '#!/usr/bin/env node' to the entry source.`);
+    }
+  }
+
   if (pkg.requiredPeer && !(pkg.requiredPeer in (packageJson.peerDependencies ?? {}))) {
     failures.push(`${pkg.id}: package.json peerDependencies must include ${pkg.requiredPeer}`);
   }


### PR DESCRIPTION
## Bug
`npm i -g @ganglion/xacpx-relay` then `xacpx-relay add token` fails:
```
xacpx-relay: line 1: import: command not found
xacpx-relay: line 2: syntax error near unexpected token `('
```
The published `dist/cli.js` has **no `#!/usr/bin/env node` shebang**, so the bin symlink is executed by the shell as a script instead of by node. (Root `src/cli.ts` has the shebang; `packages/relay/src/cli.ts` did not.)

## Why it slipped through
Every test path ran the cli via `node packages/relay/dist/cli.js …` (verify:publish, the sandbox, unit tests) — never via the installed `xacpx-relay` bin — so the missing shebang never surfaced until a real global install.

## Fix
- Add `#!/usr/bin/env node` as line 1 of `packages/relay/src/cli.ts` (bun build --target node preserves it; tsc accepts a shebang on the entry).
- **Guard** in `scripts/verify-publish.mjs`: every package `bin` target must start with `#!`, else verify:publish fails. Catches this class for all packages (root + relay).
- relay `0.2.0` → `0.2.1`. channel-relay unaffected.

## Verified
dist/cli.js now starts with the shebang; executing it directly prints usage (bug gone); `verify:publish` passes; the new guard fails on a stripped-shebang bin (negative-tested). Publish via tag `relay-v0.2.1` after merge.