### PR TITLE
feat(relay-web): git branch + worktree context in the dashboard

### DIFF
--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -268,6 +268,12 @@ export interface FsDiffResult {
   /** Unified diff text vs HEAD (possibly truncated). */
   diff: string;
   truncated: boolean;
+  /** Symbolic branch name (abbrev-ref HEAD); omitted when HEAD is detached. */
+  branch?: string;
+  /** True when HEAD is detached (no branch). */
+  detached?: boolean;
+  /** Working-tree context: top-level root, and whether it's a linked (non-primary) worktree. */
+  worktree?: { root: string; linked: boolean };
 }
 export interface FsSearchPayload {
   workspace: string;

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -107,6 +107,34 @@ describe("FilesPanel navigation rail", () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it("shows the branch, worktree path, and a linked badge in the Changes tab git context", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    files.tab = "changes";
+    files.diff = {
+      workspace: "ws", files: [{ path: "a.ts", status: " M" }], diff: "+x\n-y\n", truncated: false,
+      branch: "feature", worktree: { root: "/Users/dev/.worktrees/feature", linked: true },
+    } as never;
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="changes-branch"]').text()).toBe("feature");
+    expect(w.find('[data-test="worktree-linked"]').exists()).toBe(true);
+    expect(w.find('[data-test="worktree-path"]').text()).toContain("/Users/dev/.worktrees/feature");
+  });
+
+  it("falls back to a detached label and hides the linked badge on the primary worktree", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    files.tab = "changes";
+    files.diff = {
+      workspace: "ws", files: [], diff: "", truncated: false,
+      detached: true, worktree: { root: "/repo", linked: false },
+    } as never;
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="changes-branch"]').text()).toBeTruthy(); // a detached label, not a branch
+    expect(w.find('[data-test="worktree-linked"]').exists()).toBe(false);
+    expect(w.find('[data-test="worktree-path"]').exists()).toBe(true);
+  });
+
   it("shows a calm empty state (not a dismiss-less error banner) for a non-git workspace's Changes tab", async () => {
     const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
     const files = useFilesStore();

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -21,6 +21,16 @@ describe("session-controls store", () => {
     expect(s.available).toEqual(["gpt-5.2[high]", "gpt-5.2[low]"]);
   });
 
+  it("loadModel coerces a malformed result to safe defaults (no array → [])", async () => {
+    // A partial/garbled connector reply (e.g. {}) must not leave `available` undefined —
+    // the composer reads `available.length` during render and would white-screen otherwise.
+    rpc.mockResolvedValueOnce({});
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "backend");
+    expect(s.available).toEqual([]);
+    expect(s.current).toBeUndefined();
+  });
+
   it("loadModel resets on missing instance/alias without an rpc", async () => {
     const s = useSessionControlsStore();
     await s.loadModel(null, "backend");

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -69,23 +69,24 @@ const verb = computed(() => {
       <!-- header -->
       <div class="shrink-0 flex min-h-11 lg:h-11 items-center gap-2.5 border-b border-border bg-surface/60 px-3 lg:px-5 py-1.5 lg:py-0 backdrop-blur-md">
         <h1 class="hidden lg:block text-[14px] font-semibold tracking-tight text-fg">{{ chat.sessionAlias }}</h1>
-        <div v-if="currentSession || instance" class="flex flex-wrap items-center gap-1">
+        <div v-if="currentSession || instance" class="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
           <button v-if="currentSession?.workspace" data-test="ctx-chip-workspace"
-                  class="flex items-center gap-1.5 rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
+                  class="flex min-w-0 max-w-[10rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
                   :title='$t("chat.browseFiles")'
-                  @click="emit('show-files')"><Folder :size="11" class="text-warn" />{{ currentSession.workspace }}</button>
+                  @click="emit('show-files')"><Folder :size="11" class="shrink-0 text-warn" /><span class="min-w-0 truncate">{{ currentSession.workspace }}</span></button>
           <span v-if="instance?.name" data-test="ctx-chip-instance"
-                class="flex items-center gap-1 rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><span class="font-mono text-accent">@</span>{{ instance.name }}</span>
+                class="flex min-w-0 max-w-[9rem] items-center gap-1 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><span class="shrink-0 font-mono text-accent">@</span><span class="min-w-0 truncate">{{ instance.name }}</span></span>
           <span v-if="currentSession?.agent" data-test="ctx-chip-agent"
-                class="flex items-center gap-1.5 rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><Bot :size="11" class="text-accent" />{{ currentSession.agent }}</span>
+                class="flex min-w-0 max-w-[9rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><Bot :size="11" class="shrink-0 text-accent" /><span class="min-w-0 truncate">{{ currentSession.agent }}</span></span>
           <button v-if="files.gitSummary" data-test="git-summary"
-                  class="flex items-center gap-1.5 rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
-                  :title='$t("chat.viewChanges")'
+                  class="flex min-w-0 max-w-[13rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
+                  :title="files.gitSummary.branch || $t('chat.viewChanges')"
                   @click="files.tab = 'changes'; emit('show-files')">
-            <GitBranch :size="11" class="text-warn" />
-            <span v-if="files.gitSummary.branch">{{ files.gitSummary.branch }}</span>
-            <span class="h-1 w-1 rounded-full bg-warn" aria-hidden="true" />
-            <span class="text-warn">{{ files.gitSummary.changedCount }} {{ $t("chat.changed") }}</span>
+            <GitBranch :size="11" class="shrink-0 text-warn" />
+            <span v-if="files.gitSummary.branch" class="min-w-0 truncate font-mono">{{ files.gitSummary.branch }}</span>
+            <span v-else-if="files.gitSummary.detached" class="shrink-0 italic">{{ $t("files.detached") }}</span>
+            <span class="h-1 w-1 shrink-0 rounded-full bg-warn" aria-hidden="true" />
+            <span class="shrink-0 text-warn">{{ files.gitSummary.changedCount }} {{ $t("chat.changed") }}</span>
           </button>
         </div>
       </div>

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { ChevronRight, CornerLeftUp, File, FileText, Folder, GitBranch, List, RefreshCw, X } from "lucide-vue-next";
+import { ChevronRight, CornerLeftUp, File, FileText, Folder, FolderGit2, GitBranch, List, RefreshCw, X } from "lucide-vue-next";
 import type { FsEntryDto } from "@ganglion/xacpx-relay-protocol";
 import { useFilesStore } from "../stores/files";
 import { useInstancesStore } from "../stores/instances";
@@ -27,6 +27,14 @@ function upOne() {
 const activeWorkspace = computed(() => {
   const inst = props.instanceId ? instances.byId(props.instanceId) : undefined;
   return inst?.sessions.find((s) => s.alias === chat.sessionAlias)?.workspace ?? null;
+});
+
+// Git context for the Changes header: branch / detached HEAD + worktree (root path,
+// linked flag), straight off the loaded diff result. null until a diff is loaded.
+const gitCtx = computed(() => {
+  const d = files.diff;
+  if (!d) return null;
+  return { branch: d.branch, detached: d.detached === true, worktree: d.worktree };
 });
 
 // Changes summary: `N files · +X −Y`, derived (read-only) from the loaded diff.
@@ -233,12 +241,25 @@ watch(
       <!-- Changes (git status) tab: pinned summary; only the changed-files list scrolls. -->
       <div v-else class="flex min-h-0 flex-1 flex-col">
         <template v-if="files.diff">
-          <div v-if="changesSummary" data-test="changes-summary" class="flex shrink-0 items-center justify-between border-b border-border px-2.5 py-2">
-            <span class="text-[10.5px] font-semibold uppercase tracking-wider text-fg-muted">{{ $t("files.changes") }}</span>
-            <div class="flex items-center gap-1.5 font-mono text-[10.5px] tabular-nums">
-              <span class="text-fg-muted">{{ changesSummary.fileCount }} {{ $t("files.filesCount") }}</span>
-              <span class="text-run">+{{ changesSummary.add }}</span>
-              <span class="text-danger">−{{ changesSummary.del }}</span>
+          <!-- pinned git context: branch / detached + worktree, then the change counts -->
+          <div class="shrink-0 border-b border-border">
+            <div data-test="changes-summary" class="flex items-center gap-1.5 px-2.5 pt-2" :class="gitCtx?.worktree ? 'pb-1' : 'pb-2'">
+              <GitBranch :size="12" class="shrink-0 text-accent" />
+              <span v-if="gitCtx?.branch" data-test="changes-branch" class="truncate font-mono text-[11.5px] font-medium text-fg">{{ gitCtx.branch }}</span>
+              <span v-else-if="gitCtx?.detached" data-test="changes-branch" class="truncate font-mono text-[11.5px] italic text-fg-muted">{{ $t("files.detached") }}</span>
+              <span v-else class="text-[10.5px] font-semibold uppercase tracking-wider text-fg-muted">{{ $t("files.changes") }}</span>
+              <span v-if="gitCtx?.worktree?.linked" data-test="worktree-linked"
+                    class="shrink-0 rounded-full border border-accent/30 bg-accent/10 px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide text-accent">{{ $t("files.linked") }}</span>
+              <span class="flex-1" />
+              <div v-if="changesSummary" class="flex shrink-0 items-center gap-1.5 font-mono text-[10.5px] tabular-nums">
+                <span class="text-fg-muted">{{ changesSummary.fileCount }} {{ $t("files.filesCount") }}</span>
+                <span class="text-run">+{{ changesSummary.add }}</span>
+                <span class="text-danger">−{{ changesSummary.del }}</span>
+              </div>
+            </div>
+            <div v-if="gitCtx?.worktree" data-test="worktree-path" class="flex items-center gap-1.5 px-2.5 pb-2 text-[10px] text-fg-muted" :title="`${$t('files.worktree')}: ${gitCtx.worktree.root}`">
+              <FolderGit2 :size="11" class="shrink-0 opacity-70" />
+              <span class="truncate font-mono" dir="rtl">{{ gitCtx.worktree.root }}</span>
             </div>
           </div>
           <ul class="min-h-0 flex-1 overflow-y-auto thin-scroll p-2.5 space-y-px">

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -136,6 +136,9 @@ export default {
     binaryNotShown: "Binary file not shown.",
     noDiffContent: "No diff content.",
     diffTruncated: "diff truncated",
+    detached: "detached",
+    linked: "linked",
+    worktree: "worktree",
   },
   instance: {
     newSession: "New session",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -134,6 +134,9 @@ export default {
     binaryNotShown: "不显示二进制文件。",
     noDiffContent: "无差异内容。",
     diffTruncated: "差异已截断",
+    detached: "分离 HEAD",
+    linked: "链接",
+    worktree: "工作树",
   },
   instance: {
     newSession: "新建会话",

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -28,7 +28,7 @@ export const useFilesStore = defineStore("files", () => {
   const changed = ref<Record<string, string>>({}); // relPath -> git porcelain status, for Files-tab badges
   // Standalone read-only summary for the header chip — independent of the browsed
   // workspace above, so showing it never disturbs file-browser navigation state.
-  const gitSummary = ref<{ workspace: string; changedCount: number; branch?: string } | null>(null);
+  const gitSummary = ref<{ workspace: string; changedCount: number; branch?: string; detached?: boolean } | null>(null);
   const query = ref("");
   const results = ref<string[]>([]);
   const searchTruncated = ref(false);
@@ -84,8 +84,9 @@ export const useFilesStore = defineStore("files", () => {
   }
 
   /** Read-only git summary for a session's workspace (header chip). Quiet: a
-   *  non-git workspace just clears the summary. `branch` is populated only if the
-   *  backend ever adds it to the diff result; today it stays undefined. */
+   *  non-git workspace just clears the summary. `branch`/`detached` come from the
+   *  diff result's git context (worktree detail is read off the full diff in the
+   *  Changes tab, not mirrored here). */
   async function loadGitSummary(id: string, ws: string): Promise<void> {
     if (!id || !ws) {
       gitSummary.value = null;
@@ -97,8 +98,14 @@ export const useFilesStore = defineStore("files", () => {
         gitSummary.value = null;
         return;
       }
-      const branch = typeof (r as { branch?: unknown }).branch === "string" ? (r as { branch?: string }).branch : undefined;
-      gitSummary.value = { workspace: ws, changedCount: r.files.length, ...(branch ? { branch } : {}) };
+      const branch = typeof r.branch === "string" ? r.branch : undefined;
+      const detached = r.detached === true;
+      gitSummary.value = {
+        workspace: ws,
+        changedCount: r.files.length,
+        ...(branch ? { branch } : {}),
+        ...(detached ? { detached: true } : {}),
+      };
     } catch {
       gitSummary.value = null;
     }

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -24,8 +24,10 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     try {
       const r = await api.rpc<SessionModelResult>(instanceId, "control.session.model.get", { sessionAlias: alias });
       if (isErrorPayload(r)) { reset(); return; }
-      current.value = r.current;
-      available.value = r.available;
+      current.value = typeof r.current === "string" ? r.current : undefined;
+      // Never trust the wire to hand back an array — a malformed/partial result must
+      // not blow up the composer's `available.length` reads (white-screens the input).
+      available.value = Array.isArray(r.available) ? r.available : [];
     } catch {
       reset();
     } finally {

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -123,7 +123,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="flex h-screen flex-col bg-bg text-fg">
+  <div class="flex h-dvh flex-col bg-bg text-fg">
     <!-- Global top bar: brand lockup + connection pill on the left; search, theme, settings on the right. -->
     <header class="sticky top-0 z-30 flex h-11 shrink-0 items-center justify-between border-b border-border bg-surface/80 px-3 backdrop-blur-xl">
       <!-- Left: brand X mark + "xacpx · relay" lockup, then the Connected pill. The

--- a/src/control/workspace-fs.ts
+++ b/src/control/workspace-fs.ts
@@ -64,6 +64,12 @@ export interface WorkspaceDiff {
   files: DiffFile[];
   diff: string;
   truncated: boolean;
+  /** Symbolic branch name (abbrev-ref HEAD); omitted when HEAD is detached. */
+  branch?: string;
+  /** True when HEAD is detached (no branch). */
+  detached?: boolean;
+  /** Working-tree context: its top-level root, and whether it's a linked (non-primary) worktree. */
+  worktree?: { root: string; linked: boolean };
 }
 
 export interface WorkspaceRef {
@@ -221,6 +227,32 @@ export class WorkspaceFs {
       }
     }
     const truncated = diff.length > DIFF_CAP;
-    return { workspace, files, diff: truncated ? diff.slice(0, DIFF_CAP) : diff, truncated };
+    return { workspace, files, diff: truncated ? diff.slice(0, DIFF_CAP) : diff, truncated, ...(await this.gitContext(root)) };
+  }
+
+  /** Branch + worktree context for a repo root. Best-effort: any git hiccup just
+   *  omits the fields so the diff itself still returns. */
+  private async gitContext(root: string): Promise<Pick<WorkspaceDiff, "branch" | "detached" | "worktree">> {
+    const run = async (...args: string[]): Promise<string | null> => {
+      try {
+        return (await execFileAsync("git", ["-C", root, ...args], { maxBuffer: GIT_MAX_BUFFER })).stdout.trim();
+      } catch {
+        return null;
+      }
+    };
+    const ctx: Pick<WorkspaceDiff, "branch" | "detached" | "worktree"> = {};
+    const head = await run("rev-parse", "--abbrev-ref", "HEAD");
+    if (head === "HEAD") ctx.detached = true;
+    else if (head) ctx.branch = head;
+
+    const top = await run("rev-parse", "--show-toplevel");
+    if (top) {
+      // A linked worktree's per-worktree git dir differs from the repo's common dir
+      // (e.g. <main>/.git/worktrees/<name> vs <main>/.git). The primary checkout has them equal.
+      const gitDir = await run("rev-parse", "--absolute-git-dir");
+      const commonDir = await run("rev-parse", "--path-format=absolute", "--git-common-dir");
+      ctx.worktree = { root: top, linked: !!gitDir && !!commonDir && gitDir !== commonDir };
+    }
+    return ctx;
   }
 }

--- a/tests/unit/control/workspace-fs.test.ts
+++ b/tests/unit/control/workspace-fs.test.ts
@@ -120,4 +120,56 @@ describe("WorkspaceFs git diff", () => {
     expect(d.diff).toContain("+two");
     rmSync(repo, { recursive: true, force: true });
   });
+
+  test("reports the branch and the (primary) worktree context", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "wsfs-git-"));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+    git("init", "-q", "-b", "trunk");
+    git("config", "user.email", "t@t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "f.txt"), "one\n");
+    git("add", "."); git("commit", "-qm", "init");
+    const gfs = new WorkspaceFs(() => [{ name: "g", cwd: repo }]);
+    const d = await gfs.gitDiff("g");
+    expect(d.branch).toBe("trunk");
+    expect(d.detached).toBeFalsy();
+    expect(d.worktree?.linked).toBe(false);
+    // The worktree root resolves to the repo (realpath, so /private prefix on macOS is fine).
+    expect(d.worktree?.root.endsWith(repo.split("/").pop()!)).toBe(true);
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test("flags a detached HEAD without a branch name", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "wsfs-git-"));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+    git("init", "-q");
+    git("config", "user.email", "t@t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "f.txt"), "one\n");
+    git("add", "."); git("commit", "-qm", "init");
+    git("checkout", "-q", "--detach", "HEAD");
+    const gfs = new WorkspaceFs(() => [{ name: "g", cwd: repo }]);
+    const d = await gfs.gitDiff("g");
+    expect(d.detached).toBe(true);
+    expect(d.branch).toBeUndefined();
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test("marks a linked worktree", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "wsfs-git-"));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+    git("init", "-q", "-b", "main");
+    git("config", "user.email", "t@t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "f.txt"), "one\n");
+    git("add", "."); git("commit", "-qm", "init");
+    const wt = join(repo, "..", `wt-${repo.split("/").pop()}`);
+    git("worktree", "add", "-q", "-b", "feature", wt);
+    const gfs = new WorkspaceFs(() => [{ name: "wt", cwd: wt }]);
+    const d = await gfs.gitDiff("wt");
+    expect(d.branch).toBe("feature");
+    expect(d.worktree?.linked).toBe(true);
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(wt, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
**Stacked on #49** — base this PR's merge AFTER #49 (it branches off `feat/relay-web-right-rail-scroll`). Once #49 merges, retarget this to `main`.

Surfaces the git **branch** and **worktree** of a session's workspace in the dashboard.

## Backend
`WorkspaceFs.gitDiff` now also returns, via a few cheap `rev-parse` calls, `branch` (abbrev-ref HEAD), a `detached` flag, and `worktree` context (top-level root + a `linked` flag for non-primary worktrees). Threaded through `FsDiffResult` (the web client, header chip, and a previously-dormant test were already wired to consume `branch`).

## Web
- **Chat-header chip** shows the branch (or `detached`), glanceable on every screen incl. mobile.
- **Files → Changes tab** gains a pinned git-context header: branch, a `linked` badge, and the worktree root path.
- i18n: `files.detached` / `files.linked` / `files.worktree` added to both en + zh-CN.

## Layout fixes found in review
- Header context chips no longer wrap to a second row and overflow the fixed-height header — they stay on one line and truncate (`min-w-0` + `max-w` + `overflow-hidden`); full branch name in the `title`.
- Dashboard root uses `h-dvh` instead of `h-screen` (mobile-safe viewport).
- **session-controls hardening**: `loadModel` coerces `available` to an array — a malformed/partial `control.session.model.get` reply no longer white-screens the composer (`available.length` during render). Regression test added.

## Tests
Backend git tests (branch / detached / linked worktree) + FilesPanel git-context + session-controls guard; full relay-web suite (309) green.