### PR TITLE
fix(sessions): recreate transport session when re-prompting an archived session

### DIFF
--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -745,6 +745,20 @@ async function promptWithSession(
   // the same key `setArchived` expects.
   if (session.archived) {
     await context.sessions.setArchived(session.alias, false);
+    // Archiving an unshared session cancels + closes its acpx session
+    // (archiveSessionWithTransport). acpx excludes closed records from name lookup,
+    // so checkTransportSession reports the session missing and the next
+    // transport.prompt would throw "No acpx session found" (wrongly telling the user
+    // to re-run /session new). Recreate it here before prompting, but only when it's
+    // actually gone — the shared-transport case (archive left the acpx session
+    // intact) stays promptable and must not be recreated. Concurrent re-prompts to
+    // one session are already serialized by the per-session turn lane, so no extra
+    // lock is needed here. NOTE: ensureSession starts a FRESH acpx session (acpx
+    // can't resume a closed record by name), so the restored conversation resumes
+    // with empty agent context — history is not carried over.
+    if (!(await context.lifecycle.checkTransportSession(session))) {
+      await context.lifecycle.ensureTransportSession(session, reply, perfSpan);
+    }
   }
   const effectiveReplyMode = resolveEffectiveReplyMode(context.config, chatKey, session.replyMode);
   // Ensure the session carries the resolved value so downstream transports

--- a/tests/unit/commands/handlers/session-handler.test.ts
+++ b/tests/unit/commands/handlers/session-handler.test.ts
@@ -93,6 +93,62 @@ test("handlePrompt falls back to getCurrentSession when metadata has no boundSes
   expect(calls.filter((c) => c.startsWith("getByInternal:"))).toHaveLength(0);
 });
 
+function makeArchivedRestoreContext(order: string[], transportExists: boolean) {
+  const archivedSession = {
+    alias: "relay:agent-claude",
+    agent: "claude",
+    workspace: "agent",
+    transportSession: "agent:relay:agent-claude",
+    archived: true,
+  } as any;
+  return {
+    sessions: {
+      getCurrentSession: async (_chatKey: string) => archivedSession,
+      setArchived: async (alias: string, archived: boolean) => {
+        order.push(`setArchived:${alias}:${archived}`);
+      },
+    },
+    orchestration: undefined,
+    config: undefined,
+    logger: { info: async () => {}, warn: async () => {}, error: async () => {}, debug: async () => {} },
+    lifecycle: {
+      checkTransportSession: async () => { order.push("check"); return transportExists; },
+      ensureTransportSession: async () => { order.push("ensure"); },
+    },
+    interaction: {
+      promptTransportSession: async () => { order.push("prompt"); return { text: "ok" }; },
+    },
+    recovery: {},
+  } as any;
+}
+
+test("re-prompting an archived session recreates the torn-down transport before prompting", async () => {
+  // Archiving an unshared session closes its acpx session. Restore-on-message must
+  // recreate it, else transport.prompt throws "No acpx session found" and the user
+  // is wrongly told to re-run /session new (the reported bug).
+  const order: string[] = [];
+  const res = await handlePrompt(makeArchivedRestoreContext(order, /*transportExists*/ false), "relay:agent-claude:u", "hi");
+  expect(res.text).toBe("ok");
+  expect(order).toEqual([
+    "setArchived:relay:agent-claude:false",
+    "check",
+    "ensure",
+    "prompt",
+  ]);
+});
+
+test("re-prompting an archived session whose transport survived (shared) does not re-create it", async () => {
+  const order: string[] = [];
+  const res = await handlePrompt(makeArchivedRestoreContext(order, /*transportExists*/ true), "relay:agent-claude:u", "hi");
+  expect(res.text).toBe("ok");
+  // checkTransportSession reports it still exists → no ensure, just prompt.
+  expect(order).toEqual([
+    "setArchived:relay:agent-claude:false",
+    "check",
+    "prompt",
+  ]);
+});
+
 test("switching to a session with a stored background result appends it", async () => {
   const context = {
     sessions: {


### PR DESCRIPTION
## The bug

Archive a relay session, then send a new message → the agent never runs and the user gets:

> 当前会话「relay:agent-claude」暂时不可用。
> 请先在微信里重新执行：/session new relay:agent-claude --agent claude --ws agent
> …

## Root cause

`archiveSessionWithTransport` cancels **and closes** the acpx session (`acpx sessions close`) when the transport isn't shared. acpx marks the record `closed:true` and **excludes closed records from name lookup** (`matchesSessionEntry`, `includeClosed=false`). Restore-on-message in `promptWithSession` only flipped the logical `archived` flag back off — it never recreated the transport session. So `checkTransportSession` reports it missing and the next `transport.prompt` throws `No acpx session found`, which `renderTransportError` turns into the scary "go re-run `/session new`" hint (the "in WeChat" wording is just the relay path inheriting the shared hint).

## Fix

In the restore-on-message branch, after un-archiving, recreate the transport session before prompting — `ensureTransportSession` **only when** `checkTransportSession` reports it's gone, so the shared-transport case (archive left the acpx session intact) isn't re-created. Concurrent re-prompts to one session are already serialized by the per-session turn lane, so no extra lock is taken.

Sits on the common prompt path → fixes relay / WeChat / Feishu at once. Non-archived prompts are untouched (the branch only runs when `session.archived`).

## Known limitation

acpx can't resume a *closed* record by name (`sessions new` / `sessions ensure` both skip closed records), so `ensureSession` starts a **fresh** acpx session — the restored conversation resumes with **empty agent context** (history not carried over). Preserving history would require capturing the agent session id at archive time and resuming it; tracked as a separate follow-up.

## Tests

`tests/unit/commands/handlers/session-handler.test.ts`:
- archived re-prompt with a missing transport → un-archive, then `check → ensure → prompt`;
- archived re-prompt with a surviving (shared) transport → `check → prompt`, no re-creation.

`npx tsc --noEmit` clean; core unit tests pass.