### PR TITLE
feat(relay-web): context-usage meter from ACP usage_update

### DIFF
--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -148,6 +148,8 @@ export type ControlEventDto =
   | { type: "tool-event"; chatKey: string; sessionAlias: string; step: ToolStepDto }
   | { type: "turn-thought"; chatKey: string; sessionAlias: string; chunk: string }
   | { type: "plan"; chatKey: string; sessionAlias: string; entries: PlanEntryDto[] }
+  // Context-usage meter: `used` tokens in context, `size` total context window. Replace-latest.
+  | { type: "turn-usage"; chatKey: string; sessionAlias: string; used: number; size: number }
   | { type: "turn-finished"; chatKey: string; sessionAlias: string; ok: boolean; errorMessage?: string; cancelled?: boolean }
   | { type: "sessions-changed" }
   | { type: "scheduled-changed"; chatKey: string }

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -56,6 +56,7 @@ const CONTROL_EVENT_TYPES = new Set([
   "tool-event",
   "turn-thought",
   "plan",
+  "turn-usage",
   "turn-finished",
   "sessions-changed",
   "scheduled-changed",
@@ -125,6 +126,8 @@ function validControlEvent(e: unknown): boolean {
     return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
   if (c.type === "plan")
     return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.entries);
+  if (c.type === "turn-usage")
+    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.used === "number" && typeof c.size === "number";
   if (c.type === "tool-event")
     return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && validToolStep(c.step);
   return true; // sessions-changed / orchestration-changed carry no extra required fields

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -61,6 +61,26 @@ test("a scheduled turn-started for an unselected session does not pollute the op
   expect(store.messages.some((m) => m.text === "do thing")).toBe(false);
 });
 
+test("turn-usage updates sessionUsage (REPLACE) and survives turn-finished", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-usage", chatKey: "relay:a1", sessionAlias: "backend", used: 34606, size: 200000 } } as never);
+  expect(store.sessionUsage).toEqual({ used: 34606, size: 200000 });
+  // The model corrects the window mid-turn → latest wins.
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-usage", chatKey: "relay:a1", sessionAlias: "backend", used: 34612, size: 1000000 } } as never);
+  expect(store.sessionUsage).toEqual({ used: 34612, size: 1000000 });
+  // Persists past turn-finished (session-scoped, decoupled from the live turn).
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true } });
+  expect(store.sessionUsage).toEqual({ used: 34612, size: 1000000 });
+});
+
+test("turn-usage for an unselected session does not leak into sessionUsage", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-usage", chatKey: "relay:a1", sessionAlias: "other", used: 1, size: 2 } } as never);
+  expect(store.sessionUsage).toBeNull();
+});
+
 test("requestScrollToScheduled bumps a nonce-keyed scroll request", () => {
   const store = useChatStore();
   expect(store.scrollRequest).toBeNull();

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -1,15 +1,27 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from "vue";
-import { Brain, Check, ChevronDown, Send } from "lucide-vue-next";
+import { computed, nextTick, ref, watch } from "vue";
+import { Brain, Check, ChevronDown, Gauge, Send } from "lucide-vue-next";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
 import { useComposerStore } from "../stores/composer";
 import { useSessionControlsStore } from "../stores/session-controls";
+import { useChatStore } from "../stores/chat";
 
 const props = defineProps<{ busy?: boolean; draftKey?: string; instanceId?: string | null; sessionAlias?: string | null }>();
 const emit = defineEmits<{ send: [text: string]; cancel: [] }>();
 
 const composer = useComposerStore();
 const controls = useSessionControlsStore();
+const chat = useChatStore();
+
+// Context-usage meter (ACP usage_update) for the current session. Null when the agent
+// doesn't report it (e.g. codex) or the window is unknown — the chip then hides.
+const context = computed(() => {
+  const u = chat.sessionUsage;
+  if (!u || u.size <= 0) return null;
+  const pct = Math.min(100, Math.round((u.used / u.size) * 100));
+  const tone = pct >= 90 ? "danger" : pct >= 75 ? "warn" : "accent";
+  return { used: u.used, size: u.size, pct, tone };
+});
 
 // Load the session's model for the composer chip whenever the session changes.
 const modelMenuOpen = ref(false);
@@ -128,6 +140,19 @@ function onInput() {
             </li>
           </ul>
           <span v-if="controls.error" data-test="model-error" class="text-xs text-danger">{{ controls.error }}</span>
+          <!-- context-usage meter: sits to the right of the model chip -->
+          <span v-if="context" data-test="context-meter"
+                class="flex shrink-0 items-center gap-1.5 whitespace-nowrap pl-0.5"
+                :title="$t('chat.contextUsage', { used: context.used.toLocaleString(), size: context.size.toLocaleString() })">
+            <Gauge :size="13" class="shrink-0"
+                   :class="context.tone === 'danger' ? 'text-danger' : context.tone === 'warn' ? 'text-warn' : 'text-accent'" />
+            <span class="relative h-1 w-8 shrink-0 overflow-hidden rounded-full bg-border">
+              <span class="absolute inset-y-0 left-0 rounded-full"
+                    :class="context.tone === 'danger' ? 'bg-danger' : context.tone === 'warn' ? 'bg-warn' : 'bg-accent'"
+                    :style="{ width: context.pct + '%' }" />
+            </span>
+            <span class="shrink-0 text-[11.5px] font-medium tabular-nums text-fg-muted">{{ context.pct }}%</span>
+          </span>
         </div>
         <span v-else />
 

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -72,6 +72,7 @@ export default {
     working: "Agent is working… (Esc to stop)",
     message: "Message",
     jumpLatest: "↓ Latest",
+    contextUsage: "Context: {used} / {size} tokens",
   },
   session: {
     newSession: "New session",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -70,6 +70,7 @@ export default {
     working: "Agent 正在工作…（按 Esc 停止）",
     message: "消息",
     jumpLatest: "↓ 最新",
+    contextUsage: "上下文：{used} / {size} tokens",
   },
   session: {
     newSession: "新建会话",

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -70,6 +70,10 @@ export const useChatStore = defineStore("chat", () => {
   // turn-finished — an agent often ends a turn mid-plan to ask a question, and the panel
   // must not vanish. REPLACE semantics: a newer plan event for the session supersedes it.
   const plans = ref<Record<string, PlanEntryDto[]>>({});
+  // Context-usage meter per session (latest `turn-usage`): `used` tokens in context +
+  // `size` total window. Session-scoped like `plans` so it persists across turns (REPLACE
+  // semantics). Absent for agents that don't report usage (e.g. codex) — the meter hides.
+  const usage = ref<Record<string, { used: number; size: number }>>({});
   // Sessions whose turn finished while NOT being viewed — drives the "unread" attention
   // dot in the session list. Reassigned (never mutated in place) so the Set stays reactive.
   const unread = ref<Set<string>>(new Set());
@@ -103,6 +107,9 @@ export const useChatStore = defineStore("chat", () => {
   );
   const sessionPlan = computed<PlanEntryDto[] | null>(() =>
     selectedKey.value ? plans.value[selectedKey.value] ?? null : null,
+  );
+  const sessionUsage = computed<{ used: number; size: number } | null>(() =>
+    selectedKey.value ? usage.value[selectedKey.value] ?? null : null,
   );
   const streaming = computed(() => (liveTurn.value ? textOf(liveTurn.value.parts) : ""));
   const liveToolSteps = computed(() => (liveTurn.value ? toolStepsOf(liveTurn.value.parts) : []));
@@ -273,6 +280,9 @@ export const useChatStore = defineStore("chat", () => {
       // Lifetime decoupled from the live turn: persists past turn-finished, replaced only
       // by a newer plan for this session. Keyed per session.
       plans.value[bufKey(event.instanceId, e.sessionAlias)] = e.entries;
+    } else if (e.type === "turn-usage") {
+      // Latest context-usage for the session (REPLACE). Like plans, persists across turns.
+      usage.value[bufKey(event.instanceId, e.sessionAlias)] = { used: e.used, size: e.size };
     } else if (e.type === "session-history") {
       // A freshly-attached native session's prior conversation was just seeded into the
       // hub. If we're viewing it, reload history so the backlog appears (otherwise it's
@@ -351,5 +361,5 @@ export const useChatStore = defineStore("chat", () => {
     }
   }
 
-  return { instanceId, sessionAlias, messages, streaming, liveTurn, sessionPlan, liveToolSteps, busy, unread, sessionAttention, runningSince, sending, error, scrollRequest, requestScrollToScheduled, hasMoreOlder, loadingOlder, select, loadHistory, loadOlder, loadActiveTurns, seedActiveTurns, applyEvent, send, resend, cancel };
+  return { instanceId, sessionAlias, messages, streaming, liveTurn, sessionPlan, sessionUsage, liveToolSteps, busy, unread, sessionAttention, runningSince, sending, error, scrollRequest, requestScrollToScheduled, hasMoreOlder, loadingOlder, select, loadHistory, loadOlder, loadActiveTurns, seedActiveTurns, applyEvent, send, resend, cancel };
 });

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -26,7 +26,8 @@ type BridgePromptStreamEvent =
   | { type: "prompt.segment"; text: string }
   | { type: "prompt.tool_event"; event: ToolUseEvent }
   | { type: "prompt.thought"; text: string }
-  | { type: "prompt.plan"; entries: PlanEntry[] };
+  | { type: "prompt.plan"; entries: PlanEntry[] }
+  | { type: "prompt.usage"; used: number; size: number };
 
 export class EnsureSessionFailedError extends Error {
   readonly kind: "missing_optional_dep" | "generic";
@@ -816,6 +817,9 @@ export async function runStreamingPrompt(
         : {}),
       ...(onEvent
         ? { onPlan: (entries) => onEvent({ type: "prompt.plan", entries }) }
+        : {}),
+      ...(onEvent
+        ? { onUsage: (usage) => onEvent({ type: "prompt.usage", used: usage.used, size: usage.size }) }
         : {}),
     });
     let lastReplyAt = now();

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -3,6 +3,7 @@ import {
   encodeBridgePromptSegmentEvent,
   encodeBridgePromptThoughtEvent,
   encodeBridgePromptToolEvent,
+  encodeBridgePromptUsageEvent,
   encodeBridgeSessionNoteEvent,
   encodeBridgeSessionProgressEvent,
   type BridgeMethod,
@@ -221,6 +222,13 @@ export class BridgeServer {
               id: requestId,
               event: "prompt.plan",
               entries: event.entries,
+            }));
+          } else if (event.type === "prompt.usage") {
+            writeLine?.(encodeBridgePromptUsageEvent({
+              id: requestId,
+              event: "prompt.usage",
+              used: event.used,
+              size: event.size,
             }));
           }
         });

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -141,6 +141,7 @@ export class CommandRouter {
     onThought?: (chunk: string) => void | Promise<void>,
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
+    onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
   ): Promise<RouterResponse> {
     const startedAt = Date.now();
     let command = parseCommand(input);
@@ -389,6 +390,7 @@ export class CommandRouter {
               perfSpan,
               metadata,
               onPlan,
+              onUsage,
             );
           }
           if (metadata?.scheduledSessionAlias) {
@@ -411,6 +413,7 @@ export class CommandRouter {
               perfSpan,
               metadata,
               onPlan,
+              onUsage,
             );
           }
           return await handlePrompt(
@@ -427,6 +430,7 @@ export class CommandRouter {
             perfSpan,
             metadata,
             onPlan,
+            onUsage,
           );
         }
       }
@@ -641,8 +645,8 @@ export class CommandRouter {
       setModelTransportSession: (session, modelId) => this.setModelTransportSession(session, modelId),
       getModelTransportSession: (session) => this.getModelTransportSession(session),
       cancelTransportSession: (session) => this.cancelTransportSession(session),
-      promptTransportSession: (session, text, reply, replyContext, media, abortSignal, onToolEvent, onThought, perfSpanOverride, onPlan) =>
-        this.promptTransportSession(session, text, reply, replyContext, media, abortSignal, onToolEvent, onThought, perfSpanOverride ?? perfSpan, onPlan),
+      promptTransportSession: (session, text, reply, replyContext, media, abortSignal, onToolEvent, onThought, perfSpanOverride, onPlan, onUsage) =>
+        this.promptTransportSession(session, text, reply, replyContext, media, abortSignal, onToolEvent, onThought, perfSpanOverride ?? perfSpan, onPlan, onUsage),
     };
   }
 
@@ -872,6 +876,7 @@ export class CommandRouter {
     onThought?: (chunk: string) => void | Promise<void>,
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
+    onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
   ) {
     session.mcpCoordinatorSession ??= stableCoordinatorSession(session.transportSession);
     // `done` closes the race window between prompt resolving and the abort
@@ -939,6 +944,7 @@ export class CommandRouter {
           ...(onToolEvent ? { onToolEvent } : {}),
           ...(onThought ? { onThought } : {}),
           ...(onPlan ? { onPlan } : {}),
+          ...(onUsage ? { onUsage } : {}),
         }),
       );
     } catch (error) {

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -721,6 +721,7 @@ async function promptWithSession(
   perfSpan?: PerfSpan,
   metadata?: ChatRequestMetadata,
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
+  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
 ): Promise<RouterResponse> {
   const effectiveReplyMode = resolveEffectiveReplyMode(context.config, chatKey, session.replyMode);
   // Ensure the session carries the resolved value so downstream transports
@@ -778,6 +779,7 @@ async function promptWithSession(
       onThought,
       perfSpan,
       onPlan,
+      onUsage,
     );
     if (claimHumanReply) {
       try {
@@ -823,13 +825,14 @@ export async function handlePromptWithSession(
   perfSpan?: PerfSpan,
   metadata?: ChatRequestMetadata,
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
+  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
 ): Promise<RouterResponse> {
   try {
-    return await promptWithSession(context, session, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan);
+    return await promptWithSession(context, session, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage);
   } catch (error) {
     const recovered = await context.recovery.tryRecoverMissingSession(session, error);
     if (recovered) {
-      return await promptWithSession(context, recovered, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan);
+      return await promptWithSession(context, recovered, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage);
     }
     return context.recovery.renderTransportError(session, error);
   }
@@ -849,6 +852,7 @@ export async function handlePrompt(
   perfSpan?: PerfSpan,
   metadata?: ChatRequestMetadata,
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
+  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
 ): Promise<RouterResponse> {
   const session = metadata?.boundSessionAlias
     ? context.sessions.getResolvedSessionByInternalAlias(metadata.boundSessionAlias)
@@ -857,7 +861,7 @@ export async function handlePrompt(
     return { text: t().session.noCurrent };
   }
 
-  return await handlePromptWithSession(context, session, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan);
+  return await handlePromptWithSession(context, session, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage);
 }
 
 function toCoordinatorRouteChatMetadata(

--- a/src/commands/router-types.ts
+++ b/src/commands/router-types.ts
@@ -152,6 +152,7 @@ export interface SessionInteractionOps {
     onThought?: (chunk: string) => void | Promise<void>,
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
+    onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
   ) => Promise<{ text: string }>;
 }
 

--- a/src/console-agent.ts
+++ b/src/console-agent.ts
@@ -22,6 +22,7 @@ interface RouterLike {
     onThought?: (chunk: string) => void | Promise<void>,
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
+    onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
   ): Promise<ChatResponse>;
   clearSession?: (chatKey: string) => Promise<void>;
 }
@@ -67,6 +68,7 @@ export class ConsoleAgent implements WechatAgent {
       request.onThought,
       request.perfSpan,
       request.onPlan,
+      request.onUsage,
     );
   }
 

--- a/src/control/control-event-bus.ts
+++ b/src/control/control-event-bus.ts
@@ -15,6 +15,8 @@ export type ControlEvent =
   | { type: "tool-event"; chatKey: string; sessionAlias: string; event: ToolUseEvent }
   | { type: "turn-thought"; chatKey: string; sessionAlias: string; chunk: string }
   | { type: "plan"; chatKey: string; sessionAlias: string; entries: PlanEntry[] }
+  // Context-usage meter: `used` tokens in context, `size` total context window. Replace-latest.
+  | { type: "turn-usage"; chatKey: string; sessionAlias: string; used: number; size: number }
   | { type: "turn-finished"; chatKey: string; sessionAlias: string; ok: boolean; errorMessage?: string; cancelled?: boolean }
   | { type: "sessions-changed" }
   | { type: "scheduled-changed"; chatKey: string }

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -480,6 +480,15 @@ export class ControlService {
             entries,
           });
         },
+        onUsage: (usage) => {
+          this.deps.events.emit({
+            type: "turn-usage",
+            chatKey: params.chatKey,
+            sessionAlias: params.sessionAlias,
+            used: usage.used,
+            size: usage.size,
+          });
+        },
       });
       if (response.text) {
         emitChunk(response.text);

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -26,6 +26,7 @@ export type BridgeEvent =
   | { type: "prompt.tool_event"; event: ToolUseEvent }
   | { type: "prompt.thought"; text: string }
   | { type: "prompt.plan"; entries: PlanEntry[] }
+  | { type: "prompt.usage"; used: number; size: number }
   | { type: "session.progress"; stage: EnsureSessionProgressStage }
   | { type: "session.note"; text: string };
 
@@ -117,6 +118,12 @@ export class AcpxBridgeClient {
         pending.onEvent?.({
           type: "prompt.plan",
           entries: message.entries,
+        });
+      } else if (message.event === "prompt.usage") {
+        pending.onEvent?.({
+          type: "prompt.usage",
+          used: message.used,
+          size: message.size,
         });
       } else if (message.event === "session.progress") {
         pending.onEvent?.({

--- a/src/transport/acpx-bridge/acpx-bridge-protocol.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-protocol.ts
@@ -80,6 +80,13 @@ export interface BridgePromptPlanEvent {
   entries: PlanEntry[];
 }
 
+export interface BridgePromptUsageEvent {
+  id: string;
+  event: "prompt.usage";
+  used: number;
+  size: number;
+}
+
 export interface BridgeSessionProgressEvent {
   id: string;
   event: "session.progress";
@@ -99,6 +106,7 @@ export type BridgeMessage<TResult = unknown> =
   | BridgePromptToolEvent
   | BridgePromptThoughtEvent
   | BridgePromptPlanEvent
+  | BridgePromptUsageEvent
   | BridgeSessionProgressEvent
   | BridgeSessionNoteEvent;
 export type BridgeResponse<TResult = unknown> = BridgeSuccessResponse<TResult> | BridgeErrorResponse;
@@ -120,6 +128,10 @@ export function encodeBridgePromptThoughtEvent(event: BridgePromptThoughtEvent):
 }
 
 export function encodeBridgePromptPlanEvent(event: BridgePromptPlanEvent): string {
+  return `${JSON.stringify(event)}\n`;
+}
+
+export function encodeBridgePromptUsageEvent(event: BridgePromptUsageEvent): string {
   return `${JSON.stringify(event)}\n`;
 }
 

--- a/src/transport/acpx-bridge/acpx-bridge-transport.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-transport.ts
@@ -86,6 +86,8 @@ export class AcpxBridgeTransport implements SessionTransport {
     let thoughtChain = Promise.resolve();
     let planError: unknown;
     let planChain = Promise.resolve();
+    let usageError: unknown;
+    let usageChain = Promise.resolve();
     let toolEventMode = resolveToolEventMode(options);
     // Safety net: structured/both without an onToolEvent handler would
     // silently drop tool calls. Demote to 'text' so verbose tool calls
@@ -155,11 +157,25 @@ export class AcpxBridgeTransport implements SessionTransport {
         }
         return;
       }
+      if (event.type === "prompt.usage") {
+        const onUsage = options?.onUsage;
+        if (onUsage) {
+          const usage = { used: event.used, size: event.size };
+          // Serialize handler invocations; first error wins.
+          usageChain = usageChain
+            .then(() => onUsage(usage))
+            .catch((error) => {
+              usageError ??= error;
+            });
+        }
+        return;
+      }
     });
     await segmentChain;
     await toolEventChain;
     await thoughtChain;
     await planChain;
+    await usageChain;
     if (sink) {
       const { overflowCount } = sink.finalize();
       // Drain in-flight reply() promises and propagate any QuotaDeferredError
@@ -189,6 +205,9 @@ export class AcpxBridgeTransport implements SessionTransport {
       if (planError) {
         throw planError;
       }
+      if (usageError) {
+        throw usageError;
+      }
       return { text: summary ? `${summary}\n\n${result.text}` : "" };
     }
     if (segmentError) {
@@ -202,6 +221,9 @@ export class AcpxBridgeTransport implements SessionTransport {
     }
     if (planError) {
       throw planError;
+    }
+    if (usageError) {
+      throw usageError;
     }
     return result;
   }

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -20,6 +20,7 @@ export interface StreamingPromptState {
   onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
   onThought?: (chunk: string) => void | Promise<void>;
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
+  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>;
   finalize: () => string;
 }
 
@@ -39,6 +40,9 @@ interface StreamEvent {
       rawInput?: unknown;
       rawOutput?: unknown;
       entries?: unknown;
+      // ACP `usage_update`: tokens currently in context + total context window.
+      used?: number;
+      size?: number;
     };
   };
 }
@@ -51,6 +55,7 @@ export type CreateStreamingPromptStateOptions =
       onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
       onThought?: (chunk: string) => void | Promise<void>;
       onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
+      onUsage?: (usage: { used: number; size: number }) => void | Promise<void>;
     };
 
 export function createStreamingPromptState(
@@ -61,6 +66,7 @@ export function createStreamingPromptState(
   let onToolEvent: ((event: ToolUseEvent) => void | Promise<void>) | undefined;
   let onThought: ((chunk: string) => void | Promise<void>) | undefined;
   let onPlan: ((entries: PlanEntry[]) => void | Promise<void>) | undefined;
+  let onUsage: ((usage: { used: number; size: number }) => void | Promise<void>) | undefined;
   let rawStream = false;
 
   if (options === undefined) {
@@ -74,6 +80,7 @@ export function createStreamingPromptState(
     onToolEvent = options.onToolEvent;
     onThought = options.onThought;
     onPlan = options.onPlan;
+    onUsage = options.onUsage;
     rawStream = options.rawStream ?? false;
     toolEventMode = resolveToolEventMode({
       toolEventMode: options.mode,
@@ -93,6 +100,7 @@ export function createStreamingPromptState(
     onToolEvent,
     onThought,
     onPlan,
+    onUsage,
     finalize(): string {
       if (this.pendingLine.trim().length > 0) {
         parseStreamingChunks(this, this.pendingLine);
@@ -175,6 +183,16 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
           !!x && typeof x === "object" && typeof (x as PlanEntry).content === "string" && typeof (x as PlanEntry).status === "string")
       : [];
     if (entries.length > 0) void state.onPlan?.(entries);
+    return;
+  }
+
+  if (update.sessionUpdate === "usage_update") {
+    // Context-usage meter: `used` = tokens currently in context, `size` = the model's
+    // total context window. Replace-latest scalar (agents may re-report mid-turn, e.g.
+    // a default window then the model's real one). Drop a malformed/zero-window frame.
+    const used = typeof update.used === "number" && Number.isFinite(update.used) ? update.used : undefined;
+    const size = typeof update.size === "number" && Number.isFinite(update.size) ? update.size : undefined;
+    if (used !== undefined && size !== undefined && size > 0) void state.onUsage?.({ used, size });
     return;
   }
 

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -125,6 +125,13 @@ export interface PromptOptions {
    */
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
   /**
+   * Context-usage side-channel: the agent's ACP `usage_update` — `used` tokens
+   * currently in context and `size`, the model's total context window. Replace-latest
+   * scalar (re-sent during a turn). Optional — only agents that report it fire this
+   * (e.g. claude does, codex does not), and text channels omit the handler.
+   */
+  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>;
+  /**
    * How tool_call / tool_call_update events are surfaced for this prompt.
    *
    * - "text" (default when no handler): legacy emoji-prefixed segments in the reply stream.

--- a/src/weixin/agent/interface.ts
+++ b/src/weixin/agent/interface.ts
@@ -53,6 +53,8 @@ export interface ChatRequest {
   onThought?: (chunk: string) => void | Promise<void>;
   /** Structured plan/todo side-channel; see PromptOptions.onPlan. */
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
+  /** Context-usage side-channel; see PromptOptions.onUsage. */
+  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>;
   /**
    * Optional per-turn performance tracing span. When `logging.perf.enabled` is
    * true, the channel handler attaches a `PerfSpan` so downstream layers can

--- a/tests/unit/packages/relay-protocol/web-dtos.test.ts
+++ b/tests/unit/packages/relay-protocol/web-dtos.test.ts
@@ -100,6 +100,17 @@ test("parseWebServerEvent accepts a plan control event", () => {
   })).not.toBeNull();
 });
 
+test("parseWebServerEvent accepts a turn-usage control event and rejects malformed ones", () => {
+  // The gate (CONTROL_EVENT_TYPES + validControlEvent) must let well-formed usage through…
+  expect(roundtrip({
+    kind: "control-event", instanceId: "i1",
+    event: { type: "turn-usage", chatKey: "k", sessionAlias: "a", used: 34606, size: 200000 },
+  })).not.toBeNull();
+  // …and reject non-numeric or missing used/size, or it would crash the meter's math.
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "turn-usage", chatKey: "k", sessionAlias: "a", used: 1 } })).toBeNull();
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "turn-usage", chatKey: "k", sessionAlias: "a", used: "x", size: 200000 } })).toBeNull();
+});
+
 test("parseWebServerEvent rejects a plan event without entries", () => {
   expect(roundtrip({
     kind: "control-event", instanceId: "i1",

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -182,3 +182,18 @@ test("buildToolUseEvent 透传 locations/rawOutput/content/rawInput", () => {
     rawOutput,
   }));
 });
+
+test("usage_update fires onUsage with the latest used/size, ignoring malformed frames", () => {
+  const seen: { used: number; size: number }[] = [];
+  const state = createStreamingPromptState(false, { onUsage: (u) => seen.push(u) });
+  const usage = (used: unknown, size: unknown) =>
+    JSON.stringify({ method: "session/update", params: { update: { sessionUpdate: "usage_update", used, size } } });
+  parseStreamingChunks(state, usage(34606, 200000));
+  parseStreamingChunks(state, usage(34612, 1000000)); // model corrects the window mid-turn
+  parseStreamingChunks(state, usage(40000, 0));       // zero window — dropped
+  parseStreamingChunks(state, usage("nope", 200000)); // non-numeric — dropped
+  expect(seen).toEqual([
+    { used: 34606, size: 200000 },
+    { used: 34612, size: 1000000 },
+  ]);
+});


### PR DESCRIPTION
Adds a per-session **context-usage meter** to the dashboard composer, driven by the agent's ACP `usage_update` (tokens currently in context + the model's total context window). Standalone PR off `main`.

### Confirmed before building (live acpx probe)
| agent | `usage_update`? |
|---|---|
| **claude** | ✅ ~3×/turn — `used` 34.6k, `size` 200k→1M (model corrects the window mid-turn) |
| **codex** | ❌ none |

So the meter is coverage-dependent and **degrades gracefully** (hidden when no data).

### Plumbing (mirrors the `onThought`/`onPlan` rail end to end)
- **Transport** — `streaming-prompt` parses the `usage_update` session/update and fires a new `onUsage({used,size})` (replace-latest; drops malformed/zero-window frames). Threaded through `PromptOptions`, the acpx-bridge protocol/client/transport, and bridge runtime/server.
- **Control** — `onUsage` threads through console-agent → command-router → handlers → router-types to the transport; `control-service` emits a new `turn-usage` `ControlEvent`. Mirrored in the relay-protocol `ControlEventDto` and the **web gate** (`CONTROL_EVENT_TYPES` + `validControlEvent`). Connector rides the existing generic passthrough — no change.
- **Web** — chat store keeps `sessionUsage` per session (survives `turn-finished`, REPLACE semantics). A compact meter sits in the composer **to the right of the model chip**: `Gauge` icon + a `%` bar, tiered at 75% (warn) / 90% (danger), hidden when the agent reports no usage. i18n in en + zh-CN.

### Tests
New: `usage_update` parser, the `turn-usage` web-dtos gate (accept valid / reject non-numeric), chat-store `sessionUsage` (REPLACE + survives finish + per-session isolation). Full relay-web suite (311) green; core typecheck + relay-web/connector/hub typecheck green; bridge/control/command/handler suites green.

### Deployment note
Real end-to-end needs the connector (`channel-relay`) + hub rebuilt/redeployed alongside core (new `turn-usage` event). The web link was verified in a local mock hub that pushes real `turn-usage` envelopes (validated by the web's own `parseWebServerEvent`).