### PR TITLE
fix(relay-web): mobile file viewer + scheduled-task input layout

### DIFF
--- a/packages/relay-web/src/components/FileViewer.vue
+++ b/packages/relay-web/src/components/FileViewer.vue
@@ -66,11 +66,11 @@ function fmtSize(n?: number): string {
     <!-- header: back + path + meta -->
     <div class="flex h-11 shrink-0 items-center gap-2 border-b border-border bg-surface/60 px-3 backdrop-blur-md">
       <button data-test="fv-back-list" :aria-label="$t('files.backToList')"
-              class="flex lg:hidden items-center gap-1.5 rounded-md px-2 py-1 text-[12px] font-medium text-fg-muted transition-colors hover:bg-raised hover:text-fg"
-              @click="emit('back')"><ArrowLeft :size="14" />{{ $t("files.title") }}</button>
+              class="flex lg:hidden shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2 py-1 text-[12px] font-medium text-fg-muted transition-colors hover:bg-raised hover:text-fg"
+              @click="emit('back')"><ArrowLeft :size="14" class="shrink-0" />{{ $t("files.title") }}</button>
       <button data-test="fv-back" :aria-label="$t('files.back')"
-              class="hidden lg:flex items-center gap-1.5 rounded-md px-2 py-1 text-[12px] font-medium text-fg-muted transition-colors hover:bg-raised hover:text-fg"
-              @click="emit('close')"><ArrowLeft :size="14" />{{ $t("files.back") }}</button>
+              class="hidden lg:flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2 py-1 text-[12px] font-medium text-fg-muted transition-colors hover:bg-raised hover:text-fg"
+              @click="emit('close')"><ArrowLeft :size="14" class="shrink-0" />{{ $t("files.back") }}</button>
       <span class="h-4 w-px bg-border" aria-hidden="true" />
       <template v-if="files.file">
         <FileText :size="14" class="shrink-0 text-accent" />

--- a/packages/relay-web/src/components/ScheduledTasks.vue
+++ b/packages/relay-web/src/components/ScheduledTasks.vue
@@ -61,7 +61,7 @@ async function create() {
     <form v-if="composerOpen" data-test="scheduled-composer" class="mt-2 space-y-2 rounded-lg border border-border bg-bg p-2.5" @submit.prevent="create">
       <label class="flex flex-col gap-1">
         <span class="text-[10px] font-semibold uppercase tracking-wide text-fg-muted">{{ $t("tasks.whenLabel") }}</span>
-        <input v-model="executeAt" type="datetime-local" class="w-full rounded-md border border-border bg-surface px-2 py-1 text-xs text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent" />
+        <input v-model="executeAt" type="datetime-local" class="w-full min-w-0 rounded-md border border-border bg-surface px-2 py-1 text-xs text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent" />
       </label>
       <label class="flex flex-col gap-1">
         <span class="text-[10px] font-semibold uppercase tracking-wide text-fg-muted">{{ $t("tasks.messageLabel") }}</span>

--- a/packages/relay-web/src/style.css
+++ b/packages/relay-web/src/style.css
@@ -111,7 +111,7 @@ select:focus-visible, [tabindex]:focus-visible, [role="button"]:focus-visible {
 }
 .shiki {
   margin: 0;
-  padding: 0.75rem 1rem;
+  padding: 0.75rem;
   overflow-x: auto;
   font-size: 12.5px;
   line-height: 1.6;
@@ -120,9 +120,11 @@ select:focus-visible, [tabindex]:focus-visible, [role="button"]:focus-visible {
   display: grid;
   counter-reset: shiki-ln;
 }
+/* Line-number gutter: keep it tight so code isn't pushed far from the left edge on
+   narrow (mobile) viewports. Width fits up to 4 digits (LINE_GUTTER_LIMIT = 5000). */
 .shiki code .line {
   position: relative;
-  padding-left: 3.25rem;
+  padding-left: 2.75rem;
   min-height: 1.6em;
 }
 .shiki code .line::before {
@@ -130,8 +132,22 @@ select:focus-visible, [tabindex]:focus-visible, [role="button"]:focus-visible {
   content: counter(shiki-ln);
   position: absolute;
   left: 0;
-  width: 2.75rem;
+  width: 2.25rem;
   text-align: right;
   opacity: 0.45;
   user-select: none;
+}
+
+/* iOS Safari gives <input type="datetime-local"> an intrinsic min content width
+   that overflows a width:100% flex parent (the scheduled-task composer). Resetting
+   -webkit-appearance lets width:100% take effect. Scoped to iOS Safari via the
+   iOS-only -webkit-touch-callout feature so desktop keeps its native picker chrome. */
+@supports (-webkit-touch-callout: none) {
+  input[type="datetime-local"],
+  input[type="date"],
+  input[type="time"] {
+    -webkit-appearance: none;
+    appearance: none;
+    min-width: 0;
+  }
 }


### PR DESCRIPTION
Three mobile/PWA UI fixes in the relay-web dashboard (reported from iOS screenshots).

## Issues

1. **`datetime-local` overflows the scheduled-task composer** — iOS Safari gives `<input type=datetime-local>` an intrinsic min content width that ignores `width:100%`, so the 时间 field spilled past its rounded container. Reset `-webkit-appearance` (iOS-scoped via `@supports(-webkit-touch-callout: none)` so desktop keeps its native picker chrome) + `min-w-0`.
2. **Syntax-highlight left gutter too wide on mobile** — the Shiki line-number gutter + indent + padding pushed code ~4.25rem off the left edge, wasting ~18% of a phone's width. Tightened gutter width 2.75→2.25rem, indent 3.25→2.75rem, `.shiki` padding 1→0.75rem. Still fits 4-digit line numbers (LINE_GUTTER_LIMIT = 5000).
3. **File viewer back button wraps to two lines** (文件 / 返回 stacked) — the button had no `shrink-0`/`whitespace-nowrap`, so a long file path squeezed it. Added both + `shrink-0` on the icon.

## Verification
- `npx vitest run` — 410/410 pass
- `npm run build` — clean; Shiki language chunks stay code-split (dynamic import preserved)