### PR TITLE
fix(control): drop the dashboard 'archived' badge when a message restores the session

### DIFF
--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -440,12 +440,26 @@ export class ControlService {
     let resolveSettled!: () => void;
     const settled = new Promise<void>((resolve) => { resolveSettled = resolve; });
     this.inFlight.set(key, { controller, settled });
+    // Sending to an archived session restores it (useSession clears `archived`), but
+    // useSession emits no event — so detect the transition here and emit
+    // `sessions-changed` after, otherwise the dashboard keeps showing a stale
+    // "archived" badge on the row until the next unrelated refresh.
+    let wasArchived = false;
+    try {
+      const internalAlias = await this.deps.sessions.resolveAliasForChat(params.chatKey, params.sessionAlias);
+      wasArchived = (await this.deps.sessions.getSession(internalAlias))?.archived === true;
+    } catch {
+      /* best-effort: a detection failure just means no badge refresh */
+    }
     try {
       await this.deps.sessions.useSession(params.chatKey, params.sessionAlias);
     } catch (error) {
       this.inFlight.delete(key);
       resolveSettled();
       return { ok: false, errorMessage: toErrorMessage(error) };
+    }
+    if (wasArchived) {
+      this.deps.events.emit({ type: "sessions-changed" });
     }
     this.deps.events.emit({
       type: "turn-started",

--- a/tests/unit/control/control-service-prompt.test.ts
+++ b/tests/unit/control/control-service-prompt.test.ts
@@ -65,6 +65,42 @@ test("prompt binds session, streams chunks as events, and reports completion", a
   ]);
 });
 
+function makeControlWithArchived(archived: boolean) {
+  const events = createControlEventBus();
+  const seen: ControlEvent[] = [];
+  events.subscribe((event) => seen.push(event));
+  const control = new ControlService({
+    agent: { chat: async () => ({ text: "ok" }) },
+    sessions: {
+      listAllResolvedSessions: () => [],
+      createSession: async () => { throw new Error("unused"); },
+      removeSession: async () => ({ wasActive: false }),
+      useSession: async () => ({ alias: "backend", agent: "claude", workspace: "/ws" }),
+      resolveAliasForChat: async (_chatKey: string, alias: string) => `relay:${alias}`,
+      getSession: async () => ({ alias: "relay:backend", agent: "claude", workspace: "/ws", archived }),
+    },
+    activeTurns: { isActiveAnywhere: () => false },
+    scheduled: {} as never,
+    orchestration: {} as never,
+    events,
+  } as never);
+  return { control, seen };
+}
+
+test("prompting an archived session emits sessions-changed so the dashboard drops the stale badge", async () => {
+  // useSession un-archives on message but emits nothing; without this the sidebar keeps
+  // showing the "archived" badge until an unrelated refresh.
+  const { control, seen } = makeControlWithArchived(true);
+  await control.prompt({ chatKey: "relay:acct-1", sessionAlias: "backend", text: "hi", senderId: "acct-1" });
+  expect(seen.some((e) => e.type === "sessions-changed")).toBe(true);
+});
+
+test("prompting a non-archived session does NOT emit sessions-changed (no needless refresh)", async () => {
+  const { control, seen } = makeControlWithArchived(false);
+  await control.prompt({ chatKey: "relay:acct-1", sessionAlias: "backend", text: "hi", senderId: "acct-1" });
+  expect(seen.some((e) => e.type === "sessions-changed")).toBe(false);
+});
+
 test("multi-paragraph reply: each segment after the first restores the \\n\\n break", async () => {
   // Regression: the transport strips paragraph boundaries when splitting into
   // trimmed segments. Concatenating bare segments ran paragraphs together; the


### PR DESCRIPTION
## Bug

On the relay dashboard: archive a session, then send it a message. The message goes through and the session is restored server-side — but the **left sidebar keeps showing the "已归档" (archived) badge** on that row until some unrelated refresh.

## Root cause

Sending a message restores an archived session via `sessions.useSession`, which clears the `archived` flag — but `useSession` emits no control event. The dashboard only drops the badge when it receives a `sessions-changed` event (it re-fetches the session list, which then reports `archived: false`). `ControlService.executeTurn` called `useSession` without emitting anything, so the web never learned about the transition.

The explicit unarchive (undo) path (`ControlService.unarchiveSession`) already emits `sessions-changed`; only the restore-on-message path missed it.

## Fix

`executeTurn` now detects the was-archived state **before** `useSession` clears it, and emits `sessions-changed` after — only when the session was actually archived, so normal messages don't trigger a needless session-list refresh. The web already handles `sessions-changed` by reloading sessions (instances store), so no web change is needed.

## Tests

`tests/unit/control/control-service-prompt.test.ts`:
- prompting an archived session emits `sessions-changed`;
- prompting a non-archived session does not.

`npx tsc --noEmit` clean; control prompt/archive suites green.