### PR TITLE
feat(relay-web): open the mobile drawers with edge swipes

### DIFF
--- a/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
@@ -186,3 +186,41 @@ test("the sidebar header toggle collapses the instances column, and the edge han
   expect(left.classes()).toContain("lg:w-[248px]");
   expect(wrapper.find('[data-test="expand-left"]').exists()).toBe(false);
 });
+
+test("edge-swipe right from the left edge opens the instances drawer (mobile)", async () => {
+  const realWidth = window.innerWidth;
+  Object.defineProperty(window, "innerWidth", { value: 500, configurable: true });
+  try {
+    const wrapper = mountDash();
+    await flushPromises();
+    const left = wrapper.find('[data-drawer="left"]');
+    expect(left.classes()).toContain("-translate-x-full");
+
+    await wrapper.trigger("touchstart", { touches: [{ clientX: 6, clientY: 200 }] });
+    await wrapper.trigger("touchend", { changedTouches: [{ clientX: 110, clientY: 208 }] });
+
+    expect(left.classes()).toContain("translate-x-0");
+    expect(left.classes()).not.toContain("-translate-x-full");
+  } finally {
+    Object.defineProperty(window, "innerWidth", { value: realWidth, configurable: true });
+  }
+});
+
+test("edge-swipe left from the right edge opens the tasks/files drawer (mobile)", async () => {
+  const realWidth = window.innerWidth;
+  Object.defineProperty(window, "innerWidth", { value: 500, configurable: true });
+  try {
+    const wrapper = mountDash();
+    await flushPromises();
+    const right = wrapper.find('[data-drawer="right"]');
+    expect(right.classes()).toContain("translate-x-full");
+
+    await wrapper.trigger("touchstart", { touches: [{ clientX: 494, clientY: 200 }] });
+    await wrapper.trigger("touchend", { changedTouches: [{ clientX: 380, clientY: 206 }] });
+
+    expect(right.classes()).toContain("translate-x-0");
+    expect(right.classes()).not.toContain("translate-x-full");
+  } finally {
+    Object.defineProperty(window, "innerWidth", { value: realWidth, configurable: true });
+  }
+});

