### PR TITLE
fix(relay-web): repair mobile session archive/delete (swipe + overflow menu)

### DIFF
--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -56,6 +56,43 @@ describe("InstanceTree session management", () => {
     expect(remove).not.toHaveBeenCalled();
   });
 
+  // Regression: the menu item must survive the real mousedown→click sequence. A
+  // document-level mousedown listener nulls openMenuFor; if that unmounts the menu
+  // before click, archive/delete silently no-op (the prior bug). `trigger("click")`
+  // alone never reproduced it because it skips mousedown.
+  it("archives via the overflow menu through a real mousedown+click sequence", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    const archive = vi.spyOn(store, "archiveSession").mockResolvedValue();
+    const w = mount(InstanceTree, { attachTo: document.body, global: { stubs: { NewSessionDialog: true } } });
+    await w.find('[data-test="session-menu"]').trigger("mousedown");
+    await w.find('[data-test="session-menu"]').trigger("click");
+    const item = w.find('[data-test="action-archive"]');
+    expect(item.exists()).toBe(true);
+    await item.trigger("mousedown"); // bubbles to the document listener…
+    expect(w.find('[data-test="action-archive"]').exists()).toBe(true); // …but the menu stays mounted
+    await item.trigger("click");
+    await flushPromises();
+    expect(archive).toHaveBeenCalledWith("i1", "backend");
+    w.unmount();
+  });
+
+  // Regression: the row must wire the swipe composable to real pointer events. A
+  // left swipe past the threshold archives. Catches the `onPointerdown`-vs-`pointerdown`
+  // key bug that made `v-on="handlers"` bind dead events.
+  it("binds swipe handlers to real pointer events (left swipe archives)", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    const archive = vi.spyOn(store, "archiveSession").mockResolvedValue();
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const row = w.find('[data-test="session-row"]');
+    await row.trigger("pointerdown", { clientX: 200, clientY: 0 });
+    await row.trigger("pointermove", { clientX: 120, clientY: 0 });
+    await row.trigger("pointerup", { clientX: 120, clientY: 0 });
+    await flushPromises();
+    expect(archive).toHaveBeenCalledWith("i1", "backend");
+  });
+
   it("mounts with an empty chat store and shows no attention dot for idle sessions", () => {
     const store = useInstancesStore();
     store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -60,6 +60,9 @@ describe("InstanceTree session management", () => {
   // document-level mousedown listener nulls openMenuFor; if that unmounts the menu
   // before click, archive/delete silently no-op (the prior bug). `trigger("click")`
   // alone never reproduced it because it skips mousedown.
+  // NOTE: `attachTo: document.body` is load-bearing — the document mousedown listener
+  // only sees the event when the node is in the real DOM; without it this test goes
+  // green against the buggy code. `w.unmount()` removes the node + listener after.
   it("archives via the overflow menu through a real mousedown+click sequence", async () => {
     const store = useInstancesStore();
     store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
@@ -91,6 +94,25 @@ describe("InstanceTree session management", () => {
     await row.trigger("pointerup", { clientX: 120, clientY: 0 });
     await flushPromises();
     expect(archive).toHaveBeenCalledWith("i1", "backend");
+  });
+
+  // Symmetric to the left-swipe case: a right swipe past the threshold opens the
+  // destructive delete confirm (it must NOT delete until confirmed).
+  it("binds swipe handlers to real pointer events (right swipe asks to delete)", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    const remove = vi.spyOn(store, "removeSession").mockResolvedValue();
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const row = w.find('[data-test="session-row"]');
+    await row.trigger("pointerdown", { clientX: 100, clientY: 0 });
+    await row.trigger("pointermove", { clientX: 200, clientY: 0 });
+    await row.trigger("pointerup", { clientX: 200, clientY: 0 });
+    await flushPromises();
+    expect(useConfirmState().value?.title).toBe("Delete session?");
+    expect(remove).not.toHaveBeenCalled();
+    settleConfirm(true);
+    await flushPromises();
+    expect(remove).toHaveBeenCalledWith("i1", "backend");
   });
 
   it("mounts with an empty chat store and shows no attention dot for idle sessions", () => {

--- a/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
+++ b/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
@@ -42,13 +42,12 @@ describe("useSwipeActions", () => {
     expect(onSwipeLeft).not.toHaveBeenCalled();
     expect(onSwipeRight).not.toHaveBeenCalled();
   });
-  it("fires nothing and resets after pointercancel (browser reclassified as scroll)", () => {
+  it("fires nothing after pointercancel (browser reclassified as scroll)", () => {
     const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
-    const { offset, handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
     handlers.pointerdown(pointer(200));
     handlers.pointermove(pointer(120)); // past the threshold…
     handlers.pointercancel();           // …but the gesture is cancelled
-    expect(offset.value).toBe(0);
     handlers.pointerup(pointer(120));   // a stray up after cancel must not fire
     expect(onSwipeLeft).not.toHaveBeenCalled();
     expect(onSwipeRight).not.toHaveBeenCalled();

--- a/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
+++ b/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
@@ -14,7 +14,7 @@ describe("useSwipeActions", () => {
   // "binds swipe handlers to real pointer events" regression test for the wiring.
   it("exposes bare pointer-event handler keys", () => {
     const { handlers } = useSwipeActions({ onSwipeLeft: vi.fn(), onSwipeRight: vi.fn() });
-    expect(Object.keys(handlers).sort()).toEqual(["pointerdown", "pointermove", "pointerup"]);
+    expect(Object.keys(handlers).sort()).toEqual(["pointercancel", "pointerdown", "pointermove", "pointerup"]);
   });
   it("fires onSwipeLeft past the threshold", () => {
     const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
@@ -39,6 +39,17 @@ describe("useSwipeActions", () => {
     handlers.pointerdown(pointer(200));
     handlers.pointermove(pointer(180));
     handlers.pointerup(pointer(180));
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+  it("fires nothing and resets after pointercancel (browser reclassified as scroll)", () => {
+    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
+    const { offset, handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+    handlers.pointerdown(pointer(200));
+    handlers.pointermove(pointer(120)); // past the threshold…
+    handlers.pointercancel();           // …but the gesture is cancelled
+    expect(offset.value).toBe(0);
+    handlers.pointerup(pointer(120));   // a stray up after cancel must not fire
     expect(onSwipeLeft).not.toHaveBeenCalled();
     expect(onSwipeRight).not.toHaveBeenCalled();
   });

--- a/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
+++ b/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
@@ -8,29 +8,37 @@ function pointer(x: number, y = 0) {
 }
 
 describe("useSwipeActions", () => {
+  // Handler keys must be bare DOM event names so `v-on="handlers"` binds real
+  // pointer events (Vue re-applies the `on` prefix); an `onPointerdown` key would
+  // bind a dead event and the swipe would silently never fire. See InstanceTree's
+  // "binds swipe handlers to real pointer events" regression test for the wiring.
+  it("exposes bare pointer-event handler keys", () => {
+    const { handlers } = useSwipeActions({ onSwipeLeft: vi.fn(), onSwipeRight: vi.fn() });
+    expect(Object.keys(handlers).sort()).toEqual(["pointerdown", "pointermove", "pointerup"]);
+  });
   it("fires onSwipeLeft past the threshold", () => {
     const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
     const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
-    handlers.onPointerdown(pointer(200));
-    handlers.onPointermove(pointer(120));
-    handlers.onPointerup(pointer(120));
+    handlers.pointerdown(pointer(200));
+    handlers.pointermove(pointer(120));
+    handlers.pointerup(pointer(120));
     expect(onSwipeLeft).toHaveBeenCalled();
     expect(onSwipeRight).not.toHaveBeenCalled();
   });
   it("fires onSwipeRight past the threshold", () => {
     const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
     const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
-    handlers.onPointerdown(pointer(100));
-    handlers.onPointermove(pointer(200));
-    handlers.onPointerup(pointer(200));
+    handlers.pointerdown(pointer(100));
+    handlers.pointermove(pointer(200));
+    handlers.pointerup(pointer(200));
     expect(onSwipeRight).toHaveBeenCalled();
   });
   it("ignores sub-threshold and vertical-dominant moves", () => {
     const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
     const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
-    handlers.onPointerdown(pointer(200));
-    handlers.onPointermove(pointer(180));
-    handlers.onPointerup(pointer(180));
+    handlers.pointerdown(pointer(200));
+    handlers.pointermove(pointer(180));
+    handlers.pointerup(pointer(180));
     expect(onSwipeLeft).not.toHaveBeenCalled();
     expect(onSwipeRight).not.toHaveBeenCalled();
   });

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -159,7 +159,11 @@ const rowSwipes = computed(() => {
             <button data-test="session-menu" :aria-label="$t('common.more')"
                     class="grid h-5 w-5 place-items-center rounded text-fg-muted hover:bg-raised hover:text-fg opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
                     @click.stop="openMenuFor = openMenuFor === `${inst.id}:${s.alias}` ? null : `${inst.id}:${s.alias}`"><MoreHorizontal :size="13" /></button>
-            <div v-if="openMenuFor === `${inst.id}:${s.alias}`" class="absolute right-0 z-20 mt-1 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
+            <!-- `@mousedown.stop`: the document-level mousedown listener nulls openMenuFor,
+                 which would unmount this menu in the microtask BEFORE the item's click
+                 fires (mousedown → Vue flush → mouseup → click on a detached node), so
+                 archive/delete silently no-op. Stopping mousedown keeps the menu mounted. -->
+            <div v-if="openMenuFor === `${inst.id}:${s.alias}`" @mousedown.stop class="absolute right-0 z-20 mt-1 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
               <button v-if="!s.archived" data-test="action-archive" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="onArchive(inst.id, s.alias)"><Archive :size="12" />{{ $t("instance.archiveSession") }}</button>
               <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
             </div>

--- a/packages/relay-web/src/lib/use-swipe-actions.ts
+++ b/packages/relay-web/src/lib/use-swipe-actions.ts
@@ -14,16 +14,20 @@ export function useSwipeActions(opts: SwipeActionsOptions) {
   const offset = ref(0);
   let startX = 0, startY = 0, active = false;
 
-  function onPointerdown(e: { clientX: number; clientY: number }) {
+  // Keys MUST be bare DOM event names (`pointerdown`, not `onPointerdown`): the row
+  // binds these via `v-on="handlers"`, and Vue's object-`v-on` re-applies the `on`
+  // prefix itself. An `onPointerdown` key would be re-prefixed to a dead event and
+  // the swipe would silently never fire.
+  function pointerdown(e: { clientX: number; clientY: number }) {
     active = true; startX = e.clientX; startY = e.clientY; offset.value = 0;
   }
-  function onPointermove(e: { clientX: number; clientY: number }) {
+  function pointermove(e: { clientX: number; clientY: number }) {
     if (!active) return;
     const dx = e.clientX - startX, dy = e.clientY - startY;
     if (Math.abs(dy) > Math.abs(dx)) { active = false; offset.value = 0; return; }
     offset.value = dx;
   }
-  function onPointerup(e: { clientX: number; clientY: number }) {
+  function pointerup(e: { clientX: number; clientY: number }) {
     if (!active) return;
     active = false;
     const dx = e.clientX - startX, dy = e.clientY - startY;
@@ -33,5 +37,5 @@ export function useSwipeActions(opts: SwipeActionsOptions) {
     else if (dx >= threshold) opts.onSwipeRight();
   }
 
-  return { offset, handlers: { onPointerdown, onPointermove, onPointerup } };
+  return { offset, handlers: { pointerdown, pointermove, pointerup } };
 }

--- a/packages/relay-web/src/lib/use-swipe-actions.ts
+++ b/packages/relay-web/src/lib/use-swipe-actions.ts
@@ -36,6 +36,12 @@ export function useSwipeActions(opts: SwipeActionsOptions) {
     if (dx <= -threshold) opts.onSwipeLeft();
     else if (dx >= threshold) opts.onSwipeRight();
   }
+  // The browser fires `pointercancel` (and no `pointerup`) when it reclassifies the
+  // drag as a scroll/gesture. Reset so a cancelled gesture never fires an action and
+  // never leaves a stale `offset` hanging.
+  function pointercancel() {
+    active = false; offset.value = 0;
+  }
 
-  return { offset, handlers: { pointerdown, pointermove, pointerup } };
+  return { offset, handlers: { pointerdown, pointermove, pointerup, pointercancel } };
 }

--- a/packages/relay-web/src/lib/use-swipe-actions.ts
+++ b/packages/relay-web/src/lib/use-swipe-actions.ts
@@ -1,5 +1,3 @@
-import { ref } from "vue";
-
 export interface SwipeActionsOptions {
   onSwipeLeft: () => void;
   onSwipeRight: () => void;
@@ -8,10 +6,9 @@ export interface SwipeActionsOptions {
 
 /** Minimal horizontal-swipe detector for a list row. Tracks pointer travel and fires
  *  left/right past the threshold, ignoring vertical-dominant gestures so it doesn't
- *  fight the scroll container. `offset` is exposed for an optional reveal animation. */
+ *  fight the scroll container. */
 export function useSwipeActions(opts: SwipeActionsOptions) {
   const threshold = opts.threshold ?? 64;
-  const offset = ref(0);
   let startX = 0, startY = 0, active = false;
 
   // Keys MUST be bare DOM event names (`pointerdown`, not `onPointerdown`): the row
@@ -19,29 +16,26 @@ export function useSwipeActions(opts: SwipeActionsOptions) {
   // prefix itself. An `onPointerdown` key would be re-prefixed to a dead event and
   // the swipe would silently never fire.
   function pointerdown(e: { clientX: number; clientY: number }) {
-    active = true; startX = e.clientX; startY = e.clientY; offset.value = 0;
+    active = true; startX = e.clientX; startY = e.clientY;
   }
   function pointermove(e: { clientX: number; clientY: number }) {
     if (!active) return;
     const dx = e.clientX - startX, dy = e.clientY - startY;
-    if (Math.abs(dy) > Math.abs(dx)) { active = false; offset.value = 0; return; }
-    offset.value = dx;
+    if (Math.abs(dy) > Math.abs(dx)) active = false; // vertical-dominant → yield to scroll
   }
   function pointerup(e: { clientX: number; clientY: number }) {
     if (!active) return;
     active = false;
     const dx = e.clientX - startX, dy = e.clientY - startY;
-    offset.value = 0;
     if (Math.abs(dy) > Math.abs(dx)) return;
     if (dx <= -threshold) opts.onSwipeLeft();
     else if (dx >= threshold) opts.onSwipeRight();
   }
   // The browser fires `pointercancel` (and no `pointerup`) when it reclassifies the
-  // drag as a scroll/gesture. Reset so a cancelled gesture never fires an action and
-  // never leaves a stale `offset` hanging.
+  // drag as a scroll/gesture. Reset so a cancelled gesture never fires an action.
   function pointercancel() {
-    active = false; offset.value = 0;
+    active = false;
   }
 
-  return { offset, handlers: { pointerdown, pointermove, pointerup, pointercancel } };
+  return { handlers: { pointerdown, pointermove, pointerup, pointercancel } };
 }


### PR DESCRIPTION
## Problem

On mobile, archiving/deleting a session is impossible: swipe does nothing, and tapping **Archive** in the ⋯ overflow menu has no effect. The backend control chain (`control.sessions.archive/remove`) is fine — both failures are frontend wiring bugs that the existing tests structurally couldn't catch because they bypassed the real browser event sequence.

## Root causes

**1. Swipe never fires** — `useSwipeActions` returned `on`-prefixed handler keys (`onPointerdown/onPointermove/onPointerup`). Bound via `v-on="handlers"`, Vue re-applies the `on` prefix itself, so the keys became dead event names and the real `pointerdown/move/up` events had no listener. → bare event names now.

**2. Menu archive/delete no-op** — a document-level `mousedown` listener nulls `openMenuFor`. The real tap sequence is `mousedown → (Vue flushes in a microtask, unmounting the menu) → mouseup → click on a detached node`, so `@click="onArchive"` never runs. → `@mousedown.stop` on the menu container keeps it mounted until click lands.

Both bugs also affect desktop mouse input; mobile just hits them first.

## Why the tests missed it

- Swipe unit test called the closures directly (`handlers.onPointerdown(...)`), never exercising the `v-on` binding.
- Menu test used `trigger("click")` — a lone click with no preceding `mousedown`, so the race never reproduced.

## Fix + tests

- `use-swipe-actions.ts`: return `{ pointerdown, pointermove, pointerup }`.
- `InstanceTree.vue`: `@mousedown.stop` on the overflow-menu container.
- New regression tests drive the **real** DOM event sequences (mousedown+click; pointerdown/move/up on the row) and assert `archiveSession` is called. Verified each fails on the buggy source and passes with the fix.
- Added a handler-key-name contract assertion to lock the swipe wiring.

## Verification

- New regression tests: fail without fix, pass with fix (confirmed by reintroducing each bug).
- `vue-tsc --noEmit`: clean.
- Full relay-web suite: **329/329 passing**.