### PR TITLE
feat(relay-web): redesign login as a terminal window

### DIFF
--- a/packages/relay-web/src/__tests__/loginview.test.ts
+++ b/packages/relay-web/src/__tests__/loginview.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 
@@ -8,10 +8,20 @@ vi.mock("vue-router", () => ({ useRouter: () => ({ replace }) }));
 import LoginView from "../views/LoginView.vue";
 import { useAuthStore } from "../stores/auth";
 
+// jsdom has no navigator.clipboard by default; the copy test stubs it. Restore
+// afterwards so the stub never leaks into other test files (which may assert the
+// insecure-context path where clipboard is undefined).
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
 describe("LoginView", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     replace.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalClipboard) Object.defineProperty(navigator, "clipboard", originalClipboard);
+    else delete (navigator as { clipboard?: unknown }).clipboard;
   });
 
   it("renders the terminal window chrome and the mint command", () => {
@@ -47,6 +57,22 @@ describe("LoginView", () => {
     await w.find('[data-test="login-window"]').trigger("submit");
     await flushPromises();
     expect(login).toHaveBeenCalledWith("rl_secret_token");
+    expect(replace).toHaveBeenCalledWith("/");
+  });
+
+  it("disables the form and shows a pending label while a login is in flight", async () => {
+    const auth = useAuthStore();
+    let resolveLogin!: (ok: boolean) => void;
+    vi.spyOn(auth, "login").mockReturnValue(new Promise((r) => (resolveLogin = r)));
+    const w = mount(LoginView);
+    await w.find('[data-test="token-input"]').setValue("rl_secret_token");
+    await w.find('[data-test="login-window"]').trigger("submit");
+    await flushPromises();
+    expect(w.find('[data-test="signin"]').attributes("disabled")).toBeDefined();
+    expect(w.find('[data-test="token-input"]').attributes("disabled")).toBeDefined();
+    expect(w.find('[data-test="signin"]').text()).toContain("Signing in");
+    resolveLogin(true);
+    await flushPromises();
     expect(replace).toHaveBeenCalledWith("/");
   });
 

--- a/packages/relay-web/src/__tests__/loginview.test.ts
+++ b/packages/relay-web/src/__tests__/loginview.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+
+const replace = vi.fn();
+vi.mock("vue-router", () => ({ useRouter: () => ({ replace }) }));
+
+import LoginView from "../views/LoginView.vue";
+import { useAuthStore } from "../stores/auth";
+
+describe("LoginView", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    replace.mockReset();
+  });
+
+  it("renders the terminal window chrome and the mint command", () => {
+    const w = mount(LoginView);
+    expect(w.find('[data-test="login-window"]').exists()).toBe(true);
+    expect(w.text()).toContain("xacpx-relay");
+    expect(w.text()).toContain("xacpx-relay add token");
+    expect(w.find('[data-test="signin"]').text()).toContain("Sign in");
+  });
+
+  it("toggles token visibility with the eye button", async () => {
+    const w = mount(LoginView);
+    expect(w.find('[data-test="token-input"]').attributes("type")).toBe("password");
+    await w.find('[data-test="toggle-visibility"]').trigger("click");
+    expect(w.find('[data-test="token-input"]').attributes("type")).toBe("text");
+    await w.find('[data-test="toggle-visibility"]').trigger("click");
+    expect(w.find('[data-test="token-input"]').attributes("type")).toBe("password");
+  });
+
+  it("copies the mint command to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const w = mount(LoginView);
+    await w.find('[data-test="copy-command"]').trigger("click");
+    expect(writeText).toHaveBeenCalledWith("xacpx-relay add token");
+  });
+
+  it("logs in with the entered token and redirects home on success", async () => {
+    const auth = useAuthStore();
+    const login = vi.spyOn(auth, "login").mockResolvedValue(true);
+    const w = mount(LoginView);
+    await w.find('[data-test="token-input"]').setValue("rl_secret_token");
+    await w.find('[data-test="login-window"]').trigger("submit");
+    await flushPromises();
+    expect(login).toHaveBeenCalledWith("rl_secret_token");
+    expect(replace).toHaveBeenCalledWith("/");
+  });
+
+  it("surfaces an error and does not redirect on failed login", async () => {
+    const auth = useAuthStore();
+    vi.spyOn(auth, "login").mockImplementation(async () => {
+      auth.error = "invalid-token";
+      return false;
+    });
+    const w = mount(LoginView);
+    await w.find('[data-test="login-window"]').trigger("submit");
+    await flushPromises();
+    expect(replace).not.toHaveBeenCalled();
+    const err = w.find('[data-test="login-error"]');
+    expect(err.exists()).toBe(true);
+    expect(err.text()).toContain("invalid-token");
+    expect(err.attributes("role")).toBe("alert");
+  });
+});

