### PR TITLE
fix(channels): channel rm clears stored credentials (xacpx 0.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.12.1] - 2026-06-21
+
+### Fixed
+
+- **`xacpx channel rm <type>` now clears the channel's stored credentials.** Previously it only removed the config entry and left credentials behind — for the relay connector this orphaned `~/.xacpx/relay/credential.json`, so after the hub's database was reset the connector kept presenting the dead credential (`unknown instance or bad credential`) and the dashboard showed no instances, with no CLI path to clear it. `channel rm` now invokes the runtime's destructive `logout()` hook (relay clears its credential; WeChat clears its login) so a later re-add re-pairs cleanly. Pass `--keep-credentials` to remove only the config entry.
+
 ## [relay 0.5.1] - 2026-06-20
 
 ### Fixed

--- a/docs/channel-management.md
+++ b/docs/channel-management.md
@@ -35,6 +35,8 @@ xacpx ch show feishu
 
 Current limitation: only one instance can be configured per channel type, so the channel `id` must equal its `type`, for example `weixin`, `feishu`, `yuanbao`.
 
+`channel rm <type>` also clears that channel's **stored credentials** (e.g. the relay instance credential at `~/.xacpx/relay/credential.json`, or the WeChat login), so a later re-add re-pairs/re-logs-in cleanly instead of silently reusing an orphaned credential. Pass `--keep-credentials` to remove only the config entry and leave the stored credential in place (e.g. when temporarily disabling a channel without re-authenticating).
+
 ---
 
 ## WeChat Channel

--- a/docs/zh/channel-management_zh.md
+++ b/docs/zh/channel-management_zh.md
@@ -35,6 +35,8 @@ xacpx ch show feishu
 
 当前限制：同一种频道类型只能配置一个实例，所以频道 `id` 必须等于 `type`，例如 `weixin`、`feishu`、`yuanbao`。
 
