### PR TITLE
fix(relay-web): login hint referenced a non-existent CLI command (relay 0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [relay 0.5.1] - 2026-06-20
+
+### Fixed
+
+- **Login screen pointed at a non-existent command:** the dashboard login hint told users to paste the access token from `xacpx-relay user new`, but the relay CLI has no such command. Corrected to `xacpx-relay add token` (the actual token command). A regression test now asserts the hint references the real command.
+
 ## [relay 0.5.0] - 2026-06-20
 
 A `@ganglion/xacpx-relay` hub release (core `@ganglion/xacpx` unchanged). The hub bundles the dashboard, so this ships the relay-web change below.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11704,7 +11704,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/packages/relay-web/src/__tests__/longtail-i18n.test.ts
+++ b/packages/relay-web/src/__tests__/longtail-i18n.test.ts
@@ -22,4 +22,11 @@ describe("long-tail components i18n", () => {
     // Token input placeholder ("Access token" → 访问令牌).
     expect(w.find('input#access-token').attributes("placeholder")).toBe("访问令牌");
   });
+
+  it("points users at the real token command (xacpx-relay add token, not user new)", () => {
+    const w = mount(LoginView, { global: { plugins: [router] } });
+    const hint = w.find("#token-hint").text();
+    expect(hint).toContain("xacpx-relay add token");
+    expect(hint).not.toContain("user new");
+  });
 });

--- a/packages/relay-web/src/views/LoginView.vue
+++ b/packages/relay-web/src/views/LoginView.vue
@@ -30,7 +30,7 @@ async function submit() {
       <input id="access-token" v-model="token" type="password" autocomplete="off" aria-describedby="token-hint"
              class="w-full rounded border border-border bg-bg px-3 py-2 text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50"
              :placeholder="$t('login.tokenPlaceholder')" :disabled="pending" />
-      <p id="token-hint" class="text-sm text-fg-muted">{{ $t("login.hintBefore") }}<code>xacpx-relay user new</code>{{ $t("login.hintAfter") }}</p>
+      <p id="token-hint" class="text-sm text-fg-muted">{{ $t("login.hintBefore") }}<code>xacpx-relay add token</code>{{ $t("login.hintAfter") }}</p>
       <p v-if="auth.error" class="text-sm text-danger">{{ auth.error }}</p>
       <button class="w-full rounded bg-accent px-3 py-2 text-white hover:bg-accent-hover disabled:opacity-50" type="submit" :disabled="pending">
         {{ pending ? $t("login.signingIn") : $t("login.signIn") }}

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": ["xacpx", "relay", "hub"],


### PR DESCRIPTION
The dashboard login screen tells users to paste the access token from `xacpx-relay user new`, but the relay CLI has **no such command**. The actual token command is `xacpx-relay add token`.

relay CLI subcommands (from `packages/relay/src/cli.ts`): `start` / `add token` / `ls` / `rm token`.

## Change
- `LoginView.vue`: hardcoded `<code>xacpx-relay user new</code>` → `xacpx-relay add token` (fixes both EN and ZH — the command string is shared, only the surrounding `hintBefore`/`hintAfter` are localized).
- Regression test in `longtail-i18n.test.ts`: asserts the `#token-hint` references `xacpx-relay add token` and not `user new`.
- Bump `@ganglion/xacpx-relay` 0.5.0 → **0.5.1** (the hub bundles the dashboard) + CHANGELOG entry.

317 web tests pass.