### PR TITLE
feat: session archive & real delete (web + all channels)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-session-archive-and-real-delete.md
+++ b/docs/superpowers/plans/2026-06-21-session-archive-and-real-delete.md
@@ -1,0 +1,1477 @@
+# Session Archive & Real Delete Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make session deletion a real delete (acpx history gone, same-name re-create starts fresh) and add session archive (process closed now, row greyed + sunk to bottom, restored by sending a message) across all channels + the relay-web dashboard.
+
+**Architecture:** acpx gains a focused `sessions rm` (single-record hard delete). The xacpx transport gains `deleteSession` (= `acpx sessions rm`); archive reuses the existing `removeSession` (= `acpx sessions close`). Orchestration (shared-transport guard, cancel, transport teardown) lives in `CommandRouter` and is shared by the chat `/session` handlers and the web `ControlService`. The logical session gains an `archived` flag, cleared on the next `useSession` (which every prompt calls). relay-web adds a desktop ⋯ menu + mobile swipe, greys + sinks archived rows, and an undo toast.
+
+**Tech Stack:** TypeScript, Node, Bun (build/test), Vue 3 + Pinia + Tailwind (relay-web), Vitest, acpx (sibling repo at `../acpx`).
+
+**Companion spec:** `docs/superpowers/specs/2026-06-21-session-archive-and-real-delete-design.md`
+
+**Two repos:** Phase 1 tasks run in `/Users/maijiazhen/Projects/acpx`. Phases 2–5 run in `/Users/maijiazhen/Projects/weacpx-github`. Phase 2 depends on Phase 1 being released and the xacpx bundled `acpx` dep bumped; during development of Phases 2–5 the new acpx can be linked locally.
+
+**Git hygiene (every task):** never `git add -A`/`git add .`; stage only the exact files named in the task. Never stage `bun.lock`, `dist/`, `node_modules` unless the task says so. Each task is its own commit.
+
+---
+
+## Phase 1 — acpx: `sessions rm` (repo: `/Users/maijiazhen/Projects/acpx`)
+
+### Task 1: Single-record hard-delete helper in the repository
+
+**Files:**
+- Modify: `src/session/persistence/repository.ts` (add an exported `deleteSessionRecord`; helpers `pruneSessionFiles`/`unlinkCountingBytes`/`isSessionStreamFile` already live here)
+- Modify: `src/session/persistence.ts` (re-export `deleteSessionRecord`)
+- Test: `src/session/persistence/repository.delete-session.test.ts` (new)
+
+The existing `pruneSessionFiles(record, sessionDir, dirEntries, includeHistory)` already deletes a single record's files. We expose a name-agnostic, id-based single-record delete that kills a running pid (reusing `closeSession`'s kill loop) then removes files.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/session/persistence/repository.delete-session.test.ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { writeSessionRecord, deleteSessionRecord } from "./repository.js";
+
+const sessionDir = path.join(os.homedir(), ".acpx", "sessions");
+
+async function seedRecord(id: string): Promise<string> {
+  await fs.mkdir(sessionDir, { recursive: true });
+  const file = path.join(sessionDir, `${encodeURIComponent(id)}.json`);
+  const record = {
+    acpxRecordId: id, acpSessionId: id, agentCommand: "test-agent", cwd: "/tmp/x",
+    name: "demo", closed: true, createdAt: "2020-01-01T00:00:00.000Z",
+    lastUsedAt: "2020-01-01T00:00:00.000Z", messages: [],
+  };
+  await writeSessionRecord(record as never);
+  return file;
+}
+
+describe("deleteSessionRecord", () => {
+  it("removes the record json and reports bytes freed", async () => {
+    const id = `del-test-${process.pid}-a`;
+    const file = await seedRecord(id);
+    expect(await fs.stat(file).then(() => true).catch(() => false)).toBe(true);
+    const result = await deleteSessionRecord(id);
+    expect(result.bytesFreed).toBeGreaterThan(0);
+    expect(await fs.stat(file).then(() => true).catch(() => false)).toBe(false);
+  });
+
+  it("is idempotent for a missing record (no throw, zero bytes)", async () => {
+    const result = await deleteSessionRecord(`del-test-${process.pid}-missing`);
+    expect(result.bytesFreed).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd /Users/maijiazhen/Projects/acpx && npx vitest run src/session/persistence/repository.delete-session.test.ts`
+Expected: FAIL — `deleteSessionRecord` is not exported.
+
+- [ ] **Step 3: Implement `deleteSessionRecord`**
+
+Add to `src/session/persistence/repository.ts` (after `closeSession`, near line 461 — it must be in the same module as the private `pruneSessionFiles`/`killSignalCandidates`/`resolveSessionRecord`/`sessionBaseDir`):
+
+```ts
+/**
+ * Hard-delete a single session record by id: kill a running pid (best-effort),
+ * then remove its on-disk files (record json + event-stream artifacts).
+ * Idempotent: a missing record resolves to { bytesFreed: 0 } without throwing.
+ */
+export async function deleteSessionRecord(
+  id: string,
+  options: { includeHistory?: boolean } = {},
+): Promise<{ bytesFreed: number }> {
+  const includeHistory = options.includeHistory !== false; // default true: a real delete wipes history
+  let record: SessionRecord;
+  try {
+    record = await resolveSessionRecord(id);
+  } catch {
+    return { bytesFreed: 0 };
+  }
+
+  if (record.pid) {
+    for (const signal of killSignalCandidates(record.lastAgentExitSignal ?? undefined)) {
+      try {
+        process.kill(record.pid, signal);
+      } catch {
+        // ignore — process already gone
+      }
+    }
+  }
+
+  const sessionDir = sessionBaseDir();
+  let dirEntries: string[] = [];
+  if (includeHistory) {
+    try {
+      dirEntries = await fs.readdir(sessionDir);
+    } catch {
+      // ignore
+    }
+  }
+  const bytesFreed = await pruneSessionFiles(record, sessionDir, dirEntries, includeHistory);
+
+  await rebuildSessionIndex(sessionDir).catch(() => {
+    // best-effort cache rebuild
+  });
+  return { bytesFreed };
+}
+```
+
+Then re-export it from `src/session/persistence.ts` — add `deleteSessionRecord,` to the existing `export { ... } from "./persistence/repository.js"` block (the one currently listing `closeSession`, `pruneSessions`, etc.).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd /Users/maijiazhen/Projects/acpx && npx vitest run src/session/persistence/repository.delete-session.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/maijiazhen/Projects/acpx
+git add src/session/persistence/repository.ts src/session/persistence.ts src/session/persistence/repository.delete-session.test.ts
+git commit -m "feat(sessions): add deleteSessionRecord single-record hard delete"
+```
+
+---
+
+### Task 2: `acpx <agent> sessions rm [name]` command + handler
+
+**Files:**
+- Modify: `src/cli/command-handlers.ts` (add `handleSessionsRm`)
+- Modify: `src/cli/command-registration.ts` (register `rm` subcommand)
+- Test: `src/cli/sessions-rm.test.ts` (new)
+
+`rm` mirrors `close`: resolve the record by cwd+name (but `includeClosed: true` so an already-closed/archived session can be deleted), then `deleteSessionRecord(record.acpxRecordId)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/cli/sessions-rm.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../session/persistence.js", async (orig) => {
+  const actual = await orig<typeof import("../session/persistence.js")>();
+  return { ...actual };
+});
+
+import { handleSessionsRm } from "./command-handlers.js";
+
+describe("handleSessionsRm", () => {
+  it("throws a scoped not-found error when no matching session exists", async () => {
+    const fakeCommand = { optsWithGlobals: () => ({}), parent: null } as never;
+    await expect(
+      handleSessionsRm("nonexistent-agent-xyz", "no-such-session", fakeCommand, { agents: {} } as never),
+    ).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd /Users/maijiazhen/Projects/acpx && npx vitest run src/cli/sessions-rm.test.ts`
+Expected: FAIL — `handleSessionsRm` is not exported.
+
+- [ ] **Step 3: Implement `handleSessionsRm`**
+
+Add to `src/cli/command-handlers.ts` (next to `handleSessionsClose`, ~line 776). Mirror `handleSessionsClose`, swapping `closeSession` for `deleteSessionRecord` and passing `includeClosed: true` to `findSession`:
+
+```ts
+export async function handleSessionsRm(
+  explicitAgentName: string | undefined,
+  sessionName: string | undefined,
+  command: Command,
+  config: ResolvedAcpxConfig,
+): Promise<void> {
+  const globalFlags = resolveGlobalFlags(command, config);
+  const agent = resolveAgentInvocation(explicitAgentName, globalFlags, config);
+  const { deleteSessionRecord } = await loadSessionModule();
+
+  const record = await findSession({
+    agentCommand: agent.agentCommand,
+    cwd: agent.cwd,
+    name: sessionName,
+    includeClosed: true,
+  });
+
+  if (!record) {
+    throw new Error(missingScopedSessionMessage(agent, sessionName));
+  }
+
+  await deleteSessionRecord(record.acpxRecordId);
+}
+```
+
+`findSession`, `loadSessionModule`, `resolveGlobalFlags`, `resolveAgentInvocation`, `missingScopedSessionMessage` are already imported/defined in this file (used by `handleSessionsClose`). Confirm `deleteSessionRecord` is exposed by `loadSessionModule()` — `loadSessionModule` dynamically imports `../session/persistence.js`, which now re-exports it (Task 1).
+
+- [ ] **Step 4: Register the subcommand**
+
+In `src/cli/command-registration.ts`, immediately after the `close` subcommand block (~line 129), add (and import `handleSessionsRm` alongside `handleSessionsClose` at the top of the file):
+
+```ts
+  sessionsCommand
+    .command("rm")
+    .description("Delete a session and its history (irreversible)")
+    .argument("[name]", "Session name", parseSessionName)
+    .action(async function (this: Command, name?: string) {
+      await handleSessionsRm(explicitAgentName, name, this, config);
+    });
+```
+
+- [ ] **Step 5: Run the test + typecheck**
+
+Run: `cd /Users/maijiazhen/Projects/acpx && npx vitest run src/cli/sessions-rm.test.ts && npx tsc --noEmit`
+Expected: PASS + clean typecheck.
+
+- [ ] **Step 6: Manual smoke (optional but recommended)**
+
+```bash
+cd /Users/maijiazhen/Projects/acpx && npm run build
+# create + delete a throwaway codex/claude session in a temp dir, then:
+node dist/cli.js <agent> sessions rm demo
+node dist/cli.js <agent> sessions list   # demo should be gone
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/maijiazhen/Projects/acpx
+git add src/cli/command-handlers.ts src/cli/command-registration.ts src/cli/sessions-rm.test.ts
+git commit -m "feat(cli): add 'sessions rm' to delete a single session + history"
+```
+
+---
+
+### Task 3: acpx CHANGELOG + version bump + release
+
+**Files:**
+- Modify: `CHANGELOG.md` (Unreleased → Changes)
+- Modify: `package.json` (version bump)
+
+- [ ] **Step 1: Add CHANGELOG entry**
+
+Under `## Unreleased` → `### Changes` in `/Users/maijiazhen/Projects/acpx/CHANGELOG.md`:
+
+```markdown
+- CLI/sessions: add `sessions rm [name]` to hard-delete a single session and its history (kills the process if running). Complements `close` (keeps history) and `prune` (bulk by date).
+```
+
+- [ ] **Step 2: Bump version**
+
+In `package.json`, bump `"version"` from `0.10.0` to `0.11.0` (new feature, minor).
+
+- [ ] **Step 3: Full test + build**
+
+Run: `cd /Users/maijiazhen/Projects/acpx && npm test && npm run build`
+Expected: all pass.
+
+- [ ] **Step 4: Commit + release**
+
+```bash
+cd /Users/maijiazhen/Projects/acpx
+git add CHANGELOG.md package.json
+git commit -m "chore: release acpx 0.11.0 (sessions rm)"
+```
+
+Then follow the acpx repo's normal publish flow (tag + npm publish). **Record the published version** — Phase 2 Task 4b bumps xacpx's bundled `acpx` dependency to `^0.11.0`.
+
+---
+
+## Phase 2 — xacpx transport (repo: `/Users/maijiazhen/Projects/weacpx-github`)
+
+### Task 4: `SessionTransport.deleteSession` + acpx-cli implementation
+
+**Files:**
+- Modify: `src/transport/types.ts` (interface)
+- Modify: `src/transport/acpx-cli/acpx-cli-transport.ts` (impl)
+- Test: `tests/unit/transport/acpx-cli-delete-session.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Mirror the existing acpx-cli transport tests (find them with `ls tests/unit/transport/`). The test asserts `deleteSession` runs `acpx ... sessions rm <name>` and tolerates a missing session.
+
+```ts
+// tests/unit/transport/acpx-cli-delete-session.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { AcpxCliTransport } from "../../../src/transport/acpx-cli/acpx-cli-transport";
+
+function makeSession() {
+  return { alias: "a", agent: "codex", workspace: "w", transportSession: "w:a", cwd: "/tmp/w" } as never;
+}
+
+describe("AcpxCliTransport.deleteSession", () => {
+  it("invokes `sessions rm <transportSession>`", async () => {
+    const transport = new AcpxCliTransport({ command: "acpx" } as never);
+    const run = vi
+      .spyOn(transport as never, "runCommand")
+      .mockResolvedValue({ code: 0, stdout: "", stderr: "" } as never);
+    await transport.deleteSession(makeSession());
+    const args = (run.mock.calls[0] as unknown[])[1] as string[];
+    expect(args).toContain("sessions");
+    expect(args).toContain("rm");
+    expect(args).toContain("w:a");
+  });
+
+  it("treats a missing acpx session as success", async () => {
+    const transport = new AcpxCliTransport({ command: "acpx" } as never);
+    vi.spyOn(transport as never, "runCommand").mockResolvedValue({
+      code: 1, stdout: "", stderr: "no session found for cwd",
+    } as never);
+    await expect(transport.deleteSession(makeSession())).resolves.toBeUndefined();
+  });
+});
+```
+
+> Note: match the real `AcpxCliTransport` constructor signature from `src/transport/acpx-cli/acpx-cli-transport.ts` (look at an existing test in `tests/unit/transport/` for the exact construction; adjust `makeSession`/constructor accordingly).
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run tests/unit/transport/acpx-cli-delete-session.test.ts`
+Expected: FAIL — `deleteSession` does not exist.
+
+- [ ] **Step 3: Add to the interface**
+
+In `src/transport/types.ts`, add below `removeSession?` (line 169):
+
+```ts
+  /**
+   * Hard-delete the transport session AND its history (`acpx sessions rm`).
+   * Distinct from removeSession (= `acpx sessions close`, which keeps history for
+   * resume). Optional: transports that can't delete omit it. Treats a missing
+   * acpx session as success (idempotent).
+   */
+  deleteSession?(session: ResolvedSession): Promise<void>;
+```
+
+- [ ] **Step 4: Implement in acpx-cli**
+
+In `src/transport/acpx-cli/acpx-cli-transport.ts`, add next to `removeSession` (~line 400), mirroring it but with `rm`:
+
+```ts
+  async deleteSession(session: ResolvedSession): Promise<void> {
+    const result = await this.runCommand(this.command, this.buildArgs(session, [
+      "sessions",
+      "rm",
+      session.transportSession,
+    ]));
+    if (result.code === 0) {
+      return;
+    }
+    if (isMissingAcpxSessionError(result.stderr, result.stdout)) {
+      return;
+    }
+    const detail = normalizeCommandError(result) ?? `command failed with exit code ${result.code}`;
+    throw new Error(detail);
+  }
+```
+
+- [ ] **Step 4b: Bump the bundled acpx dependency**
+
+In `package.json`, bump the `acpx` dependency to the version published in Task 3 (`^0.11.0`). Run `npm install --package-lock-only` (with `npm_config_registry=https://registry.npmjs.org/`) to sync `package-lock.json`. Do NOT stage `bun.lock`.
+
+- [ ] **Step 5: Run the test + typecheck**
+
+Run: `npx vitest run tests/unit/transport/acpx-cli-delete-session.test.ts && npx tsc --noEmit`
+Expected: PASS + clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/transport/types.ts src/transport/acpx-cli/acpx-cli-transport.ts tests/unit/transport/acpx-cli-delete-session.test.ts package.json package-lock.json
+git commit -m "feat(transport): add deleteSession (acpx sessions rm) + bump acpx 0.11.0"
+```
+
+---
+
+### Task 5: Bridge transport `deleteSession`
+
+**Files:**
+- Modify: `src/transport/acpx-bridge/acpx-bridge-protocol.ts` (add `"deleteSession"` to `BridgeMethod`)
+- Modify: `src/transport/acpx-bridge/acpx-bridge-transport.ts` (client method)
+- Modify: `src/bridge/bridge-server.ts` (dispatch case)
+- Modify: `src/bridge/bridge-runtime.ts` (runtime method calling the underlying acpx-cli transport's `deleteSession`)
+- Test: `tests/unit/bridge/bridge-delete-session.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Find the existing bridge `removeSession` test (grep `removeSession` under `tests/unit/bridge/`) and mirror it for `deleteSession` — assert the bridge-server routes a `deleteSession` request to `runtime.deleteSession`.
+
+```ts
+// tests/unit/bridge/bridge-delete-session.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { BridgeServer } from "../../../src/bridge/bridge-server";
+
+describe("bridge deleteSession", () => {
+  it("routes deleteSession to the runtime", async () => {
+    const runtime = { deleteSession: vi.fn().mockResolvedValue(undefined) };
+    const server = new BridgeServer(runtime as never);
+    const result = await (server as never).handleRequest({
+      id: "1", method: "deleteSession", params: { transportSession: "w:a" },
+    });
+    expect(runtime.deleteSession).toHaveBeenCalled();
+    expect((result as { ok: boolean }).ok).toBe(true);
+  });
+});
+```
+
+> Adjust constructor/handler names to match the real `BridgeServer` (read `src/bridge/bridge-server.ts:274` area where `removeSession` is dispatched).
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run tests/unit/bridge/bridge-delete-session.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `"deleteSession"` to `BridgeMethod`**
+
+In `src/transport/acpx-bridge/acpx-bridge-protocol.ts`, add `| "deleteSession"` to the `BridgeMethod` union (after `"removeSession"`, line 17).
+
+- [ ] **Step 4: Client method**
+
+In `src/transport/acpx-bridge/acpx-bridge-transport.ts`, add next to `removeSession` (line 254):
+
+```ts
+  async deleteSession(session: ResolvedSession): Promise<void> {
+    await this.client.request("deleteSession", this.toParams(session));
+  }
+```
+
+- [ ] **Step 5: Bridge server dispatch**
+
+In `src/bridge/bridge-server.ts`, next to the `removeSession` case (~line 274), add a `deleteSession` case that calls `this.runtime.deleteSession({...})` with the same param shape as `removeSession`.
+
+- [ ] **Step 6: Bridge runtime method**
+
+In `src/bridge/bridge-runtime.ts`, add a `deleteSession` method mirroring its `removeSession` (which delegates to the underlying acpx-cli transport). It must call the underlying transport's `deleteSession`.
+
+- [ ] **Step 7: Run the test + typecheck**
+
+Run: `npx vitest run tests/unit/bridge/bridge-delete-session.test.ts && npx tsc --noEmit`
+Expected: PASS + clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/transport/acpx-bridge/acpx-bridge-protocol.ts src/transport/acpx-bridge/acpx-bridge-transport.ts src/bridge/bridge-server.ts src/bridge/bridge-runtime.ts tests/unit/bridge/bridge-delete-session.test.ts
+git commit -m "feat(bridge): wire deleteSession through bridge protocol/server/runtime"
+```
+
+---
+
+## Phase 3 — core: archived flag + orchestration + control wiring
+
+### Task 6: `LogicalSession.archived` + `SessionService.setArchived` + restore-on-use
+
+**Files:**
+- Modify: `src/state/types.ts` (`LogicalSession` fields)
+- Modify: `src/sessions/session-service.ts` (`setArchived` + clear in `useSession`)
+- Test: `tests/unit/sessions/session-archived.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/sessions/session-archived.test.ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { SessionService } from "../../../src/sessions/session-service";
+// Reuse the existing session-service test harness for building config/state.
+// Find an existing test in tests/unit/sessions/ and copy its setup helpers.
+
+function setup() {
+  // Build config with one agent "codex" + one workspace, an empty AppState,
+  // and a stub stateStore { save: async () => {} }. Mirror an existing test.
+  // Return { service, state }.
+}
+
+describe("SessionService archived flag", () => {
+  it("setArchived(true) marks the session archived and persists; setArchived(false) clears it", async () => {
+    const { service, state } = setup() as never;
+    // seed a logical session "demo" via service.attachSession(...) as existing tests do
+    await service.setArchived("demo", true);
+    expect(state.sessions["demo"].archived).toBe(true);
+    expect(typeof state.sessions["demo"].archived_at).toBe("string");
+    await service.setArchived("demo", false);
+    expect(state.sessions["demo"].archived).toBeUndefined();
+    expect(state.sessions["demo"].archived_at).toBeUndefined();
+  });
+
+  it("useSession clears an archived flag (restore-on-message)", async () => {
+    const { service, state } = setup() as never;
+    await service.setArchived("demo", true);
+    await service.useSession("relay:acct", "demo"); // chatKey form used by the channel
+    expect(state.sessions["demo"].archived).toBeUndefined();
+  });
+});
+```
+
+> Copy the exact `setup()` (config/state/attach) from an existing file in `tests/unit/sessions/` — do not invent the harness.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run tests/unit/sessions/session-archived.test.ts`
+Expected: FAIL — `setArchived` not a function.
+
+- [ ] **Step 3: Add fields to `LogicalSession`**
+
+In `src/state/types.ts`, inside `interface LogicalSession`, add after `reply_mode`:
+
+```ts
+  /** True when the user archived this session: process closed, row greyed + sunk.
+   *  Cleared on the next useSession (restore-on-message). */
+  archived?: boolean;
+  archived_at?: string;
+```
+
+- [ ] **Step 4: Add `setArchived` + clear in `useSession`**
+
+In `src/sessions/session-service.ts`, add the method (near `removeSession`):
+
+```ts
+  async setArchived(alias: string, archived: boolean): Promise<void> {
+    await this.mutate(async () => {
+      const session = this.state.sessions[alias];
+      if (!session) {
+        throw new Error(`session "${alias}" does not exist`);
+      }
+      if (archived) {
+        session.archived = true;
+        session.archived_at = new Date(this.now()).toISOString();
+      } else {
+        delete session.archived;
+        delete session.archived_at;
+      }
+      await this.persist();
+    });
+  }
+```
+
+Then, in `useSession`, after the line `session.last_used_at = new Date().toISOString();`, add the restore clear:
+
+```ts
+      // Sending a message to (or selecting) an archived session restores it.
+      if (session.archived) {
+        delete session.archived;
+        delete session.archived_at;
+      }
+```
+
+- [ ] **Step 5: Run the test + typecheck**
+
+Run: `npx vitest run tests/unit/sessions/session-archived.test.ts && npx tsc --noEmit`
+Expected: PASS + clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/state/types.ts src/sessions/session-service.ts tests/unit/sessions/session-archived.test.ts
+git commit -m "feat(sessions): archived flag + setArchived + restore-on-useSession"
+```
+
+---
+
+### Task 7: CommandRouter orchestration (`removeSessionWithTransport`, `archiveSessionWithTransport`, `unarchiveSession`) + make `/session rm` a real delete
+
+**Files:**
+- Modify: `src/commands/command-router.ts` (3 new public methods)
+- Modify: `src/commands/handlers/session-handler.ts` (`handleSessionRemove` uses `deleteSession`; new `handleSessionArchive`)
+- Test: `tests/unit/commands/session-archive-delete.test.ts` (new)
+
+**Why here:** `SessionService` has no transport reference; the handler/router layer is where transport + sessions co-exist (`createHandlerContext`). These router methods become the single orchestration shared by chat handlers (Task 11) and `ControlService` (Task 8).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/commands/session-archive-delete.test.ts
+import { describe, it, expect, vi } from "vitest";
+// Build a CommandRouter with stub sessions + transport. Mirror an existing
+// command-router test in tests/unit/commands/ for construction.
+
+describe("CommandRouter session archive/delete orchestration", () => {
+  it("removeSessionWithTransport deletes history when no alias shares the transport", async () => {
+    // sessions.countAliasesSharingTransport -> 0
+    // expect transport.deleteSession called, transport.removeSession NOT called
+  });
+
+  it("removeSessionWithTransport skips transport teardown when shared", async () => {
+    // sessions.countAliasesSharingTransport -> 1
+    // expect transport.deleteSession NOT called; logical removeSession still called
+  });
+
+  it("archiveSessionWithTransport cancels + closes (unshared) then sets archived", async () => {
+    // expect transport.cancel + transport.removeSession called, sessions.setArchived(alias,true)
+  });
+
+  it("unarchiveSession only clears the flag", async () => {
+    // expect sessions.setArchived(alias,false); no transport calls
+  });
+});
+```
+
+> Fill the stubs from an existing command-router test harness. Keep assertions on which transport/sessions methods are called.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run tests/unit/commands/session-archive-delete.test.ts`
+Expected: FAIL — methods not defined.
+
+- [ ] **Step 3: Add the router methods**
+
+In `src/commands/command-router.ts`, add (the class already holds `private readonly sessions` and `private readonly transport`):
+
+```ts
+  /** Real delete: logical removal + acpx history delete, guarded so a transport
+   *  session shared by another alias is left intact. Returns the shared count and
+   *  whether the transport was torn down (for chat-text formatting). */
+  async removeSessionWithTransport(internalAlias: string): Promise<{
+    wasActive: boolean;
+    sharedAliasCount: number;
+    transportTornDown: boolean;
+    transportTeardownWarning?: string;
+  }> {
+    const session = await this.sessions.getSession(internalAlias);
+    if (!session) {
+      throw new Error(`session "${internalAlias}" does not exist`);
+    }
+    const sharedAliasCount = this.sessions.countAliasesSharingTransport(session.transportSession, internalAlias);
+    const { wasActive } = await this.sessions.removeSession(internalAlias);
+
+    let transportTornDown = false;
+    let transportTeardownWarning: string | undefined;
+    if (sharedAliasCount === 0 && this.transport.deleteSession) {
+      try {
+        await this.transport.deleteSession(session);
+        transportTornDown = true;
+      } catch (error) {
+        transportTeardownWarning = error instanceof Error ? error.message : String(error);
+        await this.logger.error("session.transport_delete_failed", "failed to delete acpx session after logical remove", {
+          alias: internalAlias, transportSession: session.transportSession, message: transportTeardownWarning,
+        });
+      }
+    }
+    return { wasActive, sharedAliasCount, transportTornDown, ...(transportTeardownWarning ? { transportTeardownWarning } : {}) };
+  }
+
+  /** Archive: close the acpx process (keep history) when no other alias shares the
+   *  transport, then flag the logical session archived. */
+  async archiveSessionWithTransport(internalAlias: string): Promise<void> {
+    const session = await this.sessions.getSession(internalAlias);
+    if (!session) {
+      throw new Error(`session "${internalAlias}" does not exist`);
+    }
+    const shared = this.sessions.countAliasesSharingTransport(session.transportSession, internalAlias) > 0;
+    if (!shared) {
+      try { await this.transport.cancel(session); } catch { /* best-effort */ }
+      if (this.transport.removeSession) {
+        try {
+          await this.transport.removeSession(session);
+        } catch (error) {
+          await this.logger.error("session.archive_close_failed", "failed to close acpx session on archive", {
+            alias: internalAlias, transportSession: session.transportSession,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+    await this.sessions.setArchived(internalAlias, true);
+  }
+
+  /** Explicit un-archive (web undo / manual). No process action — it resumes on the
+   *  next message via useSession. */
+  async unarchiveSession(internalAlias: string): Promise<void> {
+    await this.sessions.setArchived(internalAlias, false);
+  }
+```
+
+> If `this.sessions.getSession` / `getResolvedSessionByInternalAlias` differ in your tree, use whichever returns a transport-capable session (the rm handler at `session-handler.ts` uses `context.sessions.getSession(internalAlias)`).
+
+- [ ] **Step 4: Make chat `/session rm` a real delete**
+
+In `src/commands/handlers/session-handler.ts`, in `handleSessionRemove`, replace the transport teardown block (currently calls `context.transport.removeSession(session)` when `shouldTeardownTransport`) so it calls `context.transport.deleteSession(session)` instead. Keep all surrounding logic (shared guard, orchestration purge, warnings, promotion text). The minimal change is swapping `context.transport.removeSession` → `context.transport.deleteSession` and the guard `context.transport.removeSession` → `context.transport.deleteSession` in the same `if`.
+
+- [ ] **Step 5: Run the test + the existing session-handler tests + typecheck**
+
+Run: `npx vitest run tests/unit/commands/session-archive-delete.test.ts tests/unit/commands/ && npx tsc --noEmit`
+Expected: PASS (new) + existing command tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/command-router.ts src/commands/handlers/session-handler.ts tests/unit/commands/session-archive-delete.test.ts
+git commit -m "feat(router): archive/real-delete orchestration; /session rm now real-deletes"
+```
+
+---
+
+### Task 8: ControlService archive/unarchive + real-delete wiring + `archived` in `ControlSessionInfo`
+
+**Files:**
+- Modify: `src/control/control-service.ts` (deps, `removeSession` → real delete, new `archiveSession`/`unarchiveSession`, `ControlSessionInfo.archived` + builders)
+- Modify: `src/main.ts` (wire new deps to router methods)
+- Test: `tests/unit/control/control-archive.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/control/control-archive.test.ts
+import { describe, it, expect, vi } from "vitest";
+// Build ControlService with stub deps mirroring an existing control-service test.
+
+describe("ControlService archive/unarchive + real delete", () => {
+  it("archiveSession resolves the alias, calls archiveSessionWithTransport, emits sessions-changed", async () => {
+    // deps.archiveSessionWithTransport spy, deps.events.emit spy
+  });
+  it("unarchiveSession calls unarchiveSession + emits sessions-changed", async () => {});
+  it("removeSession routes through removeSessionWithTransport (real delete) + emits", async () => {});
+  it("listSessions includes archived flag from the resolved session", async () => {});
+});
+```
+
+> Copy the control-service test harness from `tests/unit/control/`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run tests/unit/control/control-archive.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Extend `ControlServiceDeps`**
+
+In `src/control/control-service.ts`, add to `ControlServiceDeps`:
+
+```ts
+  // Full-lifecycle session teardown/archival, wired to CommandRouter in main.ts so
+  // the web path shares the chat path's shared-transport guard + acpx teardown.
+  removeSessionWithTransport: (internalAlias: string) => Promise<{ wasActive: boolean }>;
+  archiveSessionWithTransport: (internalAlias: string) => Promise<void>;
+  unarchiveSession: (internalAlias: string) => Promise<void>;
+```
+
+Add `archived: boolean` to `ControlSessionInfo`:
+
+```ts
+export interface ControlSessionInfo {
+  alias: string;
+  agent: string;
+  workspace: string;
+  transportSession: string;
+  running: boolean;
+  archived: boolean;
+}
+```
+
+In `listSessions`, add `archived: session.archived === true` to the `.map(...)` object. In `createSession`'s returned object (lines ~255-261), add `archived: false`.
+
+Replace `removeSession` body to use the router orchestration, and add the two new methods:
+
+```ts
+  async removeSession(chatKey: string, alias: string): Promise<{ wasActive: boolean }> {
+    const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, alias);
+    const result = await this.deps.removeSessionWithTransport(internalAlias);
+    this.deps.events.emit({ type: "sessions-changed" });
+    return result;
+  }
+
+  async archiveSession(chatKey: string, alias: string): Promise<void> {
+    const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, alias);
+    await this.deps.archiveSessionWithTransport(internalAlias);
+    this.deps.events.emit({ type: "sessions-changed" });
+  }
+
+  async unarchiveSession(chatKey: string, alias: string): Promise<void> {
+    const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, alias);
+    await this.deps.unarchiveSession(internalAlias);
+    this.deps.events.emit({ type: "sessions-changed" });
+  }
+```
+
+> `listAllResolvedSessions()` must surface `archived`. Check `src/sessions/session-service.ts` `listAllResolvedSessions` / `ResolvedSession` — if `archived` isn't carried on the resolved shape, add it there (pass through `session.archived`). Add a one-line test in `session-archived.test.ts` asserting `listAllResolvedSessions()` includes `archived` if you extend it.
+
+- [ ] **Step 4: Wire deps in `main.ts`**
+
+In `src/main.ts`, in the `new ControlService({ ... })` deps object (~line 750), add:
+
+```ts
+    removeSessionWithTransport: (internalAlias) => router.removeSessionWithTransport(internalAlias),
+    archiveSessionWithTransport: (internalAlias) => router.archiveSessionWithTransport(internalAlias),
+    unarchiveSession: (internalAlias) => router.unarchiveSession(internalAlias),
+```
+
+- [ ] **Step 5: Run test + typecheck**
+
+Run: `npx vitest run tests/unit/control/control-archive.test.ts && npx tsc --noEmit`
+Expected: PASS + clean (fix any other ControlService constructor call sites in tests that now need the new deps).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/control/control-service.ts src/main.ts tests/unit/control/control-archive.test.ts
+git commit -m "feat(control): archive/unarchive + real-delete wiring + archived in session info"
+```
+
+---
+
+## Phase 4 — protocol, connector, chat command
+
+### Task 9: relay-protocol — message types, payloads, `SessionDto.archived`
+
+**Files:**
+- Modify: `packages/relay-protocol/src/messages.ts` (MSG keys + payloads)
+- Modify: `packages/relay-protocol/src/dtos.ts` (`SessionDto.archived`)
+- Test: `packages/relay-protocol/src/__tests__/archive-dtos.test.ts` (new, if the package has tests; else skip the test file and rely on tsc)
+
+- [ ] **Step 1: Add MSG keys**
+
+In `packages/relay-protocol/src/messages.ts`, add to the `MSG` object (after `sessionsRemove`):
+
+```ts
+  sessionsArchive: "control.sessions.archive",
+  sessionsUnarchive: "control.sessions.unarchive",
+```
+
+Add payload interfaces (after `SessionsRemovePayload`/`SessionsRemoveResult`):
+
+```ts
+export interface SessionsArchivePayload {
+  chatKey: string;
+  alias: string;
+}
+export interface SessionsUnarchivePayload {
+  chatKey: string;
+  alias: string;
+}
+```
+
+- [ ] **Step 2: Add `archived` to `SessionDto`**
+
+In `packages/relay-protocol/src/dtos.ts`:
+
+```ts
+export interface SessionDto {
+  alias: string;
+  agent: string;
+  workspace: string;
+  transportSession: string;
+  running: boolean;
+  archived: boolean;
+}
+```
+
+- [ ] **Step 3: Build the protocol package**
+
+Per [[reference_bun_barrel_empty_export]], this package must be built with `tsc`, not bun. Run the package's build (check `packages/relay-protocol/package.json` scripts — typically `npm run -w @ganglion/xacpx-relay-protocol build` or `tsc -p packages/relay-protocol`). Confirm `dist/messages.d.ts` contains the new keys.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean (consumers that build `SessionDto` now require `archived` — those are fixed in Task 8 core builder + Task 12 web; if core/web aren't both updated yet, expect TS errors there until those tasks land — sequence Phase 3 before this).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/relay-protocol/src/messages.ts packages/relay-protocol/src/dtos.ts
+# include built dist only if the repo commits protocol dist (check git status of packages/relay-protocol/dist)
+git commit -m "feat(protocol): archive/unarchive messages + SessionDto.archived"
+```
+
+---
+
+### Task 10: Connector control-bridge dispatch
+
+**Files:**
+- Modify: `packages/channel-relay/src/control-bridge.ts` (imports + 2 cases)
+- Test: `packages/channel-relay/src/__tests__/control-bridge-archive.test.ts` (new, if the package has tests; else rely on tsc + manual)
+
+- [ ] **Step 1: Add the dispatch cases**
+
+In `packages/channel-relay/src/control-bridge.ts`, add to the import of payload types (line 27) `SessionsArchivePayload, SessionsUnarchivePayload`, and add cases next to `MSG.sessionsRemove` (~line 92):
+
+```ts
+    case MSG.sessionsArchive: {
+      const input = payload as SessionsArchivePayload;
+      await control.archiveSession(input.chatKey, input.alias);
+      return {};
+    }
+    case MSG.sessionsUnarchive: {
+      const input = payload as SessionsUnarchivePayload;
+      await control.unarchiveSession(input.chatKey, input.alias);
+      return {};
+    }
+```
+
+- [ ] **Step 2: Build connector + verify**
+
+Per [[reference_sandbox_connector_from_plugin_home]] and [[reference_bun_barrel_empty_export]], rebuild the connector package (`tsc`-based) so the new cases ship. Run the package typecheck/build.
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/channel-relay/src/control-bridge.ts
+git commit -m "feat(connector): dispatch sessions.archive/unarchive to ControlService"
+```
+
+---
+
+### Task 11: Chat `/session archive <alias>` command
+
+**Files:**
+- Modify: `src/commands/parse-command.ts` (parse case + `ParsedCommand` union)
+- Modify: `src/commands/command-router.ts` (dispatch case)
+- Modify: `src/commands/handlers/session-handler.ts` (`handleSessionArchive`)
+- Modify: `src/i18n/messages/en/*.ts` + `src/i18n/messages/zh/*.ts` (session strings)
+- Test: `tests/unit/commands/parse-command.test.ts` (extend) + handler test
+
+- [ ] **Step 1: Write the failing parse test**
+
+In `tests/unit/commands/parse-command.test.ts` (or a new sibling), add:
+
+```ts
+it("parses /session archive <alias>", () => {
+  expect(parseCommand("/session archive backend")).toEqual({ kind: "session.archive", alias: "backend" });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run tests/unit/commands/parse-command.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the parse case + union member**
+
+In `src/commands/parse-command.ts`, add to `ParsedCommand`: `| { kind: "session.archive"; alias: string }`. Add the parse case next to `session.rm`:
+
+```ts
+  if (command === "/session" && parts[1] === "archive" && parts[2] && parts.length === 3) {
+    return { kind: "session.archive", alias: parts[2] };
+  }
+```
+
+- [ ] **Step 4: Add the handler**
+
+In `src/commands/handlers/session-handler.ts`, add `handleSessionArchive` mirroring `handleSessionRemove`'s resolution but calling the archive orchestration. It receives `context` (which carries `sessions`+`transport`). Since the router method `archiveSessionWithTransport` lives on `CommandRouter`, expose it to the handler by adding a thin context op OR dispatch directly in the router (simpler). Use the router-dispatch approach in Step 5.
+
+```ts
+export async function handleSessionArchive(
+  context: SessionHandlerContext,
+  chatKey: string,
+  alias: string,
+  archive: (internalAlias: string) => Promise<void>,
+): Promise<RouterResponse> {
+  const internalAlias = await context.sessions.resolveAliasForChat(chatKey, alias);
+  const session = await context.sessions.getSession(internalAlias);
+  if (!session) {
+    return { text: t().session.sessionNotFound(alias) };
+  }
+  await archive(internalAlias);
+  return { text: t().session.sessionArchived(alias) };
+}
+```
+
+- [ ] **Step 5: Dispatch in the router**
+
+In `src/commands/command-router.ts`, add next to the `session.rm` case:
+
+```ts
+        case "session.archive":
+          return await handleSessionArchive(
+            this.createSessionHandlerContext(undefined, perfSpan),
+            chatKey,
+            command.alias,
+            (internalAlias) => this.archiveSessionWithTransport(internalAlias),
+          );
+```
+
+Import `handleSessionArchive` next to `handleSessionRemove` (line 33).
+
+- [ ] **Step 6: Add i18n string `sessionArchived`**
+
+Find where `sessionRemoved` is defined in the i18n session messages (grep `sessionRemoved(` under `src/i18n/`). Add a sibling in both en and zh:
+
+```ts
+// en
+sessionArchived: (alias: string) => `Archived session "${alias}". Send a message to restore it.`,
+// zh
+sessionArchived: (alias: string) => `已归档会话「${alias}」。发送消息即可恢复。`,
+```
+
+Add `sessionArchived` to the i18n type in `src/i18n/types.ts` (find the `session` block).
+
+- [ ] **Step 7: Run tests + typecheck**
+
+Run: `npx vitest run tests/unit/commands/ && npx tsc --noEmit`
+Expected: PASS + clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/commands/parse-command.ts src/commands/command-router.ts src/commands/handlers/session-handler.ts src/i18n tests/unit/commands/parse-command.test.ts
+git commit -m "feat(commands): add /session archive <alias>"
+```
+
+---
+
+## Phase 5 — relay-web UI (`packages/relay-web`)
+
+Run relay-web tests with: `bun run --cwd packages/relay-web test -- <filter>` (vitest; not whole-dir bun test — see [[reference_whole_dir_bun_test_state_leak]]).
+
+### Task 12: Store actions + archived sort
+
+**Files:**
+- Modify: `packages/relay-web/src/stores/instances.ts` (`archiveSession`, `unarchiveSession`, export)
+- Test: `packages/relay-web/src/__tests__/instances-archive.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/relay-web/src/__tests__/instances-archive.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useInstancesStore } from "../stores/instances";
+import { api } from "../api/client";
+
+describe("instances archive actions", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+  it("archiveSession calls control.sessions.archive then reloads", async () => {
+    const store = useInstancesStore();
+    const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [] } as never);
+    await store.archiveSession("i1", "backend");
+    expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.archive", { alias: "backend" });
+  });
+  it("unarchiveSession calls control.sessions.unarchive", async () => {
+    const store = useInstancesStore();
+    const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [] } as never);
+    await store.unarchiveSession("i1", "backend");
+    expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.unarchive", { alias: "backend" });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bun run --cwd packages/relay-web test -- instances-archive`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the actions**
+
+In `packages/relay-web/src/stores/instances.ts`, after `removeSession` (line 175):
+
+```ts
+  async function archiveSession(instanceId: string, alias: string): Promise<void> {
+    await api.rpc(instanceId, "control.sessions.archive", { alias });
+    await loadSessions(instanceId);
+  }
+  async function unarchiveSession(instanceId: string, alias: string): Promise<void> {
+    await api.rpc(instanceId, "control.sessions.unarchive", { alias });
+    await loadSessions(instanceId);
+  }
+```
+
+Add `archiveSession, unarchiveSession` to the returned object (line 204).
+
+- [ ] **Step 4: Run the test + vue-tsc**
+
+Run: `bun run --cwd packages/relay-web test -- instances-archive && bun run --cwd packages/relay-web build`
+Expected: PASS + build clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/relay-web/src/stores/instances.ts packages/relay-web/src/__tests__/instances-archive.test.ts
+git commit -m "feat(relay-web): archiveSession/unarchiveSession store actions"
+```
+
+---
+
+### Task 13: InstanceTree — overflow menu, archived rendering (greyed + sunk), offline-disable
+
+**Files:**
+- Modify: `packages/relay-web/src/components/InstanceTree.vue`
+- Modify: `packages/relay-web/src/__tests__/instancetree.test.ts`
+- Modify: `packages/relay-web/src/i18n/messages/zh-CN.ts` + `en.ts` (archive strings)
+
+- [ ] **Step 1: Add i18n strings**
+
+In both locales, inside the `instance:` block, add:
+
+```ts
+// en.ts
+archiveSession: "Archive session",
+sessionArchivedBadge: "archived",
+sessionArchivedToast: "Archived \"{alias}\"",
+undo: "Undo",
+// zh-CN.ts
+archiveSession: "归档会话",
+sessionArchivedBadge: "已归档",
+sessionArchivedToast: "已归档「{alias}」",
+undo: "撤销",
+```
+
+- [ ] **Step 2: Write failing component tests**
+
+Add to `instancetree.test.ts`:
+
+```ts
+it("greys archived sessions and sinks them to the bottom of the group", () => {
+  const store = useInstancesStore();
+  store.instances = [instance([
+    { alias: "active", agent: "claude", workspace: "home", transportSession: "t1", running: false, archived: false },
+    { alias: "arch", agent: "codex", workspace: "home", transportSession: "t2", running: false, archived: true },
+  ])] as never;
+  const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+  const rows = w.findAll('[data-test="session-row"]');
+  expect(rows[rows.length - 1].text()).toContain("arch"); // archived sunk to bottom
+  expect(w.find('[data-test="archived-badge"]').exists()).toBe(true);
+});
+
+it("disables row actions when the instance is offline", () => {
+  const store = useInstancesStore();
+  store.instances = [{ ...instance([{ alias: "a", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }]), online: false }] as never;
+  const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+  expect(w.find('[data-test="session-actions"]').exists()).toBe(false);
+});
+```
+
+Update existing rows in the file's `instance(...)` session fixtures to include `archived: false` (the new required DTO field).
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `bun run --cwd packages/relay-web test -- instancetree`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement the component changes**
+
+In `InstanceTree.vue`:
+
+1. Replace the iteration source with a computed that sinks archived rows. Add to `<script setup>`:
+
+```ts
+import { computed } from "vue";
+import { MoreHorizontal, Archive, Trash2 } from "lucide-vue-next";
+
+function orderedSessions(sessions: { archived?: boolean }[]) {
+  // stable: actives keep server order, archived go last
+  return [...sessions].sort((a, b) => Number(a.archived ?? false) - Number(b.archived ?? false));
+}
+
+const openMenuFor = ref<string | null>(null); // `${instanceId}:${alias}` or null
+
+async function onArchive(id: string, alias: string) {
+  openMenuFor.value = null;
+  await store.archiveSession(id, alias).catch(() => {});
+  showUndoToast(id, alias); // defined in Task 15
+}
+```
+
+2. In the template, change `v-for="s in inst.sessions"` → `v-for="s in orderedSessions(inst.sessions)"`, add `data-test="session-row"` to the row `<div>`, and on `s.archived` grey the title (`text-fg-muted`) + suppress the attention/running dots (`v-if="!s.archived && ..."`) + render a badge:
+
+```vue
+<span v-if="s.archived" data-test="archived-badge" class="shrink-0 rounded bg-bg px-1 py-px text-[9px] text-fg-muted">{{ $t("instance.sessionArchivedBadge") }}</span>
+```
+
+3. Replace the single delete button with a `data-test="session-actions"` cluster gated on `inst.online` — a `⋯` button toggling `openMenuFor`, and a popover with Archive + Delete:
+
+```vue
+<div v-if="inst.online" data-test="session-actions" class="relative mr-1 shrink-0">
+  <button data-test="session-menu" :aria-label="$t('common.more')"
+          class="grid h-5 w-5 place-items-center rounded text-fg-muted hover:bg-raised hover:text-fg [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 opacity-100"
+          @click.stop="openMenuFor = openMenuFor === `${inst.id}:${s.alias}` ? null : `${inst.id}:${s.alias}`"><MoreHorizontal :size="13" /></button>
+  <div v-if="openMenuFor === `${inst.id}:${s.alias}`" class="absolute right-0 z-20 mt-1 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
+    <button v-if="!s.archived" data-test="action-archive" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="onArchive(inst.id, s.alias)"><Archive :size="12" />{{ $t("instance.archiveSession") }}</button>
+    <button data-test="action-delete" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
+  </div>
+</div>
+```
+
+Add a document-level click handler to close the menu on outside-click (mirror `SelectMenu.vue`'s `mousedown` outside-click pattern). Keep `askDelete` unchanged (already a destructive confirm).
+
+- [ ] **Step 5: Run the tests + build**
+
+Run: `bun run --cwd packages/relay-web test -- instancetree && bun run --cwd packages/relay-web build`
+Expected: PASS + clean. (The `showUndoToast` reference will be stubbed/no-op until Task 15 — define a local no-op now and replace in Task 15, or sequence Task 15's toast store before wiring; to keep this task green, add a temporary `function showUndoToast() {}` and remove it in Task 15.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/relay-web/src/components/InstanceTree.vue packages/relay-web/src/__tests__/instancetree.test.ts packages/relay-web/src/i18n/messages/zh-CN.ts packages/relay-web/src/i18n/messages/en.ts
+git commit -m "feat(relay-web): session overflow menu + archived greyed/sunk + offline-disable"
+```
+
+---
+
+### Task 14: Mobile swipe gestures (`useSwipeActions` composable)
+
+**Files:**
+- Create: `packages/relay-web/src/lib/use-swipe-actions.ts`
+- Modify: `packages/relay-web/src/components/InstanceTree.vue` (bind to rows)
+- Test: `packages/relay-web/src/__tests__/use-swipe-actions.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/relay-web/src/__tests__/use-swipe-actions.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { useSwipeActions } from "../lib/use-swipe-actions";
+
+function pointer(type: string, x: number) {
+  return new PointerEvent(type, { clientX: x, clientY: 0, pointerId: 1, bubbles: true });
+}
+
+describe("useSwipeActions", () => {
+  it("fires onSwipeLeft past the threshold", () => {
+    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
+    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+    handlers.onPointerdown(pointer("pointerdown", 200));
+    handlers.onPointermove(pointer("pointermove", 120));
+    handlers.onPointerup(pointer("pointerup", 120));
+    expect(onSwipeLeft).toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+  it("fires onSwipeRight past the threshold", () => {
+    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
+    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+    handlers.onPointerdown(pointer("pointerdown", 100));
+    handlers.onPointermove(pointer("pointermove", 200));
+    handlers.onPointerup(pointer("pointerup", 200));
+    expect(onSwipeRight).toHaveBeenCalled();
+  });
+  it("ignores sub-threshold and vertical-dominant moves", () => {
+    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
+    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+    handlers.onPointerdown(pointer("pointerdown", 200));
+    handlers.onPointermove(pointer("pointermove", 180));
+    handlers.onPointerup(pointer("pointerup", 180));
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bun run --cwd packages/relay-web test -- use-swipe-actions`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the composable**
+
+```ts
+// packages/relay-web/src/lib/use-swipe-actions.ts
+import { ref } from "vue";
+
+export interface SwipeActionsOptions {
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+  threshold?: number; // px of horizontal travel required to fire
+}
+
+/** Minimal horizontal-swipe detector for a list row. Tracks pointer travel and
+ *  fires left/right past the threshold, ignoring vertical-dominant gestures (so
+ *  it doesn't fight the scroll container). `offset` is exposed for a reveal anim. */
+export function useSwipeActions(opts: SwipeActionsOptions) {
+  const threshold = opts.threshold ?? 64;
+  const offset = ref(0);
+  let startX = 0, startY = 0, active = false;
+
+  function onPointerdown(e: PointerEvent) {
+    active = true; startX = e.clientX; startY = e.clientY; offset.value = 0;
+  }
+  function onPointermove(e: PointerEvent) {
+    if (!active) return;
+    const dx = e.clientX - startX, dy = e.clientY - startY;
+    if (Math.abs(dy) > Math.abs(dx)) { active = false; offset.value = 0; return; } // vertical → let it scroll
+    offset.value = dx;
+  }
+  function onPointerup(e: PointerEvent) {
+    if (!active) return;
+    active = false;
+    const dx = e.clientX - startX, dy = e.clientY - startY;
+    offset.value = 0;
+    if (Math.abs(dy) > Math.abs(dx)) return;
+    if (dx <= -threshold) opts.onSwipeLeft();
+    else if (dx >= threshold) opts.onSwipeRight();
+  }
+
+  return { offset, handlers: { onPointerdown, onPointermove, onPointerup } };
+}
+```
+
+- [ ] **Step 4: Bind in InstanceTree (mobile only)**
+
+In `InstanceTree.vue`, for each session row attach the pointer handlers (they no-op on desktop where the user uses the ⋯ menu; the swipe just provides a second path). Create a per-row binding helper that calls `onArchive` on swipe-left and `askDelete` on swipe-right, gated on `inst.online`. Bind `@pointerdown/@pointermove/@pointerup` on the row `<div>`. Keep `touch-action: pan-y` on the row so vertical scroll still works (`class="... touch-pan-y"`).
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `bun run --cwd packages/relay-web test -- use-swipe-actions instancetree && bun run --cwd packages/relay-web build`
+Expected: PASS + clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/relay-web/src/lib/use-swipe-actions.ts packages/relay-web/src/components/InstanceTree.vue packages/relay-web/src/__tests__/use-swipe-actions.test.ts
+git commit -m "feat(relay-web): mobile swipe — left archive / right delete"
+```
+
+---
+
+### Task 15: Undo toast
+
+**Files:**
+- Create: `packages/relay-web/src/lib/use-action-toast.ts` (local toast singleton with an action button)
+- Create: `packages/relay-web/src/components/ActionToast.vue`
+- Modify: `packages/relay-web/src/views/DashboardView.vue` (mount `<ActionToast />`)
+- Modify: `packages/relay-web/src/components/InstanceTree.vue` (wire `showUndoToast` → `unarchiveSession`)
+- Test: `packages/relay-web/src/__tests__/action-toast.test.ts` (new)
+
+The existing `notices` store is a passive server feed with no action button; the undo toast is a separate local singleton modeled on `use-confirm.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/relay-web/src/__tests__/action-toast.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { showActionToast, useActionToastState, runToastAction, dismissToast } from "../lib/use-action-toast";
+
+describe("action toast", () => {
+  it("exposes the message + action and runs the action once", () => {
+    const action = vi.fn();
+    showActionToast({ message: "Archived \"x\"", actionLabel: "Undo", action });
+    expect(useActionToastState().value?.message).toContain("Archived");
+    runToastAction();
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(useActionToastState().value).toBeNull();
+  });
+  it("dismiss clears without running the action", () => {
+    const action = vi.fn();
+    showActionToast({ message: "m", actionLabel: "Undo", action });
+    dismissToast();
+    expect(action).not.toHaveBeenCalled();
+    expect(useActionToastState().value).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bun run --cwd packages/relay-web test -- action-toast`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the toast singleton**
+
+```ts
+// packages/relay-web/src/lib/use-action-toast.ts
+import { ref } from "vue";
+
+export interface ActionToast {
+  message: string;
+  actionLabel: string;
+  action: () => void;
+}
+
+const current = ref<ActionToast | null>(null);
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+export function useActionToastState() { return current; }
+
+/** Show a toast with one action button; auto-dismisses after `ms` (default 6s). */
+export function showActionToast(toast: ActionToast, ms = 6000): void {
+  if (timer) clearTimeout(timer);
+  current.value = toast;
+  timer = setTimeout(() => { current.value = null; timer = null; }, ms);
+}
+
+export function runToastAction(): void {
+  const t = current.value;
+  current.value = null;
+  if (timer) { clearTimeout(timer); timer = null; }
+  t?.action();
+}
+
+export function dismissToast(): void {
+  current.value = null;
+  if (timer) { clearTimeout(timer); timer = null; }
+}
+```
+
+- [ ] **Step 4: Toast component + mount**
+
+```vue
+<!-- packages/relay-web/src/components/ActionToast.vue -->
+<script setup lang="ts">
+import { useActionToastState, runToastAction, dismissToast } from "../lib/use-action-toast";
+const toast = useActionToastState();
+</script>
+<template>
+  <Teleport to="body">
+    <div v-if="toast" data-test="action-toast"
+         class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-fg shadow-lg">
+      <span>{{ toast.message }}</span>
+      <button data-test="toast-action" class="font-medium text-accent hover:underline" @click="runToastAction">{{ toast.actionLabel }}</button>
+      <button class="text-fg-muted hover:text-fg" :aria-label="$t('common.dismiss')" @click="dismissToast">×</button>
+    </div>
+  </Teleport>
+</template>
+```
+
+Mount `<ActionToast />` once in `DashboardView.vue` next to `<NoticeToast />` (import + place in template).
+
+- [ ] **Step 5: Wire archive undo in InstanceTree**
+
+Replace the temporary `showUndoToast` no-op from Task 13 with:
+
+```ts
+import { showActionToast } from "../lib/use-action-toast";
+import { useI18n } from "vue-i18n";
+
+function showUndoToast(id: string, alias: string) {
+  showActionToast({
+    message: t("instance.sessionArchivedToast", { alias }),
+    actionLabel: t("instance.undo"),
+    action: () => { void store.unarchiveSession(id, alias).catch(() => {}); },
+  });
+}
+```
+
+- [ ] **Step 6: Run tests + build**
+
+Run: `bun run --cwd packages/relay-web test -- action-toast instancetree && bun run --cwd packages/relay-web build`
+Expected: PASS + clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/relay-web/src/lib/use-action-toast.ts packages/relay-web/src/components/ActionToast.vue packages/relay-web/src/views/DashboardView.vue packages/relay-web/src/components/InstanceTree.vue packages/relay-web/src/__tests__/action-toast.test.ts
+git commit -m "feat(relay-web): undo toast for session archive"
+```
+
+---
+
+### Task 16: Full verification
+
+- [ ] **Step 1: Core typecheck + unit tests**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: all green.
+
+- [ ] **Step 2: relay-web full suite + build**
+
+Run: `bun run --cwd packages/relay-web test && bun run --cwd packages/relay-web build`
+Expected: all green + build clean.
+
+- [ ] **Step 3: Protocol + connector build**
+
+Run the `tsc`-based builds for `packages/relay-protocol` and `packages/channel-relay` and confirm dist contains the new message keys/cases ([[reference_bun_barrel_empty_export]]).
+
+- [ ] **Step 4: Manual end-to-end (sandbox)**
+
+Per [[reference_sandbox_connector_from_plugin_home]]: rebuild + reinstall the connector into its plugin home, restart the console, then in relay-web: archive a codex session (row greys + sinks, undo toast appears), send it a message (restores + history intact), delete a session (gone; re-create same name → fresh, no history). Verify offline instance disables the actions.
+
+---
+
+## Self-Review notes (addressed)
+
+- **Spec coverage:** Module 1 → Tasks 1–3; Module 2 → Tasks 4–5 (deleteSession) + archive reuse of removeSession (Task 7); Module 3 → Tasks 6–8; Module 4 → Tasks 9–11; Module 5 → Tasks 12–15. Restore-on-message → Task 6 (`useSession` clear). Smart shared-transport guard → Task 7. Offline-disable → Task 13. Undo → Task 15. Sunk+greyed → Task 13.
+- **Type consistency:** `deleteSession` (transport), `deleteSessionRecord` (acpx repo), `setArchived` (SessionService), `archiveSessionWithTransport`/`removeSessionWithTransport`/`unarchiveSession` (router + control deps), `archived` (LogicalSession + ControlSessionInfo + SessionDto), `MSG.sessionsArchive`/`sessionsUnarchive` + `SessionsArchivePayload`/`SessionsUnarchivePayload` (protocol), `control.sessions.archive`/`.unarchive` (RPC strings), `archiveSession`/`unarchiveSession` (web store + control-service) — used consistently across tasks.
+- **Sequencing:** Phase 1 → release acpx → Phase 2 (bump dep). Phase 3 before Task 9 (so the `SessionDto.archived` required-field change has its core/web builders updated in the same merge). Task 13 leaves a temporary `showUndoToast` no-op removed in Task 15.

--- a/docs/superpowers/plans/2026-06-21-session-archive-and-real-delete.md
+++ b/docs/superpowers/plans/2026-06-21-session-archive-and-real-delete.md
@@ -4,330 +4,193 @@
 
 **Goal:** Make session deletion a real delete (acpx history gone, same-name re-create starts fresh) and add session archive (process closed now, row greyed + sunk to bottom, restored by sending a message) across all channels + the relay-web dashboard.
 
-**Architecture:** acpx gains a focused `sessions rm` (single-record hard delete). The xacpx transport gains `deleteSession` (= `acpx sessions rm`); archive reuses the existing `removeSession` (= `acpx sessions close`). Orchestration (shared-transport guard, cancel, transport teardown) lives in `CommandRouter` and is shared by the chat `/session` handlers and the web `ControlService`. The logical session gains an `archived` flag, cleared on the next `useSession` (which every prompt calls). relay-web adds a desktop ⋯ menu + mobile swipe, greys + sinks archived rows, and an undo toast.
+**Architecture:** acpx is a third-party dependency and is NOT modified. The xacpx transport gains `deleteSession`, which closes the session via acpx's existing `sessions close` then deletes acpx's on-disk record files directly (Route B); archive reuses the existing `removeSession` (= `acpx sessions close`). Orchestration (shared-transport guard, cancel, transport teardown) lives in `CommandRouter` and is shared by the chat `/session` handlers and the web `ControlService`. The logical session gains an `archived` flag, cleared on the next `useSession` (which every prompt calls). relay-web adds a desktop ⋯ menu + mobile swipe, greys + sinks archived rows, and an undo toast.
 
 **Tech Stack:** TypeScript, Node, Bun (build/test), Vue 3 + Pinia + Tailwind (relay-web), Vitest, acpx (sibling repo at `../acpx`).
 
 **Companion spec:** `docs/superpowers/specs/2026-06-21-session-archive-and-real-delete-design.md`
 
-**Two repos:** Phase 1 tasks run in `/Users/maijiazhen/Projects/acpx`. Phases 2–5 run in `/Users/maijiazhen/Projects/weacpx-github`. Phase 2 depends on Phase 1 being released and the xacpx bundled `acpx` dep bumped; during development of Phases 2–5 the new acpx can be linked locally.
+**Single repo:** all tasks run in `/Users/maijiazhen/Projects/weacpx-github`. acpx is a third-party dependency and is **not** modified (see Phase 1 rationale).
 
 **Git hygiene (every task):** never `git add -A`/`git add .`; stage only the exact files named in the task. Never stage `bun.lock`, `dist/`, `node_modules` unless the task says so. Each task is its own commit.
 
 ---
 
-## Phase 1 — acpx: `sessions rm` (repo: `/Users/maijiazhen/Projects/acpx`)
+## Phase 1 — xacpx real-delete mechanism (Route B; no acpx changes)
 
-### Task 1: Single-record hard-delete helper in the repository
+> **Why Route B:** acpx is a third-party dependency, not ours to modify. acpx has no
+> single-session hard-delete command, so xacpx closes the session via acpx's existing
+> CLI and then deletes acpx's on-disk record files directly. This reuses coupling xacpx
+> already has (`acpx-session-index.ts` / `native-session-history.ts` read
+> `~/.acpx/sessions`; transports resolve `acpxRecordId` via `acpx sessions show`).
+> (An earlier draft's Tasks 4–5 added an acpx `sessions rm` command — removed.)
+
+### Task 1: `acpx-session-files.ts` — delete a session's on-disk files
 
 **Files:**
-- Modify: `src/session/persistence/repository.ts` (add an exported `deleteSessionRecord`; helpers `pruneSessionFiles`/`unlinkCountingBytes`/`isSessionStreamFile` already live here)
-- Modify: `src/session/persistence.ts` (re-export `deleteSessionRecord`)
-- Test: `src/session/persistence/repository.delete-session.test.ts` (new)
+- Create: `src/transport/acpx-session-files.ts`
+- Test: `tests/unit/transport/acpx-session-files.test.ts` (new)
 
-The existing `pruneSessionFiles(record, sessionDir, dirEntries, includeHistory)` already deletes a single record's files. We expose a name-agnostic, id-based single-record delete that kills a running pid (reusing `closeSession`'s kill loop) then removes files.
+The only unit that encodes acpx's on-disk record naming. Mirrors acpx's own
+`pruneSessionFiles` (`safeId = encodeURIComponent(acpxRecordId)`; record `<safeId>.json`
++ stream artifacts `<safeId>.stream.ndjson` / `.stream.lock` / `.stream.*`). Sessions
+dir defaults to `~/.acpx/sessions`, overridable for tests (same pattern as
+`native-session-history.ts`).
 
 - [ ] **Step 1: Write the failing test**
 
 ```ts
-// src/session/persistence/repository.delete-session.test.ts
-import { describe, it, expect, beforeEach } from "vitest";
+// tests/unit/transport/acpx-session-files.test.ts
+import { describe, it, expect } from "vitest";
 import { promises as fs } from "node:fs";
-import path from "node:path";
-import os from "node:os";
-import { writeSessionRecord, deleteSessionRecord } from "./repository.js";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { deleteAcpxSessionFiles } from "../../../src/transport/acpx-session-files";
 
-const sessionDir = path.join(os.homedir(), ".acpx", "sessions");
-
-async function seedRecord(id: string): Promise<string> {
-  await fs.mkdir(sessionDir, { recursive: true });
-  const file = path.join(sessionDir, `${encodeURIComponent(id)}.json`);
-  const record = {
-    acpxRecordId: id, acpSessionId: id, agentCommand: "test-agent", cwd: "/tmp/x",
-    name: "demo", closed: true, createdAt: "2020-01-01T00:00:00.000Z",
-    lastUsedAt: "2020-01-01T00:00:00.000Z", messages: [],
-  };
-  await writeSessionRecord(record as never);
-  return file;
+async function tempSessionsDir(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "acpx-sessions-"));
 }
 
-describe("deleteSessionRecord", () => {
-  it("removes the record json and reports bytes freed", async () => {
-    const id = `del-test-${process.pid}-a`;
-    const file = await seedRecord(id);
-    expect(await fs.stat(file).then(() => true).catch(() => false)).toBe(true);
-    const result = await deleteSessionRecord(id);
-    expect(result.bytesFreed).toBeGreaterThan(0);
-    expect(await fs.stat(file).then(() => true).catch(() => false)).toBe(false);
+describe("deleteAcpxSessionFiles", () => {
+  it("removes the record json and its stream artifacts", async () => {
+    const dir = await tempSessionsDir();
+    const id = "ws:demo";
+    const safe = encodeURIComponent(id);
+    await writeFile(join(dir, `${safe}.json`), "{}");
+    await writeFile(join(dir, `${safe}.stream.ndjson`), "");
+    await writeFile(join(dir, `${safe}.stream.lock`), "");
+    await deleteAcpxSessionFiles({ acpxRecordId: id, sessionsDir: dir });
+    const left = await fs.readdir(dir);
+    expect(left).toHaveLength(0);
   });
 
-  it("is idempotent for a missing record (no throw, zero bytes)", async () => {
-    const result = await deleteSessionRecord(`del-test-${process.pid}-missing`);
-    expect(result.bytesFreed).toBe(0);
+  it("is idempotent when nothing exists", async () => {
+    const dir = await tempSessionsDir();
+    await expect(deleteAcpxSessionFiles({ acpxRecordId: "ws:none", sessionsDir: dir })).resolves.toBeUndefined();
+  });
+
+  it("only deletes the target session's files, not siblings", async () => {
+    const dir = await tempSessionsDir();
+    await writeFile(join(dir, `${encodeURIComponent("ws:keep")}.json`), "{}");
+    await writeFile(join(dir, `${encodeURIComponent("ws:gone")}.json`), "{}");
+    await deleteAcpxSessionFiles({ acpxRecordId: "ws:gone", sessionsDir: dir });
+    const left = await fs.readdir(dir);
+    expect(left).toEqual([`${encodeURIComponent("ws:keep")}.json`]);
   });
 });
 ```
 
 - [ ] **Step 2: Run it to verify it fails**
 
-Run: `cd /Users/maijiazhen/Projects/acpx && npx vitest run src/session/persistence/repository.delete-session.test.ts`
-Expected: FAIL — `deleteSessionRecord` is not exported.
+Run: `npx vitest run tests/unit/transport/acpx-session-files.test.ts`
+Expected: FAIL — module missing.
 
-- [ ] **Step 3: Implement `deleteSessionRecord`**
-
-Add to `src/session/persistence/repository.ts` (after `closeSession`, near line 461 — it must be in the same module as the private `pruneSessionFiles`/`killSignalCandidates`/`resolveSessionRecord`/`sessionBaseDir`):
+- [ ] **Step 3: Implement the helper**
 
 ```ts
-/**
- * Hard-delete a single session record by id: kill a running pid (best-effort),
- * then remove its on-disk files (record json + event-stream artifacts).
- * Idempotent: a missing record resolves to { bytesFreed: 0 } without throwing.
- */
-export async function deleteSessionRecord(
-  id: string,
-  options: { includeHistory?: boolean } = {},
-): Promise<{ bytesFreed: number }> {
-  const includeHistory = options.includeHistory !== false; // default true: a real delete wipes history
-  let record: SessionRecord;
+// src/transport/acpx-session-files.ts
+import { readdir, stat, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface DeleteAcpxSessionFilesOptions {
+  acpxRecordId: string;
+  /** Override for the acpx sessions dir (tests). Defaults to `<home>/.acpx/sessions`. */
+  sessionsDir?: string;
+}
+
+/** Best-effort delete of a single acpx session's on-disk files: the record json and
+ *  its event-stream artifacts. Mirrors acpx's own per-record file layout
+ *  (`<encodeURIComponent(acpxRecordId)>.json` + `<safeId>.stream.*`). Idempotent —
+ *  missing files are ignored. acpx tolerates the now-stale index entry and self-heals
+ *  it on its next `sessions` operation, so we do not rewrite index.json. */
+export async function deleteAcpxSessionFiles(options: DeleteAcpxSessionFilesOptions): Promise<void> {
+  const dir = options.sessionsDir ?? join(homedir(), ".acpx", "sessions");
+  const safeId = encodeURIComponent(options.acpxRecordId);
+
+  await unlink(join(dir, `${safeId}.json`)).catch(() => undefined);
+
+  let entries: string[];
   try {
-    record = await resolveSessionRecord(id);
+    entries = await readdir(dir);
   } catch {
-    return { bytesFreed: 0 };
+    return; // dir gone → nothing more to remove
   }
-
-  if (record.pid) {
-    for (const signal of killSignalCandidates(record.lastAgentExitSignal ?? undefined)) {
-      try {
-        process.kill(record.pid, signal);
-      } catch {
-        // ignore — process already gone
-      }
-    }
+  const streamFiles = entries.filter(
+    (name) => name === `${safeId}.stream.ndjson` || name === `${safeId}.stream.lock` || name.startsWith(`${safeId}.stream.`),
+  );
+  for (const name of streamFiles) {
+    await unlink(join(dir, name)).catch(() => undefined);
   }
-
-  const sessionDir = sessionBaseDir();
-  let dirEntries: string[] = [];
-  if (includeHistory) {
-    try {
-      dirEntries = await fs.readdir(sessionDir);
-    } catch {
-      // ignore
-    }
-  }
-  const bytesFreed = await pruneSessionFiles(record, sessionDir, dirEntries, includeHistory);
-
-  await rebuildSessionIndex(sessionDir).catch(() => {
-    // best-effort cache rebuild
-  });
-  return { bytesFreed };
 }
 ```
 
-Then re-export it from `src/session/persistence.ts` — add `deleteSessionRecord,` to the existing `export { ... } from "./persistence/repository.js"` block (the one currently listing `closeSession`, `pruneSessions`, etc.).
+(`stat` import is unused — drop it; left here only as a reminder that no byte-counting is needed, unlike acpx's prune. Keep the import list to exactly what's used: `readdir`, `unlink`.)
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `cd /Users/maijiazhen/Projects/acpx && npx vitest run src/session/persistence/repository.delete-session.test.ts`
-Expected: PASS (2 tests).
+Run: `npx vitest run tests/unit/transport/acpx-session-files.test.ts && npx tsc --noEmit`
+Expected: PASS (3 tests) + clean typecheck (no unused imports).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /Users/maijiazhen/Projects/acpx
-git add src/session/persistence/repository.ts src/session/persistence.ts src/session/persistence/repository.delete-session.test.ts
-git commit -m "feat(sessions): add deleteSessionRecord single-record hard delete"
+git add src/transport/acpx-session-files.ts tests/unit/transport/acpx-session-files.test.ts
+git commit -m "feat(transport): add deleteAcpxSessionFiles (single-session on-disk cleanup)"
 ```
 
 ---
 
-### Task 2: `acpx <agent> sessions rm [name]` command + handler
-
-**Files:**
-- Modify: `src/cli/command-handlers.ts` (add `handleSessionsRm`)
-- Modify: `src/cli/command-registration.ts` (register `rm` subcommand)
-- Test: `src/cli/sessions-rm.test.ts` (new)
-
-`rm` mirrors `close`: resolve the record by cwd+name (but `includeClosed: true` so an already-closed/archived session can be deleted), then `deleteSessionRecord(record.acpxRecordId)`.
-
-- [ ] **Step 1: Write the failing test**
-
-```ts
-// src/cli/sessions-rm.test.ts
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-vi.mock("../session/persistence.js", async (orig) => {
-  const actual = await orig<typeof import("../session/persistence.js")>();
-  return { ...actual };
-});
-
-import { handleSessionsRm } from "./command-handlers.js";
-
-describe("handleSessionsRm", () => {
-  it("throws a scoped not-found error when no matching session exists", async () => {
-    const fakeCommand = { optsWithGlobals: () => ({}), parent: null } as never;
-    await expect(
-      handleSessionsRm("nonexistent-agent-xyz", "no-such-session", fakeCommand, { agents: {} } as never),
-    ).rejects.toThrow();
-  });
-});
-```
-
-- [ ] **Step 2: Run it to verify it fails**
-
-Run: `cd /Users/maijiazhen/Projects/acpx && npx vitest run src/cli/sessions-rm.test.ts`
-Expected: FAIL — `handleSessionsRm` is not exported.
-
-- [ ] **Step 3: Implement `handleSessionsRm`**
-
-Add to `src/cli/command-handlers.ts` (next to `handleSessionsClose`, ~line 776). Mirror `handleSessionsClose`, swapping `closeSession` for `deleteSessionRecord` and passing `includeClosed: true` to `findSession`:
-
-```ts
-export async function handleSessionsRm(
-  explicitAgentName: string | undefined,
-  sessionName: string | undefined,
-  command: Command,
-  config: ResolvedAcpxConfig,
-): Promise<void> {
-  const globalFlags = resolveGlobalFlags(command, config);
-  const agent = resolveAgentInvocation(explicitAgentName, globalFlags, config);
-  const { deleteSessionRecord } = await loadSessionModule();
-
-  const record = await findSession({
-    agentCommand: agent.agentCommand,
-    cwd: agent.cwd,
-    name: sessionName,
-    includeClosed: true,
-  });
-
-  if (!record) {
-    throw new Error(missingScopedSessionMessage(agent, sessionName));
-  }
-
-  await deleteSessionRecord(record.acpxRecordId);
-}
-```
-
-`findSession`, `loadSessionModule`, `resolveGlobalFlags`, `resolveAgentInvocation`, `missingScopedSessionMessage` are already imported/defined in this file (used by `handleSessionsClose`). Confirm `deleteSessionRecord` is exposed by `loadSessionModule()` — `loadSessionModule` dynamically imports `../session/persistence.js`, which now re-exports it (Task 1).
-
-- [ ] **Step 4: Register the subcommand**
-
-In `src/cli/command-registration.ts`, immediately after the `close` subcommand block (~line 129), add (and import `handleSessionsRm` alongside `handleSessionsClose` at the top of the file):
-
-```ts
-  sessionsCommand
-    .command("rm")
-    .description("Delete a session and its history (irreversible)")
-    .argument("[name]", "Session name", parseSessionName)
-    .action(async function (this: Command, name?: string) {
-      await handleSessionsRm(explicitAgentName, name, this, config);
-    });
-```
-
-- [ ] **Step 5: Run the test + typecheck**
-
-Run: `cd /Users/maijiazhen/Projects/acpx && npx vitest run src/cli/sessions-rm.test.ts && npx tsc --noEmit`
-Expected: PASS + clean typecheck.
-
-- [ ] **Step 6: Manual smoke (optional but recommended)**
-
-```bash
-cd /Users/maijiazhen/Projects/acpx && npm run build
-# create + delete a throwaway codex/claude session in a temp dir, then:
-node dist/cli.js <agent> sessions rm demo
-node dist/cli.js <agent> sessions list   # demo should be gone
-```
-
-- [ ] **Step 7: Commit**
-
-```bash
-cd /Users/maijiazhen/Projects/acpx
-git add src/cli/command-handlers.ts src/cli/command-registration.ts src/cli/sessions-rm.test.ts
-git commit -m "feat(cli): add 'sessions rm' to delete a single session + history"
-```
-
----
-
-### Task 3: acpx CHANGELOG + version bump + release
-
-**Files:**
-- Modify: `CHANGELOG.md` (Unreleased → Changes)
-- Modify: `package.json` (version bump)
-
-- [ ] **Step 1: Add CHANGELOG entry**
-
-Under `## Unreleased` → `### Changes` in `/Users/maijiazhen/Projects/acpx/CHANGELOG.md`:
-
-```markdown
-- CLI/sessions: add `sessions rm [name]` to hard-delete a single session and its history (kills the process if running). Complements `close` (keeps history) and `prune` (bulk by date).
-```
-
-- [ ] **Step 2: Bump version**
-
-In `package.json`, bump `"version"` from `0.10.0` to `0.11.0` (new feature, minor).
-
-- [ ] **Step 3: Full test + build**
-
-Run: `cd /Users/maijiazhen/Projects/acpx && npm test && npm run build`
-Expected: all pass.
-
-- [ ] **Step 4: Commit + release**
-
-```bash
-cd /Users/maijiazhen/Projects/acpx
-git add CHANGELOG.md package.json
-git commit -m "chore: release acpx 0.11.0 (sessions rm)"
-```
-
-Then follow the acpx repo's normal publish flow (tag + npm publish). **Record the published version** — Phase 2 Task 4b bumps xacpx's bundled `acpx` dependency to `^0.11.0`.
-
----
-
-## Phase 2 — xacpx transport (repo: `/Users/maijiazhen/Projects/weacpx-github`)
-
-### Task 4: `SessionTransport.deleteSession` + acpx-cli implementation
+### Task 2: `SessionTransport.deleteSession` + acpx-cli implementation
 
 **Files:**
 - Modify: `src/transport/types.ts` (interface)
 - Modify: `src/transport/acpx-cli/acpx-cli-transport.ts` (impl)
 - Test: `tests/unit/transport/acpx-cli-delete-session.test.ts` (new)
 
-- [ ] **Step 1: Write the failing test**
+`deleteSession` = resolve `acpxRecordId` via the existing private `readSessionRecord`
+→ `acpx sessions close` (clean process + queue-owner shutdown) → `deleteAcpxSessionFiles`.
+A missing acpx session is a no-op success.
 
-Mirror the existing acpx-cli transport tests (find them with `ls tests/unit/transport/`). The test asserts `deleteSession` runs `acpx ... sessions rm <name>` and tolerates a missing session.
+- [ ] **Step 1: Write the failing test**
 
 ```ts
 // tests/unit/transport/acpx-cli-delete-session.test.ts
 import { describe, it, expect, vi } from "vitest";
 import { AcpxCliTransport } from "../../../src/transport/acpx-cli/acpx-cli-transport";
+import * as files from "../../../src/transport/acpx-session-files";
 
 function makeSession() {
   return { alias: "a", agent: "codex", workspace: "w", transportSession: "w:a", cwd: "/tmp/w" } as never;
 }
 
 describe("AcpxCliTransport.deleteSession", () => {
-  it("invokes `sessions rm <transportSession>`", async () => {
+  it("closes the session then deletes its files by acpxRecordId", async () => {
     const transport = new AcpxCliTransport({ command: "acpx" } as never);
-    const run = vi
-      .spyOn(transport as never, "runCommand")
-      .mockResolvedValue({ code: 0, stdout: "", stderr: "" } as never);
+    vi.spyOn(transport as never, "readSessionRecord").mockResolvedValue({ acpxRecordId: "rec-123" } as never);
+    const remove = vi.spyOn(transport, "removeSession").mockResolvedValue();
+    const del = vi.spyOn(files, "deleteAcpxSessionFiles").mockResolvedValue();
     await transport.deleteSession(makeSession());
-    const args = (run.mock.calls[0] as unknown[])[1] as string[];
-    expect(args).toContain("sessions");
-    expect(args).toContain("rm");
-    expect(args).toContain("w:a");
+    expect(remove).toHaveBeenCalled();              // closed first
+    expect(del).toHaveBeenCalledWith(expect.objectContaining({ acpxRecordId: "rec-123" }));
   });
 
-  it("treats a missing acpx session as success", async () => {
+  it("is a no-op when the acpx session cannot be resolved (already gone)", async () => {
     const transport = new AcpxCliTransport({ command: "acpx" } as never);
-    vi.spyOn(transport as never, "runCommand").mockResolvedValue({
-      code: 1, stdout: "", stderr: "no session found for cwd",
-    } as never);
+    vi.spyOn(transport as never, "readSessionRecord").mockRejectedValue(new Error("no session"));
+    const del = vi.spyOn(files, "deleteAcpxSessionFiles").mockResolvedValue();
     await expect(transport.deleteSession(makeSession())).resolves.toBeUndefined();
+    expect(del).not.toHaveBeenCalled();
   });
 });
 ```
 
-> Note: match the real `AcpxCliTransport` constructor signature from `src/transport/acpx-cli/acpx-cli-transport.ts` (look at an existing test in `tests/unit/transport/` for the exact construction; adjust `makeSession`/constructor accordingly).
+> Match the real `AcpxCliTransport` constructor + `readSessionRecord` shape from
+> `src/transport/acpx-cli/acpx-cli-transport.ts` (read an existing test in
+> `tests/unit/transport/` for exact construction; `readSessionRecord` returns
+> `{ acpxRecordId: string; agentSessionId?: string }`). Adjust the spy target if
+> `readSessionRecord` is private (spy via `as never`).
 
 - [ ] **Step 2: Run it to verify it fails**
 
@@ -340,39 +203,40 @@ In `src/transport/types.ts`, add below `removeSession?` (line 169):
 
 ```ts
   /**
-   * Hard-delete the transport session AND its history (`acpx sessions rm`).
-   * Distinct from removeSession (= `acpx sessions close`, which keeps history for
-   * resume). Optional: transports that can't delete omit it. Treats a missing
-   * acpx session as success (idempotent).
+   * Hard-delete the transport session AND its on-disk history: close the acpx
+   * process, then delete acpx's record files. Distinct from removeSession (=
+   * `acpx sessions close`, which keeps history for resume). Optional: transports
+   * that can't delete omit it. A missing acpx session is a no-op (idempotent).
    */
   deleteSession?(session: ResolvedSession): Promise<void>;
 ```
 
 - [ ] **Step 4: Implement in acpx-cli**
 
-In `src/transport/acpx-cli/acpx-cli-transport.ts`, add next to `removeSession` (~line 400), mirroring it but with `rm`:
+In `src/transport/acpx-cli/acpx-cli-transport.ts`, import the helper at the top:
+
+```ts
+import { deleteAcpxSessionFiles } from "../acpx-session-files.js";
+```
+
+Add the method next to `removeSession` (~line 400):
 
 ```ts
   async deleteSession(session: ResolvedSession): Promise<void> {
-    const result = await this.runCommand(this.command, this.buildArgs(session, [
-      "sessions",
-      "rm",
-      session.transportSession,
-    ]));
-    if (result.code === 0) {
-      return;
+    let acpxRecordId: string;
+    try {
+      ({ acpxRecordId } = await this.readSessionRecord(session));
+    } catch {
+      return; // acpx session already gone → nothing to delete
     }
-    if (isMissingAcpxSessionError(result.stderr, result.stdout)) {
-      return;
-    }
-    const detail = normalizeCommandError(result) ?? `command failed with exit code ${result.code}`;
-    throw new Error(detail);
+    // Close first so no live process / queue owner holds the files, then unlink.
+    await this.removeSession(session);
+    await deleteAcpxSessionFiles({ acpxRecordId });
   }
 ```
 
-- [ ] **Step 4b: Bump the bundled acpx dependency**
-
-In `package.json`, bump the `acpx` dependency to the version published in Task 3 (`^0.11.0`). Run `npm install --package-lock-only` (with `npm_config_registry=https://registry.npmjs.org/`) to sync `package-lock.json`. Do NOT stage `bun.lock`.
+> Confirm `readSessionRecord` returns `{ acpxRecordId }` (it does, ~line 441) and that
+> `removeSession` is the `acpx sessions close` method (it is, ~line 400).
 
 - [ ] **Step 5: Run the test + typecheck**
 
@@ -382,19 +246,19 @@ Expected: PASS + clean.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/transport/types.ts src/transport/acpx-cli/acpx-cli-transport.ts tests/unit/transport/acpx-cli-delete-session.test.ts package.json package-lock.json
-git commit -m "feat(transport): add deleteSession (acpx sessions rm) + bump acpx 0.11.0"
+git add src/transport/types.ts src/transport/acpx-cli/acpx-cli-transport.ts tests/unit/transport/acpx-cli-delete-session.test.ts
+git commit -m "feat(transport): deleteSession (close + delete acpx record files)"
 ```
 
 ---
 
-### Task 5: Bridge transport `deleteSession`
+### Task 3: Bridge transport `deleteSession`
 
 **Files:**
 - Modify: `src/transport/acpx-bridge/acpx-bridge-protocol.ts` (add `"deleteSession"` to `BridgeMethod`)
 - Modify: `src/transport/acpx-bridge/acpx-bridge-transport.ts` (client method)
 - Modify: `src/bridge/bridge-server.ts` (dispatch case)
-- Modify: `src/bridge/bridge-runtime.ts` (runtime method calling the underlying acpx-cli transport's `deleteSession`)
+- Modify: `src/bridge/bridge-runtime.ts` (runtime method → underlying acpx-cli `deleteSession`)
 - Test: `tests/unit/bridge/bridge-delete-session.test.ts` (new)
 
 - [ ] **Step 1: Write the failing test**
@@ -419,7 +283,8 @@ describe("bridge deleteSession", () => {
 });
 ```
 
-> Adjust constructor/handler names to match the real `BridgeServer` (read `src/bridge/bridge-server.ts:274` area where `removeSession` is dispatched).
+> Adjust constructor/handler names to match the real `BridgeServer` (read
+> `src/bridge/bridge-server.ts` where `removeSession` is dispatched, ~line 274).
 
 - [ ] **Step 2: Run it to verify it fails**
 
@@ -460,7 +325,6 @@ git add src/transport/acpx-bridge/acpx-bridge-protocol.ts src/transport/acpx-bri
 git commit -m "feat(bridge): wire deleteSession through bridge protocol/server/runtime"
 ```
 
----
 
 ## Phase 3 — core: archived flag + orchestration + control wiring
 
@@ -1472,6 +1336,6 @@ Per [[reference_sandbox_connector_from_plugin_home]]: rebuild + reinstall the co
 
 ## Self-Review notes (addressed)
 
-- **Spec coverage:** Module 1 → Tasks 1–3; Module 2 → Tasks 4–5 (deleteSession) + archive reuse of removeSession (Task 7); Module 3 → Tasks 6–8; Module 4 → Tasks 9–11; Module 5 → Tasks 12–15. Restore-on-message → Task 6 (`useSession` clear). Smart shared-transport guard → Task 7. Offline-disable → Task 13. Undo → Task 15. Sunk+greyed → Task 13.
-- **Type consistency:** `deleteSession` (transport), `deleteSessionRecord` (acpx repo), `setArchived` (SessionService), `archiveSessionWithTransport`/`removeSessionWithTransport`/`unarchiveSession` (router + control deps), `archived` (LogicalSession + ControlSessionInfo + SessionDto), `MSG.sessionsArchive`/`sessionsUnarchive` + `SessionsArchivePayload`/`SessionsUnarchivePayload` (protocol), `control.sessions.archive`/`.unarchive` (RPC strings), `archiveSession`/`unarchiveSession` (web store + control-service) — used consistently across tasks.
-- **Sequencing:** Phase 1 → release acpx → Phase 2 (bump dep). Phase 3 before Task 9 (so the `SessionDto.archived` required-field change has its core/web builders updated in the same merge). Task 13 leaves a temporary `showUndoToast` no-op removed in Task 15.
+- **Spec coverage:** Module 1 (acpx-session-files) → Task 1; Module 2 (transport deleteSession) → Tasks 2–3 + archive reuse of removeSession (Task 7); Module 3 → Tasks 6–8; Module 4 → Tasks 9–11; Module 5 → Tasks 12–15. Restore-on-message → Task 6 (`useSession` clear). Smart shared-transport guard → Task 7. Offline-disable → Task 13. Undo → Task 15. Sunk+greyed → Task 13.
+- **Type consistency:** `deleteAcpxSessionFiles` (acpx-session-files), `deleteSession` (transport), `setArchived` (SessionService), `archiveSessionWithTransport`/`removeSessionWithTransport`/`unarchiveSession` (router + control deps), `archived` (LogicalSession + ControlSessionInfo + SessionDto), `MSG.sessionsArchive`/`sessionsUnarchive` + `SessionsArchivePayload`/`SessionsUnarchivePayload` (protocol), `control.sessions.archive`/`.unarchive` (RPC strings), `archiveSession`/`unarchiveSession` (web store + control-service) — used consistently across tasks.
+- **Sequencing:** Phase 1 (transport `deleteSession` via Route B file deletion — no acpx changes) → Phase 3 before Task 9 (so the `SessionDto.archived` required-field change has its core/web builders updated in the same merge). Task 13 leaves a temporary `showUndoToast` no-op removed in Task 15.

--- a/docs/superpowers/specs/2026-06-21-session-archive-and-real-delete-design.md
+++ b/docs/superpowers/specs/2026-06-21-session-archive-and-real-delete-design.md
@@ -26,37 +26,59 @@ A single transport session can be shared by multiple logical aliases
 (`countAliasesSharingTransport`, `session-service.ts:483`). Any history-destroying
 delete must guard against nuking a transport session another alias still uses.
 
-## acpx primitives (already present)
+## Approach decision (revised)
 
-- `acpx sessions close <name>` — kills the agent process, marks the record
-  `closed`, **keeps history**, resumable. Exposed today as
+During brainstorming, "real delete of history" was scoped as **Route A** — add a
+focused `sessions rm` to acpx — on the mistaken premise that acpx was ours to change.
+**acpx is a third-party dependency**, so Route A is off the table. We use **Route B**:
+xacpx performs the history delete itself, with no acpx source change, using acpx's
+existing CLI to close the session, then deleting acpx's on-disk record files directly.
+
+This is an **incremental** use of coupling xacpx already has: it already reads acpx's
+session store at `~/.acpx/sessions/index.json` (`acpx-session-index.ts`,
+`native-session-history.ts`) and resolves `acpxRecordId` via `acpx sessions show`
+(`acpx-cli-transport.ts readSessionRecord`). No new dependency surface; no acpx release.
+
+## acpx primitives (already present — used as-is)
+
+- `acpx sessions close <name>` — kills the agent process + queue owner, marks the
+  record `closed`, **keeps history**, resumable. Exposed today as
   `transport.removeSession` (`acpx-cli-transport.ts:400`, bridge mirror). This is
-  the archive primitive.
-- `acpx sessions prune` — bulk delete of closed records by date. Not usable for a
-  single session (no id/name filter).
-- **Missing:** a focused single-session hard delete. Added in Module 1.
+  the archive primitive AND the first step of delete (clean process shutdown).
+- `acpx sessions show <name>` — resolves a session's `acpxRecordId` (already used by
+  `readSessionRecord`). Used by delete to find the on-disk files.
+- `acpx sessions prune` — bulk delete of closed records by date; not usable for a
+  single session. **Not used** by this feature.
+- acpx has **no** single-session hard-delete command, so xacpx deletes the files.
+
+## acpx on-disk layout (the only acpx internals delete touches)
+
+- Sessions dir: `~/.acpx/sessions/`. Record file: `<encodeURIComponent(acpxRecordId)>.json`.
+- Event-stream artifacts: `<safeId>.stream.ndjson`, `<safeId>.stream.lock`, `<safeId>.stream.*`.
+- `index.json` lists records; acpx tolerates a stale entry whose file is gone (it
+  skips unreadable records and self-heals the index on the next `sessions` operation),
+  so xacpx does not need to rewrite the index after deleting a record file.
 
 ## Semantics
 
-| Action      | acpx layer            | xacpx logical layer                         | process     | history          |
-|-------------|-----------------------|---------------------------------------------|-------------|------------------|
-| **Archive** | `sessions close`      | set `archived=true`, keep logical session   | close now   | keep             |
-| **Restore** | `sessions ensure` (resume) | clear `archived` (implicit on next prompt) | restart     | reuse            |
-| **Delete**  | `sessions rm` (new)   | delete logical session + prune chat-context refs | close   | delete\*         |
+| Action      | acpx interaction              | xacpx logical layer                         | process     | history          |
+|-------------|-------------------------------|---------------------------------------------|-------------|------------------|
+| **Archive** | `sessions close`              | set `archived=true`, keep logical session   | close now   | keep             |
+| **Restore** | `sessions ensure` (resume)    | clear `archived` (implicit on next prompt)  | restart     | reuse            |
+| **Delete**  | `sessions close` + file unlink | delete logical session + prune chat-context refs | close  | delete\*         |
 
 \* History is deleted only when no other logical alias shares the transport session
 (`countAliasesSharingTransport(transportSession, excludeAlias) === 0`). Otherwise the
 delete removes only the logical alias and leaves the shared transport session intact.
 
-## Module 1 — acpx: `sessions rm <name>`
+## Module 1 — xacpx acpx-session-files helper
 
-New focused command on the per-agent `sessions` group (alongside `list` / `ensure`
-/ `new` / `close` / `prune`). Behavior: resolve the record by name → kill the
-process if running (reuse `closeSession`'s kill path) → delete the record file and
-its associated artifacts (event-log, lock), reusing the per-record file cleanup that
-`pruneSessions` already performs, applied to a single record. Idempotent: a missing
-session is a no-op success (so xacpx's delete is safe to retry). Requires releasing
-acpx and bumping xacpx's bundled `acpx` dependency.
+New module `src/transport/acpx-session-files.ts`: `deleteAcpxSessionFiles({ acpxRecordId,
+sessionsDir? })` — computes `safeId = encodeURIComponent(acpxRecordId)` and best-effort
+unlinks `<safeId>.json` plus the `<safeId>.stream.*` artifacts under the sessions dir
+(default `~/.acpx/sessions`, overridable for tests, mirroring `native-session-history.ts`).
+Idempotent: missing files are a no-op. This is the only place that encodes acpx's
+on-disk record naming, kept in one small, testable unit.
 
 ## Module 2 — transport layer
 
@@ -64,9 +86,13 @@ acpx and bumping xacpx's bundled `acpx` dependency.
   semantics unchanged. Existing callers (`session-reset-handler.ts:95`,
   `session-handler.ts:671`, `main.ts:657`, `scheduled-dispatch.ts:92`) keep their
   current close semantics.
-- **New** `transport.deleteSession?(session): Promise<void>` = `acpx sessions rm
-  <name>` — used by real delete. Optional on the interface; both transports
-  (`acpx-cli`, `acpx-bridge` + bridge protocol/runtime) implement it.
+- **New** `transport.deleteSession?(session): Promise<void>` — real delete. Steps:
+  resolve `acpxRecordId` via the existing `readSessionRecord` (idempotent: a missing
+  acpx session is a no-op success) → `acpx sessions close` (clean process + queue-owner
+  shutdown so nothing holds the files) → `deleteAcpxSessionFiles({ acpxRecordId })`.
+  Optional on the interface; both transports (`acpx-cli`, `acpx-bridge` + bridge
+  protocol/runtime) implement it. The bridge runtime delegates to the underlying
+  acpx-cli transport's `deleteSession`.
 
 ## Module 3 — core `SessionService`
 
@@ -138,8 +164,10 @@ Logical session record gains `archived?: boolean` and `archived_at?: string`
   `unarchiveSession` (clears flag, no process op), redefined `removeSession` with the
   shared-transport guard (deletes history only when unshared), restore-clears-archived
   on prompt.
-- acpx: `sessions rm` handler (kills running, deletes record + artifacts, idempotent on
-  missing).
+- `acpx-session-files.ts`: `deleteAcpxSessionFiles` unlinks record + stream artifacts
+  by `acpxRecordId` (using a temp `sessionsDir`), idempotent on missing files.
+- transport `deleteSession`: resolves acpxRecordId → close → deletes files; missing
+  acpx session is a no-op (mocked `readSessionRecord`/`runCommand`).
 - `control-service`: `archiveSession` wiring; `removeSession` real-delete path.
 - relay-protocol: `archive-session` DTO + `archived` field validation / allow-list.
 - relay-web: swipe + overflow-menu triggers, greyed-and-sunk archived rows, offline

--- a/docs/superpowers/specs/2026-06-21-session-archive-and-real-delete-design.md
+++ b/docs/superpowers/specs/2026-06-21-session-archive-and-real-delete-design.md
@@ -1,0 +1,154 @@
+# Session Archive & Real Delete — Design
+
+**Date:** 2026-06-21
+**Status:** Approved (design), pending implementation plan
+
+## Goal
+
+Make web session deletion a *real* delete (history gone, re-creating a same-named
+session starts fresh) and add a *session archive* feature (process closed
+immediately, title greyed and sunk to the bottom of its group, restored by sending
+a new message). The change is system-wide: it redefines deletion across all
+channels (WeChat / Feishu / relay / web) and adds an archive command + web UI.
+
+## Background — why today's delete is "fake"
+
+The web delete button → `control-service.removeSession` →
+`SessionService.removeSession` (`src/sessions/session-service.ts:497`). That method
+only deletes the **logical** session (`state.sessions[alias]`) and prunes
+chat-context references. It never touches the **transport** session: the acpx
+record and history at `~/.acpx/sessions/<id>.json` survive untouched. Re-creating a
+same-named session resumes that record, so the old history reappears. There are two
+session concepts (logical = xacpx-managed, transport = acpx-managed); deletion only
+removed one.
+
+A single transport session can be shared by multiple logical aliases
+(`countAliasesSharingTransport`, `session-service.ts:483`). Any history-destroying
+delete must guard against nuking a transport session another alias still uses.
+
+## acpx primitives (already present)
+
+- `acpx sessions close <name>` — kills the agent process, marks the record
+  `closed`, **keeps history**, resumable. Exposed today as
+  `transport.removeSession` (`acpx-cli-transport.ts:400`, bridge mirror). This is
+  the archive primitive.
+- `acpx sessions prune` — bulk delete of closed records by date. Not usable for a
+  single session (no id/name filter).
+- **Missing:** a focused single-session hard delete. Added in Module 1.
+
+## Semantics
+
+| Action      | acpx layer            | xacpx logical layer                         | process     | history          |
+|-------------|-----------------------|---------------------------------------------|-------------|------------------|
+| **Archive** | `sessions close`      | set `archived=true`, keep logical session   | close now   | keep             |
+| **Restore** | `sessions ensure` (resume) | clear `archived` (implicit on next prompt) | restart     | reuse            |
+| **Delete**  | `sessions rm` (new)   | delete logical session + prune chat-context refs | close   | delete\*         |
+
+\* History is deleted only when no other logical alias shares the transport session
+(`countAliasesSharingTransport(transportSession, excludeAlias) === 0`). Otherwise the
+delete removes only the logical alias and leaves the shared transport session intact.
+
+## Module 1 — acpx: `sessions rm <name>`
+
+New focused command on the per-agent `sessions` group (alongside `list` / `ensure`
+/ `new` / `close` / `prune`). Behavior: resolve the record by name → kill the
+process if running (reuse `closeSession`'s kill path) → delete the record file and
+its associated artifacts (event-log, lock), reusing the per-record file cleanup that
+`pruneSessions` already performs, applied to a single record. Idempotent: a missing
+session is a no-op success (so xacpx's delete is safe to retry). Requires releasing
+acpx and bumping xacpx's bundled `acpx` dependency.
+
+## Module 2 — transport layer
+
+- `transport.removeSession` (exists, = `sessions close`) — **reused by archive**,
+  semantics unchanged. Existing callers (`session-reset-handler.ts:95`,
+  `session-handler.ts:671`, `main.ts:657`, `scheduled-dispatch.ts:92`) keep their
+  current close semantics.
+- **New** `transport.deleteSession?(session): Promise<void>` = `acpx sessions rm
+  <name>` — used by real delete. Optional on the interface; both transports
+  (`acpx-cli`, `acpx-bridge` + bridge protocol/runtime) implement it.
+
+## Module 3 — core `SessionService`
+
+Logical session record gains `archived?: boolean` and `archived_at?: string`
+(persisted in `state.sessions[alias]`).
+
+- **New `archiveSession(alias)`**: cancel any in-flight turn → `transport.removeSession`
+  (close process, keep history) → set `archived=true` + `archived_at` → `persist()`
+  → emit `sessions-changed`. Does **not** delete the logical session.
+- **New `unarchiveSession(alias)`**: clear `archived` / `archived_at` → `persist()` →
+  emit `sessions-changed`. No process action (the process stays closed and resumes on
+  the next message). This is the explicit "un-archive" used by the web undo toast and
+  by selecting a manual restore; it is distinct from the implicit restore-on-prompt.
+- **Redefined `removeSession(alias)`** (now a real delete): compute
+  `sharesTransport = countAliasesSharingTransport(transportSession, alias) > 0` →
+  if not shared, `transport.deleteSession(session)` (delete history); if shared, skip
+  history delete → delete logical session + existing chat-context pruning → emit. This
+  changes `/session rm` from a fake delete to a real delete everywhere.
+- **Restore**: `ensureSession` (prompt path) clears `archived` when the target session
+  is archived; acpx resume already reuses the history. Restore is implicit on the next
+  message — no separate unarchive call needed. Selecting/viewing an archived session
+  does not resume it; only sending a message does.
+
+## Module 4 — control / protocol / connector / commands
+
+- `control-service`: add `archiveSession(chatKey, alias)` and
+  `unarchiveSession(chatKey, alias)` mirroring the existing `removeSession(chatKey,
+  alias)` (direct `SessionService` call + `sessions-changed` emit). `removeSession`
+  automatically becomes a real delete via Module 3.
+- relay-protocol: add `archive-session` and `unarchive-session` request DTOs; add
+  `archived: boolean` to the session DTO so the web can grey/sink archived rows; update
+  `web-dtos` allow-lists.
+- connector `control-bridge`: add `archiveSession` and `unarchiveSession` cases
+  mirroring `removeSession`.
+- commands: add `/session archive <alias>` (`parse-command.ts` + `session-handler.ts`),
+  mirroring `/session rm`. Available on WeChat / Feishu / relay.
+
+## Module 5 — relay-web UI
+
+- **Triggers** (`InstanceTree.vue`): desktop = a trailing `⋯` overflow menu with
+  *Archive* and *Delete*; mobile = swipe gestures (swipe-left → archive, swipe-right →
+  delete) via a new `useSwipeActions` composable with a reveal animation. The existing
+  hover/touch visibility fix for the trailing control is superseded by the menu/swipe.
+- **Delete**: keeps the confirm dialog with danger-toned, real-delete wording.
+- **Archive**: no confirm; optimistic, with an undo toast ("已归档 · 撤销"). Undo clears
+  the `archived` flag and restores the row's active position. The acpx process stays
+  closed after undo (it resumes on the next message, same as any idle session) — the
+  undo is a cheap flag clear, not a deferred-close.
+- **Archived rows**: title greyed (`text-fg-muted`), **sunk to the bottom of their
+  instance group**, attention/running dots suppressed, small "已归档" badge. Still
+  selectable — clicking opens the session and shows its history. Sending a message
+  restores it (optimistic flag clear) and moves it back up.
+- store (`instances.ts`): add `archiveSession` / `unarchiveSession` actions and
+  optimistic `archived` toggling; `removeSession` now drives the real delete. The undo
+  toast calls `unarchiveSession`.
+
+## Edge cases
+
+- **In-flight turn**: archive and delete cancel the running turn first, then close /
+  rm.
+- **Instance offline**: archive and delete both require reaching acpx, so both actions
+  are disabled (greyed) in the UI when the instance is offline. No queueing in v1.
+- **Shared transport session**: delete removes only the logical alias and skips the
+  history delete (see Semantics note).
+
+## Testing
+
+- `SessionService`: `archiveSession` (cancel → close → flag → persist),
+  `unarchiveSession` (clears flag, no process op), redefined `removeSession` with the
+  shared-transport guard (deletes history only when unshared), restore-clears-archived
+  on prompt.
+- acpx: `sessions rm` handler (kills running, deletes record + artifacts, idempotent on
+  missing).
+- `control-service`: `archiveSession` wiring; `removeSession` real-delete path.
+- relay-protocol: `archive-session` DTO + `archived` field validation / allow-list.
+- relay-web: swipe + overflow-menu triggers, greyed-and-sunk archived rows, offline
+  disables actions, undo toast, send-message-restores.
+
+## Out of scope (YAGNI)
+
+- Auto-archive on idle/TTL (the acpx warm window already closes idle processes; archive
+  is an explicit user action that additionally greys/sinks the row).
+- Bulk archive/delete.
+- Deferred-close on archive undo.
+- Offline queueing of archive/delete.

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -25,6 +25,8 @@ import {
   type SessionsListPayload,
   type SessionsNativeListPayload,
   type SessionsRemovePayload,
+  type SessionsArchivePayload,
+  type SessionsUnarchivePayload,
   type WorkspacesCreatePayload,
   type WorkspacesRemovePayload,
 } from "@ganglion/xacpx-relay-protocol";
@@ -92,6 +94,16 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
     case MSG.sessionsRemove: {
       const input = payload as SessionsRemovePayload;
       return await control.removeSession(input.chatKey, input.alias);
+    }
+    case MSG.sessionsArchive: {
+      const input = payload as SessionsArchivePayload;
+      await control.archiveSession(input.chatKey, input.alias);
+      return {};
+    }
+    case MSG.sessionsUnarchive: {
+      const input = payload as SessionsUnarchivePayload;
+      await control.unarchiveSession(input.chatKey, input.alias);
+      return {};
     }
     case MSG.agentsList:
       return { agents: control.listAgents() };

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -5,6 +5,7 @@ export interface SessionDto {
   workspace: string;
   transportSession: string;
   running: boolean;
+  archived: boolean;
 }
 
 /** Wire DTO for a configured agent on an instance. */

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -12,6 +12,8 @@ export const MSG = {
   sessionsCreate: "control.sessions.create",
   sessionsNativeList: "control.sessions.native.list",
   sessionsRemove: "control.sessions.remove",
+  sessionsArchive: "control.sessions.archive",
+  sessionsUnarchive: "control.sessions.unarchive",
   agentsList: "control.agents.list",
   workspacesList: "control.workspaces.list",
   workspacesCreate: "control.workspaces.create",
@@ -129,6 +131,14 @@ export interface SessionsRemovePayload {
 }
 export interface SessionsRemoveResult {
   wasActive: boolean;
+}
+export interface SessionsArchivePayload {
+  chatKey: string;
+  alias: string;
+}
+export interface SessionsUnarchivePayload {
+  chatKey: string;
+  alias: string;
 }
 export interface AgentsListResult {
   agents: AgentDto[];

--- a/packages/relay-web/src/__tests__/action-toast.test.ts
+++ b/packages/relay-web/src/__tests__/action-toast.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from "vitest";
+import { showActionToast, useActionToastState, runToastAction, dismissToast } from "../lib/use-action-toast";
+
+describe("action toast", () => {
+  it("exposes the message + action and runs the action once", () => {
+    const action = vi.fn();
+    showActionToast({ message: 'Archived "x"', actionLabel: "Undo", action });
+    expect(useActionToastState().value?.message).toContain("Archived");
+    runToastAction();
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(useActionToastState().value).toBeNull();
+  });
+  it("dismiss clears without running the action", () => {
+    const action = vi.fn();
+    showActionToast({ message: "m", actionLabel: "Undo", action });
+    dismissToast();
+    expect(action).not.toHaveBeenCalled();
+    expect(useActionToastState().value).toBeNull();
+  });
+});

--- a/packages/relay-web/src/__tests__/instances-archive.test.ts
+++ b/packages/relay-web/src/__tests__/instances-archive.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useInstancesStore } from "../stores/instances";
+import { api } from "../api/client";
+
+describe("instances archive actions", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+  it("archiveSession calls control.sessions.archive then reloads", async () => {
+    const store = useInstancesStore();
+    const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [] } as never);
+    await store.archiveSession("i1", "backend");
+    expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.archive", { alias: "backend" });
+  });
+  it("unarchiveSession calls control.sessions.unarchive", async () => {
+    const store = useInstancesStore();
+    const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [] } as never);
+    await store.unarchiveSession("i1", "backend");
+    expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.unarchive", { alias: "backend" });
+  });
+});

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -30,10 +30,11 @@ describe("InstanceTree session management", () => {
 
   it("opens a popup confirm and deletes only after confirming", async () => {
     const store = useInstancesStore();
-    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
     const remove = vi.spyOn(store, "removeSession").mockResolvedValue();
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
-    // Clicking the trash opens the global confirm, but does NOT delete yet.
+    // Open the overflow menu, then click Delete: opens the global confirm but does NOT delete yet.
+    await w.find('[data-test="session-menu"]').trigger("click");
     await w.find('[data-test="delete-session"]').trigger("click");
     expect(remove).not.toHaveBeenCalled();
     expect(useConfirmState().value?.title).toBe("Delete session?");
@@ -45,9 +46,10 @@ describe("InstanceTree session management", () => {
 
   it("does not delete when the confirm is cancelled", async () => {
     const store = useInstancesStore();
-    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
     const remove = vi.spyOn(store, "removeSession").mockResolvedValue();
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    await w.find('[data-test="session-menu"]').trigger("click");
     await w.find('[data-test="delete-session"]').trigger("click");
     settleConfirm(false);
     await flushPromises();
@@ -56,14 +58,14 @@ describe("InstanceTree session management", () => {
 
   it("mounts with an empty chat store and shows no attention dot for idle sessions", () => {
     const store = useInstancesStore();
-    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
     expect(w.find('[data-test="attention-dot"]').exists()).toBe(false);
   });
 
   it("renders a working dot when the chat store reports a live turn", () => {
     const instances = useInstancesStore();
-    instances.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    instances.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
     const chat = useChatStore();
     chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
@@ -74,7 +76,7 @@ describe("InstanceTree session management", () => {
 
   it("renders an unread dot for a finished, unviewed session", () => {
     const instances = useInstancesStore();
-    instances.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    instances.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
     const chat = useChatStore();
     chat.select("i1", "other"); // not viewing backend
     chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "backend", ok: true } } as never);
@@ -99,7 +101,7 @@ describe("InstanceTree session management", () => {
 
   it("renders an elapsed badge for a working session", () => {
     const instances = useInstancesStore();
-    instances.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    instances.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
     const chat = useChatStore();
     chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
@@ -110,8 +112,27 @@ describe("InstanceTree session management", () => {
 
   it("shows no elapsed badge for an idle session", () => {
     const store = useInstancesStore();
-    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false }])] as never;
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
     expect(w.find('[data-test="session-elapsed"]').exists()).toBe(false);
+  });
+
+  it("greys archived sessions and sinks them to the bottom of the group", () => {
+    const store = useInstancesStore();
+    store.instances = [instance([
+      { alias: "active", agent: "claude", workspace: "home", transportSession: "t1", running: false, archived: false },
+      { alias: "arch", agent: "codex", workspace: "home", transportSession: "t2", running: false, archived: true },
+    ])] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const rows = w.findAll('[data-test="session-row"]');
+    expect(rows[rows.length - 1].text()).toContain("arch"); // archived sunk to bottom
+    expect(w.find('[data-test="archived-badge"]').exists()).toBe(true);
+  });
+
+  it("hides row actions when the instance is offline", () => {
+    const store = useInstancesStore();
+    store.instances = [{ ...instance([{ alias: "a", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }]), online: false }] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="session-actions"]').exists()).toBe(false);
   });
 });

--- a/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
+++ b/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { useSwipeActions } from "../lib/use-swipe-actions";
+
+// jsdom doesn't implement PointerEvent, so feed the handlers plain coordinate
+// objects — the composable only reads clientX/clientY.
+function pointer(x: number, y = 0) {
+  return { clientX: x, clientY: y };
+}
+
+describe("useSwipeActions", () => {
+  it("fires onSwipeLeft past the threshold", () => {
+    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
+    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+    handlers.onPointerdown(pointer(200));
+    handlers.onPointermove(pointer(120));
+    handlers.onPointerup(pointer(120));
+    expect(onSwipeLeft).toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+  it("fires onSwipeRight past the threshold", () => {
+    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
+    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+    handlers.onPointerdown(pointer(100));
+    handlers.onPointermove(pointer(200));
+    handlers.onPointerup(pointer(200));
+    expect(onSwipeRight).toHaveBeenCalled();
+  });
+  it("ignores sub-threshold and vertical-dominant moves", () => {
+    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
+    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+    handlers.onPointerdown(pointer(200));
+    handlers.onPointermove(pointer(180));
+    handlers.onPointerup(pointer(180));
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+});

--- a/packages/relay-web/src/components/ActionToast.vue
+++ b/packages/relay-web/src/components/ActionToast.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { useActionToastState, runToastAction, dismissToast } from "../lib/use-action-toast";
+const toast = useActionToastState();
+</script>
+<template>
+  <Teleport to="body">
+    <div v-if="toast" data-test="action-toast"
+         class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-fg shadow-lg">
+      <span>{{ toast.message }}</span>
+      <button data-test="toast-action" class="font-medium text-accent hover:underline" @click="runToastAction">{{ toast.actionLabel }}</button>
+      <button class="text-fg-muted hover:text-fg" :aria-label="$t('common.dismiss')" @click="dismissToast">×</button>
+    </div>
+  </Teleport>
+</template>

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -5,6 +5,7 @@ import { Archive, ChevronDown, ChevronRight, MoreHorizontal, Plus, Settings2, Tr
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { confirm } from "../lib/use-confirm";
+import { showActionToast } from "../lib/use-action-toast";
 import { useSwipeActions } from "../lib/use-swipe-actions";
 import NewSessionDialog from "./NewSessionDialog.vue";
 import ManageInstanceDialog from "./ManageInstanceDialog.vue";
@@ -67,8 +68,13 @@ async function onArchive(id: string, alias: string) {
   await store.archiveSession(id, alias).catch(() => {});
   showUndoToast(id, alias);
 }
-// TEMPORARY no-op — the real undo toast lands in a later task.
-function showUndoToast(_id: string, _alias: string) { /* replaced by the undo-toast task */ }
+function showUndoToast(id: string, alias: string) {
+  showActionToast({
+    message: t("instance.sessionArchivedToast", { alias }),
+    actionLabel: t("instance.undo"),
+    action: () => { void store.unarchiveSession(id, alias).catch(() => {}); },
+  });
+}
 
 // Deleting a session is destructive and irreversible → confirm via the popup dialog.
 async function askDelete(id: string, alias: string) {

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { onUnmounted, ref } from "vue";
+import { onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { ChevronDown, ChevronRight, Plus, Settings2, Trash2 } from "lucide-vue-next";
+import { Archive, ChevronDown, ChevronRight, MoreHorizontal, Plus, Settings2, Trash2 } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { confirm } from "../lib/use-confirm";
@@ -49,8 +49,29 @@ function toggle(id: string) {
   if (isExpanded(id)) void store.loadSessions(id).catch(() => {});
 }
 
+// Archived sessions sink to the bottom of their instance group (stable: actives keep
+// server order, archived last) so the active work stays at the top of the list.
+function orderedSessions<T extends { archived?: boolean }>(sessions: T[]): T[] {
+  return [...sessions].sort((a, b) => Number(a.archived ?? false) - Number(b.archived ?? false));
+}
+
+// Desktop overflow (⋯) menu open-state, keyed by `${instanceId}:${alias}`.
+const openMenuFor = ref<string | null>(null);
+function onDocPointerDown() { openMenuFor.value = null; }
+onMounted(() => document.addEventListener("mousedown", onDocPointerDown));
+onUnmounted(() => document.removeEventListener("mousedown", onDocPointerDown));
+
+async function onArchive(id: string, alias: string) {
+  openMenuFor.value = null;
+  await store.archiveSession(id, alias).catch(() => {});
+  showUndoToast(id, alias);
+}
+// TEMPORARY no-op — the real undo toast lands in a later task.
+function showUndoToast(_id: string, _alias: string) { /* replaced by the undo-toast task */ }
+
 // Deleting a session is destructive and irreversible → confirm via the popup dialog.
 async function askDelete(id: string, alias: string) {
+  openMenuFor.value = null;
   const ok = await confirm({
     title: t("instance.deleteSessionTitle"),
     message: t("instance.deleteSessionBody", { alias }),
@@ -82,8 +103,9 @@ async function askDelete(id: string, alias: string) {
       <!-- Indented session rows under an accent-able left rule. -->
       <div v-show="isExpanded(inst.id)" class="ml-2.5 mt-px space-y-px border-l border-border pl-2.5">
         <div
-          v-for="s in inst.sessions"
+          v-for="s in orderedSessions(inst.sessions)"
           :key="s.alias"
+          data-test="session-row"
           class="group relative flex items-center rounded-md transition-colors"
           :class="isSelected(inst.id, s.alias) ? 'bg-accent/10' : 'hover:bg-raised'"
         >
@@ -93,21 +115,29 @@ async function askDelete(id: string, alias: string) {
             class="flex min-w-0 flex-1 items-center gap-2 py-1 pl-2.5 pr-1.5 text-left"
             @click="emit('select', inst.id, s.alias)"
           >
-            <span v-if="chat.sessionAttention(inst.id, s.alias) === 'working'" data-test="attention-dot" data-attention="working"
+            <span v-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'working'" data-test="attention-dot" data-attention="working"
                   class="pulse-dot h-2 w-2 shrink-0 rounded-full bg-run-bright" />
-            <span v-else-if="chat.sessionAttention(inst.id, s.alias) === 'unread'" data-test="attention-dot" data-attention="unread"
+            <span v-else-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'unread'" data-test="attention-dot" data-attention="unread"
                   class="h-2 w-2 shrink-0 rounded-full bg-info" />
-            <span v-else-if="s.running" data-test="attention-dot" data-attention="running" class="h-2 w-2 shrink-0 rounded-full bg-run" />
-            <span class="truncate text-[12.5px] font-medium" :class="isSelected(inst.id, s.alias) ? 'font-semibold text-accent' : 'text-fg'">{{ s.alias }}</span>
+            <span v-else-if="!s.archived && s.running" data-test="attention-dot" data-attention="running" class="h-2 w-2 shrink-0 rounded-full bg-run" />
+            <span class="truncate text-[12.5px] font-medium"
+                  :class="s.archived ? 'text-fg-muted' : (isSelected(inst.id, s.alias) ? 'font-semibold text-accent' : 'text-fg')">{{ s.alias }}</span>
             <span class="shrink-0 rounded px-1 py-px font-mono text-[9.5px]"
                   :class="isSelected(inst.id, s.alias) ? 'bg-accent/15 text-accent' : 'bg-bg text-fg-muted'">{{ s.agent }}</span>
-            <span v-if="elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
+            <span v-if="s.archived" data-test="archived-badge" class="shrink-0 rounded bg-bg px-1 py-px text-[9px] text-fg-muted">{{ $t("instance.sessionArchivedBadge") }}</span>
+            <span v-if="!s.archived && elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
                   class="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-run">{{ elapsedLabel(inst.id, s.alias) }}</span>
           </button>
-          <!-- Delete: icon button → popup confirm. -->
-          <button data-test="delete-session" :title="$t('instance.deleteSession')" :aria-label="$t('instance.deleteSession')"
-                  class="mr-1 grid h-5 w-5 shrink-0 place-items-center rounded text-fg-muted opacity-0 transition-opacity hover:bg-danger/15 hover:text-danger group-hover:opacity-100"
-                  @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" /></button>
+          <!-- Row actions: desktop overflow (⋯) menu → archive / delete. Hidden when the instance is offline. -->
+          <div v-if="inst.online" data-test="session-actions" class="relative mr-1 shrink-0">
+            <button data-test="session-menu" :aria-label="$t('common.more')"
+                    class="grid h-5 w-5 place-items-center rounded text-fg-muted hover:bg-raised hover:text-fg opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
+                    @click.stop="openMenuFor = openMenuFor === `${inst.id}:${s.alias}` ? null : `${inst.id}:${s.alias}`"><MoreHorizontal :size="13" /></button>
+            <div v-if="openMenuFor === `${inst.id}:${s.alias}`" class="absolute right-0 z-20 mt-1 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
+              <button v-if="!s.archived" data-test="action-archive" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="onArchive(inst.id, s.alias)"><Archive :size="12" />{{ $t("instance.archiveSession") }}</button>
+              <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
+            </div>
+          </div>
         </div>
 
         <div v-if="inst.online && !inst.sessionsLoaded && !inst.sessions.length" data-test="sessions-loading"

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { Archive, ChevronDown, ChevronRight, MoreHorizontal, Plus, Settings2, Trash2 } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { confirm } from "../lib/use-confirm";
+import { useSwipeActions } from "../lib/use-swipe-actions";
 import NewSessionDialog from "./NewSessionDialog.vue";
 import ManageInstanceDialog from "./ManageInstanceDialog.vue";
 
@@ -80,6 +81,24 @@ async function askDelete(id: string, alias: string) {
   });
   if (ok) void store.removeSession(id, alias).catch(() => {});
 }
+
+// Mobile-native second path: swipe a row left → archive, right → delete (mirrors the
+// desktop ⋯ menu). Handlers are built per visible row of online instances and keyed by
+// `${instanceId}:${alias}`, so the template binds a stable set instead of recreating
+// closures on every render. Offline instances are excluded (mirrors the action gate).
+const rowSwipes = computed(() => {
+  const map: Record<string, ReturnType<typeof useSwipeActions>["handlers"]> = {};
+  for (const inst of store.instances) {
+    if (!inst.online) continue;
+    for (const s of inst.sessions) {
+      map[`${inst.id}:${s.alias}`] = useSwipeActions({
+        onSwipeLeft: () => { void onArchive(inst.id, s.alias); },
+        onSwipeRight: () => { askDelete(inst.id, s.alias); },
+      }).handlers;
+    }
+  }
+  return map;
+});
 </script>
 
 <template>
@@ -106,8 +125,9 @@ async function askDelete(id: string, alias: string) {
           v-for="s in orderedSessions(inst.sessions)"
           :key="s.alias"
           data-test="session-row"
-          class="group relative flex items-center rounded-md transition-colors"
+          class="group relative flex items-center rounded-md transition-colors touch-pan-y"
           :class="isSelected(inst.id, s.alias) ? 'bg-accent/10' : 'hover:bg-raised'"
+          v-on="inst.online ? rowSwipes[`${inst.id}:${s.alias}`] ?? {} : {}"
         >
           <!-- Selected row: left accent bar. -->
           <span v-if="isSelected(inst.id, s.alias)" class="absolute bottom-1 left-0 top-1 w-[3px] rounded-full bg-accent" />

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -147,6 +147,8 @@ export default {
     deleteSession: "Delete session",
     archiveSession: "Archive session",
     sessionArchivedBadge: "archived",
+    sessionArchivedToast: "Archived \"{alias}\"",
+    undo: "Undo",
     manage: "Manage instance",
     coreVersion: "connector core {version}",
     coreVersionUnknown: "connector core version unknown (legacy or pre-version connector)",

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -8,6 +8,7 @@ export default {
     ok: "OK",
     back: "← Back",
     delete: "Delete",
+    more: "More",
     remove: "Remove",
     dismiss: "dismiss",
     dismissNotice: "Dismiss",
@@ -144,6 +145,8 @@ export default {
   instance: {
     newSession: "New session",
     deleteSession: "Delete session",
+    archiveSession: "Archive session",
+    sessionArchivedBadge: "archived",
     manage: "Manage instance",
     coreVersion: "connector core {version}",
     coreVersionUnknown: "connector core version unknown (legacy or pre-version connector)",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -145,6 +145,8 @@ export default {
     deleteSession: "删除会话",
     archiveSession: "归档会话",
     sessionArchivedBadge: "已归档",
+    sessionArchivedToast: "已归档「{alias}」",
+    undo: "撤销",
     manage: "管理实例",
     coreVersion: "连接器内核 {version}",
     coreVersionUnknown: "连接器内核版本未知（旧版或无版本信息的连接器）",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -6,6 +6,7 @@ export default {
     ok: "确定",
     back: "← 返回",
     delete: "删除",
+    more: "更多",
     remove: "移除",
     dismiss: "关闭",
     dismissNotice: "关闭通知",
@@ -142,6 +143,8 @@ export default {
   instance: {
     newSession: "新建会话",
     deleteSession: "删除会话",
+    archiveSession: "归档会话",
+    sessionArchivedBadge: "已归档",
     manage: "管理实例",
     coreVersion: "连接器内核 {version}",
     coreVersionUnknown: "连接器内核版本未知（旧版或无版本信息的连接器）",

--- a/packages/relay-web/src/lib/use-action-toast.ts
+++ b/packages/relay-web/src/lib/use-action-toast.ts
@@ -1,0 +1,31 @@
+import { ref } from "vue";
+
+export interface ActionToast {
+  message: string;
+  actionLabel: string;
+  action: () => void;
+}
+
+const current = ref<ActionToast | null>(null);
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+export function useActionToastState() { return current; }
+
+/** Show a toast with one action button; auto-dismisses after `ms` (default 6s). */
+export function showActionToast(toast: ActionToast, ms = 6000): void {
+  if (timer) clearTimeout(timer);
+  current.value = toast;
+  timer = setTimeout(() => { current.value = null; timer = null; }, ms);
+}
+
+export function runToastAction(): void {
+  const t = current.value;
+  current.value = null;
+  if (timer) { clearTimeout(timer); timer = null; }
+  t?.action();
+}
+
+export function dismissToast(): void {
+  current.value = null;
+  if (timer) { clearTimeout(timer); timer = null; }
+}

--- a/packages/relay-web/src/lib/use-swipe-actions.ts
+++ b/packages/relay-web/src/lib/use-swipe-actions.ts
@@ -1,0 +1,37 @@
+import { ref } from "vue";
+
+export interface SwipeActionsOptions {
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+  threshold?: number; // px of horizontal travel required to fire
+}
+
+/** Minimal horizontal-swipe detector for a list row. Tracks pointer travel and fires
+ *  left/right past the threshold, ignoring vertical-dominant gestures so it doesn't
+ *  fight the scroll container. `offset` is exposed for an optional reveal animation. */
+export function useSwipeActions(opts: SwipeActionsOptions) {
+  const threshold = opts.threshold ?? 64;
+  const offset = ref(0);
+  let startX = 0, startY = 0, active = false;
+
+  function onPointerdown(e: { clientX: number; clientY: number }) {
+    active = true; startX = e.clientX; startY = e.clientY; offset.value = 0;
+  }
+  function onPointermove(e: { clientX: number; clientY: number }) {
+    if (!active) return;
+    const dx = e.clientX - startX, dy = e.clientY - startY;
+    if (Math.abs(dy) > Math.abs(dx)) { active = false; offset.value = 0; return; }
+    offset.value = dx;
+  }
+  function onPointerup(e: { clientX: number; clientY: number }) {
+    if (!active) return;
+    active = false;
+    const dx = e.clientX - startX, dy = e.clientY - startY;
+    offset.value = 0;
+    if (Math.abs(dy) > Math.abs(dx)) return;
+    if (dx <= -threshold) opts.onSwipeLeft();
+    else if (dx >= threshold) opts.onSwipeRight();
+  }
+
+  return { offset, handlers: { onPointerdown, onPointermove, onPointerup } };
+}

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -174,6 +174,16 @@ export const useInstancesStore = defineStore("instances", () => {
     await loadSessions(instanceId);
   }
 
+  async function archiveSession(instanceId: string, alias: string): Promise<void> {
+    await api.rpc(instanceId, "control.sessions.archive", { alias });
+    await loadSessions(instanceId);
+  }
+
+  async function unarchiveSession(instanceId: string, alias: string): Promise<void> {
+    await api.rpc(instanceId, "control.sessions.unarchive", { alias });
+    await loadSessions(instanceId);
+  }
+
   // The instance name lives solely in the relay DB (not on the connector), so this
   // is a plain relay HTTP PATCH — no control RPC. On success we mutate the local
   // view so the sidebar/dialog reflect the new name without a full reload.
@@ -201,5 +211,5 @@ export const useInstancesStore = defineStore("instances", () => {
     return instances.value.find((i) => i.id === id);
   }
 
-  return { instances, loadInstances, loadSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, listNativeSessions, listModelSuggestions, removeSession, renameInstance, applyEvent, byId };
+  return { instances, loadInstances, loadSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, listNativeSessions, listModelSuggestions, removeSession, archiveSession, unarchiveSession, renameInstance, applyEvent, byId };
 });

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -13,6 +13,7 @@ import FileViewer from "../components/FileViewer.vue";
 import TaskPanel from "../components/TaskPanel.vue";
 import FilesPanel from "../components/FilesPanel.vue";
 import NoticeToast from "../components/NoticeToast.vue";
+import ActionToast from "../components/ActionToast.vue";
 import ConnectionBadge from "../components/ConnectionBadge.vue";
 import CommandPalette from "../components/CommandPalette.vue";
 import BrandLogo from "../components/BrandLogo.vue";
@@ -252,6 +253,7 @@ onUnmounted(() => {
       </div>
     </div>
     <NoticeToast />
+    <ActionToast />
     <CommandPalette v-if="paletteOpen"
                     @close="paletteOpen = false"
                     @select-session="(id, alias) => { onSelect(id, alias); paletteOpen = false; }" />

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -14,6 +14,7 @@ import { deriveParentPackageName } from "../recovery/discover-parent-package-pat
 import { AcpxQueueOwnerLauncher } from "../transport/acpx-queue-owner-launcher";
 import { permissionModeToFlag } from "../transport/permission-mode-flag";
 import { runAgentSessionList } from "../transport/agent-session-list";
+import { deleteAcpxSessionFiles } from "../transport/acpx-session-files";
 import type {
   EnsureSessionProgress,
   MissingOptionalDepErrorData,
@@ -622,6 +623,24 @@ export class BridgeRuntime {
       return {};
     }
     throw new Error(result.stderr || result.stdout || "sessions close failed");
+  }
+
+  async deleteSession(input: {
+    agent: string;
+    agentCommand?: string;
+    cwd: string;
+    name: string;
+  }): Promise<Record<string, never>> {
+    let acpxRecordId: string;
+    try {
+      ({ acpxRecordId } = await this.readSessionRecord(input));
+    } catch {
+      return {}; // acpx session already gone → nothing to delete
+    }
+    // Close first so no live process / queue owner holds the files, then unlink.
+    await this.removeSession(input);
+    await deleteAcpxSessionFiles({ acpxRecordId });
+    return {};
   }
 
   async shutdown(): Promise<Record<string, never>> {

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -484,7 +484,9 @@ export class BridgeRuntime {
         acpxRecordId = parsed.id;
       }
       const agentSessionId = typeof parsed.agentSessionId === "string" ? parsed.agentSessionId : undefined;
-      if (acpxRecordId) {
+      // Guard the parsed id with the same format check the parse-failure fallback
+      // applies, so a malformed/empty id from acpx never flows into file deletion.
+      if (acpxRecordId && /^[\w.:-]+$/.test(acpxRecordId) && acpxRecordId.length >= 8) {
         return { acpxRecordId, agentSessionId };
       }
     } catch {
@@ -637,7 +639,10 @@ export class BridgeRuntime {
     } catch {
       return {}; // acpx session already gone → nothing to delete
     }
-    // Close first so no live process / queue owner holds the files, then unlink.
+    // Close the acpx session (best-effort), then unlink its on-disk files. close
+    // returning does NOT mean the backing process exited — acpx keeps a warm
+    // queue-owner alive via --ttl. See deleteAcpxSessionFiles for the residual
+    // orphan-stream-file risk this leaves (notably on Windows).
     await this.removeSession(input);
     await deleteAcpxSessionFiles({ acpxRecordId });
     return {};

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -37,6 +37,7 @@ const BRIDGE_METHODS = new Set<BridgeMethod>([
   "getSessionModel",
   "cancel",
   "removeSession",
+  "deleteSession",
   "getAgentSessionId",
 ]);
 
@@ -51,6 +52,7 @@ const SESSION_SCOPED_METHODS = new Set<BridgeMethod>([
   "getSessionModel",
   "cancel",
   "removeSession",
+  "deleteSession",
   "getAgentSessionId",
 ]);
 
@@ -272,6 +274,13 @@ export class BridgeServer {
         });
       case "removeSession":
         return await this.runtime.removeSession({
+          agent: requireString(params, "agent"),
+          agentCommand: asOptionalString(params.agentCommand),
+          cwd: requireString(params, "cwd"),
+          name: requireString(params, "name"),
+        });
+      case "deleteSession":
+        return await this.runtime.deleteSession({
           agent: requireString(params, "agent"),
           agentCommand: asOptionalString(params.agentCommand),
           cwd: requireString(params, "cwd"),

--- a/src/commands/command-policy.ts
+++ b/src/commands/command-policy.ts
@@ -145,6 +145,7 @@ export function authorizeCommandForChat(command: ParsedCommand, metadata?: ChatR
 const COMMAND_KIND_TO_LABEL: Record<string, string> = {
   "session.reset": "/clear",
   "session.rm": "/session rm",
+  "session.archive": "/session archive",
   "session.tail": "/session tail",
   "replymode.set": "/replymode",
   "replymode.reset": "/replymode reset",

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -573,8 +573,29 @@ export class CommandRouter {
     if (!session) {
       throw new Error(`session "${internalAlias}" does not exist`);
     }
+    // Both delete entry points (this web/control path and chat `handleSessionRemove`)
+    // MUST enforce the orchestration blocking-task guard + reference purge, or a
+    // coordinator session with in-flight delegated tasks can be irreversibly wiped.
+    if (this.orchestration) {
+      const blocking = await this.orchestration.listSessionBlockingTasks(session.transportSession);
+      if (blocking.length > 0) {
+        throw new Error(`session "${internalAlias}" has ${blocking.length} blocking task(s); cancel them before deleting`);
+      }
+    }
     const sharedAliasCount = this.sessions.countAliasesSharingTransport(session.transportSession, internalAlias);
     const { wasActive } = await this.sessions.removeSession(internalAlias);
+
+    if (this.orchestration) {
+      try {
+        await this.orchestration.purgeSessionReferences(session.transportSession);
+      } catch (error) {
+        await this.logger.error("session.orchestration_purge_failed", "failed to purge orchestration references after web remove", {
+          alias: internalAlias,
+          transportSession: session.transportSession,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     let transportTornDown = false;
     let transportTeardownWarning: string | undefined;
@@ -605,6 +626,11 @@ export class CommandRouter {
     const session = await this.sessions.getSession(internalAlias);
     if (!session) {
       throw new Error(`session "${internalAlias}" does not exist`);
+    }
+    // Archiving cancels+closes acpx; refuse while a turn is in flight so we don't
+    // race (and silently abort) the running prompt.
+    if (this.activeTurns?.isActiveAnywhere(internalAlias)) {
+      throw new Error(`session "${internalAlias}" has a running turn; stop it before archiving`);
     }
     const shared = this.sessions.countAliasesSharingTransport(session.transportSession, internalAlias) > 0;
     if (!shared) {

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -553,6 +553,79 @@ export class CommandRouter {
     }
   }
 
+  /** Real delete: logical removal + acpx history delete, guarded so a transport
+   *  session shared by another alias is left intact. */
+  async removeSessionWithTransport(internalAlias: string): Promise<{
+    wasActive: boolean;
+    sharedAliasCount: number;
+    transportTornDown: boolean;
+    transportTeardownWarning?: string;
+  }> {
+    const session = await this.sessions.getSession(internalAlias);
+    if (!session) {
+      throw new Error(`session "${internalAlias}" does not exist`);
+    }
+    const sharedAliasCount = this.sessions.countAliasesSharingTransport(session.transportSession, internalAlias);
+    const { wasActive } = await this.sessions.removeSession(internalAlias);
+
+    let transportTornDown = false;
+    let transportTeardownWarning: string | undefined;
+    if (sharedAliasCount === 0 && this.transport.deleteSession) {
+      try {
+        await this.transport.deleteSession(session);
+        transportTornDown = true;
+      } catch (error) {
+        transportTeardownWarning = error instanceof Error ? error.message : String(error);
+        await this.logger.error("session.transport_delete_failed", "failed to delete acpx session after logical remove", {
+          alias: internalAlias,
+          transportSession: session.transportSession,
+          message: transportTeardownWarning,
+        });
+      }
+    }
+    return {
+      wasActive,
+      sharedAliasCount,
+      transportTornDown,
+      ...(transportTeardownWarning ? { transportTeardownWarning } : {}),
+    };
+  }
+
+  /** Archive: close the acpx process (keep history) when no other alias shares the
+   *  transport, then flag the logical session archived. */
+  async archiveSessionWithTransport(internalAlias: string): Promise<void> {
+    const session = await this.sessions.getSession(internalAlias);
+    if (!session) {
+      throw new Error(`session "${internalAlias}" does not exist`);
+    }
+    const shared = this.sessions.countAliasesSharingTransport(session.transportSession, internalAlias) > 0;
+    if (!shared) {
+      try {
+        await this.transport.cancel(session);
+      } catch {
+        /* best-effort */
+      }
+      if (this.transport.removeSession) {
+        try {
+          await this.transport.removeSession(session);
+        } catch (error) {
+          await this.logger.error("session.archive_close_failed", "failed to close acpx session on archive", {
+            alias: internalAlias,
+            transportSession: session.transportSession,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+    await this.sessions.setArchived(internalAlias, true);
+  }
+
+  /** Explicit un-archive (web undo / manual). No process action — it resumes on the
+   *  next message via useSession. */
+  async unarchiveSession(internalAlias: string): Promise<void> {
+    await this.sessions.setArchived(internalAlias, false);
+  }
+
   /**
    * List the agent-native (acpx-owned) sessions for a given agent + workspace, for the
    * web "attach a native session" picker. Resolves the workspace's cwd from config and

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -31,6 +31,7 @@ import {
   handleSessionAttach,
   handleSessionNew,
   handleSessionRemove,
+  handleSessionArchive,
   handleSessionReset,
   handleSessionTail,
   handleSessions,
@@ -289,6 +290,13 @@ export class CommandRouter {
           return await handleSessionTail(this.createSessionHandlerContext(undefined, perfSpan), chatKey, command.lines);
         case "session.rm":
           return await handleSessionRemove(this.createSessionHandlerContext(undefined, perfSpan), chatKey, command.alias);
+        case "session.archive":
+          return await handleSessionArchive(
+            this.createSessionHandlerContext(undefined, perfSpan),
+            chatKey,
+            command.alias,
+            (internalAlias) => this.archiveSessionWithTransport(internalAlias),
+          );
         case "groups":
           return await handleGroupList(this.createHandlerContext(), chatKey, command.filter);
         case "group.new":

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -666,9 +666,9 @@ export async function handleSessionRemove(
 
   let transportTeardownWarning: string | undefined;
   const shouldTeardownTransport = sharedAliasCount === 0;
-  if (shouldTeardownTransport && context.transport.removeSession) {
+  if (shouldTeardownTransport && context.transport.deleteSession) {
     try {
-      await context.transport.removeSession(session);
+      await context.transport.deleteSession(session);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       transportTeardownWarning = message;

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -738,6 +738,13 @@ async function promptWithSession(
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
   onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
 ): Promise<RouterResponse> {
+  // Restore-on-message: a real prompt to an archived session un-archives it (mirrors
+  // useSession on the web path, which the chat prompt path bypasses). The guard avoids
+  // a needless persist on every normal prompt. `session.alias` is the internal alias,
+  // the same key `setArchived` expects.
+  if (session.archived) {
+    await context.sessions.setArchived(session.alias, false);
+  }
   const effectiveReplyMode = resolveEffectiveReplyMode(context.config, chatKey, session.replyMode);
   // Ensure the session carries the resolved value so downstream transports
   // see "verbose" instead of undefined and format tool-call progress correctly.

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -706,6 +706,21 @@ export async function handleSessionRemove(
   return { text: lines.join("\n") };
 }
 
+export async function handleSessionArchive(
+  context: SessionHandlerContext,
+  chatKey: string,
+  alias: string,
+  archive: (internalAlias: string) => Promise<void>,
+): Promise<RouterResponse> {
+  const internalAlias = await context.sessions.resolveAliasForChat(chatKey, alias);
+  const session = await context.sessions.getSession(internalAlias);
+  if (!session) {
+    return { text: t().session.sessionNotFound(alias) };
+  }
+  await archive(internalAlias);
+  return { text: t().session.sessionArchived(alias) };
+}
+
 async function promptWithSession(
   context: SessionHandlerContext,
   session: ResolvedSession,

--- a/src/commands/parse-command.ts
+++ b/src/commands/parse-command.ts
@@ -35,6 +35,7 @@ export type ParsedCommand =
   | { kind: "session.reset" }
   | { kind: "session.tail"; lines?: number }
   | { kind: "session.rm"; alias: string }
+  | { kind: "session.archive"; alias: string }
   | { kind: "delegate.request"; targetAgent: string; role?: string; groupId?: string; task: string }
   | { kind: "groups"; filter?: GroupListFilter }
   | { kind: "group.new"; title: string }
@@ -145,6 +146,9 @@ export function parseCommand(input: string): ParsedCommand {
   }
   if (command === "/session" && parts[1] === "rm" && parts[2] && parts.length === 3) {
     return { kind: "session.rm", alias: parts[2] };
+  }
+  if (command === "/session" && parts[1] === "archive" && parts[2] && parts.length === 3) {
+    return { kind: "session.archive", alias: parts[2] };
   }
   if (command === "/ssn") {
     if (parts.length === 1) {
@@ -431,7 +435,7 @@ export function parseCommand(input: string): ParsedCommand {
     }
   }
 
-  if (command === "/session" && parts[1] && parts[1] !== "new" && parts[1] !== "attach" && parts[1] !== "reset" && parts[1] !== "rm") {
+  if (command === "/session" && parts[1] && parts[1] !== "new" && parts[1] !== "attach" && parts[1] !== "reset" && parts[1] !== "rm" && parts[1] !== "archive") {
     const shortcutTarget = readSessionShortcutTarget(parts, 2);
     if (shortcutTarget) {
       return { kind: "session.shortcut", agent: parts[1], ...shortcutTarget };

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -335,6 +335,7 @@ export function parseConfig(
         ? { sessionInitTimeoutMs: transport.sessionInitTimeoutMs }
         : {}),
       ...(typeof transport.permissionPolicy === "string" ? { permissionPolicy: transport.permissionPolicy } : {}),
+      ...(typeof transport.preferLocalAgents === "boolean" ? { preferLocalAgents: transport.preferLocalAgents } : {}),
       type: transportType,
       permissionMode,
       nonInteractivePermissions,

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -29,6 +29,7 @@ export interface ControlSessionInfo {
   workspace: string;
   transportSession: string;
   running: boolean;
+  archived: boolean;
 }
 
 export interface ControlAgentInfo {
@@ -63,6 +64,11 @@ export interface ControlServiceDeps {
   // wired to CommandRouter.createSessionWithTransport in main.ts. Replaces the
   // logical-only sessions.createSession so control-created sessions are promptable.
   createSessionWithTransport: (internalAlias: string, agent: string, workspace: string, model?: string) => Promise<ResolvedSession>;
+  // Full-lifecycle session teardown/archival, wired to CommandRouter in main.ts so the
+  // web path shares the chat path's shared-transport guard + acpx teardown.
+  removeSessionWithTransport: (internalAlias: string) => Promise<{ wasActive: boolean }>;
+  archiveSessionWithTransport: (internalAlias: string) => Promise<void>;
+  unarchiveSession: (internalAlias: string) => Promise<void>;
   // List the agent-native sessions for an agent + workspace (web native-attach picker).
   listNativeSessions: (agent: string, workspace: string) => Promise<AgentSession[]>;
   // Bind a new logical session to an EXISTING agent-native session (resume), the web
@@ -200,6 +206,7 @@ export class ControlService {
         workspace: session.workspace,
         transportSession: session.transportSession,
         running: this.deps.activeTurns.isActiveAnywhere(session.alias),
+        archived: session.archived === true,
       }));
   }
 
@@ -258,14 +265,27 @@ export class ControlService {
       workspace: session.workspace,
       transportSession: session.transportSession,
       running: false,
+      archived: false,
     };
   }
 
   async removeSession(chatKey: string, alias: string): Promise<{ wasActive: boolean }> {
     const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, alias);
-    const result = await this.deps.sessions.removeSession(internalAlias);
+    const result = await this.deps.removeSessionWithTransport(internalAlias);
     this.deps.events.emit({ type: "sessions-changed" });
     return result;
+  }
+
+  async archiveSession(chatKey: string, alias: string): Promise<void> {
+    const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, alias);
+    await this.deps.archiveSessionWithTransport(internalAlias);
+    this.deps.events.emit({ type: "sessions-changed" });
+  }
+
+  async unarchiveSession(chatKey: string, alias: string): Promise<void> {
+    const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, alias);
+    await this.deps.unarchiveSession(internalAlias);
+    this.deps.events.emit({ type: "sessions-changed" });
   }
 
   listAgents(): ControlAgentInfo[] {

--- a/src/i18n/messages/en/session.ts
+++ b/src/i18n/messages/en/session.ts
@@ -88,6 +88,7 @@ export const session: SessionMessages = {
   sessionBlockedByTasksHint:
     "Use /tasks to list tasks, or /task cancel <id> to cancel one.",
   sessionRemoved: (alias) => `Session "${alias}" removed.`,
+  sessionArchived: (alias) => `Archived session "${alias}". Send a message to restore it.`,
   sessionRemovedWasActive:
     "This was the active session. Its chat context has been cleared.",
   sessionRemovedWasActivePromoted: (alias) =>

--- a/src/i18n/messages/zh/session.ts
+++ b/src/i18n/messages/zh/session.ts
@@ -82,6 +82,7 @@ export const session: SessionMessages = {
     `会话「${alias}」下还有 ${count} 个未结束的任务，请先取消或等待完成。`,
   sessionBlockedByTasksHint: "使用 /tasks 查看任务列表，或 /task cancel <id> 取消任务。",
   sessionRemoved: (alias) => `已删除会话「${alias}」。`,
+  sessionArchived: (alias) => `已归档会话「${alias}」。发送消息即可恢复。`,
   sessionRemovedWasActive: "该会话是当前活跃会话，已自动清除相关聊天上下文。",
   sessionRemovedWasActivePromoted: (alias) =>
     `该会话是当前活跃会话，已切换回上一个会话「${alias}」。`,

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -72,6 +72,7 @@ export interface SessionMessages {
   sessionBlockedByTasks: (alias: string, count: number) => string;
   sessionBlockedByTasksHint: string;
   sessionRemoved: (alias: string) => string;
+  sessionArchived: (alias: string) => string;
   sessionRemovedWasActive: string;
   sessionRemovedWasActivePromoted: (alias: string) => string;
   sessionTransportShared: (transportSession: string, count: number) => string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -771,6 +771,9 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
       router.listNativeSessionsForControl(agent, workspace),
     attachNativeSessionWithTransport: (internalAlias, agent, workspace, agentSessionId, nativeMeta) =>
       router.attachNativeSessionWithTransport(internalAlias, agent, workspace, agentSessionId, nativeMeta),
+    removeSessionWithTransport: (internalAlias) => router.removeSessionWithTransport(internalAlias),
+    archiveSessionWithTransport: (internalAlias) => router.archiveSessionWithTransport(internalAlias),
+    unarchiveSession: (internalAlias) => router.unarchiveSession(internalAlias),
     activeTurns,
     scheduled: scheduledService,
     orchestration,

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -255,6 +255,11 @@ export class SessionService {
         previousCurrent && previousCurrent !== internalAlias ? previousCurrent : prevCtx?.previous_session;
 
       session.last_used_at = new Date().toISOString();
+      // Sending a message to (or selecting) an archived session restores it.
+      if (session.archived) {
+        delete session.archived;
+        delete session.archived_at;
+      }
       // Spread the previous context so unread background_results (and any other
       // per-chat state) survive the switch; only current/previous change.
       const nextCtx: ChatContextState = { ...prevCtx, current_session: internalAlias };
@@ -492,6 +497,23 @@ export class SessionService {
       count += 1;
     }
     return count;
+  }
+
+  async setArchived(alias: string, archived: boolean): Promise<void> {
+    await this.mutate(async () => {
+      const session = this.state.sessions[alias];
+      if (!session) {
+        throw new Error(`session "${alias}" does not exist`);
+      }
+      if (archived) {
+        session.archived = true;
+        session.archived_at = new Date(this.now()).toISOString();
+      } else {
+        delete session.archived;
+        delete session.archived_at;
+      }
+      await this.persist();
+    });
   }
 
   async removeSession(alias: string): Promise<{ wasActive: boolean }> {

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -675,6 +675,7 @@ export class SessionService {
       replyMode: session.reply_mode,
       effectiveReplyMode,
       cwd: workspaceConfig.cwd,
+      archived: session.archived === true,
     };
   }
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -34,6 +34,10 @@ export interface LogicalSession {
   /** Per-session LLM model override (e.g. `gpt-5.2[high]`); falls back to the agent config default. */
   model?: string;
   reply_mode?: "stream" | "final" | "verbose";
+  /** True when the user archived this session: process closed, row greyed + sunk.
+   *  Cleared on the next useSession (restore-on-message). */
+  archived?: boolean;
+  archived_at?: string;
   created_at: string;
   last_used_at: string;
 }

--- a/src/transport/acpx-bridge/acpx-bridge-protocol.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-protocol.ts
@@ -15,6 +15,7 @@ export type BridgeMethod =
   | "getSessionModel"
   | "cancel"
   | "removeSession"
+  | "deleteSession"
   | "getAgentSessionId";
 
 export interface BridgeRequest {

--- a/src/transport/acpx-bridge/acpx-bridge-transport.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-transport.ts
@@ -255,6 +255,10 @@ export class AcpxBridgeTransport implements SessionTransport {
     await this.client.request("removeSession", this.toParams(session));
   }
 
+  async deleteSession(session: ResolvedSession): Promise<void> {
+    await this.client.request("deleteSession", this.toParams(session));
+  }
+
   async getAgentSessionId(session: ResolvedSession): Promise<string | undefined> {
     const result = await this.client.request<{ agentSessionId?: string }>(
       "getAgentSessionId",

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -30,6 +30,7 @@ import { AcpxQueueOwnerLauncher } from "../acpx-queue-owner-launcher";
 import { permissionModeToFlag } from "../permission-mode-flag";
 import { resolveToolEventMode, type ToolEventMode } from "../tool-event-mode.js";
 import { runAgentSessionList } from "../agent-session-list";
+import { deleteAcpxSessionFiles } from "../acpx-session-files";
 
 interface AcpxCliTransportOptions {
   command?: string;
@@ -411,6 +412,18 @@ export class AcpxCliTransport implements SessionTransport {
     }
     const detail = normalizeCommandError(result) ?? `command failed with exit code ${result.code}`;
     throw new Error(detail);
+  }
+
+  async deleteSession(session: ResolvedSession): Promise<void> {
+    let acpxRecordId: string;
+    try {
+      ({ acpxRecordId } = await this.readSessionRecord(session));
+    } catch {
+      return; // acpx session already gone → nothing to delete
+    }
+    // Close first so no live process / queue owner holds the files, then unlink.
+    await this.removeSession(session);
+    await deleteAcpxSessionFiles({ acpxRecordId });
   }
 
   async hasSession(session: ResolvedSession): Promise<boolean> {

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -421,7 +421,10 @@ export class AcpxCliTransport implements SessionTransport {
     } catch {
       return; // acpx session already gone → nothing to delete
     }
-    // Close first so no live process / queue owner holds the files, then unlink.
+    // Close the acpx session (best-effort), then unlink its on-disk files. close
+    // returning does NOT mean the backing process exited — acpx keeps a warm
+    // queue-owner alive via --ttl. See deleteAcpxSessionFiles for the residual
+    // orphan-stream-file risk this leaves (notably on Windows).
     await this.removeSession(session);
     await deleteAcpxSessionFiles({ acpxRecordId });
   }
@@ -469,7 +472,9 @@ export class AcpxCliTransport implements SessionTransport {
           ? parsed.id
           : undefined;
       const agentSessionId = typeof parsed.agentSessionId === "string" ? parsed.agentSessionId : undefined;
-      if (acpxRecordId) {
+      // Guard the parsed id with the same format check the parse-failure fallback
+      // applies, so a malformed/empty id from acpx never flows into file deletion.
+      if (acpxRecordId && /^[\w.:-]+$/.test(acpxRecordId) && acpxRecordId.length >= 8) {
         return { acpxRecordId, agentSessionId };
       }
     } catch {

--- a/src/transport/acpx-session-files.ts
+++ b/src/transport/acpx-session-files.ts
@@ -1,0 +1,37 @@
+import { readdir, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface DeleteAcpxSessionFilesOptions {
+  acpxRecordId: string;
+  /** Override for the acpx sessions dir (tests). Defaults to `<home>/.acpx/sessions`. */
+  sessionsDir?: string;
+}
+
+/** Best-effort delete of a single acpx session's on-disk files: the record json and
+ *  its event-stream artifacts. Mirrors acpx's per-record file layout
+ *  (`<encodeURIComponent(acpxRecordId)>.json` + `<safeId>.stream.*`). Idempotent —
+ *  missing files are ignored. acpx tolerates the now-stale index.json entry and
+ *  self-heals it on its next `sessions` operation, so we do not rewrite the index. */
+export async function deleteAcpxSessionFiles(options: DeleteAcpxSessionFilesOptions): Promise<void> {
+  const dir = options.sessionsDir ?? join(homedir(), ".acpx", "sessions");
+  const safeId = encodeURIComponent(options.acpxRecordId);
+
+  await unlink(join(dir, `${safeId}.json`)).catch(() => undefined);
+
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return; // dir gone → nothing more to remove
+  }
+  const streamFiles = entries.filter(
+    (name) =>
+      name === `${safeId}.stream.ndjson` ||
+      name === `${safeId}.stream.lock` ||
+      name.startsWith(`${safeId}.stream.`),
+  );
+  for (const name of streamFiles) {
+    await unlink(join(dir, name)).catch(() => undefined);
+  }
+}

--- a/src/transport/acpx-session-files.ts
+++ b/src/transport/acpx-session-files.ts
@@ -11,8 +11,22 @@ export interface DeleteAcpxSessionFilesOptions {
 /** Best-effort delete of a single acpx session's on-disk files: the record json and
  *  its event-stream artifacts. Mirrors acpx's per-record file layout
  *  (`<encodeURIComponent(acpxRecordId)>.json` + `<safeId>.stream.*`). Idempotent —
- *  missing files are ignored. acpx tolerates the now-stale index.json entry and
- *  self-heals it on its next `sessions` operation, so we do not rewrite the index. */
+ *  missing files are ignored.
+ *
+ *  Deleting the `.json` record leaves a dangling index.json entry, but acpx rebuilds
+ *  its index from the surviving `.json` files on its next `sessions` operation, so we
+ *  do not rewrite the index ourselves.
+ *
+ *  The `.stream.*` unlinks are NOT guaranteed to take effect: acpx keeps a warm
+ *  queue-owner alive via `--ttl`, so `sessions close` returning does not mean the
+ *  backing process has released those files. On POSIX the unlink drops the directory
+ *  entry and the owner keeps writing to the now-unlinked inode until `--ttl` expires
+ *  (no visible orphan). On Windows the unlink of a still-open file rejects and is
+ *  swallowed below, leaving the `.stream.*` file as a true orphan. acpx does NOT
+ *  auto-reclaim such an orphan — index rebuild scans only `.json` files, and
+ *  `sessions prune` skips stream files unless run with `--include-history` — so a
+ *  Windows orphan persists until a manual prune. This is an accepted residual risk:
+ *  the queue-owner is a third-party process we cannot reap or await from here. */
 export async function deleteAcpxSessionFiles(options: DeleteAcpxSessionFilesOptions): Promise<void> {
   const dir = options.sessionsDir ?? join(homedir(), ".acpx", "sessions");
   const safeId = encodeURIComponent(options.acpxRecordId);
@@ -25,12 +39,7 @@ export async function deleteAcpxSessionFiles(options: DeleteAcpxSessionFilesOpti
   } catch {
     return; // dir gone → nothing more to remove
   }
-  const streamFiles = entries.filter(
-    (name) =>
-      name === `${safeId}.stream.ndjson` ||
-      name === `${safeId}.stream.lock` ||
-      name.startsWith(`${safeId}.stream.`),
-  );
+  const streamFiles = entries.filter((name) => name.startsWith(`${safeId}.stream.`));
   for (const name of streamFiles) {
     await unlink(join(dir, name)).catch(() => undefined);
   }

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -168,6 +168,13 @@ export interface SessionTransport {
   resumeAgentSession?(session: ResolvedSession, agentSessionId: string): Promise<void>;
   removeSession?(session: ResolvedSession): Promise<void>;
   /**
+   * Hard-delete the transport session AND its on-disk history: close the acpx
+   * process, then delete acpx's record files. Distinct from removeSession (=
+   * `acpx sessions close`, which keeps history for resume). Optional: transports
+   * that can't delete omit it. A missing acpx session is a no-op (idempotent).
+   */
+  deleteSession?(session: ResolvedSession): Promise<void>;
+  /**
    * Read the underlying agent-native session id for an existing transport
    * session. Used by `/clear` to keep a native session native: the fresh
    * post-clear session is itself backed by a new agent rollout, and this

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -60,6 +60,11 @@ export interface ResolvedSession {
    * persisted state by alias) does not apply.
    */
   transient?: boolean;
+  /**
+   * True when the user archived this session (process closed, greyed out in the
+   * web dashboard). Surfaced to the control/web path via ControlSessionInfo.
+   */
+  archived?: boolean;
 }
 
 export interface AgentSession {

--- a/tests/unit/bridge/bridge-delete-session.test.ts
+++ b/tests/unit/bridge/bridge-delete-session.test.ts
@@ -1,0 +1,34 @@
+import { expect, mock, test } from "bun:test";
+
+import { BridgeRuntime } from "../../../src/bridge/bridge-runtime";
+import { BridgeServer } from "../../../src/bridge/bridge-server";
+
+test("bridge routes deleteSession to the runtime", async () => {
+  const deleteSession = mock(async () => ({}));
+  const runtime = {
+    shutdown: async () => ({}),
+    updatePermissionPolicy: async () => ({}),
+    hasSession: async () => ({ exists: true }),
+    ensureSession: async () => ({}),
+    prompt: async () => ({ text: "ok" }),
+    setMode: async () => ({}),
+    cancel: async () => ({ cancelled: true, message: "cancelled" }),
+    removeSession: async () => ({}),
+    deleteSession,
+  } as unknown as BridgeRuntime;
+  const server = new BridgeServer(runtime);
+
+  await expect(server.handleLine(JSON.stringify({
+    id: "del-1",
+    method: "deleteSession",
+    params: { agent: "codex", cwd: "/repo", name: "demo" },
+  }))).resolves.toBe('{"id":"del-1","ok":true,"result":{}}\n');
+
+  expect(deleteSession).toHaveBeenCalledTimes(1);
+  expect(deleteSession).toHaveBeenCalledWith({
+    agent: "codex",
+    agentCommand: undefined,
+    cwd: "/repo",
+    name: "demo",
+  });
+});

--- a/tests/unit/bridge/bridge-runtime-delete-session.test.ts
+++ b/tests/unit/bridge/bridge-runtime-delete-session.test.ts
@@ -1,0 +1,71 @@
+import { test, expect, mock } from "bun:test";
+
+const deleteFiles = mock(async () => {});
+// Stub the sibling helper so we can assert deleteSession invokes the real file
+// delete with the resolved acpxRecordId, without touching the real ~/.acpx dir.
+// bridge-runtime imports "../transport/acpx-session-files"; mock.module matches
+// by resolved module path, so stub the source module the runtime references.
+mock.module("../../../src/transport/acpx-session-files", () => ({
+  deleteAcpxSessionFiles: deleteFiles,
+}));
+
+import { BridgeRuntime } from "../../../src/bridge/bridge-runtime";
+
+const input = { agent: "codex", cwd: "/repo", name: "demo" };
+const recordId = "019d009c-1111-7000-8000-aaaaaaaaaaaa";
+
+test("deleteSession closes then deletes files by acpxRecordId", async () => {
+  deleteFiles.mockClear();
+  const calls: string[][] = [];
+  // readSessionRecord (`sessions show`) returns the record JSON; removeSession
+  // (`sessions close`) returns a clean exit. Both flow through `this.run`.
+  const run = mock(async (_command: string, args: string[]) => {
+    calls.push(args);
+    if (args.includes("show")) {
+      return { code: 0, stdout: JSON.stringify({ acpxRecordId: recordId }), stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const runtime = new BridgeRuntime("acpx", run);
+
+  await runtime.deleteSession(input);
+
+  // sessions show (record read) then sessions close (removeSession) both ran.
+  expect(calls.some((args) => args.includes("show"))).toBe(true);
+  expect(calls.some((args) => args.includes("close"))).toBe(true);
+  // Then delete the on-disk record files for the resolved record id.
+  expect(deleteFiles).toHaveBeenCalledTimes(1);
+  expect(deleteFiles).toHaveBeenCalledWith({ acpxRecordId: recordId });
+});
+
+test("deleteSession is a no-op when the record can't be resolved", async () => {
+  deleteFiles.mockClear();
+  const calls: string[][] = [];
+  // `sessions show` fails → readSessionRecord throws → no-op branch.
+  const run = mock(async (_command: string, args: string[]) => {
+    calls.push(args);
+    return { code: 1, stdout: "", stderr: "no named session" };
+  });
+  const runtime = new BridgeRuntime("acpx", run);
+
+  await expect(runtime.deleteSession(input)).resolves.toEqual({});
+  // No close was issued and no files were deleted.
+  expect(calls.some((args) => args.includes("close"))).toBe(false);
+  expect(deleteFiles).not.toHaveBeenCalled();
+});
+
+test("deleteSession treats a malformed record id as unresolvable (no delete)", async () => {
+  deleteFiles.mockClear();
+  // acpx returns valid JSON but an empty/short id → must hit the no-op branch
+  // rather than deleting files for a bad id.
+  const run = mock(async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return { code: 0, stdout: JSON.stringify({ acpxRecordId: "" }), stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const runtime = new BridgeRuntime("acpx", run);
+
+  await expect(runtime.deleteSession(input)).resolves.toEqual({});
+  expect(deleteFiles).not.toHaveBeenCalled();
+});

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -951,7 +951,7 @@ test("bridge runtime retries native session listing without --filter-cwd when un
 test("getAgentSessionId returns the agentSessionId from sessions show", async () => {
   const run = async (_command: string, _args: string[]) => ({
     code: 0,
-    stdout: JSON.stringify({ acpxRecordId: "rec-1", agentSessionId: "agent-xyz" }),
+    stdout: JSON.stringify({ acpxRecordId: "acpx-rec-1", agentSessionId: "agent-xyz" }),
     stderr: "",
   });
   const runtime = new BridgeRuntime("acpx", run);
@@ -969,7 +969,7 @@ test("getAgentSessionId returns the agentSessionId from sessions show", async ()
 test("getAgentSessionId returns undefined agentSessionId when absent", async () => {
   const run = async (_command: string, _args: string[]) => ({
     code: 0,
-    stdout: JSON.stringify({ acpxRecordId: "rec-1" }),
+    stdout: JSON.stringify({ acpxRecordId: "acpx-rec-1" }),
     stderr: "",
   });
   const runtime = new BridgeRuntime("acpx", run);

--- a/tests/unit/commands/command-router-interaction.test.ts
+++ b/tests/unit/commands/command-router-interaction.test.ts
@@ -30,7 +30,7 @@ import {
   getMarkTaskInjectionFailedMock,
   getDirectCancelTaskMock,
   getPromptMock,
-  getRemoveSessionMock,
+  getDeleteSessionMock,
   getRequestDelegateMock,
   getSetModeMock,
 } from "./command-router-test-support";
@@ -1588,9 +1588,9 @@ test("tears down the transport session when removing a logical session", async (
   const reply = await router.handle("wx:user", "/session rm main");
 
   expect(reply.text).toContain("已删除会话「main」");
-  const removeMock = getRemoveSessionMock(transport);
-  expect(removeMock.mock.calls).toHaveLength(1);
-  expect(removeMock.mock.calls[0]?.[0]).toMatchObject({
+  const deleteMock = getDeleteSessionMock(transport);
+  expect(deleteMock.mock.calls).toHaveLength(1);
+  expect(deleteMock.mock.calls[0]?.[0]).toMatchObject({
     alias: "main",
     transportSession: "backend:main",
   });
@@ -1601,7 +1601,7 @@ test("still removes the logical session and warns when transport teardown fails"
   const config = createConfig();
   const sessions = new SessionService(config, new MemoryStateStore(), createEmptyState());
   const transport = createTransport();
-  getRemoveSessionMock(transport).mockImplementationOnce(async () => {
+  getDeleteSessionMock(transport).mockImplementationOnce(async () => {
     throw new Error("backend unreachable");
   });
   const router = new CommandRouter(sessions, transport, config);
@@ -1628,7 +1628,7 @@ test("skips transport teardown when another logical session shares the same tran
 
   expect(reply.text).toContain("已删除会话「main」");
   expect(reply.text).toContain("仍被其他 1 个会话引用，未关闭");
-  expect(getRemoveSessionMock(transport).mock.calls).toHaveLength(0);
+  expect(getDeleteSessionMock(transport).mock.calls).toHaveLength(0);
   expect(await sessions.getSession("mirror")).not.toBeNull();
 });
 
@@ -1645,8 +1645,8 @@ test("still tears down transport after the last shared alias is removed", async 
 
   expect(reply.text).toContain("已删除会话「mirror」");
   expect(reply.text).not.toContain("仍被其他");
-  expect(getRemoveSessionMock(transport).mock.calls).toHaveLength(1);
-  expect(getRemoveSessionMock(transport).mock.calls[0]?.[0]).toMatchObject({
+  expect(getDeleteSessionMock(transport).mock.calls).toHaveLength(1);
+  expect(getDeleteSessionMock(transport).mock.calls[0]?.[0]).toMatchObject({
     alias: "mirror",
     transportSession: "backend:shared",
   });
@@ -1669,7 +1669,7 @@ test("still removes the logical session and warns when orchestration purge fails
   expect(reply.text).toContain("清理任务编排引用失败");
   expect(reply.text).toContain("state store offline");
   expect(await sessions.getSession("main")).toBeNull();
-  expect(getRemoveSessionMock(transport).mock.calls).toHaveLength(1);
+  expect(getDeleteSessionMock(transport).mock.calls).toHaveLength(1);
 });
 
 test("refuses to remove a session that has active orchestration tasks", async () => {

--- a/tests/unit/commands/command-router-session.test.ts
+++ b/tests/unit/commands/command-router-session.test.ts
@@ -84,6 +84,23 @@ test("stores recovered transport agent command after session creation", async ()
   });
 });
 
+test("a plain chat prompt un-archives the resolved session (restore-on-message)", async () => {
+  const sessions = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  const transport = createTransport();
+  const router = new CommandRouter(sessions, transport);
+
+  await router.handle("wx:user", "/session new api-fix --agent codex --ws backend");
+  const internalAlias = sessions.peekCurrentSessionAlias("wx:user")!;
+  await sessions.setArchived(internalAlias, true);
+  expect(sessions.getResolvedSessionByInternalAlias(internalAlias)?.archived).toBe(true);
+
+  await router.handle("wx:user", "hello there", async () => {});
+
+  expect(sessions.getResolvedSessionByInternalAlias(internalAlias)?.archived).toBe(false);
+  // The prompt still ran after the un-archive.
+  expect(getPromptMock(transport).mock.calls.length).toBeGreaterThan(0);
+});
+
 test("rejects session creation when acpx reports success but the named session is still missing", async () => {
   const sessions = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
   const transport = createTransport();

--- a/tests/unit/commands/command-router-test-support.ts
+++ b/tests/unit/commands/command-router-test-support.ts
@@ -163,6 +163,7 @@ export function createTransport(): SessionTransport {
     listAgentSessions: mock(async () => ({ source: "agent" as const, sessions: [] })),
     resumeAgentSession: mock(async (_session: ResolvedSession, _agentSessionId: string) => {}),
     removeSession: mock(async (_session: ResolvedSession) => {}),
+    deleteSession: mock(async (_session: ResolvedSession) => {}),
     updatePermissionPolicy: mock(async (_policy) => {}),
   };
 }
@@ -856,6 +857,10 @@ export function getUpdatePermissionPolicyMock(transport: SessionTransport) {
 
 export function getRemoveSessionMock(transport: SessionTransport) {
   return transport.removeSession as ReturnType<typeof mock>;
+}
+
+export function getDeleteSessionMock(transport: SessionTransport) {
+  return transport.deleteSession as ReturnType<typeof mock>;
 }
 
 export function getRequestDelegateMock(orchestration: ReturnType<typeof createOrchestrationService>) {

--- a/tests/unit/commands/parse-command.test.ts
+++ b/tests/unit/commands/parse-command.test.ts
@@ -357,6 +357,10 @@ test("rejects /session tail when N is invalid", () => {
   });
 });
 
+test("parses /session archive <alias>", () => {
+  expect(parseCommand("/session archive backend")).toEqual({ kind: "session.archive", alias: "backend" });
+});
+
 test("parses orchestration delegate commands", () => {
   expect(parseCommand("/delegate claude 审查当前方案")).toEqual({
     kind: "delegate.request",

--- a/tests/unit/commands/session-archive-delete.test.ts
+++ b/tests/unit/commands/session-archive-delete.test.ts
@@ -1,0 +1,106 @@
+import { test, expect, mock } from "bun:test";
+import { CommandRouter } from "../../../src/commands/command-router";
+import type { SessionService } from "../../../src/sessions/session-service";
+import type { ResolvedSession, SessionTransport } from "../../../src/transport/types";
+
+function makeSession(): ResolvedSession {
+  return {
+    alias: "demo",
+    agent: "codex",
+    workspace: "backend",
+    transportSession: "backend:demo",
+    cwd: "/tmp/backend",
+  } as unknown as ResolvedSession;
+}
+
+function makeSessions(overrides: {
+  sharedCount: number;
+}): SessionService {
+  const session = makeSession();
+  return {
+    getSession: mock(async (_alias: string) => session),
+    countAliasesSharingTransport: mock(
+      (_transportSession: string, _excludeAlias?: string) => overrides.sharedCount,
+    ),
+    removeSession: mock(async (_alias: string) => ({ wasActive: true })),
+    setArchived: mock(async (_alias: string, _archived: boolean) => {}),
+  } as unknown as SessionService;
+}
+
+function makeTransport(): SessionTransport {
+  return {
+    cancel: mock(async () => ({ cancelled: true, message: "cancelled" })),
+    removeSession: mock(async (_session: ResolvedSession) => {}),
+    deleteSession: mock(async (_session: ResolvedSession) => {}),
+  } as unknown as SessionTransport;
+}
+
+test("removeSessionWithTransport deletes acpx history when no other alias shares the transport", async () => {
+  const sessions = makeSessions({ sharedCount: 0 });
+  const transport = makeTransport();
+  const router = new CommandRouter(sessions, transport);
+
+  const result = await router.removeSessionWithTransport("backend:demo");
+
+  expect((sessions.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  expect((transport.deleteSession as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  expect((transport.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect(result.transportTornDown).toBe(true);
+  expect(result.sharedAliasCount).toBe(0);
+});
+
+test("removeSessionWithTransport leaves the shared transport intact", async () => {
+  const sessions = makeSessions({ sharedCount: 1 });
+  const transport = makeTransport();
+  const router = new CommandRouter(sessions, transport);
+
+  const result = await router.removeSessionWithTransport("backend:demo");
+
+  expect((sessions.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  expect((transport.deleteSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect(result.transportTornDown).toBe(false);
+  expect(result.sharedAliasCount).toBe(1);
+});
+
+test("archiveSessionWithTransport closes the unshared process then flags archived", async () => {
+  const sessions = makeSessions({ sharedCount: 0 });
+  const transport = makeTransport();
+  const router = new CommandRouter(sessions, transport);
+
+  await router.archiveSessionWithTransport("backend:demo");
+
+  expect((transport.cancel as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  expect((transport.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  const setArchived = sessions.setArchived as ReturnType<typeof mock>;
+  expect(setArchived.mock.calls.length).toBe(1);
+  expect(setArchived.mock.calls[0]).toEqual(["backend:demo", true]);
+  // archive must not delete history.
+  expect((transport.deleteSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+});
+
+test("archiveSessionWithTransport keeps a shared process running", async () => {
+  const sessions = makeSessions({ sharedCount: 2 });
+  const transport = makeTransport();
+  const router = new CommandRouter(sessions, transport);
+
+  await router.archiveSessionWithTransport("backend:demo");
+
+  expect((transport.cancel as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect((transport.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect((sessions.setArchived as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+});
+
+test("unarchiveSession flips the archived flag with no transport action", async () => {
+  const sessions = makeSessions({ sharedCount: 0 });
+  const transport = makeTransport();
+  const router = new CommandRouter(sessions, transport);
+
+  await router.unarchiveSession("backend:demo");
+
+  const setArchived = sessions.setArchived as ReturnType<typeof mock>;
+  expect(setArchived.mock.calls.length).toBe(1);
+  expect(setArchived.mock.calls[0]).toEqual(["backend:demo", false]);
+  expect((transport.cancel as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect((transport.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect((transport.deleteSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+});

--- a/tests/unit/commands/session-archive-delete.test.ts
+++ b/tests/unit/commands/session-archive-delete.test.ts
@@ -90,6 +90,94 @@ test("archiveSessionWithTransport keeps a shared process running", async () => {
   expect((sessions.setArchived as ReturnType<typeof mock>).mock.calls.length).toBe(1);
 });
 
+function makeOrchestration(overrides: {
+  blocking: unknown[];
+}) {
+  return {
+    listSessionBlockingTasks: mock(async (_transportSession: string) => overrides.blocking),
+    purgeSessionReferences: mock(async (_transportSession: string) => {}),
+  };
+}
+
+function makeActiveTurns(active: boolean) {
+  return {
+    isActiveAnywhere: mock((_alias: string) => active),
+  };
+}
+
+test("removeSessionWithTransport throws and deletes nothing when orchestration reports blocking tasks", async () => {
+  const sessions = makeSessions({ sharedCount: 0 });
+  const transport = makeTransport();
+  const orchestration = makeOrchestration({ blocking: [{ taskId: "t1" }] });
+  const router = new CommandRouter(
+    sessions,
+    transport,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    orchestration as never,
+  );
+
+  await expect(router.removeSessionWithTransport("backend:demo")).rejects.toThrow(/blocking task/);
+
+  expect((orchestration.listSessionBlockingTasks as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  expect((sessions.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect((transport.deleteSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect((orchestration.purgeSessionReferences as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+});
+
+test("removeSessionWithTransport purges orchestration references after a successful unshared delete", async () => {
+  const sessions = makeSessions({ sharedCount: 0 });
+  const transport = makeTransport();
+  const orchestration = makeOrchestration({ blocking: [] });
+  const router = new CommandRouter(
+    sessions,
+    transport,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    orchestration as never,
+  );
+
+  const result = await router.removeSessionWithTransport("backend:demo");
+
+  expect((sessions.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  expect((transport.deleteSession as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  const purge = orchestration.purgeSessionReferences as ReturnType<typeof mock>;
+  expect(purge.mock.calls.length).toBe(1);
+  expect(purge.mock.calls[0]).toEqual(["backend:demo"]);
+  expect(result.transportTornDown).toBe(true);
+});
+
+test("archiveSessionWithTransport throws and touches nothing when a turn is active", async () => {
+  const sessions = makeSessions({ sharedCount: 0 });
+  const transport = makeTransport();
+  const activeTurns = makeActiveTurns(true);
+  const router = new CommandRouter(
+    sessions,
+    transport,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    activeTurns as never,
+  );
+
+  await expect(router.archiveSessionWithTransport("backend:demo")).rejects.toThrow(/running turn/);
+
+  expect((activeTurns.isActiveAnywhere as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  expect((transport.cancel as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect((transport.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  expect((sessions.setArchived as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+});
+
 test("unarchiveSession flips the archived flag with no transport action", async () => {
   const sessions = makeSessions({ sharedCount: 0 });
   const transport = makeTransport();

--- a/tests/unit/config/load-config.test.ts
+++ b/tests/unit/config/load-config.test.ts
@@ -146,6 +146,47 @@ test("loads an explicit transport.queueOwnerTtlSeconds (including 0 = forever)",
   await rm(dir, { recursive: true, force: true });
 });
 
+test("threads an explicit transport.preferLocalAgents through to the runtime config", async () => {
+  // Regression: the loader validated preferLocalAgents but dropped it from the
+  // returned transport object, so `preferLocalAgents: false` was a no-op and a
+  // host with a native CLI installed always resolved to the local command.
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-config-"));
+  const path = join(dir, "config.json");
+
+  await writeFile(
+    path,
+    JSON.stringify({
+      transport: { type: "acpx-cli", command: "acpx", preferLocalAgents: false },
+      agents: { codex: { driver: "codex" } },
+      workspaces: { backend: { cwd: "/tmp/backend" } },
+    }),
+  );
+
+  const config = await loadConfig(path);
+  expect(config.transport.preferLocalAgents).toBe(false);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("leaves transport.preferLocalAgents undefined when omitted (defaults to preferring local)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-config-"));
+  const path = join(dir, "config.json");
+
+  await writeFile(
+    path,
+    JSON.stringify({
+      transport: { type: "acpx-cli", command: "acpx" },
+      agents: { codex: { driver: "codex" } },
+      workspaces: { backend: { cwd: "/tmp/backend" } },
+    }),
+  );
+
+  const config = await loadConfig(path);
+  expect(config.transport.preferLocalAgents).toBeUndefined();
+
+  await rm(dir, { recursive: true, force: true });
+});
+
 test("rejects a negative transport.queueOwnerTtlSeconds", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-config-"));
   const path = join(dir, "config.json");

--- a/tests/unit/control/control-archive.test.ts
+++ b/tests/unit/control/control-archive.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test";
+
+import { ControlService } from "../../../src/control/control-service";
+import { createControlEventBus, type ControlEvent } from "../../../src/control/control-event-bus";
+
+function makeDeps() {
+  const events = createControlEventBus();
+  const seen: ControlEvent[] = [];
+  events.subscribe((event) => seen.push(event));
+  const calls: Array<{ kind: "remove" | "archive" | "unarchive"; internalAlias: string }> = [];
+  const session = {
+    alias: "backend",
+    agent: "claude",
+    workspace: "/ws/backend",
+    transportSession: "xacpx-backend",
+    archived: true,
+  };
+  const deps = {
+    agent: { chat: async () => ({ text: "" }) },
+    sessions: {
+      listAllResolvedSessions: () => [session],
+      removeSession: async (_alias: string) => ({ wasActive: false }),
+      useSession: async () => ({ alias: "backend", agent: "claude", workspace: "/ws/backend" }),
+      resolveAliasForChat: async (_chatKey: string, alias: string) => `relay:${alias}`,
+      getSession: async () => session,
+      setSessionModel: async () => {},
+    },
+    transport: {},
+    createSessionWithTransport: async () => session,
+    listNativeSessions: async () => [],
+    attachNativeSessionWithTransport: async () => session,
+    removeSessionWithTransport: async (internalAlias: string) => {
+      calls.push({ kind: "remove", internalAlias });
+      return { wasActive: true };
+    },
+    archiveSessionWithTransport: async (internalAlias: string) => {
+      calls.push({ kind: "archive", internalAlias });
+    },
+    unarchiveSession: async (internalAlias: string) => {
+      calls.push({ kind: "unarchive", internalAlias });
+    },
+    activeTurns: { isActiveAnywhere: () => false },
+    scheduled: { listPending: () => [], listRecentForChat: () => [], createTask: async () => { throw new Error("unused"); }, cancelPending: async () => false },
+    orchestration: { listTasks: async () => [], getTask: async () => null, requestTaskCancellation: async () => { throw new Error("unused"); } },
+    events,
+    agents: { list: () => [], catalog: () => [], create: async () => { throw new Error("unused"); }, remove: async () => {} },
+    workspaces: { list: () => [], create: async () => { throw new Error("unused"); }, remove: async () => {} },
+  };
+  return { deps, seen, calls };
+}
+
+test("archiveSession resolves internal alias, routes through transport, and emits sessions-changed", async () => {
+  const { deps, seen, calls } = makeDeps();
+  const control = new ControlService(deps as never);
+  await control.archiveSession("relay:acct", "backend");
+  expect(calls).toEqual([{ kind: "archive", internalAlias: "relay:backend" }]);
+  expect(seen).toContainEqual({ type: "sessions-changed" });
+});
+
+test("unarchiveSession routes through transport and emits sessions-changed", async () => {
+  const { deps, seen, calls } = makeDeps();
+  const control = new ControlService(deps as never);
+  await control.unarchiveSession("relay:acct", "backend");
+  expect(calls).toEqual([{ kind: "unarchive", internalAlias: "relay:backend" }]);
+  expect(seen).toContainEqual({ type: "sessions-changed" });
+});
+
+test("removeSession routes through removeSessionWithTransport (real delete), not the logical-only removeSession", async () => {
+  const { deps, seen, calls } = makeDeps();
+  const control = new ControlService(deps as never);
+  const result = await control.removeSession("relay:acct", "backend");
+  expect(result.wasActive).toBe(true);
+  expect(calls).toEqual([{ kind: "remove", internalAlias: "relay:backend" }]);
+  expect(seen).toContainEqual({ type: "sessions-changed" });
+});
+
+test("listSessions includes the archived flag on each session", () => {
+  const { deps } = makeDeps();
+  const control = new ControlService(deps as never);
+  const sessions = control.listSessions("relay:acct");
+  expect(sessions).toHaveLength(1);
+  expect(sessions[0]?.archived).toBe(true);
+});

--- a/tests/unit/control/control-service-sessions.test.ts
+++ b/tests/unit/control/control-service-sessions.test.ts
@@ -22,6 +22,9 @@ function makeDeps() {
       useSession: async () => ({ alias: "backend", agent: "claude", workspace: "/ws/backend" }),
       resolveAliasForChat: async (_chatKey: string, alias: string) => alias,
     },
+    removeSessionWithTransport: async (_internalAlias: string) => ({ wasActive: true }),
+    archiveSessionWithTransport: async (_internalAlias: string) => {},
+    unarchiveSession: async (_internalAlias: string) => {},
     createSessionWithTransport: async (internalAlias: string, agent: string, workspace: string, model?: string) => {
       calls.push({ kind: "fresh", internalAlias, agent, workspace, ...(model ? { model } : {}) });
       return { ...session, alias: internalAlias, agent, workspace };
@@ -65,6 +68,7 @@ test("listSessions maps resolved sessions with running flag", () => {
       workspace: "/ws/backend",
       transportSession: "xacpx-backend",
       running: true,
+      archived: false,
     },
   ]);
 });

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -159,7 +159,11 @@ test("external coordinator delegation sees agents added after daemon startup", a
   await writeFile(
     configPath,
     JSON.stringify({
-      transport: { type: "acpx-cli", command: "acpx" },
+      // preferLocalAgents:false keeps agentCommand resolution deterministic across
+      // hosts — without it, a machine with the `opencode` CLI installed resolves to
+      // "opencode acp" and the agentCommand:undefined assertions below fail (passes
+      // in CI, fails locally).
+      transport: { type: "acpx-cli", command: "acpx", preferLocalAgents: false },
       agents: {
         codex: { driver: "codex" },
         opencode: { driver: "opencode" },

--- a/tests/unit/sessions/session-archived.test.ts
+++ b/tests/unit/sessions/session-archived.test.ts
@@ -1,0 +1,85 @@
+import { beforeAll, expect, test } from "bun:test";
+
+import type { AppConfig } from "../../../src/config/types";
+import { createEmptyState } from "../../../src/state/types";
+import type { AppState } from "../../../src/state/types";
+import type { StateStore } from "../../../src/state/state-store";
+import { SessionService } from "../../../src/sessions/session-service";
+import { registerKnownChannelId } from "../../../src/channels/channel-scope";
+import { setLocale } from "../../../src/i18n";
+
+beforeAll(() => {
+  setLocale("zh");
+});
+
+function createConfig(): AppConfig {
+  return {
+    transport: { type: "acpx-cli", command: "acpx", permissionMode: "approve-all", nonInteractivePermissions: "deny" },
+    logging: { level: "info", maxSizeBytes: 1024, maxFiles: 2, retentionDays: 1 },
+    channel: { type: "weixin", replyMode: "stream" },
+    channels: [{ id: "weixin", type: "weixin", enabled: true }],
+    agents: {
+      codex: { driver: "codex" },
+      claude: { driver: "claude" },
+    },
+    workspaces: {
+      backend: {
+        cwd: "/tmp/backend",
+      },
+    },
+    orchestration: {
+      maxPendingAgentRequestsPerCoordinator: 3,
+      allowWorkerChainedRequests: false,
+      allowedAgentRequestTargets: [],
+      allowedAgentRequestRoles: [],
+    },
+  };
+}
+
+class MemoryStateStore implements Pick<StateStore, "save"> {
+  public savedStates: AppState[] = [];
+
+  async save(state: AppState): Promise<void> {
+    this.savedStates.push(structuredClone(state));
+  }
+}
+
+function seedSession(state: AppState, alias: string): void {
+  state.sessions[alias] = {
+    alias,
+    agent: "codex",
+    workspace: "backend",
+    transport_session: `backend:${alias}`,
+    created_at: "2026-01-01T00:00:00.000Z",
+    last_used_at: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+test("setArchived(true) sets archived + archived_at; setArchived(false) clears both", async () => {
+  const state = createEmptyState();
+  seedSession(state, "weixin:foo");
+  const service = new SessionService(createConfig(), new MemoryStateStore(), state, { now: () => 1_700_000_000_000 });
+
+  await service.setArchived("weixin:foo", true);
+  expect(state.sessions["weixin:foo"]?.archived).toBe(true);
+  expect(typeof state.sessions["weixin:foo"]?.archived_at).toBe("string");
+
+  await service.setArchived("weixin:foo", false);
+  expect(state.sessions["weixin:foo"]?.archived).toBeUndefined();
+  expect(state.sessions["weixin:foo"]?.archived_at).toBeUndefined();
+});
+
+test("useSession restores an archived session (clears archived)", async () => {
+  registerKnownChannelId("weixin");
+  const state = createEmptyState();
+  seedSession(state, "weixin:foo");
+  const service = new SessionService(createConfig(), new MemoryStateStore(), state);
+
+  await service.setArchived("weixin:foo", true);
+  expect(state.sessions["weixin:foo"]?.archived).toBe(true);
+
+  await service.useSession("weixin:acc:user", "weixin:foo");
+
+  expect(state.sessions["weixin:foo"]?.archived).toBeUndefined();
+  expect(state.sessions["weixin:foo"]?.archived_at).toBeUndefined();
+});

--- a/tests/unit/transport/acpx-cli-delete-session.test.ts
+++ b/tests/unit/transport/acpx-cli-delete-session.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, spyOn, mock } from "bun:test";
+
+const deleteFiles = mock(async () => {});
+// Stub the sibling helper so we can assert deleteSession invokes the real file
+// delete with the resolved acpxRecordId, without touching the real ~/.acpx dir.
+// The impl imports "../acpx-session-files.js"; mock.module matches by resolved
+// module path, so stub the source module both transports/tests reference.
+mock.module("../../../src/transport/acpx-session-files", () => ({
+  deleteAcpxSessionFiles: deleteFiles,
+}));
+
+import { AcpxCliTransport } from "../../../src/transport/acpx-cli/acpx-cli-transport";
+import type { ResolvedSession } from "../../../src/transport/types";
+
+const session: ResolvedSession = {
+  alias: "api-fix",
+  agent: "codex",
+  agentCommand: "./node_modules/.bin/codex-acp",
+  workspace: "backend",
+  transportSession: "backend:api-fix",
+  cwd: "/tmp/backend",
+};
+
+function makeTransport() {
+  const run = mock(async () => ({ code: 0, stdout: "", stderr: "" }));
+  const runPty = mock(async () => ({ code: 0, stdout: "", stderr: "" }));
+  return new AcpxCliTransport({ command: "acpx" }, run, runPty);
+}
+
+test("deleteSession closes then deletes files by acpxRecordId", async () => {
+  deleteFiles.mockClear();
+  const transport = makeTransport();
+  const recordId = "ws:rec-123";
+
+  const readRecord = spyOn(transport as never, "readSessionRecord").mockResolvedValue({
+    acpxRecordId: recordId,
+  } as never);
+  const remove = spyOn(transport, "removeSession" as never).mockResolvedValue(undefined as never);
+
+  await transport.deleteSession?.(session);
+
+  expect(readRecord).toHaveBeenCalledTimes(1);
+  // Close first (keeps a live process/queue owner from holding the files).
+  expect(remove).toHaveBeenCalledTimes(1);
+  expect(remove).toHaveBeenCalledWith(session);
+  // Then delete the on-disk record files for the resolved record id.
+  expect(deleteFiles).toHaveBeenCalledTimes(1);
+  expect(deleteFiles).toHaveBeenCalledWith({ acpxRecordId: recordId });
+});
+
+test("deleteSession is a no-op when the session can't be resolved", async () => {
+  deleteFiles.mockClear();
+  const transport = makeTransport();
+
+  spyOn(transport as never, "readSessionRecord").mockRejectedValue(new Error("no session") as never);
+  const remove = spyOn(transport, "removeSession" as never).mockResolvedValue(undefined as never);
+
+  await expect(transport.deleteSession?.(session)).resolves.toBeUndefined();
+  expect(remove).not.toHaveBeenCalled();
+  expect(deleteFiles).not.toHaveBeenCalled();
+});

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -1921,7 +1921,7 @@ test("onThought: only the first handler error is surfaced", async () => {
 test("getAgentSessionId returns the agentSessionId from sessions show", async () => {
   const run = mock(async () => ({
     code: 0,
-    stdout: JSON.stringify({ acpxRecordId: "rec-1", agentSessionId: "agent-xyz" }),
+    stdout: JSON.stringify({ acpxRecordId: "acpx-rec-1", agentSessionId: "agent-xyz" }),
     stderr: "",
   }));
   const runPty = mock(async () => ({ code: 0, stdout: "", stderr: "" }));
@@ -1936,7 +1936,7 @@ test("getAgentSessionId returns the agentSessionId from sessions show", async ()
 test("getAgentSessionId returns undefined when the record has no agentSessionId", async () => {
   const run = mock(async () => ({
     code: 0,
-    stdout: JSON.stringify({ acpxRecordId: "rec-1" }),
+    stdout: JSON.stringify({ acpxRecordId: "acpx-rec-1" }),
     stderr: "",
   }));
   const runPty = mock(async () => ({ code: 0, stdout: "", stderr: "" }));

--- a/tests/unit/transport/acpx-session-files.test.ts
+++ b/tests/unit/transport/acpx-session-files.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test";
+import { promises as fs } from "node:fs";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { deleteAcpxSessionFiles } from "../../../src/transport/acpx-session-files";
+
+async function tempSessionsDir(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "acpx-sessions-"));
+}
+
+test("deleteAcpxSessionFiles removes the record json and its stream artifacts", async () => {
+  const dir = await tempSessionsDir();
+  const id = "ws:demo";
+  const safe = encodeURIComponent(id);
+  await writeFile(join(dir, `${safe}.json`), "{}");
+  await writeFile(join(dir, `${safe}.stream.ndjson`), "");
+  await writeFile(join(dir, `${safe}.stream.lock`), "");
+  await deleteAcpxSessionFiles({ acpxRecordId: id, sessionsDir: dir });
+  expect(await fs.readdir(dir)).toHaveLength(0);
+});
+
+test("deleteAcpxSessionFiles is idempotent when nothing exists", async () => {
+  const dir = await tempSessionsDir();
+  await expect(deleteAcpxSessionFiles({ acpxRecordId: "ws:none", sessionsDir: dir })).resolves.toBeUndefined();
+});
+
+test("deleteAcpxSessionFiles only deletes the target session's files, not siblings", async () => {
+  const dir = await tempSessionsDir();
+  await writeFile(join(dir, `${encodeURIComponent("ws:keep")}.json`), "{}");
+  await writeFile(join(dir, `${encodeURIComponent("ws:gone")}.json`), "{}");
+  await deleteAcpxSessionFiles({ acpxRecordId: "ws:gone", sessionsDir: dir });
+  expect(await fs.readdir(dir)).toEqual([`${encodeURIComponent("ws:keep")}.json`]);
+});


### PR DESCRIPTION
## Summary

Makes session deletion a **real delete** and adds **session archive**, across the relay-web dashboard and all channels (WeChat / Feishu / relay).

- **Real delete** (web ⋯ menu Delete, `/session rm`, or swipe-right): closes the acpx session and deletes its on-disk record files, so re-creating a same-named session starts fresh — fixing the previous "fake delete" where the web only removed the logical session and acpx resurrected the history. Guarded so a transport session shared by another logical alias is never file-deleted.
- **Archive** (⋯ menu Archive, `/session archive <alias>`, or swipe-left): closes the acpx process immediately (keeps history), greys + sinks the row to the bottom of its instance group, shows an undo toast. Sending a message (or undo) restores it.

**acpx is a third-party dependency and is NOT modified.** acpx has no single-session hard-delete command, so xacpx closes the session via acpx's existing `sessions close` then deletes acpx's on-disk record files directly — reusing the on-disk coupling xacpx already has (`acpx-session-index`, `native-session-history`).

## What changed (by layer)

- **transport**: `acpx-session-files.ts` (scoped single-session file delete) + `transport.deleteSession` on acpx-cli and bridge (resolve `acpxRecordId` → `sessions close` → unlink record + stream files; idempotent).
- **core**: `LogicalSession.archived` flag; `SessionService.setArchived`; `useSession` clears it (restore-on-message); `CommandRouter.{removeSessionWithTransport, archiveSessionWithTransport, unarchiveSession}` with the shared-transport guard; `/session rm` now real-deletes.
- **control / protocol / connector / commands**: `ControlService.{archiveSession, unarchiveSession}` + real-delete wiring; `archived` threaded through `ControlSessionInfo` → `SessionDto`; `MSG.sessionsArchive/Unarchive` + payloads; connector dispatch cases; `/session archive` chat command (en/zh).
- **relay-web**: store `archiveSession`/`unarchiveSession`; InstanceTree desktop ⋯ overflow menu + mobile swipe (left archive / right delete); archived rows greyed + sunk + badge + dots suppressed; offline disables the actions; undo toast.

## Design docs
- `docs/superpowers/specs/2026-06-21-session-archive-and-real-delete-design.md`
- `docs/superpowers/plans/2026-06-21-session-archive-and-real-delete.md`

## Test plan
- [x] Core typecheck clean; core unit suite green (one pre-existing unrelated `main.test.ts` flake that also fails on `main`)
- [x] relay-web 326/326 vitest pass; relay-web build clean
- [x] relay-protocol + connector tsc-built (barrel-export guard passes)
- [x] New unit tests: acpx-session-files, transport/bridge deleteSession, archived flag + restore, router orchestration (shared-transport guard), control archive/unarchive, parse `/session archive`, store actions, swipe composable, undo toast, InstanceTree archived/offline
- [ ] Manual E2E in sandbox: archive → grey/sink + undo; send message → restore with history intact; delete → re-create same name starts fresh; offline disables actions

## Notes
- Delete history is wiped only when no other logical alias shares the transport session (smart guard).
- Minor follow-ups noted in review (non-blocking): a direct unit test of the bridge-runtime's own close→delete path; surfacing transport-teardown warnings to the web.