### PR TITLE
feat(relay-web): rename instances from the dashboard

### DIFF
--- a/packages/relay-web/src/__tests__/instances.test.ts
+++ b/packages/relay-web/src/__tests__/instances.test.ts
@@ -61,6 +61,17 @@ test("applyEvent instance-status loads sessions when an instance comes online", 
   vi.restoreAllMocks();
 });
 
+test("renameInstance PATCHes the instance and updates local name", async () => {
+  const store = useInstancesStore();
+  store.instances = [{ id: "i1", name: "old", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];
+  const { api } = await import("../api/client");
+  const patch = vi.spyOn(api, "patch").mockResolvedValue({ ok: true });
+  await store.renameInstance("i1", "new");
+  expect(patch).toHaveBeenCalledWith("/api/instances/i1", { name: "new" });
+  expect(store.byId("i1")!.name).toBe("new");
+  vi.restoreAllMocks();
+});
+
 describe("createSession timeout handling", () => {
   beforeEach(() => setActivePinia(createPinia()));
 

--- a/packages/relay-web/src/__tests__/manageinstancedialog-rename.test.ts
+++ b/packages/relay-web/src/__tests__/manageinstancedialog-rename.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import ManageInstanceDialog from "../components/ManageInstanceDialog.vue";
+import { useInstancesStore } from "../stores/instances";
+import { i18n } from "../i18n";
+
+beforeEach(() => setActivePinia(createPinia()));
+afterEach(() => { i18n.global.locale.value = "en"; });
+
+function mountDialog() {
+  const store = useInstancesStore();
+  store.instances = [{
+    id: "i1", name: "old", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true,
+    agents: [], workspaces: [], agentCatalog: [],
+  }];
+  // loadFormOptions runs onMounted; stub it so the dialog leaves its loading state
+  // without hitting the network, and stub the child managers to isolate the dialog.
+  vi.spyOn(store, "loadFormOptions").mockResolvedValue(undefined as never);
+  const rename = vi.spyOn(store, "renameInstance").mockResolvedValue(undefined as never);
+  const w = mount(ManageInstanceDialog, {
+    props: { instanceId: "i1", instanceName: "old" },
+    global: {
+      stubs: { WorkspacesManager: true, AgentsManager: true, Teleport: true },
+    },
+  });
+  return { store, rename, w };
+}
+
+test("typing a new name and clicking Save calls renameInstance with the trimmed value", async () => {
+  const { rename, w } = mountDialog();
+  await flushPromises(); // let onMounted's loadFormOptions settle → render body
+  await w.get('[data-test="rename-name"]').setValue("  fresh name  ");
+  await w.get('[data-test="rename-save"]').trigger("click");
+  await flushPromises();
+  expect(rename).toHaveBeenCalledWith("i1", "fresh name");
+});
+
+test("the header reflects the updated name after a successful save", async () => {
+  const { w } = mountDialog();
+  await flushPromises();
+  await w.get('[data-test="rename-name"]').setValue("renamed-live");
+  await w.get('[data-test="rename-save"]').trigger("click");
+  await flushPromises();
+  expect(w.get('[data-test="manage-instance-dialog"]').find("h2").text()).toContain("renamed-live");
+});
+
+test("Save is disabled for an empty name and does not call renameInstance", async () => {
+  const { rename, w } = mountDialog();
+  await flushPromises();
+  await w.get('[data-test="rename-name"]').setValue("   ");
+  expect((w.get('[data-test="rename-save"]').element as HTMLButtonElement).disabled).toBe(true);
+  await w.get('[data-test="rename-save"]').trigger("click");
+  await flushPromises();
+  expect(rename).not.toHaveBeenCalled();
+});
+
+test("renders the Save affordance in Chinese when locale is zh-CN", async () => {
+  i18n.global.locale.value = "zh-CN";
+  const { w } = mountDialog();
+  await flushPromises();
+  expect(w.get('[data-test="rename-save"]').text()).toBe("保存");
+});

--- a/packages/relay-web/src/api/client.ts
+++ b/packages/relay-web/src/api/client.ts
@@ -20,6 +20,7 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
 export const api = {
   get: <T>(path: string) => request<T>("GET", path),
   post: <T>(path: string, body?: unknown) => request<T>("POST", path, body),
+  patch: <T>(path: string, body?: unknown) => request<T>("PATCH", path, body),
   del: <T>(path: string) => request<T>("DELETE", path),
   /** Proxy a control RPC to an instance via the relay. */
   rpc: <T>(instanceId: string, type: string, payload: unknown = {}) =>

--- a/packages/relay-web/src/components/ManageInstanceDialog.vue
+++ b/packages/relay-web/src/components/ManageInstanceDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import { X } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
 import WorkspacesManager from "./WorkspacesManager.vue";
@@ -8,8 +9,29 @@ import AgentsManager from "./AgentsManager.vue";
 const props = defineProps<{ instanceId: string; instanceName: string }>();
 const emit = defineEmits<{ close: [] }>();
 const store = useInstancesStore();
+const { t } = useI18n();
 
 const loading = ref(true);
+
+// Seed the editable name from the prop. The dialog header binds to this local ref
+// (not the static prop) so the title updates live the moment a rename succeeds.
+const name = ref(props.instanceName);
+const renameError = ref("");
+const renaming = ref(false);
+
+async function saveName(): Promise<void> {
+  const next = name.value.trim();
+  if (!next || renaming.value) return;
+  renaming.value = true; renameError.value = "";
+  try {
+    await store.renameInstance(props.instanceId, next);
+    name.value = next;
+  } catch (e) {
+    renameError.value = e instanceof Error ? e.message : t("instance.renameFailed");
+  } finally {
+    renaming.value = false;
+  }
+}
 
 onMounted(async () => {
   try {
@@ -29,11 +51,22 @@ onMounted(async () => {
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="emit('close')">
     <div class="max-h-[85vh] w-full max-w-xl overflow-y-auto rounded-xl border border-border bg-raised shadow-xl" data-test="manage-instance-dialog">
       <header class="flex items-center justify-between border-b border-border px-5 py-3">
-        <h2 class="text-sm font-semibold text-fg">{{ $t("instance.manageTitle", { name: instanceName }) }}</h2>
+        <h2 class="text-sm font-semibold text-fg">{{ $t("instance.manageTitle", { name }) }}</h2>
         <button class="rounded p-1 text-fg-muted hover:bg-fg/5 hover:text-fg" :aria-label="$t('instance.close')" @click="emit('close')"><X :size="16" /></button>
       </header>
       <div v-if="loading" class="py-6 text-center text-sm text-fg-muted">{{ $t("instance.dialogLoading") }}</div>
       <div v-else class="space-y-6 p-5">
+        <section class="space-y-3">
+          <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("instance.nameLabel") }}</h3>
+          <p v-if="renameError" data-test="rename-error" class="rounded bg-danger/10 px-3 py-2 text-sm text-danger">{{ renameError }}</p>
+          <div class="flex gap-2">
+            <input v-model="name" data-test="rename-name" :placeholder="$t('instance.renamePlaceholder')"
+                   class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                   @keyup.enter="saveName" />
+            <button data-test="rename-save" class="shrink-0 rounded bg-accent px-3 py-1.5 text-sm text-white hover:bg-accent-hover disabled:opacity-50"
+                    :disabled="renaming || !name.trim()" @click="saveName">{{ renaming ? $t("instance.renameSaving") : $t("instance.renameSave") }}</button>
+          </div>
+        </section>
         <WorkspacesManager :instance-id="instanceId" />
         <AgentsManager :instance-id="instanceId" />
       </div>

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -151,6 +151,11 @@ export default {
     manageTitle: "Manage · {name}",
     close: "Close",
     dialogLoading: "Loading…",
+    nameLabel: "Name",
+    renamePlaceholder: "instance name",
+    renameSave: "Save",
+    renameSaving: "Saving…",
+    renameFailed: "rename failed",
   },
   agents: {
     title: "Agents",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -149,6 +149,11 @@ export default {
     manageTitle: "管理 · {name}",
     close: "关闭",
     dialogLoading: "加载中…",
+    nameLabel: "名称",
+    renamePlaceholder: "实例名称",
+    renameSave: "保存",
+    renameSaving: "保存中…",
+    renameFailed: "重命名失败",
   },
   agents: {
     title: "Agent",

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -174,6 +174,15 @@ export const useInstancesStore = defineStore("instances", () => {
     await loadSessions(instanceId);
   }
 
+  // The instance name lives solely in the relay DB (not on the connector), so this
+  // is a plain relay HTTP PATCH — no control RPC. On success we mutate the local
+  // view so the sidebar/dialog reflect the new name without a full reload.
+  async function renameInstance(id: string, name: string): Promise<void> {
+    await api.patch(`/api/instances/${id}`, { name });
+    const inst = byId(id);
+    if (inst) inst.name = name;
+  }
+
   function applyEvent(event: WebServerEvent): void {
     if (event.kind === "instance-status") {
       const inst = byId(event.instanceId);
@@ -192,5 +201,5 @@ export const useInstancesStore = defineStore("instances", () => {
     return instances.value.find((i) => i.id === id);
   }
 
-  return { instances, loadInstances, loadSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, listNativeSessions, listModelSuggestions, removeSession, applyEvent, byId };
+  return { instances, loadInstances, loadSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, listNativeSessions, listModelSuggestions, removeSession, renameInstance, applyEvent, byId };
 });

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -199,6 +199,16 @@ export function createApp(deps: AppDeps): Hono<Vars> {
     return c.json({ token: issued.token, expiresAt: issued.expiresAt });
   });
 
+  app.patch("/api/instances/:id", async (c) => {
+    if (!requireJson(c.req.header("content-type"))) return c.json({ error: "unsupported-media-type" }, 415);
+    const account = c.get("account");
+    const body = (await c.req.json().catch(() => ({}))) as { name?: string };
+    const name = (body.name ?? "").trim();
+    if (!name) return c.json({ error: "invalid-name" }, 400);
+    const ok = deps.instances.rename(c.req.param("id"), account.id, name);
+    return ok ? c.json({ ok: true }) : c.json({ error: "not-found" }, 404);
+  });
+
   app.delete("/api/instances/:id", (c) => {
     const account = c.get("account");
     const removed = deps.instances.remove(c.req.param("id"), account.id);

--- a/packages/relay/src/stores/instances.ts
+++ b/packages/relay/src/stores/instances.ts
@@ -120,6 +120,12 @@ export class InstanceStore {
     return true;
   }
 
+  rename(instanceId: string, accountId: string, name: string): boolean {
+    if (!this.getOwned(instanceId, accountId)) return false;
+    this.db.run("UPDATE instances SET name = ? WHERE id = ?", [name, instanceId]);
+    return true;
+  }
+
   /** Deletes expired or already-used pairing tokens. Returns rows removed. */
   prunePairingTokens(now: Date): number {
     const iso = now.toISOString();

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -216,6 +216,64 @@ test("instances: pairing token, list with online flag, account isolation, rpc st
   })).status).toBe(404);
 });
 
+test("PATCH /api/instances/:id renames an owned instance", async () => {
+  const { app, instances, loginToken, login } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const { instanceId, accountId } = instances.redeemPairingToken(token)!;
+
+  const res = await app.request(`/api/instances/${instanceId}`, {
+    method: "PATCH", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "renamed" }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+  expect(instances.getOwned(instanceId, accountId)?.name).toBe("renamed");
+});
+
+test("PATCH /api/instances/:id with an empty/whitespace name → 400 invalid-name", async () => {
+  const { app, instances, loginToken, login } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const { instanceId } = instances.redeemPairingToken(token)!;
+
+  const res = await app.request(`/api/instances/${instanceId}`, {
+    method: "PATCH", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "   " }),
+  });
+  expect(res.status).toBe(400);
+  expect(((await res.json()) as { error: string }).error).toBe("invalid-name");
+});
+
+test("PATCH /api/instances/:id on a non-owned instance → 404 not-found", async () => {
+  const { app, loginToken, login } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const res = await app.request(`/api/instances/not-mine`, {
+    method: "PATCH", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "x" }),
+  });
+  expect(res.status).toBe(404);
+  expect(((await res.json()) as { error: string }).error).toBe("not-found");
+});
+
+test("PATCH /api/instances/:id with a non-JSON content-type → 415", async () => {
+  const { app, instances, loginToken, login } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const { instanceId } = instances.redeemPairingToken(token)!;
+
+  const res = await app.request(`/api/instances/${instanceId}`, {
+    method: "PATCH", headers: { cookie, "content-type": "text/plain" }, body: JSON.stringify({ name: "renamed" }),
+  });
+  expect(res.status).toBe(415);
+});
+
 test("rpc command.execute echoes input and output into history", async () => {
   const { app, instances, gateway, messages, loginToken, login } = await makeApp();
   const { cookie } = await login(loginToken);

--- a/tests/unit/packages/relay/stores-instances.test.ts
+++ b/tests/unit/packages/relay/stores-instances.test.ts
@@ -67,6 +67,25 @@ test("registerInstanceForAccount multiple calls create independent instances", a
   expect(listed.length).toBe(2);
 });
 
+test("rename updates the name for an owned instance", async () => {
+  const { instances, account } = await makeStores();
+  const created = instances.registerInstanceForAccount(account.id, "old-name");
+  expect(instances.rename(created.instanceId, account.id, "new name")).toBe(true);
+  expect(instances.getOwned(created.instanceId, account.id)?.name).toBe("new name");
+});
+
+test("rename of an instance owned by a different account returns false and does not change the name", async () => {
+  const { instances, account } = await makeStores();
+  const created = instances.registerInstanceForAccount(account.id, "old-name");
+  expect(instances.rename(created.instanceId, "other-account", "hijacked")).toBe(false);
+  expect(instances.getOwned(created.instanceId, account.id)?.name).toBe("old-name");
+});
+
+test("rename of a non-existent instance returns false", async () => {
+  const { instances, account } = await makeStores();
+  expect(instances.rename("ghost", account.id, "whatever")).toBe(false);
+});
+
 test("touch updates last_seen; listByAccount scopes; remove enforces ownership", async () => {
   const { instances, account, setNow } = await makeStores();
   const redeemed = instances.redeemPairingToken(


### PR DESCRIPTION
## Summary

Lets users **rename an instance** from the relay-web dashboard. Previously an instance's name was set once at pairing time and was immutable (rename required delete + re-pair).

Relay-hub only — **no protocol/connector changes** (the name lives solely in the relay `instances` table). Mirrors the existing `remove` flow:

- **Store:** `InstanceStore.rename(id, accountId, name)` — ownership-gated, single `UPDATE`, returns boolean.
- **HTTP:** `PATCH /api/instances/:id` — 415 non-JSON · 400 `invalid-name` (empty/whitespace) · 404 `not-found` (not-owned/missing) · 200 `{ok:true}`. Reuses the `requireJson` guard; account comes from the session cookie, never the body.
- **Web:** `api.patch` helper + `renameInstance` store action (updates local `InstanceView.name`).
- **UI:** a Name input + Save at the top of **Manage instance**; header updates live; new strings localized in both en/zh catalogs (parity-tested).

> Supersedes #47 (which GitHub auto-closed when its stacked base branch was deleted on the #46 merge). Now based directly on `main`.

## Test Plan
- [x] Relay store + http tests (rename success, **foreign-account rejected**, non-existent → 404, invalid-name → 400, non-JSON → 415) — 32 pass
- [x] Web suite — 306 tests pass (incl. i18n-parity + rename UI test)
- [x] Root `tsc --noEmit` + relay-web `vue-tsc --noEmit` — clean
- [x] node:sqlite path verified (plain UPDATE, no FK concern); ownership enforcement reviewed 4 ways
- [ ] Manual: Manage instance → edit name → Save → confirm sidebar + header update and persist across reload