### PR TITLE
fix(relay-web): mobile — teleport session/manage dialogs out of the drawer transform

### DIFF
--- a/packages/relay-web/src/__tests__/newsessiondialog.test.ts
+++ b/packages/relay-web/src/__tests__/newsessiondialog.test.ts
@@ -28,7 +28,12 @@ function mountDialog(opts: DialogOptions = {}) {
   vi.spyOn(store, "createSession").mockResolvedValue({ pending: false });
   vi.spyOn(store, "listNativeSessions").mockResolvedValue(opts.nativeSessions ?? []);
   vi.spyOn(store, "listModelSuggestions").mockResolvedValue(opts.modelSuggestions ?? []);
-  const wrapper = mount(NewSessionDialog, { props: { instanceId: "i1", instanceName: "pc" } });
+  // Stub <Teleport> so the dialog renders in-place and wrapper.find() reaches it
+  // (in the app it teleports to body to escape the mobile drawer's transform).
+  const wrapper = mount(NewSessionDialog, {
+    props: { instanceId: "i1", instanceName: "pc" },
+    global: { stubs: { teleport: true } },
+  });
   return { wrapper, store };
 }
 

--- a/packages/relay-web/src/components/ManageInstanceDialog.vue
+++ b/packages/relay-web/src/components/ManageInstanceDialog.vue
@@ -23,6 +23,9 @@ onMounted(async () => {
 </script>
 
 <template>
+  <!-- Teleport to body: the mobile instance drawer uses `transform`, which would
+       otherwise trap this fixed overlay inside the narrow off-canvas drawer. -->
+  <Teleport to="body">
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="emit('close')">
     <div class="max-h-[85vh] w-full max-w-xl overflow-y-auto rounded-xl border border-border bg-raised shadow-xl" data-test="manage-instance-dialog">
       <header class="flex items-center justify-between border-b border-border px-5 py-3">
@@ -36,4 +39,5 @@ onMounted(async () => {
       </div>
     </div>
   </div>
+  </Teleport>
 </template>

--- a/packages/relay-web/src/components/NewSessionDialog.vue
+++ b/packages/relay-web/src/components/NewSessionDialog.vue
@@ -281,6 +281,10 @@ async function submit(): Promise<void> {
 </script>
 
 <template>
+  <!-- Teleport to body: the mobile instance drawer uses `transform`, which would
+       otherwise make this fixed overlay resolve against the drawer (narrow,
+       off-canvas) instead of the viewport. -->
+  <Teleport to="body">
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="emit('close')">
     <div class="w-full max-w-md rounded-xl border border-border bg-raised shadow-xl" data-test="new-session-dialog">
       <header class="flex items-center justify-between border-b border-border px-5 py-3">
@@ -413,4 +417,5 @@ async function submit(): Promise<void> {
       </footer>
     </div>
   </div>
+  </Teleport>
 </template>

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": ["xacpx", "relay", "hub"],


### PR DESCRIPTION
## Bug (mobile)
On a phone, opening **New session** (or **Manage instance**) renders the dialog left-shifted and narrowed, with the chat pane showing through on the right — instead of a centered full-screen modal.

## Cause
The instance tree is an off-canvas drawer that slides with `transform: translateX(...)` (`DashboardView.vue`). A CSS `transform` makes the element the **containing block for `position: fixed` descendants**. `NewSessionDialog`/`ManageInstanceDialog` are rendered *inside* the drawer (via `InstanceTree`) and their `fixed inset-0` overlay therefore resolves against the **narrow off-canvas drawer**, not the viewport. Desktop is fine (`lg:transform-none`).

## Fix
Wrap both dialogs' roots in `<Teleport to="body">` so the overlay escapes the transformed ancestor and covers the real viewport — the same pattern `ConfirmDialog` already uses ("Teleports to body so…"). Test stubs `teleport` so `wrapper.find` still reaches the in-place content.

## Verified
vue-tsc green; relay-web 279/279 (incl. the dialog + instance-tree tests). Ships via the embedded dashboard → relay `0.2.2` → `0.2.3`; publish `relay-v0.2.3` after merge.