### PR TITLE
fix(relay): propagate CLI workspace edits to the web panel + drop blank reasoning blocks

### DIFF
--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -237,7 +237,9 @@ function historyMessagesToRows(
     const reasoningChunks: string[] = [];
     for (const p of m.parts ?? []) {
       if (p.kind === "text") parts!.push({ type: "text", text: p.text });
-      else if (p.kind === "reasoning") { parts!.push({ type: "reasoning", text: p.text }); reasoningChunks.push(p.text); }
+      // Skip blank reasoning parts so an imported native session never seeds an empty
+      // reasoning block (same invariant the live-turn path enforces in relay/server.ts).
+      else if (p.kind === "reasoning") { if (!p.text.trim()) continue; parts!.push({ type: "reasoning", text: p.text }); reasoningChunks.push(p.text); }
       else if (p.kind === "tool") { const step = toolUseEventToStepDto(p.tool); parts!.push({ type: "tool", step }); toolSteps!.push(step); }
     }
     const hasStructured = toolSteps!.length > 0 || reasoningChunks.length > 0 || parts!.length > 0;

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -177,6 +177,9 @@ export type ControlEventDto =
   | { type: "agent-commands"; chatKey: string; sessionAlias: string; commands: AgentCommandDto[] }
   | { type: "turn-finished"; chatKey: string; sessionAlias: string; ok: boolean; errorMessage?: string; cancelled?: boolean }
   | { type: "sessions-changed" }
+  // The configured workspace set changed (out-of-band CLI edit or `/config`); the web
+  // re-fetches the workspace list. No payload.
+  | { type: "workspaces-changed" }
   | { type: "scheduled-changed"; chatKey: string }
   // Recovered prior conversation for a freshly-attached native session; the hub seeds
   // these rows into the session's history so the dashboard isn't blank.

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -71,6 +71,7 @@ const CONTROL_EVENT_TYPES = new Set([
   "agent-commands",
   "turn-finished",
   "sessions-changed",
+  "workspaces-changed",
   "scheduled-changed",
   "orchestration-changed",
 ]);
@@ -146,7 +147,7 @@ function validControlEvent(e: unknown): boolean {
       && c.commands.every((x) => x !== null && typeof x === "object" && typeof (x as { name?: unknown }).name === "string");
   if (c.type === "tool-event")
     return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && validToolStep(c.step);
-  return true; // sessions-changed / orchestration-changed carry no extra required fields
+  return true; // sessions-changed / workspaces-changed / orchestration-changed carry no extra fields
 }
 
 const NOTICE_KINDS = new Set(["task-completion", "task-progress", "coordinator-message"]);

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -523,3 +523,30 @@ test("a cancelled turn on an unviewed session does NOT mark unread", () => {
   store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "frontend", ok: false, cancelled: true } } as never);
   expect(store.sessionAttention("i1", "frontend")).toBe("idle");
 });