+`channel rm <type>` 在删除频道的同时会**清除该频道的存储凭证**（例如 relay 实例凭证 `~/.xacpx/relay/credential.json`，或微信登录态），这样以后重新添加会干净地重新配对/登录，而不是悄悄复用一份遗留的旧凭证。若只想删配置、保留已存凭证（例如临时禁用某频道又不想重新认证），加 `--keep-credentials`。
+
 ---
 
 ## 微信频道

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/src/channels/cli/channel-cli.ts
+++ b/src/channels/cli/channel-cli.ts
@@ -19,6 +19,14 @@ export interface ChannelCliDeps extends ChannelCliIo {
   saveChannels: (channels: ChannelRuntimeConfig[]) => Promise<void>;
   getDaemonStatus: () => Promise<DaemonStatusForChannelCli>;
   restartDaemon: () => Promise<number>;
+  /**
+   * Optional: clears a channel's stored credentials via the runtime's
+   * destructive `logout()` hook (e.g. the relay instance credential at
+   * ~/.xacpx/relay/credential.json). Invoked by `channel rm` unless
+   * `--keep-credentials`. Absent in some test harnesses, where rm stays
+   * config-only.
+   */
+  clearChannelCredentials?: (channel: ChannelRuntimeConfig) => Promise<void>;
 }
 
 export async function handleChannelCli(args: string[], deps: ChannelCliDeps): Promise<number | null> {
@@ -332,6 +340,7 @@ async function removeChannel(type: string, rawArgs: string[], deps: ChannelCliDe
     deps.print(restartFlags.message);
     return 1;
   }
+  const keepCredentials = restartFlags.rest.includes("--keep-credentials");
   const config = await deps.loadConfig();
   ensureChannelsArray(config);
   const channel = findChannel(config.channels, type);
@@ -346,6 +355,20 @@ async function removeChannel(type: string, rawArgs: string[], deps: ChannelCliDe
   config.channels = config.channels.filter((entry) => entry.id !== channel.id);
   await deps.saveChannels(config.channels);
   deps.print(t().channelCli.channelRemoved(channel.id));
+  // Removing a channel also clears its stored credentials (e.g. the relay
+  // instance credential) so a later re-add re-pairs cleanly instead of reusing
+  // an orphaned credential. --keep-credentials opts out (e.g. temporarily
+  // removing a channel without dropping its login).
+  if (keepCredentials) {
+    deps.print(t().channelCli.channelCredentialsKept(channel.id));
+  } else if (deps.clearChannelCredentials) {
+    try {
+      await deps.clearChannelCredentials(channel);
+      deps.print(t().channelCli.channelCredentialsCleared(channel.id));
+    } catch (error) {
+      deps.print(t().channelCli.channelCredentialsClearFailed(channel.id, error instanceof Error ? error.message : String(error)));
+    }
+  }
   return await maybeRestartAfterMutation(restartFlags.restart, deps);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1151,6 +1151,14 @@ async function createChannelCliDeps(input: {
       return { state: "stopped" as const };
     },
     restartDaemon: async () => await restartDaemonCli(controller, input.print),
+    clearChannelCredentials: async (channel) => {
+      // Reuse the runtime's declared destructive-removal hook so credential
+      // cleanup stays owned by each channel/plugin (relay clears its instance
+      // credential; weixin clears its login). Plugins are already loaded for the
+      // channel CLI path, so the factory resolves.
+      const { createMessageChannel } = await import("./channels/create-channel.js");
+      createMessageChannel(channel.type, channel).logout();
+    },
   };
   return { ...base, ...input.overrides };
 }

--- a/src/i18n/messages/en/channel-cli.ts
+++ b/src/i18n/messages/en/channel-cli.ts
@@ -21,6 +21,9 @@ export const channelCli: ChannelCliMessages = {
   // removeChannel
   cannotRemoveLastEnabled: "Cannot remove the last enabled channel.",
   channelRemoved: (id) => `Channel ${id} removed`,
+  channelCredentialsCleared: (id) => `Removed stored credentials for channel ${id}`,
+  channelCredentialsClearFailed: (id, error) => `Channel ${id} removed, but clearing its stored credentials failed: ${error}`,
+  channelCredentialsKept: (id) => `Kept stored credentials for channel ${id} (--keep-credentials)`,
 
   // setChannelEnabled
   cannotDisableLastEnabled: "Cannot disable the last enabled channel.",

--- a/src/i18n/messages/zh/channel-cli.ts
+++ b/src/i18n/messages/zh/channel-cli.ts
@@ -21,6 +21,9 @@ export const channelCli: ChannelCliMessages = {
   // removeChannel
   cannotRemoveLastEnabled: "不能删除最后一个启用的频道。",
   channelRemoved: (id) => `频道 ${id} 已删除`,
+  channelCredentialsCleared: (id) => `已移除频道 ${id} 的存储凭证`,
+  channelCredentialsClearFailed: (id, error) => `频道 ${id} 已删除，但清除其存储凭证失败：${error}`,
+  channelCredentialsKept: (id) => `已保留频道 ${id} 的存储凭证（--keep-credentials）`,
 
   // setChannelEnabled
   cannotDisableLastEnabled: "不能禁用最后一个启用的频道。",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -995,6 +995,9 @@ export interface ChannelCliMessages {
   // removeChannel
   cannotRemoveLastEnabled: string;
   channelRemoved: (id: string) => string;
+  channelCredentialsCleared: (id: string) => string;
+  channelCredentialsClearFailed: (id: string, error: string) => string;
+  channelCredentialsKept: (id: string) => string;
 
   // setChannelEnabled
   cannotDisableLastEnabled: string;

--- a/tests/unit/channels/cli/channel-cli.test.ts
+++ b/tests/unit/channels/cli/channel-cli.test.ts
@@ -58,3 +58,42 @@ test("set-reply-mode accepts a trailing --no-restart flag like the other mutatin
   expect(code).toBe(0);
   expect(getStored().channels.find((c: any) => c.id === "feishu").replyMode).toBe("stream");
 });
+
+test("channel rm clears the removed channel's stored credentials by default", async () => {
+  const { deps, out, getStored } = makeDeps([
+    { id: "weixin", type: "weixin", enabled: true },
+    { id: "relay", type: "relay", enabled: true },
+  ]);
+  const cleared: any[] = [];
+  deps.clearChannelCredentials = async (ch: any) => { cleared.push(ch); };
+  const code = await handleChannelCli(["rm", "relay"], deps);
+  expect(code).toBe(0);
+  expect(getStored().channels.map((c: any) => c.id)).toEqual(["weixin"]);
+  expect(cleared.map((c) => c.id)).toEqual(["relay"]);
+  expect(out.join("\n")).toContain("存储凭证");
+});
+
+test("channel rm --keep-credentials leaves stored credentials in place", async () => {
+  const { deps, out } = makeDeps([
+    { id: "weixin", type: "weixin", enabled: true },
+    { id: "relay", type: "relay", enabled: true },
+  ]);
+  let called = false;
+  deps.clearChannelCredentials = async () => { called = true; };
+  const code = await handleChannelCli(["rm", "relay", "--keep-credentials"], deps);
+  expect(code).toBe(0);
+  expect(called).toBe(false);
+  expect(out.join("\n")).toContain("已保留");
+});
+
+test("channel rm still succeeds and reports when credential cleanup throws", async () => {
+  const { deps, out, getStored } = makeDeps([
+    { id: "weixin", type: "weixin", enabled: true },
+    { id: "relay", type: "relay", enabled: true },
+  ]);
+  deps.clearChannelCredentials = async () => { throw new Error("boom"); };
+  const code = await handleChannelCli(["rm", "relay"], deps);
+  expect(code).toBe(0); // channel still removed
+  expect(getStored().channels.map((c: any) => c.id)).toEqual(["weixin"]);
+  expect(out.join("\n")).toContain("boom");
+});

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.12.0", () => {
+test("root package version is 0.12.1", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.12.0");
+  expect(pkg.version).toBe("0.12.1");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.12.0"
+    "@ganglion/xacpx": "^0.12.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
`xacpx channel rm <type>` previously only removed the config entry and left the channel's stored credentials behind. For the relay connector this orphaned `~/.xacpx/relay/credential.json`; after the hub's DB was reset the connector kept presenting the dead credential (`unknown instance or bad credential`) → the dashboard showed no instances, with **no CLI path to clear it** (`xacpx logout` is WeChat-only).

## Change
- `channel rm` now invokes the runtime's declared destructive `logout()` hook (relay clears its instance credential; WeChat clears its login) so a later re-add re-pairs cleanly.
- `--keep-credentials` opts out (config-only removal).
- Wired via an injectable `clearChannelCredentials` dep; cleanup failures are reported but don't fail the removal.
- Tests (default-clear / keep / cleanup-throws) + EN/ZH messages + channel-management docs.

Bumps core `@ganglion/xacpx` + `weacpx` shim to **0.12.1**.