### PR TITLE
fix(orchestration): don't prefix every message with the coordinator user-message label

### DIFF
--- a/src/orchestration/build-coordinator-prompt.ts
+++ b/src/orchestration/build-coordinator-prompt.ts
@@ -262,7 +262,17 @@ export async function buildCoordinatorPrompt(input: {
   }
 
   if (input.userText) {
-    sections.push([t().coordinatorPrompt.userMessageLabel, input.userText].join("\n"));
+    // Only label the user's message when orchestration context precedes it (pending
+    // results, blockers, an active human-question package), so the agent can tell the
+    // injected context apart from the actual message. In an ordinary session with no
+    // such context — including a plain native session — send the text verbatim rather
+    // than prefixing every single message with the label.
+    const hasOrchestrationContext = sections.length > 0;
+    sections.push(
+      hasOrchestrationContext
+        ? [t().coordinatorPrompt.userMessageLabel, input.userText].join("\n")
+        : input.userText,
+    );
   }
 
   const claimHumanReply =

--- a/tests/unit/orchestration/build-coordinator-prompt.test.ts
+++ b/tests/unit/orchestration/build-coordinator-prompt.test.ts
@@ -426,3 +426,43 @@ test("truncates prompt when sections exceed maxPromptLength", async () => {
   expect(result.promptText.length).toBeLessThanOrEqual(1000);
   expect(result.promptText).toContain("...");
 });
+
+test("sends the user's message verbatim (no label) when there is no orchestration context", async () => {
+  // Regression: an ordinary session (no pending results, blockers, or active package)
+  // must NOT get every message prefixed with the "user's latest message" label — that
+  // label only exists to separate the message from injected orchestration context.
+  const result = await buildCoordinatorPrompt({
+    orchestration: {
+      listPendingCoordinatorResults: async () => [],
+    },
+    coordinatorSession: "backend:main",
+    userText: "帮我看看这个函数",
+  });
+
+  expect(result.promptText).toBe("帮我看看这个函数");
+  expect(result.promptText).not.toContain(t().coordinatorPrompt.userMessageLabel);
+  expect(result.taskIds).toEqual([]);
+  expect(result.groupIds).toEqual([]);
+});
+
+test("still labels the user's message when pending results precede it", async () => {
+  const result = await buildCoordinatorPrompt({
+    orchestration: {
+      listPendingCoordinatorResults: async () => [
+        {
+          taskId: "task-1",
+          status: "succeeded",
+          summary: "done",
+          resultText: "result body",
+          createdAt: "2026-04-13T00:00:00.000Z",
+          updatedAt: "2026-04-13T00:00:00.000Z",
+        },
+      ],
+    },
+    coordinatorSession: "backend:main",
+    userText: "继续",
+  });
+
+  expect(result.promptText).toContain(t().coordinatorPrompt.userMessageLabel + "\n继续");
+  expect(result.taskIds).toEqual(["task-1"]);
+});


### PR DESCRIPTION
## Problem

In a plain session (e.g. a native Claude Code session with no delegated tasks), every user message was being sent to the agent prefixed with `用户最新消息：` ("user's latest message:").

## Root cause

`preparePromptWithFallback` (`session-handler.ts`) runs `buildCoordinatorPrompt` on **every** inbound message — it's not gated by coordinator status, and `orchestration` is always wired. Inside the builder, the user-message label was appended **unconditionally**:

```ts
if (input.userText) {
  sections.push([t().coordinatorPrompt.userMessageLabel, input.userText].join("\n"));
}
```

The label only exists to separate the user's message from **injected orchestration context** (pending delegated results, blocker questions, an active human-question package). With no such context, `sections` should have stayed empty and the text sent verbatim — but this line always pushed a section, so the `sections.length > 0 ? … : userText` fallback never fired, and the label leaked onto every message in ordinary sessions.

## Fix

Only label the message when orchestration context precedes it; otherwise send the user's text verbatim.

```ts
const hasOrchestrationContext = sections.length > 0;
sections.push(hasOrchestrationContext
  ? [t().coordinatorPrompt.userMessageLabel, input.userText].join("\n")
  : input.userText);
```

## Tests

- No context → message sent verbatim, no label (regression guard).
- Pending results present → message still labeled.

Full orchestration unit suite + core typecheck green.