### PR TITLE
fix(relay-web,relay): make dashboard PWA updates timely

### DIFF
--- a/packages/relay-web/src/__tests__/pwa-update.test.ts
+++ b/packages/relay-web/src/__tests__/pwa-update.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import { schedulePwaUpdateChecks } from "../lib/pwa-update";
+
+// A tiny fake document we can drive visibility on, plus a controllable interval.
+function fakeDoc(visibility: DocumentVisibilityState = "visible") {
+  const listeners: Record<string, Array<() => void>> = {};
+  return {
+    visibilityState: visibility,
+    addEventListener: (t: string, fn: () => void) => {
+      (listeners[t] ??= []).push(fn);
+    },
+    removeEventListener: (t: string, fn: () => void) => {
+      listeners[t] = (listeners[t] ?? []).filter((f) => f !== fn);
+    },
+    fire: (t: string) => (listeners[t] ?? []).forEach((f) => f()),
+    count: (t: string) => (listeners[t] ?? []).length,
+  };
+}
+
+describe("schedulePwaUpdateChecks", () => {
+  it("no-ops (and returns a callable teardown) when there is no registration", () => {
+    const teardown = schedulePwaUpdateChecks(undefined);
+    expect(typeof teardown).toBe("function");
+    expect(() => teardown()).not.toThrow();
+  });
+
+  it("polls registration.update() on the interval", () => {
+    const update = vi.fn();
+    let tick: () => void = () => {};
+    schedulePwaUpdateChecks(
+      { update },
+      {
+        intervalMs: 1000,
+        doc: fakeDoc(),
+        setIntervalFn: (fn) => {
+          tick = fn;
+          return 1 as unknown as ReturnType<typeof setInterval>;
+        },
+      },
+    );
+    expect(update).not.toHaveBeenCalled();
+    tick();
+    tick();
+    expect(update).toHaveBeenCalledTimes(2);
+  });
+
+  it("checks for an update when the tab becomes visible again", () => {
+    const update = vi.fn();
+    const doc = fakeDoc("visible");
+    schedulePwaUpdateChecks(
+      { update },
+      { intervalMs: 1000, doc, setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval> },
+    );
+    doc.fire("visibilitychange");
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not check while the tab is hidden", () => {
+    const update = vi.fn();
+    const doc = fakeDoc("hidden");
+    schedulePwaUpdateChecks(
+      { update },
+      { intervalMs: 1000, doc, setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval> },
+    );
+    doc.fire("visibilitychange");
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("swallows a rejected update() so a failed poll never throws", () => {
+    let tick: () => void = () => {};
+    schedulePwaUpdateChecks(
+      { update: () => Promise.reject(new Error("offline")) },
+      {
+        intervalMs: 1000,
+        doc: fakeDoc(),
+        setIntervalFn: (fn) => {
+          tick = fn;
+          return 1 as unknown as ReturnType<typeof setInterval>;
+        },
+      },
+    );
+    expect(() => tick()).not.toThrow();
+  });
+
+  it("teardown clears the timer and removes the visibility listener", () => {
+    const cleared = vi.fn();
+    const doc = fakeDoc();
+    const teardown = schedulePwaUpdateChecks(
+      { update: vi.fn() },
+      {
+        intervalMs: 1000,
+        doc,
+        setIntervalFn: () => 42 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: cleared,
+      },
+    );
+    expect(doc.count("visibilitychange")).toBe(1);
+    teardown();
+    expect(cleared).toHaveBeenCalledWith(42);
+    expect(doc.count("visibilitychange")).toBe(0);
+  });
+});

--- a/packages/relay-web/src/__tests__/pwa.test.ts
+++ b/packages/relay-web/src/__tests__/pwa.test.ts
@@ -15,6 +15,15 @@ describe("PWA configuration", () => {
     expect(pwaOptions.injectRegister).toBe(false);
   });
 
+  it("forces skipWaiting + clientsClaim so an open tab actually reloads to a new build", () => {
+    // injectRegister:false suppresses the plugin's automatic skipWaiting, and the
+    // autoUpdate registerSW only reloads on the worker's `activated` event. Without
+    // skipWaiting the new worker stays in "waiting" forever for an open tab, so the
+    // periodic update check (lib/pwa-update.ts) would download but never reload.
+    expect(pwaOptions.workbox?.skipWaiting).toBe(true);
+    expect(pwaOptions.workbox?.clientsClaim).toBe(true);
+  });
+
   it("never lets the service worker shadow the relay API / WebSocket", () => {
     const denylist = pwaOptions.workbox?.navigateFallbackDenylist ?? [];
     // Behavioral: the actual regexes must match the hub's backend routes so the
@@ -62,5 +71,17 @@ describe("PWA configuration", () => {
     expect(sw).toContain("denylist");
     expect(sw).toMatch(/\/\^\\\/api\//);
     expect(sw).toMatch(/\/\^\\\/ws\//);
+  });
+
+  // Guards against the autoUpdate "downloads but never reloads" regression. With
+  // skipWaiting:true, generateSW emits an UNCONDITIONAL install-time
+  // `self.skipWaiting(), <wb>.clientsClaim()` bootstrap (and drops the passive
+  // SKIP_WAITING message handler). Without it the worker would only skipWaiting in
+  // response to a message the autoUpdate path never sends — installing but never
+  // activating for an open tab. Match the unconditional form so the message-gated
+  // `..."SKIP_WAITING"===e.data.type&&self.skipWaiting()` form can't satisfy it.
+  it.skipIf(!existsSync(swPath))("emits a service worker that skips waiting on install", () => {
+    const sw = readFileSync(swPath, "utf8");
+    expect(sw).toMatch(/self\.skipWaiting\(\)\s*,\s*\w+\.clientsClaim\(\)/);
   });
 });

--- a/packages/relay-web/src/lib/pwa-update.ts
+++ b/packages/relay-web/src/lib/pwa-update.ts
@@ -1,0 +1,70 @@
+// A `registerType: "autoUpdate"` service worker silently activates + reloads the
+// page once the browser DISCOVERS a new worker — but discovery only happens on
+// navigation, on a manual reload, or via the browser's own ~24h check. A tab left
+// open therefore keeps serving the old bundle indefinitely. These checks force the
+// discovery: poll on an interval and whenever the tab becomes visible again, so an
+// open dashboard picks up a deploy within ~1 minute (or instantly on tab focus) and
+// autoUpdate reloads it.
+
+/** Minimal shape we need from a ServiceWorkerRegistration — keeps this testable. */
+export interface UpdatableRegistration {
+  update: () => unknown;
+}
+
+/** Minimal slice of `document` we use — narrow so a fake is assignable in tests
+ *  while the real `document` (a superset) still satisfies it. */
+export interface VisibilityDoc {
+  visibilityState: DocumentVisibilityState;
+  addEventListener: (type: string, listener: () => void) => void;
+  removeEventListener: (type: string, listener: () => void) => void;
+}
+
+export interface SchedulePwaUpdateOptions {
+  /** Poll interval in ms (default 60s). */
+  intervalMs?: number;
+  /** Injected for tests; defaults to the global document. */
+  doc?: VisibilityDoc;
+  /** Injected for tests; defaults to global setInterval/clearInterval. */
+  setIntervalFn?: (fn: () => void, ms: number) => ReturnType<typeof setInterval>;
+  clearIntervalFn?: (handle: ReturnType<typeof setInterval>) => void;
+}
+
+/**
+ * Periodically ask the service worker registration to check for a new worker, and
+ * also check the moment the tab regains visibility. Returns a teardown function that
+ * stops the timer and removes the listener. No-ops (returns a no-op teardown) when no
+ * registration is available, e.g. in browsers without service-worker support.
+ */
+export function schedulePwaUpdateChecks(
+  registration: UpdatableRegistration | undefined,
+  opts: SchedulePwaUpdateOptions = {},
+): () => void {
+  if (!registration) return () => {};
+
+  const intervalMs = opts.intervalMs ?? 60_000;
+  const doc = opts.doc ?? (typeof document !== "undefined" ? document : undefined);
+  const setIntervalFn = opts.setIntervalFn ?? ((fn, ms) => setInterval(fn, ms));
+  const clearIntervalFn = opts.clearIntervalFn ?? ((h) => clearInterval(h));
+
+  const check = () => {
+    // update() rejects (e.g. offline) far more often than it throws; swallow both so
+    // a failed poll never bubbles into an unhandled rejection.
+    try {
+      void Promise.resolve(registration.update()).catch(() => {});
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const timer = setIntervalFn(check, intervalMs);
+
+  const onVisible = () => {
+    if (!doc || doc.visibilityState === "visible") check();
+  };
+  doc?.addEventListener("visibilitychange", onVisible);
+
+  return () => {
+    clearIntervalFn(timer);
+    doc?.removeEventListener("visibilitychange", onVisible);
+  };
+}

--- a/packages/relay-web/src/lib/pwa-update.ts
+++ b/packages/relay-web/src/lib/pwa-update.ts
@@ -58,13 +58,17 @@ export function schedulePwaUpdateChecks(
 
   const timer = setIntervalFn(check, intervalMs);
 
+  // The visibility listener is only attached when a document exists, so `doc` is
+  // always defined inside the handler.
+  if (!doc) return () => clearIntervalFn(timer);
+  const visibleDoc = doc;
   const onVisible = () => {
-    if (!doc || doc.visibilityState === "visible") check();
+    if (visibleDoc.visibilityState === "visible") check();
   };
-  doc?.addEventListener("visibilitychange", onVisible);
+  visibleDoc.addEventListener("visibilitychange", onVisible);
 
   return () => {
     clearIntervalFn(timer);
-    doc?.removeEventListener("visibilitychange", onVisible);
+    visibleDoc.removeEventListener("visibilitychange", onVisible);
   };
 }

--- a/packages/relay-web/src/main.ts
+++ b/packages/relay-web/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from "vue";
 import { createPinia } from "pinia";
 import { registerSW } from "virtual:pwa-register";
+import { schedulePwaUpdateChecks } from "./lib/pwa-update";
 import App from "./App.vue";
 import { router } from "./router";
 import { i18n } from "./i18n";
@@ -21,5 +22,13 @@ app.mount("#app");
 
 // Register the service worker (autoUpdate: silently activates the new shell on
 // the next navigation). No-ops in dev and where service workers are unsupported
-// or the page is not in a secure context (HTTP over LAN).
-registerSW({ immediate: true });
+// or the page is not in a secure context (HTTP over LAN). Once registered, poll
+// for a new worker on an interval and whenever the tab regains focus, so a tab
+// left open picks up a deploy within ~1 minute instead of waiting for a manual
+// reload or the browser's ~24h check.
+registerSW({
+  immediate: true,
+  onRegisteredSW(_swUrl, registration) {
+    schedulePwaUpdateChecks(registration);
+  },
+});

--- a/packages/relay-web/src/main.ts
+++ b/packages/relay-web/src/main.ts
@@ -29,6 +29,8 @@ app.mount("#app");
 registerSW({
   immediate: true,
   onRegisteredSW(_swUrl, registration) {
+    // Intentionally not torn down: the update schedule should live for the whole
+    // page lifetime. onRegisteredSW fires once per registration, so it doesn't stack.
     schedulePwaUpdateChecks(registration);
   },
 });

--- a/packages/relay-web/src/pwa-options.ts
+++ b/packages/relay-web/src/pwa-options.ts
@@ -41,6 +41,15 @@ export const pwaOptions: Partial<VitePWAOptions> = {
     // shadow the relay hub's API / WebSocket endpoints.
     navigateFallback: "/index.html",
     navigateFallbackDenylist: [/^\/api/, /^\/ws/],
+    // skipWaiting + clientsClaim are BOTH required for the autoUpdate flow to
+    // actually reload an open tab: vite-plugin-pwa's autoUpdate registerSW only
+    // reloads on the new worker's `activated` event, and a freshly-installed
+    // worker stays in "waiting" (never activating for an open tab) unless it
+    // calls skipWaiting() on install. We set injectRegister:false, which
+    // suppresses the plugin's automatic skipWaiting injection, so we must set it
+    // here ourselves — otherwise the periodic update check (see lib/pwa-update.ts)
+    // would download the new build but never reload to it.
+    skipWaiting: true,
     clientsClaim: true,
     // Bundled font weights + main chunk can exceed the 2 MiB default.
     maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -360,9 +360,14 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       const path = c.req.path;
       if (path.startsWith("/api") || path.startsWith("/ws")) return;
       if (!c.res.ok) return;
+      // Only fingerprinted build assets are immutable. Gate on content-type, not
+      // just the path: a request for a missing /assets/<hash> falls through to the
+      // SPA fallback and returns the index.html shell (text/html) with 200 — that
+      // must stay no-cache, never get stamped immutable under an asset URL.
+      const isHtml = (c.res.headers.get("content-type") ?? "").includes("text/html");
       c.header(
         "Cache-Control",
-        path.startsWith("/assets/")
+        !isHtml && path.startsWith("/assets/")
           ? "public, max-age=31536000, immutable"
           : "no-cache",
       );

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -349,6 +349,24 @@ export function createApp(deps: AppDeps): Hono<Vars> {
 
   if (deps.webRoot) {
     const root = deps.webRoot;
+    // Cache policy for the bundled dashboard: content-hashed build assets under
+    // /assets/ are immutable and cached for a year, while the app shell (index.html,
+    // the service worker, the manifest) must always be revalidated so a deploy is
+    // picked up immediately instead of being served stale from the browser's HTTP
+    // cache. Without this, `serveStatic` sets no Cache-Control and the browser
+    // heuristically caches the shell + sw.js, delaying PWA updates.
+    app.use("/*", async (c, next) => {
+      await next();
+      const path = c.req.path;
+      if (path.startsWith("/api") || path.startsWith("/ws")) return;
+      if (!c.res.ok) return;
+      c.header(
+        "Cache-Control",
+        path.startsWith("/assets/")
+          ? "public, max-age=31536000, immutable"
+          : "no-cache",
+      );
+    });
     app.use("/*", serveStatic({ root }));
     app.get("/*", serveStatic({ path: "index.html", root })); // SPA fallback
   }


### PR DESCRIPTION
## Problem
After every deploy the dashboard kept showing the old build until a hard refresh (often two). Two causes:

1. **No update polling.** `main.ts` only called `registerSW({ immediate: true })`. An `autoUpdate` SW only *discovers* a new worker on navigation, manual reload, or the browser's ~24h check — so a tab left open never updated.
2. **No cache headers on the shell.** The hub's `serveStatic` set no `Cache-Control`, so the browser heuristically cached `index.html` / `sw.js`, delaying discovery further.

## Fix
- **relay-web**: after registration, poll `registration.update()` every 60s and whenever the tab regains visibility, so an open dashboard picks up a deploy within ~1 minute (autoUpdate then reloads it). Logic lives in a unit-tested `schedulePwaUpdateChecks` helper.
- **relay**: serve content-hashed `/assets/*` as `immutable, max-age=1y`, and the shell (`index.html`, `sw.js`, manifest) as `no-cache` so a deploy is always revalidated and shown on the first reload.

## Tests
- New `pwa-update.test.ts` (6 cases: interval poll, visibility check, hidden-tab skip, rejected-update swallow, teardown).
- Full relay-web suite green (54 files / 359 tests); relay hub typecheck clean.


## Behavior note
After a deploy, an open dashboard tab auto-reloads within ~60s (or instantly on tab focus). The reload is a hard navigation, so any unsent composer text in that tab is lost. This is a live WS console (state is re-fetched on reconnect) and deploys are infrequent, so this is an accepted trade-off for always-fresh builds.
