### PR TITLE
fix(relay-web): notch safe-area insets for the Settings route

### DIFF
--- a/packages/relay-web/src/views/SettingsView.vue
+++ b/packages/relay-web/src/views/SettingsView.vue
@@ -46,7 +46,10 @@ async function onLogout() {
 </script>
 
 <template>
-  <div class="mx-auto max-w-2xl p-6">
+  <!-- Standalone full-screen route (no shared safe-area header like the dashboard has),
+       so apply the notch/home-indicator insets here. body is already bg-bg, so the area
+       behind the notch stays dark. -->
+  <div class="mx-auto max-w-2xl px-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] pt-[calc(1.5rem+env(safe-area-inset-top))]">
     <header class="mb-6 flex items-center justify-between">
       <h1 class="text-lg font-semibold text-fg">{{ $t("settings.title") }}</h1>
       <router-link to="/" class="text-sm text-fg-muted hover:underline">{{ $t("common.back") }}</router-link>


### PR DESCRIPTION
## Problem

The Settings screen is a standalone full-screen route with no shared safe-area header (the dashboard has one). On iPhones with a notch / home indicator, its root `p-6` padding sat **under** the notch at the top and under the home indicator at the bottom.

## Fix

Add `env(safe-area-inset-top/bottom)` to the root padding:

```
p-6  →  px-6 pt-[calc(1.5rem+env(safe-area-inset-top))] pb-[calc(1.5rem+env(safe-area-inset-bottom))]
```

`body` is already `bg-bg`, so the area behind the notch stays dark — no extra background work needed.

## Provenance

Salvaged from the abandoned local branch `fix/relay-web-mobile-touch-affordances`. That branch's other half (an always-visible-on-touch delete button) is already in `main` via the #56 overflow-menu refactor, which applies the same `[@media(hover:hover)]` pattern — so only this notch fix was still relevant.

## Verification

- `vue-tsc --noEmit`: clean.
- `settings.test.ts`: 4/4 passing.