### PR TITLE
feat(sessions): keep archived sessions resumable so re-prompting continues history

### DIFF
--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -624,8 +624,10 @@ export class CommandRouter {
     };
   }
 
-  /** Archive: close the acpx process (keep history) when no other alias shares the
-   *  transport, then flag the logical session archived. */
+  /** Archive: cancel any in-flight turn (when no other alias shares the transport)
+   *  but keep the acpx session alive and resumable, then flag the logical session
+   *  archived. Re-prompting later resumes the same conversation with full history;
+   *  the warm process idles out via acpx's TTL like any inactive session. */
   async archiveSessionWithTransport(internalAlias: string): Promise<void> {
     const session = await this.sessions.getSession(internalAlias);
     if (!session) {

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -631,8 +631,10 @@ export class CommandRouter {
     if (!session) {
       throw new Error(`session "${internalAlias}" does not exist`);
     }
-    // Archiving cancels+closes acpx; refuse while a turn is in flight so we don't
-    // race (and silently abort) the running prompt.
+    // Archiving cancels any in-flight turn but deliberately KEEPS the acpx session
+    // alive, so re-prompting later resumes the same conversation with full agent
+    // context + history. Refuse while a turn is in flight so we don't race (and
+    // silently abort) the running prompt.
     if (this.activeTurns?.isActiveAnywhere(internalAlias)) {
       throw new Error(`session "${internalAlias}" has a running turn; stop it before archiving`);
     }
@@ -643,17 +645,13 @@ export class CommandRouter {
       } catch {
         /* best-effort */
       }
-      if (this.transport.removeSession) {
-        try {
-          await this.transport.removeSession(session);
-        } catch (error) {
-          await this.logger.error("session.archive_close_failed", "failed to close acpx session on archive", {
-            alias: internalAlias,
-            transportSession: session.transportSession,
-            message: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
+      // NOTE: we intentionally do NOT close the acpx session here. `sessions close`
+      // marks the record `closed`, which acpx excludes from name lookup — the
+      // session then becomes unresumable and the next prompt would start fresh,
+      // losing history (that fallback still lives in the restore-on-message branch
+      // for genuinely-missing sessions). Leaving it open keeps the conversation
+      // resumable on the next message; its warm queue-owner process idles out via
+      // acpx's TTL exactly like any other inactive session.
     }
     await this.sessions.setArchived(internalAlias, true);
   }

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -745,17 +745,16 @@ async function promptWithSession(
   // the same key `setArchived` expects.
   if (session.archived) {
     await context.sessions.setArchived(session.alias, false);
-    // Archiving an unshared session cancels + closes its acpx session
-    // (archiveSessionWithTransport). acpx excludes closed records from name lookup,
-    // so checkTransportSession reports the session missing and the next
-    // transport.prompt would throw "No acpx session found" (wrongly telling the user
-    // to re-run /session new). Recreate it here before prompting, but only when it's
-    // actually gone — the shared-transport case (archive left the acpx session
-    // intact) stays promptable and must not be recreated. Concurrent re-prompts to
-    // one session are already serialized by the per-session turn lane, so no extra
-    // lock is needed here. NOTE: ensureSession starts a FRESH acpx session (acpx
-    // can't resume a closed record by name), so the restored conversation resumes
-    // with empty agent context — history is not carried over.
+    // Archive keeps the acpx session alive (archiveSessionWithTransport only
+    // cancels), so checkTransportSession normally reports it present here and the
+    // prompt resumes the existing conversation with full history. This recreate is a
+    // safety net for the cases where the acpx session really is gone — a session
+    // archived under the old close-on-archive behavior, a manual `sessions close`,
+    // or an acpx crash — where the next transport.prompt would otherwise throw
+    // "No acpx session found" and wrongly tell the user to re-run /session new. Only
+    // recreate when actually missing (a recreated session starts fresh, no history).
+    // Concurrent re-prompts to one session are already serialized by the per-session
+    // turn lane, so no extra lock is needed here.
     if (!(await context.lifecycle.checkTransportSession(session))) {
       await context.lifecycle.ensureTransportSession(session, reply, perfSpan);
     }

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -743,18 +743,24 @@ async function promptWithSession(
   // useSession on the web path, which the chat prompt path bypasses). The guard avoids
   // a needless persist on every normal prompt. `session.alias` is the internal alias,
   // the same key `setArchived` expects.
+  // NOTE: this branch only runs when the session still carries `archived` at prompt
+  // time — i.e. the WeChat/chat path, which reaches handlePrompt directly. The
+  // web/control path calls sessions.useSession() first (ControlService.executeTurn),
+  // and useSession clears `archived`, so this branch is skipped there. That's fine
+  // post-#72: archive keeps the acpx session alive, so the web path's transport.prompt
+  // resumes the existing conversation without needing recreation.
   if (session.archived) {
     await context.sessions.setArchived(session.alias, false);
     // Archive keeps the acpx session alive (archiveSessionWithTransport only
-    // cancels), so checkTransportSession normally reports it present here and the
-    // prompt resumes the existing conversation with full history. This recreate is a
-    // safety net for the cases where the acpx session really is gone — a session
-    // archived under the old close-on-archive behavior, a manual `sessions close`,
-    // or an acpx crash — where the next transport.prompt would otherwise throw
-    // "No acpx session found" and wrongly tell the user to re-run /session new. Only
-    // recreate when actually missing (a recreated session starts fresh, no history).
-    // Concurrent re-prompts to one session are already serialized by the per-session
-    // turn lane, so no extra lock is needed here.
+    // cancels), so checkTransportSession normally reports it present and the prompt
+    // resumes the existing conversation with full history. The recreate is a safety
+    // net for the chat path when the acpx session really is gone (a session archived
+    // under the old close-on-archive build, a manual `sessions close`, or an acpx
+    // crash) — otherwise transport.prompt throws "No acpx session found". A recreated
+    // session starts fresh (no history). The web path doesn't reach this recreate, so
+    // a genuinely-missing session there surfaces the transport error instead; that
+    // only affects pre-#72 closed sessions (a transient migration edge). Concurrent
+    // re-prompts to one session are already serialized by the per-session turn lane.
     if (!(await context.lifecycle.checkTransportSession(session))) {
       await context.lifecycle.ensureTransportSession(session, reply, perfSpan);
     }

--- a/tests/unit/commands/session-archive-delete.test.ts
+++ b/tests/unit/commands/session-archive-delete.test.ts
@@ -62,7 +62,7 @@ test("removeSessionWithTransport leaves the shared transport intact", async () =
   expect(result.sharedAliasCount).toBe(1);
 });
 
-test("archiveSessionWithTransport closes the unshared process then flags archived", async () => {
+test("archiveSessionWithTransport cancels the in-flight turn but KEEPS the acpx session resumable", async () => {
   const sessions = makeSessions({ sharedCount: 0 });
   const transport = makeTransport();
   const router = new CommandRouter(sessions, transport);
@@ -70,7 +70,10 @@ test("archiveSessionWithTransport closes the unshared process then flags archive
   await router.archiveSessionWithTransport("backend:demo");
 
   expect((transport.cancel as ReturnType<typeof mock>).mock.calls.length).toBe(1);
-  expect((transport.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  // Must NOT close: closing marks the acpx record `closed`, making it unresumable
+  // and losing history on the next prompt. The session stays alive so re-prompting
+  // resumes the same conversation.
+  expect((transport.removeSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
   const setArchived = sessions.setArchived as ReturnType<typeof mock>;
   expect(setArchived.mock.calls.length).toBe(1);
   expect(setArchived.mock.calls[0]).toEqual(["backend:demo", true]);


### PR DESCRIPTION
## Goal

Follow-up to #71. Make **re-prompting an archived session continue the same conversation** (full agent context + history), instead of resuming with an empty session.

## Background

#71 fixed the "session unavailable / re-run /session new" error, but because archive ran `acpx sessions close`, the restored session could only be **recreated fresh** — acpx marks closed records `closed` and excludes them from name lookup, so neither `sessions new` nor `sessions ensure` can resume a closed record by name. Result: restore worked, but with empty agent context.

## Change

Archive now **only cancels the in-flight turn and leaves the acpx session alive** (`archiveSessionWithTransport` no longer calls `removeSession`/`sessions close`). So:

- Re-prompting an archived session resumes the **same** conversation with full agent context + history.
- It works **repeatably** (archive → restore → archive → restore), unlike a resume-by-id approach which acpx only honors on the first attach (it wipes the source record's messages on `--resume-session`).
- `checkTransportSession` reports the session present, so the #71 restore-on-message recreate is now a no-op on the happy path. It **stays as a safety net** for sessions that really are gone (archived under the old close behavior, a manual `sessions close`, or an acpx crash) — there it still recreates a fresh session rather than erroring.

## Tradeoff (intentional)

The warm queue-owner process is **no longer freed instantly** on archive. It idles out via acpx's TTL (`transport.queueOwnerTtlSeconds`, default 1800s) — identical to any other inactive session, so this adds no new resource pressure. acpx has no "free the process but keep the record resumable" primitive (`close` is the only teardown and it marks the record unresumable; `--ttl` is a spawn-time arg that can't be retargeted at a running owner), so immediate reclamation is dropped in favor of resumability.

## Known minor

Archived sessions' acpx records now stay open, so they remain visible in the web "attach native session" picker (`listNativeSessionsForControl`). Harmless (it's an explicit power-user action); can be filtered in a follow-up if it proves noisy.

## Tests

`tests/unit/commands/session-archive-delete.test.ts`: archive **cancels but does NOT close** (keeps the session resumable); history still not deleted; shared-transport case unchanged. Restore-on-message safety-net tests (#71) unchanged. `npx tsc --noEmit` clean; full unit suite green (281 files, 0 failures).