+
+test("blank thought chunks never open an empty reasoning block", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  const ev = (event: unknown) => store.applyEvent({ kind: "control-event", instanceId: "i1", event } as never);
+  ev({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend" });
+  // Some models (e.g. glm-5.2) stream empty / whitespace-only thought deltas.
+  ev({ type: "turn-thought", chatKey: "relay:a1", sessionAlias: "backend", chunk: "" });
+  ev({ type: "turn-thought", chatKey: "relay:a1", sessionAlias: "backend", chunk: "   \n" });
+  ev({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "hi" });
+  ev({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+  const m = store.messages.at(-1)!;
+  expect(m.structured?.reasoning).toBeUndefined();
+  expect((m.structured?.parts ?? []).some((p) => p.type === "reasoning")).toBe(false);
+});
+
+test("whitespace between non-blank reasoning chunks is preserved", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  const ev = (event: unknown) => store.applyEvent({ kind: "control-event", instanceId: "i1", event } as never);
+  ev({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend" });
+  ev({ type: "turn-thought", chatKey: "relay:a1", sessionAlias: "backend", chunk: "line1" });
+  ev({ type: "turn-thought", chatKey: "relay:a1", sessionAlias: "backend", chunk: "\n\n" });
+  ev({ type: "turn-thought", chatKey: "relay:a1", sessionAlias: "backend", chunk: "line2" });
+  ev({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+  expect(store.messages.at(-1)!.structured?.reasoning).toBe("line1\n\nline2");
+});

--- a/packages/relay-web/src/__tests__/instances.test.ts
+++ b/packages/relay-web/src/__tests__/instances.test.ts
@@ -61,6 +61,19 @@ test("applyEvent instance-status loads sessions when an instance comes online", 
   vi.restoreAllMocks();
 });
 
+test("applyEvent workspaces-changed re-fetches the instance's workspace list", async () => {
+  const store = useInstancesStore();
+  store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ workspaces: [{ name: "backend", cwd: "/srv/api" }] });
+  // Simulates `xacpx workspace add` on the instance: the daemon emits workspaces-changed.
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "workspaces-changed" } });
+  await new Promise((r) => setTimeout(r, 0));
+  expect(rpc).toHaveBeenCalledWith("i1", "control.workspaces.list");
+  expect(store.byId("i1")!.workspaces).toEqual([{ name: "backend", cwd: "/srv/api" }]);
+  vi.restoreAllMocks();
+});
+
 test("renameInstance PATCHes the instance and updates local name", async () => {
   const store = useInstancesStore();
   store.instances = [{ id: "i1", name: "old", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -183,7 +183,7 @@ watch(
               <!-- Legacy rows persisted before `parts`: aggregated fallback. -->
               <template v-else>
                 <ToolCallPanel v-if="m.structured?.toolSteps?.length" :steps="m.structured.toolSteps" />
-                <ReasoningPanel v-if="m.structured?.reasoning" :reasoning="m.structured.reasoning" :default-open="false" />
+                <ReasoningPanel v-if="m.structured?.reasoning?.trim()" :reasoning="m.structured.reasoning" :default-open="false" />
                 <StreamMarkdown v-if="m.text" :text="m.text" class="text-[14px] leading-relaxed text-fg" />
               </template>
               <!-- Dedicated action/info row for this record: copy + time + status, on its own line. -->

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -15,7 +15,7 @@ const isLast = (i: number): boolean => props.streaming === true && i === props.p
 <template>
   <div class="space-y-2.5">
     <template v-for="(p, i) in parts" :key="i">
-      <ReasoningPanel v-if="p.type === 'reasoning'" :reasoning="p.text" :streaming="isLast(i)" :default-open="false" />
+      <ReasoningPanel v-if="p.type === 'reasoning' && p.text.trim()" :reasoning="p.text" :streaming="isLast(i)" :default-open="false" />
       <ToolStepCard v-else-if="p.type === 'tool'" :step="p.step" />
       <StreamMarkdown v-else :text="p.text" :streaming="isLast(i)"
                       class="text-[14px] leading-relaxed text-fg" :class="isLast(i) ? 'caret' : ''" />

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -44,8 +44,15 @@ function appendText(parts: TurnPart[], chunk: string): void {
 }
 function appendReasoning(parts: TurnPart[], chunk: string): void {
   const last = parts[parts.length - 1];
-  if (last?.type === "reasoning") last.text += chunk;
-  else parts.push({ type: "reasoning", text: chunk });
+  if (last?.type === "reasoning") {
+    // Block already open: append verbatim so internal whitespace/newlines survive.
+    last.text += chunk;
+    return;
+  }
+  // Don't OPEN a reasoning block on a blank chunk — some models (e.g. glm-5.2) emit
+  // empty/whitespace thought deltas, which otherwise render as an empty "推理" panel.
+  if (!chunk.trim()) return;
+  parts.push({ type: "reasoning", text: chunk });
 }
 function upsertTool(parts: TurnPart[], step: ToolStepDto): void {
   const i = parts.findIndex((p) => p.type === "tool" && p.step.toolCallId === step.toolCallId);

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -204,6 +204,10 @@ export const useInstancesStore = defineStore("instances", () => {
       }
     } else if (event.kind === "control-event" && event.event.type === "sessions-changed") {
       void loadSessions(event.instanceId).catch(() => {});
+    } else if (event.kind === "control-event" && event.event.type === "workspaces-changed") {
+      // A workspace was added/removed/edited on the instance (e.g. `xacpx workspace add`
+      // from the terminal) — re-fetch so the file browser + create-session form reflect it.
+      void loadWorkspaces(event.instanceId).catch(() => {});
     }
   }
 

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -81,8 +81,11 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   };
   const pushReasoningPart = (a: TurnAccumulator, chunk: string) => {
     const last = a.parts[a.parts.length - 1];
-    if (last?.type === "reasoning") last.text = (last.text + chunk).slice(0, REASONING_CAP);
-    else a.parts.push({ type: "reasoning", text: chunk.slice(0, REASONING_CAP) });
+    if (last?.type === "reasoning") { last.text = (last.text + chunk).slice(0, REASONING_CAP); return; }
+    // Don't open a reasoning part on a blank chunk: some models stream empty/whitespace
+    // thought deltas, which would persist as an empty reasoning block in replayed history.
+    if (!chunk.trim()) return;
+    a.parts.push({ type: "reasoning", text: chunk.slice(0, REASONING_CAP) });
   };
   const pushToolPart = (a: TurnAccumulator, step: ToolStepDto) => {
     const i = a.parts.findIndex((p) => p.type === "tool" && p.step.toolCallId === step.toolCallId);
@@ -133,10 +136,13 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
           turnBuffers.delete(k);
           if (!a) return;
           const steps = [...a.steps.values()];
-          const hasStructured = steps.length > 0 || a.reasoning.length > 0;
+          // Treat whitespace-only reasoning as absent: it would otherwise persist as an
+          // empty `structured.reasoning` and render as a blank reasoning panel in history.
+          const hasReasoning = a.reasoning.trim().length > 0;
+          const hasStructured = steps.length > 0 || hasReasoning;
           if (a.text || hasStructured) {
             const structured = hasStructured
-              ? { toolSteps: steps, ...(a.reasoning ? { reasoning: a.reasoning } : {}), ...(a.parts.length ? { parts: a.parts } : {}) }
+              ? { toolSteps: steps, ...(hasReasoning ? { reasoning: a.reasoning } : {}), ...(a.parts.length ? { parts: a.parts } : {}) }
               : undefined;
             messages.append(instanceId, event.sessionAlias, "out", a.text, structured);
           }

--- a/src/config/config-watcher.ts
+++ b/src/config/config-watcher.ts
@@ -1,0 +1,90 @@
+import { watch, type FSWatcher } from "node:fs";
+import { basename, dirname } from "node:path";
+
+import type { AppLogger } from "../logging/app-logger";
+
+export interface ConfigWatcherOptions {
+  /** Absolute path to the config file (e.g. `~/.xacpx/config.json`). */
+  configPath: string;
+  /** Fired (debounced) when the config file is created, replaced, or modified. */
+  onChange: () => void;
+  /** Debounce window to coalesce one logical save's burst of fs events. Default 250ms. */
+  debounceMs?: number;
+  logger?: AppLogger;
+  /** Injection seam for tests; defaults to node:fs `watch`. */
+  watchFactory?: typeof watch;
+}
+
+export interface ConfigWatcher {
+  close: () => void;
+}
+
+/**
+ * Watch the config file for out-of-band edits and fire a debounced callback.
+ *
+ * Why watch the DIRECTORY, not the file: config writes go through
+ * write-file-atomic (temp file + rename), which replaces the target's inode.
+ * An `fs.watch` bound to the original file goes deaf after the first atomic
+ * replace. Watching the containing directory and filtering on the basename
+ * survives every replace.
+ *
+ * The callback is debounced because one logical save emits several directory
+ * events (temp create, rename-into-place, attribute change), and because the
+ * daemon's own writes (web-driven `/config` edits) trip the watcher too — the
+ * caller is expected to no-op when nothing it cares about actually changed.
+ *
+ * Failure to start (exotic/network filesystems where `fs.watch` throws) is
+ * swallowed: the daemon keeps working, operators just fall back to the
+ * pre-existing "restart to pick up CLI edits" behavior.
+ */
+export function startConfigWatcher(options: ConfigWatcherOptions): ConfigWatcher {
+  const { configPath, onChange, debounceMs = 250, logger } = options;
+  const watchFactory = options.watchFactory ?? watch;
+  const dir = dirname(configPath);
+  const target = basename(configPath);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let watcher: FSWatcher | undefined;
+
+  const fire = (): void => {
+    timer = undefined;
+    try {
+      onChange();
+    } catch (error) {
+      void logger?.error("config.watch.callback_failed", "config watch callback threw", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  try {
+    // `persistent: false` so the watcher never keeps the process alive on its own.
+    watcher = watchFactory(dir, { persistent: false }, (_event, filename) => {
+      // `filename` is null on some platforms — when present, ignore unrelated
+      // directory entries (state.json, the lockfile, temp files) so a busy state
+      // write doesn't trigger needless config reloads.
+      if (filename !== null && basename(filename.toString()) !== target) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(fire, debounceMs);
+    });
+    watcher.on("error", (error) => {
+      void logger?.error("config.watch.error", "config watcher errored", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  } catch (error) {
+    void logger?.error("config.watch.start_failed", "could not start config watcher", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return {
+    close: () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      watcher?.close();
+      watcher = undefined;
+    },
+  };
+}

--- a/src/control/control-event-bus.ts
+++ b/src/control/control-event-bus.ts
@@ -22,6 +22,10 @@ export type ControlEvent =
   | { type: "agent-commands"; chatKey: string; sessionAlias: string; commands: AgentCommand[] }
   | { type: "turn-finished"; chatKey: string; sessionAlias: string; ok: boolean; errorMessage?: string; cancelled?: boolean }
   | { type: "sessions-changed" }
+  // The set of configured workspaces changed (e.g. a separate `xacpx workspace add`
+  // CLI process edited config.json, or a `/config` mutation). Carries no payload;
+  // structured consumers re-fetch the workspace list.
+  | { type: "workspaces-changed" }
   | { type: "scheduled-changed"; chatKey: string }
   // Recovered prior conversation for a freshly-attached native session, so the hub can
   // seed it into history. `sessionAlias` is the display alias the web loads history by.

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ import { createControlEventBus } from "./control/control-event-bus";
 import { ControlService } from "./control/control-service";
 import { UploadStore } from "./control/upload-store.js";
 import { listAgentCatalog } from "./config/agent-catalog";
+import { startConfigWatcher } from "./config/config-watcher";
 
 export interface RuntimePaths {
   configPath: string;
@@ -811,6 +812,10 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
       create: async (name, cwd, description) => {
         const updated = await configStore.upsertWorkspace(name, cwd, description);
         replaceRuntimeConfig(config, updated);
+        // Push to every web client (the caller updates optimistically; peers need this).
+        // The config watcher won't double-fire: it diffs against in-memory config, which
+        // replaceRuntimeConfig already refreshed above, so its later event is a no-op.
+        controlEvents.emit({ type: "workspaces-changed" });
         // The persisted values equal the inputs; build the DTO from them directly
         // (avoids an unchecked index read of the freshly-written workspaces map).
         return { name, cwd, ...(description ? { description } : {}) };
@@ -818,10 +823,49 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
       remove: async (name) => {
         const updated = await configStore.removeWorkspace(name);
         replaceRuntimeConfig(config, updated);
+        controlEvents.emit({ type: "workspaces-changed" });
       },
     },
     uploadStore,
   });
+
+  // Pick up out-of-band config edits without a daemon restart. `xacpx workspace add`
+  // (and `agent add`, `/config` from another process) run as separate CLI processes:
+  // they only write config.json and can't reach this daemon's in-memory config, so the
+  // control API — and thus the relay web panel — would serve a stale list until restart.
+  // Reload on file change; when the workspace set actually changed, tell structured
+  // consumers so they re-fetch. The whole config (agents included) is refreshed in
+  // memory either way, so a manual web refresh also reflects out-of-band agent edits.
+  // A collision-free signature of the workspace set (JSON of sorted name/cwd/description
+  // tuples), used to decide whether a config reload actually changed workspaces.
+  const workspaceSignature = (cfg: AppConfig): string =>
+    JSON.stringify(
+      Object.keys(cfg.workspaces)
+        .sort()
+        .map((name) => {
+          const ws = cfg.workspaces[name]!;
+          return [name, ws.cwd, ws.description ?? ""];
+        }),
+    );
+  const configWatcher = startConfigWatcher({
+    configPath: paths.configPath,
+    logger,
+    onChange: () => {
+      const before = workspaceSignature(config);
+      void reloadRuntimeConfig()
+        .then(() => {
+          if (workspaceSignature(config) !== before) {
+            controlEvents.emit({ type: "workspaces-changed" });
+          }
+        })
+        .catch((error) => {
+          void logger.error("config.reload_failed", "failed to reload config after file change", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    },
+  });
+
   const scheduledScheduler = new ScheduledTaskScheduler(scheduledService, {
     dispatchTask: buildScheduledDispatchTask({
       getSession: (alias) => sessions.getSession(alias),
@@ -901,6 +945,7 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
     reapStaleQueueOwners: () => reapWarmQueueOwners("startup"),
     dispose: async () => {
       scheduledScheduler.stop();
+      configWatcher.close();
       clearInterval(uploadCleanupInterval);
       if (progressHeartbeatInterval !== undefined) {
         clearInterval(progressHeartbeatInterval);

--- a/tests/unit/config/config-watcher.test.ts
+++ b/tests/unit/config/config-watcher.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test";
+import type { FSWatcher } from "node:fs";
+
+import { startConfigWatcher } from "../../../src/config/config-watcher";
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// A fake node:fs `watch` that captures the listener so tests can drive directory
+// events synchronously — no real filesystem, no timing flake on the logic paths.
+function fakeWatch() {
+  const state = { closed: 0, watchedPath: "" };
+  let listener: ((event: string, filename: string | null) => void) | undefined;
+  const factory = ((dir: string, _opts: unknown, cb: (e: string, f: string | null) => void) => {
+    state.watchedPath = dir;
+    listener = cb;
+    return { close: () => { state.closed += 1; }, on: () => {} } as unknown as FSWatcher;
+  }) as never;
+  return { factory, state, emit: (filename: string | null) => listener?.("change", filename) };
+}
+
+test("coalesces a burst of events on the config file into one debounced callback", async () => {
+  const fake = fakeWatch();
+  let fired = 0;
+  const w = startConfigWatcher({ configPath: "/x/config.json", onChange: () => { fired += 1; }, debounceMs: 20, watchFactory: fake.factory });
+  // One logical save emits several directory events (temp create, rename, attrs).
+  fake.emit("config.json");
+  fake.emit("config.json");
+  fake.emit("config.json");
+  await delay(50);
+  expect(fired).toBe(1);
+  w.close();
+});
+
+test("ignores changes to unrelated directory entries", async () => {
+  const fake = fakeWatch();
+  let fired = 0;
+  const w = startConfigWatcher({ configPath: "/x/config.json", onChange: () => { fired += 1; }, debounceMs: 20, watchFactory: fake.factory });
+  fake.emit("state.json");
+  fake.emit("config.json.lock");
+  fake.emit("config.json.tmp-12345");
+  await delay(50);
+  expect(fired).toBe(0);
+  w.close();
+});
+
+test("still fires when the platform reports a null filename", async () => {
+  const fake = fakeWatch();
+  let fired = 0;
+  const w = startConfigWatcher({ configPath: "/x/config.json", onChange: () => { fired += 1; }, debounceMs: 20, watchFactory: fake.factory });
+  fake.emit(null);
+  await delay(50);
+  expect(fired).toBe(1);
+  w.close();
+});
+
+test("close() clears a pending callback and closes the underlying watcher", async () => {
+  const fake = fakeWatch();
+  let fired = 0;
+  const w = startConfigWatcher({ configPath: "/x/config.json", onChange: () => { fired += 1; }, debounceMs: 20, watchFactory: fake.factory });
+  fake.emit("config.json");
+  w.close();
+  await delay(50);
+  expect(fired).toBe(0);
+  expect(fake.state.closed).toBe(1);
+});
+
+test("a throwing onChange is swallowed and does not crash the watcher", async () => {
+  const fake = fakeWatch();
+  const w = startConfigWatcher({ configPath: "/x/config.json", onChange: () => { throw new Error("boom"); }, debounceMs: 10, watchFactory: fake.factory });
+  fake.emit("config.json");
+  await delay(40);
+  // No unhandled rejection / throw escaped; reaching here is the assertion.
+  expect(fake.state.closed).toBe(0);
+  w.close();
+});
+
+test("a failing fs.watch start degrades gracefully (no throw, close is a no-op)", () => {
+  const throwingFactory = (() => { throw new Error("ENOSYS: watch not supported"); }) as never;
+  const w = startConfigWatcher({ configPath: "/x/config.json", onChange: () => {}, watchFactory: throwingFactory });
+  expect(() => w.close()).not.toThrow();
+});
+
+test("watches the parent DIRECTORY, not the config file itself", () => {
+  // Config writes go through write-file-atomic (temp + rename), which replaces the
+  // file's inode — a watch bound to the file would go deaf after one save. Watching
+  // the containing directory survives every atomic replace; assert we do exactly that.
+  const fake = fakeWatch();
+  const w = startConfigWatcher({ configPath: "/home/u/.xacpx/config.json", onChange: () => {}, watchFactory: fake.factory });
+  expect(fake.state.watchedPath).toBe("/home/u/.xacpx");
+  w.close();
+});


### PR DESCRIPTION
Fixes two unrelated relay-web defects reported from a live instance.

## 1. CLI-added workspaces never appeared in the web panel

A workspace added on an instance via `xacpx workspace add` did not show up in the relay web dashboard, even after a page refresh.

**Root cause:** `xacpx workspace add` runs as a separate CLI process that only writes `~/.xacpx/config.json`. The running daemon holds a stale in-memory `config` and never reloads it, so the control API — and thus relay-web — kept serving the old workspace list. Refresh didn't help because it re-queries the daemon's stale in-memory copy, not the file.

**Fix (the "1+2 combo"):**
1. **Daemon watches config.json** (`src/config/config-watcher.ts`): watches the file's *directory* (config writes are atomic temp+rename, which swaps the inode and would make a file-bound watch go deaf), debounced 250ms, basename-filtered (ignores `state.json`/lockfiles), degrades gracefully if `fs.watch` throws. On change it reloads the runtime config (agents included).
2. **New `workspaces-changed` control event**: emitted only when the workspace set actually changed, threaded through the event bus → relay-protocol DTOs + `validControlEvent` whitelist → relay-web `applyEvent`, which re-fetches the workspace list. Connector and hub forward control events generically, so no change was needed there. Web-driven create/remove emit it directly for peer clients (the watcher won't double-fire — it diffs against the already-refreshed in-memory config).

## 2. Some reasoning blocks rendered blank

The `glm-5.2` model streams empty/whitespace-only thought deltas, which opened empty "推理" panels.

**Fix:** don't open a reasoning block on a blank chunk — applied at the live path (`chat.ts`), the persisted path (`relay/server.ts` + `turn-finished` guard), and native-session history import (`channel-relay`). Internal whitespace between non-blank chunks is preserved. Render-guarded with `.trim()` in `TurnParts.vue` and `MessageList.vue` as defense in depth.

## Tests
- Config watcher: debounce coalescing, basename filtering, null-filename, `close()` cleanup, graceful start failure, watches-parent-directory.
- `workspaces-changed` re-fetch in the instances store.
- Reasoning blank-skip + internal-whitespace-preservation invariants.

Typechecks clean across core, relay, relay-protocol, channel-relay; full core unit suite + relay-web suite green.

## Shipping note
The workspace-propagation fix spans core (the watcher + emit) and the relay packages (whitelist + web handler), so it needs a **core** release and a **relay** release to reach users' instances. Until then, `xacpx restart` on the instance picks up CLI-added workspaces immediately.

Reviewed by a code-reviewer subagent: verdict *Ready to merge*.