--- a/packages/relay-web/src/__tests__/edge-swipe.test.ts
+++ b/packages/relay-web/src/__tests__/edge-swipe.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEdgeSwipe, type EdgeSwipeOptions } from "../lib/edge-swipe";
+
+function setup(over: Partial<EdgeSwipeOptions> = {}) {
+  const calls = {
+    openLeft: vi.fn(),
+    openRight: vi.fn(),
+    closeLeft: vi.fn(),
+    closeRight: vi.fn(),
+  };
+  const opts: EdgeSwipeOptions = {
+    isEnabled: () => true,
+    isLeftOpen: () => false,
+    isRightOpen: () => false,
+    viewportWidth: () => 400,
+    ...calls,
+    ...over,
+  };
+  return { swipe: createEdgeSwipe(opts), ...calls };
+}
+
+const start = (x: number, y: number) => ({ touches: [{ clientX: x, clientY: y }] });
+const end = (x: number, y: number) => ({ changedTouches: [{ clientX: x, clientY: y }] });
+
+describe("createEdgeSwipe", () => {
+  it("opens the left drawer on a rightward swipe from the left edge", () => {
+    const { swipe, openLeft } = setup();
+    swipe.onTouchStart(start(8, 200));
+    swipe.onTouchEnd(end(90, 210));
+    expect(openLeft).toHaveBeenCalledOnce();
+  });
+
+  it("opens the right drawer on a leftward swipe from the right edge", () => {
+    const { swipe, openRight } = setup(); // viewportWidth 400 → right edge ≥ 370
+    swipe.onTouchStart(start(394, 200));
+    swipe.onTouchEnd(end(300, 205));
+    expect(openRight).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a swipe that does not start near an edge", () => {
+    const { swipe, openLeft, openRight } = setup();
+    swipe.onTouchStart(start(200, 200));
+    swipe.onTouchEnd(end(300, 205));
+    expect(openLeft).not.toHaveBeenCalled();
+    expect(openRight).not.toHaveBeenCalled();
+  });
+
+  it("ignores a swipe shorter than the threshold", () => {
+    const { swipe, openLeft } = setup();
+    swipe.onTouchStart(start(8, 200));
+    swipe.onTouchEnd(end(40, 205)); // dx 32 < 45
+    expect(openLeft).not.toHaveBeenCalled();
+  });
+
+  it("ignores a vertical-dominant gesture from the edge (a scroll, not a swipe)", () => {
+    const { swipe, openLeft } = setup();
+    swipe.onTouchStart(start(8, 100));
+    swipe.onTouchEnd(end(70, 260)); // dx 62, dy 160 → vertical wins
+    expect(openLeft).not.toHaveBeenCalled();
+  });
+
+  it("rejects an exact 45° (|dx| === |dy|) swipe as not horizontal-dominant", () => {
+    const { swipe, openLeft } = setup();
+    swipe.onTouchStart(start(8, 100));
+    swipe.onTouchEnd(end(68, 160)); // dx 60, dy 60 → tie, must not open
+    expect(openLeft).not.toHaveBeenCalled();
+  });
+
+  it("closes the left drawer on a leftward swipe when it is open", () => {
+    const { swipe, closeLeft, openRight } = setup({ isLeftOpen: () => true });
+    swipe.onTouchStart(start(220, 200)); // start anywhere — backdrop covers content
+    swipe.onTouchEnd(end(120, 205));
+    expect(closeLeft).toHaveBeenCalledOnce();
+    expect(openRight).not.toHaveBeenCalled();
+  });
+
+  it("does not close the left drawer on a rightward (wrong-direction) swipe", () => {
+    const { swipe, closeLeft } = setup({ isLeftOpen: () => true });
+    swipe.onTouchStart(start(120, 200));
+    swipe.onTouchEnd(end(220, 205));
+    expect(closeLeft).not.toHaveBeenCalled();
+  });
+
+  it("closes the right drawer on a rightward swipe when it is open", () => {
+    const { swipe, closeRight } = setup({ isRightOpen: () => true });
+    swipe.onTouchStart(start(180, 200));
+    swipe.onTouchEnd(end(280, 205));
+    expect(closeRight).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing when disabled (desktop / static columns)", () => {
+    const { swipe, openLeft, openRight } = setup({ isEnabled: () => false });
+    swipe.onTouchStart(start(8, 200));
+    swipe.onTouchEnd(end(120, 205));
+    expect(openLeft).not.toHaveBeenCalled();
+    expect(openRight).not.toHaveBeenCalled();
+  });
+
+  it("does not open from just outside the edge zone", () => {
+    const { swipe, openLeft } = setup({ edgeZone: 30 });
+    swipe.onTouchStart(start(45, 200)); // 45 > 30
+    swipe.onTouchEnd(end(140, 205));
+    expect(openLeft).not.toHaveBeenCalled();
+  });
+
+  it("does not arm open-right from just inside of the right edge zone", () => {
+    const { swipe, openRight } = setup({ edgeZone: 30 }); // width 400 → arm only ≥ 370
+    swipe.onTouchStart(start(360, 200));
+    swipe.onTouchEnd(end(260, 205));
+    expect(openRight).not.toHaveBeenCalled();
+  });
+
+  it("ignores a multi-touch start (pinch / two-finger scroll)", () => {
+    const { swipe, openLeft } = setup();
+    swipe.onTouchStart({ touches: [{ clientX: 6, clientY: 200 }, { clientX: 80, clientY: 240 }] });
+    swipe.onTouchEnd(end(110, 205));
+    expect(openLeft).not.toHaveBeenCalled();
+  });
+
+  it("does not close when the swipe starts inside the drawer panel (only the backdrop closes)", () => {
+    const inDrawer = { closest: (sel: string) => (sel === "[data-drawer]" ? {} : null) };
+    const { swipe, closeLeft } = setup({ isLeftOpen: () => true });
+    swipe.onTouchStart({ touches: [{ clientX: 120, clientY: 200 }], target: inDrawer as unknown as EventTarget });
+    swipe.onTouchEnd(end(20, 205));
+    expect(closeLeft).not.toHaveBeenCalled();
+  });
+
+  it("resets the armed gesture on touchcancel", () => {
+    const { swipe, openLeft } = setup();
+    swipe.onTouchStart(start(8, 200));
+    swipe.onTouchCancel();
+    swipe.onTouchEnd(end(110, 205));
+    expect(openLeft).not.toHaveBeenCalled();
+  });
+
+  it("does nothing on a touchend with no point", () => {
+    const { swipe, openLeft } = setup();
+    swipe.onTouchStart(start(8, 200));
+    expect(() => swipe.onTouchEnd({})).not.toThrow();
+    expect(openLeft).not.toHaveBeenCalled();
+  });
+});

