### PR TITLE
feat(relay-web): attach images & files to chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,18 +519,26 @@ For more filtering, aliases, and troubleshooting, see [docs/native-sessions.md](
 
 If you run several xacpx instances and want to drive them all from one browser dashboard, you can self-host the **relay hub**. Each instance dials out to the hub over WebSocket and registers; you log in to a multi-tenant web dashboard and manage every instance's sessions — chat, scheduled tasks, and orchestration — from one place. Streaming agent replies render as markdown, and the layout works on mobile.
 
-> Status: the relay packages are built and audited but **not yet published to npm**, so today you deploy from a source checkout. See the full guide for the exact steps.
+The hub ships as an npm package (`@ganglion/xacpx-relay`) with the dashboard **bundled in** — no separate build. It serves everything on a single port (HTTP API + dashboard + the instance WebSocket gateway), and authentication is a single **access token** used for both web login and connector pairing.
 
 ```bash
-# Build the hub server + dashboard from a repo checkout
-git clone https://github.com/gadzan/xacpx && cd xacpx && bun install
-bun run build:relay && bun run build:relay-web
+# 1. On the hub host: install (dashboard is bundled — nothing else to build)
+npm i -g @ganglion/xacpx-relay
 
-# Create the first admin, then start (point --web-root at the built dashboard)
-node packages/relay/dist/cli.js init-admin --username admin --db /var/lib/xacpx-relay/relay.db
-node packages/relay/dist/cli.js start --db /var/lib/xacpx-relay/relay.db \
-  --web-root packages/relay-web/dist --host 0.0.0.0
+# 2. Mint an access token (DB auto-created at ~/.xacpx-relay/relay.db)
+xacpx-relay add token
+#   → prints the token once; use it to log into the dashboard AND to pair connectors
+
+# 3. Start the hub (defaults: --host 0.0.0.0 --http-port 8787, dashboard auto-detected)
+xacpx-relay start
+
+# 4. On each instance host: add the connector channel and point it at the hub
+xacpx plugin add @ganglion/xacpx-channel-relay   # requires xacpx >= 0.11.0
+xacpx channel add relay --url wss://relay.example.com --token <access-token> --name my-box
+xacpx restart
 ```
+
+In production, terminate TLS at a reverse proxy in front of the single port and have instances dial `wss://`. There's no `stop`/`status` subcommand — manage the process with systemd/pm2/Docker (`Ctrl-C`/`SIGTERM` to stop); update with `xacpx-relay update`.
 
 Full walkthrough — pairing instances, TLS/reverse-proxy, systemd, backups, troubleshooting: **[Self-Hosting the Relay Hub](https://gadzan.github.io/xacpx/guide/relay-self-hosting)** (or [docs/relay-deployment.md](./docs/relay-deployment.md) for the terse runbook).
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "weacpx-console",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "acpx": "^0.9.0",
+        "acpx": "^0.11.0",
         "node-pty": "^1.1.0",
         "proper-lockfile": "^4.1.2",
         "protobufjs": "^7.5.6",
@@ -39,7 +39,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.4.0",
+      "version": "0.7.0",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },
@@ -88,7 +88,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.1",
+      "version": "0.1.2",
     },
     "packages/relay-web": {
       "name": "@ganglion/xacpx-relay-web",
@@ -122,7 +122,7 @@
     },
   },
   "packages": {
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.22.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.25.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ=="],
 
     "@algolia/abtesting": ["@algolia/abtesting@1.19.0", "", { "dependencies": { "@algolia/client-common": "5.53.0", "@algolia/requester-browser-xhr": "5.53.0", "@algolia/requester-fetch": "5.53.0", "@algolia/requester-node-http": "5.53.0" } }, "sha512-Lhnez3hhXHk25lfxLAMxvkP4fmN3+1RgADhD2ssMDBYuAsDVReeyP+3SGRx+ntq8ijMrLqUyfvO72TB6jsTteQ=="],
 
@@ -676,7 +676,7 @@
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
-    "acpx": ["acpx@0.9.0", "", { "dependencies": { "@agentclientprotocol/sdk": "^0.22.1", "commander": "^14.0.3", "skillflag": "^0.1.4", "tsx": "^4.22.0", "zod": "^4.4.3" }, "bin": { "acpx": "dist/cli.js" } }, "sha512-y12XZ0hqtnDXkbap12YFjNCSePdoU2+9YPF+dAy8G/duytOMJhOnnysT+XWmX16NvMFQuRnW77B3rljunKPtCw=="],
+    "acpx": ["acpx@0.11.0", "", { "dependencies": { "@agentclientprotocol/sdk": "^0.25.0", "commander": "^15.0.0", "skillflag": "^0.1.4", "tsx": "^4.22.4", "zod": "^4.4.3" }, "bin": { "acpx": "dist/cli.js" } }, "sha512-l42LJFmd6kvbr1UytvwWmr5Mdy/v9l3FM6Necs01PWbjUIkxjCdxg97duqoRfRqxtDAfnNPb1IlgIf2ZgMZQqA=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -794,7 +794,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@14.0.3", "https://registry.npmmirror.com/commander/-/commander-14.0.3.tgz", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
 
@@ -1528,7 +1528,7 @@
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
-    "tsx": ["tsx@4.22.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg=="],
+    "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
 
     "type-fest": ["type-fest@0.16.0", "", {}, "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="],
 

--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -83,6 +83,79 @@ turn 结束时无论成功或失败都发出 `turn-finished`（失败时含 `err
 事件总线只保证「`ControlService` 自身发起的变更」会发事件；其它入口
 （如微信频道命令）造成的变更暂不发事件，消费者如需全局快照应主动拉取。
 
+## 文件上传（`control.upload`）
+
+### RPC 描述
+
+`control.upload` 将单个文件以 base64 内容上传到 daemon，写入 `~/.xacpx/runtime/uploads/<rand>/<safe-name>`。
+它是**非聊天域** RPC（no `chatKey`/`senderId` 注入）：relay hub 直接转发给 daemon，不盖戳会话身份。
+
+**请求**（`UploadPayload`，来自 `packages/relay-protocol`）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `filename` | `string` | 原始文件名（服务端会 sanitize，去掉路径分隔符）。 |
+| `content` | `string` | 纯 base64 编码的文件内容（无 `data:...;base64,` 前缀）。 |
+| `mimeType` | `string` | 文件 MIME 类型（如 `image/png`、`text/plain`）。 |
+
+**响应**（`UploadResult`）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | `string` | 随机生成的上传 ID（UUID-like），供后续 `PromptAttachmentRef` 引用。 |
+| `path` | `string` | daemon 宿主机上的绝对路径（`~/.xacpx/runtime/uploads/<id>/<safe-name>`）。 |
+| `filename` | `string` | 经 sanitize 后的实际存储文件名。 |
+| `mimeType` | `string` | 原样回传。 |
+| `size` | `number` | 文件字节数（服务端写入后计算）。 |
+
+**安全约束：**
+- 文件名 sanitize：路径分隔符（`/`、`..`）被替换，防止路径穿越写入。
+- 单文件上限 **10 MB**（daemon 侧 `UploadStore` 检查，relay hub 另设同等 413 守卫）。
+- relay hub 对非聊天域 RPC 不覆写 `chatKey`/`senderId`，避免把文件 ID 与某个具体会话绑定。
+
+**TTL 清理：** `UploadStore` 在 daemon 启动时自动扫描 `~/.xacpx/runtime/uploads/`，
+删除创建时间超过 **24 小时**的目录。运行期间不做清理，不影响已在途的 prompt。
+
+### 实现位置
+
+- `src/control/upload-store.ts` — `UploadStore`：写文件、sanitize、10MB 检查、TTL cleanup。
+- `src/control/control-service.ts` — `uploadFile()` 委托给 `UploadStore`，对外暴露为 `ControlService.uploadFile()`。
+- `packages/channel-relay/src/control-bridge.ts` — 分发 `control.upload` 消息到 `ControlService.uploadFile`。
+
+## 带附件的 prompt（`control.prompt` 的 `media` 字段）
+
+`ControlPromptInput`（及线协议 `PromptPayload`）带有可选字段 `media?: PromptAttachmentRef[]`：
+
+```ts
+interface PromptAttachmentRef {
+  id: string;          // control.upload 返回的 id
+  filePath: string;    // daemon 宿主机绝对路径（~/.xacpx/runtime/uploads/...）
+  fileName: string;    // 文件名
+  mimeType: string;
+  kind: "image" | "file";
+  size: number;
+  previewUrl?: string; // 图片：downscaled data URL；非图片省略
+}
+```
+
+`ControlService.prompt()` 将 `media` 映射为 `ChannelMediaAttachment[]`（`channelId: "relay"`），
+通过已有的 `agent.chat → router → transport.prompt → prompt-media.ts` 链路转发给 agent：
+
+- **`kind: "image"`** → ACP `image` content block（base64 或 data URL）。
+- **`kind: "file"`** → ACP `resource` content block（file URI 或内容），并追加一段文字摘要：
+
+  ```
+  Attachments available as local files:
+  - <filename> (<size> bytes): <daemon-absolute-path>
+  ```
+
+**重要注意事项（非图片文件的访问限制）：**
+非图片文件以 **daemon 宿主机绝对路径**形式传递给 agent（resource block + 文字摘要路径）。
+agent 必须对 `~/.xacpx/runtime/uploads/` 目录下的路径有**文件系统读取权限**；
+该目录位于 workspace 之外，Claude Code / codex 可读取绝对路径，但若 agent 运行在
+沙箱或受限工作目录中则可能无法访问。图片文件则以内容（base64）直接嵌入 ACP image block，
+不存在此限制。
+
 ## 关联包
 
 - **`packages/relay-protocol`** — relay 线协议（信封 + wire DTO），零依赖、

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -242,6 +242,57 @@ export interface LiveTurn {
 - 历史 `out` 消息：若 `m.structured?.toolSteps?.length` 则在 markdown 下方插入 `<ToolCallPanel>`；若 `m.structured?.reasoning` 则插入 `<ReasoningPanel :default-open="false">`（折叠）。
 - 实时流气泡：若 `liveTurn?.toolSteps.length` 则插入 `<ToolCallPanel>`（实时展开）；若 `liveTurn?.reasoning` 则插入 `<ReasoningPanel>`（`defaultOpen` 不传，默认展开）。
 
+## 消息附件（图片 / 文件上传）
+
+用户可在 `PromptInput.vue` 随 prompt 一并发送图片或文件；附件经 `control.upload` RPC
+上传到 daemon，再随 `control.prompt` 的 `media` 字段转发给 agent。
+
+### 触发方式
+
+1. **附件按钮**：输入框左侧的 `📎` 按钮打开系统文件选择器（`<input type="file" multiple>`）。
+2. **剪贴板粘贴**：在输入框聚焦状态下按 `Ctrl/Cmd+V`，若剪贴板含图片文件则自动读取。
+3. **拖放**：将文件拖入输入框区域即可附加；非文件拖放（如文本）不受影响。
+
+### 限制
+
+- 单次最多 **5 个文件**；超出时忽略多余文件并提示。
+- 每个文件最大 **10 MB**；超大文件在客户端侧拒绝，不上传（relay hub 亦有同步 413 守卫）。
+
+### 待发 chips
+
+选中的文件在输入框上方以"附件 chip"形式排列，可单独移除；
+发送成功或取消后自动清空。
+
+### 图片预处理（客户端降采样）
+
+类型为 `image/*` 的文件在上传前由 `Canvas` 降缩：长边超过 **512 px** 时按比例缩小，
+再以 JPEG 格式编码，得到 base64 `previewUrl`。此 preview 随 `PromptAttachmentRef` 传给
+relay hub 并持久化到 `attachments` 列，用于历史重显。非图片文件不做预处理，
+`previewUrl` 字段省略。
+
+### 发送流程
+
+1. 选文件后，每个文件单独调用 `control.upload`（`UploadPayload`），
+   daemon 返回 `UploadResult`（含服务器绝对路径 `path`）。
+2. 构造 `PromptAttachmentRef[]` 并附在 `control.prompt` 的 `media` 字段内发送。
+3. Hub 将 `attachments`（`AttachmentMetadata[]`）持久化到消息记录。
+
+### 渲染
+
+- **`MessageAttachments.vue`**：
+  - 图片（`kind: "image"`）显示缩略图（来自持久化的 `previewUrl`，点击可放大）。
+  - 非图片文件（`kind: "file"`）显示文件卡片（文件名 + 大小）。
+- **`MessageList.vue`**：每条消息若含 `attachments`，在气泡下方插入 `<MessageAttachments>`。
+- **历史重显**：页面刷新后，附件从服务端持久化的 `MessageRecordDto.attachments` 中恢复，
+  图片缩略图和文件卡片均可再次显示。
+
+### 相关文件
+
+- `packages/relay-web/src/components/PromptInput.vue` — 上传触发 + chip UI
+- `packages/relay-web/src/components/MessageAttachments.vue` — 附件渲染
+- `packages/relay-web/src/components/MessageList.vue` — 附件在消息气泡下插入
+- `packages/relay-web/src/stores/chat.ts` — 发送时调用 upload + 附件随 media 字段传出
+
 ## 阶段范围边界
 
 - **阶段三**交付登录 + 实例/会话树 + 对话流。
@@ -250,4 +301,5 @@ export interface LiveTurn {
 - **阶段五**审计修复：API 客户端始终带 JSON content-type（对齐服务端 CSRF 415 守卫）、重连重拉快照 +
   重连定时器清理、聊天错误横幅 + 回合失败浮现 + 失败消息样式 + 切换会话清错 + 乐观失败标记、
   取消在途回合（`control.prompt.cancel`）、左栏实例树会话创建/删除 UI。
+- **阶段七**消息附件：`PromptInput` 附件入口 + `MessageAttachments` 渲染 + 客户端 512px 降采样持久 preview（见上节）。
 - 历史保留策略为服务端配置（`--history-retention-days`），v1 在 Web 端只读、不可编辑（见 docs/relay-module.md）。

--- a/docs/superpowers/plans/2026-06-22-relay-web-message-attachments.md
+++ b/docs/superpowers/plans/2026-06-22-relay-web-message-attachments.md
@@ -1,0 +1,1365 @@
+# relay-web Message Attachments (Images + Files) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the relay-web dashboard attach images or arbitrary files to a chat message, delivered through relay hub → connector → core into the acpx session, with attachments persisted for history re-display.
+
+**Architecture:** Two-phase upload (mirrors the existing `control.fs.*` workspace-fs RPC pattern). Phase 1: a new non-chat-scoped `control.upload` RPC carries base64 bytes hub→connector→core, where `ControlService.uploadFile` sanitizes + writes them to a daemon-side temp dir and returns the absolute path. Phase 2: `control.prompt` carries lightweight attachment refs (path + metadata), which `ControlService` maps to `ChannelMediaAttachment[]` and feeds to the already-wired `agent.chat → router → transport.prompt({media}) → prompt-media → ACP image/resource block` chain. The hub persists attachment metadata (incl. a downscaled image preview) so history re-displays after reload.
+
+**Tech Stack:** TypeScript, Bun (build/test), Vue 3 + Pinia + Vitest (relay-web), Hono + node:sqlite/bun:sqlite (relay hub), node:fs (core).
+
+## Global Constraints
+
+- **Per-file size cap:** 10 MB (enforced at hub AND core — defense in depth).
+- **Per-message attachment count:** ≤ 5.
+- **Persisted preview:** images only; client downscales to ≤ 512px before producing `previewUrl` (data URL). Non-images get no preview.
+- **Temp upload dir:** `~/.xacpx/runtime/uploads/<rand>/<safe-name>`; cleaned on daemon startup + TTL 24h. History re-display relies on the persisted `previewUrl`, never on temp-file survival.
+- **Filename safety:** sanitize to basename, strip `..` and path separators, reject path escape.
+- **`control.upload` is NOT chat-scoped** — it must NOT be added to `CHAT_SCOPED_TYPES` (no `chatKey`/`senderId` injection), matching `control.fs.*`.
+- **relay-protocol builds with tsc + bun then asserts** — after changing it run `bun run build:relay-protocol` and confirm `assert:relay-protocol` passes (guards the "empty barrel" tree-shake bug).
+- **Core media path is already wired** — do NOT modify `src/transport/**`, `src/console-agent.ts`, `src/commands/**`, or `prompt-media.ts`. The only core change is in `src/control/`.
+- **Tests:** relay-web `bun run --cwd packages/relay-web test`; core/connector `npm test` (typecheck + unit). Verify relay-web tests file-by-file, never whole-dir `bun test`.
+
+---
+
+### Task 1: relay-protocol types (upload RPC, attachment refs, persisted metadata)
+
+**Files:**
+- Modify: `packages/relay-protocol/src/messages.ts` (MSG constant ~6-39; PromptPayload ~176-182; add upload payload/result + PromptAttachmentRef)
+- Modify: `packages/relay-protocol/src/web-dtos.ts` (MessageRecordDto ~11-25; add AttachmentMetadata)
+
+**Interfaces:**
+- Produces:
+  - `MSG.upload = "control.upload"`
+  - `interface UploadPayload { filename: string; content: string; mimeType: string }`
+  - `interface UploadResult { id: string; path: string; filename: string; mimeType: string; size: number }`
+  - `interface PromptAttachmentRef { id: string; filePath: string; fileName: string; mimeType: string; kind: "image" | "file"; size: number; previewUrl?: string }`
+  - `PromptPayload.media?: PromptAttachmentRef[]`
+  - `interface AttachmentMetadata { id: string; filename: string; mimeType: string; size: number; kind: "image" | "file"; previewUrl?: string }`
+  - `MessageRecordDto.attachments?: AttachmentMetadata[]`
+
+- [ ] **Step 1: Add `upload` to the MSG constant**
+
+In `packages/relay-protocol/src/messages.ts`, add to the `MSG` object (next to the `fs*` entries):
+
+```typescript
+  fsSearch: "control.fs.search",
+  upload: "control.upload",
+  sessionModelGet: "control.session.model.get",
+```
+
+- [ ] **Step 2: Add upload + attachment-ref interfaces**
+
+In `packages/relay-protocol/src/messages.ts`, near `PromptPayload`/`PromptResult` (~176-187), add:
+
+```typescript
+export interface PromptAttachmentRef {
+  /** Stable id from the upload step; used as a message id for the channel media source. */
+  id: string;
+  /** Absolute path on the daemon host (returned by control.upload). */
+  filePath: string;
+  fileName: string;
+  mimeType: string;
+  kind: "image" | "file";
+  size: number;
+  /** Downscaled data URL for images; carried so the hub can persist a preview. Omitted for files. */
+  previewUrl?: string;
+}
+
+export interface UploadPayload {
+  filename: string;
+  /** base64-encoded file bytes (no data-URL prefix). */
+  content: string;
+  mimeType: string;
+}
+
+export interface UploadResult {
+  id: string;
+  /** Absolute path on the daemon host where the bytes were written. */
+  path: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+```
+
+- [ ] **Step 3: Add `media` to PromptPayload**
+
+In `packages/relay-protocol/src/messages.ts`, extend `PromptPayload` (~176-182):
+
+```typescript
+export interface PromptPayload {
+  chatKey: string;
+  sessionAlias: string;
+  text: string;
+  senderId: string;
+  isOwner?: boolean;
+  media?: PromptAttachmentRef[];
+}
+```
+
+- [ ] **Step 4: Add AttachmentMetadata + extend MessageRecordDto**
+
+In `packages/relay-protocol/src/web-dtos.ts`, add the interface and extend `MessageRecordDto` (~11-25):
+
+```typescript
+export interface AttachmentMetadata {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  kind: "image" | "file";
+  /** Downscaled data URL for images; omitted for files. */
+  previewUrl?: string;
+}
+
+export interface MessageRecordDto {
+  id?: number;
+  instanceId: string;
+  sessionAlias: string;
+  direction: MessageDirection;
+  text: string;
+  createdAt: string;
+  structured?: { toolSteps?: ToolStepDto[]; reasoning?: string; parts?: TurnPartDto[]; scheduled?: ScheduledOriginDto };
+  attachments?: AttachmentMetadata[];
+}
+```
+
+- [ ] **Step 5: Build relay-protocol and verify the barrel assert passes**
+
+Run: `bun run build:relay-protocol`
+Expected: completes, ending with the `assert:relay-protocol` step printing no FATAL and exit 0.
+
+- [ ] **Step 6: Typecheck the whole repo**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (new exports compile; no consumers broken yet).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/relay-protocol/src/messages.ts packages/relay-protocol/src/web-dtos.ts packages/relay-protocol/dist
+git commit -m "feat(relay-protocol): add control.upload + attachment ref/metadata types"
+```
+
+---
+
+### Task 2: core UploadStore (write bytes to temp dir, sanitize, size cap, TTL cleanup)
+
+**Files:**
+- Create: `src/control/upload-store.ts`
+- Create: `tests/unit/control/upload-store.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from prior tasks (self-contained core module).
+- Produces:
+  - `class UploadStore { constructor(opts?: { rootDir?: string; maxBytes?: number; ttlMs?: number; now?: () => Date }); save(filename: string, base64: string, mimeType: string): Promise<{ id: string; path: string; filename: string; mimeType: string; size: number }>; cleanup(): Promise<number>; }`
+  - Default `rootDir` resolves to `<coreHome>/runtime/uploads`; default `maxBytes` 10 MiB; default `ttlMs` 24h.
+  - `save` throws `Error("file-too-large")` over the cap and `Error("empty-file")` on zero bytes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/control/upload-store.test.ts`:
+
+```typescript
+import { mkdtemp, readFile, stat, utimes, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { UploadStore } from "../../../src/control/upload-store";
+
+async function freshRoot(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "upload-store-test-"));
+}
+
+describe("UploadStore", () => {
+  it("writes base64 bytes to a sandboxed file and returns an absolute path + size", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root });
+    const bytes = Buffer.from("hello world");
+    const res = await store.save("note.txt", bytes.toString("base64"), "text/plain");
+
+    expect(res.path.startsWith(root)).toBe(true);
+    expect(res.filename).toBe("note.txt");
+    expect(res.size).toBe(bytes.byteLength);
+    expect(res.id).toMatch(/.+/);
+    expect((await readFile(res.path)).equals(bytes)).toBe(true);
+  });
+
+  it("sanitizes path-traversal filenames to a basename", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root });
+    const res = await store.save("../../etc/passwd", Buffer.from("x").toString("base64"), "text/plain");
+
+    expect(res.filename).toBe("passwd");
+    expect(res.path.startsWith(root)).toBe(true);
+    expect(res.path.includes("..")).toBe(false);
+  });
+
+  it("rejects files over the byte cap", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root, maxBytes: 8 });
+    await expect(store.save("big.bin", Buffer.alloc(9).toString("base64"), "application/octet-stream")).rejects.toThrow(
+      "file-too-large",
+    );
+  });
+
+  it("rejects empty content", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root });
+    await expect(store.save("empty.txt", "", "text/plain")).rejects.toThrow("empty-file");
+  });
+
+  it("cleanup() removes upload dirs older than the TTL and keeps fresh ones", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root, ttlMs: 1000 });
+    const stale = await store.save("old.txt", Buffer.from("old").toString("base64"), "text/plain");
+    const fresh = await store.save("new.txt", Buffer.from("new").toString("base64"), "text/plain");
+
+    // Backdate the stale entry's directory mtime well beyond the TTL.
+    const staleDir = join(stale.path, "..");
+    const past = new Date(Date.now() - 60_000);
+    await utimes(staleDir, past, past);
+
+    const removed = await store.cleanup();
+    expect(removed).toBeGreaterThanOrEqual(1);
+    await expect(stat(stale.path)).rejects.toThrow();
+    expect((await stat(fresh.path)).isFile()).toBe(true);
+    expect((await readdir(root)).length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun run --cwd . vitest run tests/unit/control/upload-store.test.ts` (or `npx vitest run tests/unit/control/upload-store.test.ts`)
+Expected: FAIL with "Cannot find module '../../../src/control/upload-store'".
+
+- [ ] **Step 3: Implement UploadStore**
+
+Create `src/control/upload-store.ts`:
+
+```typescript
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import { coreHomeDir } from "../runtime/core-home.js";
+
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024; // 10 MiB
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+export interface UploadStoreOptions {
+  rootDir?: string;
+  maxBytes?: number;
+  ttlMs?: number;
+  now?: () => Date;
+}
+
+export interface SavedUpload {
+  id: string;
+  path: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+
+function defaultRootDir(): string {
+  const home = process.env.HOME ?? homedir();
+  return path.join(coreHomeDir(home), "runtime", "uploads");
+}
+
+/** Strip directory components and traversal segments, leaving a safe basename. */
+export function sanitizeUploadFilename(raw: string): string {
+  const base = path.basename(raw).replace(/[/\\]/g, "").replace(/^\.+/, "");
+  const cleaned = base.trim();
+  return cleaned.length > 0 ? cleaned : "file";
+}
+
+export class UploadStore {
+  private readonly rootDir: string;
+  private readonly maxBytes: number;
+  private readonly ttlMs: number;
+  private readonly now: () => Date;
+
+  constructor(opts: UploadStoreOptions = {}) {
+    this.rootDir = opts.rootDir ?? defaultRootDir();
+    this.maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  async save(filename: string, base64: string, mimeType: string): Promise<SavedUpload> {
+    const bytes = Buffer.from(base64, "base64");
+    if (bytes.byteLength === 0) throw new Error("empty-file");
+    if (bytes.byteLength > this.maxBytes) throw new Error("file-too-large");
+
+    const safeName = sanitizeUploadFilename(filename);
+    await mkdtemp(this.rootDir + path.sep).catch(() => undefined); // ensure parent exists below
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(this.rootDir, { recursive: true });
+    const dir = await mkdtemp(path.join(this.rootDir, "u-"));
+    const filePath = path.join(dir, safeName);
+    await writeFile(filePath, bytes);
+
+    return {
+      id: path.basename(dir),
+      path: filePath,
+      filename: safeName,
+      mimeType,
+      size: bytes.byteLength,
+    };
+  }
+
+  /** Remove upload dirs whose mtime is older than the TTL. Returns count removed. */
+  async cleanup(): Promise<number> {
+    let entries: string[];
+    try {
+      entries = await readdir(this.rootDir);
+    } catch {
+      return 0;
+    }
+    const cutoff = this.now().getTime() - this.ttlMs;
+    let removed = 0;
+    for (const name of entries) {
+      const dir = path.join(this.rootDir, name);
+      try {
+        const info = await stat(dir);
+        if (info.mtimeMs < cutoff) {
+          await rm(dir, { recursive: true, force: true });
+          removed += 1;
+        }
+      } catch {
+        // ignore races
+      }
+    }
+    return removed;
+  }
+}
+```
+
+> Note: the `mkdtemp(this.rootDir + sep)` line is a no-op safety attempt; the authoritative directory creation is the `mkdir(this.rootDir, { recursive: true })` immediately after. Keep both — the catch swallows the case where the root does not yet exist.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/control/upload-store.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Simplify the directory-creation (remove the dead mkdtemp probe)**
+
+Replace the two-line probe with a single clear `mkdir`. In `src/control/upload-store.ts` `save()`:
+
+```typescript
+    const safeName = sanitizeUploadFilename(filename);
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(this.rootDir, { recursive: true });
+    const dir = await mkdtemp(path.join(this.rootDir, "u-"));
+```
+
+- [ ] **Step 6: Re-run the test**
+
+Run: `npx vitest run tests/unit/control/upload-store.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/control/upload-store.ts tests/unit/control/upload-store.test.ts
+git commit -m "feat(control): UploadStore — sandboxed temp writes, size cap, TTL cleanup"
+```
+
+---
+
+### Task 3: core ControlService — `uploadFile` + media passthrough into `agent.chat`
+
+**Files:**
+- Modify: `src/control/control-service.ts` (ControlPromptInput ~103-110; constructor/fields ~142-149; add `uploadFile`; `prompt()`/`executeTurn` ~364-512)
+- Create: `tests/unit/control/control-service-media.test.ts`
+
+**Interfaces:**
+- Consumes: `UploadStore` from Task 2 (`save`, `cleanup`); `PromptAttachmentRef`, `UploadPayload`, `UploadResult` from Task 1.
+- Produces:
+  - `ControlService.uploadFile(input: UploadPayload): Promise<UploadResult>`
+  - `ControlPromptInput.media?: PromptAttachmentRef[]`
+  - `executeTurn` builds `ChannelMediaAttachment[]` and passes it as `agent.chat({ media })`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/control/control-service-media.test.ts`. This test uses a fake `agent` to capture what `chat()` receives, plus a real `UploadStore` pointed at a temp dir.
+
+```typescript
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import { ControlService } from "../../../src/control/control-service";
+import { UploadStore } from "../../../src/control/upload-store";
+
+// Minimal deps stub — only what prompt()/uploadFile touch in this test.
+function buildService(chatSpy: ReturnType<typeof vi.fn>, uploadStore: UploadStore) {
+  const deps = {
+    agent: { chat: chatSpy },
+    sessions: { resolve: vi.fn(async () => ({ alias: "main", agent: "claude", workspace: "ws", transportSession: "t", cwd: "/tmp" })) },
+    events: { emit: vi.fn() },
+    workspaces: { list: () => [] },
+    uploadStore,
+    // ...any other deps your ControlService requires can be added as vi.fn() stubs
+  } as unknown as ConstructorParameters<typeof ControlService>[0];
+  return new ControlService(deps);
+}
+
+describe("ControlService media", () => {
+  it("uploadFile writes bytes and returns an absolute daemon path", async () => {
+    const root = await mkdtemp(join(tmpdir(), "cs-upload-"));
+    const store = new UploadStore({ rootDir: root });
+    const svc = buildService(vi.fn(), store);
+
+    const res = await svc.uploadFile({ filename: "shot.png", content: Buffer.from("PNG").toString("base64"), mimeType: "image/png" });
+    expect(res.path.startsWith(root)).toBe(true);
+    expect(res.filename).toBe("shot.png");
+    expect(res.size).toBe(3);
+  });
+
+  it("prompt() forwards media refs to agent.chat as ChannelMediaAttachment[]", async () => {
+    const chat = vi.fn(async () => ({ text: "ok" }));
+    const root = await mkdtemp(join(tmpdir(), "cs-upload-"));
+    const svc = buildService(chat, new UploadStore({ rootDir: root }));
+
+    await svc.prompt({
+      chatKey: "relay:a1",
+      sessionAlias: "main",
+      text: "look at this",
+      senderId: "a1",
+      isOwner: true,
+      media: [{ id: "u-1", filePath: "/tmp/u-1/shot.png", fileName: "shot.png", mimeType: "image/png", kind: "image", size: 3 }],
+    });
+
+    expect(chat).toHaveBeenCalledTimes(1);
+    const arg = chat.mock.calls[0][0];
+    expect(Array.isArray(arg.media)).toBe(true);
+    expect(arg.media[0]).toMatchObject({
+      kind: "image",
+      filePath: "/tmp/u-1/shot.png",
+      mimeType: "image/png",
+      fileName: "shot.png",
+    });
+    expect(arg.media[0].source.channelId).toBe("relay");
+  });
+});
+```
+
+> If `ControlService`'s constructor requires additional non-optional deps, add them as `vi.fn()` stubs in `buildService` — do not change production types to satisfy the test. Inspect `ControlServiceDeps` (`src/control/control-service.ts` ~54-101) and stub each field minimally.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/control/control-service-media.test.ts`
+Expected: FAIL — `uploadFile` is not a function / `media` not forwarded.
+
+- [ ] **Step 3: Add `uploadStore` to ControlServiceDeps and the `uploadFile` method**
+
+In `src/control/control-service.ts`:
+
+3a. Add to the `ControlServiceDeps` interface (~54-101):
+
+```typescript
+  uploadStore: import("./upload-store.js").UploadStore;
+```
+
+3b. Add the import at the top of the file:
+
+```typescript
+import type { UploadStore } from "./upload-store.js";
+```
+
+(and change the deps field to `uploadStore: UploadStore;`)
+
+3c. Add the method next to the fs methods (~151-165):
+
+```typescript
+  async uploadFile(input: { filename: string; content: string; mimeType: string }): Promise<{ id: string; path: string; filename: string; mimeType: string; size: number }> {
+    return this.deps.uploadStore.save(input.filename, input.content, input.mimeType);
+  }
+```
+
+- [ ] **Step 4: Add `media` to ControlPromptInput and thread it through `prompt()` → `executeTurn`**
+
+4a. Extend `ControlPromptInput` (~103-110):
+
+```typescript
+export interface ControlPromptInput {
+  chatKey: string;
+  sessionAlias: string;
+  text: string;
+  accountId?: string;
+  senderId: string;
+  isOwner?: boolean;
+  media?: import("@ganglion/xacpx-relay-protocol").PromptAttachmentRef[];
+}
+```
+
+> If the file already imports from `@ganglion/xacpx-relay-protocol`, add `PromptAttachmentRef` to that import and use the bare name instead of the inline `import(...)`.
+
+4b. In `prompt()` (~364-372), forward media into the `executeTurn` params:
+
+```typescript
+  async prompt(input: ControlPromptInput): Promise<ControlPromptResult> {
+    return this.executeTurn({
+      chatKey: input.chatKey,
+      sessionAlias: input.sessionAlias,
+      text: input.text,
+      senderId: input.senderId,
+      ...(input.isOwner !== undefined ? { isOwner: input.isOwner } : {}),
+      ...(input.accountId !== undefined ? { accountId: input.accountId } : {}),
+      ...(input.media !== undefined ? { media: input.media } : {}),
+    });
+  }
+```
+
+4c. Add `media?` to the `executeTurn` params type (find the `private async executeTurn(params: {...})` signature) by adding:
+
+```typescript
+    media?: import("@ganglion/xacpx-relay-protocol").PromptAttachmentRef[];
+```
+
+4d. In `executeTurn`, where it calls `this.deps.agent.chat({...})` (~470-512), build and pass the media array. Add this just before the `agent.chat` call:
+
+```typescript
+    const chatMedia = (params.media ?? []).map((ref) => ({
+      kind: ref.kind,
+      filePath: ref.filePath,
+      mimeType: ref.mimeType,
+      ...(ref.fileName ? { fileName: ref.fileName } : {}),
+      sizeBytes: ref.size,
+      source: {
+        channelId: "relay",
+        accountId: params.accountId ?? "control",
+        chatKey: params.chatKey,
+        messageId: ref.id,
+      },
+    }));
+```
+
+and add to the `agent.chat({...})` object literal:
+
+```typescript
+      ...(chatMedia.length > 0 ? { media: chatMedia } : {}),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/control/control-service-media.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Wire UploadStore into the runtime + startup cleanup**
+
+Find where `ControlService` is constructed (grep `new ControlService(`) — likely in `src/main.ts` (`buildApp`) or a control wiring module. Add an `UploadStore` instance to its deps:
+
+```typescript
+import { UploadStore } from "./control/upload-store.js";
+// ...
+const uploadStore = new UploadStore();
+void uploadStore.cleanup(); // best-effort startup sweep
+// ...pass `uploadStore` into the ControlService deps object.
+```
+
+> Place the `void uploadStore.cleanup()` call in the same startup path as other best-effort reaps. A periodic sweep is optional; the startup sweep + 24h-stale check on each startup is the minimum. Do NOT block startup on it.
+
+- [ ] **Step 7: Typecheck + run the full core unit suite**
+
+Run: `npx tsc --noEmit && npm run test:unit`
+Expected: PASS (typecheck clean; existing suites green; new tests included).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/control/control-service.ts src/main.ts tests/unit/control/control-service-media.test.ts
+git commit -m "feat(control): uploadFile RPC method + forward prompt media into agent.chat"
+```
+
+---
+
+### Task 4: connector control-bridge — `control.upload` case
+
+**Files:**
+- Modify: `packages/channel-relay/src/control-bridge.ts` (dispatch switch ~79-217)
+- Modify (test): add or extend the connector's control-bridge test if one exists (grep `dispatchControlRequest` under `packages/channel-relay/**/__tests__` or `tests`)
+
+**Interfaces:**
+- Consumes: `MSG.upload`, `UploadPayload` from Task 1; `ControlService.uploadFile` from Task 3.
+- Produces: dispatch of `control.upload` → `control.uploadFile(payload)`.
+
+- [ ] **Step 1: Add the dispatch case**
+
+In `packages/channel-relay/src/control-bridge.ts`, in `dispatchControlRequest`, next to the `fs*` cases, add:
+
+```typescript
+    case MSG.upload: {
+      const input = payload as UploadPayload;
+      if (!input.filename || !input.content || !input.mimeType) {
+        return errorPayload("bad-request", "filename, content and mimeType are required");
+      }
+      return await control.uploadFile(input);
+    }
+```
+
+- [ ] **Step 2: Add the `UploadPayload` import**
+
+Add `UploadPayload` to the existing `@ganglion/xacpx-relay-protocol` import in that file (alongside `FsListPayload` etc.).
+
+- [ ] **Step 3: Typecheck the connector package**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: (If a control-bridge test exists) add a dispatch test**
+
+If `packages/channel-relay` has a test that calls `dispatchControlRequest` with a fake `ControlService`, add a case asserting `MSG.upload` calls `control.uploadFile` and bad input returns an `errorPayload`. Mirror the existing `fsList` test exactly. If no such test exists, skip this step (coverage lives in Task 3 + Task 8 e2e).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/channel-relay/src/control-bridge.ts
+git commit -m "feat(connector): dispatch control.upload to ControlService.uploadFile"
+```
+
+---
+
+### Task 5: relay hub — persist attachment metadata + size re-validation
+
+**Files:**
+- Modify: `packages/relay/src/db.ts` (messages table ~110-119; add `attachments` column + idempotent guard)
+- Modify: `packages/relay/src/stores/messages.ts` (`append` ~26-31; `listBySession` map ~60-69)
+- Modify: `packages/relay/src/http/app.ts` (RPC endpoint persist ~277-280; optional upload size guard ~262)
+- Modify (test): `packages/relay/**` message store test (grep `MessageStore` under relay tests)
+
+**Interfaces:**
+- Consumes: `AttachmentMetadata`, `PromptAttachmentRef`, `MSG.upload` from Task 1.
+- Produces:
+  - `MessageStore.append(instanceId, sessionAlias, direction, text, structured?, attachments?)`
+  - `listBySession` returns `attachments` on rows that have them.
+  - Hub maps inbound `PromptPayload.media` → `AttachmentMetadata[]` when persisting the user message.
+
+- [ ] **Step 1: Add the `attachments` column (create + idempotent ALTER)**
+
+In `packages/relay/src/db.ts`, add `attachments TEXT` to the `messages` CREATE TABLE (~110-118):
+
+```typescript
+    CREATE TABLE IF NOT EXISTS messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      instance_id TEXT NOT NULL REFERENCES instances(id),
+      session_alias TEXT NOT NULL,
+      direction TEXT NOT NULL CHECK (direction IN ('in','out')),
+      text TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      structured TEXT,
+      attachments TEXT
+    );
+```
+
+Then, at the END of `initSchema` (after the CREATE blocks), add an idempotent guard for the already-existing local dev DB:
+
+```typescript
+  // Idempotent column add for pre-existing local dev DBs (create-only schema otherwise).
+  const messageCols = db.all<{ name: string }>("PRAGMA table_info(messages)");
+  if (!messageCols.some((c) => c.name === "attachments")) {
+    db.exec("ALTER TABLE messages ADD COLUMN attachments TEXT");
+  }
+```
+
+> If `SqlDriver` exposes `all` differently, match the existing call style used elsewhere in `db.ts`/stores. The PRAGMA returns one row per column.
+
+- [ ] **Step 2: Write the failing store test**
+
+In the existing relay message-store test file (or create `packages/relay/src/stores/messages.test.ts`), add:
+
+```typescript
+it("persists and returns attachment metadata on inbound messages", () => {
+  // `db` and `store` setup mirrors the existing tests in this file.
+  const atts = [{ id: "u-1", filename: "shot.png", mimeType: "image/png", size: 3, kind: "image" as const, previewUrl: "data:image/png;base64,AAAA" }];
+  store.append("i1", "main", "in", "look", undefined, atts);
+  const page = store.listBySession("acc1", "i1", "main");
+  expect(page.messages.at(-1)?.attachments).toEqual(atts);
+});
+```
+
+> Reuse this file's existing `beforeEach` DB/account/instance fixture. If the fixture inserts an account+instance, do the same so the JOIN in `listBySession` matches.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `bun run --cwd packages/relay test -- messages` (match the package's test runner; if it uses `vitest run`, filter by file)
+Expected: FAIL — `append` ignores the 6th arg / `attachments` undefined on result.
+
+- [ ] **Step 4: Extend `append` and `listBySession`**
+
+In `packages/relay/src/stores/messages.ts`:
+
+4a. Add the import + row field:
+
+```typescript
+import type { AttachmentMetadata, MessageDirection, MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
+```
+
+Add `attachments: string | null;` to `interface MessageRow`.
+
+4b. Replace `append`:
+
+```typescript
+  append(
+    instanceId: string,
+    sessionAlias: string,
+    direction: MessageDirection,
+    text: string,
+    structured?: StructuredTurn,
+    attachments?: AttachmentMetadata[],
+  ): void {
+    this.db.run(
+      "INSERT INTO messages (instance_id, session_alias, direction, text, created_at, structured, attachments) VALUES (?,?,?,?,?,?,?)",
+      [
+        instanceId,
+        sessionAlias,
+        direction,
+        text,
+        this.now().toISOString(),
+        structured ? JSON.stringify(structured) : null,
+        attachments && attachments.length > 0 ? JSON.stringify(attachments) : null,
+      ],
+    );
+  }
+```
+
+4c. Add `m.attachments` to the SELECT column list in `listBySession`:
+
+```typescript
+      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments
+       FROM messages m JOIN instances i ON i.id = m.instance_id
+```
+
+4d. Add to the row map:
+
+```typescript
+        ...(r.structured ? { structured: JSON.parse(r.structured) as StructuredTurn } : {}),
+        ...(r.attachments ? { attachments: JSON.parse(r.attachments) as AttachmentMetadata[] } : {}),
+```
+
+- [ ] **Step 5: Run the store test to verify it passes**
+
+Run: `bun run --cwd packages/relay test -- messages`
+Expected: PASS.
+
+- [ ] **Step 6: Persist attachments from the prompt payload + re-validate size in the hub**
+
+In `packages/relay/src/http/app.ts`, in the RPC endpoint (~277-280), change the inbound persist for `MSG.prompt` to also map+store attachments:
+
+```typescript
+      if (body.type === MSG.prompt || body.type === MSG.commandExecute) {
+        const p = payload as { sessionAlias?: string; text?: string; media?: import("@ganglion/xacpx-relay-protocol").PromptAttachmentRef[] };
+        if (p.sessionAlias && p.text !== undefined) {
+          const attachments = (p.media ?? []).map((m) => ({
+            id: m.id,
+            filename: m.fileName,
+            mimeType: m.mimeType,
+            size: m.size,
+            kind: m.kind,
+            ...(m.previewUrl ? { previewUrl: m.previewUrl } : {}),
+          }));
+          deps.messages.append(instance.id, p.sessionAlias, "in", p.text, undefined, attachments);
+        }
+      }
+```
+
+> Note `p.text !== undefined` replaces the old `p.text` truthy check so a media-only message (empty text) still persists. Confirm core treats empty-text+media as valid (it does — `ConsoleAgent.chat` returns early only when BOTH text and media are empty).
+
+Then add a server-side base64 size guard for `control.upload` (defense in depth, before forwarding) near the top of the try block:
+
+```typescript
+      if (body.type === MSG.upload) {
+        const up = payload as { content?: string };
+        const approxBytes = up.content ? Math.floor((up.content.length * 3) / 4) : 0;
+        if (approxBytes > 10 * 1024 * 1024) return c.json({ error: "file-too-large" }, 413);
+      }
+```
+
+- [ ] **Step 7: Typecheck + run hub tests**
+
+Run: `npx tsc --noEmit && bun run --cwd packages/relay test`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/relay/src/db.ts packages/relay/src/stores/messages.ts packages/relay/src/http/app.ts
+git commit -m "feat(relay): persist message attachments + upload size guard"
+```
+
+---
+
+### Task 6: relay-web data layer — upload client, image downscale, composer attachment state, send wiring
+
+**Files:**
+- Modify: `packages/relay-web/src/api/client.ts` (add `upload`)
+- Create: `packages/relay-web/src/lib/image-downscale.ts`
+- Modify: `packages/relay-web/src/stores/composer.ts` (add attachment state)
+- Modify: `packages/relay-web/src/stores/chat.ts` (`send` accepts attachments ~310-336)
+- Create: `packages/relay-web/src/__tests__/attachments.test.ts`
+
+**Interfaces:**
+- Consumes: `MSG.upload`/`UploadResult`/`PromptAttachmentRef`/`AttachmentMetadata` from Task 1.
+- Produces:
+  - `api.upload(instanceId, { filename, content, mimeType }): Promise<UploadResult>`
+  - `downscaleImage(file: File, maxPx?: number): Promise<string | undefined>` — returns a data URL or `undefined` for non-images.
+  - composer store: `pending: Ref<PendingAttachment[]>`, `addFiles(files: File[]): Promise<void>`, `removeAttachment(id)`, `clearAttachments()`, `uploading: Ref<boolean>`. `PendingAttachment = { id; filename; mimeType; size; kind: "image" | "file"; previewUrl?: string; filePath?: string; status: "uploading" | "ready" | "error" }`.
+  - `chat.send(text, attachments?: PromptAttachmentRef[])` and optimistic `ChatMessage.attachments`.
+
+- [ ] **Step 1: Add the upload API call**
+
+In `packages/relay-web/src/api/client.ts`, add to the `api` object (after `rpc`):
+
+```typescript
+  /** Upload a file to the instance daemon; returns its absolute on-host path. */
+  upload: (instanceId: string, payload: { filename: string; content: string; mimeType: string }) =>
+    request<{ result: import("@ganglion/xacpx-relay-protocol").UploadResult }>(
+      "POST",
+      `/api/instances/${instanceId}/rpc`,
+      { type: "control.upload", payload },
+    ).then((r) => r.result),
+```
+
+- [ ] **Step 2: Write the failing test (downscale + composer + send)**
+
+Create `packages/relay-web/src/__tests__/attachments.test.ts`:
+
+```typescript
+import { setActivePinia, createPinia } from "pinia";
+import { beforeEach, expect, test, vi } from "vitest";
+
+const rpc = vi.fn();
+const upload = vi.fn();
+vi.mock("../api/client", () => ({
+  ApiError: class ApiError extends Error {},
+  api: {
+    rpc: (...a: unknown[]) => rpc(...a),
+    upload: (...a: unknown[]) => upload(...a),
+  },
+}));
+
+import { useComposerStore } from "../stores/composer";
+import { useChatStore } from "../stores/chat";
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  rpc.mockReset();
+  upload.mockReset();
+});
+
+test("addFiles uploads each file and tracks ready state with daemon path", async () => {
+  upload.mockResolvedValue({ id: "u-1", path: "/home/.xacpx/runtime/uploads/u-1/a.txt", filename: "a.txt", mimeType: "text/plain", size: 3 });
+  const composer = useComposerStore();
+  composer.bindInstance("i1");
+  const file = new File([new Uint8Array([97, 98, 99])], "a.txt", { type: "text/plain" });
+  await composer.addFiles([file]);
+  expect(upload).toHaveBeenCalledTimes(1);
+  expect(composer.pending).toHaveLength(1);
+  expect(composer.pending[0]).toMatchObject({ filename: "a.txt", kind: "file", status: "ready", filePath: "/home/.xacpx/runtime/uploads/u-1/a.txt" });
+});
+
+test("addFiles rejects beyond the 5-attachment cap", async () => {
+  upload.mockResolvedValue({ id: "u", path: "/p", filename: "f", mimeType: "text/plain", size: 1 });
+  const composer = useComposerStore();
+  composer.bindInstance("i1");
+  const mk = (n: string) => new File([new Uint8Array([1])], n, { type: "text/plain" });
+  await composer.addFiles([mk("1"), mk("2"), mk("3"), mk("4"), mk("5")]);
+  await composer.addFiles([mk("6")]);
+  expect(composer.pending).toHaveLength(5);
+});
+
+test("chat.send forwards ready attachments as media refs and clears them", async () => {
+  rpc.mockResolvedValue({ ok: true });
+  const chat = useChatStore();
+  chat.select("i1", "main");
+  await chat.send("hi", [{ id: "u-1", filePath: "/p/a.png", fileName: "a.png", mimeType: "image/png", kind: "image", size: 3, previewUrl: "data:image/png;base64,AA" }]);
+  const [, type, payload] = rpc.mock.calls[0];
+  expect(type).toBe("control.prompt");
+  expect((payload as { media?: unknown[] }).media).toHaveLength(1);
+  expect(chat.messages.at(-1)).toMatchObject({ direction: "in", text: "hi" });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `bun run --cwd packages/relay-web test -- attachments`
+Expected: FAIL — `bindInstance`/`addFiles` undefined; `send` ignores attachments.
+
+- [ ] **Step 4: Implement the image downscale util**
+
+Create `packages/relay-web/src/lib/image-downscale.ts`:
+
+```typescript
+/** Returns a downscaled data URL (≤ maxPx on the long edge) for images, or undefined for non-images. */
+export async function downscaleImage(file: File, maxPx = 512): Promise<string | undefined> {
+  if (!file.type.startsWith("image/")) return undefined;
+  const bitmap = await createImageBitmap(file).catch(() => null);
+  if (!bitmap) return undefined;
+  const scale = Math.min(1, maxPx / Math.max(bitmap.width, bitmap.height));
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return undefined;
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close();
+  return canvas.toDataURL("image/jpeg", 0.8);
+}
+
+/** Reads a File as base64 (no data-URL prefix). */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.slice(result.indexOf(",") + 1));
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+```
+
+- [ ] **Step 5: Implement composer attachment state**
+
+Rewrite `packages/relay-web/src/stores/composer.ts` to keep the existing insert API and add attachments:
+
+```typescript
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+import { api } from "../api/client";
+import { downscaleImage, fileToBase64 } from "../lib/image-downscale";
+
+const MAX_ATTACHMENTS = 5;
+const MAX_BYTES = 10 * 1024 * 1024;
+
+export interface PendingAttachment {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  kind: "image" | "file";
+  previewUrl?: string;
+  filePath?: string;
+  status: "uploading" | "ready" | "error";
+}
+
+export const useComposerStore = defineStore("composer", () => {
+  const insertRequest = ref<{ key: string; text: string; seq: number } | null>(null);
+  let seq = 0;
+  function requestInsert(key: string, text: string): void {
+    insertRequest.value = { key, text, seq: ++seq };
+  }
+
+  const pending = ref<PendingAttachment[]>([]);
+  const uploading = ref(false);
+  let instanceId = "";
+  let localSeq = 0;
+  function bindInstance(id: string): void {
+    instanceId = id;
+  }
+
+  async function addFiles(files: File[]): Promise<void> {
+    if (!instanceId) return;
+    for (const file of files) {
+      if (pending.value.length >= MAX_ATTACHMENTS) break;
+      if (file.size > MAX_BYTES) continue;
+      const localId = `local-${++localSeq}`;
+      const kind: "image" | "file" = file.type.startsWith("image/") ? "image" : "file";
+      const entry: PendingAttachment = { id: localId, filename: file.name, mimeType: file.type || "application/octet-stream", size: file.size, kind, status: "uploading" };
+      pending.value.push(entry);
+      uploading.value = true;
+      try {
+        const previewUrl = await downscaleImage(file);
+        if (previewUrl) entry.previewUrl = previewUrl;
+        const content = await fileToBase64(file);
+        const res = await api.upload(instanceId, { filename: file.name, content, mimeType: entry.mimeType });
+        entry.filePath = res.path;
+        entry.id = res.id;
+        entry.size = res.size;
+        entry.status = "ready";
+      } catch {
+        entry.status = "error";
+      }
+    }
+    uploading.value = pending.value.some((p) => p.status === "uploading");
+  }
+
+  function removeAttachment(id: string): void {
+    pending.value = pending.value.filter((p) => p.id !== id);
+  }
+  function clearAttachments(): void {
+    pending.value = [];
+  }
+
+  return { insertRequest, requestInsert, pending, uploading, bindInstance, addFiles, removeAttachment, clearAttachments };
+});
+```
+
+- [ ] **Step 6: Wire `chat.send` to accept and forward attachments**
+
+In `packages/relay-web/src/stores/chat.ts`, update `send` (~310-336). First ensure the `ChatMessage` type allows `attachments?: AttachmentMetadata[]` (add the field where `ChatMessage` is declared, importing `AttachmentMetadata` / `PromptAttachmentRef` from `@ganglion/xacpx-relay-protocol`). Then:
+
+```typescript
+  async function send(text: string, attachments: PromptAttachmentRef[] = []): Promise<void> {
+    if (!instanceId.value || !sessionAlias.value) return;
+    error.value = "";
+    sending.value = true;
+    const optimistic: ChatMessage = {
+      instanceId: instanceId.value,
+      sessionAlias: sessionAlias.value,
+      direction: "in",
+      text,
+      createdAt: new Date().toISOString(),
+      ...(attachments.length > 0
+        ? { attachments: attachments.map((a) => ({ id: a.id, filename: a.fileName, mimeType: a.mimeType, size: a.size, kind: a.kind, ...(a.previewUrl ? { previewUrl: a.previewUrl } : {}) })) }
+        : {}),
+    };
+    messages.value.push(optimistic);
+    try {
+      const res = await api.rpc<{ ok?: boolean; errorMessage?: string }>(instanceId.value, "control.prompt", {
+        sessionAlias: sessionAlias.value,
+        text,
+        ...(attachments.length > 0 ? { media: attachments } : {}),
+      });
+      if (res && res.ok === false) {
+        error.value = res.errorMessage ?? "prompt-failed";
+        optimistic.failed = true;
+      }
+    } catch (e) {
+      const isTimeout = e instanceof ApiError && (e.status === 504 || e.code === "timeout");
+      if (!isTimeout) {
+        error.value = e instanceof ApiError ? e.code : "send-failed";
+        optimistic.failed = true;
+      }
+    } finally {
+      sending.value = false;
+    }
+  }
+```
+
+- [ ] **Step 7: Run the attachments test to verify it passes**
+
+Run: `bun run --cwd packages/relay-web test -- attachments`
+Expected: PASS (3 tests).
+
+> The downscale path uses `createImageBitmap`/canvas which jsdom lacks — the test files are `text/plain` so `downscaleImage` returns early (non-image). No canvas mock needed.
+
+- [ ] **Step 8: Run the full relay-web suite + typecheck**
+
+Run: `bun run --cwd packages/relay-web test && npx vue-tsc --noEmit -p packages/relay-web/tsconfig.json`
+Expected: PASS (existing 150+ tests + new ones; types clean).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/relay-web/src/api/client.ts packages/relay-web/src/lib/image-downscale.ts packages/relay-web/src/stores/composer.ts packages/relay-web/src/stores/chat.ts packages/relay-web/src/__tests__/attachments.test.ts
+git commit -m "feat(relay-web): upload client, image downscale, composer attachments, send wiring"
+```
+
+---
+
+### Task 7: relay-web UI — attach button, paste/drag, pending chips, message rendering
+
+**Files:**
+- Modify: `packages/relay-web/src/components/PromptInput.vue` (attach button + paste + drag; submit ~69)
+- Modify: `packages/relay-web/src/components/ChatPane.vue` (wire composer attachments into `chat.send`; bind instance)
+- Create: `packages/relay-web/src/components/MessageAttachments.vue`
+- Modify: `packages/relay-web/src/components/MessageList.vue` (render attachments in user row ~147-170)
+- Modify: relay-web i18n locale files (add `chat.attach.*` keys — grep for `chat.scheduled` to find them)
+- Create: `packages/relay-web/src/__tests__/message-attachments.test.ts`
+
+**Interfaces:**
+- Consumes: composer store (`pending`, `addFiles`, `removeAttachment`, `clearAttachments`, `uploading`, `bindInstance`) from Task 6; `AttachmentMetadata` from Task 1.
+- Produces: visible attach UI + `MessageAttachments.vue` rendering images as thumbnails and files as icon cards.
+
+- [ ] **Step 1: Write the failing component test for MessageAttachments**
+
+Create `packages/relay-web/src/__tests__/message-attachments.test.ts`:
+
+```typescript
+import { mount } from "@vue/test-utils";
+import { expect, test } from "vitest";
+
+import MessageAttachments from "../components/MessageAttachments.vue";
+
+test("renders an image attachment as a thumbnail using previewUrl", () => {
+  const wrapper = mount(MessageAttachments, {
+    props: { attachments: [{ id: "1", filename: "a.png", mimeType: "image/png", size: 10, kind: "image", previewUrl: "data:image/png;base64,AA" }] },
+  });
+  const img = wrapper.find('[data-test="att-image"]');
+  expect(img.exists()).toBe(true);
+  expect(img.attributes("src")).toBe("data:image/png;base64,AA");
+});
+
+test("renders a non-image attachment as a file card with name + size", () => {
+  const wrapper = mount(MessageAttachments, {
+    props: { attachments: [{ id: "2", filename: "report.pdf", mimeType: "application/pdf", size: 2048, kind: "file" }] },
+  });
+  expect(wrapper.find('[data-test="att-file"]').exists()).toBe(true);
+  expect(wrapper.text()).toContain("report.pdf");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun run --cwd packages/relay-web test -- message-attachments`
+Expected: FAIL — cannot resolve `../components/MessageAttachments.vue`.
+
+- [ ] **Step 3: Implement MessageAttachments.vue**
+
+Create `packages/relay-web/src/components/MessageAttachments.vue`:
+
+```vue
+<script setup lang="ts">
+import { FileText } from "lucide-vue-next";
+import type { AttachmentMetadata } from "@ganglion/xacpx-relay-protocol";
+
+defineProps<{ attachments: AttachmentMetadata[] }>();
+
+function fmtSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+</script>
+
+<template>
+  <div class="mt-1 flex flex-wrap gap-2">
+    <template v-for="a in attachments" :key="a.id">
+      <img
+        v-if="a.kind === 'image' && a.previewUrl"
+        data-test="att-image"
+        :src="a.previewUrl"
+        :alt="a.filename"
+        class="max-h-40 max-w-[200px] rounded-lg border border-border object-cover"
+      />
+      <div
+        v-else
+        data-test="att-file"
+        class="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2 text-[13px]"
+      >
+        <FileText :size="16" class="shrink-0 text-muted" />
+        <span class="max-w-[180px] truncate">{{ a.filename }}</span>
+        <span class="text-muted">{{ fmtSize(a.size) }}</span>
+      </div>
+    </template>
+  </div>
+</template>
+```
+
+> `lucide-vue-next` is already a dependency (used by `MessageList.vue` `Clock`). If `FileText` is not exported in the installed version, use `File` instead. Match the project's Tailwind token classes (`border-border`, `bg-surface`, `text-muted`) — confirm these exist by grepping an existing component; if the palette differs, use the nearest existing tokens.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun run --cwd packages/relay-web test -- message-attachments`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Render attachments in the user message row**
+
+In `packages/relay-web/src/components/MessageList.vue`, import the component in `<script setup>`:
+
+```typescript
+import MessageAttachments from "./MessageAttachments.vue";
+```
+
+Then inside the user row's bubble (`data-test="msg-in"` block, ~160-163), after the `<p>...</p>`, add:
+
+```vue
+                <p class="whitespace-pre-wrap text-[14px] leading-relaxed text-fg">{{ m.text }}</p>
+                <MessageAttachments v-if="m.attachments?.length" :attachments="m.attachments" />
+```
+
+> Ensure the `ChatMessage` type used by `MessageList` carries `attachments?` (added in Task 6 step 6). If `MessageList` maps from `MessageRecordDto`, confirm the mapping copies `attachments` through.
+
+- [ ] **Step 6: Add the attach button + paste + drag to PromptInput.vue**
+
+In `packages/relay-web/src/components/PromptInput.vue`:
+
+6a. Add imports + composer wiring in `<script setup>`:
+
+```typescript
+import { Paperclip, X } from "lucide-vue-next";
+import { useComposerStore } from "../stores/composer";
+
+const composer = useComposerStore();
+const fileInput = ref<HTMLInputElement | null>(null);
+
+function openPicker() {
+  fileInput.value?.click();
+}
+async function onFilesPicked(e: Event) {
+  const input = e.target as HTMLInputElement;
+  if (input.files) await composer.addFiles(Array.from(input.files));
+  input.value = "";
+}
+async function onPaste(e: ClipboardEvent) {
+  const files = Array.from(e.clipboardData?.files ?? []);
+  if (files.length > 0) {
+    e.preventDefault();
+    await composer.addFiles(files);
+  }
+}
+async function onDrop(e: DragEvent) {
+  const files = Array.from(e.dataTransfer?.files ?? []);
+  if (files.length > 0) {
+    e.preventDefault();
+    await composer.addFiles(files);
+  }
+}
+```
+
+6b. Update `submit()` (~69) to include ready attachments and clear them. Replace the `emit("send", value)` line:
+
+```typescript
+function submit() {
+  if (props.busy) return;
+  const ready = composer.pending.filter((p) => p.status === "ready");
+  const value = text.value.trim();
+  if (!value && ready.length === 0) return;
+  if (composer.uploading) return; // wait for in-flight uploads
+  const media = ready.map((p) => ({ id: p.id, filePath: p.filePath as string, fileName: p.filename, mimeType: p.mimeType, kind: p.kind, size: p.size, ...(p.previewUrl ? { previewUrl: p.previewUrl } : {}) }));
+  emit("send", value, media);
+  composer.clearAttachments();
+  // ...keep the rest of the existing submit() body (history push, clear text, etc.)
+}
+```
+
+6c. Update the `emit` type declaration to `(e: "send", text: string, media: PromptAttachmentRef[]): void` (import `PromptAttachmentRef` from `@ganglion/xacpx-relay-protocol`). Keep any other existing emits.
+
+6d. In the template: add a hidden file input, an attach button next to the send button, the paste/drop handlers on the textarea/root, and a pending-chips strip. Add near the textarea:
+
+```vue
+    <input ref="fileInput" type="file" multiple class="hidden" data-test="attach-input" @change="onFilesPicked" />
+    <button type="button" data-test="attach-btn" :title="$t('chat.attach.add')" class="..." @click="openPicker">
+      <Paperclip :size="18" />
+    </button>
+```
+
+Add `@paste="onPaste"` to the `<textarea>` and `@drop="onDrop" @dragover.prevent` to the composer root. Above the textarea, render the chips strip:
+
+```vue
+    <div v-if="composer.pending.length" class="flex flex-wrap gap-2 px-2 pt-2">
+      <div v-for="p in composer.pending" :key="p.id" class="flex items-center gap-1 rounded-md border border-border bg-surface px-2 py-1 text-[12px]">
+        <img v-if="p.previewUrl" :src="p.previewUrl" class="h-6 w-6 rounded object-cover" :alt="p.filename" />
+        <span class="max-w-[120px] truncate">{{ p.filename }}</span>
+        <span v-if="p.status === 'uploading'" class="text-muted">…</span>
+        <span v-else-if="p.status === 'error'" class="text-danger">!</span>
+        <button type="button" :title="$t('chat.attach.remove')" @click="composer.removeAttachment(p.id)"><X :size="12" /></button>
+      </div>
+    </div>
+```
+
+> Match existing button/utility classes in this file rather than inventing new ones. Grep the file for the send button's classes and reuse them for the attach button.
+
+- [ ] **Step 7: Wire ChatPane to pass media through + bind the instance**
+
+In `packages/relay-web/src/components/ChatPane.vue`, find where it listens to `PromptInput`'s `send` and calls `chat.send(text)`. Update the handler to forward media:
+
+```typescript
+function onSend(text: string, media: PromptAttachmentRef[] = []) {
+  void chat.send(text, media);
+}
+```
+
+and the template binding: `@send="onSend"`. Also bind the composer to the active instance (e.g. in the existing watcher that reacts to `chat.instanceId`):
+
+```typescript
+import { useComposerStore } from "../stores/composer";
+const composer = useComposerStore();
+watch(() => chat.instanceId, (id) => { if (id) composer.bindInstance(id); }, { immediate: true });
+```
+
+> If `ChatPane` already exposes the active instance id under a different name, use that. Confirm the `resend` path (`emit('resend', m)`) still re-sends without attachments — that's acceptable for v1 (resend is text-only).
+
+- [ ] **Step 8: Add i18n keys**
+
+Find the locale files (grep `"scheduled"` under `packages/relay-web/src` for the `chat` namespace). Add to each locale (English + Chinese):
+
+English:
+```json
+"attach": { "add": "Attach file", "remove": "Remove" }
+```
+Chinese:
+```json
+"attach": { "add": "添加附件", "remove": "移除" }
+```
+
+(nested under the existing `chat` object).
+
+- [ ] **Step 9: Run the full relay-web suite + typecheck**
+
+Run: `bun run --cwd packages/relay-web test && npx vue-tsc --noEmit -p packages/relay-web/tsconfig.json`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/relay-web/src/components/PromptInput.vue packages/relay-web/src/components/ChatPane.vue packages/relay-web/src/components/MessageList.vue packages/relay-web/src/components/MessageAttachments.vue packages/relay-web/src/__tests__/message-attachments.test.ts packages/relay-web/src/locales
+git commit -m "feat(relay-web): attach button, paste/drag, pending chips, attachment rendering"
+```
+
+---
+
+### Task 8: End-to-end validation + docs
+
+**Files:**
+- Modify: `docs/relay-web-module.md` (document the attachment surface)
+- Modify: `docs/control-module.md` (document `control.upload` RPC + prompt `media`)
+
+**Interfaces:** none (integration + documentation).
+
+- [ ] **Step 1: Full build + typecheck + all unit suites**
+
+Run:
+```bash
+bun run build:relay-protocol
+bun run build
+npx tsc --noEmit
+npm test
+bun run --cwd packages/relay test
+bun run --cwd packages/relay-web test
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Real-relay end-to-end smoke (manual, mirrors HAPI-borrow/workspace-fs)**
+
+Follow the sandbox full-stack procedure from prior relay work:
+1. `bun run build` in this repo.
+2. Refresh the installed connector copy (`cp -R` the connector `dist` into the test HOME `~/.xacpx/plugins/...`), and `rm -rf` any nested `node_modules/@ganglion/xacpx-relay-protocol` shadow copy so it resolves the refreshed sibling protocol.
+3. Restart the console: `node dist/cli.js run` connected to the hub gateway.
+4. In relay-web: select a session, click the attach button, pick a PNG, confirm the chip shows a thumbnail and "ready", send with text.
+5. Verify the agent received the image (acpx `prompt.json` contains an `image` content block; check `~/.xacpx/runtime/app.log`).
+6. Attach a non-image file (e.g. a `.txt`), send, verify the agent gets the `resource` block + the "Attachments available as local files:" path summary and can read it.
+7. Reload the page; confirm the image thumbnail + file card re-display from persisted history.
+8. Negative: attempt an >10MB file → rejected (413 / size error); confirm a `../`-named file lands sanitized under `~/.xacpx/runtime/uploads/`.
+
+Record the results (pass/fail per step) in the commit message or PR description. If any step fails, fix before proceeding.
+
+- [ ] **Step 3: Document the feature**
+
+Add a section to `docs/relay-web-module.md` describing: attach button/paste/drag, ≤5 files, 10MB cap, image thumbnails vs file cards, persisted preview. Add to `docs/control-module.md`: the `control.upload` RPC (`UploadPayload`→`UploadResult`, non-chat-scoped, writes to `~/.xacpx/runtime/uploads/`, TTL 24h) and the `media` field on `control.prompt` (`PromptAttachmentRef[]` → ACP image/resource blocks; non-image files reach the agent as a daemon-absolute path the agent must have fs read access to).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/relay-web-module.md docs/control-module.md
+git commit -m "docs: relay-web message attachments + control.upload RPC"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §3 data flow → Tasks 1,3,4,5,6,7. §4 layer changes → all tasks map (relay-web 6/7, protocol 1, hub 5, connector 4, core 2/3, "already wired" verified — no transport task). §5 params (10MB/5/512px/TTL/uploads dir) → Global Constraints + Tasks 2,5,6. §6 types → Task 1. §7 security (sanitize, dual size check, non-chat-scoped, file caveat) → Tasks 2,5,4, Task 8 docs. §8 tests → each task's TDD steps + Task 8 e2e. §10 YAGNI honored (no chunking/transcoding/audio-video UI/server archive/other channels).
+- **Caveat carried:** non-image files reach the agent by absolute daemon path (resource block + text summary); agent needs fs read on the temp dir — documented in Task 8 step 3.
+- **Type consistency:** `PromptAttachmentRef` ({id, filePath, fileName, mimeType, kind, size, previewUrl?}) and `AttachmentMetadata` ({id, filename, mimeType, size, kind, previewUrl?}) are used consistently; the web→hub persist mapping (`fileName`→`filename`, drop `filePath`) is explicit in Task 5 step 6 and Task 6 step 6.

--- a/docs/superpowers/plans/2026-06-22-relay-web-message-attachments.md
+++ b/docs/superpowers/plans/2026-06-22-relay-web-message-attachments.md
@@ -18,7 +18,7 @@
 - **`control.upload` is NOT chat-scoped** — it must NOT be added to `CHAT_SCOPED_TYPES` (no `chatKey`/`senderId` injection), matching `control.fs.*`.
 - **relay-protocol builds with tsc + bun then asserts** — after changing it run `bun run build:relay-protocol` and confirm `assert:relay-protocol` passes (guards the "empty barrel" tree-shake bug).
 - **Core media path is already wired** — do NOT modify `src/transport/**`, `src/console-agent.ts`, `src/commands/**`, or `prompt-media.ts`. The only core change is in `src/control/`.
-- **Tests:** relay-web `bun run --cwd packages/relay-web test`; core/connector `npm test` (typecheck + unit). Verify relay-web tests file-by-file, never whole-dir `bun test`.
+- **Tests:** core/hub/connector unit tests use the **`bun:test`** API (`import { ... } from "bun:test"`) and live under `tests/unit/...` (NOT inside the package dirs). Run a single file with `bun test <path/to/file.test.ts>` (one file = one process, safe). Run the full isolated suite with `npm run test:unit` (`node ./scripts/run-tests.mjs tests/unit`, each file in its own process). NEVER run a whole directory via `bun test tests/unit/<dir>` — single-process state leak gives false failures. relay-web uses **vitest** (`bun run --cwd packages/relay-web test [-- <filter>]`); typecheck relay-web with `bun run --cwd packages/relay-web build` (runs `vue-tsc --noEmit` first).
 
 ---
 
@@ -165,7 +165,7 @@ Create `tests/unit/control/upload-store.test.ts`:
 import { mkdtemp, readFile, stat, utimes, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 import { UploadStore } from "../../../src/control/upload-store";
 
@@ -233,7 +233,7 @@ describe("UploadStore", () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `bun run --cwd . vitest run tests/unit/control/upload-store.test.ts` (or `npx vitest run tests/unit/control/upload-store.test.ts`)
+Run: `bun test tests/unit/control/upload-store.test.ts`
 Expected: FAIL with "Cannot find module '../../../src/control/upload-store'".
 
 - [ ] **Step 3: Implement UploadStore**
@@ -343,7 +343,7 @@ export class UploadStore {
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npx vitest run tests/unit/control/upload-store.test.ts`
+Run: `bun test tests/unit/control/upload-store.test.ts`
 Expected: PASS (5 tests).
 
 - [ ] **Step 5: Simplify the directory-creation (remove the dead mkdtemp probe)**
@@ -359,7 +359,7 @@ Replace the two-line probe with a single clear `mkdir`. In `src/control/upload-s
 
 - [ ] **Step 6: Re-run the test**
 
-Run: `npx vitest run tests/unit/control/upload-store.test.ts`
+Run: `bun test tests/unit/control/upload-store.test.ts`
 Expected: PASS (5 tests).
 
 - [ ] **Step 7: Commit**
@@ -392,20 +392,20 @@ Create `tests/unit/control/control-service-media.test.ts`. This test uses a fake
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, mock } from "bun:test";
 
 import { ControlService } from "../../../src/control/control-service";
 import { UploadStore } from "../../../src/control/upload-store";
 
 // Minimal deps stub — only what prompt()/uploadFile touch in this test.
-function buildService(chatSpy: ReturnType<typeof vi.fn>, uploadStore: UploadStore) {
+function buildService(chatSpy: ReturnType<typeof mock>, uploadStore: UploadStore) {
   const deps = {
     agent: { chat: chatSpy },
-    sessions: { resolve: vi.fn(async () => ({ alias: "main", agent: "claude", workspace: "ws", transportSession: "t", cwd: "/tmp" })) },
-    events: { emit: vi.fn() },
+    sessions: { resolve: mock(async () => ({ alias: "main", agent: "claude", workspace: "ws", transportSession: "t", cwd: "/tmp" })) },
+    events: { emit: mock(() => {}) },
     workspaces: { list: () => [] },
     uploadStore,
-    // ...any other deps your ControlService requires can be added as vi.fn() stubs
+    // ...any other deps your ControlService requires can be added as mock(() => {}) stubs
   } as unknown as ConstructorParameters<typeof ControlService>[0];
   return new ControlService(deps);
 }
@@ -414,7 +414,7 @@ describe("ControlService media", () => {
   it("uploadFile writes bytes and returns an absolute daemon path", async () => {
     const root = await mkdtemp(join(tmpdir(), "cs-upload-"));
     const store = new UploadStore({ rootDir: root });
-    const svc = buildService(vi.fn(), store);
+    const svc = buildService(mock(() => {}), store);
 
     const res = await svc.uploadFile({ filename: "shot.png", content: Buffer.from("PNG").toString("base64"), mimeType: "image/png" });
     expect(res.path.startsWith(root)).toBe(true);
@@ -423,7 +423,7 @@ describe("ControlService media", () => {
   });
 
   it("prompt() forwards media refs to agent.chat as ChannelMediaAttachment[]", async () => {
-    const chat = vi.fn(async () => ({ text: "ok" }));
+    const chat = mock(async () => ({ text: "ok" }));
     const root = await mkdtemp(join(tmpdir(), "cs-upload-"));
     const svc = buildService(chat, new UploadStore({ rootDir: root }));
 
@@ -437,7 +437,7 @@ describe("ControlService media", () => {
     });
 
     expect(chat).toHaveBeenCalledTimes(1);
-    const arg = chat.mock.calls[0][0];
+    const arg = (chat.mock.calls[0] as unknown[])[0] as { media: Array<Record<string, unknown> & { source: { channelId: string } }> };
     expect(Array.isArray(arg.media)).toBe(true);
     expect(arg.media[0]).toMatchObject({
       kind: "image",
@@ -450,11 +450,11 @@ describe("ControlService media", () => {
 });
 ```
 
-> If `ControlService`'s constructor requires additional non-optional deps, add them as `vi.fn()` stubs in `buildService` — do not change production types to satisfy the test. Inspect `ControlServiceDeps` (`src/control/control-service.ts` ~54-101) and stub each field minimally.
+> If `ControlService`'s constructor requires additional non-optional deps, add them as `mock(() => {})` stubs in `buildService` — do not change production types to satisfy the test. Inspect `ControlServiceDeps` (`src/control/control-service.ts` ~54-101) and stub each field minimally. NOTE: `prompt()` runs the full turn through `executeTurn`, which resolves a session and may need more deps stubbed than shown (e.g. session resolution, transport). If wiring a real turn proves heavy, narrow the second test to assert the media-mapping helper directly — but prefer the integration-style test above; add stubs as the compiler/runtime demands.
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npx vitest run tests/unit/control/control-service-media.test.ts`
+Run: `bun test tests/unit/control/control-service-media.test.ts`
 Expected: FAIL — `uploadFile` is not a function / `media` not forwarded.
 
 - [ ] **Step 3: Add `uploadStore` to ControlServiceDeps and the `uploadFile` method**
@@ -549,7 +549,7 @@ and add to the `agent.chat({...})` object literal:
 
 - [ ] **Step 5: Run the test to verify it passes**
 
-Run: `npx vitest run tests/unit/control/control-service-media.test.ts`
+Run: `bun test tests/unit/control/control-service-media.test.ts`
 Expected: PASS (2 tests).
 
 - [ ] **Step 6: Wire UploadStore into the runtime + startup cleanup**
@@ -584,7 +584,7 @@ git commit -m "feat(control): uploadFile RPC method + forward prompt media into 
 
 **Files:**
 - Modify: `packages/channel-relay/src/control-bridge.ts` (dispatch switch ~79-217)
-- Modify (test): add or extend the connector's control-bridge test if one exists (grep `dispatchControlRequest` under `packages/channel-relay/**/__tests__` or `tests`)
+- Modify (test): `tests/unit/packages/channel-relay/control-bridge.test.ts` (existing, `bun:test`; imports `createControlBridge` from `packages/channel-relay/src/control-bridge`)
 
 **Interfaces:**
 - Consumes: `MSG.upload`, `UploadPayload` from Task 1; `ControlService.uploadFile` from Task 3.
@@ -613,9 +613,9 @@ Add `UploadPayload` to the existing `@ganglion/xacpx-relay-protocol` import in t
 Run: `npx tsc --noEmit`
 Expected: PASS.
 
-- [ ] **Step 4: (If a control-bridge test exists) add a dispatch test**
+- [ ] **Step 4: Add a dispatch test for control.upload**
 
-If `packages/channel-relay` has a test that calls `dispatchControlRequest` with a fake `ControlService`, add a case asserting `MSG.upload` calls `control.uploadFile` and bad input returns an `errorPayload`. Mirror the existing `fsList` test exactly. If no such test exists, skip this step (coverage lives in Task 3 + Task 8 e2e).
+In `tests/unit/packages/channel-relay/control-bridge.test.ts` (`bun:test`), add a test that drives a `control.upload` request through the bridge with a fake `ControlService` whose `uploadFile` returns a known `UploadResult`, and assert the bridge returns it. Inspect the existing tests in that file first to see how requests are dispatched (e.g. how `fsList`/`prompt` cases are exercised and how the fake control service is constructed) and mirror that exact harness. Also assert that a missing-field payload returns an `errorPayload` (`{ error: "bad-request", ... }`). Run: `bun test tests/unit/packages/channel-relay/control-bridge.test.ts` — expect PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -632,7 +632,7 @@ git commit -m "feat(connector): dispatch control.upload to ControlService.upload
 - Modify: `packages/relay/src/db.ts` (messages table ~110-119; add `attachments` column + idempotent guard)
 - Modify: `packages/relay/src/stores/messages.ts` (`append` ~26-31; `listBySession` map ~60-69)
 - Modify: `packages/relay/src/http/app.ts` (RPC endpoint persist ~277-280; optional upload size guard ~262)
-- Modify (test): `packages/relay/**` message store test (grep `MessageStore` under relay tests)
+- Modify (test): `tests/unit/packages/relay/stores-messages.test.ts` (existing, `bun:test`, has a `seeded()` DB fixture); optionally `tests/unit/packages/relay/db.test.ts` for the column
 
 **Interfaces:**
 - Consumes: `AttachmentMetadata`, `PromptAttachmentRef`, `MSG.upload` from Task 1.
@@ -672,11 +672,11 @@ Then, at the END of `initSchema` (after the CREATE blocks), add an idempotent gu
 
 - [ ] **Step 2: Write the failing store test**
 
-In the existing relay message-store test file (or create `packages/relay/src/stores/messages.test.ts`), add:
+In `tests/unit/packages/relay/stores-messages.test.ts` (`bun:test`), add a test that mirrors the file's existing setup. Read the top of the file first to reuse its DB fixture (it has a `seeded()` helper that creates a driver via `createSqlDriver`/`initSchema` and inserts an account+instance so the `listBySession` JOIN matches). Then add:
 
 ```typescript
-it("persists and returns attachment metadata on inbound messages", () => {
-  // `db` and `store` setup mirrors the existing tests in this file.
+test("persists and returns attachment metadata on inbound messages", async () => {
+  const { store } = await seeded(); // use whatever the existing helper returns; match its account/instance ids below
   const atts = [{ id: "u-1", filename: "shot.png", mimeType: "image/png", size: 3, kind: "image" as const, previewUrl: "data:image/png;base64,AAAA" }];
   store.append("i1", "main", "in", "look", undefined, atts);
   const page = store.listBySession("acc1", "i1", "main");
@@ -684,11 +684,11 @@ it("persists and returns attachment metadata on inbound messages", () => {
 });
 ```
 
-> Reuse this file's existing `beforeEach` DB/account/instance fixture. If the fixture inserts an account+instance, do the same so the JOIN in `listBySession` matches.
+> Replace `"acc1"`/`"i1"` with the exact account/instance ids the existing `seeded()` fixture inserts (read the file). The point is: append with attachments → listBySession returns them.
 
 - [ ] **Step 3: Run the test to verify it fails**
 
-Run: `bun run --cwd packages/relay test -- messages` (match the package's test runner; if it uses `vitest run`, filter by file)
+Run: `bun test tests/unit/packages/relay/stores-messages.test.ts`
 Expected: FAIL — `append` ignores the 6th arg / `attachments` undefined on result.
 
 - [ ] **Step 4: Extend `append` and `listBySession`**
@@ -745,7 +745,7 @@ Add `attachments: string | null;` to `interface MessageRow`.
 
 - [ ] **Step 5: Run the store test to verify it passes**
 
-Run: `bun run --cwd packages/relay test -- messages`
+Run: `bun test tests/unit/packages/relay/stores-messages.test.ts`
 Expected: PASS.
 
 - [ ] **Step 6: Persist attachments from the prompt payload + re-validate size in the hub**
@@ -781,10 +781,16 @@ Then add a server-side base64 size guard for `control.upload` (defense in depth,
       }
 ```
 
-- [ ] **Step 7: Typecheck + run hub tests**
+- [ ] **Step 7: Typecheck + run hub tests (each file in its own process)**
 
-Run: `npx tsc --noEmit && bun run --cwd packages/relay test`
-Expected: PASS.
+Run each separately (multiple files in one `bun test` process can leak module state → false failures):
+```bash
+npx tsc --noEmit
+bun test tests/unit/packages/relay/stores-messages.test.ts
+bun test tests/unit/packages/relay/db.test.ts
+bun test tests/unit/packages/relay/http-app.test.ts
+```
+Expected: all PASS.
 
 - [ ] **Step 8: Commit**
 
@@ -1056,8 +1062,8 @@ Expected: PASS (3 tests).
 
 - [ ] **Step 8: Run the full relay-web suite + typecheck**
 
-Run: `bun run --cwd packages/relay-web test && npx vue-tsc --noEmit -p packages/relay-web/tsconfig.json`
-Expected: PASS (existing 150+ tests + new ones; types clean).
+Run: `bun run --cwd packages/relay-web test && bun run --cwd packages/relay-web build`
+Expected: PASS (existing 150+ tests + new ones; `build` runs `vue-tsc --noEmit` first, so types are checked, then vite builds).
 
 - [ ] **Step 9: Commit**
 
@@ -1298,8 +1304,8 @@ Chinese:
 
 - [ ] **Step 9: Run the full relay-web suite + typecheck**
 
-Run: `bun run --cwd packages/relay-web test && npx vue-tsc --noEmit -p packages/relay-web/tsconfig.json`
-Expected: PASS.
+Run: `bun run --cwd packages/relay-web test && bun run --cwd packages/relay-web build`
+Expected: PASS (`build` runs `vue-tsc --noEmit` first).
 
 - [ ] **Step 10: Commit**
 
@@ -1325,9 +1331,8 @@ Run:
 bun run build:relay-protocol
 bun run build
 npx tsc --noEmit
-npm test
-bun run --cwd packages/relay test
-bun run --cwd packages/relay-web test
+npm test                              # run-tests.mjs: core + hub + connector + protocol, each file isolated
+bun run --cwd packages/relay-web test # relay-web vitest (NOT covered by npm test)
 ```
 Expected: all PASS.
 

--- a/docs/superpowers/specs/2026-06-22-relay-web-message-attachments-design.md
+++ b/docs/superpowers/specs/2026-06-22-relay-web-message-attachments-design.md
@@ -1,0 +1,127 @@
+# relay-web 消息附件(图片为主,文件其次)— 设计
+
+- **日期**: 2026-06-22
+- **分支**: `feat/relay-web-message-attachments`
+- **状态**: 设计已批,待写实现 plan
+- **范围**: 让 relay-web 看板的消息输入框支持给一条消息附带图片或任意文件,经 relay hub → connector → core 喂给 acpx 会话;并在历史中持久化重显。
+
+## 1. 背景与约束
+
+- 现状:`PromptInput.vue` 只发纯文本;`chat.send(text)` → `control.prompt { sessionAlias, text }` → hub 注入 `chatKey/senderId/isOwner` → gateway → connector → `ControlService.prompt`(text-only)→ `agent.chat` → `transport.prompt` → acpx。
+- **关键复用**:core 的媒体链路**已全通**,无需改动:
+  - `transport/types.ts`: `PromptOptions.media?: PromptMediaInput`、`PromptMedia { type:"image"|"audio"|"video"|"file"; filePath; mimeType; fileName? }`。
+  - `transport/prompt-media.ts`: `createStructuredPromptFile(text, media)` 已把 media 转成 ACP content blocks —— 图片→`image`(base64)、文件→`resource`(`file://` URI)外加一段 `Attachments available as local files:` 文本摘要列出绝对路径;并写 `prompt.json` 给 acpx。
+  - `weixin/agent/interface.ts`: `ChatRequest.media` 已存在;`acpx-bridge-transport.ts` 已把 `options.media` 透传 acpx。
+- **架构约束**:文件最终要落在 **daemon 侧磁盘**给 acpx 读。relay hub 与 daemon 可能不同机,字节必须沿 hub→connector RPC 通道走到 daemon。
+- **同模式先例**:workspace-fs(`src/control/workspace-fs.ts` + `control.fs.*` RPC,经 `control.` 前缀白名单透传,hub 无需改),本特性沿用同一套穿透模式。
+
+## 2. 方案抉择(已定)
+
+- **附件类型**:图片为主、文件其次(两者都支持)。
+- **传输架构**:**HAPI 两段式上传**。独立 `control.upload` RPC 先把字节落到 daemon 临时盘并返回路径,发送时消息只带"路径 + 元数据",不再重传字节。
+  - 否决"内联 base64 进 prompt":虽改动面更小,但重发/历史会反复带字节、不利大文件、上传无独立进度。
+- **历史重显**:**持久化元数据 + 预览**。`MessageRecordDto` 加 `attachments`,刷新/重进会话后图片缩略图与文件卡照常显示。
+- **前端 UX**:对齐 HAPI —— picker 按钮 + 剪贴板粘贴 + 拖拽;pending 附件芯片(上传进度/删除);图片缩略图、文件用 mime 图标卡片。
+
+## 3. 端到端数据流
+
+```
+[上传阶段]
+relay-web 选/粘/拖文件
+  → 读 base64;若为图片,客户端降采样到 ≤512px 生成 previewUrl(data URL)
+  → api.rpc(instanceId, "control.upload", { filename, content(base64), mimeType })
+  → POST /api/instances/:id/rpc
+  → hub:control.* 白名单、非 chat-scoped,直接经 gateway 透传(hub 不改业务)
+  → connector control-bridge:新增 "control.upload" case
+  → ControlService.uploadFile():sanitize 文件名 → 写 ~/.xacpx/runtime/uploads/<rand>/<safe-name>
+  → 返回 UploadResult { id, path, filename, mimeType, size }
+
+[发送阶段]
+relay-web 发送(附 pending 附件)
+  → control.prompt { sessionAlias, text, media:[{ id, filePath:path, mimeType, fileName, kind }] }
+  → hub 注入 chatKey/senderId/isOwner(原样),持久化入站消息时一并存 attachments
+  → connector → ControlService.prompt():media 透传
+  → agent.chat({ ..., media }) → transport.prompt(session, text, { media })
+  → prompt-media.createStructuredPromptFile:图片→image block / 文件→resource block + 文本路径摘要
+  → acpx
+```
+
+## 4. 各层改动清单
+
+| 层 | 改动 |
+|---|---|
+| **relay-web** | 附件 UI(`PromptInput.vue`:picker 按钮 + paste + drag;`composer` store 持 pending 附件态与上传进度);`api/client.ts` 加 upload 调用;新 `MessageAttachments.vue` + `MessageList.vue` 渲染缩略图/文件卡;客户端图片降采样工具 |
+| **relay-protocol** | 新增 `control.upload` 的 payload(`{ filename, content(base64), mimeType }`)与 result(`{ id, path, filename, mimeType, size }`)类型;`PromptPayload` 加 `media?: PromptAttachmentRef[]`;`MessageRecordDto` 加 `attachments?: AttachmentMetadata[]` |
+| **relay (hub)** | upload RPC 走现有 `control.` 前缀白名单透传(**基本不改**,确认非 chat-scoped 分支已覆盖 `control.upload`);消息持久化时落 attachments;base64 大小二次校验 |
+| **connector** | `control-bridge` 加 `control.upload` case → `ControlService.uploadFile` |
+| **core `src/control`** | `ControlService.uploadFile()`(写临时文件 + sanitize + 大小校验 + 返回路径);`ControlPromptInput` 加 `media`;`prompt()` 把 media 透传 `agent.chat`;临时目录 TTL 清扫(启动 + 周期) |
+| **core(已就绪,零改)** | `agent.chat` / `transport.prompt` / `prompt-media.ts` / acpx |
+
+## 5. 参数与边界(默认值,实现时可调)
+
+- **单文件上限**:10 MB(base64 over RPC)。
+- **单条消息附件数**:≤ 5。
+- **持久化预览**:仅图片;客户端**降采样到 ≤512px** 再存 `previewUrl`,避免把大 data URL 灌进 SQLite(比 HAPI 直接存 ≤5MB data URL 更省)。原图仍按上限上传给 agent。
+- **临时文件生命周期**:`~/.xacpx/runtime/uploads/<rand>/`;**daemon 启动清扫 + TTL 24h 周期清扫**;不绑定 session-end(会话长寿)。历史重显依赖持久化的 `previewUrl`,不依赖临时文件存活。
+- **图片 vs 文件 渲染**:图片→缩略图(用 previewUrl);文件→mime 图标 + 文件名 + 大小卡片。
+
+## 6. 数据类型(草案)
+
+```ts
+// relay-protocol
+interface UploadPayload { filename: string; content: string /*base64*/; mimeType: string }
+interface UploadResult  { id: string; path: string; filename: string; mimeType: string; size: number }
+
+// 发送时消息携带的轻量引用(不含字节)
+interface PromptAttachmentRef {
+  id: string;
+  filePath: string;      // daemon 侧绝对路径(upload 返回)
+  fileName: string;
+  mimeType: string;
+  kind: "image" | "file";
+}
+
+// 历史持久化与重显
+interface AttachmentMetadata {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  kind: "image" | "file";
+  previewUrl?: string;   // 仅图片,降采样 data URL
+}
+```
+
+`PromptAttachmentRef → PromptMedia` 映射:`kind:"image"→type:"image"`,其余 `→type:"file"`(交给 `prompt-media` 走 resource block)。
+
+## 7. 安全
+
+- 文件名 sanitize:去 `..` 与路径分隔符,落盘到随机化临时目录(容器化),拒绝路径逃逸。
+- base64 大小在 **hub 与 core 两侧都校验**(防客户端绕过)。
+- upload RPC 沿 `control.` 白名单、非 chat-scoped(不注入 chatKey/senderId),与 workspace-fs 一致。
+- **caveat(非图片文件)**:文件作为 `resource` block + 文本路径摘要传给 agent,agent 需对 daemon 上该绝对路径有 fs 读权限。临时目录在 workspace 外,Claude Code/codex 等可读绝对路径的 agent 能直接打开;若某 agent 受限于 workspace,实现时考虑把上传目录纳入其可读范围或落到 workspace 下的 `.xacpx-uploads/`。
+
+## 8. 测试策略
+
+- **core 单测**:`uploadFile`(写盘 / sanitize / 大小校验 / 路径逃逸拒绝)、TTL 清扫、`prompt()` media 透传到 `agent.chat`。
+- **relay-protocol**:新增类型编译 + 序列化 round-trip。
+- **relay 持久化**:`MessageRecordDto.attachments` 存取。
+- **relay-web vitest**:`composer` store 加/删/进度/上限;`MessageAttachments.vue` 图片 vs 文件渲染分支;图片降采样工具。
+- **端到端**:沿用 HAPI-borrow / workspace-fs 的真实 relay 联调(console 从分支跑 `node dist/cli.js run` 连 hub gateway,刷新连接器安装副本、清嵌套协议副本),验证上传→发送→agent 收到图片 block + 文件路径;含一类大小拒绝、一类路径逃逸拒绝。
+
+## 9. 实现顺序(供写 plan 参考)
+
+1. relay-protocol 类型(upload payload/result、PromptPayload.media、MessageRecordDto.attachments)。
+2. core:`ControlService.uploadFile` + 临时目录/清扫 + `prompt()` media 透传 + 单测。
+3. connector control-bridge `control.upload` case。
+4. relay hub:确认 `control.upload` 透传白名单 + 持久化 attachments + 大小校验。
+5. relay-web:upload 客户端 + composer 附件态 + 上传 UI + 渲染 + 降采样 + vitest。
+6. 真实 relay 端到端联调与收尾。
+
+## 10. 明确不做(YAGNI)
+
+- 大文件分片/断点续传(>10MB 直接拒)。
+- 服务端图片转码/缩略图生成(预览由客户端降采样)。
+- 音频/视频专门 UI(core 类型支持,但 UI 不做特殊处理)。
+- 附件的服务端长期存档(临时文件 TTL 清,历史只留元数据 + 小预览)。
+- 微信等其它 channel 的附件接收/发送(本特性仅 relay-web → agent 方向)。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "acpx": "^0.9.0",
+        "acpx": "^0.11.0",
         "node-pty": "^1.1.0",
         "proper-lockfile": "^4.1.2",
         "protobufjs": "^7.5.6",
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.22.1.tgz",
-      "integrity": "sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.25.1.tgz",
+      "integrity": "sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -4108,15 +4108,15 @@
       }
     },
     "node_modules/acpx": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/acpx/-/acpx-0.9.0.tgz",
-      "integrity": "sha512-y12XZ0hqtnDXkbap12YFjNCSePdoU2+9YPF+dAy8G/duytOMJhOnnysT+XWmX16NvMFQuRnW77B3rljunKPtCw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/acpx/-/acpx-0.11.0.tgz",
+      "integrity": "sha512-l42LJFmd6kvbr1UytvwWmr5Mdy/v9l3FM6Necs01PWbjUIkxjCdxg97duqoRfRqxtDAfnNPb1IlgIf2ZgMZQqA==",
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.22.1",
-        "commander": "^14.0.3",
+        "@agentclientprotocol/sdk": "^0.25.0",
+        "commander": "^15.0.0",
         "skillflag": "^0.1.4",
-        "tsx": "^4.22.0",
+        "tsx": "^4.22.4",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -4925,10 +4925,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/common-tags": {
@@ -9758,9 +9760,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/tsx": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.2.tgz",
-      "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11662,7 +11664,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -11704,7 +11706,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.5.2",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -11721,7 +11723,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT"
     },
     "packages/relay-web": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "acpx": "^0.9.0",
+    "acpx": "^0.11.0",
     "node-pty": "^1.1.0",
     "proper-lockfile": "^4.1.2",
     "protobufjs": "^7.5.6",

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -27,6 +27,7 @@ import {
   type SessionsRemovePayload,
   type SessionsArchivePayload,
   type SessionsUnarchivePayload,
+  type UploadPayload,
   type WorkspacesCreatePayload,
   type WorkspacesRemovePayload,
 } from "@ganglion/xacpx-relay-protocol";
@@ -210,6 +211,13 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
       if (!input.sessionAlias || !input.modelId) return errorPayload("bad-request", "sessionAlias and modelId are required");
       await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId);
       return { ok: true };
+    }
+    case MSG.upload: {
+      const input = payload as UploadPayload;
+      if (!input.filename || !input.content || !input.mimeType) {
+        return errorPayload("bad-request", "filename, content and mimeType are required");
+      }
+      return await control.uploadFile(input);
     }
     default:
       return errorPayload("unknown-type", `unsupported rpc type: ${envelope.type}`);

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -145,6 +145,12 @@ export interface UsageCostDto {
   amount?: number;
   currency?: string;
 }
+/** An agent-advertised slash command (mirror of src AgentCommand). */
+export interface AgentCommandDto {
+  name: string;
+  description?: string;
+  hasInput?: boolean;
+}
 /** Per-turn token breakdown (mirror of src UsageBreakdown). All fields optional. */
 export interface UsageBreakdownDto {
   inputTokens?: number;
@@ -167,6 +173,8 @@ export type ControlEventDto =
   // Context-usage meter: `used` tokens in context, `size` total context window. Replace-latest.
   // `cost`/`breakdown` are optional extras (acpx ≥0.11.0); absent for adapters that don't report them.
   | { type: "turn-usage"; chatKey: string; sessionAlias: string; used: number; size: number; cost?: UsageCostDto; breakdown?: UsageBreakdownDto }
+  // Agent-advertised slash commands (e.g. /compact). Session-scoped, replace-latest.
+  | { type: "agent-commands"; chatKey: string; sessionAlias: string; commands: AgentCommandDto[] }
   | { type: "turn-finished"; chatKey: string; sessionAlias: string; ok: boolean; errorMessage?: string; cancelled?: boolean }
   | { type: "sessions-changed" }
   | { type: "scheduled-changed"; chatKey: string }

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -140,6 +140,21 @@ export interface PlanEntryDto {
   priority?: "high" | "medium" | "low";
 }
 
+/** Cumulative session cost the agent reported (mirror of src UsageCost). Both optional. */
+export interface UsageCostDto {
+  amount?: number;
+  currency?: string;
+}
+/** Per-turn token breakdown (mirror of src UsageBreakdown). All fields optional. */
+export interface UsageBreakdownDto {
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedReadTokens?: number;
+  cachedWriteTokens?: number;
+  thoughtTokens?: number;
+  totalTokens?: number;
+}
+
 /** Wire mirror of src/control ControlEvent (tool-event carries the NORMALIZED step). */
 export type ControlEventDto =
   | { type: "turn-output"; chatKey: string; sessionAlias: string; chunk: string }
@@ -150,7 +165,8 @@ export type ControlEventDto =
   | { type: "turn-thought"; chatKey: string; sessionAlias: string; chunk: string }
   | { type: "plan"; chatKey: string; sessionAlias: string; entries: PlanEntryDto[] }
   // Context-usage meter: `used` tokens in context, `size` total context window. Replace-latest.
-  | { type: "turn-usage"; chatKey: string; sessionAlias: string; used: number; size: number }
+  // `cost`/`breakdown` are optional extras (acpx ≥0.11.0); absent for adapters that don't report them.
+  | { type: "turn-usage"; chatKey: string; sessionAlias: string; used: number; size: number; cost?: UsageCostDto; breakdown?: UsageBreakdownDto }
   | { type: "turn-finished"; chatKey: string; sessionAlias: string; ok: boolean; errorMessage?: string; cancelled?: boolean }
   | { type: "sessions-changed" }
   | { type: "scheduled-changed"; chatKey: string }

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -34,6 +34,7 @@ export const MSG = {
   fsRead: "control.fs.read",
   fsDiff: "control.fs.diff",
   fsSearch: "control.fs.search",
+  upload: "control.upload",
   sessionModelGet: "control.session.model.get",
   sessionModelSet: "control.session.model.set",
 } as const;
@@ -173,12 +174,42 @@ export interface WorkspacesRemovePayload {
 export interface OkResult {
   ok: true;
 }
+export interface PromptAttachmentRef {
+  /** Stable id from the upload step; used as a message id for the channel media source. */
+  id: string;
+  /** Absolute path on the daemon host (returned by control.upload). */
+  filePath: string;
+  fileName: string;
+  mimeType: string;
+  kind: "image" | "file";
+  size: number;
+  /** Downscaled data URL for images; carried so the hub can persist a preview. Omitted for files. */
+  previewUrl?: string;
+}
+
+export interface UploadPayload {
+  filename: string;
+  /** base64-encoded file bytes (no data-URL prefix). */
+  content: string;
+  mimeType: string;
+}
+
+export interface UploadResult {
+  id: string;
+  /** Absolute path on the daemon host where the bytes were written. */
+  path: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+
 export interface PromptPayload {
   chatKey: string;
   sessionAlias: string;
   text: string;
   senderId: string;
   isOwner?: boolean;
+  media?: PromptAttachmentRef[];
 }
 export interface PromptResult {
   ok: boolean;

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -68,6 +68,7 @@ const CONTROL_EVENT_TYPES = new Set([
   "turn-thought",
   "plan",
   "turn-usage",
+  "agent-commands",
   "turn-finished",
   "sessions-changed",
   "scheduled-changed",
@@ -139,6 +140,8 @@ function validControlEvent(e: unknown): boolean {
     return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.entries);
   if (c.type === "turn-usage")
     return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.used === "number" && typeof c.size === "number";
+  if (c.type === "agent-commands")
+    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.commands);
   if (c.type === "tool-event")
     return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && validToolStep(c.step);
   return true; // sessions-changed / orchestration-changed carry no extra required fields

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -7,6 +7,16 @@ export const WEB_EVENT_TYPE = "web.event";
 
 export type MessageDirection = "in" | "out";
 
+export interface AttachmentMetadata {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  kind: "image" | "file";
+  /** Downscaled data URL for images; omitted for files. */
+  previewUrl?: string;
+}
+
 /** A cached chat line echoed to the web client. */
 export interface MessageRecordDto {
   /** Monotonic row id from the hub store. Present on persisted rows (used as the
@@ -22,6 +32,7 @@ export interface MessageRecordDto {
    *  jump survive a history reload). `parts` is the ordered transcript; `toolSteps`/
    *  `reasoning` are a flat fallback for older rows that predate `parts`. */
   structured?: { toolSteps?: ToolStepDto[]; reasoning?: string; parts?: TurnPartDto[]; scheduled?: ScheduledOriginDto };
+  attachments?: AttachmentMetadata[];
 }
 
 /** A snapshot of a turn still in flight on an instance, handed to a (re)connecting

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -141,7 +141,9 @@ function validControlEvent(e: unknown): boolean {
   if (c.type === "turn-usage")
     return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.used === "number" && typeof c.size === "number";
   if (c.type === "agent-commands")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.commands);
+    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string"
+      && Array.isArray(c.commands)
+      && c.commands.every((x) => x !== null && typeof x === "object" && typeof (x as { name?: unknown }).name === "string");
   if (c.type === "tool-event")
     return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && validToolStep(c.step);
   return true; // sessions-changed / orchestration-changed carry no extra required fields

--- a/packages/relay-web/src/__tests__/attachments.test.ts
+++ b/packages/relay-web/src/__tests__/attachments.test.ts
@@ -41,7 +41,7 @@ test("addFiles rejects beyond the 5-attachment cap", async () => {
   expect(composer.pending).toHaveLength(5);
 });
 
-test("chat.send forwards ready attachments as media refs and clears them", async () => {
+test("chat.send forwards ready attachments as media refs", async () => {
   rpc.mockResolvedValue({ ok: true });
   const chat = useChatStore();
   chat.select("i1", "main");

--- a/packages/relay-web/src/__tests__/attachments.test.ts
+++ b/packages/relay-web/src/__tests__/attachments.test.ts
@@ -41,6 +41,26 @@ test("addFiles rejects beyond the 5-attachment cap", async () => {
   expect(composer.pending).toHaveLength(5);
 });
 
+test("sets rejection.reason=too-many when 6 files are added", async () => {
+  upload.mockResolvedValue({ id: "u", path: "/p", filename: "f", mimeType: "text/plain", size: 1 });
+  const composer = useComposerStore();
+  composer.bindInstance("i1");
+  const mk = (n: string) => new File([new Uint8Array([1])], n, { type: "text/plain" });
+  await composer.addFiles([mk("1"), mk("2"), mk("3"), mk("4"), mk("5"), mk("6")]);
+  expect(composer.rejection?.reason).toBe("too-many");
+  expect(composer.rejection?.filename).toBe("6");
+});
+
+test("sets rejection.reason=too-large when a file exceeds 10MB", async () => {
+  const composer = useComposerStore();
+  composer.bindInstance("i1");
+  const file = new File([new Uint8Array(1)], "big.png", { type: "image/png" });
+  Object.defineProperty(file, "size", { value: 11 * 1024 * 1024 });
+  await composer.addFiles([file]);
+  expect(composer.rejection?.reason).toBe("too-large");
+  expect(composer.rejection?.filename).toBe("big.png");
+});
+
 test("chat.send forwards ready attachments as media refs", async () => {
   rpc.mockResolvedValue({ ok: true });
   const chat = useChatStore();

--- a/packages/relay-web/src/__tests__/attachments.test.ts
+++ b/packages/relay-web/src/__tests__/attachments.test.ts
@@ -1,0 +1,53 @@
+import { setActivePinia, createPinia } from "pinia";
+import { beforeEach, expect, test, vi } from "vitest";
+
+const rpc = vi.fn();
+const upload = vi.fn();
+vi.mock("../api/client", () => ({
+  ApiError: class ApiError extends Error {},
+  api: {
+    rpc: (...a: unknown[]) => rpc(...a),
+    upload: (...a: unknown[]) => upload(...a),
+  },
+}));
+
+import { useComposerStore } from "../stores/composer";
+import { useChatStore } from "../stores/chat";
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  rpc.mockReset();
+  upload.mockReset();
+});
+
+test("addFiles uploads each file and tracks ready state with daemon path", async () => {
+  upload.mockResolvedValue({ id: "u-1", path: "/home/.xacpx/runtime/uploads/u-1/a.txt", filename: "a.txt", mimeType: "text/plain", size: 3 });
+  const composer = useComposerStore();
+  composer.bindInstance("i1");
+  const file = new File([new Uint8Array([97, 98, 99])], "a.txt", { type: "text/plain" });
+  await composer.addFiles([file]);
+  expect(upload).toHaveBeenCalledTimes(1);
+  expect(composer.pending).toHaveLength(1);
+  expect(composer.pending[0]).toMatchObject({ filename: "a.txt", kind: "file", status: "ready", filePath: "/home/.xacpx/runtime/uploads/u-1/a.txt" });
+});
+
+test("addFiles rejects beyond the 5-attachment cap", async () => {
+  upload.mockResolvedValue({ id: "u", path: "/p", filename: "f", mimeType: "text/plain", size: 1 });
+  const composer = useComposerStore();
+  composer.bindInstance("i1");
+  const mk = (n: string) => new File([new Uint8Array([1])], n, { type: "text/plain" });
+  await composer.addFiles([mk("1"), mk("2"), mk("3"), mk("4"), mk("5")]);
+  await composer.addFiles([mk("6")]);
+  expect(composer.pending).toHaveLength(5);
+});
+
+test("chat.send forwards ready attachments as media refs and clears them", async () => {
+  rpc.mockResolvedValue({ ok: true });
+  const chat = useChatStore();
+  chat.select("i1", "main");
+  await chat.send("hi", [{ id: "u-1", filePath: "/p/a.png", fileName: "a.png", mimeType: "image/png", kind: "image", size: 3, previewUrl: "data:image/png;base64,AA" }]);
+  const [, type, payload] = rpc.mock.calls[0];
+  expect(type).toBe("control.prompt");
+  expect((payload as { media?: unknown[] }).media).toHaveLength(1);
+  expect(chat.messages.at(-1)).toMatchObject({ direction: "in", text: "hi" });
+});

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -74,6 +74,19 @@ test("turn-usage updates sessionUsage (REPLACE) and survives turn-finished", () 
   expect(store.sessionUsage).toEqual({ used: 34612, size: 1000000 });
 });
 
+test("turn-usage retains cost and breakdown for the selected session", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: {
+    type: "turn-usage", chatKey: "relay:a1", sessionAlias: "backend", used: 1000, size: 200000,
+    cost: { amount: 0.42, currency: "USD" }, breakdown: { inputTokens: 800, totalTokens: 920 },
+  } } as never);
+  expect(store.sessionUsage).toEqual({
+    used: 1000, size: 200000,
+    cost: { amount: 0.42, currency: "USD" }, breakdown: { inputTokens: 800, totalTokens: 920 },
+  });
+});
+
 test("turn-usage for an unselected session does not leak into sessionUsage", () => {
   const store = useChatStore();
   store.select("i1", "backend");

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -94,6 +94,22 @@ test("turn-usage for an unselected session does not leak into sessionUsage", () 
   expect(store.sessionUsage).toBeNull();
 });
 
+test("agent-commands populate sessionCommands for the selected session", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: {
+    type: "agent-commands", chatKey: "relay:a1", sessionAlias: "backend",
+    commands: [{ name: "compact", description: "Compact" }, { name: "run", hasInput: true }],
+  } } as never);
+  expect(store.sessionCommands).toEqual([{ name: "compact", description: "Compact" }, { name: "run", hasInput: true }]);
+});
+
+test("sessionCommands is empty for a session that advertised none", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  expect(store.sessionCommands).toEqual([]);
+});
+
 test("requestScrollToScheduled bumps a nonce-keyed scroll request", () => {
   const store = useChatStore();
   expect(store.scrollRequest).toBeNull();

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -379,7 +379,7 @@ test("PromptInput emits send with trimmed text and clears", async () => {
   const wrapper = mount(PromptInput);
   await wrapper.find("textarea").setValue("  do it  ");
   await wrapper.find("form").trigger("submit.prevent");
-  expect(wrapper.emitted("send")?.[0]).toEqual(["do it"]);
+  expect(wrapper.emitted("send")?.[0]).toEqual(["do it", []]);
   expect((wrapper.find("textarea").element as HTMLTextAreaElement).value).toBe("");
 });
 

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -12,6 +12,7 @@ import ChatPane from "../components/ChatPane.vue";
 import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
 import { useFilesStore } from "../stores/files";
+import { useComposerStore } from "../stores/composer";
 
 beforeEach(() => setActivePinia(createPinia()));
 afterEach(() => { i18n.global.locale.value = "en"; });
@@ -86,6 +87,28 @@ it("hides the HUD when no turn is active", () => {
   chat.select("i1", "backend");
   const w = mount(ChatPane);
   expect(w.find('[data-test="turn-hud"]').exists()).toBe(false);
+});
+
+it("clears staged attachments when switching session so they don't leak to the next target", async () => {
+  seedInstance();
+  const instances = useInstancesStore();
+  instances.instances.push({
+    id: "i1", name: "prod-box", online: true, lastSeenAt: null,
+    sessions: [{ alias: "frontend", agent: "codex", workspace: "gaia" }],
+    agents: [], workspaces: [], agentCatalog: [],
+  } as never);
+  const chat = useChatStore();
+  const composer = useComposerStore();
+  chat.select("i1", "backend");
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  // Stage a chip on the current session.
+  composer.pending.push({ id: "p1", filename: "a.png", mimeType: "image/png", size: 3, kind: "image", status: "ready" });
+  expect(composer.pending).toHaveLength(1);
+  // Switch to a different session on the same instance → staged chips drop.
+  chat.select("i1", "frontend");
+  await w.vm.$nextTick();
+  expect(composer.pending).toHaveLength(0);
 });
 
 it("cycles the working verb every ~10s while the turn runs", async () => {

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -88,7 +88,7 @@ it("hides the HUD when no turn is active", () => {
   expect(w.find('[data-test="turn-hud"]').exists()).toBe(false);
 });
 
-it("cycles the working verb every ~4s while the turn runs", async () => {
+it("cycles the working verb every ~10s while the turn runs", async () => {
   vi.useFakeTimers();
   vi.setSystemTime(0);
   const chat = useChatStore();
@@ -97,7 +97,10 @@ it("cycles the working verb every ~4s while the turn runs", async () => {
   const w = mount(ChatPane);
   await w.vm.$nextTick();
   expect(w.find('[data-test="turn-hud"]').text()).toContain("Working"); // bucket 0
-  vi.advanceTimersByTime(5000); // 5s → bucket 1, also drives the 1Hz clock
+  vi.advanceTimersByTime(5000); // 5s → still bucket 0 on the calm ~10s cadence
+  await w.vm.$nextTick();
+  expect(w.find('[data-test="turn-hud"]').text()).toContain("Working");
+  vi.advanceTimersByTime(6000); // 11s total → bucket 1, also drives the 1Hz clock
   await w.vm.$nextTick();
   const t = w.find('[data-test="turn-hud"]').text();
   expect(t).not.toContain("Working");

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -80,6 +80,25 @@ describe("InstanceTree session management", () => {
     w.unmount();
   });
 
+  // Regression: the ⋯ dropdown must render OUTSIDE the swipe clip layer, else the
+  // swipe's `overflow-hidden` clips it to the row's height (the menu appeared trapped
+  // inside the row). Assert the open menu is a child of the row but NOT inside the
+  // (overflow-hidden) swipe track.
+  it("renders the ⋯ dropdown outside the swipe clip layer (not clipped to the row)", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    const w = mount(InstanceTree, { attachTo: document.body, global: { stubs: { NewSessionDialog: true } } });
+    await w.find('[data-test="session-menu"]').trigger("mousedown");
+    await w.find('[data-test="session-menu"]').trigger("click");
+    const menu = w.find('[data-test="delete-session"]').element;
+    expect(menu).toBeTruthy();
+    // Inside the row…
+    expect(menu.closest('[data-test="session-row"]')).not.toBeNull();
+    // …but NOT inside the overflow-hidden swipe track (which would clip it).
+    expect(menu.closest('[data-test="swipe-track"]')).toBeNull();
+    w.unmount();
+  });
+
   // Regression: the row must wire the swipe composable to real pointer events. A
   // right→left swipe REVEALS the action blocks (it must NOT execute anything on its
   // own); tapping the revealed archive block then archives. Catches the

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -81,32 +81,40 @@ describe("InstanceTree session management", () => {
   });
 
   // Regression: the row must wire the swipe composable to real pointer events. A
-  // left swipe past the threshold archives. Catches the `onPointerdown`-vs-`pointerdown`
-  // key bug that made `v-on="handlers"` bind dead events.
-  it("binds swipe handlers to real pointer events (left swipe archives)", async () => {
+  // right→left swipe REVEALS the action blocks (it must NOT execute anything on its
+  // own); tapping the revealed archive block then archives. Catches the
+  // `onPointerdown`-vs-`pointerdown` key bug that made `v-on="handlers"` bind dead events.
+  it("right→left swipe reveals actions; tapping archive archives (no execute on swipe)", async () => {
     const store = useInstancesStore();
     store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
     const archive = vi.spyOn(store, "archiveSession").mockResolvedValue();
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
-    const row = w.find('[data-test="session-row"]');
-    await row.trigger("pointerdown", { clientX: 200, clientY: 0 });
-    await row.trigger("pointermove", { clientX: 120, clientY: 0 });
-    await row.trigger("pointerup", { clientX: 120, clientY: 0 });
+    const track = w.find('[data-test="swipe-track"]');
+    await track.trigger("pointerdown", { clientX: 200, clientY: 0 });
+    await track.trigger("pointermove", { clientX: 120, clientY: 0 });
+    await track.trigger("pointerup", { clientX: 120, clientY: 0 });
+    await flushPromises();
+    // The swipe alone reveals — it does not archive.
+    expect(archive).not.toHaveBeenCalled();
+    await w.find('[data-test="swipe-archive"]').trigger("click");
     await flushPromises();
     expect(archive).toHaveBeenCalledWith("i1", "backend");
   });
 
-  // Symmetric to the left-swipe case: a right swipe past the threshold opens the
-  // destructive delete confirm (it must NOT delete until confirmed).
-  it("binds swipe handlers to real pointer events (right swipe asks to delete)", async () => {
+  // The revealed delete block opens the destructive confirm only on tap — never on the
+  // swipe itself, and never deletes until confirmed.
+  it("tapping the revealed delete block asks to delete (not on swipe)", async () => {
     const store = useInstancesStore();
     store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
     const remove = vi.spyOn(store, "removeSession").mockResolvedValue();
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
-    const row = w.find('[data-test="session-row"]');
-    await row.trigger("pointerdown", { clientX: 100, clientY: 0 });
-    await row.trigger("pointermove", { clientX: 200, clientY: 0 });
-    await row.trigger("pointerup", { clientX: 200, clientY: 0 });
+    const track = w.find('[data-test="swipe-track"]');
+    await track.trigger("pointerdown", { clientX: 200, clientY: 0 });
+    await track.trigger("pointermove", { clientX: 120, clientY: 0 });
+    await track.trigger("pointerup", { clientX: 120, clientY: 0 });
+    await flushPromises();
+    expect(useConfirmState().value).toBeFalsy(); // swipe alone opens nothing
+    await w.find('[data-test="swipe-delete"]').trigger("click");
     await flushPromises();
     expect(useConfirmState().value?.title).toBe("Delete session?");
     expect(remove).not.toHaveBeenCalled();

--- a/packages/relay-web/src/__tests__/manageinstancedialog-rename.test.ts
+++ b/packages/relay-web/src/__tests__/manageinstancedialog-rename.test.ts
@@ -62,6 +62,23 @@ test("renders the Save affordance in Chinese when locale is zh-CN", async () => 
   expect(w.get('[data-test="rename-save"]').text()).toBe("保存");
 });
 
+test("tabs switch between the general and agents panes", async () => {
+  const { w } = mountDialog();
+  await flushPromises();
+  expect(w.find('[data-test="rename-name"]').exists()).toBe(true); // general is default
+  await w.get('[data-test="tab-agents"]').trigger("click");
+  expect(w.find('[data-test="rename-name"]').exists()).toBe(false); // general pane unmounted
+  await w.get('[data-test="tab-general"]').trigger("click");
+  expect(w.find('[data-test="rename-name"]').exists()).toBe(true);
+});
+
+test("Escape closes the dialog", async () => {
+  const { w } = mountDialog();
+  await flushPromises();
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+  expect(w.emitted("close")).toBeTruthy();
+});
+
 test("shows the instance version row from the store's coreVersion", async () => {
   const store = useInstancesStore();
   store.instances = [{

--- a/packages/relay-web/src/__tests__/manageinstancedialog-rename.test.ts
+++ b/packages/relay-web/src/__tests__/manageinstancedialog-rename.test.ts
@@ -72,6 +72,26 @@ test("tabs switch between the general and agents panes", async () => {
   expect(w.find('[data-test="rename-name"]').exists()).toBe(true);
 });
 
+test("the active pane is a labelled tabpanel and arrow keys move tab selection", async () => {
+  const { w } = mountDialog();
+  await flushPromises();
+  // The default (general) pane is a tabpanel labelled by its tab.
+  const panel = w.get("#tabpanel-general");
+  expect(panel.attributes("role")).toBe("tabpanel");
+  expect(panel.attributes("aria-labelledby")).toBe("tab-general");
+  expect(w.get('[data-test="tab-general"]').attributes("aria-controls")).toBe("tabpanel-general");
+  // Roving tabindex: only the selected tab is in the tab order.
+  expect(w.get('[data-test="tab-general"]').attributes("tabindex")).toBe("0");
+  expect(w.get('[data-test="tab-workspaces"]').attributes("tabindex")).toBe("-1");
+  // ArrowRight on the tablist advances selection to the next tab.
+  await w.get('[role="tablist"]').trigger("keydown", { key: "ArrowRight" });
+  expect(w.get('[data-test="tab-workspaces"]').attributes("aria-selected")).toBe("true");
+  expect(w.find('[data-test="rename-name"]').exists()).toBe(false); // general pane unmounted
+  // ArrowLeft wraps back to general.
+  await w.get('[role="tablist"]').trigger("keydown", { key: "ArrowLeft" });
+  expect(w.get('[data-test="tab-general"]').attributes("aria-selected")).toBe("true");
+});
+
 test("Escape closes the dialog", async () => {
   const { w } = mountDialog();
   await flushPromises();

--- a/packages/relay-web/src/__tests__/managers.test.ts
+++ b/packages/relay-web/src/__tests__/managers.test.ts
@@ -26,6 +26,7 @@ test("WorkspacesManager creates a workspace", async () => {
   const store = useInstancesStore(); seed(store);
   const createWorkspace = vi.spyOn(store, "createWorkspace").mockResolvedValue(undefined as never);
   const w = mount(WorkspacesManager, { props: { instanceId: "i1" } });
+  await w.get('[data-test="wm-add-toggle"]').trigger("click");
   await w.get('[data-test="wm-name"]').setValue("frontend");
   await w.get('[data-test="wm-path"]').setValue("/f");
   await w.get('[data-test="wm-create"]').trigger("click");
@@ -47,6 +48,7 @@ test("WorkspacesManager resets its inputs after a successful create", async () =
   const store = useInstancesStore(); seed(store);
   vi.spyOn(store, "createWorkspace").mockResolvedValue(undefined as never);
   const w = mount(WorkspacesManager, { props: { instanceId: "i1" } });
+  await w.get('[data-test="wm-add-toggle"]').trigger("click");
   await w.get('[data-test="wm-name"]').setValue("frontend");
   await w.get('[data-test="wm-path"]').setValue("/f");
   await w.get('[data-test="wm-desc"]').setValue("the frontend");
@@ -61,6 +63,7 @@ test("AgentsManager adds an agent from the catalog driver picker", async () => {
   const store = useInstancesStore(); seed(store);
   const createAgent = vi.spyOn(store, "createAgent").mockResolvedValue(undefined as never);
   const w = mount(AgentsManager, { props: { instanceId: "i1" } });
+  await w.get('[data-test="am-add-toggle"]').trigger("click");
   await w.get('[data-test="am-driver"]').setValue("gemini");
   await w.get('[data-test="am-add"]').trigger("click");
   expect(createAgent).toHaveBeenCalledWith("i1", "gemini", "gemini");
@@ -91,7 +94,7 @@ test("managers render Chinese affordances when locale is zh-CN", async () => {
   i18n.global.locale.value = "zh-CN";
   const store = useInstancesStore(); seed(store);
   const wm = mount(WorkspacesManager, { props: { instanceId: "i1" } });
-  expect(wm.get('[data-test="wm-create"]').text()).toBe("添加工作区");
+  expect(wm.get('[data-test="wm-add-toggle"]').text()).toBe("添加工作区");
   const am = mount(AgentsManager, { props: { instanceId: "i1" } });
-  expect(am.get('[data-test="am-add"]').text()).toBe("添加 Agent");
+  expect(am.get('[data-test="am-add-toggle"]').text()).toBe("添加 Agent");
 });

--- a/packages/relay-web/src/__tests__/message-attachments.test.ts
+++ b/packages/relay-web/src/__tests__/message-attachments.test.ts
@@ -1,0 +1,21 @@
+import { mount } from "@vue/test-utils";
+import { expect, test } from "vitest";
+
+import MessageAttachments from "../components/MessageAttachments.vue";
+
+test("renders an image attachment as a thumbnail using previewUrl", () => {
+  const wrapper = mount(MessageAttachments, {
+    props: { attachments: [{ id: "1", filename: "a.png", mimeType: "image/png", size: 10, kind: "image", previewUrl: "data:image/png;base64,AA" }] },
+  });
+  const img = wrapper.find('[data-test="att-image"]');
+  expect(img.exists()).toBe(true);
+  expect(img.attributes("src")).toBe("data:image/png;base64,AA");
+});
+
+test("renders a non-image attachment as a file card with name + size", () => {
+  const wrapper = mount(MessageAttachments, {
+    props: { attachments: [{ id: "2", filename: "report.pdf", mimeType: "application/pdf", size: 2048, kind: "file" }] },
+  });
+  expect(wrapper.find('[data-test="att-file"]').exists()).toBe(true);
+  expect(wrapper.text()).toContain("report.pdf");
+});

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -81,6 +81,27 @@ describe("PromptInput composer", () => {
     expect(w.emitted("send")).toBeFalsy();
   });
 
+  it("closes the agent-command menu once the token is no longer a bare /word", async () => {
+    const { useChatStore } = await import("../stores/chat");
+    const chat = useChatStore();
+    chat.select("i1", "backend");
+    chat.applyEvent({ kind: "control-event", instanceId: "i1", event: {
+      type: "agent-commands", chatKey: "relay:a1", sessionAlias: "backend",
+      commands: [{ name: "compact" }],
+    } } as never);
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("/co");
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="cmd-menu"]').exists()).toBe(true);
+    // A space ends the command token → menu closes and Enter submits verbatim.
+    await ta.setValue("/compact now");
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="cmd-menu"]').exists()).toBe(false);
+    await ta.trigger("keydown", { key: "Enter" });
+    expect(w.emitted("send")?.[0]).toEqual(["/compact now", []]);
+  });
+
   it("inserts text from a composer store request targeting this session", async () => {
     const { useComposerStore } = await import("../stores/composer");
     const composer = useComposerStore();

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -59,6 +59,28 @@ describe("PromptInput composer", () => {
     expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("half-typed");
   });
 
+  it("typing / shows agent-command autocomplete and Enter completes without sending", async () => {
+    const { useChatStore } = await import("../stores/chat");
+    const chat = useChatStore();
+    chat.select("i1", "backend");
+    chat.applyEvent({ kind: "control-event", instanceId: "i1", event: {
+      type: "agent-commands", chatKey: "relay:a1", sessionAlias: "backend",
+      commands: [{ name: "compact", description: "Compact the conversation" }, { name: "clear" }],
+    } } as never);
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("/co");
+    await w.vm.$nextTick();
+    const items = w.findAll('[data-test="cmd-item"]');
+    expect(items.length).toBe(1); // only /compact matches "/co"
+    expect(items[0].text()).toContain("/compact");
+    // Enter completes the command (and does NOT submit the turn).
+    await ta.trigger("keydown", { key: "Enter" });
+    await w.vm.$nextTick();
+    expect((ta.element as HTMLTextAreaElement).value).toBe("/compact ");
+    expect(w.emitted("send")).toBeFalsy();
+  });
+
   it("inserts text from a composer store request targeting this session", async () => {
     const { useComposerStore } = await import("../stores/composer");
     const composer = useComposerStore();

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -102,6 +102,17 @@ describe("PromptInput composer", () => {
     expect(w.emitted("send")?.[0]).toEqual(["/compact now", []]);
   });
 
+  it("disables the send button while an upload is in flight (no silent dead click)", async () => {
+    const { useComposerStore } = await import("../stores/composer");
+    const composer = useComposerStore();
+    const w = mount(PromptInput);
+    await w.find("textarea").setValue("ready to go"); // would normally enable Send
+    expect((w.get('[data-test="composer-send"]').element as HTMLButtonElement).disabled).toBe(false);
+    composer.uploading = true;
+    await w.vm.$nextTick();
+    expect((w.get('[data-test="composer-send"]').element as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("inserts text from a composer store request targeting this session", async () => {
     const { useComposerStore } = await import("../stores/composer");
     const composer = useComposerStore();

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -26,7 +26,7 @@ describe("PromptInput composer", () => {
     const ta = w.find("textarea");
     await ta.setValue("/status");
     await ta.trigger("keydown", { key: "Enter" });
-    expect(w.emitted("send")?.[0]).toEqual(["/status"]);
+    expect(w.emitted("send")?.[0]).toEqual(["/status", []]);
   });
 
   it("Enter sends a plain message and records it in history for ↑ recall", async () => {
@@ -34,7 +34,7 @@ describe("PromptInput composer", () => {
     const ta = w.find("textarea");
     await ta.setValue("hello there");
     await ta.trigger("keydown", { key: "Enter" });
-    expect(w.emitted("send")?.[0]).toEqual(["hello there"]);
+    expect(w.emitted("send")?.[0]).toEqual(["hello there", []]);
     expect((ta.element as HTMLTextAreaElement).value).toBe(""); // cleared
     // Caret at start of an empty field → ArrowUp recalls the last sent line.
     await ta.trigger("keydown", { key: "ArrowUp" });

--- a/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
+++ b/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
@@ -11,45 +11,49 @@ describe("useSwipeActions", () => {
   // Handler keys must be bare DOM event names so `v-on="handlers"` binds real
   // pointer events (Vue re-applies the `on` prefix); an `onPointerdown` key would
   // bind a dead event and the swipe would silently never fire. See InstanceTree's
-  // "binds swipe handlers to real pointer events" regression test for the wiring.
+  // swipe regression tests for the wiring.
   it("exposes bare pointer-event handler keys", () => {
-    const { handlers } = useSwipeActions({ onSwipeLeft: vi.fn(), onSwipeRight: vi.fn() });
+    const { handlers } = useSwipeActions({});
     expect(Object.keys(handlers).sort()).toEqual(["pointercancel", "pointerdown", "pointermove", "pointerup"]);
   });
-  it("fires onSwipeLeft past the threshold", () => {
-    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
-    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+  it("reports a live delta during a horizontal drag, then ends with the final delta", () => {
+    const onMove = vi.fn(), onEnd = vi.fn();
+    const { handlers } = useSwipeActions({ onMove, onEnd });
     handlers.pointerdown(pointer(200));
-    handlers.pointermove(pointer(120));
+    handlers.pointermove(pointer(160)); // dx -40 → horizontal
+    handlers.pointermove(pointer(120)); // dx -80
+    expect(onMove).toHaveBeenNthCalledWith(1, -40);
+    expect(onMove).toHaveBeenNthCalledWith(2, -80);
     handlers.pointerup(pointer(120));
-    expect(onSwipeLeft).toHaveBeenCalled();
-    expect(onSwipeRight).not.toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalledWith(-80);
   });
-  it("fires onSwipeRight past the threshold", () => {
-    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
-    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
-    handlers.pointerdown(pointer(100));
-    handlers.pointermove(pointer(200));
-    handlers.pointerup(pointer(200));
-    expect(onSwipeRight).toHaveBeenCalled();
+  it("yields to vertical scroll: no move, ends with 0", () => {
+    const onMove = vi.fn(), onEnd = vi.fn();
+    const { handlers } = useSwipeActions({ onMove, onEnd });
+    handlers.pointerdown(pointer(200, 200));
+    handlers.pointermove(pointer(196, 260)); // vertical-dominant
+    expect(onMove).not.toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalledWith(0);
+    handlers.pointerup(pointer(196, 260)); // stray up after yield must not re-fire
+    expect(onEnd).toHaveBeenCalledTimes(1);
   });
-  it("ignores sub-threshold and vertical-dominant moves", () => {
-    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
-    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+  it("a sub-intent tap never starts a drag (no move, ends with 0)", () => {
+    const onMove = vi.fn(), onEnd = vi.fn();
+    const { handlers } = useSwipeActions({ onMove, onEnd });
     handlers.pointerdown(pointer(200));
-    handlers.pointermove(pointer(180));
-    handlers.pointerup(pointer(180));
-    expect(onSwipeLeft).not.toHaveBeenCalled();
-    expect(onSwipeRight).not.toHaveBeenCalled();
+    handlers.pointermove(pointer(198)); // 2px < intent
+    handlers.pointerup(pointer(198));
+    expect(onMove).not.toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalledWith(0);
   });
-  it("fires nothing after pointercancel (browser reclassified as scroll)", () => {
-    const onSwipeLeft = vi.fn(), onSwipeRight = vi.fn();
-    const { handlers } = useSwipeActions({ onSwipeLeft, onSwipeRight, threshold: 60 });
+  it("ends with 0 on pointercancel and a stray up does not re-fire", () => {
+    const onMove = vi.fn(), onEnd = vi.fn();
+    const { handlers } = useSwipeActions({ onMove, onEnd });
     handlers.pointerdown(pointer(200));
-    handlers.pointermove(pointer(120)); // past the threshold…
-    handlers.pointercancel();           // …but the gesture is cancelled
-    handlers.pointerup(pointer(120));   // a stray up after cancel must not fire
-    expect(onSwipeLeft).not.toHaveBeenCalled();
-    expect(onSwipeRight).not.toHaveBeenCalled();
+    handlers.pointermove(pointer(120)); // horizontal drag…
+    handlers.pointercancel();           // …but the browser reclassified it as scroll
+    handlers.pointerup(pointer(120));   // stray up after cancel must not re-fire
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledWith(0);
   });
 });

--- a/packages/relay-web/src/api/client.ts
+++ b/packages/relay-web/src/api/client.ts
@@ -25,4 +25,11 @@ export const api = {
   /** Proxy a control RPC to an instance via the relay. */
   rpc: <T>(instanceId: string, type: string, payload: unknown = {}) =>
     request<{ result: T }>("POST", `/api/instances/${instanceId}/rpc`, { type, payload }).then((r) => r.result),
+  /** Upload a file to the instance daemon; returns its absolute on-host path. */
+  upload: (instanceId: string, payload: { filename: string; content: string; mimeType: string }) =>
+    request<{ result: import("@ganglion/xacpx-relay-protocol").UploadResult }>(
+      "POST",
+      `/api/instances/${instanceId}/rpc`,
+      { type: "control.upload", payload },
+    ).then((r) => r.result),
 };

--- a/packages/relay-web/src/components/AgentsManager.vue
+++ b/packages/relay-web/src/components/AgentsManager.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { Trash2 } from "lucide-vue-next";
+import { Plus, Trash2 } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
 import { confirm } from "../lib/use-confirm";
 
@@ -14,8 +14,17 @@ const driver = ref("");
 const customName = ref("");
 const error = ref("");
 const busy = ref(false);
+const formOpen = ref(false);
+const filter = ref("");
 
 const addableDrivers = computed(() => (inst.value?.agentCatalog ?? []).filter((c) => !c.configured));
+const all = computed(() => inst.value?.agents ?? []);
+const showFilter = computed(() => all.value.length > 6);
+const list = computed(() => {
+  const q = filter.value.trim().toLowerCase();
+  if (!q) return all.value;
+  return all.value.filter((a) => a.name.toLowerCase().includes(q) || (a.driver ?? "").toLowerCase().includes(q));
+});
 
 async function add(): Promise<void> {
   if (!driver.value || busy.value) return;
@@ -49,27 +58,41 @@ function hint(installed: string): string {
 
 <template>
   <section class="space-y-3">
-    <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("agents.title") }}</h3>
     <p v-if="error" data-test="am-error" class="rounded bg-danger/10 px-3 py-2 text-sm text-danger">{{ error }}</p>
-    <p v-if="!(inst?.agents ?? []).length" data-test="am-empty" class="text-sm text-fg-muted">{{ $t("agents.empty") }}</p>
-    <ul v-else class="divide-y divide-border rounded border border-border">
-      <li v-for="a in inst?.agents ?? []" :key="a.name" class="flex items-center justify-between px-3 py-2 text-sm text-fg">
-        <span><span class="font-medium">{{ a.name }}</span> · <span class="text-fg-muted">{{ a.driver }}</span></span>
+    <input v-if="showFilter" v-model="filter" data-test="am-filter" :placeholder="$t('common.filter')"
+           class="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
+    <p v-if="!all.length" data-test="am-empty" class="text-sm text-fg-muted">{{ $t("agents.empty") }}</p>
+    <ul v-else class="max-h-64 divide-y divide-border overflow-y-auto rounded border border-border">
+      <li v-for="a in list" :key="a.name" class="flex items-center justify-between gap-2 px-3 py-2 text-sm">
+        <span class="min-w-0 truncate" :title="`${a.name} · ${a.driver}`">
+          <span class="font-medium text-fg">{{ a.name }}</span><span class="text-fg-muted"> · {{ a.driver }}</span>
+        </span>
         <button :data-test="`am-remove-${a.name}`" :title="$t('agents.remove', { name: a.name })" :aria-label="$t('agents.removeAria', { name: a.name })"
                 class="grid h-7 w-7 shrink-0 place-items-center rounded text-fg-muted transition-colors hover:bg-danger/15 hover:text-danger disabled:opacity-50"
                 :disabled="busy" @click="remove(a.name)"><Trash2 :size="14" /></button>
       </li>
+      <li v-if="!list.length" class="px-3 py-2 text-sm text-fg-muted">{{ $t("common.noMatch") }}</li>
     </ul>
-    <div class="grid grid-cols-1 gap-2 sm:grid-cols-3">
-      <select v-model="driver" data-test="am-driver" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent">
-        <option value="" disabled>{{ $t("agents.chooseDriver") }}</option>
-        <option v-for="c in addableDrivers" :key="c.driver" :value="c.driver" :disabled="c.installed === 'unknown'">
-          {{ c.driver }} ({{ hint(c.installed) }})
-        </option>
-      </select>
-      <input v-model="customName" data-test="am-name" :placeholder="$t('agents.namePlaceholder')" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
-      <button data-test="am-add" class="rounded bg-accent px-3 py-1.5 text-sm text-white hover:bg-accent-hover disabled:opacity-50"
-              :disabled="busy || !driver" @click="add">{{ $t("agents.add") }}</button>
+
+    <button v-if="!formOpen" type="button" data-test="am-add-toggle" @click="formOpen = true"
+            class="flex items-center gap-1.5 rounded border border-dashed border-border px-3 py-1.5 text-sm text-fg-muted transition-colors hover:border-accent hover:text-fg">
+      <Plus :size="14" /> {{ $t("agents.add") }}
+    </button>
+    <div v-else class="space-y-2 rounded border border-border p-3">
+      <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <select v-model="driver" data-test="am-driver" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent">
+          <option value="" disabled>{{ $t("agents.chooseDriver") }}</option>
+          <option v-for="c in addableDrivers" :key="c.driver" :value="c.driver" :disabled="c.installed === 'unknown'">
+            {{ c.driver }} ({{ hint(c.installed) }})
+          </option>
+        </select>
+        <input v-model="customName" data-test="am-name" :placeholder="$t('agents.namePlaceholder')" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
+      </div>
+      <div class="flex gap-2">
+        <button data-test="am-add" class="rounded bg-accent px-3 py-1.5 text-sm text-white hover:bg-accent-hover disabled:opacity-50"
+                :disabled="busy || !driver" @click="add">{{ $t("common.add") }}</button>
+        <button type="button" data-test="am-add-cancel" class="rounded px-3 py-1.5 text-sm text-fg-muted hover:bg-fg/5 hover:text-fg" @click="formOpen = false">{{ $t("common.cancel") }}</button>
+      </div>
     </div>
   </section>
 </template>

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -3,6 +3,8 @@ import { computed, onUnmounted, ref, watch } from "vue";
 import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
 import { useFilesStore } from "../stores/files";
+import { useComposerStore } from "../stores/composer";
+import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import MessageList from "./MessageList.vue";
 import PromptInput from "./PromptInput.vue";
 import PlanPanel from "./PlanPanel.vue";
@@ -13,6 +15,14 @@ const emit = defineEmits<{ (e: "show-files"): void }>();
 const chat = useChatStore();
 const instances = useInstancesStore();
 const files = useFilesStore();
+const composer = useComposerStore();
+
+function onSend(text: string, media: PromptAttachmentRef[] = []) {
+  void chat.send(text, media);
+}
+
+// Bind the composer to the active instance so file uploads target the right daemon.
+watch(() => chat.instanceId, (id) => { if (id) composer.bindInstance(id); }, { immediate: true });
 
 // Context for the header chips: the current session's workspace/agent plus the
 // instance name. Branch comes from the read-only git summary (undefined until the
@@ -116,7 +126,7 @@ const verb = computed(() => {
         <PlanPanel v-if="chat.sessionPlan?.length" :entries="chat.sessionPlan" :active="chat.busy" />
         <PromptInput :busy="chat.busy" :draft-key="`${chat.instanceId}\0${chat.sessionAlias}`"
                      :instance-id="chat.instanceId" :session-alias="chat.sessionAlias"
-                     @send="chat.send" @cancel="chat.cancel" />
+                     @send="onSend" @cancel="chat.cancel" />
       </div>
     </template>
   </div>

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -56,7 +56,7 @@ const elapsed = computed(() => {
 const runningTools = computed(() => chat.liveToolSteps.filter((t) => t.status === "running").length);
 
 // Whimsical near-synonyms cycled through while a turn runs (à la Claude Code / HAPI's
-// "vibing messages"). Purely cosmetic; reuses the 1Hz clock, rotating every ~4s on a
+// "vibing messages"). Purely cosmetic; reuses the 1Hz clock, rotating every ~10s on a
 // calm interval rather than re-rolling every frame. "Working" stays first for t≈0.
 const VERBS = [
   "Working", "Thinking", "Pondering", "Cogitating", "Reasoning", "Computing",
@@ -66,7 +66,7 @@ const VERBS = [
 const verb = computed(() => {
   if (!chat.liveTurn) return VERBS[0];
   const s = Math.max(0, Math.floor((nowMs.value - chat.liveTurn.startedAt) / 1000));
-  return VERBS[Math.floor(s / 4) % VERBS.length];
+  return VERBS[Math.floor(s / 10) % VERBS.length];
 });
 </script>
 

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -24,6 +24,16 @@ function onSend(text: string, media: PromptAttachmentRef[] = []) {
 // Bind the composer to the active instance so file uploads target the right daemon.
 watch(() => chat.instanceId, (id) => { if (id) composer.bindInstance(id); }, { immediate: true });
 
+// Clear staged attachments whenever the active session OR instance changes: `pending`
+// is a single global array, so leftover chips from one target would otherwise attach to
+// the next. Watch both identifiers and drop the staged files on any switch.
+watch(
+  () => [chat.instanceId, chat.sessionAlias] as const,
+  ([id, alias], prev) => {
+    if (prev && (id !== prev[0] || alias !== prev[1])) composer.clearAttachments();
+  },
+);
+
 // Context for the header chips: the current session's workspace/agent plus the
 // instance name. Branch comes from the read-only git summary (undefined until the
 // backend ever adds it to the diff result).

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -64,14 +64,30 @@ const openMenuFor = ref<string | null>(null);
 // Single ref ⇒ opening one row auto-closes any other. Swipe right→left reveals;
 // tapping a block executes; tapping the row body or anywhere outside closes.
 const openSwipeFor = ref<string | null>(null);
+// Live drag: the row currently being dragged + its raw horizontal delta, so the row
+// follows the finger 1:1 (transition is off while dragging, on for the snap release).
+const draggingKey = ref<string | null>(null);
+const dragDx = ref(0);
 function onDocPointerDown() { openMenuFor.value = null; openSwipeFor.value = null; }
 onMounted(() => document.addEventListener("mousedown", onDocPointerDown));
 onUnmounted(() => document.removeEventListener("mousedown", onDocPointerDown));
 
-// Px the row shifts left to reveal its blocks: 64px per visible block (delete always,
-// archive only when the session isn't already archived).
+// Px the row shifts left to reveal its blocks: one 56px block per visible action
+// (delete always, archive only when the session isn't already archived).
 function revealPx(s: { archived?: boolean }): number {
-  return s.archived ? 64 : 128;
+  return s.archived ? 56 : 112;
+}
+// translateX for a row: follow the finger while dragging (clamped to the reveal
+// range), else snap to fully open / closed.
+function rowTransform(instanceId: string, s: { alias: string; archived?: boolean }): string {
+  const key = `${instanceId}:${s.alias}`;
+  const reveal = revealPx(s);
+  if (draggingKey.value === key) {
+    const base = openSwipeFor.value === key ? -reveal : 0;
+    const x = Math.max(-reveal, Math.min(0, base + dragDx.value));
+    return `translateX(${x}px)`;
+  }
+  return openSwipeFor.value === key ? `translateX(-${reveal}px)` : "translateX(0)";
 }
 // Tapping the row body: if its blocks are open, the tap just closes them (iOS-style);
 // otherwise it selects the session.
@@ -119,9 +135,17 @@ const rowSwipes = computed(() => {
     if (!inst.online) continue;
     for (const s of inst.sessions) {
       const key = `${inst.id}:${s.alias}`;
+      const reveal = revealPx(s);
       map[key] = useSwipeActions({
-        onSwipeLeft: () => { openMenuFor.value = null; openSwipeFor.value = key; },
-        onSwipeRight: () => { if (openSwipeFor.value === key) openSwipeFor.value = null; },
+        onMove: (dx) => { openMenuFor.value = null; draggingKey.value = key; dragDx.value = dx; },
+        onEnd: (dx) => {
+          // Snap open if the row ended past the halfway point, else closed.
+          const base = openSwipeFor.value === key ? -reveal : 0;
+          const finalX = Math.max(-reveal, Math.min(0, base + dx));
+          openSwipeFor.value = finalX <= -reveal / 2 ? key : null;
+          draggingKey.value = null;
+          dragDx.value = 0;
+        },
       }).handlers;
     }
   }
@@ -160,8 +184,9 @@ const rowSwipes = computed(() => {
                `overflow-hidden` on the parent clips them away when closed. -->
           <div
             data-test="swipe-track"
-            class="flex touch-pan-y transition-transform duration-200 ease-out"
-            :style="openSwipeFor === `${inst.id}:${s.alias}` ? { transform: `translateX(-${revealPx(s)}px)` } : {}"
+            class="flex touch-pan-y ease-out"
+            :class="draggingKey === `${inst.id}:${s.alias}` ? '' : 'transition-transform duration-200'"
+            :style="{ transform: rowTransform(inst.id, s) }"
             v-on="inst.online ? rowSwipes[`${inst.id}:${s.alias}`] ?? {} : {}"
           >
             <!-- Foreground row content (spans the full row width). -->
@@ -204,12 +229,12 @@ const rowSwipes = computed(() => {
             <!-- Swipe-revealed action blocks (touch). Sit just past the right edge; the
                  `@click.stop` prevents the row tap from also firing. -->
             <template v-if="inst.online">
-              <button v-if="!s.archived" data-test="swipe-archive" :aria-label="$t('instance.archiveSession')"
-                      class="flex w-16 shrink-0 flex-col items-center justify-center gap-0.5 bg-warn text-[10px] font-medium text-white"
-                      @click.stop="onArchive(inst.id, s.alias)"><Archive :size="15" />{{ $t("instance.archive") }}</button>
-              <button data-test="swipe-delete" :aria-label="$t('common.delete')"
-                      class="flex w-16 shrink-0 flex-col items-center justify-center gap-0.5 bg-danger text-[10px] font-medium text-white"
-                      @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="15" />{{ $t("common.delete") }}</button>
+              <button v-if="!s.archived" data-test="swipe-archive" :aria-label="$t('instance.archiveSession')" :title="$t('instance.archiveSession')"
+                      class="flex w-14 shrink-0 items-center justify-center bg-warn text-white transition-colors hover:bg-warn/90"
+                      @click.stop="onArchive(inst.id, s.alias)"><Archive :size="16" /></button>
+              <button data-test="swipe-delete" :aria-label="$t('common.delete')" :title="$t('common.delete')"
+                      class="flex w-14 shrink-0 items-center justify-center bg-danger text-white transition-colors hover:bg-danger/90"
+                      @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="16" /></button>
             </template>
           </div>
         </div>

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -177,11 +177,14 @@ const rowSwipes = computed(() => {
           v-for="s in orderedSessions(inst.sessions)"
           :key="s.alias"
           data-test="session-row"
-          class="group relative overflow-hidden rounded-md"
+          class="group relative rounded-md"
         >
+          <!-- Clip layer: bounds ONLY the swipe track so the off-screen action blocks
+               stay hidden until revealed. The row itself is NOT clipped, so the ⋯
+               dropdown (rendered below as a row child) can overflow past the row. -->
+          <div class="overflow-hidden rounded-md">
           <!-- Swipe track: full-width row content followed by the off-screen action
-               blocks. Swiping right→left translates the track left to reveal them;
-               `overflow-hidden` on the parent clips them away when closed. -->
+               blocks. Swiping right→left translates the track left to reveal them. -->
           <div
             data-test="swipe-track"
             class="flex touch-pan-y ease-out"
@@ -216,14 +219,6 @@ const rowSwipes = computed(() => {
                 <button data-test="session-menu" :aria-label="$t('common.more')"
                         class="grid h-5 w-5 place-items-center rounded text-fg-muted hover:bg-raised hover:text-fg opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
                         @click.stop="openSwipeFor = null; openMenuFor = openMenuFor === `${inst.id}:${s.alias}` ? null : `${inst.id}:${s.alias}`"><MoreHorizontal :size="13" /></button>
-                <!-- `@mousedown.stop`: the document-level mousedown listener nulls openMenuFor,
-                     which would unmount this menu in the microtask BEFORE the item's click
-                     fires (mousedown → Vue flush → mouseup → click on a detached node), so
-                     archive/delete silently no-op. Stopping mousedown keeps the menu mounted. -->
-                <div v-if="openMenuFor === `${inst.id}:${s.alias}`" @mousedown.stop class="absolute right-0 z-20 mt-1 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
-                  <button v-if="!s.archived" data-test="action-archive" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="onArchive(inst.id, s.alias)"><Archive :size="12" />{{ $t("instance.archiveSession") }}</button>
-                  <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
-                </div>
               </div>
             </div>
             <!-- Swipe-revealed action blocks (touch). Sit just past the right edge; the
@@ -236,6 +231,18 @@ const rowSwipes = computed(() => {
                       class="flex w-14 shrink-0 items-center justify-center bg-danger text-white transition-colors hover:bg-danger/90"
                       @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="16" /></button>
             </template>
+          </div>
+          </div>
+          <!-- ⋯ dropdown: a child of the ROW (not the clip layer), so it overflows the
+               row downward instead of being clipped to the row's height.
+               `@mousedown.stop`: the document-level mousedown listener nulls openMenuFor,
+               which would unmount this menu in the microtask BEFORE the item's click
+               fires (mousedown → Vue flush → mouseup → click on a detached node), so
+               archive/delete silently no-op. Stopping mousedown keeps the menu mounted. -->
+          <div v-if="inst.online && openMenuFor === `${inst.id}:${s.alias}`" @mousedown.stop
+               class="absolute right-1 top-full z-30 mt-0.5 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
+            <button v-if="!s.archived" data-test="action-archive" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="onArchive(inst.id, s.alias)"><Archive :size="12" />{{ $t("instance.archiveSession") }}</button>
+            <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
           </div>
         </div>
 

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -47,6 +47,7 @@ function toggle(id: string) {
   if (next.has(id)) next.delete(id);
   else next.add(id);
   collapsed.value = next;
+  openSwipeFor.value = null;
   // Refresh on (re)expand in case the list drifted while collapsed.
   if (isExpanded(id)) void store.loadSessions(id).catch(() => {});
 }
@@ -59,12 +60,30 @@ function orderedSessions<T extends { archived?: boolean }>(sessions: T[]): T[] {
 
 // Desktop overflow (⋯) menu open-state, keyed by `${instanceId}:${alias}`.
 const openMenuFor = ref<string | null>(null);
-function onDocPointerDown() { openMenuFor.value = null; }
+// Touch swipe-to-reveal: the row whose action blocks (archive/delete) are revealed.
+// Single ref ⇒ opening one row auto-closes any other. Swipe right→left reveals;
+// tapping a block executes; tapping the row body or anywhere outside closes.
+const openSwipeFor = ref<string | null>(null);
+function onDocPointerDown() { openMenuFor.value = null; openSwipeFor.value = null; }
 onMounted(() => document.addEventListener("mousedown", onDocPointerDown));
 onUnmounted(() => document.removeEventListener("mousedown", onDocPointerDown));
 
+// Px the row shifts left to reveal its blocks: 64px per visible block (delete always,
+// archive only when the session isn't already archived).
+function revealPx(s: { archived?: boolean }): number {
+  return s.archived ? 64 : 128;
+}
+// Tapping the row body: if its blocks are open, the tap just closes them (iOS-style);
+// otherwise it selects the session.
+function onRowTap(id: string, alias: string) {
+  const key = `${id}:${alias}`;
+  if (openSwipeFor.value === key) { openSwipeFor.value = null; return; }
+  emit("select", id, alias);
+}
+
 async function onArchive(id: string, alias: string) {
   openMenuFor.value = null;
+  openSwipeFor.value = null;
   await store.archiveSession(id, alias).catch(() => {});
   showUndoToast(id, alias);
 }
@@ -79,6 +98,7 @@ function showUndoToast(id: string, alias: string) {
 // Deleting a session is destructive and irreversible → confirm via the popup dialog.
 async function askDelete(id: string, alias: string) {
   openMenuFor.value = null;
+  openSwipeFor.value = null;
   const ok = await confirm({
     title: t("instance.deleteSessionTitle"),
     message: t("instance.deleteSessionBody", { alias }),
@@ -88,18 +108,20 @@ async function askDelete(id: string, alias: string) {
   if (ok) void store.removeSession(id, alias).catch(() => {});
 }
 
-// Mobile-native second path: swipe a row left → archive, right → delete (mirrors the
-// desktop ⋯ menu). Handlers are built per visible row of online instances and keyed by
-// `${instanceId}:${alias}`, so the template binds a stable set instead of recreating
-// closures on every render. Offline instances are excluded (mirrors the action gate).
+// Touch second path: swipe a row right→left to REVEAL its archive/delete blocks (tap a
+// block to execute); swipe left→right to close. This replaces the old swipe-to-execute
+// (which deleted on a single right-swipe — too easy to mis-trigger). Handlers are built
+// per visible row of online instances and keyed by `${instanceId}:${alias}`, so the
+// template binds a stable set. Offline instances are excluded (mirrors the action gate).
 const rowSwipes = computed(() => {
   const map: Record<string, ReturnType<typeof useSwipeActions>["handlers"]> = {};
   for (const inst of store.instances) {
     if (!inst.online) continue;
     for (const s of inst.sessions) {
-      map[`${inst.id}:${s.alias}`] = useSwipeActions({
-        onSwipeLeft: () => { void onArchive(inst.id, s.alias); },
-        onSwipeRight: () => { askDelete(inst.id, s.alias); },
+      const key = `${inst.id}:${s.alias}`;
+      map[key] = useSwipeActions({
+        onSwipeLeft: () => { openMenuFor.value = null; openSwipeFor.value = key; },
+        onSwipeRight: () => { if (openSwipeFor.value === key) openSwipeFor.value = null; },
       }).handlers;
     }
   }
@@ -131,42 +153,64 @@ const rowSwipes = computed(() => {
           v-for="s in orderedSessions(inst.sessions)"
           :key="s.alias"
           data-test="session-row"
-          class="group relative flex items-center rounded-md transition-colors touch-pan-y"
-          :class="isSelected(inst.id, s.alias) ? 'bg-accent/10' : 'hover:bg-raised'"
-          v-on="inst.online ? rowSwipes[`${inst.id}:${s.alias}`] ?? {} : {}"
+          class="group relative overflow-hidden rounded-md"
         >
-          <!-- Selected row: left accent bar. -->
-          <span v-if="isSelected(inst.id, s.alias)" class="absolute bottom-1 left-0 top-1 w-[3px] rounded-full bg-accent" />
-          <button
-            class="flex min-w-0 flex-1 items-center gap-2 py-1 pl-2.5 pr-1.5 text-left"
-            @click="emit('select', inst.id, s.alias)"
+          <!-- Swipe track: full-width row content followed by the off-screen action
+               blocks. Swiping right→left translates the track left to reveal them;
+               `overflow-hidden` on the parent clips them away when closed. -->
+          <div
+            data-test="swipe-track"
+            class="flex touch-pan-y transition-transform duration-200 ease-out"
+            :style="openSwipeFor === `${inst.id}:${s.alias}` ? { transform: `translateX(-${revealPx(s)}px)` } : {}"
+            v-on="inst.online ? rowSwipes[`${inst.id}:${s.alias}`] ?? {} : {}"
           >
-            <span v-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'working'" data-test="attention-dot" data-attention="working"
-                  class="pulse-dot h-2 w-2 shrink-0 rounded-full bg-run-bright" />
-            <span v-else-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'unread'" data-test="attention-dot" data-attention="unread"
-                  class="h-2 w-2 shrink-0 rounded-full bg-info" />
-            <span v-else-if="!s.archived && s.running" data-test="attention-dot" data-attention="running" class="h-2 w-2 shrink-0 rounded-full bg-run" />
-            <span class="truncate text-[12.5px] font-medium"
-                  :class="s.archived ? 'text-fg-muted' : (isSelected(inst.id, s.alias) ? 'font-semibold text-accent' : 'text-fg')">{{ s.alias }}</span>
-            <span class="shrink-0 rounded px-1 py-px font-mono text-[9.5px]"
-                  :class="isSelected(inst.id, s.alias) ? 'bg-accent/15 text-accent' : 'bg-bg text-fg-muted'">{{ s.agent }}</span>
-            <span v-if="s.archived" data-test="archived-badge" class="shrink-0 rounded bg-bg px-1 py-px text-[9px] text-fg-muted">{{ $t("instance.sessionArchivedBadge") }}</span>
-            <span v-if="!s.archived && elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
-                  class="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-run">{{ elapsedLabel(inst.id, s.alias) }}</span>
-          </button>
-          <!-- Row actions: desktop overflow (⋯) menu → archive / delete. Hidden when the instance is offline. -->
-          <div v-if="inst.online" data-test="session-actions" class="relative mr-1 shrink-0">
-            <button data-test="session-menu" :aria-label="$t('common.more')"
-                    class="grid h-5 w-5 place-items-center rounded text-fg-muted hover:bg-raised hover:text-fg opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
-                    @click.stop="openMenuFor = openMenuFor === `${inst.id}:${s.alias}` ? null : `${inst.id}:${s.alias}`"><MoreHorizontal :size="13" /></button>
-            <!-- `@mousedown.stop`: the document-level mousedown listener nulls openMenuFor,
-                 which would unmount this menu in the microtask BEFORE the item's click
-                 fires (mousedown → Vue flush → mouseup → click on a detached node), so
-                 archive/delete silently no-op. Stopping mousedown keeps the menu mounted. -->
-            <div v-if="openMenuFor === `${inst.id}:${s.alias}`" @mousedown.stop class="absolute right-0 z-20 mt-1 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
-              <button v-if="!s.archived" data-test="action-archive" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="onArchive(inst.id, s.alias)"><Archive :size="12" />{{ $t("instance.archiveSession") }}</button>
-              <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
+            <!-- Foreground row content (spans the full row width). -->
+            <div class="relative flex w-full shrink-0 items-center rounded-md transition-colors"
+                 :class="isSelected(inst.id, s.alias) ? 'bg-accent/10' : 'hover:bg-raised'">
+              <!-- Selected row: left accent bar. -->
+              <span v-if="isSelected(inst.id, s.alias)" class="absolute bottom-1 left-0 top-1 w-[3px] rounded-full bg-accent" />
+              <button
+                class="flex min-w-0 flex-1 items-center gap-2 py-2 pl-2.5 pr-1.5 text-left"
+                @click="onRowTap(inst.id, s.alias)"
+              >
+                <span v-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'working'" data-test="attention-dot" data-attention="working"
+                      class="pulse-dot h-2 w-2 shrink-0 rounded-full bg-run-bright" />
+                <span v-else-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'unread'" data-test="attention-dot" data-attention="unread"
+                      class="h-2 w-2 shrink-0 rounded-full bg-info" />
+                <span v-else-if="!s.archived && s.running" data-test="attention-dot" data-attention="running" class="h-2 w-2 shrink-0 rounded-full bg-run" />
+                <span class="truncate text-[12.5px] font-medium"
+                      :class="s.archived ? 'text-fg-muted' : (isSelected(inst.id, s.alias) ? 'font-semibold text-accent' : 'text-fg')">{{ s.alias }}</span>
+                <span class="shrink-0 rounded px-1 py-px font-mono text-[9.5px]"
+                      :class="isSelected(inst.id, s.alias) ? 'bg-accent/15 text-accent' : 'bg-bg text-fg-muted'">{{ s.agent }}</span>
+                <span v-if="s.archived" data-test="archived-badge" class="shrink-0 rounded bg-bg px-1 py-px text-[9px] text-fg-muted">{{ $t("instance.sessionArchivedBadge") }}</span>
+                <span v-if="!s.archived && elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
+                      class="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-run">{{ elapsedLabel(inst.id, s.alias) }}</span>
+              </button>
+              <!-- Row actions: desktop overflow (⋯) menu → archive / delete. Hidden when the instance is offline. -->
+              <div v-if="inst.online" data-test="session-actions" class="relative mr-1 shrink-0">
+                <button data-test="session-menu" :aria-label="$t('common.more')"
+                        class="grid h-5 w-5 place-items-center rounded text-fg-muted hover:bg-raised hover:text-fg opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
+                        @click.stop="openSwipeFor = null; openMenuFor = openMenuFor === `${inst.id}:${s.alias}` ? null : `${inst.id}:${s.alias}`"><MoreHorizontal :size="13" /></button>
+                <!-- `@mousedown.stop`: the document-level mousedown listener nulls openMenuFor,
+                     which would unmount this menu in the microtask BEFORE the item's click
+                     fires (mousedown → Vue flush → mouseup → click on a detached node), so
+                     archive/delete silently no-op. Stopping mousedown keeps the menu mounted. -->
+                <div v-if="openMenuFor === `${inst.id}:${s.alias}`" @mousedown.stop class="absolute right-0 z-20 mt-1 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
+                  <button v-if="!s.archived" data-test="action-archive" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="onArchive(inst.id, s.alias)"><Archive :size="12" />{{ $t("instance.archiveSession") }}</button>
+                  <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
+                </div>
+              </div>
             </div>
+            <!-- Swipe-revealed action blocks (touch). Sit just past the right edge; the
+                 `@click.stop` prevents the row tap from also firing. -->
+            <template v-if="inst.online">
+              <button v-if="!s.archived" data-test="swipe-archive" :aria-label="$t('instance.archiveSession')"
+                      class="flex w-16 shrink-0 flex-col items-center justify-center gap-0.5 bg-warn text-[10px] font-medium text-white"
+                      @click.stop="onArchive(inst.id, s.alias)"><Archive :size="15" />{{ $t("instance.archive") }}</button>
+              <button data-test="swipe-delete" :aria-label="$t('common.delete')"
+                      class="flex w-16 shrink-0 flex-col items-center justify-center gap-0.5 bg-danger text-[10px] font-medium text-white"
+                      @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="15" />{{ $t("common.delete") }}</button>
+            </template>
           </div>
         </div>
 

--- a/packages/relay-web/src/components/ManageInstanceDialog.vue
+++ b/packages/relay-web/src/components/ManageInstanceDialog.vue
@@ -15,7 +15,25 @@ const coreVersion = computed(() => store.byId(props.instanceId)?.coreVersion ?? 
 
 const loading = ref(true);
 type Tab = "general" | "workspaces" | "agents";
+const TABS = ["general", "workspaces", "agents"] as const;
 const tab = ref<Tab>("general");
+
+// Roving-tabindex arrow-key navigation across the tablist (Left/Right wrap, Home/End
+// jump to the ends). Moving selection also moves focus to the newly selected tab.
+function onTabKeydown(e: KeyboardEvent): void {
+  const idx = TABS.indexOf(tab.value);
+  let next = idx;
+  if (e.key === "ArrowRight") next = (idx + 1) % TABS.length;
+  else if (e.key === "ArrowLeft") next = (idx - 1 + TABS.length) % TABS.length;
+  else if (e.key === "Home") next = 0;
+  else if (e.key === "End") next = TABS.length - 1;
+  else return;
+  e.preventDefault();
+  tab.value = TABS[next];
+  void nextTick(() => {
+    dialogEl.value?.querySelector<HTMLElement>(`#tab-${TABS[next]}`)?.focus();
+  });
+}
 
 // Seed the editable name from the prop. The dialog header binds to this local ref
 // (not the static prop) so the title updates live the moment a rename succeeds.
@@ -89,9 +107,10 @@ onBeforeUnmount(() => {
       <div v-if="loading" class="py-6 text-center text-sm text-fg-muted">{{ $t("instance.dialogLoading") }}</div>
       <template v-else>
         <!-- Tab strip: General / Workspaces / Agents — Agents is always one click away. -->
-        <nav class="flex shrink-0 gap-1 border-b border-border px-3 pt-2" role="tablist">
+        <nav class="flex shrink-0 gap-1 border-b border-border px-3 pt-2" role="tablist" @keydown="onTabKeydown">
           <button v-for="tb in (['general','workspaces','agents'] as const)" :key="tb"
-                  :data-test="`tab-${tb}`" role="tab" :aria-selected="tab === tb"
+                  :id="`tab-${tb}`" :data-test="`tab-${tb}`" role="tab" :aria-selected="tab === tb"
+                  :aria-controls="`tabpanel-${tb}`" :tabindex="tab === tb ? 0 : -1"
                   class="rounded-t px-3 py-1.5 text-sm font-medium transition-colors"
                   :class="tab === tb ? 'border-b-2 border-accent text-fg' : 'text-fg-muted hover:text-fg'"
                   @click="tab = tb">
@@ -99,7 +118,7 @@ onBeforeUnmount(() => {
           </button>
         </nav>
         <div class="flex-1 overflow-y-auto p-5">
-          <div v-if="tab === 'general'" class="space-y-6">
+          <div v-if="tab === 'general'" id="tabpanel-general" role="tabpanel" aria-labelledby="tab-general" class="space-y-6">
             <section class="space-y-3">
               <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("instance.nameLabel") }}</h3>
               <p v-if="renameError" data-test="rename-error" class="rounded bg-danger/10 px-3 py-2 text-sm text-danger">{{ renameError }}</p>
@@ -118,8 +137,8 @@ onBeforeUnmount(() => {
               </p>
             </section>
           </div>
-          <div v-else-if="tab === 'workspaces'"><WorkspacesManager :instance-id="instanceId" /></div>
-          <div v-else-if="tab === 'agents'"><AgentsManager :instance-id="instanceId" /></div>
+          <div v-else-if="tab === 'workspaces'" id="tabpanel-workspaces" role="tabpanel" aria-labelledby="tab-workspaces"><WorkspacesManager :instance-id="instanceId" /></div>
+          <div v-else-if="tab === 'agents'" id="tabpanel-agents" role="tabpanel" aria-labelledby="tab-agents"><AgentsManager :instance-id="instanceId" /></div>
         </div>
       </template>
     </div>

--- a/packages/relay-web/src/components/ManageInstanceDialog.vue
+++ b/packages/relay-web/src/components/ManageInstanceDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { X } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
@@ -14,6 +14,8 @@ const { t } = useI18n();
 const coreVersion = computed(() => store.byId(props.instanceId)?.coreVersion ?? null);
 
 const loading = ref(true);
+type Tab = "general" | "workspaces" | "agents";
+const tab = ref<Tab>("general");
 
 // Seed the editable name from the prop. The dialog header binds to this local ref
 // (not the static prop) so the title updates live the moment a rename succeeds.
@@ -35,7 +37,29 @@ async function saveName(): Promise<void> {
   }
 }
 
+// Accessibility: trap focus inside the dialog, close on Esc, and restore focus to
+// whatever was focused before the dialog opened.
+const dialogEl = ref<HTMLElement | null>(null);
+let previouslyFocused: HTMLElement | null = null;
+const FOCUSABLE = 'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
+function focusables(): HTMLElement[] {
+  return dialogEl.value ? Array.from(dialogEl.value.querySelectorAll<HTMLElement>(FOCUSABLE)) : [];
+}
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === "Escape") { e.preventDefault(); emit("close"); return; }
+  if (e.key !== "Tab") return;
+  const els = focusables();
+  if (els.length === 0) return;
+  const first = els[0], last = els[els.length - 1];
+  const active = document.activeElement as HTMLElement | null;
+  if (e.shiftKey && active === first) { e.preventDefault(); last.focus(); }
+  else if (!e.shiftKey && active === last) { e.preventDefault(); first.focus(); }
+}
+
 onMounted(async () => {
+  previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  document.addEventListener("keydown", onKeydown);
+  void nextTick(() => { (focusables()[0] ?? dialogEl.value)?.focus(); });
   try {
     await store.loadFormOptions(props.instanceId);
   } catch {
@@ -44,6 +68,11 @@ onMounted(async () => {
     loading.value = false;
   }
 });
+
+onBeforeUnmount(() => {
+  document.removeEventListener("keydown", onKeydown);
+  previouslyFocused?.focus?.();
+});
 </script>
 
 <template>
@@ -51,33 +80,48 @@ onMounted(async () => {
        otherwise trap this fixed overlay inside the narrow off-canvas drawer. -->
   <Teleport to="body">
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="emit('close')">
-    <div class="max-h-[85vh] w-full max-w-xl overflow-y-auto rounded-xl border border-border bg-raised shadow-xl" data-test="manage-instance-dialog">
-      <header class="flex items-center justify-between border-b border-border px-5 py-3">
-        <h2 class="text-sm font-semibold text-fg">{{ $t("instance.manageTitle", { name }) }}</h2>
+    <div ref="dialogEl" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="manage-instance-title"
+         class="flex max-h-[85vh] w-full max-w-xl flex-col rounded-xl border border-border bg-raised shadow-xl focus:outline-none" data-test="manage-instance-dialog">
+      <header class="flex shrink-0 items-center justify-between border-b border-border px-5 py-3">
+        <h2 id="manage-instance-title" class="truncate text-sm font-semibold text-fg">{{ $t("instance.manageTitle", { name }) }}</h2>
         <button class="rounded p-1 text-fg-muted hover:bg-fg/5 hover:text-fg" :aria-label="$t('instance.close')" @click="emit('close')"><X :size="16" /></button>
       </header>
       <div v-if="loading" class="py-6 text-center text-sm text-fg-muted">{{ $t("instance.dialogLoading") }}</div>
-      <div v-else class="space-y-6 p-5">
-        <section class="space-y-3">
-          <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("instance.nameLabel") }}</h3>
-          <p v-if="renameError" data-test="rename-error" class="rounded bg-danger/10 px-3 py-2 text-sm text-danger">{{ renameError }}</p>
-          <div class="flex gap-2">
-            <input v-model="name" data-test="rename-name" :placeholder="$t('instance.renamePlaceholder')"
-                   class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                   @keyup.enter="saveName" />
-            <button data-test="rename-save" class="shrink-0 rounded bg-accent px-3 py-1.5 text-sm text-white hover:bg-accent-hover disabled:opacity-50"
-                    :disabled="renaming || !name.trim()" @click="saveName">{{ renaming ? $t("instance.renameSaving") : $t("instance.renameSave") }}</button>
+      <template v-else>
+        <!-- Tab strip: General / Workspaces / Agents — Agents is always one click away. -->
+        <nav class="flex shrink-0 gap-1 border-b border-border px-3 pt-2" role="tablist">
+          <button v-for="tb in (['general','workspaces','agents'] as const)" :key="tb"
+                  :data-test="`tab-${tb}`" role="tab" :aria-selected="tab === tb"
+                  class="rounded-t px-3 py-1.5 text-sm font-medium transition-colors"
+                  :class="tab === tb ? 'border-b-2 border-accent text-fg' : 'text-fg-muted hover:text-fg'"
+                  @click="tab = tb">
+            {{ tb === 'general' ? $t('instance.tabGeneral') : tb === 'workspaces' ? $t('workspaces.title') : $t('agents.title') }}
+          </button>
+        </nav>
+        <div class="flex-1 overflow-y-auto p-5">
+          <div v-if="tab === 'general'" class="space-y-6">
+            <section class="space-y-3">
+              <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("instance.nameLabel") }}</h3>
+              <p v-if="renameError" data-test="rename-error" class="rounded bg-danger/10 px-3 py-2 text-sm text-danger">{{ renameError }}</p>
+              <div class="flex gap-2">
+                <input v-model="name" data-test="rename-name" :placeholder="$t('instance.renamePlaceholder')"
+                       class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                       @keyup.enter="saveName" />
+                <button data-test="rename-save" class="shrink-0 rounded bg-accent px-3 py-1.5 text-sm text-white hover:bg-accent-hover disabled:opacity-50"
+                        :disabled="renaming || !name.trim()" @click="saveName">{{ renaming ? $t("instance.renameSaving") : $t("instance.renameSave") }}</button>
+              </div>
+            </section>
+            <section class="space-y-1">
+              <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("instance.versionLabel") }}</h3>
+              <p class="text-sm text-fg-muted" data-test="instance-version">
+                {{ coreVersion ? $t("instance.coreVersion", { version: coreVersion }) : $t("instance.coreVersionUnknown") }}
+              </p>
+            </section>
           </div>
-        </section>
-        <section class="space-y-1">
-          <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("instance.versionLabel") }}</h3>
-          <p class="text-sm text-fg-muted" data-test="instance-version">
-            {{ coreVersion ? $t("instance.coreVersion", { version: coreVersion }) : $t("instance.coreVersionUnknown") }}
-          </p>
-        </section>
-        <WorkspacesManager :instance-id="instanceId" />
-        <AgentsManager :instance-id="instanceId" />
-      </div>
+          <div v-else-if="tab === 'workspaces'"><WorkspacesManager :instance-id="instanceId" /></div>
+          <div v-else-if="tab === 'agents'"><AgentsManager :instance-id="instanceId" /></div>
+        </div>
+      </template>
     </div>
   </div>
   </Teleport>

--- a/packages/relay-web/src/components/MessageAttachments.vue
+++ b/packages/relay-web/src/components/MessageAttachments.vue
@@ -26,9 +26,9 @@ function fmtSize(n: number): string {
         data-test="att-file"
         class="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2 text-[13px]"
       >
-        <FileText :size="16" class="shrink-0 text-muted" />
+        <FileText :size="16" class="shrink-0 text-fg-muted" />
         <span class="max-w-[180px] truncate">{{ a.filename }}</span>
-        <span class="text-muted">{{ fmtSize(a.size) }}</span>
+        <span class="text-fg-muted">{{ fmtSize(a.size) }}</span>
       </div>
     </template>
   </div>

--- a/packages/relay-web/src/components/MessageAttachments.vue
+++ b/packages/relay-web/src/components/MessageAttachments.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { FileText } from "lucide-vue-next";
+import type { AttachmentMetadata } from "@ganglion/xacpx-relay-protocol";
+
+defineProps<{ attachments: AttachmentMetadata[] }>();
+
+function fmtSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+</script>
+
+<template>
+  <div class="mt-1 flex flex-wrap gap-2">
+    <template v-for="a in attachments" :key="a.id">
+      <img
+        v-if="a.kind === 'image' && a.previewUrl"
+        data-test="att-image"
+        :src="a.previewUrl"
+        :alt="a.filename"
+        class="max-h-40 max-w-[200px] rounded-lg border border-border object-cover"
+      />
+      <div
+        v-else
+        data-test="att-file"
+        class="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2 text-[13px]"
+      >
+        <FileText :size="16" class="shrink-0 text-muted" />
+        <span class="max-w-[180px] truncate">{{ a.filename }}</span>
+        <span class="text-muted">{{ fmtSize(a.size) }}</span>
+      </div>
+    </template>
+  </div>
+</template>

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -7,6 +7,7 @@ import ReasoningPanel from "./ReasoningPanel.vue";
 import TurnParts from "./TurnParts.vue";
 import CopyButton from "./CopyButton.vue";
 import { Bot, CircleStop, Clock, Loader2, RotateCcw } from "lucide-vue-next";
+import MessageAttachments from "./MessageAttachments.vue";
 import { fmtTime, fmtDateTime } from "../lib/format";
 
 const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; hasMoreOlder?: boolean; loadingOlder?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null }>();
@@ -159,6 +160,7 @@ watch(
                    class="rounded-2xl rounded-tr-md border border-accent/15 bg-accent/10 px-3.5 py-2"
                    :class="m.failed ? 'ring-1 ring-danger' : ''">
                 <p class="whitespace-pre-wrap text-[14px] leading-relaxed text-fg">{{ m.text }}</p>
+                <MessageAttachments v-if="m.attachments?.length" :attachments="m.attachments" />
               </div>
               <!-- Failed sends get a compact retry affordance on their own line below. -->
               <div v-if="m.failed" class="mt-1 flex items-center gap-2">

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from "vue";
-import { Brain, Check, ChevronDown, Gauge, Send } from "lucide-vue-next";
+import { Brain, Check, ChevronDown, Gauge, Paperclip, Send, X } from "lucide-vue-next";
+import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
 import { useComposerStore } from "../stores/composer";
 import { useSessionControlsStore } from "../stores/session-controls";
 import { useChatStore } from "../stores/chat";
 
 const props = defineProps<{ busy?: boolean; draftKey?: string; instanceId?: string | null; sessionAlias?: string | null }>();
-const emit = defineEmits<{ send: [text: string]; cancel: [] }>();
+const emit = defineEmits<{ send: [text: string, media: PromptAttachmentRef[]]; cancel: [] }>();
 
 const composer = useComposerStore();
 const controls = useSessionControlsStore();
@@ -36,6 +37,30 @@ async function pickModel(id: string) {
 }
 const text = ref(loadDraft(props.draftKey ?? ""));
 const textarea = ref<HTMLTextAreaElement | null>(null);
+const fileInput = ref<HTMLInputElement | null>(null);
+
+function openPicker() {
+  fileInput.value?.click();
+}
+async function onFilesPicked(e: Event) {
+  const input = e.target as HTMLInputElement;
+  if (input.files) await composer.addFiles(Array.from(input.files));
+  input.value = "";
+}
+async function onPaste(e: ClipboardEvent) {
+  const files = Array.from(e.clipboardData?.files ?? []);
+  if (files.length > 0) {
+    e.preventDefault();
+    await composer.addFiles(files);
+  }
+}
+async function onDrop(e: DragEvent) {
+  const files = Array.from(e.dataTransfer?.files ?? []);
+  if (files.length > 0) {
+    e.preventDefault();
+    await composer.addFiles(files);
+  }
+}
 
 // Persist the draft per session and restore on switch: when the key changes, stash the
 // current text under the previous key, then load the incoming session's draft.
@@ -64,10 +89,22 @@ let historyIdx = -1; // -1 = editing a fresh line
 
 function submit() {
   if (props.busy) return;
+  if (composer.uploading) return;
   const value = text.value.trim();
-  if (!value) return;
-  emit("send", value);
-  if (history.value[history.value.length - 1] !== value) history.value.push(value);
+  const ready = composer.pending.filter((p) => p.status === "ready");
+  if (!value && ready.length === 0) return;
+  const media: PromptAttachmentRef[] = ready.map((p) => ({
+    id: p.id,
+    filePath: p.filePath as string,
+    fileName: p.filename,
+    mimeType: p.mimeType,
+    kind: p.kind,
+    size: p.size,
+    ...(p.previewUrl ? { previewUrl: p.previewUrl } : {}),
+  }));
+  emit("send", value, media);
+  composer.clearAttachments();
+  if (value && history.value[history.value.length - 1] !== value) history.value.push(value);
   historyIdx = -1;
   text.value = "";
 }
@@ -109,16 +146,32 @@ function onInput() {
   <!-- pb keeps the existing padding and adds the iOS home-indicator safe area so
        the composer is not overlapped at the bottom of an installed PWA (env() is 0
        on desktop / non-PWA, so the padding is unchanged there). -->
-  <form class="relative border-t border-border px-0 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] lg:p-3 lg:pb-[calc(0.75rem+env(safe-area-inset-bottom))]" @submit.prevent="submit">
+  <form class="relative border-t border-border px-0 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] lg:p-3 lg:pb-[calc(0.75rem+env(safe-area-inset-bottom))]" @submit.prevent="submit"
+        @drop.prevent="onDrop" @dragover.prevent>
+    <!-- hidden file picker -->
+    <input ref="fileInput" type="file" multiple class="hidden" data-test="attach-input" @change="onFilesPicked" />
     <!-- COMPOSER — single elevated card: textarea on top, controls row below. -->
     <div class="rounded-lg border border-border bg-surface shadow-e2 focus-within:border-accent/50 transition-colors">
+      <!-- Pending attachment chips -->
+      <div v-if="composer.pending.length" class="flex flex-wrap gap-2 px-2.5 pt-2.5 pb-1">
+        <div v-for="p in composer.pending" :key="p.id"
+             class="flex items-center gap-1.5 rounded-md border border-border bg-raised px-2 py-1 text-[12px]">
+          <img v-if="p.previewUrl" :src="p.previewUrl" class="h-6 w-6 rounded object-cover" :alt="p.filename" />
+          <span class="max-w-[120px] truncate text-fg">{{ p.filename }}</span>
+          <span v-if="p.status === 'uploading'" class="text-fg-muted">…</span>
+          <span v-else-if="p.status === 'error'" class="text-danger font-semibold">!</span>
+          <button type="button" :title="$t('chat.attach.remove')" class="text-fg-muted hover:text-fg transition-colors"
+                  @click="composer.removeAttachment(p.id)"><X :size="12" /></button>
+        </div>
+      </div>
       <!-- Stays enabled while busy so you can pre-compose the next message and press
            Esc to stop; submit() itself no-ops while busy. -->
       <textarea ref="textarea" v-model="text" rows="2"
                 class="w-full resize-none bg-transparent px-3.5 pt-2.5 pb-1 text-[16px] lg:text-[14px] leading-relaxed text-fg placeholder:text-fg-muted focus:outline-none"
                 :placeholder='busy ? $t("chat.working") : $t("chat.message")'
                 @input="onInput"
-                @keydown="onKeydown" />
+                @keydown="onKeydown"
+                @paste="onPaste" />
       <div class="flex items-center justify-between px-2.5 pb-2.5 pt-0.5">
         <!-- model chip (left) -->
         <div v-if="instanceId && sessionAlias" class="relative flex items-center gap-2">
@@ -160,14 +213,22 @@ function onInput() {
         <span v-else />
 
         <!-- send / stop (right) -->
-        <button v-if="busy" type="button" data-test="composer-stop"
-                class="flex items-center gap-1.5 pl-3 pr-2.5 py-1.5 rounded-md bg-danger text-white text-[12.5px] font-semibold hover:opacity-90 transition-all"
-                @click="emit('cancel')">{{ $t("chat.stop") }}</button>
-        <button v-else type="submit" data-test="composer-send" :disabled="!text.trim()"
-                class="flex items-center gap-1.5 pl-3 pr-2.5 py-1.5 rounded-md bg-accent text-white text-[12.5px] font-semibold shadow-e1 hover:bg-accent-hover hover:shadow-e2 transition-all disabled:bg-fg/10 disabled:text-fg-muted disabled:shadow-none">
-          {{ $t("chat.send") }}
-          <Send :size="14" />
-        </button>
+        <div class="flex items-center gap-1.5">
+          <!-- attach button -->
+          <button type="button" data-test="attach-btn" :title="$t('chat.attach.add')"
+                  class="flex items-center gap-1.5 px-1.5 py-1 rounded-md text-fg-muted hover:bg-raised transition-colors"
+                  @click="openPicker">
+            <Paperclip :size="15" />
+          </button>
+          <button v-if="busy" type="button" data-test="composer-stop"
+                  class="flex items-center gap-1.5 pl-3 pr-2.5 py-1.5 rounded-md bg-danger text-white text-[12.5px] font-semibold hover:opacity-90 transition-all"
+                  @click="emit('cancel')">{{ $t("chat.stop") }}</button>
+          <button v-else type="submit" data-test="composer-send" :disabled="!text.trim() && !composer.pending.filter(p => p.status === 'ready').length"
+                  class="flex items-center gap-1.5 pl-3 pr-2.5 py-1.5 rounded-md bg-accent text-white text-[12.5px] font-semibold shadow-e1 hover:bg-accent-hover hover:shadow-e2 transition-all disabled:bg-fg/10 disabled:text-fg-muted disabled:shadow-none">
+            {{ $t("chat.send") }}
+            <Send :size="14" />
+          </button>
+        </div>
       </div>
     </div>
   </form>

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -284,7 +284,7 @@ function onInput() {
           <button v-if="busy" type="button" data-test="composer-stop"
                   class="flex items-center gap-1.5 pl-3 pr-2.5 py-1.5 rounded-md bg-danger text-white text-[12.5px] font-semibold hover:opacity-90 transition-all"
                   @click="emit('cancel')">{{ $t("chat.stop") }}</button>
-          <button v-else type="submit" data-test="composer-send" :disabled="!text.trim() && !composer.pending.filter(p => p.status === 'ready').length"
+          <button v-else type="submit" data-test="composer-send" :disabled="composer.uploading || (!text.trim() && !composer.pending.filter(p => p.status === 'ready').length)"
                   class="flex items-center gap-1.5 pl-3 pr-2.5 py-1.5 rounded-md bg-accent text-white text-[12.5px] font-semibold shadow-e1 hover:bg-accent-hover hover:shadow-e2 transition-all disabled:bg-fg/10 disabled:text-fg-muted disabled:shadow-none">
             {{ $t("chat.send") }}
             <Send :size="14" />

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -161,7 +161,7 @@ function onKeydown(e: KeyboardEvent) {
   if (cmdMenuOpen.value && cmdMatches.value.length > 0) {
     if (e.key === "ArrowDown") { cmdActiveIdx.value = (cmdActiveIdx.value + 1) % cmdMatches.value.length; e.preventDefault(); return; }
     if (e.key === "ArrowUp") { cmdActiveIdx.value = (cmdActiveIdx.value - 1 + cmdMatches.value.length) % cmdMatches.value.length; e.preventDefault(); return; }
-    if (e.key === "Enter" || e.key === "Tab") { pickCommand(cmdMatches.value[cmdActiveIdx.value].name); e.preventDefault(); return; }
+    if (e.key === "Enter" || e.key === "Tab") { const c = cmdMatches.value[cmdActiveIdx.value]; if (c) pickCommand(c.name); e.preventDefault(); return; }
     if (e.key === "Escape") { cmdMenuOpen.value = false; e.preventDefault(); return; }
   }
   if (e.key === "Escape") {
@@ -208,15 +208,15 @@ function onInput() {
         {{ composer.rejection.reason === 'too-many' ? $t('chat.attach.tooMany') : $t('chat.attach.tooLarge', { name: composer.rejection.filename }) }}
       </span>
       <!-- Agent slash-command autocomplete -->
-      <ul v-if="cmdMenuOpen" data-test="cmd-menu"
+      <ul v-if="cmdMenuOpen && cmdMatches.length" data-test="cmd-menu" role="listbox"
           class="mx-2.5 mt-2 max-h-56 overflow-auto rounded-md border border-border bg-raised py-1 shadow-e2">
         <li v-for="(c, i) in cmdMatches" :key="c.name"
-            data-test="cmd-item"
+            data-test="cmd-item" role="option" :aria-selected="i === cmdActiveIdx"
             class="flex cursor-pointer items-baseline gap-2 px-3 py-1.5 text-[13px]"
             :class="i === cmdActiveIdx ? 'bg-accent/10' : ''"
             @mousedown.prevent="pickCommand(c.name)"
             @mouseenter="cmdActiveIdx = i">
-          <span class="font-medium text-fg">/{{ c.name }}</span>
+          <span class="shrink-0 font-medium text-fg">/{{ c.name }}</span>
           <span v-if="c.description" class="truncate text-fg-muted">{{ c.description }}</span>
         </li>
       </ul>

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -49,6 +49,28 @@ const text = ref(loadDraft(props.draftKey ?? ""));
 const textarea = ref<HTMLTextAreaElement | null>(null);
 const fileInput = ref<HTMLInputElement | null>(null);
 
+// Agent slash-command autocomplete: when the composer holds a single `/`-token, offer the
+// session's advertised commands. Selecting one inserts `/name `; it then sends as a normal
+// prompt (the agent interprets it). No commands / no match → no menu, composer unchanged.
+const cmdMenuOpen = ref(false);
+const cmdActiveIdx = ref(0);
+const cmdQuery = computed(() => {
+  const v = text.value;
+  if (!v.startsWith("/") || v.includes("\n") || v.slice(1).includes(" ")) return null;
+  return v.slice(1).toLowerCase();
+});
+const cmdMatches = computed(() => {
+  const q = cmdQuery.value;
+  if (q === null) return [];
+  return chat.sessionCommands.filter((c) => c.name.toLowerCase().startsWith(q)).slice(0, 8);
+});
+watch(cmdMatches, (m) => { cmdMenuOpen.value = m.length > 0; cmdActiveIdx.value = 0; });
+function pickCommand(name: string) {
+  text.value = `/${name} `;
+  cmdMenuOpen.value = false;
+  void nextTick(() => textarea.value?.focus());
+}
+
 function openPicker() {
   fileInput.value?.click();
 }
@@ -135,6 +157,13 @@ function onKeydown(e: KeyboardEvent) {
   // IME guard: never intercept keys mid-composition (CJK input) — Enter here confirms
   // the candidate, it must not submit. `isComposing` covers all input engines.
   if (e.isComposing) return;
+  // Command autocomplete takes the arrow/enter/tab/esc keys while its menu is open.
+  if (cmdMenuOpen.value && cmdMatches.value.length > 0) {
+    if (e.key === "ArrowDown") { cmdActiveIdx.value = (cmdActiveIdx.value + 1) % cmdMatches.value.length; e.preventDefault(); return; }
+    if (e.key === "ArrowUp") { cmdActiveIdx.value = (cmdActiveIdx.value - 1 + cmdMatches.value.length) % cmdMatches.value.length; e.preventDefault(); return; }
+    if (e.key === "Enter" || e.key === "Tab") { pickCommand(cmdMatches.value[cmdActiveIdx.value].name); e.preventDefault(); return; }
+    if (e.key === "Escape") { cmdMenuOpen.value = false; e.preventDefault(); return; }
+  }
   if (e.key === "Escape") {
     if (props.busy) { emit("cancel"); e.preventDefault(); }
     return;
@@ -178,6 +207,19 @@ function onInput() {
       <span v-if="composer.rejection" data-test="attach-rejected" class="block px-3 pt-2 text-xs text-danger">
         {{ composer.rejection.reason === 'too-many' ? $t('chat.attach.tooMany') : $t('chat.attach.tooLarge', { name: composer.rejection.filename }) }}
       </span>
+      <!-- Agent slash-command autocomplete -->
+      <ul v-if="cmdMenuOpen" data-test="cmd-menu"
+          class="mx-2.5 mt-2 max-h-56 overflow-auto rounded-md border border-border bg-raised py-1 shadow-e2">
+        <li v-for="(c, i) in cmdMatches" :key="c.name"
+            data-test="cmd-item"
+            class="flex cursor-pointer items-baseline gap-2 px-3 py-1.5 text-[13px]"
+            :class="i === cmdActiveIdx ? 'bg-accent/10' : ''"
+            @mousedown.prevent="pickCommand(c.name)"
+            @mouseenter="cmdActiveIdx = i">
+          <span class="font-medium text-fg">/{{ c.name }}</span>
+          <span v-if="c.description" class="truncate text-fg-muted">{{ c.description }}</span>
+        </li>
+      </ul>
       <!-- Stays enabled while busy so you can pre-compose the next message and press
            Esc to stop; submit() itself no-ops while busy. -->
       <textarea ref="textarea" v-model="text" rows="2"

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -164,6 +164,10 @@ function onInput() {
                   @click="composer.removeAttachment(p.id)"><X :size="12" /></button>
         </div>
       </div>
+      <!-- Inline feedback when an attachment is rejected (cap or size limit). -->
+      <span v-if="composer.rejection" data-test="attach-rejected" class="block px-3 pt-2 text-xs text-danger">
+        {{ composer.rejection.reason === 'too-many' ? $t('chat.attach.tooMany') : $t('chat.attach.tooLarge', { name: composer.rejection.filename }) }}
+      </span>
       <!-- Stays enabled while busy so you can pre-compose the next message and press
            Esc to stop; submit() itself no-ops while busy. -->
       <textarea ref="textarea" v-model="text" rows="2"

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, ref, watch } from "vue";
 import { Brain, Check, ChevronDown, Gauge, Paperclip, Send, X } from "lucide-vue-next";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
+import UsagePopover from "./UsagePopover.vue";
 import { useComposerStore } from "../stores/composer";
 import { useSessionControlsStore } from "../stores/session-controls";
 import { useChatStore } from "../stores/chat";
@@ -21,8 +22,17 @@ const context = computed(() => {
   if (!u || u.size <= 0) return null;
   const pct = Math.min(100, Math.round((u.used / u.size) * 100));
   const tone = pct >= 90 ? "danger" : pct >= 75 ? "warn" : "accent";
-  return { used: u.used, size: u.size, pct, tone };
+  return { used: u.used, size: u.size, pct, tone, cost: u.cost, breakdown: u.breakdown };
 });
+
+// Click the meter to open a popover with the cost & per-turn token breakdown.
+const usageOpen = ref(false);
+const usageAnchor = ref<{ top: number; left: number; width: number; height: number } | null>(null);
+function toggleUsage(e: MouseEvent) {
+  const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  usageAnchor.value = { top: r.top, left: r.left, width: r.width, height: r.height };
+  usageOpen.value = !usageOpen.value;
+}
 
 // Load the session's model for the composer chip whenever the session changes.
 const modelMenuOpen = ref(false);
@@ -200,10 +210,11 @@ function onInput() {
             </li>
           </ul>
           <span v-if="controls.error" data-test="model-error" class="text-xs text-danger">{{ controls.error }}</span>
-          <!-- context-usage meter: sits to the right of the model chip -->
-          <span v-if="context" data-test="context-meter"
-                class="flex shrink-0 items-center gap-1.5 whitespace-nowrap pl-0.5"
-                :title="$t('chat.contextUsage', { used: context.used.toLocaleString(), size: context.size.toLocaleString() })">
+          <!-- context-usage meter: click to open the cost / token-breakdown popover -->
+          <button v-if="context" type="button" data-test="context-meter"
+                  class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded pl-0.5 hover:opacity-80"
+                  :title="$t('chat.contextUsage', { used: context.used.toLocaleString(), size: context.size.toLocaleString() })"
+                  @click="toggleUsage">
             <Gauge :size="13" class="shrink-0"
                    :class="context.tone === 'danger' ? 'text-danger' : context.tone === 'warn' ? 'text-warn' : 'text-accent'" />
             <span class="relative h-1 w-8 shrink-0 overflow-hidden rounded-full bg-border">
@@ -212,7 +223,11 @@ function onInput() {
                     :style="{ width: context.pct + '%' }" />
             </span>
             <span class="shrink-0 text-[11.5px] font-medium tabular-nums text-fg-muted">{{ context.pct }}%</span>
-          </span>
+          </button>
+          <UsagePopover v-if="context && usageOpen"
+                        :used="context.used" :size="context.size" :pct="context.pct"
+                        :cost="context.cost" :breakdown="context.breakdown" :anchor="usageAnchor"
+                        @dismiss="usageOpen = false" />
         </div>
         <span v-else />
 

--- a/packages/relay-web/src/components/UsagePopover.vue
+++ b/packages/relay-web/src/components/UsagePopover.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import { computeCalloutPlacement, type Rect } from "../lib/fue-placement";
+
+type Cost = { amount?: number; currency?: string };
+type Breakdown = {
+  inputTokens?: number; outputTokens?: number; cachedReadTokens?: number;
+  cachedWriteTokens?: number; thoughtTokens?: number; totalTokens?: number;
+};
+const props = defineProps<{
+  used: number; size: number; pct: number; cost?: Cost; breakdown?: Breakdown; anchor?: Rect | null;
+}>();
+const emit = defineEmits<{ dismiss: [] }>();
+
+const card = ref<HTMLElement | null>(null);
+const style = ref<Record<string, string>>({ visibility: "hidden" });
+
+const breakdownRows = [
+  { key: "inputTokens", label: "chat.usage.input" },
+  { key: "outputTokens", label: "chat.usage.output" },
+  { key: "cachedReadTokens", label: "chat.usage.cacheRead" },
+  { key: "cachedWriteTokens", label: "chat.usage.cacheWrite" },
+  { key: "thoughtTokens", label: "chat.usage.thinking" },
+  { key: "totalTokens", label: "chat.usage.total" },
+] as const;
+
+function num(v: number | undefined): string | null {
+  return typeof v === "number" ? v.toLocaleString() : null;
+}
+function costText(): string | null {
+  const a = props.cost?.amount;
+  if (typeof a !== "number") return null;
+  const cur = props.cost?.currency;
+  try {
+    if (cur) return new Intl.NumberFormat(undefined, { style: "currency", currency: cur, maximumFractionDigits: 4 }).format(a);
+  } catch { /* unknown currency code → fall through to plain number */ }
+  return cur ? `${a} ${cur}` : String(a);
+}
+
+function reposition(): void {
+  const el = card.value;
+  if (!el) return;
+  const size = { width: el.offsetWidth || 240, height: el.offsetHeight || 160 };
+  const viewport = { width: window.innerWidth, height: window.innerHeight };
+  if (props.anchor) {
+    const p = computeCalloutPlacement(props.anchor, size, viewport);
+    style.value = { top: `${p.top}px`, left: `${p.left}px`, visibility: "visible" };
+  } else {
+    style.value = {
+      top: `${Math.max(8, viewport.height / 2 - size.height / 2)}px`,
+      left: `${Math.max(8, viewport.width / 2 - size.width / 2)}px`,
+      visibility: "visible",
+    };
+  }
+}
+function onKey(e: KeyboardEvent): void { if (e.key === "Escape") emit("dismiss"); }
+function onDocPointer(e: PointerEvent): void {
+  if (card.value && !card.value.contains(e.target as Node)) emit("dismiss");
+}
+
+onMounted(() => {
+  reposition();
+  window.addEventListener("keydown", onKey);
+  window.addEventListener("resize", reposition);
+  // Defer the outside-click listener so the opening click doesn't immediately dismiss.
+  setTimeout(() => document.addEventListener("pointerdown", onDocPointer), 0);
+});
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onKey);
+  window.removeEventListener("resize", reposition);
+  document.removeEventListener("pointerdown", onDocPointer);
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      ref="card"
+      data-test="usage-popover"
+      class="fixed z-[60] w-60 rounded-lg border border-border bg-raised p-3 text-sm shadow-e2"
+      :style="style"
+      role="dialog"
+    >
+      <p class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">{{ $t("chat.usage.contextWindow") }}</p>
+      <div class="flex items-baseline justify-between tabular-nums">
+        <span class="text-fg">{{ used.toLocaleString() }} / {{ size.toLocaleString() }}</span>
+        <span class="text-fg-muted">{{ pct }}%</span>
+      </div>
+
+      <template v-if="breakdown">
+        <p class="mb-1 mt-3 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">{{ $t("chat.usage.tokens") }}</p>
+        <dl class="space-y-0.5">
+          <template v-for="row in breakdownRows" :key="row.key">
+            <div v-if="num((breakdown as Record<string, number | undefined>)[row.key]) !== null" class="flex justify-between tabular-nums">
+              <dt class="text-fg-muted">{{ $t(row.label) }}</dt>
+              <dd class="text-fg">{{ num((breakdown as Record<string, number | undefined>)[row.key]) }}</dd>
+            </div>
+          </template>
+        </dl>
+      </template>
+
+      <template v-if="costText() !== null">
+        <p class="mb-1 mt-3 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">{{ $t("chat.usage.cost") }}</p>
+        <div class="flex justify-between tabular-nums">
+          <span class="text-fg-muted">{{ $t("chat.usage.cumulative") }}</span>
+          <span class="text-fg">{{ costText() }}</span>
+        </div>
+      </template>
+    </div>
+  </Teleport>
+</template>

--- a/packages/relay-web/src/components/WorkspacesManager.vue
+++ b/packages/relay-web/src/components/WorkspacesManager.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { Trash2 } from "lucide-vue-next";
+import { Plus, Trash2 } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
 import { confirm } from "../lib/use-confirm";
 
@@ -15,6 +15,16 @@ const path = ref("");
 const description = ref("");
 const error = ref("");
 const busy = ref(false);
+const formOpen = ref(false);
+const filter = ref("");
+
+const all = computed(() => inst.value?.workspaces ?? []);
+const showFilter = computed(() => all.value.length > 6);
+const list = computed(() => {
+  const q = filter.value.trim().toLowerCase();
+  if (!q) return all.value;
+  return all.value.filter((w) => w.name.toLowerCase().includes(q) || (w.cwd ?? "").toLowerCase().includes(q));
+});
 
 async function create(): Promise<void> {
   if (!name.value.trim() || !path.value.trim() || busy.value) return;
@@ -44,23 +54,37 @@ async function remove(wsName: string): Promise<void> {
 
 <template>
   <section class="space-y-3">
-    <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("workspaces.title") }}</h3>
     <p v-if="error" data-test="wm-error" class="rounded bg-danger/10 px-3 py-2 text-sm text-danger">{{ error }}</p>
-    <p v-if="!(inst?.workspaces ?? []).length" data-test="wm-empty" class="text-sm text-fg-muted">{{ $t("workspaces.empty") }}</p>
-    <ul v-else class="divide-y divide-border rounded border border-border">
-      <li v-for="w in inst?.workspaces ?? []" :key="w.name" class="flex items-center justify-between px-3 py-2 text-sm text-fg">
-        <span><span class="font-medium">{{ w.name }}</span> — <span class="text-fg-muted">{{ w.cwd }}</span></span>
+    <input v-if="showFilter" v-model="filter" data-test="wm-filter" :placeholder="$t('common.filter')"
+           class="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
+    <p v-if="!all.length" data-test="wm-empty" class="text-sm text-fg-muted">{{ $t("workspaces.empty") }}</p>
+    <ul v-else class="max-h-64 divide-y divide-border overflow-y-auto rounded border border-border">
+      <li v-for="w in list" :key="w.name" class="flex items-center justify-between gap-2 px-3 py-2 text-sm">
+        <span class="min-w-0 truncate" :title="`${w.name} — ${w.cwd}`">
+          <span class="font-medium text-fg">{{ w.name }}</span><span class="text-fg-muted"> — {{ w.cwd }}</span>
+        </span>
         <button :data-test="`wm-remove-${w.name}`" :title="$t('workspaces.remove', { name: w.name })" :aria-label="$t('workspaces.removeAria', { name: w.name })"
                 class="grid h-7 w-7 shrink-0 place-items-center rounded text-fg-muted transition-colors hover:bg-danger/15 hover:text-danger disabled:opacity-50"
                 :disabled="busy" @click="remove(w.name)"><Trash2 :size="14" /></button>
       </li>
+      <li v-if="!list.length" class="px-3 py-2 text-sm text-fg-muted">{{ $t("common.noMatch") }}</li>
     </ul>
-    <div class="grid grid-cols-1 gap-2 sm:grid-cols-3">
-      <input v-model="name" data-test="wm-name" :placeholder="$t('workspaces.namePlaceholder')" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
-      <input v-model="path" data-test="wm-path" :placeholder="$t('workspaces.pathPlaceholder')" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
-      <input v-model="description" data-test="wm-desc" :placeholder="$t('workspaces.descPlaceholder')" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
+
+    <button v-if="!formOpen" type="button" data-test="wm-add-toggle" @click="formOpen = true"
+            class="flex items-center gap-1.5 rounded border border-dashed border-border px-3 py-1.5 text-sm text-fg-muted transition-colors hover:border-accent hover:text-fg">
+      <Plus :size="14" /> {{ $t("workspaces.add") }}
+    </button>
+    <div v-else class="space-y-2 rounded border border-border p-3">
+      <div class="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        <input v-model="name" data-test="wm-name" :placeholder="$t('workspaces.namePlaceholder')" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
+        <input v-model="path" data-test="wm-path" :placeholder="$t('workspaces.pathPlaceholder')" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
+        <input v-model="description" data-test="wm-desc" :placeholder="$t('workspaces.descPlaceholder')" class="rounded border border-border bg-bg px-2 py-1 text-sm text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
+      </div>
+      <div class="flex gap-2">
+        <button data-test="wm-create" class="rounded bg-accent px-3 py-1.5 text-sm text-white hover:bg-accent-hover disabled:opacity-50"
+                :disabled="busy || !name.trim() || !path.trim()" @click="create">{{ $t("common.add") }}</button>
+        <button type="button" data-test="wm-add-cancel" class="rounded px-3 py-1.5 text-sm text-fg-muted hover:bg-fg/5 hover:text-fg" @click="formOpen = false">{{ $t("common.cancel") }}</button>
+      </div>
     </div>
-    <button data-test="wm-create" class="rounded bg-accent px-3 py-1.5 text-sm text-white hover:bg-accent-hover disabled:opacity-50"
-            :disabled="busy || !name.trim() || !path.trim()" @click="create">{{ $t("workspaces.add") }}</button>
   </section>
 </template>

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -77,7 +77,7 @@ export default {
     message: "Message",
     jumpLatest: "↓ Latest",
     contextUsage: "Context: {used} / {size} tokens",
-    attach: { add: "Attach file", remove: "Remove" },
+    attach: { add: "Attach file", remove: "Remove", tooMany: "Up to 5 files per message", tooLarge: "{name} is too large (max 10MB)" },
   },
   session: {
     newSession: "New session",

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -165,7 +165,6 @@ export default {
     newSession: "New session",
     deleteSession: "Delete session",
     archiveSession: "Archive session",
-    archive: "Archive",
     sessionArchivedBadge: "archived",
     sessionArchivedToast: "Archived \"{alias}\"",
     undo: "Undo",

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -12,6 +12,9 @@ export default {
     remove: "Remove",
     dismiss: "dismiss",
     dismissNotice: "Dismiss",
+    add: "Add",
+    filter: "Filter…",
+    noMatch: "No match",
   },
   connection: {
     online: "Connected",
@@ -178,6 +181,7 @@ export default {
     manageTitle: "Manage · {name}",
     close: "Close",
     dialogLoading: "Loading…",
+    tabGeneral: "General",
     nameLabel: "Name",
     renamePlaceholder: "instance name",
     renameSave: "Save",

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -77,6 +77,18 @@ export default {
     message: "Message",
     jumpLatest: "↓ Latest",
     contextUsage: "Context: {used} / {size} tokens",
+    usage: {
+      contextWindow: "Context window",
+      tokens: "Tokens (this session)",
+      input: "Input",
+      output: "Output",
+      cacheRead: "Cache read",
+      cacheWrite: "Cache write",
+      thinking: "Thinking",
+      total: "Total",
+      cost: "Cost",
+      cumulative: "Cumulative",
+    },
     attach: { add: "Attach file", remove: "Remove", tooMany: "Up to 5 files per message", tooLarge: "{name} is too large (max 10MB)" },
   },
   session: {

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -77,6 +77,7 @@ export default {
     message: "Message",
     jumpLatest: "↓ Latest",
     contextUsage: "Context: {used} / {size} tokens",
+    attach: { add: "Attach file", remove: "Remove" },
   },
   session: {
     newSession: "New session",

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -150,6 +150,7 @@ export default {
     newSession: "New session",
     deleteSession: "Delete session",
     archiveSession: "Archive session",
+    archive: "Archive",
     sessionArchivedBadge: "archived",
     sessionArchivedToast: "Archived \"{alias}\"",
     undo: "Undo",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -10,6 +10,9 @@ export default {
     remove: "移除",
     dismiss: "关闭",
     dismissNotice: "关闭通知",
+    add: "添加",
+    filter: "筛选…",
+    noMatch: "无匹配",
   },
   connection: {
     online: "已连接",
@@ -174,6 +177,7 @@ export default {
     deleteSessionTitle: "删除会话？",
     deleteSessionBody: "“{alias}” 将被永久删除，此操作无法撤销。",
     manageTitle: "管理 · {name}",
+    tabGeneral: "常规",
     close: "关闭",
     dialogLoading: "加载中…",
     nameLabel: "名称",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -75,6 +75,18 @@ export default {
     message: "消息",
     jumpLatest: "↓ 最新",
     contextUsage: "上下文：{used} / {size} tokens",
+    usage: {
+      contextWindow: "上下文窗口",
+      tokens: "Tokens（本会话）",
+      input: "输入",
+      output: "输出",
+      cacheRead: "缓存读取",
+      cacheWrite: "缓存写入",
+      thinking: "思考",
+      total: "合计",
+      cost: "费用",
+      cumulative: "累计",
+    },
     attach: { add: "添加附件", remove: "移除", tooMany: "每条消息最多 5 个文件", tooLarge: "{name} 太大（最大 10MB）" },
   },
   session: {

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -75,6 +75,7 @@ export default {
     message: "消息",
     jumpLatest: "↓ 最新",
     contextUsage: "上下文：{used} / {size} tokens",
+    attach: { add: "添加附件", remove: "移除" },
   },
   session: {
     newSession: "新建会话",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -148,6 +148,7 @@ export default {
     newSession: "新建会话",
     deleteSession: "删除会话",
     archiveSession: "归档会话",
+    archive: "归档",
     sessionArchivedBadge: "已归档",
     sessionArchivedToast: "已归档「{alias}」",
     undo: "撤销",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -75,7 +75,7 @@ export default {
     message: "消息",
     jumpLatest: "↓ 最新",
     contextUsage: "上下文：{used} / {size} tokens",
-    attach: { add: "添加附件", remove: "移除" },
+    attach: { add: "添加附件", remove: "移除", tooMany: "每条消息最多 5 个文件", tooLarge: "{name} 太大（最大 10MB）" },
   },
   session: {
     newSession: "新建会话",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -163,7 +163,6 @@ export default {
     newSession: "新建会话",
     deleteSession: "删除会话",
     archiveSession: "归档会话",
-    archive: "归档",
     sessionArchivedBadge: "已归档",
     sessionArchivedToast: "已归档「{alias}」",
     undo: "撤销",

--- a/packages/relay-web/src/lib/image-downscale.ts
+++ b/packages/relay-web/src/lib/image-downscale.ts
@@ -1,7 +1,7 @@
 /** Returns a downscaled data URL (≤ maxPx on the long edge) for images, or undefined for non-images. */
 export async function downscaleImage(file: File, maxPx = 512): Promise<string | undefined> {
   if (!file.type.startsWith("image/")) return undefined;
-  const bitmap = await createImageBitmap(file).catch(() => null);
+  const bitmap = await createImageBitmap(file, { imageOrientation: "from-image" }).catch(() => null);
   if (!bitmap) return undefined;
   const scale = Math.min(1, maxPx / Math.max(bitmap.width, bitmap.height));
   const w = Math.max(1, Math.round(bitmap.width * scale));

--- a/packages/relay-web/src/lib/image-downscale.ts
+++ b/packages/relay-web/src/lib/image-downscale.ts
@@ -1,0 +1,30 @@
+/** Returns a downscaled data URL (≤ maxPx on the long edge) for images, or undefined for non-images. */
+export async function downscaleImage(file: File, maxPx = 512): Promise<string | undefined> {
+  if (!file.type.startsWith("image/")) return undefined;
+  const bitmap = await createImageBitmap(file).catch(() => null);
+  if (!bitmap) return undefined;
+  const scale = Math.min(1, maxPx / Math.max(bitmap.width, bitmap.height));
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return undefined;
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close();
+  return canvas.toDataURL("image/jpeg", 0.8);
+}
+
+/** Reads a File as base64 (no data-URL prefix). */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.slice(result.indexOf(",") + 1));
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}

--- a/packages/relay-web/src/lib/use-swipe-actions.ts
+++ b/packages/relay-web/src/lib/use-swipe-actions.ts
@@ -1,40 +1,60 @@
 export interface SwipeActionsOptions {
-  onSwipeLeft: () => void;
-  onSwipeRight: () => void;
-  threshold?: number; // px of horizontal travel required to fire
+  /** Live horizontal delta (px) during a horizontal drag. Negative = leftward.
+   *  Fires on every pointermove once the gesture is decided horizontal, so the
+   *  consumer can translate the row 1:1 with the finger ("跟手"). */
+  onMove?: (dx: number) => void;
+  /** Fires exactly once when the gesture ends (pointerup / cancel / yielded to
+   *  vertical scroll), with the final horizontal delta (0 if it never went
+   *  horizontal). The consumer decides whether to snap open or closed. */
+  onEnd?: (dx: number) => void;
+  /** Px of movement before the gesture commits to an axis (default 4). Below this
+   *  a tap stays a tap and never starts a drag. */
+  intent?: number;
 }
 
-/** Minimal horizontal-swipe detector for a list row. Tracks pointer travel and fires
- *  left/right past the threshold, ignoring vertical-dominant gestures so it doesn't
- *  fight the scroll container. */
+/** Interactive horizontal-swipe detector for a list row. Reports a live delta so
+ *  the row can follow the finger, and yields to the scroll container the moment a
+ *  gesture is vertical-dominant. Emits exactly one `onEnd` per gesture, always. */
 export function useSwipeActions(opts: SwipeActionsOptions) {
-  const threshold = opts.threshold ?? 64;
-  let startX = 0, startY = 0, active = false;
+  const intent = opts.intent ?? 4;
+  let startX = 0, startY = 0;
+  let dragging = false, decided = false, horizontal = false;
 
   // Keys MUST be bare DOM event names (`pointerdown`, not `onPointerdown`): the row
   // binds these via `v-on="handlers"`, and Vue's object-`v-on` re-applies the `on`
   // prefix itself. An `onPointerdown` key would be re-prefixed to a dead event and
   // the swipe would silently never fire.
   function pointerdown(e: { clientX: number; clientY: number }) {
-    active = true; startX = e.clientX; startY = e.clientY;
+    startX = e.clientX; startY = e.clientY;
+    dragging = true; decided = false; horizontal = false;
   }
   function pointermove(e: { clientX: number; clientY: number }) {
-    if (!active) return;
+    if (!dragging) return;
     const dx = e.clientX - startX, dy = e.clientY - startY;
-    if (Math.abs(dy) > Math.abs(dx)) active = false; // vertical-dominant → yield to scroll
+    if (!decided) {
+      if (Math.abs(dx) < intent && Math.abs(dy) < intent) return; // still a tap
+      decided = true;
+      horizontal = Math.abs(dx) > Math.abs(dy);
+    }
+    if (!horizontal) {
+      // Vertical-dominant → yield to the scroll container and end the gesture.
+      dragging = false;
+      opts.onEnd?.(0);
+      return;
+    }
+    opts.onMove?.(dx);
   }
   function pointerup(e: { clientX: number; clientY: number }) {
-    if (!active) return;
-    active = false;
-    const dx = e.clientX - startX, dy = e.clientY - startY;
-    if (Math.abs(dy) > Math.abs(dx)) return;
-    if (dx <= -threshold) opts.onSwipeLeft();
-    else if (dx >= threshold) opts.onSwipeRight();
+    if (!dragging) return;
+    dragging = false;
+    opts.onEnd?.(horizontal ? e.clientX - startX : 0);
   }
   // The browser fires `pointercancel` (and no `pointerup`) when it reclassifies the
-  // drag as a scroll/gesture. Reset so a cancelled gesture never fires an action.
+  // drag as a scroll/gesture. End cleanly so a row is never left mid-drag.
   function pointercancel() {
-    active = false;
+    if (!dragging) return;
+    dragging = false;
+    opts.onEnd?.(0);
   }
 
   return { handlers: { pointerdown, pointermove, pointerup, pointercancel } };

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
-import type { LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, ScheduledOriginDto, ToolStepDto, TurnPartDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
+import type { AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, ScheduledOriginDto, ToolStepDto, TurnPartDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 
 // Remember which session was open so a page refresh returns to it (selection is not
@@ -307,11 +307,20 @@ export const useChatStore = defineStore("chat", () => {
     }
   }
 
-  async function send(text: string): Promise<void> {
+  async function send(text: string, attachments: PromptAttachmentRef[] = []): Promise<void> {
     if (!instanceId.value || !sessionAlias.value) return;
     error.value = "";
     sending.value = true;
-    const optimistic: ChatMessage = { instanceId: instanceId.value, sessionAlias: sessionAlias.value, direction: "in", text, createdAt: new Date().toISOString() };
+    const optimistic: ChatMessage = {
+      instanceId: instanceId.value,
+      sessionAlias: sessionAlias.value,
+      direction: "in",
+      text,
+      createdAt: new Date().toISOString(),
+      ...(attachments.length > 0
+        ? { attachments: attachments.map((a): AttachmentMetadata => ({ id: a.id, filename: a.fileName, mimeType: a.mimeType, size: a.size, kind: a.kind, ...(a.previewUrl ? { previewUrl: a.previewUrl } : {}) })) }
+        : {}),
+    };
     messages.value.push(optimistic);
     try {
       // The web dashboard is GUI-first: every message — including `/`-prefixed text —
@@ -319,7 +328,11 @@ export const useChatStore = defineStore("chat", () => {
       // not handled here; the console forwards control-channel `/` text to the agent
       // verbatim (see command-router passthrough). Only WeChat/Feishu, which lack a
       // GUI, still rely on xacpx command handling.
-      const res = await api.rpc<{ ok?: boolean; errorMessage?: string }>(instanceId.value, "control.prompt", { sessionAlias: sessionAlias.value, text });
+      const res = await api.rpc<{ ok?: boolean; errorMessage?: string }>(instanceId.value, "control.prompt", {
+        sessionAlias: sessionAlias.value,
+        text,
+        ...(attachments.length > 0 ? { media: attachments } : {}),
+      });
       if (res && res.ok === false) {
         error.value = res.errorMessage ?? "prompt-failed";
         optimistic.failed = true;

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
-import type { AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, ScheduledOriginDto, ToolStepDto, TurnPartDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
+import type { AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, ScheduledOriginDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 
 // Remember which session was open so a page refresh returns to it (selection is not
@@ -20,6 +20,9 @@ export function loadPersistedSelection(): { instanceId: string; alias: string } 
 }
 
 export type TurnStatus = "working" | "streaming" | "done" | "cancelled" | "error";
+
+/** Per-session context usage: window fill plus optional cost & token breakdown. */
+export type SessionUsage = { used: number; size: number; cost?: UsageCostDto; breakdown?: UsageBreakdownDto };
 
 /** One transcript entry, kept in arrival order so text / reasoning / tool calls
  *  render inline exactly as the agent produced them (mirrors the hub's persistence). */
@@ -73,7 +76,7 @@ export const useChatStore = defineStore("chat", () => {
   // Context-usage meter per session (latest `turn-usage`): `used` tokens in context +
   // `size` total window. Session-scoped like `plans` so it persists across turns (REPLACE
   // semantics). Absent for agents that don't report usage (e.g. codex) — the meter hides.
-  const usage = ref<Record<string, { used: number; size: number }>>({});
+  const usage = ref<Record<string, SessionUsage>>({});
   // Sessions whose turn finished while NOT being viewed — drives the "unread" attention
   // dot in the session list. Reassigned (never mutated in place) so the Set stays reactive.
   const unread = ref<Set<string>>(new Set());
@@ -108,7 +111,7 @@ export const useChatStore = defineStore("chat", () => {
   const sessionPlan = computed<PlanEntryDto[] | null>(() =>
     selectedKey.value ? plans.value[selectedKey.value] ?? null : null,
   );
-  const sessionUsage = computed<{ used: number; size: number } | null>(() =>
+  const sessionUsage = computed<SessionUsage | null>(() =>
     selectedKey.value ? usage.value[selectedKey.value] ?? null : null,
   );
   const streaming = computed(() => (liveTurn.value ? textOf(liveTurn.value.parts) : ""));
@@ -282,7 +285,7 @@ export const useChatStore = defineStore("chat", () => {
       plans.value[bufKey(event.instanceId, e.sessionAlias)] = e.entries;
     } else if (e.type === "turn-usage") {
       // Latest context-usage for the session (REPLACE). Like plans, persists across turns.
-      usage.value[bufKey(event.instanceId, e.sessionAlias)] = { used: e.used, size: e.size };
+      usage.value[bufKey(event.instanceId, e.sessionAlias)] = { used: e.used, size: e.size, ...(e.cost ? { cost: e.cost } : {}), ...(e.breakdown ? { breakdown: e.breakdown } : {}) };
     } else if (e.type === "session-history") {
       // A freshly-attached native session's prior conversation was just seeded into the
       // hub. If we're viewing it, reload history so the backlog appears (otherwise it's

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
-import type { AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, ScheduledOriginDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
+import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, ScheduledOriginDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 
 // Remember which session was open so a page refresh returns to it (selection is not
@@ -77,6 +77,9 @@ export const useChatStore = defineStore("chat", () => {
   // `size` total window. Session-scoped like `plans` so it persists across turns (REPLACE
   // semantics). Absent for agents that don't report usage (e.g. codex) — the meter hides.
   const usage = ref<Record<string, SessionUsage>>({});
+  // Agent-advertised slash commands per session (latest `agent-commands`). Session-scoped
+  // like plans/usage (REPLACE), persists across turns. Empty for agents that don't advertise.
+  const agentCommands = ref<Record<string, AgentCommandDto[]>>({});
   // Sessions whose turn finished while NOT being viewed — drives the "unread" attention
   // dot in the session list. Reassigned (never mutated in place) so the Set stays reactive.
   const unread = ref<Set<string>>(new Set());
@@ -113,6 +116,9 @@ export const useChatStore = defineStore("chat", () => {
   );
   const sessionUsage = computed<SessionUsage | null>(() =>
     selectedKey.value ? usage.value[selectedKey.value] ?? null : null,
+  );
+  const sessionCommands = computed<AgentCommandDto[]>(() =>
+    selectedKey.value ? agentCommands.value[selectedKey.value] ?? [] : [],
   );
   const streaming = computed(() => (liveTurn.value ? textOf(liveTurn.value.parts) : ""));
   const liveToolSteps = computed(() => (liveTurn.value ? toolStepsOf(liveTurn.value.parts) : []));
@@ -286,6 +292,9 @@ export const useChatStore = defineStore("chat", () => {
     } else if (e.type === "turn-usage") {
       // Latest context-usage for the session (REPLACE). Like plans, persists across turns.
       usage.value[bufKey(event.instanceId, e.sessionAlias)] = { used: e.used, size: e.size, ...(e.cost ? { cost: e.cost } : {}), ...(e.breakdown ? { breakdown: e.breakdown } : {}) };
+    } else if (e.type === "agent-commands") {
+      // Latest agent slash-command list for the session (REPLACE). Drives composer "/" hints.
+      agentCommands.value[bufKey(event.instanceId, e.sessionAlias)] = e.commands;
     } else if (e.type === "session-history") {
       // A freshly-attached native session's prior conversation was just seeded into the
       // hub. If we're viewing it, reload history so the backlog appears (otherwise it's
@@ -377,5 +386,5 @@ export const useChatStore = defineStore("chat", () => {
     }
   }
 
-  return { instanceId, sessionAlias, messages, streaming, liveTurn, sessionPlan, sessionUsage, liveToolSteps, busy, unread, sessionAttention, runningSince, sending, error, scrollRequest, requestScrollToScheduled, hasMoreOlder, loadingOlder, select, loadHistory, loadOlder, loadActiveTurns, seedActiveTurns, applyEvent, send, resend, cancel };
+  return { instanceId, sessionAlias, messages, streaming, liveTurn, sessionPlan, sessionUsage, sessionCommands, liveToolSteps, busy, unread, sessionAttention, runningSince, sending, error, scrollRequest, requestScrollToScheduled, hasMoreOlder, loadingOlder, select, loadHistory, loadOlder, loadActiveTurns, seedActiveTurns, applyEvent, send, resend, cancel };
 });

--- a/packages/relay-web/src/stores/composer.ts
+++ b/packages/relay-web/src/stores/composer.ts
@@ -39,7 +39,11 @@ export const useComposerStore = defineStore("composer", () => {
   }
 
   async function addFiles(files: File[]): Promise<void> {
-    if (!instanceId) return;
+    // Capture the target instance once at the start: an in-flight batch must keep
+    // uploading to the instance it began with, even if bindInstance() switches the
+    // active instance mid-flight (session/instance switch while files are queued).
+    const targetInstanceId = instanceId;
+    if (!targetInstanceId) return;
     rejection.value = null;
     uploading.value = true;
     for (const file of files) {
@@ -60,7 +64,7 @@ export const useComposerStore = defineStore("composer", () => {
         const previewUrl = await downscaleImage(file);
         if (previewUrl) entry.previewUrl = previewUrl;
         const content = await fileToBase64(file);
-        const res = await api.upload(instanceId, { filename: file.name, content, mimeType: entry.mimeType });
+        const res = await api.upload(targetInstanceId, { filename: file.name, content, mimeType: entry.mimeType });
         entry.filePath = res.path;
         entry.id = res.id;
         entry.size = res.size;

--- a/packages/relay-web/src/stores/composer.ts
+++ b/packages/relay-web/src/stores/composer.ts
@@ -39,6 +39,7 @@ export const useComposerStore = defineStore("composer", () => {
 
   async function addFiles(files: File[]): Promise<void> {
     if (!instanceId) return;
+    uploading.value = true;
     for (const file of files) {
       if (pending.value.length >= MAX_ATTACHMENTS) break;
       if (file.size > MAX_BYTES) continue;
@@ -53,7 +54,6 @@ export const useComposerStore = defineStore("composer", () => {
         status: "uploading",
       };
       pending.value.push(entry);
-      uploading.value = true;
       try {
         const previewUrl = await downscaleImage(file);
         if (previewUrl) entry.previewUrl = previewUrl;

--- a/packages/relay-web/src/stores/composer.ts
+++ b/packages/relay-web/src/stores/composer.ts
@@ -1,6 +1,23 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 
+import { api } from "../api/client";
+import { downscaleImage, fileToBase64 } from "../lib/image-downscale";
+
+const MAX_ATTACHMENTS = 5;
+const MAX_BYTES = 10 * 1024 * 1024;
+
+export interface PendingAttachment {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  kind: "image" | "file";
+  previewUrl?: string;
+  filePath?: string;
+  status: "uploading" | "ready" | "error";
+}
+
 /** A tiny reactive bridge so non-composer UI (e.g. the command palette) can push
  *  text into a session's composer. The bumping `seq` makes repeated inserts of the
  *  same text still trigger the watcher in PromptInput. */
@@ -10,5 +27,56 @@ export const useComposerStore = defineStore("composer", () => {
   function requestInsert(key: string, text: string): void {
     insertRequest.value = { key, text, seq: ++seq };
   }
-  return { insertRequest, requestInsert };
+
+  const pending = ref<PendingAttachment[]>([]);
+  const uploading = ref(false);
+  let instanceId = "";
+  let localSeq = 0;
+
+  function bindInstance(id: string): void {
+    instanceId = id;
+  }
+
+  async function addFiles(files: File[]): Promise<void> {
+    if (!instanceId) return;
+    for (const file of files) {
+      if (pending.value.length >= MAX_ATTACHMENTS) break;
+      if (file.size > MAX_BYTES) continue;
+      const localId = `local-${++localSeq}`;
+      const kind: "image" | "file" = file.type.startsWith("image/") ? "image" : "file";
+      const entry: PendingAttachment = {
+        id: localId,
+        filename: file.name,
+        mimeType: file.type || "application/octet-stream",
+        size: file.size,
+        kind,
+        status: "uploading",
+      };
+      pending.value.push(entry);
+      uploading.value = true;
+      try {
+        const previewUrl = await downscaleImage(file);
+        if (previewUrl) entry.previewUrl = previewUrl;
+        const content = await fileToBase64(file);
+        const res = await api.upload(instanceId, { filename: file.name, content, mimeType: entry.mimeType });
+        entry.filePath = res.path;
+        entry.id = res.id;
+        entry.size = res.size;
+        entry.status = "ready";
+      } catch {
+        entry.status = "error";
+      }
+    }
+    uploading.value = pending.value.some((p) => p.status === "uploading");
+  }
+
+  function removeAttachment(id: string): void {
+    pending.value = pending.value.filter((p) => p.id !== id);
+  }
+
+  function clearAttachments(): void {
+    pending.value = [];
+  }
+
+  return { insertRequest, requestInsert, pending, uploading, bindInstance, addFiles, removeAttachment, clearAttachments };
 });

--- a/packages/relay-web/src/stores/composer.ts
+++ b/packages/relay-web/src/stores/composer.ts
@@ -30,6 +30,7 @@ export const useComposerStore = defineStore("composer", () => {
 
   const pending = ref<PendingAttachment[]>([]);
   const uploading = ref(false);
+  const rejection = ref<{ reason: "too-many" | "too-large"; filename: string } | null>(null);
   let instanceId = "";
   let localSeq = 0;
 
@@ -39,10 +40,11 @@ export const useComposerStore = defineStore("composer", () => {
 
   async function addFiles(files: File[]): Promise<void> {
     if (!instanceId) return;
+    rejection.value = null;
     uploading.value = true;
     for (const file of files) {
-      if (pending.value.length >= MAX_ATTACHMENTS) break;
-      if (file.size > MAX_BYTES) continue;
+      if (pending.value.length >= MAX_ATTACHMENTS) { rejection.value = { reason: "too-many", filename: file.name }; break; }
+      if (file.size > MAX_BYTES) { rejection.value = { reason: "too-large", filename: file.name }; continue; }
       const localId = `local-${++localSeq}`;
       const kind: "image" | "file" = file.type.startsWith("image/") ? "image" : "file";
       const entry: PendingAttachment = {
@@ -72,11 +74,13 @@ export const useComposerStore = defineStore("composer", () => {
 
   function removeAttachment(id: string): void {
     pending.value = pending.value.filter((p) => p.id !== id);
+    rejection.value = null;
   }
 
   function clearAttachments(): void {
     pending.value = [];
+    rejection.value = null;
   }
 
-  return { insertRequest, requestInsert, pending, uploading, bindInstance, addFiles, removeAttachment, clearAttachments };
+  return { insertRequest, requestInsert, pending, uploading, rejection, bindInstance, addFiles, removeAttachment, clearAttachments };
 });

--- a/packages/relay/src/db.ts
+++ b/packages/relay/src/db.ts
@@ -114,8 +114,15 @@ export function initSchema(db: SqlDriver): void {
       direction TEXT NOT NULL CHECK (direction IN ('in','out')),
       text TEXT NOT NULL,
       created_at TEXT NOT NULL,
-      structured TEXT
+      structured TEXT,
+      attachments TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_messages_session ON messages (instance_id, session_alias, id);
   `);
+
+  // Idempotent column add for pre-existing local dev DBs (create-only schema otherwise).
+  const messageCols = db.all<{ name: string }>("PRAGMA table_info(messages)");
+  if (!messageCols.some((c) => c.name === "attachments")) {
+    db.exec("ALTER TABLE messages ADD COLUMN attachments TEXT");
+  }
 }

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -70,6 +70,19 @@ function safePreviewUrl(v: unknown): string | undefined {
   return undefined;
 }
 
+// Coarse pre-buffer ceiling for /rpc bodies: a 10MB upload as base64 inside a JSON
+// envelope is ~13.33MB; 16MB leaves headroom for envelope overhead.
+const RPC_MAX_BODY_BYTES = 16 * 1024 * 1024;
+// Design spec caps attachments at ≤5 per message; bound persisted string fields too
+// so arbitrarily long filename/mimeType can't bloat storage.
+const MAX_PERSISTED_ATTACHMENTS = 5;
+const MAX_ATTACHMENT_FIELD_LEN = 256;
+
+/** Truncate a persisted attachment string field to a bounded length. */
+function boundField<T extends string | undefined>(v: T): T {
+  return (typeof v === "string" ? v.slice(0, MAX_ATTACHMENT_FIELD_LEN) : v) as T;
+}
+
 type Vars = { Variables: { account: AccountRow } };
 
 export function createApp(deps: AppDeps): Hono<Vars> {
@@ -269,6 +282,15 @@ export function createApp(deps: AppDeps): Hono<Vars> {
     const account = c.get("account");
     const instance = deps.instances.getOwned(c.req.param("id"), account.id);
     if (!instance) return c.json({ error: "not-found" }, 404);
+    // Coarse pre-buffer guard for ALL rpc types: reject by Content-Length before we
+    // read+JSON-parse the whole body into memory. Ceiling accommodates a 10MB upload
+    // encoded as base64 inside a JSON envelope (10MB → ~13.33MB base64 + overhead).
+    // Missing/unparseable Content-Length falls through — the precise MSG.upload
+    // decoded-size check below still bounds uploads.
+    const contentLength = Number(c.req.header("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > RPC_MAX_BODY_BYTES) {
+      return c.json({ error: "payload-too-large" }, 413);
+    }
     const body = (await c.req.json().catch(() => ({}))) as { type?: string; payload?: unknown };
     if (!body.type || !body.type.startsWith("control.")) return c.json({ error: "invalid-rpc-type" }, 400);
     let payload = body.payload ?? {};
@@ -293,12 +315,15 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       if (body.type === MSG.prompt || body.type === MSG.commandExecute) {
         const p = payload as { sessionAlias?: string; text?: string; media?: import("@ganglion/xacpx-relay-protocol").PromptAttachmentRef[] };
         if (p.sessionAlias && p.text !== undefined) {
-          const attachments = (p.media ?? []).map((m) => {
+          // Cap count (≤5 per spec) and bound string fields so a malicious client
+          // can't bloat storage. Only affects what's persisted; the forwarded turn
+          // payload (sendRequest below) keeps the original media untouched.
+          const attachments = (p.media ?? []).slice(0, MAX_PERSISTED_ATTACHMENTS).map((m) => {
             const previewUrl = safePreviewUrl(m.previewUrl);
             return {
               id: m.id,
-              filename: m.fileName,
-              mimeType: m.mimeType,
+              filename: boundField(m.fileName),
+              mimeType: boundField(m.mimeType),
               size: m.size,
               kind: m.kind,
               ...(previewUrl ? { previewUrl } : {}),

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -59,6 +59,14 @@ function requireJson(contentType: string | undefined): boolean {
   return (contentType ?? "").toLowerCase().includes("application/json");
 }
 
+/** Accept a persisted attachment preview only if it's a small image data URL. */
+function safePreviewUrl(v: unknown): string | undefined {
+  if (typeof v === "string" && v.startsWith("data:image/") && v.length <= 256 * 1024) {
+    return v;
+  }
+  return undefined;
+}
+
 type Vars = { Variables: { account: AccountRow } };
 
 export function createApp(deps: AppDeps): Hono<Vars> {
@@ -282,14 +290,17 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       if (body.type === MSG.prompt || body.type === MSG.commandExecute) {
         const p = payload as { sessionAlias?: string; text?: string; media?: import("@ganglion/xacpx-relay-protocol").PromptAttachmentRef[] };
         if (p.sessionAlias && p.text !== undefined) {
-          const attachments = (p.media ?? []).map((m) => ({
-            id: m.id,
-            filename: m.fileName,
-            mimeType: m.mimeType,
-            size: m.size,
-            kind: m.kind,
-            ...(m.previewUrl ? { previewUrl: m.previewUrl } : {}),
-          }));
+          const attachments = (p.media ?? []).map((m) => {
+            const previewUrl = safePreviewUrl(m.previewUrl);
+            return {
+              id: m.id,
+              filename: m.fileName,
+              mimeType: m.mimeType,
+              size: m.size,
+              kind: m.kind,
+              ...(previewUrl ? { previewUrl } : {}),
+            };
+          });
           deps.messages.append(instance.id, p.sessionAlias, "in", p.text, undefined, attachments);
         }
       }

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -51,6 +51,9 @@ const CHAT_SCOPED_TYPES = new Set<string>([
   // `relay:<accountId>` channel scope that prompt/list resolve against, else a
   // freshly created session is unreachable by a subsequent prompt.
   MSG.sessionsList, MSG.sessionsCreate, MSG.sessionsNativeList, MSG.sessionsRemove,
+  // Archive/unarchive resolve the alias within the caller's chat scope too; without
+  // the stamp the connector calls getChannelIdFromChatKey(undefined) and throws.
+  MSG.sessionsArchive, MSG.sessionsUnarchive,
   // Model get/set resolve the session within the caller's chat scope.
   MSG.sessionModelGet, MSG.sessionModelSet,
 ]);

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -270,13 +270,28 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       };
     }
     try {
+      if (body.type === MSG.upload) {
+        const up = payload as { content?: string };
+        const approxBytes = up.content ? Math.floor((up.content.length * 3) / 4) : 0;
+        if (approxBytes > 10 * 1024 * 1024) return c.json({ error: "file-too-large" }, 413);
+      }
       // Persist the inbound user message BEFORE awaiting the turn: sendRequest
       // resolves only after the agent's turn-finished event has already
       // persisted the "out" message, so appending "in" afterwards would give it
       // a higher autoincrement id and flip the history order.
       if (body.type === MSG.prompt || body.type === MSG.commandExecute) {
-        const p = payload as { sessionAlias?: string; text?: string };
-        if (p.sessionAlias && p.text) deps.messages.append(instance.id, p.sessionAlias, "in", p.text);
+        const p = payload as { sessionAlias?: string; text?: string; media?: import("@ganglion/xacpx-relay-protocol").PromptAttachmentRef[] };
+        if (p.sessionAlias && p.text !== undefined) {
+          const attachments = (p.media ?? []).map((m) => ({
+            id: m.id,
+            filename: m.fileName,
+            mimeType: m.mimeType,
+            size: m.size,
+            kind: m.kind,
+            ...(m.previewUrl ? { previewUrl: m.previewUrl } : {}),
+          }));
+          deps.messages.append(instance.id, p.sessionAlias, "in", p.text, undefined, attachments);
+        }
       }
       const result = await deps.gateway.sendRequest(instance.id, body.type, payload);
       if (body.type === MSG.commandExecute) {

--- a/packages/relay/src/stores/messages.ts
+++ b/packages/relay/src/stores/messages.ts
@@ -1,4 +1,4 @@
-import type { MessageDirection, MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
+import type { AttachmentMetadata, MessageDirection, MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
 
 import type { SqlDriver } from "../db.js";
 
@@ -12,6 +12,7 @@ interface MessageRow {
   text: string;
   created_at: string;
   structured: string | null;
+  attachments: string | null;
 }
 
 export interface MessagePage {
@@ -23,10 +24,25 @@ export interface MessagePage {
 export class MessageStore {
   constructor(private readonly db: SqlDriver, private readonly now: () => Date = () => new Date()) {}
 
-  append(instanceId: string, sessionAlias: string, direction: MessageDirection, text: string, structured?: StructuredTurn): void {
+  append(
+    instanceId: string,
+    sessionAlias: string,
+    direction: MessageDirection,
+    text: string,
+    structured?: StructuredTurn,
+    attachments?: AttachmentMetadata[],
+  ): void {
     this.db.run(
-      "INSERT INTO messages (instance_id, session_alias, direction, text, created_at, structured) VALUES (?,?,?,?,?,?)",
-      [instanceId, sessionAlias, direction, text, this.now().toISOString(), structured ? JSON.stringify(structured) : null],
+      "INSERT INTO messages (instance_id, session_alias, direction, text, created_at, structured, attachments) VALUES (?,?,?,?,?,?,?)",
+      [
+        instanceId,
+        sessionAlias,
+        direction,
+        text,
+        this.now().toISOString(),
+        structured ? JSON.stringify(structured) : null,
+        attachments && attachments.length > 0 ? JSON.stringify(attachments) : null,
+      ],
     );
   }
 
@@ -46,7 +62,7 @@ export class MessageStore {
     const before = opts.before ?? null;
     // Fetch one extra row to detect whether older history remains, then drop it.
     const rows = this.db.all<MessageRow>(
-      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured
+      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments
        FROM messages m JOIN instances i ON i.id = m.instance_id
        WHERE i.account_id = ? AND m.instance_id = ? AND m.session_alias = ?
          AND (? IS NULL OR m.id < ?)
@@ -65,6 +81,7 @@ export class MessageStore {
         text: r.text,
         createdAt: r.created_at,
         ...(r.structured ? { structured: JSON.parse(r.structured) as StructuredTurn } : {}),
+        ...(r.attachments ? { attachments: JSON.parse(r.attachments) as AttachmentMetadata[] } : {}),
       })),
     };
   }

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -35,15 +35,12 @@ if (buildCode !== 0) {
 
 // relay/channel-relay tests import "@ganglion/xacpx-relay-protocol", which the
 // workspace link resolves to packages/relay-protocol/dist — build it up front
-// for the same order-independence reason as plugin-api above.
-const protocolBuildCode = await runOne("bun", [
-  "build",
-  "./packages/relay-protocol/src/index.ts",
-  "--outdir",
-  "./packages/relay-protocol/dist",
-  "--target",
-  "node",
-]);
+// for the same order-independence reason as plugin-api above. Use the full
+// build:relay-protocol script (NOT a bare `bun build`): bun build emits only
+// index.js, so type-only exports (interfaces like PromptAttachmentRef vanish in
+// JS) are invisible to tsc and the typecheck step fails with "no exported
+// member". The script's `tsc -p` emits the .d.ts the typecheck needs.
+const protocolBuildCode = await runOne("bun", ["run", "build:relay-protocol"]);
 if (protocolBuildCode !== 0) {
   process.exit(protocolBuildCode ?? 1);
 }

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -7,7 +7,7 @@ import type { NonInteractivePermissions, PermissionMode, WechatReplyMode } from 
 import { resolveSpawnCommand } from "../process/spawn-command";
 import { terminateProcessTree } from "../process/terminate-process-tree";
 import { getPromptText } from "../transport/prompt-output";
-import type { UsageBreakdown, UsageCost } from "../transport/types";
+import type { AgentCommand, UsageBreakdown, UsageCost } from "../transport/types";
 import { createStructuredPromptFile } from "../transport/prompt-media";
 import { createStreamingPromptState, parseStreamingDataChunk } from "../transport/streaming-prompt";
 import { parseMissingOptionalDep } from "./parse-missing-optional-dep";
@@ -29,7 +29,8 @@ type BridgePromptStreamEvent =
   | { type: "prompt.tool_event"; event: ToolUseEvent }
   | { type: "prompt.thought"; text: string }
   | { type: "prompt.plan"; entries: PlanEntry[] }
-  | { type: "prompt.usage"; used: number; size: number; cost?: UsageCost; breakdown?: UsageBreakdown };
+  | { type: "prompt.usage"; used: number; size: number; cost?: UsageCost; breakdown?: UsageBreakdown }
+  | { type: "prompt.commands"; commands: AgentCommand[] };
 
 export class EnsureSessionFailedError extends Error {
   readonly kind: "missing_optional_dep" | "generic";
@@ -845,6 +846,9 @@ export async function runStreamingPrompt(
         : {}),
       ...(onEvent
         ? { onUsage: (usage) => onEvent({ type: "prompt.usage", used: usage.used, size: usage.size, ...(usage.cost ? { cost: usage.cost } : {}), ...(usage.breakdown ? { breakdown: usage.breakdown } : {}) }) }
+        : {}),
+      ...(onEvent
+        ? { onCommands: (commands) => onEvent({ type: "prompt.commands", commands }) }
         : {}),
     });
     let lastReplyAt = now();

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -7,6 +7,7 @@ import type { NonInteractivePermissions, PermissionMode, WechatReplyMode } from 
 import { resolveSpawnCommand } from "../process/spawn-command";
 import { terminateProcessTree } from "../process/terminate-process-tree";
 import { getPromptText } from "../transport/prompt-output";
+import type { UsageBreakdown, UsageCost } from "../transport/types";
 import { createStructuredPromptFile } from "../transport/prompt-media";
 import { createStreamingPromptState, parseStreamingDataChunk } from "../transport/streaming-prompt";
 import { parseMissingOptionalDep } from "./parse-missing-optional-dep";
@@ -28,7 +29,7 @@ type BridgePromptStreamEvent =
   | { type: "prompt.tool_event"; event: ToolUseEvent }
   | { type: "prompt.thought"; text: string }
   | { type: "prompt.plan"; entries: PlanEntry[] }
-  | { type: "prompt.usage"; used: number; size: number };
+  | { type: "prompt.usage"; used: number; size: number; cost?: UsageCost; breakdown?: UsageBreakdown };
 
 export class EnsureSessionFailedError extends Error {
   readonly kind: "missing_optional_dep" | "generic";
@@ -843,7 +844,7 @@ export async function runStreamingPrompt(
         ? { onPlan: (entries) => onEvent({ type: "prompt.plan", entries }) }
         : {}),
       ...(onEvent
-        ? { onUsage: (usage) => onEvent({ type: "prompt.usage", used: usage.used, size: usage.size }) }
+        ? { onUsage: (usage) => onEvent({ type: "prompt.usage", used: usage.used, size: usage.size, ...(usage.cost ? { cost: usage.cost } : {}), ...(usage.breakdown ? { breakdown: usage.breakdown } : {}) }) }
         : {}),
     });
     let lastReplyAt = now();

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -231,6 +231,8 @@ export class BridgeServer {
               event: "prompt.usage",
               used: event.used,
               size: event.size,
+              ...(event.cost ? { cost: event.cost } : {}),
+              ...(event.breakdown ? { breakdown: event.breakdown } : {}),
             }));
           }
         });

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -4,6 +4,7 @@ import {
   encodeBridgePromptThoughtEvent,
   encodeBridgePromptToolEvent,
   encodeBridgePromptUsageEvent,
+  encodeBridgePromptCommandsEvent,
   encodeBridgeSessionNoteEvent,
   encodeBridgeSessionProgressEvent,
   type BridgeMethod,
@@ -233,6 +234,12 @@ export class BridgeServer {
               size: event.size,
               ...(event.cost ? { cost: event.cost } : {}),
               ...(event.breakdown ? { breakdown: event.breakdown } : {}),
+            }));
+          } else if (event.type === "prompt.commands") {
+            writeLine?.(encodeBridgePromptCommandsEvent({
+              id: requestId,
+              event: "prompt.commands",
+              commands: event.commands,
             }));
           }
         });

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -4,7 +4,7 @@ import type { AppConfig, TransportConfig } from "../config/types";
 import type { AppLogger } from "../logging/app-logger";
 import { createNoopAppLogger } from "../logging/app-logger";
 import type { SessionService } from "../sessions/session-service";
-import type { PromptMediaInput, PromptUsage, ReplyQuotaContext, SessionTransport } from "../transport/types";
+import type { AgentCommand, PromptMediaInput, PromptUsage, ReplyQuotaContext, SessionTransport } from "../transport/types";
 import type { AgentSession, ResolvedSession } from "../transport/types";
 import { resolveRuntimeAgentCommand } from "../config/resolve-agent-command";
 import type { PerfSpan } from "../perf/perf-tracer";
@@ -143,6 +143,7 @@ export class CommandRouter {
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
     onUsage?: (usage: PromptUsage) => void | Promise<void>,
+    onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
   ): Promise<RouterResponse> {
     const startedAt = Date.now();
     let command = parseCommand(input);
@@ -399,6 +400,7 @@ export class CommandRouter {
               metadata,
               onPlan,
               onUsage,
+              onCommands,
             );
           }
           if (metadata?.scheduledSessionAlias) {
@@ -422,6 +424,7 @@ export class CommandRouter {
               metadata,
               onPlan,
               onUsage,
+              onCommands,
             );
           }
           return await handlePrompt(
@@ -439,6 +442,7 @@ export class CommandRouter {
             metadata,
             onPlan,
             onUsage,
+            onCommands,
           );
         }
       }
@@ -752,8 +756,8 @@ export class CommandRouter {
       setModelTransportSession: (session, modelId) => this.setModelTransportSession(session, modelId),
       getModelTransportSession: (session) => this.getModelTransportSession(session),
       cancelTransportSession: (session) => this.cancelTransportSession(session),
-      promptTransportSession: (session, text, reply, replyContext, media, abortSignal, onToolEvent, onThought, perfSpanOverride, onPlan, onUsage) =>
-        this.promptTransportSession(session, text, reply, replyContext, media, abortSignal, onToolEvent, onThought, perfSpanOverride ?? perfSpan, onPlan, onUsage),
+      promptTransportSession: (session, text, reply, replyContext, media, abortSignal, onToolEvent, onThought, perfSpanOverride, onPlan, onUsage, onCommands) =>
+        this.promptTransportSession(session, text, reply, replyContext, media, abortSignal, onToolEvent, onThought, perfSpanOverride ?? perfSpan, onPlan, onUsage, onCommands),
     };
   }
 
@@ -984,6 +988,7 @@ export class CommandRouter {
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
     onUsage?: (usage: PromptUsage) => void | Promise<void>,
+    onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
   ) {
     session.mcpCoordinatorSession ??= stableCoordinatorSession(session.transportSession);
     // `done` closes the race window between prompt resolving and the abort
@@ -1052,6 +1057,7 @@ export class CommandRouter {
           ...(onThought ? { onThought } : {}),
           ...(onPlan ? { onPlan } : {}),
           ...(onUsage ? { onUsage } : {}),
+          ...(onCommands ? { onCommands } : {}),
         }),
       );
     } catch (error) {

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -4,7 +4,7 @@ import type { AppConfig, TransportConfig } from "../config/types";
 import type { AppLogger } from "../logging/app-logger";
 import { createNoopAppLogger } from "../logging/app-logger";
 import type { SessionService } from "../sessions/session-service";
-import type { PromptMediaInput, ReplyQuotaContext, SessionTransport } from "../transport/types";
+import type { PromptMediaInput, PromptUsage, ReplyQuotaContext, SessionTransport } from "../transport/types";
 import type { AgentSession, ResolvedSession } from "../transport/types";
 import { resolveRuntimeAgentCommand } from "../config/resolve-agent-command";
 import type { PerfSpan } from "../perf/perf-tracer";
@@ -142,7 +142,7 @@ export class CommandRouter {
     onThought?: (chunk: string) => void | Promise<void>,
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
-    onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
+    onUsage?: (usage: PromptUsage) => void | Promise<void>,
   ): Promise<RouterResponse> {
     const startedAt = Date.now();
     let command = parseCommand(input);
@@ -983,7 +983,7 @@ export class CommandRouter {
     onThought?: (chunk: string) => void | Promise<void>,
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
-    onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
+    onUsage?: (usage: PromptUsage) => void | Promise<void>,
   ) {
     session.mcpCoordinatorSession ??= stableCoordinatorSession(session.transportSession);
     // `done` closes the race window between prompt resolving and the abort

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -5,7 +5,7 @@ import type {
   SessionLifecycleOps,
   SessionRenderRecoveryOps,
 } from "../router-types";
-import type { PromptMediaInput, PromptUsage, ResolvedSession } from "../../transport/types";
+import type { AgentCommand, PromptMediaInput, PromptUsage, ResolvedSession } from "../../transport/types";
 import type { ReplyMode } from "../../config/types";
 import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
 import type { PerfSpan } from "../../perf/perf-tracer";
@@ -737,6 +737,7 @@ async function promptWithSession(
   metadata?: ChatRequestMetadata,
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
   onUsage?: (usage: PromptUsage) => void | Promise<void>,
+  onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
 ): Promise<RouterResponse> {
   // Restore-on-message: a real prompt to an archived session un-archives it (mirrors
   // useSession on the web path, which the chat prompt path bypasses). The guard avoids
@@ -802,6 +803,7 @@ async function promptWithSession(
       perfSpan,
       onPlan,
       onUsage,
+      onCommands,
     );
     if (claimHumanReply) {
       try {
@@ -848,13 +850,14 @@ export async function handlePromptWithSession(
   metadata?: ChatRequestMetadata,
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
   onUsage?: (usage: PromptUsage) => void | Promise<void>,
+  onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
 ): Promise<RouterResponse> {
   try {
-    return await promptWithSession(context, session, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage);
+    return await promptWithSession(context, session, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage, onCommands);
   } catch (error) {
     const recovered = await context.recovery.tryRecoverMissingSession(session, error);
     if (recovered) {
-      return await promptWithSession(context, recovered, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage);
+      return await promptWithSession(context, recovered, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage, onCommands);
     }
     return context.recovery.renderTransportError(session, error);
   }
@@ -875,6 +878,7 @@ export async function handlePrompt(
   metadata?: ChatRequestMetadata,
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
   onUsage?: (usage: PromptUsage) => void | Promise<void>,
+  onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
 ): Promise<RouterResponse> {
   const session = metadata?.boundSessionAlias
     ? context.sessions.getResolvedSessionByInternalAlias(metadata.boundSessionAlias)
@@ -883,7 +887,7 @@ export async function handlePrompt(
     return { text: t().session.noCurrent };
   }
 
-  return await handlePromptWithSession(context, session, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage);
+  return await handlePromptWithSession(context, session, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage, onCommands);
 }
 
 function toCoordinatorRouteChatMetadata(

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -5,7 +5,7 @@ import type {
   SessionLifecycleOps,
   SessionRenderRecoveryOps,
 } from "../router-types";
-import type { PromptMediaInput, ResolvedSession } from "../../transport/types";
+import type { PromptMediaInput, PromptUsage, ResolvedSession } from "../../transport/types";
 import type { ReplyMode } from "../../config/types";
 import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
 import type { PerfSpan } from "../../perf/perf-tracer";
@@ -736,7 +736,7 @@ async function promptWithSession(
   perfSpan?: PerfSpan,
   metadata?: ChatRequestMetadata,
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
-  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
+  onUsage?: (usage: PromptUsage) => void | Promise<void>,
 ): Promise<RouterResponse> {
   // Restore-on-message: a real prompt to an archived session un-archives it (mirrors
   // useSession on the web path, which the chat prompt path bypasses). The guard avoids
@@ -847,7 +847,7 @@ export async function handlePromptWithSession(
   perfSpan?: PerfSpan,
   metadata?: ChatRequestMetadata,
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
-  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
+  onUsage?: (usage: PromptUsage) => void | Promise<void>,
 ): Promise<RouterResponse> {
   try {
     return await promptWithSession(context, session, chatKey, text, reply, replyContextToken, accountId, media, abortSignal, onToolEvent, onThought, perfSpan, metadata, onPlan, onUsage);
@@ -874,7 +874,7 @@ export async function handlePrompt(
   perfSpan?: PerfSpan,
   metadata?: ChatRequestMetadata,
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
-  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
+  onUsage?: (usage: PromptUsage) => void | Promise<void>,
 ): Promise<RouterResponse> {
   const session = metadata?.boundSessionAlias
     ? context.sessions.getResolvedSessionByInternalAlias(metadata.boundSessionAlias)

--- a/src/commands/router-types.ts
+++ b/src/commands/router-types.ts
@@ -3,7 +3,7 @@ import type { AppConfig } from "../config/types";
 import type { AppLogger } from "../logging/app-logger";
 import type { OrchestrationService } from "../orchestration/orchestration-service";
 import type { SessionService } from "../sessions/session-service";
-import type { PromptMediaInput, ReplyQuotaContext, SessionTransport } from "../transport/types";
+import type { PromptMediaInput, PromptUsage, ReplyQuotaContext, SessionTransport } from "../transport/types";
 import type { QuotaManager } from "../weixin/messaging/quota-manager.js";
 import type { PlanEntry, ToolUseEvent } from "../channels/types.js";
 import type { PerfSpan } from "../perf/perf-tracer";
@@ -152,7 +152,7 @@ export interface SessionInteractionOps {
     onThought?: (chunk: string) => void | Promise<void>,
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
-    onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
+    onUsage?: (usage: PromptUsage) => void | Promise<void>,
   ) => Promise<{ text: string }>;
 }
 

--- a/src/commands/router-types.ts
+++ b/src/commands/router-types.ts
@@ -3,7 +3,7 @@ import type { AppConfig } from "../config/types";
 import type { AppLogger } from "../logging/app-logger";
 import type { OrchestrationService } from "../orchestration/orchestration-service";
 import type { SessionService } from "../sessions/session-service";
-import type { PromptMediaInput, PromptUsage, ReplyQuotaContext, SessionTransport } from "../transport/types";
+import type { AgentCommand, PromptMediaInput, PromptUsage, ReplyQuotaContext, SessionTransport } from "../transport/types";
 import type { QuotaManager } from "../weixin/messaging/quota-manager.js";
 import type { PlanEntry, ToolUseEvent } from "../channels/types.js";
 import type { PerfSpan } from "../perf/perf-tracer";
@@ -153,6 +153,7 @@ export interface SessionInteractionOps {
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
     onUsage?: (usage: PromptUsage) => void | Promise<void>,
+    onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
   ) => Promise<{ text: string }>;
 }
 

--- a/src/console-agent.ts
+++ b/src/console-agent.ts
@@ -5,6 +5,7 @@ import { createNoopAppLogger } from "./logging/app-logger";
 import { normalizeMediaArray } from "./channels/media-types.js";
 import { isKnownXacpxCommandText } from "./commands/command-list";
 import type { PlanEntry, ToolUseEvent } from "./channels/types.js";
+import type { PromptUsage } from "./transport/types";
 import type { PerfSpan } from "./perf/perf-tracer";
 import { t } from "./i18n/index.js";
 
@@ -22,7 +23,7 @@ interface RouterLike {
     onThought?: (chunk: string) => void | Promise<void>,
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
-    onUsage?: (usage: { used: number; size: number }) => void | Promise<void>,
+    onUsage?: (usage: PromptUsage) => void | Promise<void>,
   ): Promise<ChatResponse>;
   clearSession?: (chatKey: string) => Promise<void>;
 }

--- a/src/console-agent.ts
+++ b/src/console-agent.ts
@@ -5,7 +5,7 @@ import { createNoopAppLogger } from "./logging/app-logger";
 import { normalizeMediaArray } from "./channels/media-types.js";
 import { isKnownXacpxCommandText } from "./commands/command-list";
 import type { PlanEntry, ToolUseEvent } from "./channels/types.js";
-import type { PromptUsage } from "./transport/types";
+import type { AgentCommand, PromptUsage } from "./transport/types";
 import type { PerfSpan } from "./perf/perf-tracer";
 import { t } from "./i18n/index.js";
 
@@ -24,6 +24,7 @@ interface RouterLike {
     perfSpan?: PerfSpan,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
     onUsage?: (usage: PromptUsage) => void | Promise<void>,
+    onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
   ): Promise<ChatResponse>;
   clearSession?: (chatKey: string) => Promise<void>;
 }
@@ -70,6 +71,7 @@ export class ConsoleAgent implements WechatAgent {
       request.perfSpan,
       request.onPlan,
       request.onUsage,
+      request.onCommands,
     );
   }
 

--- a/src/control/control-event-bus.ts
+++ b/src/control/control-event-bus.ts
@@ -1,5 +1,6 @@
 import type { AppLogger } from "../logging/app-logger";
 import type { ToolUseEvent, PlanEntry } from "../channels/types";
+import type { UsageBreakdown, UsageCost } from "../transport/types";
 import type { NativeHistoryMessage } from "../transport/native-session-history";
 
 export interface ScheduledOrigin {
@@ -16,7 +17,7 @@ export type ControlEvent =
   | { type: "turn-thought"; chatKey: string; sessionAlias: string; chunk: string }
   | { type: "plan"; chatKey: string; sessionAlias: string; entries: PlanEntry[] }
   // Context-usage meter: `used` tokens in context, `size` total context window. Replace-latest.
-  | { type: "turn-usage"; chatKey: string; sessionAlias: string; used: number; size: number }
+  | { type: "turn-usage"; chatKey: string; sessionAlias: string; used: number; size: number; cost?: UsageCost; breakdown?: UsageBreakdown }
   | { type: "turn-finished"; chatKey: string; sessionAlias: string; ok: boolean; errorMessage?: string; cancelled?: boolean }
   | { type: "sessions-changed" }
   | { type: "scheduled-changed"; chatKey: string }

--- a/src/control/control-event-bus.ts
+++ b/src/control/control-event-bus.ts
@@ -1,6 +1,6 @@
 import type { AppLogger } from "../logging/app-logger";
 import type { ToolUseEvent, PlanEntry } from "../channels/types";
-import type { UsageBreakdown, UsageCost } from "../transport/types";
+import type { AgentCommand, UsageBreakdown, UsageCost } from "../transport/types";
 import type { NativeHistoryMessage } from "../transport/native-session-history";
 
 export interface ScheduledOrigin {
@@ -18,6 +18,8 @@ export type ControlEvent =
   | { type: "plan"; chatKey: string; sessionAlias: string; entries: PlanEntry[] }
   // Context-usage meter: `used` tokens in context, `size` total context window. Replace-latest.
   | { type: "turn-usage"; chatKey: string; sessionAlias: string; used: number; size: number; cost?: UsageCost; breakdown?: UsageBreakdown }
+  // Agent-advertised slash commands (e.g. /compact). Session-scoped, replace-latest.
+  | { type: "agent-commands"; chatKey: string; sessionAlias: string; commands: AgentCommand[] }
   | { type: "turn-finished"; chatKey: string; sessionAlias: string; ok: boolean; errorMessage?: string; cancelled?: boolean }
   | { type: "sessions-changed" }
   | { type: "scheduled-changed"; chatKey: string }

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -481,19 +481,26 @@ export class ControlService {
     // Defense-in-depth: the two-phase upload sandbox is meant to be the only source of
     // attachment bytes (the web flow echoes back the path control.upload returned, which
     // lives under the sandbox root). Drop any media ref whose resolved filePath escapes
-    // that root so a caller cannot point the agent at an arbitrary absolute path.
-    const uploadRoot = path.resolve(this.deps.uploadStore.root);
+    // that root so a caller cannot point the agent at an arbitrary absolute path. Only
+    // touch the upload store when a turn actually carries media — a plain prompt turn
+    // has no attachments and must not depend on the store being present.
     const incomingMedia = params.media ?? [];
-    const sandboxedMedia = incomingMedia.filter((ref) => {
-      const resolved = path.resolve(ref.filePath);
-      return resolved === uploadRoot || resolved.startsWith(uploadRoot + path.sep);
-    });
-    const droppedMedia = incomingMedia.length - sandboxedMedia.length;
-    if (droppedMedia > 0) {
-      console.warn(
-        `[control] dropped ${droppedMedia} media ref(s) with filePath outside the upload sandbox`,
-      );
-    }
+    const sandboxedMedia = incomingMedia.length
+      ? (() => {
+          const uploadRoot = path.resolve(this.deps.uploadStore.root);
+          const kept = incomingMedia.filter((ref) => {
+            const resolved = path.resolve(ref.filePath);
+            return resolved === uploadRoot || resolved.startsWith(uploadRoot + path.sep);
+          });
+          const dropped = incomingMedia.length - kept.length;
+          if (dropped > 0) {
+            console.warn(
+              `[control] dropped ${dropped} media ref(s) with filePath outside the upload sandbox`,
+            );
+          }
+          return kept;
+        })()
+      : incomingMedia;
     const chatMedia = sandboxedMedia.map((ref) => ({
       kind: ref.kind,
       filePath: ref.filePath,

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -535,6 +535,14 @@ export class ControlService {
             ...(usage.breakdown ? { breakdown: usage.breakdown } : {}),
           });
         },
+        onCommands: (commands) => {
+          this.deps.events.emit({
+            type: "agent-commands",
+            chatKey: params.chatKey,
+            sessionAlias: params.sessionAlias,
+            commands,
+          });
+        },
       });
       if (response.text) {
         emitChunk(response.text);

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import type { Agent as ChatAgent, ChatRequestMetadata } from "../weixin/agent/interface";
 import type { SessionService } from "../sessions/session-service";
 import type { AgentSession, ResolvedSession, SessionTransport } from "../transport/types";
@@ -476,7 +478,23 @@ export class ControlService {
       });
       emittedChunk = true;
     };
-    const chatMedia = (params.media ?? []).map((ref) => ({
+    // Defense-in-depth: the two-phase upload sandbox is meant to be the only source of
+    // attachment bytes (the web flow echoes back the path control.upload returned, which
+    // lives under the sandbox root). Drop any media ref whose resolved filePath escapes
+    // that root so a caller cannot point the agent at an arbitrary absolute path.
+    const uploadRoot = path.resolve(this.deps.uploadStore.root);
+    const incomingMedia = params.media ?? [];
+    const sandboxedMedia = incomingMedia.filter((ref) => {
+      const resolved = path.resolve(ref.filePath);
+      return resolved === uploadRoot || resolved.startsWith(uploadRoot + path.sep);
+    });
+    const droppedMedia = incomingMedia.length - sandboxedMedia.length;
+    if (droppedMedia > 0) {
+      console.warn(
+        `[control] dropped ${droppedMedia} media ref(s) with filePath outside the upload sandbox`,
+      );
+    }
+    const chatMedia = sandboxedMedia.map((ref) => ({
       kind: ref.kind,
       filePath: ref.filePath,
       mimeType: ref.mimeType,

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -531,6 +531,8 @@ export class ControlService {
             sessionAlias: params.sessionAlias,
             used: usage.used,
             size: usage.size,
+            ...(usage.cost ? { cost: usage.cost } : {}),
+            ...(usage.breakdown ? { breakdown: usage.breakdown } : {}),
           });
         },
       });

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -22,6 +22,8 @@ import type { ControlEventBus, ScheduledOrigin } from "./control-event-bus";
 import { readNativeSessionHistory, type NativeHistoryMessage } from "../transport/native-session-history";
 import type { AgentCatalogEntry } from "../config/agent-catalog";
 import { WorkspaceFs, type DirListing, type FileContent, type SearchResult, type WorkspaceDiff } from "./workspace-fs";
+import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
+import type { UploadStore } from "./upload-store.js";
 
 export interface ControlSessionInfo {
   alias: string;
@@ -98,6 +100,7 @@ export interface ControlServiceDeps {
     create(name: string, cwd: string, description?: string): Promise<ControlWorkspaceInfo>;
     remove(name: string): Promise<void>;
   };
+  uploadStore: UploadStore;
 }
 
 export interface ControlPromptInput {
@@ -107,6 +110,7 @@ export interface ControlPromptInput {
   accountId?: string;
   senderId: string;
   isOwner?: boolean;
+  media?: PromptAttachmentRef[];
 }
 
 export interface ControlPromptResult {
@@ -162,6 +166,10 @@ export class ControlService {
 
   searchWorkspace(workspace: string, query: string): Promise<SearchResult> {
     return this.workspaceFs.search(workspace, query);
+  }
+
+  async uploadFile(input: { filename: string; content: string; mimeType: string }): Promise<{ id: string; path: string; filename: string; mimeType: string; size: number }> {
+    return this.deps.uploadStore.save(input.filename, input.content, input.mimeType);
   }
 
   /** Read a session's current model and the agent-advertised available ids. */
@@ -369,6 +377,7 @@ export class ControlService {
       senderId: input.senderId,
       ...(input.isOwner !== undefined ? { isOwner: input.isOwner } : {}),
       ...(input.accountId !== undefined ? { accountId: input.accountId } : {}),
+      ...(input.media !== undefined ? { media: input.media } : {}),
     });
   }
 
@@ -400,6 +409,7 @@ export class ControlService {
     abortSignal?: AbortSignal;
     // Extra fields stamped onto turn-started for scheduled-origin turns.
     turnStarted?: { prompt?: string; scheduled?: ScheduledOrigin };
+    media?: PromptAttachmentRef[];
   }): Promise<ControlPromptResult> {
     const key = turnKey(params.chatKey, params.sessionAlias);
     const existing = this.inFlight.get(key);
@@ -466,6 +476,19 @@ export class ControlService {
       });
       emittedChunk = true;
     };
+    const chatMedia = (params.media ?? []).map((ref) => ({
+      kind: ref.kind,
+      filePath: ref.filePath,
+      mimeType: ref.mimeType,
+      ...(ref.fileName ? { fileName: ref.fileName } : {}),
+      sizeBytes: ref.size,
+      source: {
+        channelId: "relay",
+        accountId: params.accountId ?? "control",
+        chatKey: params.chatKey,
+        messageId: ref.id,
+      },
+    }));
     try {
       const response = await this.deps.agent.chat({
         accountId: params.accountId ?? "control",
@@ -473,6 +496,7 @@ export class ControlService {
         text: params.text,
         metadata: buildControlMetadata(params.senderId, params.isOwner),
         abortSignal: controller.signal,
+        ...(chatMedia.length > 0 ? { media: chatMedia } : {}),
         reply: async (chunk) => {
           emitChunk(chunk);
         },

--- a/src/control/upload-store.ts
+++ b/src/control/upload-store.ts
@@ -47,7 +47,17 @@ export class UploadStore {
     this.now = opts.now ?? (() => new Date());
   }
 
+  /** Sandbox root all uploads are written under. Callers may use this to verify a
+   *  media filePath actually originated from a control.upload (defense-in-depth). */
+  get root(): string {
+    return this.rootDir;
+  }
+
   async save(filename: string, base64: string, mimeType: string): Promise<SavedUpload> {
+    // Pre-decode size guard: a base64 string encodes ceil(n/3)*4 chars per n bytes,
+    // so reject obvious oversized payloads before materializing them into memory.
+    if (base64.length > Math.ceil((this.maxBytes * 4) / 3) + 4) throw new Error("file-too-large");
+
     const bytes = Buffer.from(base64, "base64");
     if (bytes.byteLength === 0) throw new Error("empty-file");
     if (bytes.byteLength > this.maxBytes) throw new Error("file-too-large");

--- a/src/control/upload-store.ts
+++ b/src/control/upload-store.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import { coreHomeDir } from "../runtime/core-home.js";
+
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024; // 10 MiB
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+export interface UploadStoreOptions {
+  rootDir?: string;
+  maxBytes?: number;
+  ttlMs?: number;
+  now?: () => Date;
+}
+
+export interface SavedUpload {
+  id: string;
+  path: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+
+function defaultRootDir(): string {
+  const home = process.env.HOME ?? homedir();
+  return path.join(coreHomeDir(home), "runtime", "uploads");
+}
+
+/** Strip directory components and traversal segments, leaving a safe basename. */
+export function sanitizeUploadFilename(raw: string): string {
+  const base = path.basename(raw).replace(/[/\\]/g, "").replace(/^\.+/, "");
+  const cleaned = base.trim();
+  return cleaned.length > 0 ? cleaned : "file";
+}
+
+export class UploadStore {
+  private readonly rootDir: string;
+  private readonly maxBytes: number;
+  private readonly ttlMs: number;
+  private readonly now: () => Date;
+
+  constructor(opts: UploadStoreOptions = {}) {
+    this.rootDir = opts.rootDir ?? defaultRootDir();
+    this.maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  async save(filename: string, base64: string, mimeType: string): Promise<SavedUpload> {
+    const bytes = Buffer.from(base64, "base64");
+    if (bytes.byteLength === 0) throw new Error("empty-file");
+    if (bytes.byteLength > this.maxBytes) throw new Error("file-too-large");
+
+    const safeName = sanitizeUploadFilename(filename);
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(this.rootDir, { recursive: true });
+    const dir = await mkdtemp(path.join(this.rootDir, "u-"));
+    const filePath = path.join(dir, safeName);
+    await writeFile(filePath, bytes);
+
+    return {
+      id: path.basename(dir),
+      path: filePath,
+      filename: safeName,
+      mimeType,
+      size: bytes.byteLength,
+    };
+  }
+
+  /** Remove upload dirs whose mtime is older than the TTL. Returns count removed. */
+  async cleanup(): Promise<number> {
+    let entries: string[];
+    try {
+      entries = await readdir(this.rootDir);
+    } catch {
+      return 0;
+    }
+    const cutoff = this.now().getTime() - this.ttlMs;
+    let removed = 0;
+    for (const name of entries) {
+      const dir = path.join(this.rootDir, name);
+      try {
+        const info = await stat(dir);
+        if (info.mtimeMs < cutoff) {
+          await rm(dir, { recursive: true, force: true });
+          removed += 1;
+        }
+      } catch {
+        // ignore races
+      }
+    }
+    return removed;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,7 @@ import { renderTaskHeartbeat, renderTaskProgress } from "./formatting/render-tex
 import { QuotaManager } from "./weixin/messaging/quota-manager";
 import { createControlEventBus } from "./control/control-event-bus";
 import { ControlService } from "./control/control-service";
+import { UploadStore } from "./control/upload-store.js";
 import { listAgentCatalog } from "./config/agent-catalog";
 
 export interface RuntimePaths {
@@ -761,6 +762,8 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
   );
   const agent = new ConsoleAgent(router, logger);
   const controlEvents = createControlEventBus(logger);
+  const uploadStore = new UploadStore();
+  void uploadStore.cleanup(); // best-effort startup sweep of expired uploads
   const control = new ControlService({
     agent,
     sessions,
@@ -811,6 +814,7 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
         replaceRuntimeConfig(config, updated);
       },
     },
+    uploadStore,
   });
   const scheduledScheduler = new ScheduledTaskScheduler(scheduledService, {
     dispatchTask: buildScheduledDispatchTask({

--- a/src/main.ts
+++ b/src/main.ts
@@ -764,6 +764,12 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
   const controlEvents = createControlEventBus(logger);
   const uploadStore = new UploadStore();
   void uploadStore.cleanup(); // best-effort startup sweep of expired uploads
+  // A long-lived daemon never re-sweeps on the startup pass alone, so expired uploads
+  // would accumulate forever despite the 24h TTL. Re-run hourly; cleared on dispose.
+  const uploadCleanupInterval = setInterval(
+    () => void uploadStore.cleanup().catch(() => {}),
+    60 * 60 * 1000,
+  );
   const control = new ControlService({
     agent,
     sessions,
@@ -895,6 +901,7 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
     reapStaleQueueOwners: () => reapWarmQueueOwners("startup"),
     dispose: async () => {
       scheduledScheduler.stop();
+      clearInterval(uploadCleanupInterval);
       if (progressHeartbeatInterval !== undefined) {
         clearInterval(progressHeartbeatInterval);
       }

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -13,7 +13,7 @@ import { PromptCommandError } from "../prompt-output";
 import { MissingOptionalDepError } from "../../recovery/errors";
 import { terminateProcessTree } from "../../process/terminate-process-tree";
 import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
-import type { UsageBreakdown, UsageCost } from "../types";
+import type { AgentCommand, UsageBreakdown, UsageCost } from "../types";
 import { getLocale } from "../../i18n";
 import { resolveDefaultXacpxCommand } from "../acpx-queue-owner-launcher";
 
@@ -28,6 +28,7 @@ export type BridgeEvent =
   | { type: "prompt.thought"; text: string }
   | { type: "prompt.plan"; entries: PlanEntry[] }
   | { type: "prompt.usage"; used: number; size: number; cost?: UsageCost; breakdown?: UsageBreakdown }
+  | { type: "prompt.commands"; commands: AgentCommand[] }
   | { type: "session.progress"; stage: EnsureSessionProgressStage }
   | { type: "session.note"; text: string };
 
@@ -127,6 +128,11 @@ export class AcpxBridgeClient {
           size: message.size,
           ...(message.cost ? { cost: message.cost } : {}),
           ...(message.breakdown ? { breakdown: message.breakdown } : {}),
+        });
+      } else if (message.event === "prompt.commands") {
+        pending.onEvent?.({
+          type: "prompt.commands",
+          commands: message.commands,
         });
       } else if (message.event === "session.progress") {
         pending.onEvent?.({

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -13,6 +13,7 @@ import { PromptCommandError } from "../prompt-output";
 import { MissingOptionalDepError } from "../../recovery/errors";
 import { terminateProcessTree } from "../../process/terminate-process-tree";
 import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
+import type { UsageBreakdown, UsageCost } from "../types";
 import { getLocale } from "../../i18n";
 import { resolveDefaultXacpxCommand } from "../acpx-queue-owner-launcher";
 
@@ -26,7 +27,7 @@ export type BridgeEvent =
   | { type: "prompt.tool_event"; event: ToolUseEvent }
   | { type: "prompt.thought"; text: string }
   | { type: "prompt.plan"; entries: PlanEntry[] }
-  | { type: "prompt.usage"; used: number; size: number }
+  | { type: "prompt.usage"; used: number; size: number; cost?: UsageCost; breakdown?: UsageBreakdown }
   | { type: "session.progress"; stage: EnsureSessionProgressStage }
   | { type: "session.note"; text: string };
 
@@ -124,6 +125,8 @@ export class AcpxBridgeClient {
           type: "prompt.usage",
           used: message.used,
           size: message.size,
+          ...(message.cost ? { cost: message.cost } : {}),
+          ...(message.breakdown ? { breakdown: message.breakdown } : {}),
         });
       } else if (message.event === "session.progress") {
         pending.onEvent?.({

--- a/src/transport/acpx-bridge/acpx-bridge-protocol.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-protocol.ts
@@ -1,4 +1,5 @@
 import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
+import type { UsageBreakdown, UsageCost } from "../types";
 
 export type BridgeMethod =
   | "ping"
@@ -86,6 +87,8 @@ export interface BridgePromptUsageEvent {
   event: "prompt.usage";
   used: number;
   size: number;
+  cost?: UsageCost;
+  breakdown?: UsageBreakdown;
 }
 
 export interface BridgeSessionProgressEvent {

--- a/src/transport/acpx-bridge/acpx-bridge-protocol.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-protocol.ts
@@ -1,5 +1,5 @@
 import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
-import type { UsageBreakdown, UsageCost } from "../types";
+import type { AgentCommand, UsageBreakdown, UsageCost } from "../types";
 
 export type BridgeMethod =
   | "ping"
@@ -91,6 +91,12 @@ export interface BridgePromptUsageEvent {
   breakdown?: UsageBreakdown;
 }
 
+export interface BridgePromptCommandsEvent {
+  id: string;
+  event: "prompt.commands";
+  commands: AgentCommand[];
+}
+
 export interface BridgeSessionProgressEvent {
   id: string;
   event: "session.progress";
@@ -111,6 +117,7 @@ export type BridgeMessage<TResult = unknown> =
   | BridgePromptThoughtEvent
   | BridgePromptPlanEvent
   | BridgePromptUsageEvent
+  | BridgePromptCommandsEvent
   | BridgeSessionProgressEvent
   | BridgeSessionNoteEvent;
 export type BridgeResponse<TResult = unknown> = BridgeSuccessResponse<TResult> | BridgeErrorResponse;
@@ -136,6 +143,10 @@ export function encodeBridgePromptPlanEvent(event: BridgePromptPlanEvent): strin
 }
 
 export function encodeBridgePromptUsageEvent(event: BridgePromptUsageEvent): string {
+  return `${JSON.stringify(event)}\n`;
+}
+
+export function encodeBridgePromptCommandsEvent(event: BridgePromptCommandsEvent): string {
   return `${JSON.stringify(event)}\n`;
 }
 

--- a/src/transport/acpx-bridge/acpx-bridge-transport.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-transport.ts
@@ -88,6 +88,8 @@ export class AcpxBridgeTransport implements SessionTransport {
     let planChain = Promise.resolve();
     let usageError: unknown;
     let usageChain = Promise.resolve();
+    let commandsError: unknown;
+    let commandsChain = Promise.resolve();
     let toolEventMode = resolveToolEventMode(options);
     // Safety net: structured/both without an onToolEvent handler would
     // silently drop tool calls. Demote to 'text' so verbose tool calls
@@ -170,12 +172,25 @@ export class AcpxBridgeTransport implements SessionTransport {
         }
         return;
       }
+      if (event.type === "prompt.commands") {
+        const onCommands = options?.onCommands;
+        if (onCommands) {
+          const commands = event.commands;
+          commandsChain = commandsChain
+            .then(() => onCommands(commands))
+            .catch((error) => {
+              commandsError ??= error;
+            });
+        }
+        return;
+      }
     });
     await segmentChain;
     await toolEventChain;
     await thoughtChain;
     await planChain;
     await usageChain;
+    await commandsChain;
     if (sink) {
       const { overflowCount } = sink.finalize();
       // Drain in-flight reply() promises and propagate any QuotaDeferredError
@@ -208,6 +223,9 @@ export class AcpxBridgeTransport implements SessionTransport {
       if (usageError) {
         throw usageError;
       }
+      if (commandsError) {
+        throw commandsError;
+      }
       return { text: summary ? `${summary}\n\n${result.text}` : "" };
     }
     if (segmentError) {
@@ -224,6 +242,9 @@ export class AcpxBridgeTransport implements SessionTransport {
     }
     if (usageError) {
       throw usageError;
+    }
+    if (commandsError) {
+      throw commandsError;
     }
     return result;
   }

--- a/src/transport/acpx-bridge/acpx-bridge-transport.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-transport.ts
@@ -160,7 +160,7 @@ export class AcpxBridgeTransport implements SessionTransport {
       if (event.type === "prompt.usage") {
         const onUsage = options?.onUsage;
         if (onUsage) {
-          const usage = { used: event.used, size: event.size };
+          const usage = { used: event.used, size: event.size, ...(event.cost ? { cost: event.cost } : {}), ...(event.breakdown ? { breakdown: event.breakdown } : {}) };
           // Serialize handler invocations; first error wins.
           usageChain = usageChain
             .then(() => onUsage(usage))

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -1,5 +1,5 @@
 import type { PlanEntry, ToolUseEvent, ToolUseKind, ToolUseStatus } from "../channels/types.js";
-import type { PromptUsage, UsageBreakdown, UsageCost } from "./types.js";
+import type { AgentCommand, PromptUsage, UsageBreakdown, UsageCost } from "./types.js";
 import { resolveToolEventMode } from "./tool-event-mode.js";
 import type { ToolEventMode } from "./tool-event-mode.js";
 import { TOOL_KIND_EMOJI, DEFAULT_TOOL_EMOJI } from "./tool-kind-emoji.js";
@@ -22,6 +22,7 @@ export interface StreamingPromptState {
   onThought?: (chunk: string) => void | Promise<void>;
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
   onUsage?: (usage: PromptUsage) => void | Promise<void>;
+  onCommands?: (commands: AgentCommand[]) => void | Promise<void>;
   finalize: () => string;
 }
 
@@ -47,6 +48,8 @@ interface StreamEvent {
       // ACP `usage_update` extras (acpx ≥0.11.0): cumulative cost + per-turn token breakdown.
       cost?: unknown;
       _meta?: { usage?: unknown };
+      // ACP `available_commands_update`: agent-advertised slash commands.
+      availableCommands?: unknown;
     };
   };
 }
@@ -60,6 +63,7 @@ export type CreateStreamingPromptStateOptions =
       onThought?: (chunk: string) => void | Promise<void>;
       onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
       onUsage?: (usage: PromptUsage) => void | Promise<void>;
+      onCommands?: (commands: AgentCommand[]) => void | Promise<void>;
     };
 
 export function createStreamingPromptState(
@@ -71,6 +75,7 @@ export function createStreamingPromptState(
   let onThought: ((chunk: string) => void | Promise<void>) | undefined;
   let onPlan: ((entries: PlanEntry[]) => void | Promise<void>) | undefined;
   let onUsage: ((usage: PromptUsage) => void | Promise<void>) | undefined;
+  let onCommands: ((commands: AgentCommand[]) => void | Promise<void>) | undefined;
   let rawStream = false;
 
   if (options === undefined) {
@@ -85,6 +90,7 @@ export function createStreamingPromptState(
     onThought = options.onThought;
     onPlan = options.onPlan;
     onUsage = options.onUsage;
+    onCommands = options.onCommands;
     rawStream = options.rawStream ?? false;
     toolEventMode = resolveToolEventMode({
       toolEventMode: options.mode,
@@ -105,6 +111,7 @@ export function createStreamingPromptState(
     onThought,
     onPlan,
     onUsage,
+    onCommands,
     finalize(): string {
       if (this.pendingLine.trim().length > 0) {
         parseStreamingChunks(this, this.pendingLine);
@@ -201,6 +208,13 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
       const breakdown = normalizeUsageBreakdown(update._meta?.usage);
       void state.onUsage?.({ used, size, ...(cost ? { cost } : {}), ...(breakdown ? { breakdown } : {}) });
     }
+    return;
+  }
+
+  if (update.sessionUpdate === "available_commands_update") {
+    // Agent-advertised slash commands (e.g. /compact). Full list each time (REPLACE).
+    const commands = normalizeAgentCommands(update.availableCommands);
+    if (commands.length > 0) void state.onCommands?.(commands);
     return;
   }
 
@@ -430,6 +444,19 @@ function normalizeUsageCost(value: unknown): UsageCost | undefined {
   const currency = readString(value, "currency");
   if (amount === undefined && !currency) return undefined;
   return { ...(amount !== undefined ? { amount } : {}), ...(currency ? { currency } : {}) };
+}
+
+function normalizeAgentCommands(value: unknown): AgentCommand[] {
+  if (!Array.isArray(value)) return [];
+  const out: AgentCommand[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const name = readString(entry, "name");
+    if (!name) continue;
+    const description = readString(entry, "description");
+    out.push({ name, ...(description ? { description } : {}), hasInput: entry.input != null });
+  }
+  return out;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -1,4 +1,5 @@
 import type { PlanEntry, ToolUseEvent, ToolUseKind, ToolUseStatus } from "../channels/types.js";
+import type { PromptUsage, UsageBreakdown, UsageCost } from "./types.js";
 import { resolveToolEventMode } from "./tool-event-mode.js";
 import type { ToolEventMode } from "./tool-event-mode.js";
 import { TOOL_KIND_EMOJI, DEFAULT_TOOL_EMOJI } from "./tool-kind-emoji.js";
@@ -20,7 +21,7 @@ export interface StreamingPromptState {
   onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
   onThought?: (chunk: string) => void | Promise<void>;
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
-  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>;
+  onUsage?: (usage: PromptUsage) => void | Promise<void>;
   finalize: () => string;
 }
 
@@ -43,6 +44,9 @@ interface StreamEvent {
       // ACP `usage_update`: tokens currently in context + total context window.
       used?: number;
       size?: number;
+      // ACP `usage_update` extras (acpx ≥0.11.0): cumulative cost + per-turn token breakdown.
+      cost?: unknown;
+      _meta?: { usage?: unknown };
     };
   };
 }
@@ -55,7 +59,7 @@ export type CreateStreamingPromptStateOptions =
       onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
       onThought?: (chunk: string) => void | Promise<void>;
       onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
-      onUsage?: (usage: { used: number; size: number }) => void | Promise<void>;
+      onUsage?: (usage: PromptUsage) => void | Promise<void>;
     };
 
 export function createStreamingPromptState(
@@ -66,7 +70,7 @@ export function createStreamingPromptState(
   let onToolEvent: ((event: ToolUseEvent) => void | Promise<void>) | undefined;
   let onThought: ((chunk: string) => void | Promise<void>) | undefined;
   let onPlan: ((entries: PlanEntry[]) => void | Promise<void>) | undefined;
-  let onUsage: ((usage: { used: number; size: number }) => void | Promise<void>) | undefined;
+  let onUsage: ((usage: PromptUsage) => void | Promise<void>) | undefined;
   let rawStream = false;
 
   if (options === undefined) {
@@ -192,7 +196,11 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
     // a default window then the model's real one). Drop a malformed/zero-window frame.
     const used = typeof update.used === "number" && Number.isFinite(update.used) ? update.used : undefined;
     const size = typeof update.size === "number" && Number.isFinite(update.size) ? update.size : undefined;
-    if (used !== undefined && size !== undefined && size > 0) void state.onUsage?.({ used, size });
+    if (used !== undefined && size !== undefined && size > 0) {
+      const cost = normalizeUsageCost(update.cost);
+      const breakdown = normalizeUsageBreakdown(update._meta?.usage);
+      void state.onUsage?.({ used, size, ...(cost ? { cost } : {}), ...(breakdown ? { breakdown } : {}) });
+    }
     return;
   }
 
@@ -383,6 +391,45 @@ function readFirstStringArray(record: Record<string, unknown>, keys: readonly st
     }
   }
   return undefined;
+}
+
+const USAGE_BREAKDOWN_FIELDS: ReadonlyArray<readonly [keyof UsageBreakdown, readonly string[]]> = [
+  ["inputTokens", ["inputTokens", "input_tokens"]],
+  ["outputTokens", ["outputTokens", "output_tokens"]],
+  ["cachedReadTokens", ["cachedReadTokens", "cacheReadInputTokens", "cache_read_input_tokens"]],
+  ["cachedWriteTokens", ["cachedWriteTokens", "cacheCreationInputTokens", "cache_creation_input_tokens"]],
+  ["thoughtTokens", ["thoughtTokens", "thought_tokens"]],
+  ["totalTokens", ["totalTokens", "total_tokens"]],
+];
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function firstFiniteNumber(record: Record<string, unknown>, keys: readonly string[]): number | undefined {
+  for (const key of keys) {
+    const n = asFiniteNumber(record[key]);
+    if (n !== undefined) return n;
+  }
+  return undefined;
+}
+
+function normalizeUsageBreakdown(value: unknown): UsageBreakdown | undefined {
+  if (!isRecord(value)) return undefined;
+  const out: UsageBreakdown = {};
+  for (const [key, aliases] of USAGE_BREAKDOWN_FIELDS) {
+    const n = firstFiniteNumber(value, aliases);
+    if (n !== undefined) out[key] = n;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function normalizeUsageCost(value: unknown): UsageCost | undefined {
+  if (!isRecord(value)) return undefined;
+  const amount = asFiniteNumber(value.amount);
+  const currency = readString(value, "currency");
+  if (amount === undefined && !currency) return undefined;
+  return { ...(amount !== undefined ? { amount } : {}), ...(currency ? { currency } : {}) };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -213,8 +213,11 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
 
   if (update.sessionUpdate === "available_commands_update") {
     // Agent-advertised slash commands (e.g. /compact). Full list each time (REPLACE).
-    const commands = normalizeAgentCommands(update.availableCommands);
-    if (commands.length > 0) void state.onCommands?.(commands);
+    // Emit on any explicit list — including an empty one, which is a legitimate "clear"
+    // (the agent dropped its commands); skip only malformed frames with no array.
+    if (Array.isArray(update.availableCommands)) {
+      void state.onCommands?.(normalizeAgentCommands(update.availableCommands));
+    }
     return;
   }
 

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -30,6 +30,14 @@ export interface PromptUsage {
   breakdown?: UsageBreakdown;
 }
 
+/** An agent-advertised slash command (ACP `available_commands_update`). */
+export interface AgentCommand {
+  name: string;
+  description?: string;
+  /** Whether the command accepts an argument (ACP advertised a non-null `input`). */
+  hasInput?: boolean;
+}
+
 export interface ReplyQuotaContext {
   chatKey: string;
   quota: QuotaManager;
@@ -161,6 +169,11 @@ export interface PromptOptions {
    * (e.g. claude does, codex does not), and text channels omit the handler.
    */
   onUsage?: (usage: PromptUsage) => void | Promise<void>;
+  /**
+   * Agent-advertised slash commands (ACP `available_commands_update`). Replace-latest
+   * list, re-sent when the agent updates it. Optional — not every adapter advertises.
+   */
+  onCommands?: (commands: AgentCommand[]) => void | Promise<void>;
   /**
    * How tool_call / tool_call_update events are surfaced for this prompt.
    *

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -5,6 +5,31 @@ import type { ToolEventMode } from "./tool-event-mode.js";
 
 export type { ToolEventMode } from "./tool-event-mode.js";
 
+/** Cumulative session cost the agent reported (ACP `usage_update.cost`). Both optional. */
+export interface UsageCost {
+  amount?: number;
+  currency?: string;
+}
+/**
+ * Per-turn token breakdown from ACP `usage_update._meta.usage` (Claude reports it;
+ * codex may omit). All fields optional — treat missing as "unknown", not zero.
+ */
+export interface UsageBreakdown {
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedReadTokens?: number;
+  cachedWriteTokens?: number;
+  thoughtTokens?: number;
+  totalTokens?: number;
+}
+/** Context-usage side-channel payload: window fill plus optional cost & token breakdown. */
+export interface PromptUsage {
+  used: number;
+  size: number;
+  cost?: UsageCost;
+  breakdown?: UsageBreakdown;
+}
+
 export interface ReplyQuotaContext {
   chatKey: string;
   quota: QuotaManager;
@@ -135,7 +160,7 @@ export interface PromptOptions {
    * scalar (re-sent during a turn). Optional — only agents that report it fire this
    * (e.g. claude does, codex does not), and text channels omit the handler.
    */
-  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>;
+  onUsage?: (usage: PromptUsage) => void | Promise<void>;
   /**
    * How tool_call / tool_call_update events are surfaced for this prompt.
    *

--- a/src/weixin/agent/interface.ts
+++ b/src/weixin/agent/interface.ts
@@ -1,6 +1,6 @@
 import type { ChannelMediaAttachment, OutboundChannelMedia } from "../../channels/media-types.js";
 import type { PlanEntry, ScheduledSessionDescriptor, ToolUseEvent } from "../../channels/types.js";
-import type { PromptUsage } from "../../transport/types.js";
+import type { AgentCommand, PromptUsage } from "../../transport/types.js";
 import type { PerfSpan } from "../../perf/perf-tracer.js";
 
 /**
@@ -56,6 +56,8 @@ export interface ChatRequest {
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
   /** Context-usage side-channel; see PromptOptions.onUsage. */
   onUsage?: (usage: PromptUsage) => void | Promise<void>;
+  /** Agent-advertised slash commands; see PromptOptions.onCommands. */
+  onCommands?: (commands: AgentCommand[]) => void | Promise<void>;
   /**
    * Optional per-turn performance tracing span. When `logging.perf.enabled` is
    * true, the channel handler attaches a `PerfSpan` so downstream layers can

--- a/src/weixin/agent/interface.ts
+++ b/src/weixin/agent/interface.ts
@@ -1,5 +1,6 @@
 import type { ChannelMediaAttachment, OutboundChannelMedia } from "../../channels/media-types.js";
 import type { PlanEntry, ScheduledSessionDescriptor, ToolUseEvent } from "../../channels/types.js";
+import type { PromptUsage } from "../../transport/types.js";
 import type { PerfSpan } from "../../perf/perf-tracer.js";
 
 /**
@@ -54,7 +55,7 @@ export interface ChatRequest {
   /** Structured plan/todo side-channel; see PromptOptions.onPlan. */
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
   /** Context-usage side-channel; see PromptOptions.onUsage. */
-  onUsage?: (usage: { used: number; size: number }) => void | Promise<void>;
+  onUsage?: (usage: PromptUsage) => void | Promise<void>;
   /**
    * Optional per-turn performance tracing span. When `logging.perf.enabled` is
    * true, the channel handler attaches a `PerfSpan` so downstream layers can

--- a/tests/unit/control/control-service-media.test.ts
+++ b/tests/unit/control/control-service-media.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, mock } from "bun:test";
+
+import { ControlService } from "../../../src/control/control-service";
+import { UploadStore } from "../../../src/control/upload-store";
+import { createControlEventBus } from "../../../src/control/control-event-bus";
+
+// Minimal deps stub — only what uploadFile/prompt() touch in this test.
+function buildService(chatSpy: ReturnType<typeof mock>, uploadStore: UploadStore) {
+  const events = createControlEventBus();
+  const deps = {
+    agent: { chat: chatSpy },
+    sessions: {
+      listAllResolvedSessions: () => [],
+      resolveAliasForChat: mock(async (_chatKey: string, alias: string) => alias),
+      getSession: mock(async (_alias: string) => ({
+        alias: "main",
+        agent: "claude",
+        workspace: "ws",
+        transportSession: "t",
+        cwd: "/tmp",
+        replyMode: "stream" as const,
+        effectiveReplyMode: "stream" as const,
+      })),
+      useSession: mock(async (_chatKey: string, _alias: string) => ({
+        alias: "main",
+        agent: "claude",
+        workspace: "ws",
+      })),
+      setSessionModel: mock(async () => {}),
+    },
+    activeTurns: { isActiveAnywhere: () => false },
+    scheduled: {} as never,
+    orchestration: {} as never,
+    events,
+    workspaces: { list: () => [] },
+    transport: {} as never,
+    createSessionWithTransport: mock(async () => { throw new Error("unused"); }),
+    removeSessionWithTransport: mock(async () => ({ wasActive: false })),
+    archiveSessionWithTransport: mock(async () => {}),
+    unarchiveSession: mock(async () => {}),
+    listNativeSessions: mock(async () => []),
+    attachNativeSessionWithTransport: mock(async () => { throw new Error("unused"); }),
+    agents: { list: () => [], catalog: () => [], create: mock(async () => { throw new Error("unused"); }), remove: mock(async () => {}) },
+    uploadStore,
+  } as unknown as ConstructorParameters<typeof ControlService>[0];
+  return new ControlService(deps);
+}
+
+describe("ControlService media", () => {
+  it("uploadFile writes bytes and returns an absolute daemon path", async () => {
+    const root = await mkdtemp(join(tmpdir(), "cs-upload-"));
+    const store = new UploadStore({ rootDir: root });
+    const svc = buildService(mock(() => {}), store);
+
+    const res = await svc.uploadFile({ filename: "shot.png", content: Buffer.from("PNG").toString("base64"), mimeType: "image/png" });
+    expect(res.path.startsWith(root)).toBe(true);
+    expect(res.filename).toBe("shot.png");
+    expect(res.size).toBe(3);
+  });
+
+  it("prompt() forwards media refs to agent.chat as ChannelMediaAttachment[]", async () => {
+    const chat = mock(async () => ({ text: "ok" }));
+    const root = await mkdtemp(join(tmpdir(), "cs-upload-"));
+    const svc = buildService(chat, new UploadStore({ rootDir: root }));
+
+    await svc.prompt({
+      chatKey: "relay:a1",
+      sessionAlias: "main",
+      text: "look at this",
+      senderId: "a1",
+      isOwner: true,
+      media: [{ id: "u-1", filePath: "/tmp/u-1/shot.png", fileName: "shot.png", mimeType: "image/png", kind: "image", size: 3 }],
+    });
+
+    expect(chat).toHaveBeenCalledTimes(1);
+    const arg = (chat.mock.calls[0] as unknown[])[0] as { media: Array<Record<string, unknown> & { source: { channelId: string } }> };
+    expect(Array.isArray(arg.media)).toBe(true);
+    expect(arg.media[0]).toMatchObject({
+      kind: "image",
+      filePath: "/tmp/u-1/shot.png",
+      mimeType: "image/png",
+      fileName: "shot.png",
+    });
+    expect(arg.media[0].source.channelId).toBe("relay");
+  });
+});

--- a/tests/unit/control/control-service-media.test.ts
+++ b/tests/unit/control/control-service-media.test.ts
@@ -65,6 +65,9 @@ describe("ControlService media", () => {
     const chat = mock(async () => ({ text: "ok" }));
     const root = await mkdtemp(join(tmpdir(), "cs-upload-"));
     const svc = buildService(chat, new UploadStore({ rootDir: root }));
+    // Mirror the real web flow: the path echoed back is the one control.upload returned,
+    // which lives under the sandbox root.
+    const inSandbox = join(root, "u-1", "shot.png");
 
     await svc.prompt({
       chatKey: "relay:a1",
@@ -72,7 +75,7 @@ describe("ControlService media", () => {
       text: "look at this",
       senderId: "a1",
       isOwner: true,
-      media: [{ id: "u-1", filePath: "/tmp/u-1/shot.png", fileName: "shot.png", mimeType: "image/png", kind: "image", size: 3 }],
+      media: [{ id: "u-1", filePath: inSandbox, fileName: "shot.png", mimeType: "image/png", kind: "image", size: 3 }],
     });
 
     expect(chat).toHaveBeenCalledTimes(1);
@@ -80,10 +83,36 @@ describe("ControlService media", () => {
     expect(Array.isArray(arg.media)).toBe(true);
     expect(arg.media[0]).toMatchObject({
       kind: "image",
-      filePath: "/tmp/u-1/shot.png",
+      filePath: inSandbox,
       mimeType: "image/png",
       fileName: "shot.png",
     });
     expect(arg.media[0].source.channelId).toBe("relay");
+  });
+
+  it("prompt() drops media refs whose filePath escapes the upload sandbox", async () => {
+    const chat = mock(async () => ({ text: "ok" }));
+    const root = await mkdtemp(join(tmpdir(), "cs-upload-"));
+    const svc = buildService(chat, new UploadStore({ rootDir: root }));
+    const inSandbox = join(root, "u-2", "ok.png");
+
+    await svc.prompt({
+      chatKey: "relay:a1",
+      sessionAlias: "main",
+      text: "look at this",
+      senderId: "a1",
+      isOwner: true,
+      media: [
+        // Out-of-sandbox absolute path — must be dropped.
+        { id: "u-evil", filePath: "/etc/passwd", fileName: "passwd", mimeType: "text/plain", kind: "file", size: 3 },
+        // Legitimate in-sandbox path — must pass through.
+        { id: "u-2", filePath: inSandbox, fileName: "ok.png", mimeType: "image/png", kind: "image", size: 3 },
+      ],
+    });
+
+    expect(chat).toHaveBeenCalledTimes(1);
+    const arg = (chat.mock.calls[0] as unknown[])[0] as { media: Array<Record<string, unknown>> };
+    expect(arg.media.length).toBe(1);
+    expect(arg.media[0]).toMatchObject({ kind: "image", filePath: inSandbox });
   });
 });

--- a/tests/unit/control/upload-store.test.ts
+++ b/tests/unit/control/upload-store.test.ts
@@ -41,6 +41,24 @@ describe("UploadStore", () => {
     );
   });
 
+  it("rejects an oversized base64 string before decoding it", async () => {
+    const root = await freshRoot();
+    const maxBytes = 8;
+    const store = new UploadStore({ rootDir: root, maxBytes });
+    // A base64 string longer than the pre-decode threshold is rejected without ever
+    // allocating the decoded buffer (the string itself stays tiny relative to a 10MB+
+    // payload, but exceeds the cheap length bound).
+    const threshold = Math.ceil((maxBytes * 4) / 3) + 4;
+    const oversized = "A".repeat(threshold + 1);
+    await expect(store.save("big.bin", oversized, "application/octet-stream")).rejects.toThrow("file-too-large");
+  });
+
+  it("exposes the configured rootDir via root", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root });
+    expect(store.root).toBe(root);
+  });
+
   it("rejects empty content", async () => {
     const root = await freshRoot();
     const store = new UploadStore({ rootDir: root });

--- a/tests/unit/control/upload-store.test.ts
+++ b/tests/unit/control/upload-store.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, readFile, stat, utimes, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+
+import { UploadStore } from "../../../src/control/upload-store";
+
+async function freshRoot(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "upload-store-test-"));
+}
+
+describe("UploadStore", () => {
+  it("writes base64 bytes to a sandboxed file and returns an absolute path + size", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root });
+    const bytes = Buffer.from("hello world");
+    const res = await store.save("note.txt", bytes.toString("base64"), "text/plain");
+
+    expect(res.path.startsWith(root)).toBe(true);
+    expect(res.filename).toBe("note.txt");
+    expect(res.size).toBe(bytes.byteLength);
+    expect(res.id).toMatch(/.+/);
+    expect((await readFile(res.path)).equals(bytes)).toBe(true);
+  });
+
+  it("sanitizes path-traversal filenames to a basename", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root });
+    const res = await store.save("../../etc/passwd", Buffer.from("x").toString("base64"), "text/plain");
+
+    expect(res.filename).toBe("passwd");
+    expect(res.path.startsWith(root)).toBe(true);
+    expect(res.path.includes("..")).toBe(false);
+  });
+
+  it("rejects files over the byte cap", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root, maxBytes: 8 });
+    await expect(store.save("big.bin", Buffer.alloc(9).toString("base64"), "application/octet-stream")).rejects.toThrow(
+      "file-too-large",
+    );
+  });
+
+  it("rejects empty content", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root });
+    await expect(store.save("empty.txt", "", "text/plain")).rejects.toThrow("empty-file");
+  });
+
+  it("cleanup() removes upload dirs older than the TTL and keeps fresh ones", async () => {
+    const root = await freshRoot();
+    const store = new UploadStore({ rootDir: root, ttlMs: 1000 });
+    const stale = await store.save("old.txt", Buffer.from("old").toString("base64"), "text/plain");
+    const fresh = await store.save("new.txt", Buffer.from("new").toString("base64"), "text/plain");
+
+    // Backdate the stale entry's directory mtime well beyond the TTL.
+    const staleDir = join(stale.path, "..");
+    const past = new Date(Date.now() - 60_000);
+    await utimes(staleDir, past, past);
+
+    const removed = await store.cleanup();
+    expect(removed).toBeGreaterThanOrEqual(1);
+    await expect(stat(stale.path)).rejects.toThrow();
+    expect((await stat(fresh.path)).isFile()).toBe(true);
+    expect((await readdir(root)).length).toBe(1);
+  });
+});

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -182,6 +182,22 @@ test("agents.remove and workspaces.remove return ok", async () => {
   expect(removed).toEqual(["a:gemini", "w:ws1"]);
 });
 
+test("control.upload dispatches to uploadFile and returns UploadResult", async () => {
+  const uploadResult = { id: "u1", path: "/tmp/u1.png", filename: "photo.png", mimeType: "image/png", size: 1024 };
+  const { control } = makeFakeControl({
+    uploadFile: async (input: unknown) => uploadResult,
+  });
+  const bridge = createControlBridge(control as never);
+
+  // happy path: all fields present → returns UploadResult
+  expect(await dispatch(bridge, req(MSG.upload, { filename: "photo.png", content: "abc123", mimeType: "image/png" }))).toEqual(uploadResult);
+
+  // bad-request: missing mimeType
+  expect(await dispatch(bridge, req(MSG.upload, { filename: "photo.png", content: "abc123" }))).toEqual({
+    error: { code: "bad-request", message: "filename, content and mimeType are required" },
+  });
+});
+
 test("unknown type and thrown errors become error payloads", async () => {
   const { control } = makeFakeControl();
   const broken = { ...control, listSessions: () => { throw new Error("boom"); } };

--- a/tests/unit/packages/relay-protocol/web-dtos.test.ts
+++ b/tests/unit/packages/relay-protocol/web-dtos.test.ts
@@ -111,6 +111,16 @@ test("parseWebServerEvent accepts a turn-usage control event and rejects malform
   expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "turn-usage", chatKey: "k", sessionAlias: "a", used: "x", size: 200000 } })).toBeNull();
 });
 
+test("parseWebServerEvent accepts an agent-commands control event and rejects malformed ones", () => {
+  expect(roundtrip({
+    kind: "control-event", instanceId: "i1",
+    event: { type: "agent-commands", chatKey: "k", sessionAlias: "a", commands: [{ name: "compact" }] },
+  })).not.toBeNull();
+  // commands must be an array, or the composer autocomplete has nothing iterable.
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "agent-commands", chatKey: "k", sessionAlias: "a" } })).toBeNull();
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "agent-commands", chatKey: "k", sessionAlias: "a", commands: "x" } })).toBeNull();
+});
+
 test("parseWebServerEvent rejects a plan event without entries", () => {
   expect(roundtrip({
     kind: "control-event", instanceId: "i1",

--- a/tests/unit/packages/relay-protocol/web-dtos.test.ts
+++ b/tests/unit/packages/relay-protocol/web-dtos.test.ts
@@ -119,6 +119,10 @@ test("parseWebServerEvent accepts an agent-commands control event and rejects ma
   // commands must be an array, or the composer autocomplete has nothing iterable.
   expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "agent-commands", chatKey: "k", sessionAlias: "a" } })).toBeNull();
   expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "agent-commands", chatKey: "k", sessionAlias: "a", commands: "x" } })).toBeNull();
+  // an empty list is valid (a legitimate "clear")…
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "agent-commands", chatKey: "k", sessionAlias: "a", commands: [] } })).not.toBeNull();
+  // …but a nameless entry is rejected so the composer's `c.name` access can't crash.
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "agent-commands", chatKey: "k", sessionAlias: "a", commands: [{ description: "no name" }] } })).toBeNull();
 });
 
 test("parseWebServerEvent rejects a plan event without entries", () => {

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -216,6 +216,30 @@ test("instances: pairing token, list with online flag, account isolation, rpc st
   })).status).toBe(404);
 });
 
+test("session archive/unarchive RPCs are chat-scoped (chatKey stamped, else the connector crashes)", async () => {
+  const { app, instances, loginToken, login, rpcCalls } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const redeemed = instances.redeemPairingToken(token)!;
+
+  // archive/unarchive resolve the alias within the caller's chat scope, so the hub
+  // MUST stamp chatKey just like create/list/remove. Without it the connector calls
+  // getChannelIdFromChatKey(undefined) and throws "reading 'split'".
+  for (const type of [MSG.sessionsArchive, MSG.sessionsUnarchive]) {
+    rpcCalls.length = 0;
+    const res = await app.request(`/api/instances/${redeemed.instanceId}/rpc`, {
+      method: "POST", headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ type, payload: { alias: "s" } }),
+    });
+    expect(res.status).toBe(200);
+    const stamped = rpcCalls[0]?.payload as { chatKey?: string };
+    expect(stamped.chatKey).toBe(`relay:${redeemed.accountId}`);
+  }
+});
+
 test("PATCH /api/instances/:id renames an owned instance", async () => {
   const { app, instances, loginToken, login } = await makeApp();
   const { cookie } = await login(loginToken);

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -319,6 +319,60 @@ test("rpc prompt persists the inbound message before the turn's out message (his
   expect(cached.messages.map((m) => [m.direction, m.text])).toEqual([["in", "hi"], ["out", "agent reply"]]);
 });
 
+test("rpc prompt persists a valid small image previewUrl on the attachment", async () => {
+  const { app, instances, loginToken, login } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const { instanceId, accountId } = instances.redeemPairingToken(token)!;
+
+  const previewUrl = "data:image/png;base64,abc";
+  const media = [{ id: "a1", filePath: "/tmp/a1.png", fileName: "a1.png", mimeType: "image/png", kind: "image", size: 12, previewUrl }];
+  const res = await app.request(`/api/instances/${instanceId}/rpc`, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "s", text: "hi", media } }),
+  });
+  expect(res.status).toBe(200);
+
+  const { messages: msgs } = (await app.request(`/api/instances/${instanceId}/sessions/s/messages`, { headers: { cookie } }).then((r) => r.json())) as { messages: Array<{ direction: string; attachments?: Array<{ id: string; previewUrl?: string }> }> };
+  void accountId;
+  const inbound = msgs.find((m) => m.direction === "in")!;
+  expect(inbound.attachments?.[0]?.id).toBe("a1");
+  expect(inbound.attachments?.[0]?.previewUrl).toBe(previewUrl);
+});
+
+test("rpc prompt strips an oversized or non-image previewUrl but still stores the attachment", async () => {
+  const { app, instances, loginToken, login } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const { instanceId } = instances.redeemPairingToken(token)!;
+
+  const oversized = "data:image/png;base64," + "x".repeat(256 * 1024); // > 256*1024 chars
+  const evil = "http://evil.com/track.png";
+  const media = [
+    { id: "big", filePath: "/tmp/big.png", fileName: "big.png", mimeType: "image/png", kind: "image", size: 99, previewUrl: oversized },
+    { id: "evil", filePath: "/tmp/evil.png", fileName: "evil.png", mimeType: "image/png", kind: "image", size: 33, previewUrl: evil },
+  ];
+  const res = await app.request(`/api/instances/${instanceId}/rpc`, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "s", text: "hi", media } }),
+  });
+  expect(res.status).toBe(200);
+
+  const { messages: msgs } = (await app.request(`/api/instances/${instanceId}/sessions/s/messages`, { headers: { cookie } }).then((r) => r.json())) as { messages: Array<{ direction: string; attachments?: Array<{ id: string; previewUrl?: string }> }> };
+  const inbound = msgs.find((m) => m.direction === "in")!;
+  const byId = Object.fromEntries((inbound.attachments ?? []).map((a) => [a.id, a]));
+  expect(byId.big).toBeDefined();
+  expect(byId.big?.previewUrl).toBeUndefined();
+  expect(byId.evil).toBeDefined();
+  expect(byId.evil?.previewUrl).toBeUndefined();
+});
+
 test("GET /api/config returns the retention policy from deps", async () => {
   const db = await createSqlDriver(":memory:");
   initSchema(db);

--- a/tests/unit/packages/relay/stores-messages.test.ts
+++ b/tests/unit/packages/relay/stores-messages.test.ts
@@ -32,6 +32,16 @@ test("append without structured yields no structured field", async () => {
   db.close();
 });
 
+test("persists and returns attachment metadata on inbound messages", async () => {
+  const db = await seeded();
+  const store = new MessageStore(db);
+  const atts = [{ id: "u-1", filename: "shot.png", mimeType: "image/png", size: 3, kind: "image" as const, previewUrl: "data:image/png;base64,AAAA" }];
+  store.append("i1", "main", "in", "look", undefined, atts);
+  const page = store.listBySession("a1", "i1", "main");
+  expect(page.messages.at(-1)?.attachments).toEqual(atts);
+  db.close();
+});
+
 test("listBySession paginates oldest-first with a `before` cursor and hasMore", async () => {
   const db = await seeded();
   const store = new MessageStore(db);

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -197,3 +197,44 @@ test("usage_update fires onUsage with the latest used/size, ignoring malformed f
     { used: 34612, size: 1000000 },
   ]);
 });
+
+test("usage_update surfaces cost and token breakdown", () => {
+  const seen: unknown[] = [];
+  const state = createStreamingPromptState(false, { onUsage: (u) => { seen.push(u); } });
+  parseStreamingChunks(
+    state,
+    JSON.stringify({
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "usage_update",
+          used: 1000,
+          size: 200000,
+          cost: { amount: 0.42, currency: "USD" },
+          _meta: { usage: { input_tokens: 800, output_tokens: 120, cache_read_input_tokens: 5000, total_tokens: 920 } },
+        },
+      },
+    }),
+  );
+  expect(seen).toEqual([
+    {
+      used: 1000,
+      size: 200000,
+      cost: { amount: 0.42, currency: "USD" },
+      breakdown: { inputTokens: 800, outputTokens: 120, cachedReadTokens: 5000, totalTokens: 920 },
+    },
+  ]);
+});
+
+test("usage_update without extras stays a bare used/size payload", () => {
+  const seen: unknown[] = [];
+  const state = createStreamingPromptState(false, { onUsage: (u) => { seen.push(u); } });
+  parseStreamingChunks(
+    state,
+    JSON.stringify({
+      method: "session/update",
+      params: { update: { sessionUpdate: "usage_update", used: 10, size: 100 } },
+    }),
+  );
+  expect(seen).toEqual([{ used: 10, size: 100 }]);
+});

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -258,3 +258,23 @@ test("available_commands_update surfaces agent slash commands", () => {
     { name: "run", hasInput: true },
   ]]);
 });
+
+test("available_commands_update with an empty list emits a clear", () => {
+  const seen: unknown[] = [];
+  const state = createStreamingPromptState(false, { onCommands: (c) => { seen.push(c); } });
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "available_commands_update", availableCommands: [] } },
+  }));
+  expect(seen).toEqual([[]]); // explicit clear propagates, so a stale list doesn't linger
+});
+
+test("available_commands_update with no array is ignored", () => {
+  const seen: unknown[] = [];
+  const state = createStreamingPromptState(false, { onCommands: (c) => { seen.push(c); } });
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "available_commands_update" } },
+  }));
+  expect(seen).toEqual([]);
+});

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -238,3 +238,23 @@ test("usage_update without extras stays a bare used/size payload", () => {
   );
   expect(seen).toEqual([{ used: 10, size: 100 }]);
 });
+
+test("available_commands_update surfaces agent slash commands", () => {
+  const seen: unknown[] = [];
+  const state = createStreamingPromptState(false, { onCommands: (c) => { seen.push(c); } });
+  parseStreamingChunks(
+    state,
+    JSON.stringify({
+      method: "session/update",
+      params: { update: { sessionUpdate: "available_commands_update", availableCommands: [
+        { name: "compact", description: "Compact the conversation" },
+        { name: "run", input: { hint: "args" } },
+        { description: "no name — dropped" },
+      ] } },
+    }),
+  );
+  expect(seen).toEqual([[
+    { name: "compact", description: "Compact the conversation", hasInput: false },
+    { name: "run", hasInput: true },
+  ]]);
+});


### PR DESCRIPTION
## What

Lets the relay-web dashboard attach **images or files** to a chat message, delivered end-to-end through relay hub → connector → core into the acpx session, with attachments persisted for history re-display.

Two-phase design (mirrors the existing `control.fs.*` workspace-fs RPC pattern):
1. **Upload** — relay-web reads a file → base64 → new non-chat-scoped `control.upload` RPC → connector → `ControlService.uploadFile` → `UploadStore` writes to `~/.xacpx/runtime/uploads/<rand>/<safe>` → returns the daemon absolute path.
2. **Send** — `control.prompt` carries lightweight `media: PromptAttachmentRef[]` (path + metadata). `ControlService.prompt` maps them to `ChannelMediaAttachment[]` and feeds the **already-wired** `agent.chat → router → transport.prompt → prompt-media.ts → ACP image/resource block` chain. **No changes to transport / acpx / prompt-media.**

Images get a client-downscaled (≤512px) `previewUrl` persisted for history re-display; non-image files reach the agent as a daemon-absolute path (resource block + text summary).

## Changes by package

- **relay-protocol** — `control.upload` types (`UploadPayload`/`UploadResult`), `PromptAttachmentRef`, `AttachmentMetadata`; `PromptPayload.media`, `MessageRecordDto.attachments`.
- **core (`src/control`)** — `UploadStore` (sandboxed temp writes, 10 MB cap, filename sanitization, 24h TTL cleanup on startup); `ControlService.uploadFile` + media passthrough into `agent.chat`.
- **connector (`channel-relay`)** — `control.upload` dispatch.
- **relay hub** — persists `AttachmentMetadata` (new `attachments` column + idempotent ALTER); 413 size guard; `previewUrl` validated/capped server-side (`data:image/` + ≤256 KB, else stripped); `control.upload` is non-chat-scoped.
- **relay-web** — attach button + clipboard paste + drag-drop, ≤5 files, client ≤512px preview downscale, pending chips, inline rejection feedback, image thumbnails / file cards, history re-display.

## Constraints

≤10 MB/file (enforced at hub **and** core); ≤5 attachments/message; filename sanitized to a safe basename; temp files cleaned on daemon startup + 24h TTL (history re-display relies on the persisted preview, not temp-file survival).

## Testing

- `npm test` (core + hub + connector + protocol, each file isolated): green.
- relay-web vitest: **342/342** (53 files), incl. new `attachments.test.ts` + `message-attachments.test.ts`.
- `npx tsc --noEmit` clean; relay-web `vue-tsc` + vite build clean.
- Reviewed task-by-task plus two independent whole-branch reviews (verdict: merge with follow-ups; no blockers).

## Follow-ups (non-blocking)

- Add a unit test for the hub 413 upload guard and the DB `attachments` ALTER round-trip.
- Preserve composer chips when a send fails (currently cleared optimistically; resend is text-only).
- Concurrent `addFiles` calls can momentarily exceed the 5-cap (self-corrects).
- **Release:** rebuild + republish the `channel-relay` connector dist before deploying against a live hub.
- **Manual browser e2e against a live hub+daemon is still pending** (not runnable in CI).

Spec: `docs/superpowers/specs/2026-06-22-relay-web-message-attachments-design.md`
Plan: `docs/superpowers/plans/2026-06-22-relay-web-message-attachments.md`