### PR TITLE
fix(relay): xacpx-relay bin runs (import.meta.main) — publish 0.2.2

### DIFF
--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": ["xacpx", "relay", "hub"],

--- a/packages/relay/src/cli.ts
+++ b/packages/relay/src/cli.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { createRelayRuntime, startRelayServer } from "./server.js";
 
@@ -18,13 +19,14 @@ export function defaultDbPath(): string {
 /**
  * Locates the bundled relay-web dashboard relative to the compiled cli.js.
  * Returns the path only if `index.html` is present there; otherwise undefined.
- * Defensive: returns undefined if process.argv[1] is not set.
+ *
+ * Resolves against this module's own URL (import.meta.url), NOT process.argv[1]:
+ * when invoked via the global `xacpx-relay` bin symlink, argv[1] is the symlink
+ * path (…/bin/xacpx-relay), not the real cli.js, so an argv-based path would
+ * mis-resolve. The `cliJsPath` param exists only for tests.
  */
-export function resolveBundledWebRoot(): string | undefined {
-  const argv1 = process.argv[1];
-  if (!argv1) return undefined;
-  if (!argv1.endsWith("cli.js")) return undefined;
-  const here = dirname(argv1);
+export function resolveBundledWebRoot(cliJsPath: string = fileURLToPath(import.meta.url)): string | undefined {
+  const here = dirname(cliJsPath);
   // 1. Embedded copy shipped inside the published package: build:relay copies
   //    packages/relay-web/dist into dist/relay-web (a sibling of cli.js). This is
   //    the path that exists after `npm i -g @ganglion/xacpx-relay`.
@@ -180,8 +182,10 @@ export async function runRelayCli(args: string[], io: RelayCliIo): Promise<numbe
 }
 
 // bin entry: run only when executed directly, not when imported by tests.
-const isMain = typeof process !== "undefined" && process.argv[1]?.endsWith("cli.js");
-if (isMain) {
+// Use import.meta.main (runtime "am I the entry?" flag) rather than sniffing
+// process.argv[1]: the global bin is a symlink (…/bin/xacpx-relay), so argv[1]
+// does not end with cli.js and the old check silently skipped the whole CLI.
+if (import.meta.main) {
   runRelayCli(process.argv.slice(2), { print: (line) => console.log(line) }).then(
     (code) => process.exit(code),
     (error) => {

--- a/tests/unit/packages/relay/cli.test.ts
+++ b/tests/unit/packages/relay/cli.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { runRelayCli, parseStartOptions, defaultDbPath, resolveBundledWebRoot } from "../../../../packages/relay/src/cli";
 import { createRelayRuntime } from "../../../../packages/relay/src/server";
@@ -337,22 +339,14 @@ test("parseStartOptions: explicit --ws-port → that port (legacy dedicated gate
 });
 
 // resolveBundledWebRoot reads process.argv[1], so each test stubs it and restores.
-function withArgv1<T>(fakeCliPath: string, fn: () => T): T {
-  const saved = process.argv[1];
-  process.argv[1] = fakeCliPath;
-  try {
-    return fn();
-  } finally {
-    process.argv[1] = saved;
-  }
-}
-
+// resolveBundledWebRoot resolves against its own module URL by default; the
+// cliJsPath param lets these tests point it at a fixture layout.
 test("resolveBundledWebRoot prefers the in-package dist/relay-web embed (published layout)", () => {
   const root = mkdtempSync(join(tmpdir(), "relay-webroot-"));
   const dist = join(root, "dist");
   mkdirSync(join(dist, "relay-web"), { recursive: true });
   writeFileSync(join(dist, "relay-web", "index.html"), "<html></html>");
-  expect(withArgv1(join(dist, "cli.js"), resolveBundledWebRoot)).toBe(join(dist, "relay-web"));
+  expect(resolveBundledWebRoot(join(dist, "cli.js"))).toBe(join(dist, "relay-web"));
 });
 
 test("resolveBundledWebRoot falls back to the monorepo sibling relay-web/dist", () => {
@@ -363,12 +357,34 @@ test("resolveBundledWebRoot falls back to the monorepo sibling relay-web/dist", 
   const sibling = join(root, "packages", "relay-web", "dist");
   mkdirSync(sibling, { recursive: true });
   writeFileSync(join(sibling, "index.html"), "<html></html>");
-  expect(withArgv1(join(relayDist, "cli.js"), resolveBundledWebRoot)).toBe(sibling);
+  expect(resolveBundledWebRoot(join(relayDist, "cli.js"))).toBe(sibling);
 });
 
 test("resolveBundledWebRoot returns undefined when neither location has the dashboard", () => {
   const root = mkdtempSync(join(tmpdir(), "relay-webroot-"));
   const dist = join(root, "dist");
   mkdirSync(dist, { recursive: true });
-  expect(withArgv1(join(dist, "cli.js"), resolveBundledWebRoot)).toBeUndefined();
+  expect(resolveBundledWebRoot(join(dist, "cli.js"))).toBeUndefined();
+});
+
+// Regression for the silent `add token`: npm installs the bin as a symlink whose
+// name is NOT cli.js, so process.argv[1] is …/xacpx-relay. The old main guard
+// (`argv[1].endsWith("cli.js")`) skipped the entire CLI. Build the entry the way
+// dist is built, invoke it through a differently-named symlink, and assert it
+// actually runs (prints usage) — this fails if main-detection regresses to argv.
+test("the built cli runs when invoked via a bin-style symlink (not named cli.js)", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const cliTs = join(here, "../../../../packages/relay/src/cli.ts");
+  const dir = mkdtempSync(join(tmpdir(), "relay-bin-"));
+  const built = join(dir, "cli.js");
+  // Fully bundle (no externals) so the temp artifact runs standalone under node.
+  const build = spawnSync("bun", ["build", cliTs, "--outfile", built, "--target", "node"], { encoding: "utf8" });
+  expect(build.status).toBe(0);
+
+  const binLink = join(dir, "xacpx-relay"); // the npm-style bin name
+  symlinkSync(built, binLink);
+  const run = spawnSync("node", [binLink, "definitely-not-a-command"], { encoding: "utf8" });
+  // An unknown command prints USAGE and exits non-zero — proof the CLI body ran.
+  expect(`${run.stdout}${run.stderr}`).toContain("xacpx-relay");
+  expect(run.status).not.toBe(0);
 });


### PR DESCRIPTION
## Bug
On a real server, `xacpx-relay add token` printed **nothing** (exit 0, no token). The global bin npm installs is a symlink `…/bin/xacpx-relay` → `dist/cli.js`. The entry guard was `process.argv[1]?.endsWith("cli.js")`, but via the symlink `argv[1]` is `…/bin/xacpx-relay` (not cli.js), so the guard was false and the whole CLI body was skipped. Every test/sandbox ran `node …/dist/cli.js …` (argv[1] ends with cli.js), so it never surfaced. 0.2.1's shebang fix made node execute the file; this is the next layer.

## Fix
- Main guard: `process.argv[1]?.endsWith("cli.js")` → **`import.meta.main`** (the runtime entry flag; identical to the working root `xacpx` bin).
- `resolveBundledWebRoot()` now resolves against **`import.meta.url`** (the real cli.js) instead of `argv[1]`, so `--web-root` auto-detect also works through the symlink. Param kept for tests.
- relay `0.2.1` → `0.2.2`.

## Verified
- Regression test: builds the entry, symlinks it as `xacpx-relay` (not cli.js), runs it via node → asserts it prints usage (would fail under argv-sniffing).
- Manual: `HOME=tmp node <symlink>/xacpx-relay add token` now prints the access token + hint (exit 0); `start` resolves the embedded dashboard.
- `tsc --noEmit` green; cli.test 33/33.