### PR TITLE
fix(relay-web): scrollable chip strip, consistent model label, flush composer

### DIFF
--- a/packages/relay-web/src/__tests__/model-label.test.ts
+++ b/packages/relay-web/src/__tests__/model-label.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { formatModelLabel } from "../lib/model-label";
+
+describe("formatModelLabel", () => {
+  it("normalizes a bracketed reasoning-effort suffix to model/effort", () => {
+    expect(formatModelLabel("gpt-5.5[high]")).toBe("gpt-5.5/high");
+    expect(formatModelLabel("gpt-5.5[minimal]")).toBe("gpt-5.5/minimal");
+  });
+
+  it("leaves the already-slashed form unchanged", () => {
+    expect(formatModelLabel("gpt-5.5/medium")).toBe("gpt-5.5/medium");
+  });
+
+  it("leaves a bare model id unchanged", () => {
+    expect(formatModelLabel("gpt-5.5")).toBe("gpt-5.5");
+    expect(formatModelLabel("claude-opus-4-8")).toBe("claude-opus-4-8");
+  });
+
+  it("does NOT touch a bracketed suffix that isn't a known effort (e.g. context variant)", () => {
+    expect(formatModelLabel("claude-opus-4-8[1m]")).toBe("claude-opus-4-8[1m]");
+    expect(formatModelLabel("some-model[experimental]")).toBe("some-model[experimental]");
+  });
+});

