### PR TITLE
fix: Codex terminal tool output (channel-relay) + desktop swipe stickiness (relay-web)

### DIFF
--- a/packages/channel-relay/src/tool-presentation.ts
+++ b/packages/channel-relay/src/tool-presentation.ts
@@ -87,6 +87,11 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
   // acpx may emit a scalar (bare string/number) rawOutput; rec() yields {} for those,
   // so keep the scalar form as a last-resort text fallback below.
   const rawOutputText = asString(event.rawOutput);
+  // Codex routes execute/search/read all through a terminal: the tool_call content is
+  // [{type:"terminal",…}] (no inline text) and the result lands in
+  // rawOutput.formatted_output (with exit status in rawOutput.exit_code) rather than
+  // stdout/text or a content block. Treat formatted_output as a first-class output text.
+  const terminalOut = asString(output.formatted_output);
   const pc = parsedCmd0(input);
   const fallbackTitle = event.summary ?? event.toolName;
   // On failure, surface the agent/tool error message so the web can show it in red.
@@ -94,7 +99,7 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
   // block, or the generic output field.
   const errMsg =
     event.status === "error"
-      ? asString(output.error) ?? asString(output.message) ?? textFromBlocks(blocks) ?? asString(output.output) ?? asString(output.text) ?? rawOutputText
+      ? asString(output.error) ?? asString(output.message) ?? textFromBlocks(blocks) ?? asString(output.output) ?? asString(output.text) ?? terminalOut ?? rawOutputText
       : undefined;
   const base: Omit<ToolStepDto, "title" | "detail"> = {
     toolCallId: event.toolCallId,
@@ -119,22 +124,22 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
   if (event.kind === "read") {
     const path = asString(input.file_path) ?? asString(input.path) ?? asString(pc?.name) ?? locationPath(event) ?? fallbackTitle;
     const lines = readLines(input);
-    const preview = textFromBlocks(blocks) ?? asString(output.text) ?? rawOutputText;
+    const preview = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
     const detail: ToolDetailDto = { type: "read", path, ...(lines ? { lines } : {}), ...(preview ? { preview: cap(preview) } : {}) };
     return { ...base, title: path, detail };
   }
 
   if (event.kind === "execute") {
     const command = asString(input.command) ?? asString(input.cmd) ?? asString(pc?.cmd) ?? fallbackTitle;
-    const out = asString(output.stdout) ?? textFromBlocks(blocks) ?? asString(output.text) ?? rawOutputText;
-    const exitCode = typeof output.exitCode === "number" ? output.exitCode : undefined;
+    const out = asString(output.stdout) ?? terminalOut ?? textFromBlocks(blocks) ?? asString(output.text) ?? rawOutputText;
+    const exitCode = typeof output.exitCode === "number" ? output.exitCode : typeof output.exit_code === "number" ? output.exit_code : undefined;
     const detail: ToolDetailDto = { type: "command", command, ...(out ? { output: cap(out) } : {}), ...(exitCode !== undefined ? { exitCode } : {}) };
     return { ...base, title: command, detail };
   }
 
   if (event.kind === "search") {
     const query = asString(input.query) ?? asString(input.pattern) ?? asString(input.search) ?? asString(input.command) ?? asString(pc?.cmd) ?? fallbackTitle;
-    const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? asString(output.text) ?? rawOutputText;
+    const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
     const detail: ToolDetailDto = { type: "search", query, ...(out ? { output: cap(out) } : {}) };
     return { ...base, title: query, detail };
   }
@@ -144,6 +149,6 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
     return { ...base, title: fallbackTitle, detail: { type: "text", text: cap(text) } };
   }
 
-  const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? asString(output.text) ?? rawOutputText;
+  const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
   return { ...base, title: fallbackTitle, detail: { type: "fields", fields: primitiveFields(input), ...(out ? { output: cap(out) } : {}) } };
 }

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -120,6 +120,18 @@ describe("InstanceTree session management", () => {
     expect(archive).toHaveBeenCalledWith("i1", "backend");
   });
 
