### PR TITLE
test(daemon): de-flake startup-poll permissions test with a virtual clock

### DIFF
--- a/tests/unit/daemon/daemon-controller.test.ts
+++ b/tests/unit/daemon/daemon-controller.test.ts
@@ -204,10 +204,17 @@ test("start creates the pid file with owner-only permissions", async () => {
   if (process.platform === "win32") return;
   const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
   const statusStore = new DaemonStatusStore(join(dir, "status.json"));
+  // This test only asserts the pid-file mode; startup timing is incidental. Drive a
+  // virtual clock (advanced deterministically per poll, well under the startup
+  // timeout) so the real wall-clock cost of the status write below can never trip a
+  // spurious "did not report ready" timeout — that was the source of a CI flake.
+  let now = 0;
   const controller = createController(dir, {
+    now: () => now,
     isProcessRunning: (pid) => pid === 13579,
     spawnDetached: async () => 13579,
     onStartupPoll: async () => {
+      now += 1;
       await statusStore.save({
         pid: 13579,
         started_at: "2026-03-26T00:00:00.000Z",


### PR DESCRIPTION
## Problem

`daemon-controller.test.ts` → **"start creates the pid file with owner-only permissions"** is flaky. It inherits `createController`'s default **50ms real-wall-clock** startup timeout while doing a **real status-file write** in `onStartupPoll`. Under load, the write + status reads exceed 50ms, so `waitForStartupMetadata`'s top-of-loop `Date.now() < deadline` check trips **before** re-reading the status the poll just wrote → spurious `did not report ready` rejection.

During the 0.13.0 release this failed **only** the `channel-relay` publish; the other 3 workflows ran the identical `npm test` on the same commit and passed — the signature of a load-dependent flake.

## Fix

The test only asserts the pid-file mode; startup timing is incidental. Drive a **virtual clock** (advanced +1 per poll, well under the timeout) so the deadline is decoupled from real I/O latency and can't spuriously time out. Mirrors the existing `now: () => now` pattern already used elsewhere in this file. **No production change** (real daemon uses a 10s timeout).

## Verification

- Reproduced under CPU load: **old 1/12 fail**, **fixed 0/12 fail**; **20/20** without load.
- Full unit suite **3010 pass / 0 fail**, `tsc --noEmit` clean.

Closes the recurring publish-retry need noted during the 0.13.0 release.