### PR TITLE
fix(plugins): list the relay connector in plugin known + channel-add hints

### DIFF
--- a/src/i18n/messages/en/misc.ts
+++ b/src/i18n/messages/en/misc.ts
@@ -10,6 +10,7 @@ export const misc: MiscMessages = {
   // plugins/known-plugins: channel descriptions
   pluginChannelFeishu: "Feishu channel",
   pluginChannelYuanbao: "Tencent Yuanbao channel",
+  pluginChannelRelay: "Relay hub connector (drive this instance from a self-hosted relay hub)",
   pluginChannelInstallHint: (channelType: string, packageName: string) =>
     `Channel ${channelType} requires a plugin: xacpx plugin add ${packageName}`,
 

--- a/src/i18n/messages/zh/misc.ts
+++ b/src/i18n/messages/zh/misc.ts
@@ -10,6 +10,7 @@ export const misc: MiscMessages = {
   // plugins/known-plugins: channel descriptions
   pluginChannelFeishu: "飞书频道",
   pluginChannelYuanbao: "腾讯元宝频道",
+  pluginChannelRelay: "Relay hub 连接器（从自托管 relay hub 遥控这台实例）",
   pluginChannelInstallHint: (channelType: string, packageName: string) =>
     `频道 ${channelType} 需要安装插件：xacpx plugin add ${packageName}`,
 

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1252,6 +1252,7 @@ export interface MiscMessages {
   // plugins/known-plugins: channel descriptions
   pluginChannelFeishu: string;
   pluginChannelYuanbao: string;
+  pluginChannelRelay: string;
   pluginChannelInstallHint: (channelType: string, packageName: string) => string;
 
   // doctor/orchestration-health: suggestions

--- a/src/plugins/known-plugins.ts
+++ b/src/plugins/known-plugins.ts
@@ -22,6 +22,12 @@ const KNOWN_PLUGIN_TEMPLATES: ReadonlyArray<KnownPluginTemplate> = [
     descriptionKey: "pluginChannelYuanbao",
     official: true,
   },
+  {
+    packageName: "@ganglion/xacpx-channel-relay",
+    channels: ["relay"],
+    descriptionKey: "pluginChannelRelay",
+    official: true,
+  },
 ];
 
 function resolveDescription(key: keyof ReturnType<typeof t>["misc"]): string {

--- a/tests/unit/plugins/known-plugins.test.ts
+++ b/tests/unit/plugins/known-plugins.test.ts
@@ -10,11 +10,12 @@ import { setLocale } from "../../../src/i18n";
 beforeEach(() => { setLocale("zh"); });
 afterAll(() => { setLocale("en"); });
 
-test("listKnownPlugins includes Feishu and Yuanbao first-party packages", () => {
+test("listKnownPlugins includes Feishu, Yuanbao, and the Relay connector", () => {
   const plugins = listKnownPlugins();
   const packageNames = plugins.map((plugin) => plugin.packageName);
   expect(packageNames).toContain("@ganglion/xacpx-channel-feishu");
   expect(packageNames).toContain("@ganglion/xacpx-channel-yuanbao");
+  expect(packageNames).toContain("@ganglion/xacpx-channel-relay");
 });
 
 test("listKnownPlugins marks every entry as official", () => {
@@ -41,6 +42,7 @@ test("listKnownPlugins returns a copy so callers cannot mutate the source", () =
 test("findKnownPluginByChannel returns the matching first-party package", () => {
   expect(findKnownPluginByChannel("feishu")?.packageName).toBe("@ganglion/xacpx-channel-feishu");
   expect(findKnownPluginByChannel("yuanbao")?.packageName).toBe("@ganglion/xacpx-channel-yuanbao");
+  expect(findKnownPluginByChannel("relay")?.packageName).toBe("@ganglion/xacpx-channel-relay");
 });
 
 test("findKnownPluginByChannel returns null for built-in or unknown channels", () => {
@@ -54,6 +56,9 @@ test("getMovedChannelInstallHint returns the explicit install command for known 
   );
   expect(getMovedChannelInstallHint("yuanbao")).toBe(
     "频道 yuanbao 需要安装插件：xacpx plugin add @ganglion/xacpx-channel-yuanbao",
+  );
+  expect(getMovedChannelInstallHint("relay")).toBe(
+    "频道 relay 需要安装插件：xacpx plugin add @ganglion/xacpx-channel-relay",
   );
 });
 


### PR DESCRIPTION
## Problem

`xacpx channel add relay --url … --token …` fails with:

> 未知频道类型：relay / 支持的内置频道：weixin, feishu, yuanbao

because `relay` is a connector **plugin** (`@ganglion/xacpx-channel-relay`), not a built-in channel — but that package is missing from the known-plugins registry, so:

- `xacpx plugin known` only lists feishu/yuanbao — users can't discover the relay connector or its package name.
- `xacpx channel add relay` (plugin not installed) prints a bare "unknown channel type" with no install guidance, even though the CLI already surfaces an install hint for known channels.

## Fix

Add `@ganglion/xacpx-channel-relay` (channel `relay`) to `KNOWN_PLUGIN_TEMPLATES` with EN/ZH descriptions. This makes it appear in `plugin known` and makes the unknown-channel path print:

> 频道 relay 需要安装插件：xacpx plugin add @ganglion/xacpx-channel-relay

Files: `src/plugins/known-plugins.ts`, `src/i18n/types.ts`, `src/i18n/messages/{en,zh}/misc.ts`, tests in `tests/unit/plugins/known-plugins.test.ts`.

## Tests

`tsc --noEmit` clean; `tests/unit/plugins` + `tests/unit/i18n` + `tests/unit/channels` green. Added relay assertions to known-plugins.test.ts (listing, `findKnownPluginByChannel`, install-hint).

## Note

This is a **core** change, so it reaches users only with a core patch release (e.g. 0.14.1). It does not change the connect flow itself — installing the plugin (`xacpx plugin add @ganglion/xacpx-channel-relay`) already works today.