### PR TITLE
fix(transport): merge partial ACP tool_call_update frames per toolCallId

### DIFF
--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -11,6 +11,12 @@ export interface StreamingPromptState {
   pendingLine: string;
   formatToolCalls: boolean;
   emittedToolCallIds: Set<string>;
+  // ACP `tool_call_update` frames are PARTIAL: each carries only the fields that
+  // changed, keyed by toolCallId. In particular the terminal (completed/failed)
+  // frame typically omits kind/title/content and only sets status + rawOutput. We
+  // accumulate the merged state per toolCallId so the structured event always
+  // reflects the full call (rich title + diff), not just the last sparse frame.
+  toolCalls: Map<string, MergedToolUpdate>;
   toolEventMode: ToolEventMode;
   // Raw streaming (replyMode "stream"): the consumer renders one live bubble that
   // concatenates chunks verbatim, so we DON'T split on paragraph boundaries or trim.
@@ -105,6 +111,7 @@ export function createStreamingPromptState(
     pendingLine: "",
     formatToolCalls,
     emittedToolCallIds: new Set(),
+    toolCalls: new Map(),
     toolEventMode,
     rawStream,
     onToolEvent,
@@ -168,7 +175,12 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
     // it into text. The transport-level resolveToolEventMode normally prevents
     // this state.
     if (wantsStructured && state.onToolEvent) {
-      const toolEvent = buildToolUseEvent(update);
+      // Merge partial ACP updates per toolCallId so the terminal frame (which omits
+      // kind/title/content) doesn't erase the rich in-progress frame's title + diff.
+      const merged = update.toolCallId
+        ? mergeToolCallUpdate(state, update.toolCallId, update)
+        : update;
+      const toolEvent = buildToolUseEvent(merged);
       if (toolEvent) void state.onToolEvent(toolEvent);
     }
 
@@ -286,6 +298,40 @@ function formatToolCallEvent(update: NonNullable<StreamEvent["params"]>["update"
   const summaryText = inputSummary && inputSummary !== title ? `: ${truncateToolDisplay(inputSummary)}` : "";
   const statusText = status ? ` (${status})` : "";
   return `${emoji} ${title}${statusText}${summaryText}`;
+}
+
+/** Accumulated raw tool-call fields across partial ACP `tool_call_update` frames. */
+export type MergedToolUpdate = NonNullable<NonNullable<StreamEvent["params"]>["update"]>;
+
+/** True for values that carry no information and so must NOT clobber a prior value:
+ *  undefined/null, blank strings, and empty objects/arrays. acpx's initial `tool_call`
+ *  frame ships empty `content: []` / `rawInput: {}`, and a terminal frame omits fields
+ *  entirely — neither should erase data a richer in-progress frame already supplied. */
+function isEmptyToolField(v: unknown): boolean {
+  if (v === undefined || v === null) return true;
+  if (typeof v === "string") return v.trim().length === 0;
+  if (Array.isArray(v)) return v.length === 0;
+  if (typeof v === "object") return Object.keys(v as object).length === 0;
+  return false;
+}
+
+/** Merge a partial update into the per-toolCallId accumulator (present, non-empty
+ *  fields override; absent/empty fields keep the prior value) and return the merged
+ *  view. ACP `tool_call_update` semantics: a frame carries only what changed. */
+function mergeToolCallUpdate(
+  state: StreamingPromptState,
+  toolCallId: string,
+  update: MergedToolUpdate,
+): MergedToolUpdate {
+  const prev = state.toolCalls.get(toolCallId) ?? ({ toolCallId } as MergedToolUpdate);
+  const merged: MergedToolUpdate = { ...prev };
+  for (const key of ["kind", "title", "rawInput", "content", "rawOutput", "locations", "status"] as const) {
+    const next = (update as Record<string, unknown>)[key];
+    if (!isEmptyToolField(next)) (merged as Record<string, unknown>)[key] = next;
+  }
+  merged.toolCallId = toolCallId;
+  state.toolCalls.set(toolCallId, merged);
+  return merged;
 }
 
 function buildToolUseEvent(update: NonNullable<StreamEvent["params"]>["update"]): ToolUseEvent | null {

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -327,3 +327,38 @@ test("a bare tool_call_update (only toolCallId) re-emits the accumulated call", 
   expect(last.toolName).toBe("grep");
   expect(last.rawInput).toEqual({ pattern: "TODO" });
 });
+
+test("interleaved frames for two toolCallIds keep separate accumulators", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, (e) => events.push(e));
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+
+  // Two tools in flight at once; a frame for one must not pollute the other's state.
+  send({ sessionUpdate: "tool_call", toolCallId: "a", kind: "read", title: "Read a.ts", rawInput: { path: "a.ts" }, status: "pending" });
+  send({ sessionUpdate: "tool_call", toolCallId: "b", kind: "search", title: "grep", rawInput: { pattern: "TODO" }, status: "pending" });
+  send({ sessionUpdate: "tool_call_update", toolCallId: "a", status: "completed" }); // partial: only status
+  send({ sessionUpdate: "tool_call_update", toolCallId: "b", status: "completed" }); // partial: only status
+
+  const lastA = [...events].reverse().find((e) => e.toolCallId === "a")!;
+  const lastB = [...events].reverse().find((e) => e.toolCallId === "b")!;
+  expect(lastA).toMatchObject({ toolCallId: "a", kind: "read", toolName: "Read a.ts", status: "success" });
+  expect(lastB).toMatchObject({ toolCallId: "b", kind: "search", toolName: "grep", status: "success" });
+});
+
+test("a search whose terminal frame carries only status keeps its kind/title/query", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, (e) => events.push(e));
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+
+  send({ sessionUpdate: "tool_call", toolCallId: "s1", kind: "search", title: "grep", content: [], rawInput: {}, status: "pending" });
+  send({ sessionUpdate: "tool_call_update", toolCallId: "s1", kind: "search", title: 'grep "TODO" src/', rawInput: { pattern: "TODO", path: "src/" } });
+  send({ sessionUpdate: "tool_call_update", toolCallId: "s1", status: "completed", rawOutput: { matches: 3 } });
+
+  const last = events.at(-1)!;
+  expect(last.kind).toBe("search");
+  expect(last.toolName).toBe('grep "TODO" src/');
+  expect(last.rawInput).toEqual({ pattern: "TODO", path: "src/" });
+  expect(last.status).toBe("success");
+});

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -278,3 +278,52 @@ test("available_commands_update with no array is ignored", () => {
   }));
   expect(seen).toEqual([]);
 });