+  it("ignores desktop mouse drags for the touch swipe actions", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const track = w.find('[data-test="swipe-track"]');
+    await track.trigger("pointerdown", { clientX: 200, clientY: 0, pointerType: "mouse", buttons: 1 });
+    await track.trigger("pointermove", { clientX: 80, clientY: 0, pointerType: "mouse", buttons: 1 });
+    await track.trigger("pointerup", { clientX: 80, clientY: 0, pointerType: "mouse", buttons: 0 });
+    await flushPromises();
+    expect(track.attributes("style")).toContain("translateX(0)");
+  });
+
   // The revealed delete block opens the destructive confirm only on tap — never on the
   // swipe itself, and never deletes until confirmed.
   it("tapping the revealed delete block asks to delete (not on swipe)", async () => {

--- a/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
+++ b/packages/relay-web/src/__tests__/use-swipe-actions.test.ts
@@ -27,6 +27,38 @@ describe("useSwipeActions", () => {
     handlers.pointerup(pointer(120));
     expect(onEnd).toHaveBeenCalledWith(-80);
   });
+  it("captures the pointer during a drag so release outside the row still ends it", () => {
+    const onMove = vi.fn(), onEnd = vi.fn();
+    const target = { setPointerCapture: vi.fn(), releasePointerCapture: vi.fn() };
+    const { handlers } = useSwipeActions({ onMove, onEnd });
+    handlers.pointerdown({ ...pointer(200), pointerId: 7, currentTarget: target, buttons: 1 });
+    expect(target.setPointerCapture).toHaveBeenCalledWith(7);
+    handlers.pointermove({ ...pointer(120), buttons: 1 });
+    handlers.pointerup({ ...pointer(120), pointerId: 7, buttons: 0 });
+    expect(onMove).toHaveBeenCalledWith(-80);
+    expect(onEnd).toHaveBeenCalledWith(-80);
+    expect(target.releasePointerCapture).toHaveBeenCalledWith(7);
+  });
+  it("ends a mouse drag if pointerup was missed and buttons is already 0", () => {
+    const onMove = vi.fn(), onEnd = vi.fn();
+    const { handlers } = useSwipeActions({ onMove, onEnd });
+    handlers.pointerdown({ ...pointer(200), buttons: 1 });
+    handlers.pointermove({ ...pointer(140), buttons: 1 });
+    handlers.pointermove({ ...pointer(110), buttons: 0 });
+    handlers.pointerup({ ...pointer(110), buttons: 0 }); // stray up must not re-fire
+    expect(onMove).toHaveBeenCalledWith(-60);
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledWith(-90);
+  });
+  it("ignores pointer types outside the configured allow-list", () => {
+    const onMove = vi.fn(), onEnd = vi.fn();
+    const { handlers } = useSwipeActions({ pointerTypes: ["touch", "pen"], onMove, onEnd });
+    handlers.pointerdown({ ...pointer(200), pointerType: "mouse", buttons: 1 });
+    handlers.pointermove({ ...pointer(120), pointerType: "mouse", buttons: 1 });
+    handlers.pointerup({ ...pointer(120), pointerType: "mouse", buttons: 0 });
+    expect(onMove).not.toHaveBeenCalled();
+    expect(onEnd).not.toHaveBeenCalled();
+  });
   it("yields to vertical scroll: no move, ends with 0", () => {
     const onMove = vi.fn(), onEnd = vi.fn();
     const { handlers } = useSwipeActions({ onMove, onEnd });

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -137,6 +137,7 @@ const rowSwipes = computed(() => {
       const key = `${inst.id}:${s.alias}`;
       const reveal = revealPx(s);
       map[key] = useSwipeActions({
+        pointerTypes: ["touch", "pen"],
         onMove: (dx) => { openMenuFor.value = null; draggingKey.value = key; dragDx.value = dx; },
         onEnd: (dx) => {
           // Snap open if the row ended past the halfway point, else closed.

--- a/packages/relay-web/src/lib/use-swipe-actions.ts
+++ b/packages/relay-web/src/lib/use-swipe-actions.ts
@@ -10,6 +10,21 @@ export interface SwipeActionsOptions {
   /** Px of movement before the gesture commits to an axis (default 4). Below this
    *  a tap stays a tap and never starts a drag. */
   intent?: number;
+  /** Optional PointerEvent.pointerType allow-list. Missing pointerType is allowed
+   *  so unit tests and synthetic callers can keep feeding plain coordinate objects. */
+  pointerTypes?: string[];
+}
+
+interface SwipePointerEvent {
+  clientX: number;
+  clientY: number;
+  buttons?: number;
+  pointerId?: number;
+  pointerType?: string;
+  currentTarget?: {
+    setPointerCapture?: (pointerId: number) => void;
+    releasePointerCapture?: (pointerId: number) => void;
+  } | null;
 }
 
 /** Interactive horizontal-swipe detector for a list row. Reports a live delta so
@@ -19,17 +34,59 @@ export function useSwipeActions(opts: SwipeActionsOptions) {
   const intent = opts.intent ?? 4;
   let startX = 0, startY = 0;
   let dragging = false, decided = false, horizontal = false;
+  let pointerId: number | null = null;
+  let captureTarget: SwipePointerEvent["currentTarget"] = null;
+
+  function capturePointer(e: SwipePointerEvent) {
+    pointerId = typeof e.pointerId === "number" ? e.pointerId : null;
+    captureTarget = e.currentTarget ?? null;
+    if (pointerId === null) return;
+    try {
+      captureTarget?.setPointerCapture?.(pointerId);
+    } catch {
+      // Best effort only: tests/jsdom and some synthetic events do not support capture.
+    }
+  }
+
+  function releasePointer() {
+    if (pointerId === null) return;
+    try {
+      captureTarget?.releasePointerCapture?.(pointerId);
+    } catch {
+      // The browser may already have released capture after pointerup/cancel.
+    } finally {
+      pointerId = null;
+      captureTarget = null;
+    }
+  }
+
+  function end(dx: number) {
+    if (!dragging) return;
+    dragging = false;
+    decided = false;
+    horizontal = false;
+    releasePointer();
+    opts.onEnd?.(dx);
+  }
 
   // Keys MUST be bare DOM event names (`pointerdown`, not `onPointerdown`): the row
   // binds these via `v-on="handlers"`, and Vue's object-`v-on` re-applies the `on`
   // prefix itself. An `onPointerdown` key would be re-prefixed to a dead event and
   // the swipe would silently never fire.
-  function pointerdown(e: { clientX: number; clientY: number }) {
+  function pointerdown(e: SwipePointerEvent) {
+    if (e.pointerType && opts.pointerTypes && !opts.pointerTypes.includes(e.pointerType)) return;
     startX = e.clientX; startY = e.clientY;
     dragging = true; decided = false; horizontal = false;
+    capturePointer(e);
   }
-  function pointermove(e: { clientX: number; clientY: number }) {
+  function pointermove(e: SwipePointerEvent) {
     if (!dragging) return;
+    if (e.buttons === 0) {
+      // Mouse fallback: if pointerup was missed (e.g. released outside the row and
+      // capture was unavailable), the next hover/move must still terminate the drag.
+      end(horizontal ? e.clientX - startX : 0);
+      return;
+    }
     const dx = e.clientX - startX, dy = e.clientY - startY;
     if (!decided) {
       if (Math.abs(dx) < intent && Math.abs(dy) < intent) return; // still a tap
@@ -38,23 +95,18 @@ export function useSwipeActions(opts: SwipeActionsOptions) {
     }
     if (!horizontal) {
       // Vertical-dominant → yield to the scroll container and end the gesture.
-      dragging = false;
-      opts.onEnd?.(0);
+      end(0);
       return;
     }
     opts.onMove?.(dx);
   }
-  function pointerup(e: { clientX: number; clientY: number }) {
-    if (!dragging) return;
-    dragging = false;
-    opts.onEnd?.(horizontal ? e.clientX - startX : 0);
+  function pointerup(e: SwipePointerEvent) {
+    end(horizontal ? e.clientX - startX : 0);
   }
   // The browser fires `pointercancel` (and no `pointerup`) when it reclassifies the
   // drag as a scroll/gesture. End cleanly so a row is never left mid-drag.
   function pointercancel() {
-    if (!dragging) return;
-    dragging = false;
-    opts.onEnd?.(0);
+    end(0);
   }
 
   return { handlers: { pointerdown, pointermove, pointerup, pointercancel } };

--- a/tests/unit/packages/channel-relay/tool-presentation.test.ts
+++ b/tests/unit/packages/channel-relay/tool-presentation.test.ts
@@ -22,6 +22,40 @@ test("execute reads command + stdout + exit code", () => {
   expect(step.detail).toEqual({ type: "command", command: "npm test", output: "12 passed", exitCode: 0 });
 });
 
+test("execute reads Codex terminal result (formatted_output + exit_code)", () => {
+  // Codex runs the command in a terminal: content is a bare terminal block with no
+  // text, and the result lands in rawOutput.formatted_output / exit_code (snake_case).
+  const step = toolUseEventToStepDto({
+    toolCallId: "tc1", toolName: "shell", kind: "execute", status: "success",
+    summary: "git status --short",
+    content: [{ type: "terminal", terminalId: "tc1" }],
+    rawInput: { command: "git status --short", cwd: "/repo" },
+    rawOutput: { formatted_output: " M src/a.ts\n?? b.ts", exit_code: 0 },
+  });
+  expect(step.title).toBe("git status --short");
+  expect(step.detail).toEqual({ type: "command", command: "git status --short", output: " M src/a.ts\n?? b.ts", exitCode: 0 });
+});
+
+test("search shows Codex terminal output even with empty rawInput", () => {
+  // Codex search frames carry no rawInput/content; the query is only in the title,
+  // and the matches arrive in rawOutput.formatted_output.
+  const step = toolUseEventToStepDto({
+    toolCallId: "tc2", toolName: "shell", kind: "search", status: "success",
+    summary: "Search for 'session' in relay-web",
+    rawOutput: { formatted_output: "a.ts:1:session\nb.ts:9:session", exit_code: 0 },
+  });
+  expect(step.detail).toEqual({ type: "search", query: "Search for 'session' in relay-web", output: "a.ts:1:session\nb.ts:9:session" });
+});
+
+test("read (list) shows Codex terminal output as the preview", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "tc3", toolName: "shell", kind: "read", status: "success",
+    summary: "List files in 'relay-web'",
+    rawOutput: { formatted_output: "src/main.ts\nsrc/App.vue", exit_code: 0 },
+  });
+  expect(step.detail).toMatchObject({ type: "read", path: "List files in 'relay-web'", preview: "src/main.ts\nsrc/App.vue" });
+});
+
 test("read derives path from file_path and a content array preview", () => {
   const step = toolUseEventToStepDto({
     toolCallId: "t3", toolName: "Read", kind: "read", status: "success",


### PR DESCRIPTION
Two independent fixes, bundled for one release pass. They ship in **different packages** → two tags after merge: `channel-relay-v0.3.1` (connector) and `relay-v0.9.6` (hub bundles relay-web).

---

## 1. channel-relay — Codex terminal tool output dropped

In the relay-web dashboard, Codex **search / command / read** tool steps render their title but an **empty body**. Only `edit` steps show detail.

**Root cause:** Codex routes execute/search/read **through a terminal**: `tool_call` content is `[{type:"terminal",…}]` (no inline text) and the result lands in `rawOutput.formatted_output` (exit status in `rawOutput.exit_code`), not `stdout`/`text` or a content block. The connector's mapper (`packages/channel-relay/src/tool-presentation.ts`) only checked `stdout`/`text`/content blocks, so output was dropped. `edit` survived because it carries a `diff` block. Verified against a real Codex ACP stream.

**Fix:** add `formatted_output` to the output fallback chains (execute/search/read/generic/error) + read `exit_code` alongside `exitCode`. Other agents and `edit` diffs unchanged. 3 new tests; `tool-presentation.test.ts` 15/15.

## 2. relay-web — session-row swipe sticks after a desktop mouse drag

On desktop (mouse), dragging a session row left and releasing left it stuck mid-drag.

**Fix:** restrict the InstanceTree session-row swipe to touch/pen pointers (`pointerTypes: ['touch','pen']`) so a mouse never starts a drag; harden the pointer lifecycle in `useSwipeActions` (set/release pointer capture; `buttons===0` fallback so a missed pointerup still ends the gesture). Tests 25/25.

---

## Deploy notes
- **channel-relay** runs console-side: republish + reinstall connector plugin + restart console.
- **relay-web** is bundled into the hub: `xacpx update && xacpx restart`.