--- a/packages/relay-web/src/__tests__/longtail-i18n.test.ts
+++ b/packages/relay-web/src/__tests__/longtail-i18n.test.ts
@@ -19,14 +19,15 @@ describe("long-tail components i18n", () => {
     const w = mount(LoginView, { global: { plugins: [router] } });
     // Sign-in button label ("Sign in" → 登录).
     expect(w.find('button[type="submit"]').text()).toContain("登录");
-    // Token input placeholder ("Access token" → 访问令牌).
-    expect(w.find('input#access-token').attributes("placeholder")).toBe("访问令牌");
+    // Token input placeholder ("paste token…" → 粘贴 token…).
+    expect(w.find("input#access-token").attributes("placeholder")).toBe("粘贴 token…");
   });
 
   it("points users at the real token command (xacpx-relay add token, not user new)", () => {
     const w = mount(LoginView, { global: { plugins: [router] } });
-    const hint = w.find("#token-hint").text();
-    expect(hint).toContain("xacpx-relay add token");
-    expect(hint).not.toContain("user new");
+    // The mint command is shown verbatim in the terminal command line.
+    const text = w.find('[data-test="login-window"]').text();
+    expect(text).toContain("xacpx-relay add token");
+    expect(text).not.toContain("user new");
   });
 });

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -252,12 +252,14 @@ export default {
     keep: "Keep",
   },
   login: {
+    window: "login",
     tokenLabel: "Access token",
-    tokenPlaceholder: "Access token",
+    tokenPlaceholder: "paste token…",
+    runHint: "Run this on the host to mint a token, then paste it below.",
     signIn: "Sign in",
     signingIn: "Signing in…",
-    hintBefore: "Paste the access token from ",
-    hintAfter: ".",
+    copyCommand: "Copy command",
+    toggleVisibility: "Show or hide token",
   },
   fue: { gotIt: "Got it" },
   tools: {

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -250,12 +250,14 @@ export default {
     keep: "保留",
   },
   login: {
+    window: "login",
     tokenLabel: "访问令牌",
-    tokenPlaceholder: "访问令牌",
+    tokenPlaceholder: "粘贴 token…",
+    runHint: "在主机上运行以生成 token，然后粘贴到下面。",
     signIn: "登录",
     signingIn: "登录中…",
-    hintBefore: "粘贴来自 ",
-    hintAfter: " 的访问令牌。",
+    copyCommand: "复制命令",
+    toggleVisibility: "显示或隐藏 token",
   },
   fue: { gotIt: "知道了" },
   tools: {

--- a/packages/relay-web/src/views/LoginView.vue
+++ b/packages/relay-web/src/views/LoginView.vue
@@ -2,12 +2,17 @@
 import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { useAuthStore } from "../stores/auth";
-import BrandLogo from "../components/BrandLogo.vue";
 
 const auth = useAuthStore();
 const router = useRouter();
 const token = ref("");
 const pending = ref(false);
+const revealed = ref(false);
+const copied = ref(false);
+
+// The CLI command that mints an access token on the host. Literal (not localized)
+// because it is a command the user types verbatim.
+const ADD_TOKEN_CMD = "xacpx-relay add token";
 
 async function submit() {
   if (pending.value) return;
@@ -18,23 +23,174 @@ async function submit() {
     pending.value = false;
   }
 }
+
+async function copyCommand() {
+  try {
+    await navigator.clipboard?.writeText(ADD_TOKEN_CMD);
+    copied.value = true;
+    window.setTimeout(() => (copied.value = false), 1200);
+  } catch {
+    // Clipboard unavailable (insecure context / permissions) — non-fatal.
+  }
+}
 </script>
 
 <template>
-  <div class="flex h-dvh items-center justify-center bg-bg">
-    <form class="w-80 space-y-3 rounded-lg border border-border bg-surface p-6 shadow-xl" @submit.prevent="submit">
-      <div class="mb-2 flex justify-center">
-        <BrandLogo />
+  <div class="relative flex min-h-dvh items-center justify-center overflow-hidden bg-bg px-4">
+    <!-- ambient depth: a faint brand glow + a vignetted grid, purely decorative -->
+    <div aria-hidden="true" class="login-glow"></div>
+    <div aria-hidden="true" class="login-grid"></div>
+
+    <form
+      data-test="login-window"
+      class="relative w-[22rem] max-w-full overflow-hidden rounded-2xl border border-border bg-surface font-mono shadow-e3"
+      @submit.prevent="submit"
+    >
+      <!-- window chrome -->
+      <div class="relative flex items-center border-b border-border bg-raised px-3.5 py-2.5">
+        <div aria-hidden="true" class="flex gap-[7px]">
+          <span class="h-[11px] w-[11px] rounded-full opacity-90" style="background:#ff5f56"></span>
+          <span class="h-[11px] w-[11px] rounded-full opacity-90" style="background:#ffbd2e"></span>
+          <span class="h-[11px] w-[11px] rounded-full opacity-90" style="background:#27c93f"></span>
+        </div>
+        <div class="pointer-events-none absolute inset-x-0 flex items-center justify-center gap-1.5 text-xs text-fg-muted">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <defs>
+              <linearGradient id="loginBrandX" x1="3" y1="3" x2="21" y2="21" gradientUnits="userSpaceOnUse">
+                <stop stop-color="#4F9BF5" />
+                <stop offset="1" stop-color="#69D689" />
+              </linearGradient>
+            </defs>
+            <path d="M5 5 L19 19 M19 5 L5 19" stroke="url(#loginBrandX)" stroke-width="3.4" stroke-linecap="round" />
+          </svg>
+          xacpx-relay — {{ $t("login.window") }}
+        </div>
       </div>
-      <label for="access-token" class="sr-only">{{ $t("login.tokenLabel") }}</label>
-      <input id="access-token" v-model="token" type="password" autocomplete="off" aria-describedby="token-hint"
-             class="w-full rounded border border-border bg-bg px-3 py-2 text-fg placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50"
-             :placeholder="$t('login.tokenPlaceholder')" :disabled="pending" />
-      <p id="token-hint" class="text-sm text-fg-muted">{{ $t("login.hintBefore") }}<code>xacpx-relay add token</code>{{ $t("login.hintAfter") }}</p>
-      <p v-if="auth.error" class="text-sm text-danger">{{ auth.error }}</p>
-      <button class="w-full rounded bg-accent px-3 py-2 text-white hover:bg-accent-hover disabled:opacity-50" type="submit" :disabled="pending">
-        {{ pending ? $t("login.signingIn") : $t("login.signIn") }}
-      </button>
+
+      <!-- body -->
+      <div class="px-4 pb-5 pt-4">
+        <!-- command hint + copy -->
+        <div class="flex items-center gap-2">
+          <p class="flex-1 text-[12.5px] text-fg"><span class="select-none text-run">$</span> {{ ADD_TOKEN_CMD }}</p>
+          <button
+            type="button"
+            data-test="copy-command"
+            :title="$t('login.copyCommand')"
+            :aria-label="$t('login.copyCommand')"
+            class="flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-bg"
+            :class="copied ? 'text-run' : 'text-fg-muted hover:text-fg'"
+            @click="copyCommand"
+          >
+            <svg v-if="!copied" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="9" y="9" width="13" height="13" rx="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            <svg v-else width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M20 6 9 17l-5-5" />
+            </svg>
+          </button>
+        </div>
+        <p id="login-hint" class="mb-5 mt-1 text-[11.5px] leading-relaxed text-fg-muted">{{ $t("login.runHint") }}</p>
+
+        <!-- prompt label -->
+        <div aria-hidden="true" class="mb-2 flex items-center gap-1.5 text-xs text-fg-muted">
+          <span class="text-run">▸</span> access-token
+        </div>
+
+        <!-- token input -->
+        <div class="relative">
+          <input
+            id="access-token"
+            v-model="token"
+            data-test="token-input"
+            :type="revealed ? 'text' : 'password'"
+            :placeholder="$t('login.tokenPlaceholder')"
+            :aria-label="$t('login.tokenLabel')"
+            aria-describedby="login-hint"
+            autocomplete="off"
+            :disabled="pending"
+            class="login-input w-full rounded-lg border border-border bg-bg py-2.5 pl-3 pr-10 text-sm tracking-[0.05em] text-fg placeholder:tracking-normal placeholder:text-fg-muted disabled:opacity-50"
+          />
+          <button
+            type="button"
+            data-test="toggle-visibility"
+            :title="$t('login.toggleVisibility')"
+            :aria-label="$t('login.toggleVisibility')"
+            :aria-pressed="revealed"
+            class="absolute right-1.5 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-fg-muted transition-colors hover:bg-surface hover:text-fg"
+            @click="revealed = !revealed"
+          >
+            <svg v-if="!revealed" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M9.9 4.2A11 11 0 0 1 12 4c6.5 0 10 7 10 7a13 13 0 0 1-1.7 2.7M6.6 6.6A13 13 0 0 0 2 11s3.5 7 10 7a11 11 0 0 0 3.4-.5M3 3l18 18M9.9 9.9a3 3 0 0 0 4.2 4.2" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- error -->
+        <p v-if="auth.error" data-test="login-error" role="alert" class="mt-3 flex items-start gap-1.5 text-xs text-danger">
+          <span class="font-bold">!</span><span>{{ auth.error }}</span>
+        </p>
+
+        <!-- submit: bracketed-prompt primary action -->
+        <button
+          type="submit"
+          data-test="signin"
+          :disabled="pending"
+          class="login-btn group mt-5 flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-[13.5px] font-semibold text-fg transition-colors hover:bg-run/10 hover:text-run disabled:cursor-default disabled:text-fg-muted disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+        >
+          <span class="login-arrow group-hover:translate-x-0.5" :class="pending ? 'text-fg-muted' : 'text-run'">▸</span>
+          <span>{{ pending ? $t("login.signingIn") : $t("login.signIn") }}</span>
+          <span v-if="!pending" class="ml-auto text-[11px] text-fg-muted">⏎ enter</span>
+        </button>
+      </div>
     </form>
   </div>
 </template>
+
+<style scoped>
+.login-glow {
+  position: absolute;
+  width: 32rem;
+  height: 26rem;
+  border-radius: 9999px;
+  filter: blur(90px);
+  opacity: 0.16;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 35% 35%, #4f9bf5, transparent 60%),
+    radial-gradient(circle at 65% 65%, #69d689, transparent 60%);
+}
+.login-grid {
+  position: absolute;
+  inset: 0;
+  opacity: 0.45;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgb(128 140 160 / 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(128 140 160 / 0.05) 1px, transparent 1px);
+  background-size: 30px 30px;
+  -webkit-mask-image: radial-gradient(circle at center, #000 25%, transparent 72%);
+  mask-image: radial-gradient(circle at center, #000 25%, transparent 72%);
+}
+/* Green (run) focus ring for the login surface, overriding the global accent ring. */
+.login-input:focus-visible,
+.login-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(var(--c-surface)), 0 0 0 4px rgb(var(--c-run));
+}
+.login-input:focus-visible {
+  border-color: transparent;
+}
+.login-arrow {
+  transition: transform 0.12s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .login-arrow {
+    transition: none;
+  }
+}
+</style>


### PR DESCRIPTION
Replaces the plain token-entry card with a **terminal-window login** that matches xacpx's CLI-tool identity.

## What changed
- **Window chrome**: traffic-light dots + centered `xacpx-relay — login` title with the gradient brand X.
- **Mint command line**: `$ xacpx-relay add token` shown verbatim with a one-click **copy** button (checkmark confirm), plus a short caption.
- **Prompt input**: `▸ access-token` label, mono token field with a **show/hide** toggle, green focus ring.
- **Primary action**: bracketed-prompt `▸ Sign in … ⏎ enter`, full-width hit area, hover tint + arrow nudge; loading/disabled state (`Signing in…`).
- **Color**: switched the CTA/accent from blue to **green (run)** per the ui-ux-pro-max design system's CLI/dev-tool palette (the old blue clashed with the terminal motif).
- **Polish**: ambient brand glow + vignetted grid, dual-theme (light/dark), respects `prefers-reduced-motion`, a11y labels/aria on icon buttons + token field.

## Tests
- New `loginview.test.ts`: window chrome, copy command, show/hide toggle, login→redirect, error path (role=alert).
- Updated `longtail-i18n.test.ts` for the new placeholder + command surface.
- i18n strings updated in **both** en and zh-CN (parity test green).
- Full relay-web suite: 55 files / 366 tests pass; vue-tsc clean.