--- a/packages/relay-web/src/lib/edge-swipe.ts
+++ b/packages/relay-web/src/lib/edge-swipe.ts
@@ -1,0 +1,127 @@
+/**
+ * Edge-swipe drawer gestures for the mobile dashboard.
+ *
+ * Open: a touch that STARTS within `edgeZone` px of a screen edge and then
+ * travels horizontally past `threshold` opens that side's drawer —
+ *   left edge → swipe right  ⇒ open the left (instances) drawer
+ *   right edge → swipe left  ⇒ open the right (tasks/files) drawer
+ * Close: when a drawer is already open, a horizontal swipe back toward its own
+ * edge closes it — but only when the swipe STARTS on the backdrop, not inside
+ * the drawer panel itself (so a horizontal scroll within the drawer can't close
+ * it out from under the user). The backdrop covers all the non-drawer area, so a
+ * close swipe can start anywhere on it.
+ *
+ * Gated to the off-canvas (mobile) layout via `isEnabled`; on lg+ the side
+ * columns are static and the gesture is a no-op. A horizontal-dominant check
+ * (|dx| > |dy|) plus the minimum distance keep it from firing during vertical
+ * scrolling, and multi-touch (pinch / two-finger scroll) is ignored outright.
+ *
+ * Note: the left-edge open gesture overlaps the iOS Safari back-swipe. In an
+ * installed (standalone) PWA there is no browser back gesture, so it is clean
+ * there; in a Safari browser tab the two coexist, with the system gesture
+ * usually winning — acceptable, since the dashboard's primary mobile surface is
+ * the installed PWA.
+ */
+export interface TouchPoint {
+  clientX: number;
+  clientY: number;
+}
+
+export interface TouchLike {
+  touches?: ArrayLike<TouchPoint>;
+  changedTouches?: ArrayLike<TouchPoint>;
+  target?: EventTarget | null;
+}
+
+export interface EdgeSwipeOptions {
+  /** Only act when the off-canvas (mobile) layout is active. */
+  isEnabled: () => boolean;
+  isLeftOpen: () => boolean;
+  isRightOpen: () => boolean;
+  openLeft: () => void;
+  openRight: () => void;
+  closeLeft: () => void;
+  closeRight: () => void;
+  /** Defaults to `window.innerWidth`. */
+  viewportWidth?: () => number;
+  /** Distance from a screen edge (px) within which an open gesture may start. */
+  edgeZone?: number;
+  /** Minimum horizontal travel (px) required to trigger. */
+  threshold?: number;
+}
+
+export interface EdgeSwipeHandlers {
+  onTouchStart(e: TouchLike): void;
+  onTouchEnd(e: TouchLike): void;
+  onTouchCancel(): void;
+}
+
+type Mode = "open-left" | "open-right" | "close-left" | "close-right" | null;
+
+export function createEdgeSwipe(opts: EdgeSwipeOptions): EdgeSwipeHandlers {
+  const edgeZone = opts.edgeZone ?? 30;
+  const threshold = opts.threshold ?? 45;
+  const viewportWidth = opts.viewportWidth ?? (() => window.innerWidth);
+
+  let startX = 0;
+  let startY = 0;
+  let mode: Mode = null;
+
+  // At touchstart the active touch is in `touches`; at touchend it has moved to
+  // `changedTouches`. Each lookup prefers the list that holds the active point.
+  function firstPoint(e: TouchLike): TouchPoint | null {
+    return e.touches?.[0] ?? e.changedTouches?.[0] ?? null;
+  }
+  function lastPoint(e: TouchLike): TouchPoint | null {
+    return e.changedTouches?.[0] ?? e.touches?.[0] ?? null;
+  }
+
+  // A close swipe is only valid from the backdrop, never from within the drawer
+  // panel (where horizontal content could otherwise close the drawer).
+  function startedInsideDrawer(e: TouchLike): boolean {
+    const el = e.target as Element | null | undefined;
+    return !!(el && typeof el.closest === "function" && el.closest("[data-drawer]"));
+  }
+
+  function onTouchStart(e: TouchLike): void {
+    mode = null;
+    if (!opts.isEnabled()) return;
+    if ((e.touches?.length ?? 0) > 1) return; // ignore pinch / two-finger gestures
+    const p = firstPoint(e);
+    if (!p) return;
+    startX = p.clientX;
+    startY = p.clientY;
+    // An already-open drawer takes priority: this gesture may close it (backdrop only).
+    if (opts.isLeftOpen() || opts.isRightOpen()) {
+      if (startedInsideDrawer(e)) return;
+      mode = opts.isLeftOpen() ? "close-left" : "close-right";
+      return;
+    }
+    if (startX <= edgeZone) mode = "open-left";
+    else if (startX >= viewportWidth() - edgeZone) mode = "open-right";
+  }
+
+  function onTouchEnd(e: TouchLike): void {
+    const m = mode;
+    mode = null;
+    if (!m) return;
+    const p = lastPoint(e);
+    if (!p) return;
+    const dx = p.clientX - startX;
+    const dy = p.clientY - startY;
+    if (Math.abs(dx) < threshold) return; // not far enough
+    if (Math.abs(dx) <= Math.abs(dy)) return; // not horizontal-dominant
+    if (m === "open-left" && dx > 0) opts.openLeft();
+    else if (m === "open-right" && dx < 0) opts.openRight();
+    else if (m === "close-left" && dx < 0) opts.closeLeft();
+    else if (m === "close-right" && dx > 0) opts.closeRight();
+  }
+
+  // The system reclassified the gesture (e.g. scroll / back-swipe took over);
+  // drop the armed mode so a later unrelated touchend can't fire it.
+  function onTouchCancel(): void {
+    mode = null;
+  }
+
+  return { onTouchStart, onTouchEnd, onTouchCancel };
+}

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -18,6 +18,7 @@ import ConnectionBadge from "../components/ConnectionBadge.vue";
 import CommandPalette from "../components/CommandPalette.vue";
 import BrandLogo from "../components/BrandLogo.vue";
 import { useThemeStore } from "../stores/theme";
