### PR TITLE
ci: fail fast on hung tests (per-file timeout + job timeout-minutes)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -49,6 +50,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish-channel-feishu.yml
+++ b/.github/workflows/publish-channel-feishu.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-channel-relay.yml
+++ b/.github/workflows/publish-channel-relay.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-channel-yuanbao.yml
+++ b/.github/workflows/publish-channel-yuanbao.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-relay-protocol.yml
+++ b/.github/workflows/publish-relay-protocol.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-relay.yml
+++ b/.github/workflows/publish-relay.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-xacpx.yml
+++ b/.github/workflows/publish-xacpx.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -4,6 +4,13 @@ import { buildTestPlan } from "./run-tests-lib.mjs";
 
 const root = process.argv[2] ?? "tests/unit";
 
+// Per-step wall-clock cap. A single hung test file (e.g. a leaked socket/handle
+// that never lets the process exit) otherwise wedges the whole run until the CI
+// job timeout — burning ~30min and hiding which file is at fault. Fail the step
+// here instead, naming the command, so CI fails fast and points at the culprit.
+// Declared before the first runOne() call below (const is not hoisted).
+const STEP_TIMEOUT_MS = Number(process.env.RUN_TESTS_STEP_TIMEOUT_MS ?? 180_000);
+
 // Channel-package tests import `packages/*/src`, which value-import the bare
 // specifier "weacpx/plugin-api". That resolves via the workspace-root exports
 // map to `dist/plugin-api.js`, so the bundle MUST exist before any test runs —
@@ -62,7 +69,23 @@ async function runOne(command, args) {
       ...(process.platform === "win32" ? { shell: true } : {}),
     });
 
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      console.error(`\n[run-tests] TIMEOUT after ${STEP_TIMEOUT_MS / 1000}s — killing: ${command} ${args.join(" ")}`);
+      child.kill("SIGTERM");
+      setTimeout(() => { try { child.kill("SIGKILL"); } catch { /* already gone */ } }, 5_000).unref?.();
+    }, STEP_TIMEOUT_MS);
+    timer.unref?.();
+
     child.on("exit", (code, signal) => {
+      clearTimeout(timer);
+      // Our own timeout kill → report as a failure (don't re-raise it as the
+      // parent's signal, which would mask it as a clean/odd exit).
+      if (timedOut) {
+        resolve(1);
+        return;
+      }
       if (signal) {
         process.kill(process.pid, signal);
         return;


### PR DESCRIPTION
## Motivation
A flaky test hang wedged the `relay-v0.2.1` publish on the "Run tests" step for ~30 minutes (until manually cancelled), with no signal as to which file was stuck. Two independent backstops so this fails in minutes and points at the culprit.

## Changes
- **`scripts/run-tests.mjs`**: each step (per-file `bun test`, the up-front builds, `test:web`) now runs under a **180s wall-clock cap** (`RUN_TESTS_STEP_TIMEOUT_MS` to override). On timeout it SIGTERM→SIGKILLs the child and the run exits non-zero, printing `[run-tests] TIMEOUT … killing: <command>` — so a leaked-handle hang fails fast and names the file.
- **All 8 workflows**: `timeout-minutes: 20` per job (was unset → GitHub's 6h default). Backstop for anything the per-file cap doesn't cover (install, publish, deploy).

## Verified
- Forced tiny cap (`RUN_TESTS_STEP_TIMEOUT_MS=50`) → step is killed, prints the TIMEOUT line, exits 1.
- Default cap → normal run passes (exit 0).
- Fixed a temporal-dead-zone bug (the const is declared above the first `runOne()` call).

Pure CI/infra; no package code or published artifacts affected.