### PR TITLE
docs: slim README, sync relay Caddy/pm2 guides, feature relay on the homepage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,8 +114,10 @@ There are two session concepts:
 
 ### Docs to rely on (don’t reverse-engineer from code first)
 
+- Terminal CLI reference (the full `xacpx …` command surface): [`docs/cli-reference.md`](docs/cli-reference.md)
 - Configuration schema and defaults: [`docs/config-reference.md`](docs/config-reference.md)
 - WeChat command surface: [`docs/commands.md`](docs/commands.md)
+- User-facing FAQ (`/ss new` failures, `/mode <id>`): [`docs/faq.md`](docs/faq.md)
 - Daemon subsystem notes: [`docs/daemon-module.md`](docs/daemon-module.md)
 - Commands module notes: [`docs/commands-module.md`](docs/commands-module.md)
 - MCP integration (external coordinators): [`docs/external-mcp.md`](docs/external-mcp.md)

--- a/README.md
+++ b/README.md
@@ -23,17 +23,11 @@ English · **[中文](./docs/zh/README_zh.md)**
 
 If you need to code or work remotely on a temporary basis, `xacpx` gives you a fast, convenient **remote entry point** so you can get things done from WeChat or Feishu anytime, anywhere.
 
-## Who it's for
-
-`xacpx` suits users who want lightweight, on-demand multi-agent work. You can watch tasks, send commands, and view results from WeChat, Feishu, or Yuanbao, and manage multiple sessions within the same chat.
-
-> For everyday use, remember `/ss` first: it creates or reuses an xacpx logical session. If you want to attach to an existing native session of a local agent such as Codex, use `/ssn`; see [docs/native-sessions.md](./docs/native-sessions.md) for advanced details.
+> For everyday use, remember `/ss` first: it creates or reuses an xacpx logical session. If you want to attach to an existing native session of a local agent such as Codex, use `/ssn`; see [native sessions](./docs/native-sessions.md).
 
 ## 5-minute quick start
 
 ### Prerequisites
-
-Before you start, you need at least:
 
 - Node.js 22+ or Bun
 - A working agent CLI you intend to use, such as Codex / Claude Code / Gemini / OpenCode
@@ -49,32 +43,25 @@ npm install -g @ganglion/xacpx --registry=https://registry.npmjs.org
 bun add -g @ganglion/xacpx
 ```
 
-### Log in to WeChat
+### Log in and start
 
 ```bash
-xacpx login
+xacpx login    # shows a QR code; scan it with WeChat
+xacpx start    # start the background service
 ```
 
-The terminal will show a QR code; scan it with WeChat to log in.
-
-If you want to use Feishu or Yuanbao instead of WeChat, see "Switch / add other channels" below first.
-
-### Start the service
-
-```bash
-xacpx start
-```
+To use Feishu or Yuanbao instead of WeChat, see "Other channels" below first.
 
 ### Create your first session in WeChat
 
-Send these two messages in WeChat:
+Send these messages in WeChat:
 
 ```text
 /ss codex -d /absolute/path/to/your/repo
 /help
 ```
 
-Then just send plain text, for example:
+Then just send plain text:
 
 ```text
 hello
@@ -82,14 +69,9 @@ hello
 
 If everything works, plain text goes into the current session and the agent's reply comes back to WeChat.
 
-### Switch / add other channels
+### Other channels
 
-WeChat is the built-in default channel. Feishu and Yuanbao are distributed as official plugin packages, and third-party channels follow the same plugin flow. If you can't remember the package names, check the official plugin list first:
-
-```bash
-xacpx plugin known
-# Install: xacpx plugin add <package>
-```
+WeChat is the built-in default channel. Feishu and Yuanbao are distributed as official plugin packages, and third-party channels follow the same plugin flow. If you can't remember the package names, run `xacpx plugin known` first.
 
 ```bash
 # Feishu
@@ -103,7 +85,7 @@ xacpx channel add yuanbao    # enter appKey/appSecret when prompted
 xacpx restart
 ```
 
-For full credential configuration, parameters, and management commands such as `enable/disable/rm`, see [docs/channel-management.md](./docs/channel-management.md). If you want to write your own channel plugin, see [docs/plugin-development.md](./docs/plugin-development.md).
+Full credentials, parameters, and management commands (`enable/disable/rm`): [channel-management.md](./docs/channel-management.md). To write your own channel plugin: [plugin-development.md](./docs/plugin-development.md).
 
 ## Your everyday workflow
 
@@ -111,34 +93,16 @@ The most common sequence is just four steps:
 
 1. **Start the background service**: `xacpx start`
 2. **Create or switch sessions**: `/ss ...`, `/use ...`
-3. **Send plain text directly**: let the current session keep working
-4. **Check status or cancel the current task when needed**: `/status`, `/cancel`
+3. **Send plain text directly**: any text not starting with `/` goes to the current session
+4. **Check status or cancel when needed**: `/status`, `/cancel`
 
-### 1) Create a session
+### Reply modes
 
-The most common command:
-
-```text
-/ss codex -d /absolute/path/to/your/repo
-```
-
-It uses `codex`, binds this working directory, and automatically switches to the new session.
-
-### 2) Send plain messages
-
-Any text not starting with `/` is sent to the current session.
-
-```text
-Fix this recent API timeout issue
-```
-
-### 3) View replies
-
-`xacpx` supports three common reply modes:
+`xacpx` supports three reply modes (switch per session with `/replymode`):
 
 - `stream`: stream back intermediate text
 - `final`: return only the final result
-- `verbose`: the default; in addition to streaming text, also shows tool-call summaries
+- `verbose`: the default; streaming text plus tool-call summaries
 
 For example, in `verbose` mode you'll see:
 
@@ -149,446 +113,91 @@ For example, in `verbose` mode you'll see:
 ✏️ Edit parse-command.ts
 ```
 
-### 4) Switch sessions
+## Command cheat sheet
 
-```text
-/ss
-/use backend:codex
-```
+The essentials to get going. Full references: **CLI → [cli-reference.md](./docs/cli-reference.md)**, **chat commands → [commands.md](./docs/commands.md)**.
 
-This lets you switch between sessions for different projects and different agents within the same WeChat chat.
-
-## Common CLI commands
-
-These commands run in a terminal on your computer.
+**Terminal (on the host):**
 
 | Command | Description |
 |------|------|
-| `xacpx login` | Log in to WeChat |
-| `xacpx logout` | Clear the WeChat login credentials saved on this machine |
-| `xacpx run` | Run in the foreground, useful for debugging |
-| `xacpx start` | Start the service in the background |
-| `xacpx status` | Show background status, PID, config path, and log path |
-| `xacpx stop` | Stop the background instance |
-| `xacpx restart` | Restart the background instance so channel config changes take effect |
-| `xacpx update [--all\|<name>]` | Check and update xacpx and installed plugins; when plugins are installed, it interactively lets you choose what to update |
-| `xacpx channel list\|show\|add\|rm\|enable\|disable [--account <id>]` | Manage message channels; `--account <id>` targets one bot when several share a channel (multi-bot) |
-| `xacpx plugin list\|add\|update\|remove\|enable\|disable\|doctor\|known` | Manage plugins: list/install/update/remove, toggle, run `doctor`, or list official packages with `known` |
-| `xacpx plugin add @ganglion/xacpx-channel-feishu && xacpx channel add feishu` | Install and add the Feishu channel; prompts for Feishu app credentials |
-| `xacpx plugin add @ganglion/xacpx-channel-yuanbao && xacpx channel add yuanbao` | Install and add the Yuanbao channel; prompts for Yuanbao appKey/appSecret |
+| `xacpx login` / `logout` | Log in / out of WeChat |
+| `xacpx start` / `stop` / `restart` / `status` | Manage the background service |
+| `xacpx update` | Update xacpx and installed plugins |
 | `xacpx doctor` | Run environment diagnostics |
-| `xacpx version` | Show the current version |
-| `xacpx agent list` | List agents registered on this machine |
-| `xacpx agent add <name>` | Add an agent from a built-in template; an existing agent of the same name with a different config is not overwritten |
-| `xacpx agent rm <name>` | Remove an agent |
-| `xacpx workspace list` | List workspaces registered on this machine |
-| `xacpx workspace add [name] [--raw]` | Register the current directory as a workspace; without `name`, uses the current directory name, and names with special characters are normalized automatically |
-| `xacpx workspace rm <name>` | Remove a workspace |
-| `xacpx later list` / `xacpx lt list` | List this machine's pending scheduled tasks in the terminal |
-| `xacpx later cancel <id>` / `xacpx lt cancel <id>` | Cancel a pending scheduled task in the terminal |
+| `xacpx channel add <name>` | Add a message channel (Feishu / Yuanbao / …) |
+| `xacpx ws add` / `xacpx agent add <name>` | Register a workspace / agent |
 
-The first time you run `xacpx start` or `xacpx run`, if there are no sessions, workspaces, or plugins, the CLI asks whether to register the current directory as a workspace and lets you choose a built-in agent template; after the service starts, it creates the initial acpx session through the normal session-creation flow.
-
-`workspace` can also be abbreviated as `ws`:
-
-```bash
-xacpx ws add
-xacpx ws list
-xacpx ws rm backend
-```
-
-### How to use the `workspace` CLI
-
-`xacpx workspace` maintains the `workspaces` config in `~/.xacpx/config.json` on your local machine. It's good for registering frequently used project directories in the terminal first, then referencing them directly in WeChat with `--ws <name>`.
+**Chat (in WeChat / Feishu / Yuanbao):**
 
 | Command | Description |
 |------|------|
-| `xacpx workspace list` | List registered workspaces and their paths |
-| `xacpx workspace add` | Register the current directory as a workspace, defaulting the name to the current directory name (normalized automatically) |
-| `xacpx workspace add <name>` | Register the current directory under a specific name (normalized if it contains special characters) |
-| `xacpx workspace add [name] --raw` | Keep the original name (including spaces, etc.); later commands must quote it |
-| `xacpx workspace rm <name>` | Remove a specific workspace |
-
-Common usage:
-
-```bash
-cd /absolute/path/to/backend
-xacpx workspace add backend
-
-cd /absolute/path/to/frontend
-xacpx ws add frontend
-
-xacpx ws list
-xacpx ws rm frontend
-```
-
-Once registered, you can use it directly in WeChat:
-
-```text
-/ss codex --ws backend
-/ss new claude --ws frontend
-```
-
-Note: `workspace add` always registers the **directory the terminal is currently in**. Without a name, it uses the current directory name as the workspace name. Names containing spaces, Chinese characters, etc. are normalized automatically to `[a-zA-Z0-9._-]+` (for example, the directory `My Project` is saved as `My-Project`), with `-2`, `-3` appended on collisions. To keep the original name, add `--raw`; afterwards `xacpx workspace rm`, `/ws rm`, and `--ws <name>` all need quoting, for example `xacpx workspace rm "My Project"`.
-
-### How to use the `agent` CLI
-
-`xacpx agent` maintains the `agents` config in `~/.xacpx/config.json` on your local machine; `agents` is an equivalent alias.
-
-| Command | Description |
-|------|------|
-| `xacpx agent list` | List registered agents |
-| `xacpx agent templates` | List the built-in templates you can add |
-| `xacpx agent add <name>` | Add an agent from a built-in template, e.g. `kimi`, `opencode` |
-| `xacpx agent rm <name>` | Remove a specific agent |
-
-Common usage:
-
-```bash
-xacpx agent templates
-xacpx agent add kimi
-xacpx agents list
-xacpx agent rm kimi
-```
-
-### How to use `doctor`
-
-```bash
-xacpx doctor
-xacpx doctor --verbose
-xacpx doctor --smoke
-xacpx doctor --smoke --agent codex --workspace backend
-xacpx doctor --fix
-```
-
-Notes:
-
-- `--verbose` expands the details of each check
-- `--smoke` additionally runs a minimal real transport-level prompt check
-- `--agent` / `--workspace` only affect `--smoke`
-- Without `--smoke`, the related checks show as `SKIP`
-- `--fix` applies safe local repairs (runtime dir permissions, stale locks, invalid state records) and re-checks; state-mutating repairs are withheld while the daemon runs — see [docs/doctor-command.md](docs/doctor-command.md)
-
-### How to use `update`
-
-`xacpx update` checks for and installs new versions of xacpx itself and your installed channel plugins.
-
-```bash
-xacpx update            # interactive: pick what to update
-xacpx update --all      # update everything (core + all plugins) non-interactively
-xacpx update <name>     # update a single target (the core, or a specific plugin package)
-```
-
-Notes:
-
-- When plugins are installed, the bare `xacpx update` is interactive and lets you choose which targets to update.
-- In a non-interactive environment, updating the core or plugins needs explicit confirmation: use `xacpx update --all`, or name the target with `xacpx update <name>`.
-- `update` covers the core package and channel plugins; to manage a single plugin's version directly, see `xacpx plugin update <name>` ([docs/plugin-development.md](./docs/plugin-development.md)).
-- After updating, run `xacpx restart` so a running daemon loads the new version.
-- Cross-package rename migration: this project was renamed `weacpx` → `xacpx`. If you still have the legacy `weacpx` package installed, running `weacpx update` will offer to migrate you across to `xacpx` automatically (you confirm the switch). Already on `xacpx`? Just use `xacpx update` as a normal self-update.
-
-## Common chat commands
-
-These commands are sent in a WeChat or Feishu chat. For the full command reference, see [docs/commands.md](./docs/commands.md).
-
-### Agent management
-
-The default config usually already includes `codex` and `claude`. If you want to use another acpx-supported agent, you can add it from a built-in template with `/agent add <name>`.
-
-| Command | Description |
-|------|------|
-| `/agents` | List agents |
-| `/agent add gemini` | Add the `Gemini` agent |
-| `/agent add opencode` | Add the `OpenCode` agent |
-| `/agent rm <name>` | Remove an agent |
-
-The current built-in templates align with acpx's built-in agents:
-
-```text
-codex, claude, pi, openclaw, gemini, cursor, copilot, droid,
-factory-droid, factorydroid, iflow, kilocode, kimi, kiro,
-opencode, qoder, qwen, trae
-```
-
-These templates only write `driver`; the actual launch command is resolved by acpx. For example, `/agent add kimi` saves `{ "driver": "kimi" }`. For full command docs see [docs/commands.md](./docs/commands.md), and for config fields see [docs/config-reference.md](./docs/config-reference.md).
-
-### Workspace management
-
-| Command | Description |
-|------|------|
-| `/workspaces` / `/workspace` / `/ws` | List workspaces |
-| `/ws new <name> -d <path> [--raw]` | Add a workspace; `path` is an absolute path on your computer, and Windows does not distinguish forward/back slashes; names with special characters such as spaces/Chinese are normalized automatically, and --raw keeps the original name |
-| `/workspace rm <name>` | Remove a workspace |
-
-### Sessions
-
-| Command | Description |
-|------|------|
-| `/sessions` / `/session` / `/ss` | List sessions |
-| `/ss <agent> (-d <path> \| --ws <name>)` | Create or reuse your current most-used session |
-| `/ss new <agent> (-d <path> \| --ws <name>)` | Force-create a new session |
-| `/ssn <agent> (-d <path> \| --ws <name>)` | Attach to an existing native session of a local agent; see [native sessions](./docs/native-sessions.md) |
+| `/ss <agent> -d <path>` | Create or reuse a session in a project directory |
+| `/ss new <agent> --ws <name>` | Force-create a new session |
+| `/ssn <agent> -d <path>` | Attach to a local agent's [native session](./docs/native-sessions.md) |
 | `/use <alias>` | Switch the current session |
-| `/status` | Show the current session status |
-| `/mode` / `/mode <id>` | View or set the underlying `acpx` mode |
-| `/model` / `/model <id>` | View or switch the session's LLM model (also `/session new --model`, `/agent add --model`) |
-| `/replymode` | Show the current reply mode |
-| `/replymode stream` | Streaming replies |
-| `/replymode verbose` | Streaming + tool-call summaries |
-| `/replymode final` | Return only the final result |
-| `/replymode reset` | Fall back to the global default reply mode |
-| `/session reset` | Reset the current session context |
-| `/clear` | Shortcut alias for `/session reset` |
-| `/cancel` / `/stop` | Stop the current task |
+| `/status` · `/cancel` | Show status · stop the current task |
+| `/model` · `/mode` | Switch the LLM model · set the acpx mode |
+| `/replymode stream\|verbose\|final` | Change how replies stream |
+| `/lt <time> <message>` | Schedule a one-time future message ([/later](./docs/later-command.md)) |
+| `/dg <agent> <task>` | Delegate a subtask to another agent |
+| `/pm set read` · `/config set <path> <value>` | Permissions · whitelisted config |
 
-We suggest remembering these three first:
+## Multi-agent orchestration & MCP
 
-```text
-/ss codex -d /absolute/path/to/repo
-/use <alias>
-/cancel
-```
+The current session acts as the coordinator; delegated subtasks (`/dg`, `/tasks`,
+`/task approve`) run as independent worker sessions and need human confirmation by
+default. External MCP hosts such as Codex or Claude Code can drive xacpx's
+orchestration directly by configuring `xacpx mcp-stdio` as a stdio MCP server
+(`delegate_request` / `delegate_batch` support MCP Tasks).
 
-To attach to an existing native session of a local agent such as Codex, use `/ssn codex -d /absolute/path/to/repo`; for full semantics see [docs/native-sessions.md](./docs/native-sessions.md).
-
-### Scheduled tasks (/later)
-
-Have the agent automatically receive a message at some point in the future. **By default it runs in a temporary session created just for that task** (inheriting the agent and workspace of the current session at creation time, with a fresh conversation history, destroyed once finished); adding `--bind` sends it to the current session bound at creation time. When the time comes, the message is delivered as a normal prompt and the result is pushed back to the original chat.
-
-| Command | Description |
-|------|------|
-| `/lt <time> <message>` | Create a scheduled task (runs in a temporary session by default; `/later` is a synonym) |
-| `/lt --bind <time> <message>` | Send to the current session instead |
-| `/lt list` | List globally pending tasks |
-| `/lt cancel <id>` | Cancel a pending task |
-
-The most common examples:
-
-```text
-/lt in 2h check whether CI passes        # temporary session (default)
-/lt --bind tomorrow 09:00 review the PR    # bound to the current session
-/lt list
-```
-
-Notes:
-
-- Runs in a temporary session by default; `--bind` binds to the current session. The default mode can be changed via the config `later.defaultMode` (`temp` / `bind`, default `temp`)
-- Only one-time tasks are supported; the time must be more than 10 seconds and within 7 days from now
-- The time format is a fixed whitelist (relative time / today·tomorrow·day-after-tomorrow / weekday + time); natural language is not supported
-- In normal conversation, the agent can also create, list, and cancel scheduled tasks via the current session's internal tools (`scheduled_create` / `scheduled_list` / `scheduled_cancel`); routing and permissions are resolved by the daemon from the current chat session, and the external `mcp-stdio` does not expose these tools
-- You can also manage pending tasks from the terminal with `xacpx later list` / `xacpx later cancel <id>`; the CLI only lists and cancels, it does not create scheduled tasks
-- For full time formats, temporary/bound modes, task status, and limits, see [docs/later-command.md](./docs/later-command.md)
-
-### Config and permissions
-
-| Command | Description |
-|------|------|
-| `/config` | Show the config paths that can be changed via chat commands |
-| `/config set <path> <value>` | Change a whitelisted config item |
-| `/pm` / `/permission` | Show the current permission mode |
-| `/pm set allow` | Switch to `approve-all` |
-| `/pm set read` | Switch to `approve-reads` |
-| `/pm set deny` | Switch to `deny-all` |
-| `/pm auto` | Show the current non-interactive permission policy |
-| `/pm auto deny` | Switch to `deny` |
-| `/pm auto fail` | Switch to `fail` |
-
-The most common examples:
-
-```text
-/config set wechat.replyMode final
-/pm set read
-/pm auto deny
-```
-
-> `/config set language en` (or `zh`) switches the xacpx interface language; it otherwise follows your system locale. See [docs/config-reference.md](./docs/config-reference.md).
-
-### Multi-agent orchestration
-
-The README keeps only the most common user-facing commands.
-
-| Command | Description |
-|------|------|
-| `/dg <agent> <task>` | Quickly delegate a subtask |
-| `/tasks` | List tasks under the current main line |
-| `/task <id>` | Show details of a single task |
-| `/task approve <id>` | Approve a `needs_confirmation` task |
-| `/task cancel <id>` | Cancel a task; cancelling a not-yet-approved task is equivalent to rejecting it |
-
-The most common examples:
-
-```text
-/dg claude review the 3 high-risk points of the current plan
-/tasks
-/task approve task_123
-```
-
-Notes:
-
-- The current session is the coordinator session
-- What gets delegated out are independent subtask sessions
-- Delegation requests initiated by the agent require human confirmation by default
-- If you're using an external MCP host (Codex / Claude Code), use `delegate_batch` to dispatch multiple parallel subtasks at once: pass a `tasks` array, a group is created automatically under the hood, and all results are injected back at once with no need to maintain a groupId manually
-
-If you want to first understand when to delegate and when to dispatch multiple subtasks in parallel, see:
-
-- [docs/xacpx-group-usage-guide.md](./docs/xacpx-group-usage-guide.md)
-
-
-### MCP integration: external coordinator
-
-If you want external MCP hosts such as Codex or Claude Code to use xacpx's multi-agent orchestration directly, you can configure `xacpx mcp-stdio` as a stdio MCP server.
-
-`delegate_request` supports MCP Tasks: a host that supports this capability can make the delegation request return a native task handle immediately, then get status, results, or cancel the task via `tasks/get` / `tasks/result` / `tasks/cancel`; the worker's `[PROGRESS] ...` output shows up in the `statusMessage` of `tasks/get` / `tasks/list`; in the `input_required` state, `tasks/result` returns a next-step hint and ends this result stream rather than blocking for a long time; after the client calls tools such as `task_get` / `task_approve` / `coordinator_answer_question` per the hint, it continues polling `tasks/get` / `tasks/result`. A host that does not support MCP Tasks can still use the compatibility tools `task_get` / `task_list` / `task_watch` / `task_cancel`.
-
-The natural-language creation tool for scheduled tasks is an internal capability of the xacpx current session and does not appear in the external `xacpx mcp-stdio` tool list.
-
-Start the daemon first:
-
-```bash
-xacpx start
-```
-
-We recommend keeping the MCP config simple and not binding a workspace in the launch arguments:
-
-```json
-{
-  "mcpServers": {
-    "xacpx": {
-      "command": "xacpx",
-      "args": ["mcp-stdio"]
-    }
-  }
-}
-```
-
-When an external host calls `delegate_request`, pass `workingDirectory`, and xacpx will make the delegated worker work in that directory:
-
-```json
-{
-  "targetAgent": "claude",
-  "task": "review the risks of this change",
-  "workingDirectory": "/absolute/path/to/your/repo"
-}
-```
-
-On Windows, if the MCP host won't resolve a `command` with arguments for you, put `node.exe` in `command` and the xacpx script and arguments in `args`:
-
-```json
-{
-  "type": "stdio",
-  "command": "C:\\Program Files\\nodejs\\node.exe",
-  "args": [
-    "C:\\path\\to\\xacpx\\dist\\cli.js",
-    "mcp-stdio"
-  ]
-}
-```
-
-For more identity rules, `workingDirectory` semantics, the tool list, flow diagrams, and troubleshooting, see [docs/external-mcp.md](./docs/external-mcp.md).
+- When to delegate vs. open a parallel group: [xacpx-group-usage-guide.md](./docs/xacpx-group-usage-guide.md)
+- External MCP setup, identity rules, tool list, troubleshooting: [external-mcp.md](./docs/external-mcp.md)
 
 ## Common scenarios
 
-### Keep watching a local project from your phone
-
 ```text