+import { createEdgeSwipe } from "../lib/edge-swipe";
 import { Search, Moon, Sun, Settings, X, Menu, FileText, List, PanelLeftClose, PanelLeftOpen } from "lucide-vue-next";
 
 const theme = useThemeStore();
@@ -42,6 +43,22 @@ function openRight(tab: "tasks" | "files") {
   rightTab.value = tab;
   rightOpen.value = true;
 }
+
+// Mobile edge-swipe drawers: from the left edge swipe right to open instances,
+// from the right edge swipe left to open tasks/files; when a drawer is open a
+// swipe back toward its edge closes it. Inert on lg+ (static columns).
+const swipe = createEdgeSwipe({
+  // < 1024px = the Tailwind `lg` boundary at which the drawers stop being
+  // off-canvas. innerWidth ≥ the CSS viewport width (it includes a classic
+  // scrollbar), so we never disable while the layout is still off-canvas.
+  isEnabled: () => typeof window !== "undefined" && window.innerWidth < 1024,
+  isLeftOpen: () => leftOpen.value,
+  isRightOpen: () => rightOpen.value,
+  openLeft: () => { leftOpen.value = true; },
+  openRight: () => { rightOpen.value = true; }, // keeps the last-used right tab
+  closeLeft: () => { leftOpen.value = false; },
+  closeRight: () => { rightOpen.value = false; },
+});
 // Mobile: "Back" from the file viewer returns to the FILE LIST (reopen the Files drawer),
 // not the conversation. Clearing the open file reverts the center to ChatPane underneath.
 function backToFileList() {
@@ -124,7 +141,10 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="flex h-dvh flex-col bg-bg text-fg">
+  <div class="flex h-dvh flex-col bg-bg text-fg"
+       @touchstart.passive="swipe.onTouchStart"
+       @touchend.passive="swipe.onTouchEnd"
+       @touchcancel.passive="swipe.onTouchCancel">
     <!-- Global top bar: brand lockup + connection pill on the left; search, theme, settings on the right. -->
     <!-- pt-[env(safe-area-inset-top)]: in an installed iOS PWA (viewport-fit=cover)
          the content runs under the notch / status bar; extend the bar's surface up


### PR DESCRIPTION
## Summary

On the mobile relay-web dashboard, open the off-canvas drawers with edge swipes:

- **Swipe right from the left screen edge** → open the left (instances) drawer.
- **Swipe left from the right edge** → open the right (tasks/files) drawer.
- When a drawer is open, **swipe back across the backdrop** toward its edge to close it.

Gated to the `<lg` off-canvas layout (no-op on desktop static columns). A horizontal-dominant (`|dx| > |dy|`) + minimum-distance check keeps it from firing during vertical scroll; multi-touch (pinch / two-finger) is ignored; a close swipe that starts inside the drawer panel is **not** treated as a close (only the backdrop closes); `touchcancel` disarms the gesture.

## Implementation

- New pure helper `src/lib/edge-swipe.ts` (`createEdgeSwipe`) — DOM-decoupled gesture state machine, fully unit-tested.
- Wired to the dashboard root via passive `touchstart`/`touchend`/`touchcancel` listeners in `DashboardView.vue`.

## Known trade-off

The left-edge open gesture overlaps the iOS Safari back-swipe. In an installed (standalone) PWA — the dashboard's primary mobile surface — there is no browser back gesture, so it's clean; in a Safari browser tab the system gesture usually wins. Documented in code.

## Tests

- `edge-swipe.test.ts` — 16 unit tests (both opens, both closes, threshold, horizontal-dominant + 45° tie rejection, edge-zone boundaries, multi-touch no-op, in-drawer close rejection, touchcancel reset, empty-touchend).
- `dashboard-responsive.test.ts` — 2 integration tests driving real DOM touch events through the mounted dashboard.
- All pass; `vue-tsc` build green.

## Review

Reviewed by a code-reviewer subagent (2 rounds). Round 1 flagged 3 Important issues (multi-touch misfire, in-drawer close hijack, missing touchcancel) — all fixed. Round 2 verdict: **Ready to merge**, no Critical/Important remaining.