+
+test("partial ACP tool_call_update frames merge per toolCallId (terminal frame must not erase title/diff)", () => {
+  // Reproduces acpx's real Claude Code edit sequence: a pending frame with empty
+  // payload, an in-progress frame carrying the rich title + diff content, then a
+  // terminal frame that only sets status + rawOutput (no kind/title/content). Before
+  // merging, the terminal frame clobbered the step into a generic kind:"other"
+  // "Tool" with no diff. The final emitted event must retain the edit title + diff.
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, (e) => events.push(e));
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+
+  send({ sessionUpdate: "tool_call", toolCallId: "e1", kind: "edit", title: "Edit", content: [], rawInput: {}, locations: [], status: "pending" });
+  send({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "e1",
+    kind: "edit",
+    title: "Edit skills/preflight.js",
+    content: [{ type: "diff", path: "skills/preflight.js", oldText: "const a = 1;", newText: "const a = 2;" }],
+    rawInput: { file_path: "skills/preflight.js", old_string: "const a = 1;", new_string: "const a = 2;" },
+    locations: [{ path: "skills/preflight.js" }],
+  });
+  // Terminal frame: ACP partial update — only status + rawOutput, no kind/title/content.
+  send({ sessionUpdate: "tool_call_update", toolCallId: "e1", rawOutput: { ok: true }, status: "completed" });
+
+  const last = events.at(-1)!;
+  expect(last.status).toBe("success");
+  expect(last.kind).toBe("edit"); // not clobbered to "other"
+  expect(last.toolName).toBe("Edit skills/preflight.js"); // rich title preserved
+  // The diff content from the in-progress frame survives the terminal frame.
+  expect(last.content).toEqual([
+    { type: "diff", path: "skills/preflight.js", oldText: "const a = 1;", newText: "const a = 2;" },
+  ]);
+  expect(last.rawOutput).toEqual({ ok: true });
+});
+
+test("a bare tool_call_update (only toolCallId) re-emits the accumulated call", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, (e) => events.push(e));
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+
+  send({ sessionUpdate: "tool_call", toolCallId: "s1", kind: "search", title: "grep", rawInput: { pattern: "TODO" }, status: "pending" });
+  send({ sessionUpdate: "tool_call_update", toolCallId: "s1" }); // bare keep-alive frame
+  const last = events.at(-1)!;
+  expect(last.kind).toBe("search");
+  expect(last.toolName).toBe("grep");
+  expect(last.rawInput).toEqual({ pattern: "TODO" });
+});


### PR DESCRIPTION
## Problem

In the relay-web dashboard, tool blocks showed **no meaningful title** (e.g. an edit just said "Tool") and **no diff** for file edits.

## Root cause (confirmed from a real acpx stream recording)

acpx follows ACP semantics: `tool_call_update` frames are **partial** — each carries only the fields that changed. A single edit streams as:

| frame | kind | title | content (diff) |
|---|---|---|---|
| `tool_call` (pending) | `edit` | `"Edit"` | `[]` empty |
| `tool_call_update` | `edit` | `"Edit …/file.js"` | `[{type:"diff",…}]` ← rich data |
| `tool_call_update` (completed) | **absent** | **absent** | **absent** (only `status` + `rawOutput`) |

The structured tool-event path (`streaming-prompt.ts`) built a **standalone `ToolUseEvent` per frame** with no per-`toolCallId` accumulation. Downstream (relay hub + web) merges by `toolCallId` last-write-wins, so the sparse terminal frame **clobbered** the rich in-progress frame → final step degraded to `kind:"other"`, `title:"Tool"`, diff dropped.

## Fix

Accumulate merged tool-call state per `toolCallId` in the streaming parser (present + non-empty fields override; absent/empty fields keep the prior value), and build the structured event from the merged view. The diff renderer in the web already existed — it just never received the data.

## Blast radius (other channels)

- **weixin / yuanbao**: use the legacy inline-text path (`formatToolCalls`), which is **untouched** → zero impact.
- **Feishu**: consumes structured events, but its `ToolUseStore` freezes `toolName`/`kind` on the first frame (identical before/after the merge) and never renders diff `content` → card output **unchanged**.
- **relay/web**: the intended beneficiary.

Verified: full transport suite + feishu + weixin suites green.

## Tests

Regression tests reproduce the real edit frame sequence (pending → in-progress with diff → terminal with only status) and a bare keep-alive frame, asserting the final event keeps `kind:edit` + rich title + diff content.

## Shipping note

This is a **core** fix (daemon transport) — needs a core release + `xacpx restart` on the instance. Adds to the core-release backlog (#66 known-plugins, #67 workspace propagation, #68 coordinator label, + this).