+# Keep watching a local project from your phone
 /ss codex -d /absolute/path/to/backend
 take a look at today's API timeout issue
-```
 
-### Switch between two projects in the same chat
-
-```text
+# Switch between two projects in the same chat
 /ss codex -d /absolute/path/to/backend
 /ss new codex -d /absolute/path/to/frontend
 /ss
 /use backend:codex
-/use frontend:codex
-```
 
-### Attach to an existing local Codex native session
-
-```text
+# Attach to an existing local Codex native session
 /ssn codex -d /absolute/path/to/backend
 /ssn 1
 ```
 
-For more filtering, aliases, and troubleshooting, see [docs/native-sessions.md](./docs/native-sessions.md).
-
 ## Self-hosted relay hub (optional)
 
-If you run several xacpx instances and want to drive them all from one browser dashboard, you can self-host the **relay hub**. Each instance dials out to the hub over WebSocket and registers; you log in to a multi-tenant web dashboard and manage every instance's sessions — chat, scheduled tasks, and orchestration — from one place. Streaming agent replies render as markdown, and the layout works on mobile.
-
-The hub ships as an npm package (`@ganglion/xacpx-relay`) with the dashboard **bundled in** — no separate build. It serves everything on a single port (HTTP API + dashboard + the instance WebSocket gateway), and authentication is a single **access token** used for both web login and connector pairing.
+If you run several xacpx instances and want to drive them all from one browser dashboard, you can self-host the **relay hub**. Each instance dials out to the hub over WebSocket and registers; you log in to a multi-tenant web dashboard and manage every instance's sessions — chat, scheduled tasks, and orchestration — from one place. The hub ships as an npm package (`@ganglion/xacpx-relay`) with the dashboard **bundled in**, served on a single port, with a single **access token** for both web login and connector pairing.
 
 ```bash
-# 1. On the hub host: install (dashboard is bundled — nothing else to build)
 npm i -g @ganglion/xacpx-relay
+xacpx-relay add token        # prints the access token once
+xacpx-relay start            # defaults: --host 0.0.0.0 --http-port 8787
 
