### PR TITLE
feat(relay-web): drag-to-resize the right panel (desktop only)

### DIFF
--- a/packages/relay-web/src/__tests__/resize-panel.test.ts
+++ b/packages/relay-web/src/__tests__/resize-panel.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import { clampPanelWidth, createPanelResize } from "../lib/resize-panel";
+
+describe("clampPanelWidth", () => {
+  it("clamps to the hard bounds and rounds", () => {
+    expect(clampPanelWidth(100, 240, 560)).toBe(240);
+    expect(clampPanelWidth(999, 240, 560)).toBe(560);
+    expect(clampPanelWidth(300.6, 240, 560)).toBe(301);
+  });
+
+  it("caps to a fraction of the viewport when given", () => {
+    // 0.5 * 800 = 400, below max 560 → 400 wins.
+    expect(clampPanelWidth(560, 240, 560, 800, 0.5)).toBe(400);
+  });
+
+  it("never drops below min even when the viewport cap would", () => {
+    // 0.5 * 300 = 150 < min 240 → min wins.
+    expect(clampPanelWidth(500, 240, 560, 300, 0.5)).toBe(240);
+  });
+});
+
+// Minimal event-target stub so the controller is testable without a DOM.
+function makeTarget() {
+  const listeners: Record<string, ((e: any) => void)[]> = {};
+  return {
+    addEventListener(type: string, fn: (e: any) => void) {
+      (listeners[type] ??= []).push(fn);
+    },
+    removeEventListener(type: string, fn: (e: any) => void) {
+      listeners[type] = (listeners[type] ?? []).filter((f) => f !== fn);
+    },
+    emit(type: string, e: any) {
+      for (const fn of listeners[type] ?? []) fn(e);
+    },
+    count(type: string) {
+      return (listeners[type] ?? []).length;
+    },
+  };
+}
+
+describe("createPanelResize (right panel)", () => {
+  it("widens when dragging the left edge leftward", () => {
+    let width = 296;
+    const target = makeTarget();
+    const c = createPanelResize({
+      side: "right",
+      getWidth: () => width,
+      setWidth: (w) => { width = w; },
+      min: 240, max: 560,
+      isEnabled: () => true,
+      target,
+    });
+    c.onPointerDown({ clientX: 500 });
+    target.emit("pointermove", { clientX: 460 }); // moved 40px left → +40 width
+    expect(width).toBe(336);
+    target.emit("pointermove", { clientX: 520 }); // 20px right of start → -20
+    expect(width).toBe(276);
+  });
+
+  it("is a no-op and attaches nothing when disabled", () => {
+    let width = 296;
+    const target = makeTarget();
+    const c = createPanelResize({
+      side: "right",
+      getWidth: () => width,
+      setWidth: (w) => { width = w; },
+      min: 240, max: 560,
+      isEnabled: () => false,
+      target,
+    });
+    c.onPointerDown({ clientX: 500 });
+    expect(target.count("pointermove")).toBe(0);
+    expect(width).toBe(296);
+  });
+
+  it("fires drag callbacks and detaches listeners on release", () => {
+    let width = 296;
+    const target = makeTarget();
+    const onDragStart = vi.fn();
+    const onDragEnd = vi.fn();
+    const c = createPanelResize({
+      side: "right",
+      getWidth: () => width,
+      setWidth: (w) => { width = w; },
+      min: 240, max: 560,
+      isEnabled: () => true,
+      onDragStart, onDragEnd, target,
+    });
+    c.onPointerDown({ clientX: 500 });
+    expect(onDragStart).toHaveBeenCalledOnce();
+    expect(target.count("pointermove")).toBe(1);
+    target.emit("pointerup", {});
+    expect(onDragEnd).toHaveBeenCalledOnce();
+    expect(target.count("pointermove")).toBe(0);
+    expect(target.count("pointerup")).toBe(0);
+    // A stray move after release must not move the panel.
+    target.emit("pointermove", { clientX: 100 });
+    expect(width).toBe(296);
+  });
+
+  it("cleans up on pointercancel (stolen pointer) just like pointerup", () => {
+    let width = 296;
+    const target = makeTarget();
+    const onDragEnd = vi.fn();
+    const c = createPanelResize({
+      side: "right",
+      getWidth: () => width,
+      setWidth: (w) => { width = w; },
+      min: 240, max: 560,
+      isEnabled: () => true,
+      onDragEnd, target,
+    });
+    c.onPointerDown({ clientX: 500 });
+    expect(target.count("pointercancel")).toBe(1);
+    target.emit("pointercancel", {});
+    expect(onDragEnd).toHaveBeenCalledOnce();
+    expect(target.count("pointermove")).toBe(0);
+    expect(target.count("pointerup")).toBe(0);
+    expect(target.count("pointercancel")).toBe(0);
+  });
+
+  it("mirrors direction for a left panel (dragging right widens)", () => {
+    let width = 248;
+    const target = makeTarget();
+    const c = createPanelResize({
+      side: "left",
+      getWidth: () => width,
+      setWidth: (w) => { width = w; },
+      min: 200, max: 480,
+      isEnabled: () => true,
+      target,
+    });
+    c.onPointerDown({ clientX: 300 });
+    target.emit("pointermove", { clientX: 340 }); // 40px right → +40
+    expect(width).toBe(288);
+  });
+});

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -36,6 +36,7 @@ export default {
     closeTasks: "Close tasks",
     hideSidebar: "Hide sidebar",
     showSidebar: "Show sidebar",
+    resizePanel: "Drag to resize panel",
   },
   settings: {
     title: "Settings",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -34,6 +34,7 @@ export default {
     closeTasks: "关闭任务",
     hideSidebar: "隐藏侧栏",
     showSidebar: "显示侧栏",
+    resizePanel: "拖动调整面板宽度",
   },
   settings: {
     title: "设置",

--- a/packages/relay-web/src/lib/resize-panel.ts
+++ b/packages/relay-web/src/lib/resize-panel.ts
@@ -1,0 +1,123 @@
+/**
+ * Drag-to-resize for a static dashboard side column (desktop only).
+ *
+ * The right panel is resized by dragging its LEFT edge: moving the pointer left
+ * widens the panel, moving it right narrows it (mirror logic for a left panel,
+ * which is dragged by its right edge). Width is clamped to [min, max] and
+ * optionally to a fraction of the viewport so the panel can never crowd out the
+ * center column on a narrow desktop window.
+ *
+ * Gated to the static (desktop) layout via `isEnabled` — on the off-canvas
+ * (mobile) layout the side columns are full-height drawers with a fixed width,
+ * so dragging is a no-op and the handle is hidden. Pointer move/up listeners are
+ * attached to `target` (default `window`) only for the duration of a drag, so a
+ * drag that leaves the thin handle still tracks, and they are removed on release.
+ */
+export interface PointerLike {
+  clientX: number;
+}
+
+interface EventTargetLike {
+  addEventListener(type: string, listener: (e: any) => void): void;
+  removeEventListener(type: string, listener: (e: any) => void): void;
+}
+
+export interface PanelResizeOptions {
+  /** Which edge is dragged: a "right" panel is dragged by its left edge. */
+  side: "left" | "right";
+  getWidth: () => number;
+  setWidth: (w: number) => void;
+  /** Hard lower bound (px). */
+  min: number;
+  /** Hard upper bound (px). */
+  max: number;
+  /** Optional extra cap as a fraction of viewport width (e.g. 0.5). */
+  maxViewportFraction?: number;
+  /** Defaults to `window.innerWidth`. */
+  viewportWidth?: () => number;
+  /** Only act when the static (desktop) layout is active. */
+  isEnabled: () => boolean;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
+  /** Event target for move/up listeners; defaults to `window`. */
+  target?: EventTargetLike;
+}
+
+export interface PanelResizeController {
+  onPointerDown(e: PointerLike): void;
+}
+
+/**
+ * Clamp a raw desired width to [min, hi], where hi is `max` further capped to
+ * `floor(viewportWidth * fraction)` when a fraction is given. Rounds to whole
+ * pixels. `min` always wins if the viewport cap would drop below it.
+ */
+export function clampPanelWidth(
+  raw: number,
+  min: number,
+  max: number,
+  viewportWidth?: number,
+  fraction?: number,
+): number {
+  let hi = max;
+  if (fraction != null && viewportWidth != null) {
+    hi = Math.min(hi, Math.floor(viewportWidth * fraction));
+  }
+  if (hi < min) hi = min;
+  if (raw < min) return min;
+  if (raw > hi) return hi;
+  return Math.round(raw);
+}
+
+export function createPanelResize(opts: PanelResizeOptions): PanelResizeController {
+  const viewportWidth = opts.viewportWidth ?? (() => window.innerWidth);
+  const target: EventTargetLike = opts.target ?? (window as unknown as EventTargetLike);
+
+  let startX = 0;
+  let startWidth = 0;
+  let dragging = false;
+
+  function applyWidth(clientX: number): void {
+    // Right panel: dragging left (smaller clientX) widens it. Left panel: the
+    // mirror — dragging right (larger clientX) widens it.
+    const delta = opts.side === "right" ? startX - clientX : clientX - startX;
+    const next = clampPanelWidth(
+      startWidth + delta,
+      opts.min,
+      opts.max,
+      viewportWidth(),
+      opts.maxViewportFraction,
+    );
+    opts.setWidth(next);
+  }
+
+  function onMove(e: PointerLike): void {
+    if (dragging) applyWidth(e.clientX);
+  }
+
+  // Idempotent end-of-drag: detaches every listener and restores global state.
+  // Bound to pointerup AND pointercancel — if the OS/browser steals the pointer
+  // (context menu, touch interruption) only pointercancel fires, and without this
+  // the window listeners would leak and document cursor/user-select stay stuck.
+  function onUp(): void {
+    if (!dragging) return;
+    dragging = false;
+    target.removeEventListener("pointermove", onMove);
+    target.removeEventListener("pointerup", onUp);
+    target.removeEventListener("pointercancel", onUp);
+    opts.onDragEnd?.();
+  }
+
+  function onPointerDown(e: PointerLike): void {
+    if (!opts.isEnabled()) return;
+    dragging = true;
+    startX = e.clientX;
+    startWidth = opts.getWidth();
+    target.addEventListener("pointermove", onMove);
+    target.addEventListener("pointerup", onUp);
+    target.addEventListener("pointercancel", onUp);
+    opts.onDragStart?.();
+  }
+
+  return { onPointerDown };
+}

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -19,6 +19,7 @@ import CommandPalette from "../components/CommandPalette.vue";
 import BrandLogo from "../components/BrandLogo.vue";
 import { useThemeStore } from "../stores/theme";
 import { createEdgeSwipe } from "../lib/edge-swipe";
+import { clampPanelWidth, createPanelResize } from "../lib/resize-panel";
 import { Search, Moon, Sun, Settings, X, Menu, FileText, List, PanelLeftClose, PanelLeftOpen } from "lucide-vue-next";
 
 const theme = useThemeStore();
@@ -71,6 +72,54 @@ function backToFileList() {
 const leftCollapsed = ref(localStorage.getItem("xacpx.leftCollapsed") === "1");
 watch(leftCollapsed, (v) => localStorage.setItem("xacpx.leftCollapsed", v ? "1" : "0"));
 
+// Desktop-only: drag the right panel's left edge to resize it. Mobile keeps the
+// fixed-width off-canvas drawer, so `isDesktop` gates both the handle and the
+// inline width (an inline width would otherwise override the mobile `w-72`).
+const RIGHT_MIN = 240;
+const RIGHT_MAX = 560;
+const RIGHT_DEFAULT = 296;
+const RIGHT_VIEWPORT_FRACTION = 0.5;
+// `matchMedia` is absent in some test/embedded runtimes; treat its absence as
+// "not desktop" so the resize handle and inline width simply don't engage.
+function queryDesktop(): boolean {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    && window.matchMedia("(min-width: 1024px)").matches;
+}
+const isDesktop = ref(queryDesktop());
+const rightWidth = ref(clampPanelWidth(
+  Number(localStorage.getItem("xacpx.rightWidth")) || RIGHT_DEFAULT,
+  RIGHT_MIN, RIGHT_MAX,
+  typeof window !== "undefined" ? window.innerWidth : undefined, RIGHT_VIEWPORT_FRACTION));
+const rightDragging = ref(false);
+watch(rightWidth, (v) => localStorage.setItem("xacpx.rightWidth", String(v)));
+
+const rightResize = createPanelResize({
+  side: "right",
+  getWidth: () => rightWidth.value,
+  setWidth: (w) => { rightWidth.value = w; },
+  min: RIGHT_MIN,
+  max: RIGHT_MAX,
+  maxViewportFraction: RIGHT_VIEWPORT_FRACTION,
+  isEnabled: () => isDesktop.value,
+  // Lock the cursor + suppress text selection for the whole document while
+  // dragging, so a fast drag that outruns the thin handle still feels solid.
+  onDragStart: () => {
+    rightDragging.value = true;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  },
+  onDragEnd: () => {
+    rightDragging.value = false;
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  },
+});
+
+let desktopMql: MediaQueryList | null = null;
+function onDesktopChange(e: MediaQueryListEvent | MediaQueryList) {
+  isDesktop.value = e.matches;
+}
+
 // A file/diff opened from the rail takes over the center column (FileViewer); Back
 // returns to the conversation. On mobile, opening one also closes the right drawer so
 // the viewer is actually visible.
@@ -116,6 +165,11 @@ function onStatus(online: boolean) {
 
 onMounted(async () => {
   window.addEventListener("keydown", onGlobalKey);
+  if (typeof window.matchMedia === "function") {
+    desktopMql = window.matchMedia("(min-width: 1024px)");
+    isDesktop.value = desktopMql.matches;
+    desktopMql.addEventListener("change", onDesktopChange);
+  }
   await instances.loadInstances();
   disconnect = connectEvents((event) => {
     instances.applyEvent(event);
@@ -136,6 +190,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   window.removeEventListener("keydown", onGlobalKey);
+  desktopMql?.removeEventListener("change", onDesktopChange);
   disconnect?.();
 });
 </script>
@@ -246,10 +301,23 @@ onUnmounted(() => {
         <FileViewer v-if="viewingFile" class="absolute inset-0 z-10" @back="backToFileList" @close="closeFileViewer" />
       </div>
 
-      <!-- Right: tasks. Off-canvas drawer < lg, static column ≥ lg. -->
+      <!-- Right: tasks. Off-canvas drawer < lg, static column ≥ lg. On desktop its
+           width is the user-dragged `rightWidth` (inline style overrides lg:w-[296px],
+           which stays as a no-JS fallback); on mobile no inline width is set so the
+           fixed `w-72` drawer width applies. -->
       <div data-test="column" data-drawer="right"
-           class="fixed inset-y-0 right-0 z-40 flex w-72 max-w-[85%] shrink-0 transform flex-col overflow-hidden border-l border-border bg-surface shadow-lg transition-transform pt-[env(safe-area-inset-top)] lg:static lg:z-auto lg:w-[296px] lg:max-w-none lg:translate-x-0 lg:transform-none lg:shadow-none lg:pt-0"
-           :class="rightOpen ? 'translate-x-0' : 'translate-x-full'">
+           class="fixed inset-y-0 right-0 z-40 flex w-72 max-w-[85%] shrink-0 transform flex-col overflow-hidden border-l border-border bg-surface shadow-lg transition-transform pt-[env(safe-area-inset-top)] lg:relative lg:z-auto lg:w-[296px] lg:max-w-none lg:translate-x-0 lg:transform-none lg:shadow-none lg:pt-0"
+           :class="rightOpen ? 'translate-x-0' : 'translate-x-full'"
+           :style="isDesktop ? { width: rightWidth + 'px' } : undefined">
+        <!-- Resize handle: a thin grab strip on the panel's left edge (desktop only).
+             touch-none keeps a touch on it from scrolling; it's hidden < lg anyway.
+             Pointer-only enhancement over the no-JS lg:w-[296px] fallback, so it's
+             aria-hidden (no keyboard/value semantics to honor); the title gives a
+             sighted hover hint. -->
+        <div data-test="right-resize" aria-hidden="true" :title='$t("nav.resizePanel")'
+             class="absolute inset-y-0 left-0 z-20 hidden w-1.5 cursor-col-resize touch-none select-none transition-colors lg:block"
+             :class="rightDragging ? 'bg-accent/50' : 'hover:bg-accent/30'"
+             @pointerdown.prevent="rightResize.onPointerDown" />
         <div class="flex h-9 shrink-0 items-center gap-1 border-b border-border px-2.5">
           <button data-test="right-tab-files"
                   class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11.5px] transition-colors cursor-pointer"


### PR DESCRIPTION
## What

The dashboard's right panel (tasks/files) can now be resized by dragging its **left edge** — desktop only. Drag left = wider, drag right = narrower.

## Behavior

- **Desktop only** (`matchMedia("(min-width: 1024px)")`, mirroring Tailwind's `lg:` breakpoint). On mobile (`<lg`) the panel stays the fixed-width off-canvas drawer — no resize handle, and no inline width to override `w-72`.
- **Clamped width**: hard `[240, 560]px`, further capped to **50% of the viewport** so it can never crowd out the center column (applied on init and on every drag).
- **Persisted** to `localStorage` (`xacpx.rightWidth`) across reloads.
- `matchMedia` absence degrades to "non-desktop" for SSR/test safety.

## Implementation

- New pure, dependency-injected lib `src/lib/resize-panel.ts` (`clampPanelWidth` + `createPanelResize`), same style as the sibling `edge-swipe.ts`. Listeners (`pointermove`/`pointerup`/`pointercancel`) attach on drag start and detach on release — `pointercancel` is handled so a stolen pointer can't leak listeners or leave the document stuck in `col-resize`/non-selectable.
- `DashboardView.vue`: `isDesktop` matchMedia gate (registered/cleaned in `onMounted`/`onUnmounted`), `rightWidth` ref + inline style on the right column, a thin `cursor-col-resize` grab strip (`aria-hidden`, `title` hover hint), and a global cursor/user-select lock during drag.
- i18n: `nav.resizePanel` added to en + zh-CN.

## Tests

- New `src/__tests__/resize-panel.test.ts`: clamp math (bounds, rounding, viewport-fraction cap, min-wins), right/left drag direction, disabled-gate no-op, listener detach on `pointerup` **and** `pointercancel`, drag callbacks.
- `vue-tsc --noEmit` clean; full relay-web suite green (395 tests).

## Review

Reviewed by a subagent before push; one Important (`pointercancel` cleanup) + two Minor (init viewport cap, separator ARIA) findings all fixed.