--- a/packages/relay-web/src/__tests__/promptinput-model.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput-model.test.ts
@@ -29,14 +29,17 @@ it("renders the model chip with the current model and lets you switch", async ()
 
   const chip = w.find('[data-test="model-chip"]');
   expect(chip.exists()).toBe(true);
-  expect(chip.text()).toContain("gpt-5.2[high]");
+  // Display normalizes the bracketed reasoning-effort suffix to model/effort (display only).
+  expect(chip.text()).toContain("gpt-5.2/high");
+  expect(chip.text()).not.toContain("gpt-5.2[high]");
 
   await chip.trigger("click");
   const options = w.findAll('[data-test="model-option"]');
   expect(options.length).toBe(2);
+  expect(options[1].text()).toContain("gpt-5.2/low"); // option label is normalized too
 
   rpc.mockResolvedValueOnce({ ok: true });
-  // pick the second option (gpt-5.2[low])
+  // ...but selecting still sends the RAW agent-advertised id, not the normalized label.
   await options[1].trigger("click");
   await flush();
   expect(rpc).toHaveBeenLastCalledWith("i1", "control.session.model.set", { sessionAlias: "backend", modelId: "gpt-5.2[low]" });

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -94,10 +94,10 @@ const verb = computed(() => {
                   class="flex min-w-0 max-w-[10rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
                   :title='$t("chat.browseFiles")'
                   @click="emit('show-files')"><Folder :size="11" class="shrink-0 text-warn" /><span class="min-w-0 truncate">{{ currentSession.workspace }}</span></button>
-          <span v-if="instance?.name" data-test="ctx-chip-instance"
-                class="flex min-w-0 max-w-[9rem] items-center gap-1 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><span class="shrink-0 font-mono text-accent">@</span><span class="min-w-0 truncate">{{ instance.name }}</span></span>
-          <span v-if="currentSession?.agent" data-test="ctx-chip-agent"
-                class="flex min-w-0 max-w-[9rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><Bot :size="11" class="shrink-0 text-accent" /><span class="min-w-0 truncate">{{ currentSession.agent }}</span></span>
+          <span v-if="instance?.name" data-test="ctx-chip-instance" :title="instance.name"
+                class="flex shrink-0 min-w-0 max-w-[9rem] items-center gap-1 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><span class="shrink-0 font-mono text-accent">@</span><span class="min-w-0 truncate">{{ instance.name }}</span></span>
+          <span v-if="currentSession?.agent" data-test="ctx-chip-agent" :title="currentSession.agent"
+                class="flex shrink-0 min-w-0 max-w-[9rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><Bot :size="11" class="shrink-0 text-accent" /><span class="min-w-0 truncate">{{ currentSession.agent }}</span></span>
           <button v-if="files.gitSummary" data-test="git-summary"
                   class="flex min-w-0 max-w-[13rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
                   :title="files.gitSummary.branch || $t('chat.viewChanges')"

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -89,24 +89,27 @@ const verb = computed(() => {
       <!-- header -->
       <div class="shrink-0 flex min-h-11 lg:h-11 items-center gap-2.5 border-b border-border bg-surface/60 px-3 lg:px-5 py-1.5 lg:py-0 backdrop-blur-md">
         <h1 class="hidden lg:block text-[14px] font-semibold tracking-tight text-fg">{{ chat.sessionAlias }}</h1>
-        <div v-if="currentSession || instance" class="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+        <!-- Chip strip scrolls horizontally (swipe on touch) so long workspace/branch names
+             stay fully readable instead of truncating — title tooltips don't work on touch.
+             Each chip is shrink-0 (natural width); the strip overflows and scrolls. -->
+        <div v-if="currentSession || instance" class="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto no-scrollbar">
           <button v-if="currentSession?.workspace" data-test="ctx-chip-workspace"
-                  class="flex min-w-0 max-w-[10rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
+                  class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
                   :title='$t("chat.browseFiles")'
-                  @click="emit('show-files')"><Folder :size="11" class="shrink-0 text-warn" /><span class="min-w-0 truncate">{{ currentSession.workspace }}</span></button>
-          <span v-if="instance?.name" data-test="ctx-chip-instance" :title="instance.name"
-                class="flex shrink-0 min-w-0 max-w-[9rem] items-center gap-1 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><span class="shrink-0 font-mono text-accent">@</span><span class="min-w-0 truncate">{{ instance.name }}</span></span>
-          <span v-if="currentSession?.agent" data-test="ctx-chip-agent" :title="currentSession.agent"
-                class="flex shrink-0 min-w-0 max-w-[9rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><Bot :size="11" class="shrink-0 text-accent" /><span class="min-w-0 truncate">{{ currentSession.agent }}</span></span>
+                  @click="emit('show-files')"><Folder :size="11" class="shrink-0 text-warn" /><span>{{ currentSession.workspace }}</span></button>
+          <span v-if="instance?.name" data-test="ctx-chip-instance"
+                class="flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><span class="font-mono text-accent">@</span><span>{{ instance.name }}</span></span>
+          <span v-if="currentSession?.agent" data-test="ctx-chip-agent"
+                class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted"><Bot :size="11" class="shrink-0 text-accent" /><span>{{ currentSession.agent }}</span></span>
           <button v-if="files.gitSummary" data-test="git-summary"
-                  class="flex min-w-0 max-w-[13rem] items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
+                  class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
                   :title="files.gitSummary.branch || $t('chat.viewChanges')"
                   @click="files.tab = 'changes'; emit('show-files')">
             <GitBranch :size="11" class="shrink-0 text-warn" />
-            <span v-if="files.gitSummary.branch" class="min-w-0 truncate font-mono">{{ files.gitSummary.branch }}</span>
-            <span v-else-if="files.gitSummary.detached" class="shrink-0 italic">{{ $t("files.detached") }}</span>
+            <span v-if="files.gitSummary.branch" class="font-mono">{{ files.gitSummary.branch }}</span>
+            <span v-else-if="files.gitSummary.detached" class="italic">{{ $t("files.detached") }}</span>
             <span class="h-1 w-1 shrink-0 rounded-full bg-warn" aria-hidden="true" />
-            <span class="shrink-0 text-warn">{{ files.gitSummary.changedCount }} {{ $t("chat.changed") }}</span>
+            <span class="text-warn">{{ files.gitSummary.changedCount }} {{ $t("chat.changed") }}</span>
           </button>
         </div>
       </div>

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -183,10 +183,10 @@ function onInput() {
 </script>
 
 <template>
-  <!-- The iOS home-indicator safe area is handled by the parent composer wrapper (ChatPane)
-       via max(1rem, env(safe-area-inset-bottom)); the form keeps plain symmetric padding here.
-       Applying the inset in both places double-padded the PWA bottom (looked too tall). -->
-  <form class="relative border-t border-border px-0 py-3 lg:p-3" @submit.prevent="submit"
+  <!-- No bottom padding on the form: the parent composer wrapper (ChatPane) owns the bottom
+       spacing via max(1rem, env(safe-area-inset-bottom)), so the composer sits flush above the
+       iOS home indicator (like native input bars) instead of leaving an extra gap below it. -->
+  <form class="relative border-t border-border px-0 pt-3 lg:px-3 lg:pt-3" @submit.prevent="submit"
         @drop.prevent="onDrop" @dragover.prevent>
     <!-- hidden file picker -->
     <input ref="fileInput" type="file" multiple class="hidden" data-test="attach-input" @change="onFilesPicked" />

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -7,6 +7,7 @@ import UsagePopover from "./UsagePopover.vue";
 import { useComposerStore } from "../stores/composer";
 import { useSessionControlsStore } from "../stores/session-controls";
 import { useChatStore } from "../stores/chat";
+import { formatModelLabel } from "../lib/model-label";
 
 const props = defineProps<{ busy?: boolean; draftKey?: string; instanceId?: string | null; sessionAlias?: string | null }>();
 const emit = defineEmits<{ send: [text: string, media: PromptAttachmentRef[]]; cancel: [] }>();
@@ -236,7 +237,7 @@ function onInput() {
                   :disabled="!controls.available.length"
                   @click="modelMenuOpen = !modelMenuOpen">
             <Brain :size="14" class="text-accent" />
-            <span class="font-mono text-[11.5px] font-medium text-fg">{{ controls.current || $t("chat.model") }}</span>
+            <span class="font-mono text-[11.5px] font-medium text-fg">{{ controls.current ? formatModelLabel(controls.current) : $t("chat.model") }}</span>
             <ChevronDown v-if="controls.available.length" :size="13" />
           </button>
           <ul v-if="modelMenuOpen && controls.available.length" data-test="model-menu"
@@ -246,7 +247,7 @@ function onInput() {
                       class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
                       :class="m === controls.current ? 'bg-accent/10 text-accent' : 'hover:bg-fg/10 text-fg-muted'"
                       @click="pickModel(m)">
-                <span class="font-mono">{{ m }}</span>
+                <span class="font-mono">{{ formatModelLabel(m) }}</span>
                 <Check v-if="m === controls.current" :size="14" class="ml-auto" />
               </button>
             </li>

--- a/packages/relay-web/src/lib/model-label.ts
+++ b/packages/relay-web/src/lib/model-label.ts
@@ -1,0 +1,19 @@
+// Known reasoning-effort suffixes. Agents advertise model ids inconsistently — some as
+// `model[high]`, others as `model/medium` — so the composer's model chip looked different
+// across sessions running different adapter versions.
+const EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh", "max"]);
+
+/**
+ * Display label for an agent-advertised model id.
+ *
+ * Normalizes a known reasoning-effort suffix written as `model[effort]` to the `model/effort`
+ * form, so the chip reads consistently regardless of which adapter advertised it. This is
+ * DISPLAY ONLY — callers keep the raw id for selection/comparison and send it back verbatim,
+ * since the agent expects its own id. Bracketed suffixes that are NOT a known effort (e.g. a
+ * context-window variant like `claude-opus-4-8[1m]`) are left untouched.
+ */
+export function formatModelLabel(id: string): string {
+  const m = /^(.+)\[([a-z]+)\]$/.exec(id);
+  if (m && EFFORTS.has(m[2])) return `${m[1]}/${m[2]}`;
+  return id;
+}

--- a/packages/relay-web/src/style.css
+++ b/packages/relay-web/src/style.css
@@ -91,6 +91,10 @@ select:focus-visible, [tabindex]:focus-visible, [role="button"]:focus-visible {
 .thin-scroll::-webkit-scrollbar-thumb { background: rgb(var(--c-fg-muted) / 0.28); border-radius: 8px; }
 .thin-scroll::-webkit-scrollbar-track { background: transparent; }
 
+/* Scrollable strip with no visible scrollbar (e.g. the header chip row — swipe on touch). */
+.no-scrollbar { scrollbar-width: none; -ms-overflow-style: none; }
+.no-scrollbar::-webkit-scrollbar { display: none; }
+
 @media (prefers-reduced-motion: reduce) {
   .pulse-dot, .shimmer-text, .caret::after { animation: none !important; }
 }


### PR DESCRIPTION
## Summary

Dashboard polish from PWA/Safari screenshots. relay-web-only (no protocol/core changes).

### 1. Workspace chips no longer starved to one letter
The header chip row was `flex-1 overflow-hidden` with every chip `min-w-0 truncate` and no shrink priority, so a long branch made flexbox shrink **all** chips — `codex` → `c…`, account → `MacBo…`.

Fix: make the chip strip **horizontally scrollable** (`overflow-x-auto` + a new hidden-scrollbar `.no-scrollbar` util), chips at natural width (`shrink-0`, no truncation). Long workspace/branch names stay fully readable via swipe — better than truncate+tooltip because `title` tooltips don't fire on touch.

Trade-off: when the strip overflows, the trailing `N 处改动` count can sit off-screen until you swipe. Easy to pin if preferred.

### 2. Consistent model + reasoning-effort label
The model chip showed `gpt-5.5[high]` vs `gpt-5.5/medium` across sessions. **Not a relay-web bug:** `session-controls` stores the agent-advertised `current`/`available` strings verbatim and echoes the raw id back on `set`; the format is whatever the codex-acp adapter sends (older `model[effort]`, newer `model/effort`).

New `formatModelLabel()` normalizes a **known reasoning-effort** bracket suffix to `model/effort` for **display only** (chip + menu); the **raw id is still sent on selection**. Non-effort brackets (e.g. context variant `claude-opus-4-8[1m]`) are left untouched. Real unification is upstream (the adapter).

### 3. Composer sits flush above the iOS home indicator
Follow-up to the 0.9.3 bottom-gap fix. That release de-stacked the safe-area inset but the form still added 12px below the wrapper's `max(1rem, env(safe-area-inset-bottom))`, so the PWA composer floated ~46px up. Dropped the form's bottom padding so the wrapper's inset is the sole bottom spacing — the composer now sits flush at the safe-area top (~34px, like native input bars). Desktop ~16px.

## Test plan
- New `model-label.test.ts` (4 cases incl. the `[1m]` guard).
- Updated `promptinput-model.test.ts`: chip/menu show normalized label, selection sends the **raw** id.
- `chatpane.test.ts` / `promptinput.test.ts` green.
- Full relay-web suite green; `vue-tsc` + `vite build` clean; `.no-scrollbar` present in built CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