-# 2. Mint an access token (DB auto-created at ~/.xacpx-relay/relay.db)
-xacpx-relay add token
-#   → prints the token once; use it to log into the dashboard AND to pair connectors
-
-# 3. Start the hub (defaults: --host 0.0.0.0 --http-port 8787, dashboard auto-detected)
-xacpx-relay start
-
-# 4. On each instance host: add the connector channel and point it at the hub
+# On each instance host:
 xacpx plugin add @ganglion/xacpx-channel-relay   # requires xacpx >= 0.11.0
 xacpx channel add relay --url wss://relay.example.com --token <access-token> --name my-box
 xacpx restart
 ```
 
-In production, terminate TLS at a reverse proxy in front of the single port and have instances dial `wss://`. There's no `stop`/`status` subcommand — manage the process with systemd/pm2/Docker (`Ctrl-C`/`SIGTERM` to stop); update with `xacpx-relay update`.
-
-Full walkthrough — pairing instances, TLS/reverse-proxy, systemd, backups, troubleshooting: **[Self-Hosting the Relay Hub](https://gadzan.github.io/xacpx/guide/relay-self-hosting)** (or [docs/relay-deployment.md](./docs/relay-deployment.md) for the terse runbook).
+Full walkthrough — pairing, TLS/reverse-proxy, systemd, backups, troubleshooting: **[Self-Hosting the Relay Hub](https://gadzan.github.io/xacpx/guide/relay-self-hosting)** (or [relay-deployment.md](./docs/relay-deployment.md) for the terse runbook).
 
 ## Config and runtime files
-
-Default file locations:
 
 - Config file: `~/.xacpx/config.json`
 - State file: `~/.xacpx/state.json`
 - Runtime log: `~/.xacpx/runtime/app.log`
 
-More runtime files are placed under `~/.xacpx/runtime/`.
-
-## FAQ
-
-### What if `/ss new` fails?
-
-If session creation fails in WeChat, the most common cause is not a wrong `xacpx` command format, but that the underlying session was not created successfully.
-
-You can try these two steps first:
-
-1. Confirm in the terminal that the current project directory and the agent itself work
-2. If you're familiar with `acpx`, manually create a session first, then attach to it from WeChat
-
-For example, you can create a session locally first:
-
-```bash
-./node_modules/.bin/acpx --verbose --cwd /absolute/workspace/path codex sessions new --name existing-demo
-```
-
-Then attach to it from WeChat:
-
-```text
-/ss attach demo -a codex --ws backend --name existing-demo
-```
-
-### What is the `<id>` in `/mode <id>`?
-
-The valid values for `/mode` depend on the agent you're currently using; `xacpx` does not normalize these values for you.
-
-Currently the more clearly known values are:
-
-- `codex`: `plan`
-- `cursor`: `agent`, `plan`, `ask`
-
-If you're unsure whether a value works, check the corresponding agent's docs first; if you get it wrong, you'll usually get an error such as an invalid argument.
+More runtime files are placed under `~/.xacpx/runtime/`. For the full config field reference, see [config-reference.md](./docs/config-reference.md).
 
 ## Running from source
-
-If you're using the repo source directly:
 
 ```bash
 bun install
@@ -596,27 +205,29 @@ bun run login
 bun run dev
 ```
 
+For development, debugging, and contribution details, see [developments.md](./docs/developments.md).
+
 ## More docs
 
-If what you're about to do is one of the following, you can continue from here:
+**Install & configure**
+- [channel-management.md](./docs/channel-management.md) — configure WeChat / Feishu / Yuanbao / third-party channels
+- [plugin-development.md](./docs/plugin-development.md) — write your own channel plugin
+- [config-reference.md](./docs/config-reference.md) — full config field reference
+- [config-command.md](./docs/config-command.md) — change config from chat
 
-### Installation and configuration
+**Everyday use**
+- [cli-reference.md](./docs/cli-reference.md) — full terminal CLI reference
+- [commands.md](./docs/commands.md) — full chat-command reference
+- [later-command.md](./docs/later-command.md) — scheduled tasks (`/later`)
+- [native-sessions.md](./docs/native-sessions.md) — attach to a local agent's native session
+- [xacpx-group-usage-guide.md](./docs/xacpx-group-usage-guide.md) — when to delegate vs. open a group
+- [external-mcp.md](./docs/external-mcp.md) — external MCP coordinator integration
 
-- Want to configure WeChat, Feishu, Yuanbao, or a third-party plugin channel: [docs/channel-management.md](./docs/channel-management.md)
-- Want to write your own channel plugin: [docs/plugin-development.md](./docs/plugin-development.md)
-- Want the full config field reference: [docs/config-reference.md](./docs/config-reference.md)
-- Want to change config from WeChat: [docs/config-command.md](./docs/config-command.md)
+**Troubleshoot & verify**
+- [faq.md](./docs/faq.md) — common questions (`/ss new` fails, `/mode <id>`, …)
+- [doctor-command.md](./docs/doctor-command.md) — `xacpx doctor` diagnostics and `--fix`
+- [testing.md](./docs/testing.md) — test layout and how to run tests
 
-### Everyday use
-
-- Want the full chat-command reference: [docs/commands.md](./docs/commands.md)
-- Want to schedule a one-time future message with scheduled tasks (`/later`): [docs/later-command.md](./docs/later-command.md)
-- Want to understand when to delegate and when to open a group: [docs/xacpx-group-usage-guide.md](./docs/xacpx-group-usage-guide.md)
-
-### Troubleshooting and verification
-
-- Want to run tests or understand the test layout: [docs/testing.md](./docs/testing.md)
-
-### Development and contribution
-
-- Want to develop, debug, or contribute from source: [docs/developments.md](./docs/developments.md)
+**Develop & contribute**
+- [developments.md](./docs/developments.md) — develop, debug, or contribute from source
+- [code-wiki.md](./docs/code-wiki.md) — architecture map

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,141 @@
+# CLI Reference
+
+These commands run in a terminal on the machine where xacpx is installed. For chat
+commands (sent inside WeChat / Feishu / Yuanbao), see [commands.md](./commands.md).
+
+## All commands
+
+| Command | Description |
+|------|------|
+| `xacpx login` | Log in to WeChat |
+| `xacpx logout` | Clear the WeChat login credentials saved on this machine |
+| `xacpx run` | Run in the foreground, useful for debugging |
+| `xacpx start` | Start the service in the background |
+| `xacpx status` | Show background status, PID, config path, and log path |
+| `xacpx stop` | Stop the background instance |
+| `xacpx restart` | Restart the background instance so channel config changes take effect |
+| `xacpx update [--all\|<name>]` | Check and update xacpx and installed plugins; when plugins are installed, it interactively lets you choose what to update |
+| `xacpx channel list\|show\|add\|rm\|enable\|disable [--account <id>]` | Manage message channels; `--account <id>` targets one bot when several share a channel (multi-bot) |
+| `xacpx plugin list\|add\|update\|remove\|enable\|disable\|doctor\|known` | Manage plugins: list/install/update/remove, toggle, run `doctor`, or list official packages with `known` |
+| `xacpx plugin add @ganglion/xacpx-channel-feishu && xacpx channel add feishu` | Install and add the Feishu channel; prompts for Feishu app credentials |
+| `xacpx plugin add @ganglion/xacpx-channel-yuanbao && xacpx channel add yuanbao` | Install and add the Yuanbao channel; prompts for Yuanbao appKey/appSecret |
+| `xacpx doctor` | Run environment diagnostics |
+| `xacpx version` | Show the current version |
+| `xacpx agent list` | List agents registered on this machine |
+| `xacpx agent add <name>` | Add an agent from a built-in template; an existing agent of the same name with a different config is not overwritten |
+| `xacpx agent rm <name>` | Remove an agent |
+| `xacpx workspace list` | List workspaces registered on this machine |
+| `xacpx workspace add [name] [--raw]` | Register the current directory as a workspace; without `name`, uses the current directory name, and names with special characters are normalized automatically |
+| `xacpx workspace rm <name>` | Remove a workspace |
+| `xacpx later list` / `xacpx lt list` | List this machine's pending scheduled tasks in the terminal |
+| `xacpx later cancel <id>` / `xacpx lt cancel <id>` | Cancel a pending scheduled task in the terminal |
+
+The first time you run `xacpx start` or `xacpx run`, if there are no sessions, workspaces, or plugins, the CLI asks whether to register the current directory as a workspace and lets you choose a built-in agent template; after the service starts, it creates the initial acpx session through the normal session-creation flow.
+
+`workspace` can also be abbreviated as `ws`:
+
+```bash
+xacpx ws add
+xacpx ws list
+xacpx ws rm backend
+```
+
+## `workspace` CLI
+
+`xacpx workspace` maintains the `workspaces` config in `~/.xacpx/config.json` on your local machine. It's good for registering frequently used project directories in the terminal first, then referencing them directly in WeChat with `--ws <name>`.
+
+| Command | Description |
+|------|------|
+| `xacpx workspace list` | List registered workspaces and their paths |
+| `xacpx workspace add` | Register the current directory as a workspace, defaulting the name to the current directory name (normalized automatically) |
+| `xacpx workspace add <name>` | Register the current directory under a specific name (normalized if it contains special characters) |
+| `xacpx workspace add [name] --raw` | Keep the original name (including spaces, etc.); later commands must quote it |
+| `xacpx workspace rm <name>` | Remove a specific workspace |
+
+Common usage:
+
+```bash
+cd /absolute/path/to/backend
+xacpx workspace add backend
+
+cd /absolute/path/to/frontend
+xacpx ws add frontend
+
+xacpx ws list
+xacpx ws rm frontend
+```
+
+Once registered, you can use it directly in WeChat:
+
+```text
+/ss codex --ws backend
+/ss new claude --ws frontend
+```
+
+Note: `workspace add` always registers the **directory the terminal is currently in**. Without a name, it uses the current directory name as the workspace name. Names containing spaces, Chinese characters, etc. are normalized automatically to `[a-zA-Z0-9._-]+` (for example, the directory `My Project` is saved as `My-Project`), with `-2`, `-3` appended on collisions. To keep the original name, add `--raw`; afterwards `xacpx workspace rm`, `/ws rm`, and `--ws <name>` all need quoting, for example `xacpx workspace rm "My Project"`.
+
+## `agent` CLI
+
+`xacpx agent` maintains the `agents` config in `~/.xacpx/config.json` on your local machine; `agents` is an equivalent alias.
+
+| Command | Description |
+|------|------|
+| `xacpx agent list` | List registered agents |
+| `xacpx agent templates` | List the built-in templates you can add |
+| `xacpx agent add <name>` | Add an agent from a built-in template, e.g. `kimi`, `opencode` |
+| `xacpx agent rm <name>` | Remove a specific agent |
+
+Common usage:
+
+```bash
+xacpx agent templates
+xacpx agent add kimi
+xacpx agents list
+xacpx agent rm kimi
+```
+
+The current built-in templates align with acpx's built-in agents:
+
+```text
+codex, claude, pi, openclaw, gemini, cursor, copilot, droid,
+factory-droid, factorydroid, iflow, kilocode, kimi, kiro,
+opencode, qoder, qwen, trae
+```
+
+These templates only write `driver`; the actual launch command is resolved by acpx. For example, `/agent add kimi` saves `{ "driver": "kimi" }`. For config fields see [config-reference.md](./config-reference.md).
+
+## `doctor`
+
+```bash
+xacpx doctor
+xacpx doctor --verbose
+xacpx doctor --smoke
+xacpx doctor --smoke --agent codex --workspace backend
+xacpx doctor --fix
+```
+
+Notes:
+
+- `--verbose` expands the details of each check
+- `--smoke` additionally runs a minimal real transport-level prompt check
+- `--agent` / `--workspace` only affect `--smoke`
+- Without `--smoke`, the related checks show as `SKIP`
+- `--fix` applies safe local repairs (runtime dir permissions, stale locks, invalid state records) and re-checks; state-mutating repairs are withheld while the daemon runs — see [doctor-command.md](./doctor-command.md)
+
+## `update`
+
+`xacpx update` checks for and installs new versions of xacpx itself and your installed channel plugins.
+
+```bash
+xacpx update            # interactive: pick what to update
+xacpx update --all      # update everything (core + all plugins) non-interactively
+xacpx update <name>     # update a single target (the core, or a specific plugin package)
+```
+
+Notes:
+
+- When plugins are installed, the bare `xacpx update` is interactive and lets you choose which targets to update.
+- In a non-interactive environment, updating the core or plugins needs explicit confirmation: use `xacpx update --all`, or name the target with `xacpx update <name>`.
+- `update` covers the core package and channel plugins; to manage a single plugin's version directly, see `xacpx plugin update <name>` ([plugin-development.md](./plugin-development.md)).
+- After updating, run `xacpx restart` so a running daemon loads the new version.
+- Cross-package rename migration: this project was renamed `weacpx` → `xacpx`. If you still have the legacy `weacpx` package installed, running `weacpx update` will offer to migrate you across to `xacpx` automatically (you confirm the switch). Already on `xacpx`? Just use `xacpx update` as a normal self-update.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,33 @@
+# FAQ
+
+## What if `/ss new` fails?
+
+If session creation fails in WeChat, the most common cause is not a wrong `xacpx` command format, but that the underlying session was not created successfully.
+
+You can try these two steps first:
+
+1. Confirm in the terminal that the current project directory and the agent itself work
+2. If you're familiar with `acpx`, manually create a session first, then attach to it from WeChat
+
+For example, you can create a session locally first:
+
+```bash
+./node_modules/.bin/acpx --verbose --cwd /absolute/workspace/path codex sessions new --name existing-demo
+```
+
+Then attach to it from WeChat:
+
+```text
+/ss attach demo -a codex --ws backend --name existing-demo
+```
+
+## What is the `<id>` in `/mode <id>`?
+
+The valid values for `/mode` depend on the agent you're currently using; `xacpx` does not normalize these values for you.
+
+Currently the more clearly known values are:
+
+- `codex`: `plan`
+- `cursor`: `agent`, `plan`, `ask`
+
+If you're unsure whether a value works, check the corresponding agent's docs first; if you get it wrong, you'll usually get an error such as an invalid argument.

--- a/docs/relay-deployment.md
+++ b/docs/relay-deployment.md
@@ -131,7 +131,7 @@ sudo systemctl reload caddy   # 用 Caddy 服务托管时
 
 ```bash
 # 启动并命名为 xacpx-relay（-- 之后是传给 xacpx-relay 的参数）
-pm2 start xacpx-relay --name xacpx-relay -- start --db /var/lib/xacpx-relay/relay.db --trust-proxy
+pm2 start xacpx-relay --name xacpx-relay -- start
 
 # 固化当前进程列表 + 生成开机自启脚本（按提示执行它打印的 sudo 命令）
 pm2 save
@@ -153,13 +153,15 @@ module.exports = {
   apps: [{
     name: "xacpx-relay",
     script: "xacpx-relay",
-    args: "start --db /var/lib/xacpx-relay/relay.db --trust-proxy",
+    args: "start",
     autorestart: true,
   }],
 };
 ```
 
 升级流程：`xacpx-relay update`（或 `xacpx-relay update --check` 先比对版本）→ `pm2 restart xacpx-relay` 让新版本生效。
+
+> **进阶（默认即可用，不必加）**：默认 DB（`~/.xacpx-relay/relay.db`）和默认绑定（`0.0.0.0:8787`）开箱即用。仅在需要时才往 `start` 后追加参数：`--db <path>` 自定义 DB 路径（见「端到端（自定义路径示例）」）、`--host 127.0.0.1` 仅绑定本地、`--trust-proxy` 让限速按反代转发的真实客户端 IP 统计（见「反向代理与限流」）。
 
 ## 强制全员重登录
 

--- a/docs/relay-deployment.md
+++ b/docs/relay-deployment.md
@@ -130,19 +130,20 @@ sudo systemctl reload caddy   # 用 Caddy 服务托管时
 `xacpx-relay` 没有 `stop`/`status` 子命令（用 `Ctrl-C`/`SIGTERM` 退出），适合交给 pm2 托管常驻、开机自启、崩溃重拉。
 
 ```bash
-# 启动并命名为 relay（-- 之后是传给 xacpx-relay 的参数）
-pm2 start "$(which xacpx-relay)" --name relay -- \
-  start --db /var/lib/xacpx-relay/relay.db --trust-proxy
+# 启动并命名为 xacpx-relay（-- 之后是传给 xacpx-relay 的参数）
+pm2 start xacpx-relay --name xacpx-relay -- start --db /var/lib/xacpx-relay/relay.db --trust-proxy
 
 # 固化当前进程列表 + 生成开机自启脚本（按提示执行它打印的 sudo 命令）
 pm2 save
 pm2 startup
 
 # 常用运维
-pm2 logs relay          # 看日志
-pm2 restart relay       # 改完配置 / xacpx-relay update 之后重启
-pm2 stop relay          # 停止
+pm2 logs xacpx-relay        # 看日志
+pm2 restart xacpx-relay     # 改完配置 / xacpx-relay update 之后重启
+pm2 stop xacpx-relay        # 停止
 ```
+
+pm2 会从 `PATH` 解析 `xacpx-relay` 并把绝对路径存进 dump，重启后也能恢复；万一 pm2 找不到（非标准安装），改传 `command -v xacpx-relay` 的绝对路径即可。
 
 也可以用 ecosystem 文件固定参数，`pm2 start ecosystem.config.js`：
 
@@ -150,16 +151,15 @@ pm2 stop relay          # 停止
 // ecosystem.config.js
 module.exports = {
   apps: [{
-    name: "relay",
-    // 用 `which xacpx-relay` 的输出替换成绝对路径（全局 bin 在 PATH 里的真实位置）
-    script: "/usr/local/bin/xacpx-relay",
+    name: "xacpx-relay",
+    script: "xacpx-relay",
     args: "start --db /var/lib/xacpx-relay/relay.db --trust-proxy",
     autorestart: true,
   }],
 };
 ```
 
-升级流程：`xacpx-relay update`（或 `xacpx-relay update --check` 先比对版本）→ `pm2 restart relay` 让新版本生效。
+升级流程：`xacpx-relay update`（或 `xacpx-relay update --check` 先比对版本）→ `pm2 restart xacpx-relay` 让新版本生效。
 
 ## 强制全员重登录
 

--- a/docs/relay-deployment.md
+++ b/docs/relay-deployment.md
@@ -101,6 +101,66 @@ xacpx-relay start --db /var/lib/xacpx-relay/relay.db --trust-proxy ...
 
 不经反代直接暴露时**不要**传该标志，否则客户端可伪造 `X-Forwarded-For` 绕过限流。
 
+## Caddy 反向代理（最简配置）
+
+hub 默认单端口（HTTP API + 看板 + 看板 `/ws` + 实例网关全部合并在 8787），所以 Caddy 只需一条 `reverse_proxy` 就能覆盖全部流量。Caddy v2 自动签发并续期 TLS 证书，并**透明转发 WebSocket**（实例网关的 `wss://` 与看板 `/ws` 都无需额外配置）。
+
+`/etc/caddy/Caddyfile`：
+
+```caddyfile
+relay.example.com {
+	reverse_proxy 127.0.0.1:8787
+}
+```
+
+```bash
+caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl reload caddy   # 用 Caddy 服务托管时
+```
+
+配套要点：
+
+- hub 在反代后方，启动须带 `--trust-proxy`，限流才按真实客户端 IP 统计。Caddy 默认会写 `X-Forwarded-For`，无需额外指令。
+- 实例侧 `--url` 指向同一域名的 `wss://` 根路径：`xacpx channel add relay --url wss://relay.example.com --token <token> --name <name>`。
+- Caddy 走 `https://` 即满足 PWA 的安全上下文要求，看板可「安装到主屏」。纯 `http://` 不会注册 Service Worker。
+- Caddy `reverse_proxy` 默认无请求体大小限制、对 WebSocket 长连接也不主动超时，看板的图片上传与长连接开箱可用；如需限制再按需加 `request_body max_size`。
+
+## 进程托管（pm2）
+
+`xacpx-relay` 没有 `stop`/`status` 子命令（用 `Ctrl-C`/`SIGTERM` 退出），适合交给 pm2 托管常驻、开机自启、崩溃重拉。
+
+```bash
+# 启动并命名为 relay（-- 之后是传给 xacpx-relay 的参数）
+pm2 start "$(which xacpx-relay)" --name relay -- \
+  start --db /var/lib/xacpx-relay/relay.db --trust-proxy
+
+# 固化当前进程列表 + 生成开机自启脚本（按提示执行它打印的 sudo 命令）
+pm2 save
+pm2 startup
+
+# 常用运维
+pm2 logs relay          # 看日志
+pm2 restart relay       # 改完配置 / xacpx-relay update 之后重启
+pm2 stop relay          # 停止
+```
+
+也可以用 ecosystem 文件固定参数，`pm2 start ecosystem.config.js`：
+
+```js
+// ecosystem.config.js
+module.exports = {
+  apps: [{
+    name: "relay",
+    // 用 `which xacpx-relay` 的输出替换成绝对路径（全局 bin 在 PATH 里的真实位置）
+    script: "/usr/local/bin/xacpx-relay",
+    args: "start --db /var/lib/xacpx-relay/relay.db --trust-proxy",
+    autorestart: true,
+  }],
+};
+```
+
+升级流程：`xacpx-relay update`（或 `xacpx-relay update --check` 先比对版本）→ `pm2 restart relay` 让新版本生效。
+
 ## 强制全员重登录
 
 停止 hub，在 DB 中清空 web 会话，然后重启：

--- a/docs/zh/README_zh.md
+++ b/docs/zh/README_zh.md
@@ -13,6 +13,8 @@
 
 `xacpx` 是一个可以通过微信、飞书或元宝直接控制 Codex / Claude Code / Gemini / OpenCode 等 ACP Agent 的工具。它把聊天消息通过 `acpx` 连接到 Agent CLI 会话上，让你直接在手机里：
 
+[![xacpx.png](https://s41.ax1x.com/2026/06/05/pmZXIv6.png)](https://imgchr.com/i/pmZXIv6)
+
 - 新建和切换会话
 - 让 Agent 继续在指定项目目录里工作
 - 查看流式回复、最终结果和工具调用摘要
@@ -21,17 +23,11 @@
 
 如果你需要临时远程编码或办公，`xacpx` 提供的是一个方便快捷的**远程入口**，让你在微信或飞书里就能随时随地干活。
 
-## 适合谁
-
-`xacpx` 适合轻量临时使用多 Agent 办公的用户。你可以用微信、飞书或元宝盯任务、发指令、看结果，并在同一个聊天里管理多个会话。
-
-> 日常使用优先记 `/ss`：它负责创建或复用 xacpx 逻辑会话。如果你想接入本地 Codex 等 Agent 已有的原生会话，再用 `/ssn`；进阶说明见 [docs/native-sessions.md](./native-sessions_zh.md)。
+> 日常使用优先记 `/ss`：它负责创建或复用 xacpx 逻辑会话。如果你想接入本地 Codex 等 Agent 已有的原生会话，再用 `/ssn`；进阶说明见 [原生会话](./native-sessions_zh.md)。
 
 ## 5 分钟快速开始
 
 ### 前置条件
-
-开始前，你至少需要：
 
 - Node.js 22+ 或 Bun
 - 已可用的 Codex / Claude Code / Gemini / OpenCode 等你要使用的 Agent CLI
@@ -47,32 +43,25 @@ npm install -g @ganglion/xacpx --registry=https://registry.npmjs.org
 bun add -g @ganglion/xacpx
 ```
 
-### 登录微信
+### 登录并启动
 
 ```bash
-xacpx login
+xacpx login    # 显示二维码，用微信扫码登录
+xacpx start    # 启动后台服务
 ```
 
-终端会显示二维码，请继续用微信扫码登录。
-
-如果你想使用飞书或元宝而不是微信，请先看下面的“切换/添加其它频道”。
-
-### 启动服务
-
-```bash
-xacpx start
-```
+如果你想用飞书或元宝而不是微信，先看下面的「其它频道」。
 
 ### 在微信里创建第一个会话
 
-把下面两条消息发到微信：
+在微信里发这几条消息：
 
 ```text
 /ss codex -d /absolute/path/to/your/repo
 /help
 ```
 
-然后直接发普通文本，例如：
+然后直接发普通文本：
 
 ```text
 hello
@@ -80,14 +69,9 @@ hello
 
 如果一切正常，普通文本会进入当前会话，Agent 的回复会回到微信。
 
-### 切换/添加其它频道
+### 其它频道
 
-微信是内置默认频道。飞书和元宝以官方插件包分发，第三方频道也走同样的插件流程。如果记不住包名，先看一眼官方插件清单：
-
-```bash
-xacpx plugin known
-# 安装：xacpx plugin add <package>
-```
+微信是内置默认频道。飞书和元宝以官方插件包形式分发，第三方频道走同样的插件流程。记不住包名时，先运行 `xacpx plugin known`。
 
 ```bash
 # 飞书
@@ -101,7 +85,7 @@ xacpx channel add yuanbao    # 按提示输入 appKey/appSecret
 xacpx restart
 ```
 
-完整的密钥配置、参数、`enable/disable/rm` 等管理命令见 [docs/channel-management.md](./channel-management_zh.md)。如果你想自己写一个频道插件，见 [docs/plugin-development.md](./plugin-development_zh.md)。
+完整凭据、参数和管理命令（`enable/disable/rm`）见 [channel-management_zh.md](./channel-management_zh.md)。想自己写频道插件见 [plugin-development_zh.md](./plugin-development_zh.md)。
 
 ## 你的日常使用流程
 
@@ -109,34 +93,16 @@ xacpx restart
 
 1. **启动后台服务**：`xacpx start`
 2. **创建或切换会话**：`/ss ...`、`/use ...`
-3. **直接发普通文本**：让当前会话继续工作
-4. **必要时查看状态或取消当前任务**：`/status`、`/cancel`
+3. **直接发普通文本**：非 `/` 开头的文本都会发送到当前会话
+4. **必要时查看状态或取消**：`/status`、`/cancel`
 
-### 1) 创建会话
+### 回复模式
 
-最常用命令：
-
-```text
-/ss codex -d /absolute/path/to/your/repo
-```
-
-它会使用 `codex`，绑定这个工作目录，并自动切换到新会话。
-
-### 2) 发普通消息
-
-非 `/` 开头的文本，都会发送到当前会话。
-
-```text
-修一下最近这个接口超时问题
-```
-
-### 3) 看回复
-
-`xacpx` 支持三种常用回复模式：
+`xacpx` 支持三种回复模式（用 `/replymode` 按会话切换）：
 
 - `stream`：流式返回中间文本
 - `final`：只返回最终结果
-- `verbose`：默认，在流式文本之外，额外显示工具调用摘要
+- `verbose`：默认，流式文本之外额外显示工具调用摘要
 
 例如 `verbose` 模式下，你会看到：
 
@@ -147,416 +113,90 @@ xacpx restart
 ✏️ Edit parse-command.ts
 ```
 
-### 4) 切换会话
+## 命令速查表
 
-```text
-/ss
-/use backend:codex
-```
+入门必备。完整参考：**CLI → [cli-reference_zh.md](./cli-reference_zh.md)**，**聊天命令 → [commands_zh.md](./commands_zh.md)**。
 
-这样你可以在同一个微信聊天里切换不同项目、不同 agent 的会话。
-
-## 常用 CLI 命令
-
-这些命令在电脑终端里运行。
+**终端（在主机上）：**
 
 | 命令 | 说明 |
 |------|------|
-| `xacpx login` | 登录微信 |
-| `xacpx logout` | 清除本机保存的微信登录凭证 |
-| `xacpx run` | 前台运行，适合调试 |
-| `xacpx start` | 后台启动服务 |
-| `xacpx status` | 查看后台状态、PID、配置路径、日志路径 |
-| `xacpx stop` | 停止后台实例 |
-| `xacpx restart` | 重启后台实例，让频道配置变更生效 |
-| `xacpx update [--all\|<name>]` | 检查并更新 xacpx 与已安装插件；安装了插件时会交互式选择更新项 |
-| `xacpx channel list\|show\|add\|rm\|enable\|disable [--account <id>]` | 管理消息频道；多个 bot 共用一个频道时，用 `--account <id>` 指定其中一个（多 bot） |
-| `xacpx plugin list\|add\|update\|remove\|enable\|disable\|doctor\|known` | 管理插件：列出/安装/更新/删除、启用停用、运行 `doctor`，或用 `known` 查看官方包清单 |
-| `xacpx plugin add @ganglion/xacpx-channel-feishu && xacpx channel add feishu` | 安装并添加飞书频道，会提示输入飞书应用凭据 |
-| `xacpx plugin add @ganglion/xacpx-channel-yuanbao && xacpx channel add yuanbao` | 安装并添加元宝频道，会提示输入元宝 appKey/appSecret |
+| `xacpx login` / `logout` | 登录 / 登出微信 |
+| `xacpx start` / `stop` / `restart` / `status` | 管理后台服务 |
+| `xacpx update` | 更新 xacpx 与已安装插件 |
 | `xacpx doctor` | 运行环境诊断 |
-| `xacpx version` | 查看当前版本 |
-| `xacpx agent list` | 查看本机已注册的 agent |
-| `xacpx agent add <name>` | 从内置模板添加 agent；已存在且配置不同的同名 agent 不会被覆盖 |
-| `xacpx agent rm <name>` | 删除 agent |
-| `xacpx workspace list` | 查看本机已注册的 workspace |
-| `xacpx workspace add [name] [--raw]` | 把当前目录注册成 workspace；不传 `name` 时使用当前目录名，含特殊字符的名称会被自动规范化 |
-| `xacpx workspace rm <name>` | 删除 workspace |
-| `xacpx later list` / `xacpx lt list` | 在终端查看本机待执行定时任务 |
-| `xacpx later cancel <id>` / `xacpx lt cancel <id>` | 在终端取消本机待执行定时任务 |
+| `xacpx channel add <name>` | 添加消息频道（飞书 / 元宝 / …） |
+| `xacpx ws add` / `xacpx agent add <name>` | 注册 workspace / agent |
 
-首次运行 `xacpx start` 或 `xacpx run` 时，如果没有会话、workspace 和插件，CLI 会询问是否把当前目录创建为 workspace，并选择一个内置 agent 模板；服务启动后会通过正常会话创建流程创建初始 acpx 会话。
-
-`workspace` 也可以简写为 `ws`：
-
-```bash
-xacpx ws add
-xacpx ws list
-xacpx ws rm backend
-```
-
-### `workspace` CLI 怎么用
-
-`xacpx workspace` 用来在电脑本机维护 `~/.xacpx/config.json` 里的 `workspaces` 配置。它适合先在终端里注册常用项目目录，然后在微信里用 `--ws <name>` 直接引用。
+**聊天（在微信 / 飞书 / 元宝里）：**
 
 | 命令 | 说明 |
 |------|------|
-| `xacpx workspace list` | 列出已注册的 workspace 及其路径 |
-| `xacpx workspace add` | 把当前目录注册为 workspace，名称默认取当前目录名（自动规范化） |
-| `xacpx workspace add <name>` | 把当前目录注册为指定名称（含特殊字符时自动规范化） |
-| `xacpx workspace add [name] --raw` | 保留原始名称（含空格等），后续命令需要用引号引用 |
-| `xacpx workspace rm <name>` | 删除指定 workspace |
-
-常见用法：
-
-```bash
-cd /absolute/path/to/backend
-xacpx workspace add backend
-
-cd /absolute/path/to/frontend
-xacpx ws add frontend
-
-xacpx ws list
-xacpx ws rm frontend
-```
-
-注册后，你可以在微信里直接使用：
-
-```text
-/ss codex --ws backend
-/ss new claude --ws frontend
-```
-
-注意：`workspace add` 总是注册**当前终端所在目录**。如果不传名称，会用当前目录名作为 workspace 名称。含空格、中文等字符的名称会被自动规范化为 `[a-zA-Z0-9._-]+`（例如目录 `My Project` 会保存为 `My-Project`），重名时追加 `-2`、`-3`。如需保留原始名称，加 `--raw`；之后 `xacpx workspace rm`、`/ws rm`、`--ws <name>` 都需要用引号引用，例如 `xacpx workspace rm "My Project"`。
-
-### `agent` CLI 怎么用
-
-`xacpx agent` 用来在电脑本机维护 `~/.xacpx/config.json` 里的 `agents` 配置；`agents` 是同等别名。
-
-| 命令 | 说明 |
-|------|------|
-| `xacpx agent list` | 列出已注册的 agent |
-| `xacpx agent templates` | 列出可添加的内置模板 |
-| `xacpx agent add <name>` | 从内置模板添加 agent，例如 `kimi`、`opencode` |
-| `xacpx agent rm <name>` | 删除指定 agent |
-
-常见用法：
-
-```bash
-xacpx agent templates
-xacpx agent add kimi
-xacpx agents list
-xacpx agent rm kimi
-```
-
-### `doctor` 怎么用
-
-```bash
-xacpx doctor
-xacpx doctor --verbose
-xacpx doctor --smoke
-xacpx doctor --smoke --agent codex --workspace backend
-xacpx doctor --fix
-```
-
-说明：
-
-- `--verbose` 会展开每项检查的细节
-- `--smoke` 会额外执行一次真实 transport 级别的最小 prompt 检查
-- `--agent` / `--workspace` 只影响 `--smoke`
-- 如果不传 `--smoke`，相关检查会显示为 `SKIP`
-- `--fix` 会执行安全的本地修复（运行时目录权限、残留锁、无效 state 记录）并重新检查；daemon 运行期间会扣留改动状态的修复，详见 [doctor-command_zh.md](doctor-command_zh.md)
-
-### `update` 怎么用
-
-`xacpx update` 用来检查并安装 xacpx 本体以及已安装频道插件的新版本。
-
-```bash
-xacpx update            # 交互式：选择要更新的项
-xacpx update --all      # 非交互式更新全部（本体 + 所有插件）
-xacpx update <name>     # 更新单个目标（本体，或某个具体插件包）
-```
-
-说明：
-
-- 安装了插件时，直接运行 `xacpx update` 会进入交互模式，让你选择要更新哪些目标。
-- 在非交互环境下，更新本体或插件需要显式确认：用 `xacpx update --all`，或用 `xacpx update <name>` 指定目标。
-- `update` 覆盖本体包和频道插件；如果想直接管理单个插件的版本，见 `xacpx plugin update <name>`（[docs/plugin-development.md](./plugin-development_zh.md)）。
-- 更新后运行 `xacpx restart`，让正在运行的 daemon 加载新版本。
-- 跨包改名迁移：本项目已由 `weacpx` 改名为 `xacpx`。如果你仍装着旧的 `weacpx` 包，运行 `weacpx update` 会提示自动迁移到 `xacpx`（由你确认切换）。已经在用 `xacpx`？直接用 `xacpx update` 做普通的本体自更新即可。
-
-## 常用聊天命令
-
-这些命令在微信或飞书聊天里发送。完整命令参考见：[docs/commands.md](./commands_zh.md)。
-
-### Agent 管理
-
-默认配置通常已包含 `codex` 与 `claude`。如果你要使用其它 acpx 支持的 agent，可以先用 `/agent add <name>` 从内置模板添加。
-
-| 命令 | 说明 |
-|------|------|
-| `/agents` | 查看 agent 列表 |
-| `/agent add gemini` | 添加 `Gemini` Agent |
-| `/agent add opencode` | 添加 `OpenCode` Agent |
-| `/agent rm <name>` | 删除 agent |
-
-当前内置模板与 acpx 的 built-in agents 对齐：
-
-```text
-codex, claude, pi, openclaw, gemini, cursor, copilot, droid,
-factory-droid, factorydroid, iflow, kilocode, kimi, kiro,
-opencode, qoder, qwen, trae
-```
-
-这些模板只写入 `driver`，实际启动命令交给 acpx 解析；例如 `/agent add kimi` 会保存 `{ "driver": "kimi" }`。完整命令说明见 [docs/commands.md](./commands_zh.md)，配置字段见 [docs/config-reference.md](./config-reference_zh.md)。
-
-### Workspace 管理
-
-| 命令 | 说明 |
-|------|------|
-| `/workspaces` / `/workspace` / `/ws` | 查看 workspace 列表 |
-| `/ws new <name> -d <path> [--raw]` | 添加 workspace，`path` 是电脑上的绝对路径，Windows 不用区分正反斜杠；含空格/中文等特殊字符的名称会被自动规范化，--raw 保留原名 |
-| `/workspace rm <name>` | 删除 workspace |
-
-### Session 会话
-
-| 命令 | 说明 |
-|------|------|
-| `/sessions` / `/session` / `/ss` | 查看会话列表 |
-| `/ss <agent> (-d <path> \| --ws <name>)` | 创建或复用当前最常用的会话 |
-| `/ss new <agent> (-d <path> \| --ws <name>)` | 强制新建会话 |
-| `/ssn <agent> (-d <path> \| --ws <name>)` | 接入本地已有的 Agent 原生会话，详见 [native sessions](./native-sessions_zh.md) |
+| `/ss <agent> -d <path>` | 在项目目录里创建或复用会话 |
+| `/ss new <agent> --ws <name>` | 强制新建会话 |
+| `/ssn <agent> -d <path>` | 接入本地 Agent 的[原生会话](./native-sessions_zh.md) |
 | `/use <alias>` | 切换当前会话 |
-| `/status` | 查看当前会话状态 |
-| `/mode` / `/mode <id>` | 查看或设置底层 `acpx` mode |
-| `/replymode` | 查看当前回复模式 |
-| `/replymode stream` | 流式回复 |
-| `/replymode verbose` | 流式 + 工具调用摘要 |
-| `/replymode final` | 只返回最终结果 |
-| `/replymode reset` | 回退到全局默认 reply mode |
-| `/session reset` | 重置当前会话上下文 |
-| `/clear` | `/session reset` 的快捷别名 |
-| `/cancel` / `/stop` | 停止当前任务 |
+| `/status` · `/cancel` | 查看状态 · 停止当前任务 |
+| `/model` · `/mode` | 切换 LLM 模型 · 设置 acpx mode |
+| `/replymode stream\|verbose\|final` | 改变回复流式方式 |
+| `/lt <时间> <消息>` | 安排一次性未来消息（[/later](./later-command_zh.md)） |
+| `/dg <agent> <task>` | 委派子任务给另一个 agent |
+| `/pm set read` · `/config set <path> <value>` | 权限 · 白名单配置 |
 
-建议你优先记住这三个：
+## 多 Agent 编排与 MCP
 
-```text
-/ss codex -d /absolute/path/to/repo
-/use <alias>
-/cancel
-```
+当前会话就是主控会话；被委派的子任务（`/dg`、`/tasks`、`/task approve`）作为独立
+worker 会话运行，默认需要人工确认。Codex、Claude Code 等外部 MCP host 可以把
+`xacpx mcp-stdio` 配成 stdio MCP server，直接驱动 xacpx 的编排能力
+（`delegate_request` / `delegate_batch` 支持 MCP Tasks）。
 
-如果要接入本地 Codex 等 Agent 已有的原生会话，用 `/ssn codex -d /absolute/path/to/repo`；完整语义见 [docs/native-sessions.md](./native-sessions_zh.md)。
-
-### 定时任务（/later）
-
-让 agent 在未来某个时间自动收到一条消息。**默认在一个为该任务新建的临时会话里执行**（沿用创建时当前会话的 agent 与工作区，对话历史全新，跑完即销毁）；加 `--bind` 则发送到创建时绑定的当前会话。到点后把消息作为普通 prompt 投递，结果推回原聊天。
-
-| 命令 | 说明 |
-|------|------|
-| `/lt <时间> <消息>` | 创建定时任务（默认临时会话执行；`/later` 同义） |
-| `/lt --bind <时间> <消息>` | 改为发送到当前会话 |
-| `/lt list` | 查看全局待执行任务 |
-| `/lt cancel <id>` | 取消待执行任务 |
-
-最常见例子：
-
-```text
-/lt in 2h 检查 CI 是否通过        # 临时会话（默认）
-/lt --bind 明天 09:00 看 PR        # 绑定当前会话
-/lt list
-```
-
-说明：
-
-- 默认临时会话执行，`--bind` 绑定当前会话；默认模式可用配置 `later.defaultMode`（`temp` / `bind`，默认 `temp`）修改
-- 只支持一次性任务，时间必须在 10 秒之后、7 天之内
-- 时间格式是固定白名单（相对时间 / 今天·明天·后天 / 星期几 + 时刻），不支持自然语言
-- 普通对话中 agent 也可以通过当前会话内部工具创建、查看与取消定时任务（`scheduled_create` / `scheduled_list` / `scheduled_cancel`）；路由和权限由 daemon 从当前聊天会话解析，外部 `mcp-stdio` 不暴露这些工具
-- 终端里也可以用 `xacpx later list` / `xacpx later cancel <id>` 管理待执行任务；CLI 只做查看和取消，不创建定时任务
-- 完整时间格式、临时/绑定模式、任务状态与限制见 [docs/later-command.md](./later-command_zh.md)
-
-### 配置与权限
-
-| 命令 | 说明 |
-|------|------|
-| `/config` | 查看支持通过聊天命令修改的配置路径 |
-| `/config set <path> <value>` | 修改一个白名单配置项 |
-| `/pm` / `/permission` | 查看当前权限模式 |
-| `/pm set allow` | 切到 `approve-all` |
-| `/pm set read` | 切到 `approve-reads` |
-| `/pm set deny` | 切到 `deny-all` |
-| `/pm auto` | 查看当前非交互权限策略 |
-| `/pm auto deny` | 切到 `deny` |
-| `/pm auto fail` | 切到 `fail` |
-
-最常见例子：
-
-```text
-/config set wechat.replyMode final
-/pm set read
-/pm auto deny
-```
-
-### 多 Agent 编排
-
-README 里只保留用户视角的最常用命令。
-
-| 命令 | 说明 |
-|------|------|
-| `/dg <agent> <task>` | 快速委派一个子任务 |
-| `/tasks` | 查看当前主线下的任务 |
-| `/task <id>` | 查看单个任务详情 |
-| `/task approve <id>` | 批准 `needs_confirmation` 任务 |
-| `/task cancel <id>` | 取消任务；取消一个尚未批准的任务等同于拒绝 |
-
-最常见例子：
-
-```text
-/dg claude 审查当前方案的 3 个高风险点
-/tasks
-/task approve task_123
-```
-
-说明：
-
-- 当前会话就是主控会话
-- 被委派出去的是独立子任务会话
-- agent 发起的委派请求默认需要人工确认
-- 如果你在用外部 MCP host（Codex / Claude Code），用 `delegate_batch` 一次派发多个并行子任务：传一个 `tasks` 数组，底层自动建组，全部结果一次性回注，无需手动维护 groupId
-
-如果你想先理解什么时候该用 delegate、什么时候应该并行派出多个子任务，请看：
-
-- [docs/xacpx-group-usage-guide.md](./xacpx-group-usage-guide_zh.md)
-
-
-### MCP 集成：外部 coordinator
-
-如果你想让 Codex、Claude Code 等外部 MCP host 直接使用 xacpx 的多 Agent 编排能力，可以把 `xacpx mcp-stdio` 配成一个 stdio MCP server。
-
-`delegate_request` 支持 MCP Tasks：支持该能力的 host 可以让委派请求立即返回原生 task handle，之后通过 `tasks/get` / `tasks/result` / `tasks/cancel` 获取状态、结果或取消任务；worker 输出的 `[PROGRESS] ...` 会显示在 `tasks/get` / `tasks/list` 的 `statusMessage` 里；`input_required` 状态下的 `tasks/result` 会返回下一步操作提示并结束本次 result stream，而不是长时间阻塞；client 按提示调用 `task_get` / `task_approve` / `coordinator_answer_question` 等工具后，再继续 `tasks/get` / `tasks/result` 轮询。不支持 MCP Tasks 的 host 仍可使用兼容工具 `task_get` / `task_list` / `task_watch` / `task_cancel`。
-
-定时任务的自然语言创建工具是 xacpx 当前会话内部能力，不会出现在外部 `xacpx mcp-stdio` 的工具列表里。
-
-先启动 daemon：
-
-```bash
-xacpx start
-```
-
-MCP 配置推荐保持简单，不要在启动参数里绑定 workspace：
-
-```json
-{
-  "mcpServers": {
-    "xacpx": {
-      "command": "xacpx",
-      "args": ["mcp-stdio"]
-    }
-  }
-}
-```
-
-外部 host 调用 `delegate_request` 时传 `workingDirectory`，xacpx 会让被委派的 worker 在这个目录工作：
-
-```json
-{
-  "targetAgent": "claude",
-  "task": "审查这个改动的风险点",
-  "workingDirectory": "/absolute/path/to/your/repo"
-}
-```
-
-Windows 上如果 MCP host 不会帮你解析带参数的 `command`，把 `node.exe` 放在 `command`，把 xacpx 脚本和参数放在 `args`：
-
-```json
-{
-  "type": "stdio",
-  "command": "C:\\Program Files\\nodejs\\node.exe",
-  "args": [
-    "C:\\path\\to\\xacpx\\dist\\cli.js",
-    "mcp-stdio"
-  ]
-}
-```
-
-更多身份规则、`workingDirectory` 语义、工具列表、流程图和故障排查见：[docs/external-mcp.md](./external-mcp_zh.md)。
+- 什么时候该 delegate、什么时候并行开组：[xacpx-group-usage-guide_zh.md](./xacpx-group-usage-guide_zh.md)
+- 外部 MCP 配置、身份规则、工具列表、故障排查：[external-mcp_zh.md](./external-mcp_zh.md)
 
 ## 常见场景
 
-### 在手机上继续盯一个本地项目
-
 ```text
+# 在手机上继续盯一个本地项目
 /ss codex -d /absolute/path/to/backend
 看一下今天这个接口超时问题
-```
 
-### 同一个聊天里切换两个项目
-
-```text
+# 同一个聊天里切换两个项目
 /ss codex -d /absolute/path/to/backend
 /ss new codex -d /absolute/path/to/frontend
 /ss
 /use backend:codex
-/use frontend:codex
-```
 
-### 接入本地已有 Codex 原生会话
-
-```text
+# 接入本地已有 Codex 原生会话
 /ssn codex -d /absolute/path/to/backend
 /ssn 1
 ```
 
-更多筛选、别名和故障排查见 [docs/native-sessions.md](./native-sessions_zh.md)。
+## 自托管 relay hub（可选）
+
+如果你跑了多个 xacpx 实例，想用一个浏览器看板统一遥控，可以自托管 **relay hub**。每个实例通过 WebSocket 拨向 hub 并注册；你登录一个多租户 web 看板，在一个地方管理所有实例的会话——聊天、定时任务、编排。hub 以 npm 包（`@ganglion/xacpx-relay`）形式分发，看板**已内置打包**，单端口服务，登录和连接器配对共用一个 **access token**。
+
+```bash
+npm i -g @ganglion/xacpx-relay
+xacpx-relay add token        # 仅打印一次 access token
+xacpx-relay start            # 默认：--host 0.0.0.0 --http-port 8787
+
+# 在每个实例主机上：
+xacpx plugin add @ganglion/xacpx-channel-relay   # 需要 xacpx >= 0.11.0
+xacpx channel add relay --url wss://relay.example.com --token <access-token> --name my-box
+xacpx restart
+```
+
+完整流程——配对、TLS/反向代理、systemd、备份、故障排查见：**[自托管 Relay Hub](https://gadzan.github.io/xacpx/guide/relay-self-hosting)**（或 [relay-deployment.md](../relay-deployment.md) 精简 runbook）。
 
 ## 配置与运行文件
-
-默认文件位置：
 
 - 配置文件：`~/.xacpx/config.json`
 - 状态文件：`~/.xacpx/state.json`
 - 运行日志：`~/.xacpx/runtime/app.log`
 
-更多运行时文件会放在 `~/.xacpx/runtime/` 下。
-
-## 常见问题
-
-### `/ss new` 失败怎么办？
-
-如果你在微信里创建会话失败，最常见的情况不是 `xacpx` 命令格式错了，而是底层会话没有成功创建。
-
-你可以先试这两步：
-
-1. 在终端里确认当前项目目录和 agent 本身可用
-2. 如果你熟悉 `acpx`，先手动创建一个会话，再在微信里挂回去
-
-例如，你可以先在本地创建一个会话：
-
-```bash
-./node_modules/.bin/acpx --verbose --cwd /absolute/workspace/path codex sessions new --name existing-demo
-```
-
-然后在微信里把它挂回来：
-
-```text
-/ss attach demo -a codex --ws backend --name existing-demo
-```
-
-### `/mode <id>` 里的 `<id>` 是什么？
-
-`/mode` 的可用值取决于你当前使用的 agent，`xacpx` 不会替你统一转换这些值。
-
-当前比较明确的已知值：
-
-- `codex`: `plan`
-- `cursor`: `agent`、`plan`、`ask`
-
-如果你不确定某个值能不能用，优先查对应 agent 的文档；如果填错，通常会直接收到无效参数之类的报错。
+更多运行时文件会放在 `~/.xacpx/runtime/` 下。完整配置字段参考见 [config-reference_zh.md](./config-reference_zh.md)。
 
 ## 从源码运行
-
-如果你是从仓库源码直接使用：
 
 ```bash
 bun install
@@ -564,27 +204,29 @@ bun run login
 bun run dev
 ```
 
+开发、调试与贡献细节见 [developments_zh.md](./developments_zh.md)。
+
 ## 更多文档
 
-如果你现在要做的是下面这些事，可以直接从这里继续：
+**安装与配置**
+- [channel-management_zh.md](./channel-management_zh.md) — 配置微信 / 飞书 / 元宝 / 第三方频道
+- [plugin-development_zh.md](./plugin-development_zh.md) — 自己写频道插件
+- [config-reference_zh.md](./config-reference_zh.md) — 完整配置字段参考
+- [config-command_zh.md](./config-command_zh.md) — 在聊天里改配置
 
-### 安装与配置
+**日常使用**
+- [cli-reference_zh.md](./cli-reference_zh.md) — 完整终端 CLI 参考
+- [commands_zh.md](./commands_zh.md) — 完整聊天命令参考
+- [later-command_zh.md](./later-command_zh.md) — 定时任务（`/later`）
+- [native-sessions_zh.md](./native-sessions_zh.md) — 接入本地 Agent 的原生会话
+- [xacpx-group-usage-guide_zh.md](./xacpx-group-usage-guide_zh.md) — 什么时候该 delegate vs 开组
+- [external-mcp_zh.md](./external-mcp_zh.md) — 外部 MCP coordinator 集成
 
-- 想配置微信、飞书、元宝、或第三方插件频道：[docs/channel-management.md](./channel-management_zh.md)
-- 想自己写一个频道插件：[docs/plugin-development.md](./plugin-development_zh.md)
-- 想看完整配置字段：[docs/config-reference.md](./config-reference_zh.md)
-- 想在微信里改配置：[docs/config-command.md](./config-command_zh.md)
+**排错与验证**
+- [faq_zh.md](./faq_zh.md) — 常见问题（`/ss new` 失败、`/mode <id>` 等）
+- [doctor-command_zh.md](./doctor-command_zh.md) — `xacpx doctor` 诊断与 `--fix`
+- [testing_zh.md](./testing_zh.md) — 测试分层与运行方式
 
-### 日常使用
-
-- 想查看完整聊天命令参考：[docs/commands.md](./commands_zh.md)
-- 想用定时任务（`/later`）安排一次性的未来消息：[docs/later-command.md](./later-command_zh.md)
-- 想理解什么时候该用 delegate、什么时候该开 group：[docs/xacpx-group-usage-guide.md](./xacpx-group-usage-guide_zh.md)
-
-### 排错与验证
-
-- 想跑测试或了解测试分层：[docs/testing.md](./testing_zh.md)
-
-### 开发与贡献
-
-- 想从源码开发、调试或参与贡献：[docs/developments.md](./developments_zh.md)
+**开发与贡献**
+- [developments_zh.md](./developments_zh.md) — 从源码开发、调试或参与贡献
+- [code-wiki_zh.md](./code-wiki_zh.md) — 架构地图

--- a/docs/zh/cli-reference_zh.md
+++ b/docs/zh/cli-reference_zh.md
@@ -1,0 +1,140 @@
+# CLI 命令参考
+
+这些命令在安装了 xacpx 的电脑终端里运行。聊天命令（在微信 / 飞书 / 元宝里发送）见 [commands_zh.md](./commands_zh.md)。
+
+## 全部命令
+
+| 命令 | 说明 |
+|------|------|
+| `xacpx login` | 登录微信 |
+| `xacpx logout` | 清除本机保存的微信登录凭证 |
+| `xacpx run` | 前台运行，适合调试 |
+| `xacpx start` | 后台启动服务 |
+| `xacpx status` | 查看后台状态、PID、配置路径、日志路径 |
+| `xacpx stop` | 停止后台实例 |
+| `xacpx restart` | 重启后台实例，让频道配置变更生效 |
+| `xacpx update [--all\|<name>]` | 检查并更新 xacpx 与已安装插件；安装了插件时会交互式选择更新项 |
+| `xacpx channel list\|show\|add\|rm\|enable\|disable [--account <id>]` | 管理消息频道；多个 bot 共用一个频道时，用 `--account <id>` 指定其中一个（多 bot） |
+| `xacpx plugin list\|add\|update\|remove\|enable\|disable\|doctor\|known` | 管理插件：列出/安装/更新/删除、启用停用、运行 `doctor`，或用 `known` 查看官方包清单 |
+| `xacpx plugin add @ganglion/xacpx-channel-feishu && xacpx channel add feishu` | 安装并添加飞书频道，会提示输入飞书应用凭据 |
+| `xacpx plugin add @ganglion/xacpx-channel-yuanbao && xacpx channel add yuanbao` | 安装并添加元宝频道，会提示输入元宝 appKey/appSecret |
+| `xacpx doctor` | 运行环境诊断 |
+| `xacpx version` | 查看当前版本 |
+| `xacpx agent list` | 查看本机已注册的 agent |
+| `xacpx agent add <name>` | 从内置模板添加 agent；已存在且配置不同的同名 agent 不会被覆盖 |
+| `xacpx agent rm <name>` | 删除 agent |
+| `xacpx workspace list` | 查看本机已注册的 workspace |
+| `xacpx workspace add [name] [--raw]` | 把当前目录注册成 workspace；不传 `name` 时使用当前目录名，含特殊字符的名称会被自动规范化 |
+| `xacpx workspace rm <name>` | 删除 workspace |
+| `xacpx later list` / `xacpx lt list` | 在终端查看本机待执行定时任务 |
+| `xacpx later cancel <id>` / `xacpx lt cancel <id>` | 在终端取消本机待执行定时任务 |
+
+首次运行 `xacpx start` 或 `xacpx run` 时，如果没有会话、workspace 和插件，CLI 会询问是否把当前目录创建为 workspace，并选择一个内置 agent 模板；服务启动后会通过正常会话创建流程创建初始 acpx 会话。
+
+`workspace` 也可以简写为 `ws`：
+
+```bash
+xacpx ws add
+xacpx ws list
+xacpx ws rm backend
+```
+
+## `workspace` CLI
+
+`xacpx workspace` 用来在电脑本机维护 `~/.xacpx/config.json` 里的 `workspaces` 配置。它适合先在终端里注册常用项目目录，然后在微信里用 `--ws <name>` 直接引用。
+
+| 命令 | 说明 |
+|------|------|
+| `xacpx workspace list` | 列出已注册的 workspace 及其路径 |
+| `xacpx workspace add` | 把当前目录注册为 workspace，名称默认取当前目录名（自动规范化） |
+| `xacpx workspace add <name>` | 把当前目录注册为指定名称（含特殊字符时自动规范化） |
+| `xacpx workspace add [name] --raw` | 保留原始名称（含空格等），后续命令需要用引号引用 |
+| `xacpx workspace rm <name>` | 删除指定 workspace |
+
+常见用法：
+
+```bash
+cd /absolute/path/to/backend
+xacpx workspace add backend
+
+cd /absolute/path/to/frontend
+xacpx ws add frontend
+
+xacpx ws list
+xacpx ws rm frontend
+```
+
+注册后，你可以在微信里直接使用：
+
+```text
+/ss codex --ws backend
+/ss new claude --ws frontend
+```
+
+注意：`workspace add` 总是注册**当前终端所在目录**。如果不传名称，会用当前目录名作为 workspace 名称。含空格、中文等字符的名称会被自动规范化为 `[a-zA-Z0-9._-]+`（例如目录 `My Project` 会保存为 `My-Project`），重名时追加 `-2`、`-3`。如需保留原始名称，加 `--raw`；之后 `xacpx workspace rm`、`/ws rm`、`--ws <name>` 都需要用引号引用，例如 `xacpx workspace rm "My Project"`。
+
+## `agent` CLI
+
+`xacpx agent` 用来在电脑本机维护 `~/.xacpx/config.json` 里的 `agents` 配置；`agents` 是同等别名。
+
+| 命令 | 说明 |
+|------|------|
+| `xacpx agent list` | 列出已注册的 agent |
+| `xacpx agent templates` | 列出可添加的内置模板 |
+| `xacpx agent add <name>` | 从内置模板添加 agent，例如 `kimi`、`opencode` |
+| `xacpx agent rm <name>` | 删除指定 agent |
+
+常见用法：
+
+```bash
+xacpx agent templates
+xacpx agent add kimi
+xacpx agents list
+xacpx agent rm kimi
+```
+
+当前内置模板与 acpx 的 built-in agents 对齐：
+
+```text
+codex, claude, pi, openclaw, gemini, cursor, copilot, droid,
+factory-droid, factorydroid, iflow, kilocode, kimi, kiro,
+opencode, qoder, qwen, trae
+```
+
+这些模板只写入 `driver`，实际启动命令交给 acpx 解析；例如 `/agent add kimi` 会保存 `{ "driver": "kimi" }`。配置字段见 [config-reference_zh.md](./config-reference_zh.md)。
+
+## `doctor`
+
+```bash
+xacpx doctor
+xacpx doctor --verbose
+xacpx doctor --smoke
+xacpx doctor --smoke --agent codex --workspace backend
+xacpx doctor --fix
+```
+
+说明：
+
+- `--verbose` 会展开每项检查的细节
+- `--smoke` 会额外执行一次真实 transport 级别的最小 prompt 检查
+- `--agent` / `--workspace` 只影响 `--smoke`
+- 如果不传 `--smoke`，相关检查会显示为 `SKIP`
+- `--fix` 会执行安全的本地修复（运行时目录权限、残留锁、无效 state 记录）并重新检查；daemon 运行期间会扣留改动状态的修复，详见 [doctor-command_zh.md](./doctor-command_zh.md)
+
+## `update`
+
+`xacpx update` 用来检查并安装 xacpx 本体以及已安装频道插件的新版本。
+
+```bash
+xacpx update            # 交互式：选择要更新的项
+xacpx update --all      # 非交互式更新全部（本体 + 所有插件）
+xacpx update <name>     # 更新单个目标（本体，或某个具体插件包）
+```
+
+说明：
+
+- 安装了插件时，直接运行 `xacpx update` 会进入交互模式，让你选择要更新哪些目标。
+- 在非交互环境下，更新本体或插件需要显式确认：用 `xacpx update --all`，或用 `xacpx update <name>` 指定目标。
+- `update` 覆盖本体包和频道插件；如果想直接管理单个插件的版本，见 `xacpx plugin update <name>`（[plugin-development_zh.md](./plugin-development_zh.md)）。
+- 更新后运行 `xacpx restart`，让正在运行的 daemon 加载新版本。
+- 跨包改名迁移：本项目已由 `weacpx` 改名为 `xacpx`。如果你仍装着旧的 `weacpx` 包，运行 `weacpx update` 会提示自动迁移到 `xacpx`（由你确认切换）。已经在用 `xacpx`？直接用 `xacpx update` 做普通的本体自更新即可。

--- a/docs/zh/faq_zh.md
+++ b/docs/zh/faq_zh.md
@@ -1,0 +1,33 @@
+# 常见问题
+
+## `/ss new` 失败怎么办？
+
+如果你在微信里创建会话失败，最常见的情况不是 `xacpx` 命令格式错了，而是底层会话没有成功创建。
+
+你可以先试这两步：
+
+1. 在终端里确认当前项目目录和 agent 本身可用
+2. 如果你熟悉 `acpx`，先手动创建一个会话，再在微信里挂回去
+
+例如，你可以先在本地创建一个会话：
+
+```bash
+./node_modules/.bin/acpx --verbose --cwd /absolute/workspace/path codex sessions new --name existing-demo
+```
+
+然后在微信里把它挂回来：
+
+```text
+/ss attach demo -a codex --ws backend --name existing-demo
+```
+
+## `/mode <id>` 里的 `<id>` 是什么？
+
+`/mode` 的可用值取决于你当前使用的 agent，`xacpx` 不会替你统一转换这些值。
+
+当前比较明确的已知值：
+
+- `codex`: `plan`
+- `cursor`: `agent`、`plan`、`ask`
+
+如果你不确定某个值能不能用，优先查对应 agent 的文档；如果填错，通常会直接收到无效参数之类的报错。

--- a/packages/docs/.vitepress/theme/Layout.vue
+++ b/packages/docs/.vitepress/theme/Layout.vue
@@ -15,6 +15,7 @@ import BridgeShowcase from './components/BridgeShowcase.vue';
 import ChatDemoSection from './components/ChatDemoSection.vue';
 import ArchitectureSection from './components/ArchitectureSection.vue';
 import CapabilitiesSection from './components/CapabilitiesSection.vue';
+import RelaySection from './components/RelaySection.vue';
 
 const { Layout } = DefaultTheme;
 const { lang, frontmatter } = useData();
@@ -67,6 +68,7 @@ onUnmounted(() => applyHomeTheme(false));
       <ChatDemoSection />
     </template>
     <template #home-features-after>
+      <RelaySection />
       <ArchitectureSection />
       <CapabilitiesSection />
     </template>

--- a/packages/docs/.vitepress/theme/components/RelaySection.vue
+++ b/packages/docs/.vitepress/theme/components/RelaySection.vue
@@ -1,0 +1,379 @@
+<script setup lang="ts">
+// Second pillar: the self-hosted relay hub web dashboard. Positions xacpx as
+// "chat OR browser" — a CSS browser-window mockup (instances rail + a live
+// session) above three highlights and a CTA. Single-accent, hairline-built,
+// reuses the shared .cap-section scaffold from style.css.
+import { computed } from 'vue';
+import { useData, withBase } from 'vitepress';
+
+const { lang } = useData();
+const zh = computed(() => lang.value.startsWith('zh'));
+
+const t = computed(() => ({
+  kicker: zh.value ? '网页看板' : 'The web dashboard',
+  title: zh.value ? '也可以在浏览器里遥控一切' : 'Or drive everything from your browser',
+  sub: zh.value
+    ? '自托管 relay hub，每个实例通过 WebSocket 拨入。在一个多租户看板里统一管理它们的全部会话——聊天、定时任务、编排；Agent 回复以实时 markdown 渲染，移动端也好用。'
+    : 'Self-host the relay hub and every instance dials in over WebSocket. Manage all of their sessions — chat, scheduled tasks, orchestration — from one multi-tenant dashboard that renders agent replies as live markdown and works on mobile.',
+  url: 'relay.example.com',
+  railTitle: zh.value ? '实例' : 'Instances',
+  instances: [
+    { name: 'home-pc', state: 'online', active: true },
+    { name: 'vps-1', state: 'online', active: false },
+    { name: 'laptop', state: 'offline', active: false },
+  ],
+  session: 'backend · codex',
+  userMsg: zh.value ? '修复接口超时问题' : 'fix the API timeout',
+  botMsg: zh.value ? '已调整重试退避，并加了 30s 上限' : 'Patched the retry backoff, added a 30s ceiling',
+  highlights: [
+    {
+      title: zh.value ? '多实例，一块屏' : 'Many instances, one screen',
+      body: zh.value ? '你跑的每台机器都拨入同一个 hub。' : 'Every box you run dials into the same hub.',
+      icon: 'servers',
+    },
+    {
+      title: zh.value ? '多租户且安全' : 'Multi-tenant & secure',
+      body: zh.value
+        ? '登录与连接器配对共用一个 access token；租户只见自己的实例。'
+        : 'One access token for web login and connector pairing; tenants see only their own.',
+      icon: 'shield',
+    },
+    {
+      title: zh.value ? '可安装 PWA' : 'Installable PWA',
+      body: zh.value ? '把看板添加到主屏，回复以 markdown 流式渲染。' : 'Add it to your home screen; replies stream as markdown.',
+      icon: 'install',
+    },
+  ],
+  cta: zh.value ? '自托管 relay hub' : 'Self-host the relay hub',
+  link: withBase(zh.value ? '/zh/guide/relay-self-hosting' : '/guide/relay-self-hosting'),
+}));
+</script>
+
+<template>
+  <section class="cap-section relay-section">
+    <div class="cap-head" v-reveal="0">
+      <span class="cap-kicker">{{ t.kicker }}</span>
+      <h2 class="cap-title">{{ t.title }}</h2>
+      <p class="demo-sub">{{ t.sub }}</p>
+    </div>
+
+    <!-- browser-window dashboard mockup -->
+    <div class="relay-window" v-reveal="1" aria-hidden="true">
+      <div class="relay-chrome">
+        <span class="relay-dot relay-dot-r" />
+        <span class="relay-dot relay-dot-y" />
+        <span class="relay-dot relay-dot-g" />
+        <span class="relay-url">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg>
+          {{ t.url }}
+        </span>
+      </div>
+
+      <div class="relay-body">
+        <!-- instances rail -->
+        <aside class="relay-rail">
+          <p class="relay-rail-title">{{ t.railTitle }}</p>
+          <div
+            v-for="inst in t.instances"
+            :key="inst.name"
+            class="relay-inst"
+            :class="{ 'is-active': inst.active }"
+          >
+            <span class="relay-status" :class="inst.state === 'online' ? 'is-online' : 'is-offline'" />
+            <span class="relay-inst-name">{{ inst.name }}</span>
+          </div>
+        </aside>
+
+        <!-- session pane -->
+        <div class="relay-pane">
+          <div class="relay-pane-head">
+            <span class="relay-pane-arrow">▸</span>{{ t.session }}
+          </div>
+          <div class="relay-thread">
+            <div class="relay-msg is-user">
+              <span class="relay-bubble">{{ t.userMsg }}</span>
+            </div>
+            <div class="relay-msg is-bot">
+              <span class="relay-bubble">{{ t.botMsg }}<span class="relay-caret" /></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- highlights -->
+    <ul class="relay-highlights" v-reveal="2">
+      <li v-for="h in t.highlights" :key="h.title" class="relay-hl">
+        <span class="relay-hl-icon">
+          <svg v-if="h.icon === 'servers'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="8" rx="2" /><rect x="2" y="13" width="20" height="8" rx="2" /><line x1="6" y1="7" x2="6.01" y2="7" /><line x1="6" y1="17" x2="6.01" y2="17" /></svg>
+          <svg v-else-if="h.icon === 'shield'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /><path d="m9 12 2 2 4-4" /></svg>
+          <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" /></svg>
+        </span>
+        <div>
+          <p class="relay-hl-title">{{ h.title }}</p>
+          <p class="relay-hl-body">{{ h.body }}</p>
+        </div>
+      </li>
+    </ul>
+
+    <div class="relay-cta" v-reveal="2">
+      <a class="relay-cta-btn" :href="t.link">{{ t.cta }} →</a>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.relay-section .demo-sub {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 56ch;
+}
+
+/* browser window */
+.relay-window {
+  max-width: 880px;
+  margin: 0 auto;
+  border: 1px solid var(--x-line);
+  border-radius: 16px;
+  background: var(--x-s1);
+  box-shadow: var(--x-shadow-2), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+
+.relay-chrome {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 11px 15px;
+  border-bottom: 1px solid var(--x-line);
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.relay-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+.relay-dot-r { background: #ed6a5e; }
+.relay-dot-y { background: #f4be4f; }
+.relay-dot-g { background: var(--x-status); }
+
+.relay-url {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-left: 14px;
+  padding: 4px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--x-line);
+  background: rgba(255, 255, 255, 0.02);
+  font-family: var(--x-font-mono);
+  font-size: 11.5px;
+  color: var(--vp-c-text-3);
+}
+.relay-url svg { width: 12px; height: 12px; }
+
+/* split body */
+.relay-body {
+  display: grid;
+  grid-template-columns: minmax(0, 0.42fr) minmax(0, 1fr);
+  min-height: 268px;
+}
+
+.relay-rail {
+  padding: 16px 12px;
+  border-right: 1px solid var(--x-line);
+  background: rgba(255, 255, 255, 0.012);
+}
+
+.relay-rail-title {
+  margin: 2px 6px 12px;
+  font-family: var(--x-font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+}
+
+.relay-inst {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: 9px;
+  font-family: var(--x-font-mono);
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+}
+.relay-inst.is-active {
+  background: var(--x-accent-soft);
+  color: var(--vp-c-text-1);
+  box-shadow: inset 0 0 0 1px var(--x-line-2);
+}
+
+.relay-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+}
+.relay-status.is-online {
+  background: var(--x-status);
+  animation: relay-pulse 2.6s ease-out infinite;
+}
+.relay-status.is-offline {
+  background: var(--vp-c-text-3);
+  opacity: 0.5;
+}
+
+@keyframes relay-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.5); }
+  70% { box-shadow: 0 0 0 6px rgba(52, 211, 153, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0); }
+}
+
+/* session pane */
+.relay-pane { display: flex; flex-direction: column; }
+
+.relay-pane-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 13px 18px;
+  border-bottom: 1px solid var(--x-line);
+  font-family: var(--x-font-mono);
+  font-size: 12.5px;
+  color: var(--vp-c-text-2);
+}
+.relay-pane-arrow { color: var(--x-accent-bright); }
+
+.relay-thread {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+}
+
+.relay-msg { display: flex; }
+.relay-msg.is-user { justify-content: flex-end; }
+.relay-msg.is-bot { justify-content: flex-start; }
+
+.relay-bubble {
+  max-width: 84%;
+  padding: 9px 13px;
+  border-radius: 13px;
+  font-family: var(--x-font-mono);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.is-user .relay-bubble {
+  color: #0b0a16;
+  background: var(--x-accent);
+  border-bottom-right-radius: 4px;
+  font-weight: 500;
+}
+.is-bot .relay-bubble {
+  color: var(--vp-c-text-1);
+  background: var(--x-s3);
+  border: 1px solid var(--x-line);
+  border-bottom-left-radius: 4px;
+}
+
+.relay-caret {
+  display: inline-block;
+  width: 7px;
+  height: 13px;
+  margin-left: 3px;
+  vertical-align: text-bottom;
+  background: var(--x-accent-bright);
+  border-radius: 1px;
+  animation: relay-blink 1s steps(2, start) infinite;
+}
+@keyframes relay-blink {
+  50% { opacity: 0; }
+}
+
+/* highlights */
+.relay-highlights {
+  list-style: none;
+  margin: 40px auto 0;
+  padding: 0;
+  max-width: 880px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+.relay-hl {
+  display: flex;
+  gap: 13px;
+  align-items: flex-start;
+}
+
+.relay-hl-icon {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  color: var(--x-accent-bright);
+  background: var(--x-accent-soft);
+  border: 1px solid var(--x-line);
+}
+.relay-hl-icon svg { width: 19px; height: 19px; }
+
+.relay-hl-title {
+  margin: 2px 0 0;
+  font-family: var(--x-font-display);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+.relay-hl-body {
+  margin: 5px 0 0;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--vp-c-text-2);
+}
+
+/* cta */
+.relay-cta {
+  margin-top: 36px;
+  text-align: center;
+}
+.relay-cta-btn {
+  display: inline-block;
+  padding: 11px 22px;
+  border-radius: 10px;
+  background: var(--x-accent);
+  color: #0b0a16;
+  font-family: var(--x-font-display);
+  font-size: 14.5px;
+  font-weight: 600;
+  box-shadow: var(--x-shadow-1);
+  transition: transform 0.15s ease, background-color 0.15s ease;
+}
+.relay-cta-btn:hover {
+  transform: translateY(-1px);
+  background: var(--x-accent-bright);
+}
+
+@media (max-width: 860px) {
+  .relay-highlights {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+  .relay-body { min-height: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .relay-status.is-online,
+  .relay-caret {
+    animation: none !important;
+  }
+}
+</style>

--- a/packages/docs/guide/relay-self-hosting.md
+++ b/packages/docs/guide/relay-self-hosting.md
@@ -276,7 +276,7 @@ Bind to `127.0.0.1` and let your reverse proxy face the internet. The DB and das
 If you already run Node services under [pm2](https://pm2.keymetrics.io/), it supervises the hub just as well — `xacpx-relay` has no `stop`/`status` of its own, so a process manager handles restarts and boot-time startup.
 
 ```bash
-pm2 start xacpx-relay --name xacpx-relay -- start --host 127.0.0.1 --trust-proxy
+pm2 start xacpx-relay --name xacpx-relay -- start --host 127.0.0.1
 
 pm2 save        # persist the process list
 pm2 startup     # prints a one-time command to enable boot-time startup
@@ -291,13 +291,13 @@ module.exports = {
   apps: [{
     name: "xacpx-relay",
     script: "xacpx-relay",
-    args: "start --host 127.0.0.1 --trust-proxy",
+    args: "start --host 127.0.0.1",
     autorestart: true,
   }],
 };
 ```
 
-Bind to `127.0.0.1` behind your reverse proxy (same as systemd) and pass `--trust-proxy` so rate limiting sees the real client IP. After `xacpx-relay update`, run `pm2 restart xacpx-relay` to load the new version.
+`--host 127.0.0.1` keeps the hub off the public interface, same as the systemd example. The DB (`~/.xacpx-relay/relay.db`) is auto-detected — only add `--db` for a non-default path. Add `--trust-proxy` if you want rate limiting to use the real client IP from `X-Forwarded-For` (see [TLS & reverse proxy](#tls-reverse-proxy)). After `xacpx-relay update`, run `pm2 restart xacpx-relay` to load the new version.
 
 ## Troubleshooting
 

--- a/packages/docs/guide/relay-self-hosting.md
+++ b/packages/docs/guide/relay-self-hosting.md
@@ -271,6 +271,35 @@ WantedBy=multi-user.target
 
 Bind to `127.0.0.1` and let your reverse proxy face the internet. The DB and dashboard are auto-detected from their defaults; add `--db` only if you want a non-default path.
 
+## Running under pm2 (example)
+
+If you already run Node services under [pm2](https://pm2.keymetrics.io/), it supervises the hub just as well — `xacpx-relay` has no `stop`/`status` of its own, so a process manager handles restarts and boot-time startup.
+
+```bash
+# Use the absolute path to the binary (find it with `command -v xacpx-relay`).
+pm2 start "$(command -v xacpx-relay)" --name relay -- \
+  start --host 127.0.0.1 --trust-proxy
+
+pm2 save        # persist the process list
+pm2 startup     # prints a one-time command to enable boot-time startup
+```
+
+Or pin the arguments in an ecosystem file (`pm2 start ecosystem.config.js`):
+
+```js
+// ecosystem.config.js — set script to your `command -v xacpx-relay` path
+module.exports = {
+  apps: [{
+    name: "relay",
+    script: "/usr/bin/xacpx-relay",
+    args: "start --host 127.0.0.1 --trust-proxy",
+    autorestart: true,
+  }],
+};
+```
+
+Bind to `127.0.0.1` behind your reverse proxy (same as systemd) and pass `--trust-proxy` so rate limiting sees the real client IP. After `xacpx-relay update`, run `pm2 restart relay` to load the new version.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |

--- a/packages/docs/guide/relay-self-hosting.md
+++ b/packages/docs/guide/relay-self-hosting.md
@@ -276,29 +276,28 @@ Bind to `127.0.0.1` and let your reverse proxy face the internet. The DB and das
 If you already run Node services under [pm2](https://pm2.keymetrics.io/), it supervises the hub just as well — `xacpx-relay` has no `stop`/`status` of its own, so a process manager handles restarts and boot-time startup.
 
 ```bash
-# Use the absolute path to the binary (find it with `command -v xacpx-relay`).
-pm2 start "$(command -v xacpx-relay)" --name relay -- \
-  start --host 127.0.0.1 --trust-proxy
+pm2 start xacpx-relay --name xacpx-relay -- start --host 127.0.0.1 --trust-proxy
 
 pm2 save        # persist the process list
 pm2 startup     # prints a one-time command to enable boot-time startup
 ```
 
+pm2 resolves `xacpx-relay` from your `PATH` and stores its absolute path, so the saved process survives reboots. If pm2 can't find it (non-standard install), pass the full path from `command -v xacpx-relay` instead.
+
 Or pin the arguments in an ecosystem file (`pm2 start ecosystem.config.js`):
 
 ```js
-// ecosystem.config.js — set script to your `command -v xacpx-relay` path
 module.exports = {
   apps: [{
-    name: "relay",
-    script: "/usr/bin/xacpx-relay",
+    name: "xacpx-relay",
+    script: "xacpx-relay",
     args: "start --host 127.0.0.1 --trust-proxy",
     autorestart: true,
   }],
 };
 ```
 
-Bind to `127.0.0.1` behind your reverse proxy (same as systemd) and pass `--trust-proxy` so rate limiting sees the real client IP. After `xacpx-relay update`, run `pm2 restart relay` to load the new version.
+Bind to `127.0.0.1` behind your reverse proxy (same as systemd) and pass `--trust-proxy` so rate limiting sees the real client IP. After `xacpx-relay update`, run `pm2 restart xacpx-relay` to load the new version.
 
 ## Troubleshooting
 

--- a/packages/docs/guide/relay-self-hosting.md
+++ b/packages/docs/guide/relay-self-hosting.md
@@ -276,7 +276,7 @@ Bind to `127.0.0.1` and let your reverse proxy face the internet. The DB and das
 If you already run Node services under [pm2](https://pm2.keymetrics.io/), it supervises the hub just as well — `xacpx-relay` has no `stop`/`status` of its own, so a process manager handles restarts and boot-time startup.
 
 ```bash
-pm2 start xacpx-relay --name xacpx-relay -- start --host 127.0.0.1
+pm2 start xacpx-relay --name xacpx-relay -- start
 
 pm2 save        # persist the process list
 pm2 startup     # prints a one-time command to enable boot-time startup
@@ -291,13 +291,13 @@ module.exports = {
   apps: [{
     name: "xacpx-relay",
     script: "xacpx-relay",
-    args: "start --host 127.0.0.1",
+    args: "start",
     autorestart: true,
   }],
 };
 ```
 
-`--host 127.0.0.1` keeps the hub off the public interface, same as the systemd example. The DB (`~/.xacpx-relay/relay.db`) is auto-detected — only add `--db` for a non-default path. Add `--trust-proxy` if you want rate limiting to use the real client IP from `X-Forwarded-For` (see [TLS & reverse proxy](#tls-reverse-proxy)). After `xacpx-relay update`, run `pm2 restart xacpx-relay` to load the new version.
+The defaults work out of the box. For a hardened setup, append flags to `start`: `--host 127.0.0.1` to keep the hub off the public interface (behind your reverse proxy), `--db <path>` for a non-default database, or `--trust-proxy` so rate limiting uses the real client IP from `X-Forwarded-For` (see [TLS & reverse proxy](#tls-reverse-proxy)). After `xacpx-relay update`, run `pm2 restart xacpx-relay` to load the new version.
 
 ## Troubleshooting
 

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -19,6 +19,11 @@ features:
     details: Start sessions, switch context, send prompts, and cancel work — all from a message thread.
     link: /guide/getting-started
     linkText: Get started
+  - icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>'
+    title: Web dashboard
+    details: Self-host the relay hub and drive every instance's sessions — chat, scheduled tasks, orchestration — from one multi-tenant browser dashboard.
+    link: /guide/relay-self-hosting
+    linkText: Self-host the hub
   - icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>'
     title: acpx transport bridge
     details: Run agents through the direct acpx CLI transport or the isolated JSON bridge subprocess.
@@ -85,9 +90,16 @@ xacpx ships with WeChat as the built-in default channel. Additional channels are
 
 Third-party channels follow the same plugin interface. Install a channel plugin with `xacpx plugin add <package>`, configure it with `xacpx channel add <name>`, then restart the daemon.
 
+## Web dashboard (relay hub)
+
+Chat is not the only way to drive xacpx. If you run several instances, self-host the **relay hub** — an npm package (`@ganglion/xacpx-relay`) with a web dashboard bundled in. Each instance dials into the hub over WebSocket and registers; you log in to a multi-tenant dashboard and manage every instance's sessions — chat, scheduled tasks, and orchestration — from one place. Agent replies render as live markdown, and the dashboard installs as a PWA on mobile. A single access token serves both web login and connector pairing.
+
+See [Self-Hosting the Relay Hub](/guide/relay-self-hosting) for the full walkthrough.
+
 ## Next steps
 
 - [Getting Started](/guide/getting-started) — install xacpx, log in, and run your first session
 - [Command Reference](/reference/commands) — full listing of chat commands (`/ss`, `/use`, `/cancel`, and more)
+- [Self-Hosting the Relay Hub](/guide/relay-self-hosting) — run the multi-tenant web dashboard for several instances
 - [Configuration](/reference/configuration) — config file fields, transport options, and workspace/agent registration
 - [Plugin Development](/plugins/development) — build your own channel plugin

--- a/packages/docs/zh/guide/relay-self-hosting.md
+++ b/packages/docs/zh/guide/relay-self-hosting.md
@@ -276,29 +276,28 @@ WantedBy=multi-user.target
 如果你已经在用 [pm2](https://pm2.keymetrics.io/) 托管 Node 服务，它同样能管好 Hub——`xacpx-relay` 自身没有 `stop`/`status`，交给进程管理器负责重启和开机自启最合适。
 
 ```bash
-# 使用二进制的绝对路径（用 `command -v xacpx-relay` 查出来）。
-pm2 start "$(command -v xacpx-relay)" --name relay -- \
-  start --host 127.0.0.1 --trust-proxy
+pm2 start xacpx-relay --name xacpx-relay -- start --host 127.0.0.1 --trust-proxy
 
 pm2 save        # 固化当前进程列表
 pm2 startup     # 打印一条一次性命令，执行后即开机自启
 ```
 
+pm2 会从 `PATH` 解析 `xacpx-relay` 并把绝对路径存进 dump，重启后也能恢复；万一 pm2 找不到（非标准安装），改传 `command -v xacpx-relay` 的绝对路径即可。
+
 或用 ecosystem 文件固定参数（`pm2 start ecosystem.config.js`）：
 
 ```js
-// ecosystem.config.js —— 把 script 改成你 `command -v xacpx-relay` 的路径
 module.exports = {
   apps: [{
-    name: "relay",
-    script: "/usr/bin/xacpx-relay",
+    name: "xacpx-relay",
+    script: "xacpx-relay",
     args: "start --host 127.0.0.1 --trust-proxy",
     autorestart: true,
   }],
 };
 ```
 
-与 systemd 一样绑定到 `127.0.0.1` 置于反向代理之后，并传 `--trust-proxy` 让限速看到真实客户端 IP。`xacpx-relay update` 之后执行 `pm2 restart relay` 加载新版本。
+与 systemd 一样绑定到 `127.0.0.1` 置于反向代理之后，并传 `--trust-proxy` 让限速看到真实客户端 IP。`xacpx-relay update` 之后执行 `pm2 restart xacpx-relay` 加载新版本。
 
 ## 常见问题排查
 

--- a/packages/docs/zh/guide/relay-self-hosting.md
+++ b/packages/docs/zh/guide/relay-self-hosting.md
@@ -271,6 +271,35 @@ WantedBy=multi-user.target
 
 绑定到 `127.0.0.1`，让你的反向代理面向公网。DB 和看板会从默认位置自动检测；仅在需要非默认路径时才添加 `--db`。
 
+## 在 pm2 下运行（示例）
+
+如果你已经在用 [pm2](https://pm2.keymetrics.io/) 托管 Node 服务，它同样能管好 Hub——`xacpx-relay` 自身没有 `stop`/`status`，交给进程管理器负责重启和开机自启最合适。
+
+```bash
+# 使用二进制的绝对路径（用 `command -v xacpx-relay` 查出来）。
+pm2 start "$(command -v xacpx-relay)" --name relay -- \
+  start --host 127.0.0.1 --trust-proxy
+
+pm2 save        # 固化当前进程列表
+pm2 startup     # 打印一条一次性命令，执行后即开机自启
+```
+
+或用 ecosystem 文件固定参数（`pm2 start ecosystem.config.js`）：
+
+```js
+// ecosystem.config.js —— 把 script 改成你 `command -v xacpx-relay` 的路径
+module.exports = {
+  apps: [{
+    name: "relay",
+    script: "/usr/bin/xacpx-relay",
+    args: "start --host 127.0.0.1 --trust-proxy",
+    autorestart: true,
+  }],
+};
+```
+
+与 systemd 一样绑定到 `127.0.0.1` 置于反向代理之后，并传 `--trust-proxy` 让限速看到真实客户端 IP。`xacpx-relay update` 之后执行 `pm2 restart relay` 加载新版本。
+
 ## 常见问题排查
 
 | 现象 | 原因 | 解决办法 |

--- a/packages/docs/zh/guide/relay-self-hosting.md
+++ b/packages/docs/zh/guide/relay-self-hosting.md
@@ -276,7 +276,7 @@ WantedBy=multi-user.target
 如果你已经在用 [pm2](https://pm2.keymetrics.io/) 托管 Node 服务，它同样能管好 Hub——`xacpx-relay` 自身没有 `stop`/`status`，交给进程管理器负责重启和开机自启最合适。
 
 ```bash
-pm2 start xacpx-relay --name xacpx-relay -- start --host 127.0.0.1
+pm2 start xacpx-relay --name xacpx-relay -- start
 
 pm2 save        # 固化当前进程列表
 pm2 startup     # 打印一条一次性命令，执行后即开机自启
@@ -291,13 +291,13 @@ module.exports = {
   apps: [{
     name: "xacpx-relay",
     script: "xacpx-relay",
-    args: "start --host 127.0.0.1",
+    args: "start",
     autorestart: true,
   }],
 };
 ```
 
-`--host 127.0.0.1` 让 Hub 不直接对外，与 systemd 示例一致。DB（`~/.xacpx-relay/relay.db`）会自动检测——仅在需要非默认路径时才加 `--db`。若想让限速使用 `X-Forwarded-For` 里的真实客户端 IP，再加 `--trust-proxy`（见 [TLS 与反向代理](#tls-reverse-proxy)）。`xacpx-relay update` 之后执行 `pm2 restart xacpx-relay` 加载新版本。
+默认即可用。需要更安全的部署时，再往 `start` 后追加：`--host 127.0.0.1` 让 Hub 不直接对外（置于反向代理之后）、`--db <path>` 自定义数据库路径，或 `--trust-proxy` 让限速使用 `X-Forwarded-For` 里的真实客户端 IP（见 [TLS 与反向代理](#tls-reverse-proxy)）。`xacpx-relay update` 之后执行 `pm2 restart xacpx-relay` 加载新版本。
 
 ## 常见问题排查
 

--- a/packages/docs/zh/guide/relay-self-hosting.md
+++ b/packages/docs/zh/guide/relay-self-hosting.md
@@ -276,7 +276,7 @@ WantedBy=multi-user.target
 如果你已经在用 [pm2](https://pm2.keymetrics.io/) 托管 Node 服务，它同样能管好 Hub——`xacpx-relay` 自身没有 `stop`/`status`，交给进程管理器负责重启和开机自启最合适。
 
 ```bash
-pm2 start xacpx-relay --name xacpx-relay -- start --host 127.0.0.1 --trust-proxy
+pm2 start xacpx-relay --name xacpx-relay -- start --host 127.0.0.1
 
 pm2 save        # 固化当前进程列表
 pm2 startup     # 打印一条一次性命令，执行后即开机自启
@@ -291,13 +291,13 @@ module.exports = {
   apps: [{
     name: "xacpx-relay",
     script: "xacpx-relay",
-    args: "start --host 127.0.0.1 --trust-proxy",
+    args: "start --host 127.0.0.1",
     autorestart: true,
   }],
 };
 ```
 
-与 systemd 一样绑定到 `127.0.0.1` 置于反向代理之后，并传 `--trust-proxy` 让限速看到真实客户端 IP。`xacpx-relay update` 之后执行 `pm2 restart xacpx-relay` 加载新版本。
+`--host 127.0.0.1` 让 Hub 不直接对外，与 systemd 示例一致。DB（`~/.xacpx-relay/relay.db`）会自动检测——仅在需要非默认路径时才加 `--db`。若想让限速使用 `X-Forwarded-For` 里的真实客户端 IP，再加 `--trust-proxy`（见 [TLS 与反向代理](#tls-reverse-proxy)）。`xacpx-relay update` 之后执行 `pm2 restart xacpx-relay` 加载新版本。
 
 ## 常见问题排查
 

--- a/packages/docs/zh/index.md
+++ b/packages/docs/zh/index.md
@@ -19,6 +19,11 @@ features:
     details: 在消息对话框中即可创建会话、切换上下文、发送提示词、取消任务，一气呵成。
     link: /zh/guide/getting-started
     linkText: 快速开始
+  - icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>'
+    title: 网页看板
+    details: 自托管 relay hub，在一个多租户浏览器看板里遥控所有实例的会话——聊天、定时任务、编排。
+    link: /zh/guide/relay-self-hosting
+    linkText: 自托管 hub
   - icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>'
     title: acpx 传输桥接
     details: 通过直连 acpx CLI 传输或隔离的 JSON 桥接子进程来运行 Agent。
@@ -85,9 +90,16 @@ xacpx 内置微信作为默认频道。其他频道以官方插件包形式分�
 
 第三方频道遵循相同的插件接口。使用 `xacpx plugin add <package>` 安装频道插件，使用 `xacpx channel add <name>` 配置，然后重启守护进程。
 
+## 网页看板（relay hub）
+
+聊天并不是驱动 xacpx 的唯一方式。如果你跑了多个实例，可以自托管 **relay hub**——一个内置网页看板的 npm 包（`@ganglion/xacpx-relay`）。每个实例通过 WebSocket 拨入 hub 并注册；你登录一个多租户看板，在一个地方管理所有实例的会话——聊天、定时任务、编排。Agent 回复以实时 markdown 渲染，看板可作为 PWA 安装到移动端。登录与连接器配对共用同一个 access token。
+
+完整流程见 [自托管 Relay Hub](/zh/guide/relay-self-hosting)。
+
 ## 下一步
 
 - [快速开始](/zh/guide/getting-started) — 安装 xacpx、登录并运行第一个会话
 - [命令参考](/zh/reference/commands) — 聊天命令完整列表（`/ss`、`/use`、`/cancel` 等）
+- [自托管 Relay Hub](/zh/guide/relay-self-hosting) — 为多个实例运行多租户网页看板
 - [配置说明](/zh/reference/configuration) — 配置文件字段、传输选项以及工作区和 Agent 注册
 - [插件开发](/zh/plugins/development) — 构建你自己的频道插件


### PR DESCRIPTION
## Summary

Documentation polishing across the README, the relay deployment docs, and the doc-site homepage.

### README slim-down
- `README.md` 622 → 233 lines; `docs/zh/README_zh.md` 590 → 232. Refocused on intro + 5-minute quick start + everyday workflow + a compact cheat sheet + navigation hub.
- New `docs/cli-reference.md` (+ zh) absorbs the full terminal CLI table and the `workspace`/`agent`/`doctor`/`update` detail.
- New `docs/faq.md` (+ zh) absorbs the FAQ.
- Chat-command tables dropped (already covered by `docs/commands.md`); MCP/orchestration collapsed to a teaser + links.
- `AGENTS.md`: added `cli-reference.md` and `faq.md` to "Docs to rely on".

### Relay deployment: Caddy + pm2
- Added quick Caddy reverse-proxy config and a pm2 process-manager section to the runbook (`docs/relay-deployment.md`) and both doc-site guides (`packages/docs/guide/relay-self-hosting.md` + zh).
- Basic pm2 example kept minimal — `pm2 start xacpx-relay --name xacpx-relay -- start`; `--db` / `--host` / `--trust-proxy` documented as optional/advanced.

### Homepage: relay as a second pillar
- New `RelaySection.vue` — a CSS browser-window dashboard mockup (instances rail + live session) with three highlights and a CTA, slotted into `home-features-after`. Reuses the Plasma design tokens, `.cap-section` scaffold, `v-reveal`, and respects reduced-motion.
- Added a "Web dashboard" feature card + a body section + Next-steps link. EN + ZH in sync.

## Verification
- All internal doc links resolved (EN + ZH).
- `vitepress build` passes; the new homepage section renders in light/dark and stacks on mobile.