### PR TITLE
fix(transport): hide Codex subagent threads from agent session lists

### DIFF
--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -15,6 +15,7 @@ import { deriveParentPackageName } from "../recovery/discover-parent-package-pat
 import { AcpxQueueOwnerLauncher } from "../transport/acpx-queue-owner-launcher";
 import { permissionModeToFlag } from "../transport/permission-mode-flag";
 import { runAgentSessionList } from "../transport/agent-session-list";
+import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../transport/codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../transport/acpx-session-files";
 import type {
   EnsureSessionProgress,
@@ -186,6 +187,8 @@ export class BridgeRuntime {
         return await this.run(spec.command, spec.args);
       },
       formatError: (result) => result.stderr || result.stdout || `sessions list failed with exit code ${result.code}`,
+      // Codex's session list leaks native subagent threads; hide them (fail-open).
+      isSubagentSession: input.agent === CODEX_AGENT_NAME ? codexSubagentPredicate() : undefined,
     });
   }
 

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -171,6 +171,7 @@ export class BridgeRuntime {
   async listAgentSessions(input: {
     agent: string;
     agentCommand?: string;
+    driver?: string;
     cwd: string;
     cursor?: string;
     filterCwd?: string;
@@ -188,7 +189,8 @@ export class BridgeRuntime {
       },
       formatError: (result) => result.stderr || result.stdout || `sessions list failed with exit code ${result.code}`,
       // Codex's session list leaks native subagent threads; hide them (fail-open).
-      isSubagentSession: input.agent === CODEX_AGENT_NAME ? codexSubagentPredicate() : undefined,
+      // Gate on driver so custom-named codex agents (driver "codex") are covered too.
+      isSubagentSession: (input.driver ?? input.agent) === CODEX_AGENT_NAME ? codexSubagentPredicate() : undefined,
     });
   }
 

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -156,6 +156,7 @@ export class BridgeServer {
         return await this.runtime.listAgentSessions({
           agent: requireString(params, "agent"),
           agentCommand: asOptionalString(params.agentCommand),
+          driver: asOptionalString(params.driver),
           cwd: requireString(params, "cwd"),
           cursor: asOptionalString(params.cursor),
           filterCwd: asOptionalString(params.filterCwd),

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -686,6 +686,7 @@ export class CommandRouter {
     const result = await listAgentSessions({
       agent,
       ...(agentCommand ? { agentCommand } : {}),
+      ...(agentConfig.driver ? { driver: agentConfig.driver } : {}),
       cwd: workspaceConfig.cwd,
       filterCwd: workspaceConfig.cwd,
     });

--- a/src/commands/handlers/native-session-handler.ts
+++ b/src/commands/handlers/native-session-handler.ts
@@ -18,6 +18,8 @@ interface NativeTarget {
   agent: string;
   agentDisplayName: string;
   agentCommand?: string;
+  /** Resolved acpx driver for `agent` (e.g. a `my-codex` agent has driver `codex`). */
+  driver?: string;
   workspace: string;
   workspaceLabel: string;
   cwd: string;
@@ -43,6 +45,31 @@ interface NativeCandidateEntry {
 
 const NATIVE_SESSION_CACHE_TTL_MS = 10 * 60 * 1000;
 
+// Upper bound on how many fully-filtered (empty) pages we'll skip past before giving
+// up, so a long run of filtered-out sessions can't turn into an unbounded fetch loop.
+const MAX_EMPTY_PAGE_ADVANCE = 25;
+
+/**
+ * Fetch the first page that still has sessions after transport-side filtering.
+ *
+ * The transport may filter a whole page (e.g. a page of only Codex subagent threads)
+ * down to empty while real sessions remain behind `nextCursor`. Without this, the
+ * caller would report "no sessions" while results sit one page on. We follow the
+ * cursor past empty pages, bounded by {@link MAX_EMPTY_PAGE_ADVANCE}. Exported for tests.
+ */
+export async function listFirstNonEmptyPage(
+  listAgentSessions: (query: AgentSessionListQuery) => Promise<AgentSessionListResult | undefined>,
+  query: AgentSessionListQuery,
+): Promise<AgentSessionListResult | undefined> {
+  let result = await listAgentSessions(query);
+  let guard = 0;
+  while (result && result.sessions.length === 0 && result.nextCursor && guard < MAX_EMPTY_PAGE_ADVANCE) {
+    guard++;
+    result = await listAgentSessions({ ...query, cursor: result.nextCursor });
+  }
+  return result;
+}
+
 export async function handleNativeSessionList(
   context: CommandRouterContext & { lifecycle: SessionLifecycleOps },
   chatKey: string,
@@ -61,6 +88,7 @@ export async function handleNativeSessionList(
   const query: AgentSessionListQuery = {
     agent: target.agent,
     agentCommand: target.agentCommand,
+    ...(target.driver ? { driver: target.driver } : {}),
     cwd: target.cwd,
     ...(input.cursor ? { cursor: input.cursor } : {}),
     ...(input.all ? {} : { filterCwd: target.cwd }),
@@ -68,7 +96,7 @@ export async function handleNativeSessionList(
 
   let result: AgentSessionListResult | undefined;
   try {
-    result = await listAgentSessions(query);
+    result = await listFirstNonEmptyPage(listAgentSessions, query);
   } catch (error) {
     return { text: renderNativeListError(target, error) };
   }
@@ -231,6 +259,7 @@ async function resolveNativeTarget(
     agent,
     agentDisplayName: displayAgentName(agent),
     agentCommand: resolveRuntimeAgentCommand(agentConfig.driver, agentConfig.command, context.config?.transport.preferLocalAgents !== false),
+    driver: agentConfig.driver,
     workspace: workspaceResolution.workspace,
     workspaceLabel: workspaceResolution.workspaceLabel,
     cwd: workspaceResolution.cwd,

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -233,7 +233,8 @@ export class AcpxCliTransport implements SessionTransport {
       },
       formatError: (result) => normalizeCommandError(result) ?? `command failed with exit code ${result.code}`,
       // Codex's session list leaks native subagent threads; hide them (fail-open).
-      isSubagentSession: query.agent === CODEX_AGENT_NAME ? codexSubagentPredicate() : undefined,
+      // Gate on driver so custom-named codex agents (driver "codex") are covered too.
+      isSubagentSession: (query.driver ?? query.agent) === CODEX_AGENT_NAME ? codexSubagentPredicate() : undefined,
     });
   }
 

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -30,6 +30,7 @@ import { AcpxQueueOwnerLauncher } from "../acpx-queue-owner-launcher";
 import { permissionModeToFlag } from "../permission-mode-flag";
 import { resolveToolEventMode, type ToolEventMode } from "../tool-event-mode.js";
 import { runAgentSessionList } from "../agent-session-list";
+import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../acpx-session-files";
 
 interface AcpxCliTransportOptions {
@@ -231,6 +232,8 @@ export class AcpxCliTransport implements SessionTransport {
         });
       },
       formatError: (result) => normalizeCommandError(result) ?? `command failed with exit code ${result.code}`,
+      // Codex's session list leaks native subagent threads; hide them (fail-open).
+      isSubagentSession: query.agent === CODEX_AGENT_NAME ? codexSubagentPredicate() : undefined,
     });
   }
 

--- a/src/transport/agent-session-list.ts
+++ b/src/transport/agent-session-list.ts
@@ -1,4 +1,5 @@
 import { isSamePath, isWindowsLikePath, normalizePath } from "../util/path.js";
+import { filterSubagentSessions } from "./codex-subagent-filter.js";
 import type { AgentSessionListResult } from "./types";
 
 export function isUnknownFilterCwdOption(output: string): boolean {
@@ -23,11 +24,15 @@ export interface AgentSessionListCommandResult {
  *   2. If the agent doesn't advertise `sessionCapabilities.list`, return
  *      `undefined` so callers can fall back to xacpx logical sessions.
  *   3. Otherwise parse + validate the JSON payload.
+ *   4. If `isSubagentSession` is provided (callers pass it only for agents whose
+ *      session list can leak subagent threads, e.g. Codex), drop the flagged
+ *      sessions. Fail-open — see codex-subagent-filter.
  */
 export async function runAgentSessionList(options: {
   filterCwd?: string;
   runList: (includeFilterCwd: boolean) => Promise<AgentSessionListCommandResult>;
   formatError: (result: AgentSessionListCommandResult) => string;
+  isSubagentSession?: (sessionId: string) => boolean;
 }): Promise<AgentSessionListResult | undefined> {
   let result = await options.runList(true);
   let filterLocally = false;
@@ -44,7 +49,11 @@ export async function runAgentSessionList(options: {
     throw new Error(options.formatError(result));
   }
 
-  return parseAgentSessionListOutput(result.stdout, filterLocally ? options.filterCwd : undefined);
+  const parsed = parseAgentSessionListOutput(result.stdout, filterLocally ? options.filterCwd : undefined);
+  if (parsed && options.isSubagentSession) {
+    return filterSubagentSessions(parsed, options.isSubagentSession);
+  }
+  return parsed;
 }
 
 export function parseAgentSessionListOutput(stdout: string, filterCwd?: string): AgentSessionListResult | undefined {

--- a/src/transport/codex-subagent-filter.ts
+++ b/src/transport/codex-subagent-filter.ts
@@ -39,6 +39,29 @@ export function resolveCodexHome(env: NodeJS.ProcessEnv = process.env): string {
   return fromEnv ? fromEnv : join(homedir(), ".codex");
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * True iff a Codex rollout `session_meta` `source` positively identifies a subagent
+ * thread. A real subagent source is `{ subagent: { <variant>: { parent_thread_id: string, … } } }`
+ * (the variant is `thread_spawn` for spawned subagents; review/compact/… are siblings).
+ *
+ * We require that full shape rather than just a `subagent` key, so format drift
+ * (`{ subagent: null }`, `{ subagent: {} }`, `{ subagent: "x" }`) stays **fail-open**
+ * (not recognized as a subagent → session kept visible).
+ */
+function isSubagentSource(source: unknown): boolean {
+  if (!isPlainObject(source) || !Object.hasOwn(source, "subagent")) return false;
+  const subagent = source.subagent;
+  if (!isPlainObject(subagent)) return false;
+  // Any variant object that carries a string parent_thread_id confirms a spawned subagent.
+  return Object.values(subagent).some(
+    (variant) => isPlainObject(variant) && typeof variant.parent_thread_id === "string",
+  );
+}
+
 /**
  * True iff a rollout's first `session_meta` line marks it as a subagent thread.
  * Pure: returns false for undefined/malformed input or a non-subagent source.
@@ -52,8 +75,7 @@ export function sessionMetaLineIsSubagent(line: string | undefined): boolean {
     return false;
   }
   const payload = (parsed as { payload?: unknown })?.payload;
-  const source = (payload as { source?: unknown })?.source;
-  return !!source && typeof source === "object" && !Array.isArray(source) && "subagent" in source;
+  return isSubagentSource((payload as { source?: unknown })?.source);
 }
 
 /** Reads rollout files; injectable so the predicate is unit-testable without a real FS. */

--- a/src/transport/codex-subagent-filter.ts
+++ b/src/transport/codex-subagent-filter.ts
@@ -1,0 +1,176 @@
+import { closeSync, openSync, readdirSync, readSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AgentSessionListResult } from "./types";
+
+/**
+ * Hide Codex subagent threads from agent session lists.
+ *
+ * Codex's native `spawn_agent` tool runs subagents as their own threads. Those
+ * threads show up in `acpx codex sessions list` alongside real user sessions
+ * (they share the parent's cwd, so the cwd filter doesn't exclude them), and
+ * acpx's list JSON only carries `{sessionId, cwd, title, updatedAt}` — it drops
+ * the `parentThreadId`/source that would let us tell them apart. So there is no
+ * signal in the list payload itself.
+ *
+ * The one place the distinction survives is Codex's own rollout store
+ * (`$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<sessionId>.jsonl`): the first
+ * `session_meta` line carries `payload.source`, which is an object shaped like
+ * `{ subagent: { thread_spawn: { parent_thread_id, ... } } }` for subagents and
+ * a bare string (`"unknown"`, `"vscode"`, …) for real sessions.
+ *
+ * This is a deliberate hack: Codex-specific, reaching into Codex's private
+ * on-disk format. It is **fail-open** — any missing/unreadable/unparseable
+ * rollout leaves the session visible — so a format change degrades to "shows a
+ * phantom subagent session", never to "hides a real session". It is gated to
+ * the Codex agent by callers; do not apply it to other agents.
+ */
+
+export const CODEX_AGENT_NAME = "codex";
+
+/** Cap on bytes read while looking for a rollout's first line (session_meta). */
+const FIRST_LINE_READ_CAP = 1024 * 1024;
+const READ_CHUNK = 64 * 1024;
+const ROLLOUT_RE = /rollout-.*-([0-9a-fA-F-]{36})\.jsonl$/;
+
+/** Resolve Codex's home dir: `$CODEX_HOME` if set, else `~/.codex`. */
+export function resolveCodexHome(env: NodeJS.ProcessEnv = process.env): string {
+  const fromEnv = env.CODEX_HOME?.trim();
+  return fromEnv ? fromEnv : join(homedir(), ".codex");
+}
+
+/**
+ * True iff a rollout's first `session_meta` line marks it as a subagent thread.
+ * Pure: returns false for undefined/malformed input or a non-subagent source.
+ */
+export function sessionMetaLineIsSubagent(line: string | undefined): boolean {
+  if (!line) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return false;
+  }
+  const payload = (parsed as { payload?: unknown })?.payload;
+  const source = (payload as { source?: unknown })?.source;
+  return !!source && typeof source === "object" && !Array.isArray(source) && "subagent" in source;
+}
+
+/** Reads rollout files; injectable so the predicate is unit-testable without a real FS. */
+export interface RolloutReader {
+  /** Absolute paths of every rollout file under the Codex home (recursive). */
+  listRolloutPaths(): string[];
+  /** First line of a rollout file, or undefined if it can't be read. */
+  readFirstLine(path: string): string | undefined;
+}
+
+/**
+ * Build a `sessionId → isSubagent` predicate from a {@link RolloutReader}. The
+ * rollout index is built lazily on first use and results are memoized. Fail-open:
+ * any error or unknown session resolves to `false` (treated as a real session).
+ */
+export function createSubagentPredicate(reader: RolloutReader): (sessionId: string) => boolean {
+  let index: Map<string, string> | null = null;
+  const cache = new Map<string, boolean>();
+  return (sessionId: string): boolean => {
+    const cached = cache.get(sessionId);
+    if (cached !== undefined) return cached;
+    let result = false;
+    try {
+      if (!index) {
+        index = new Map();
+        for (const path of reader.listRolloutPaths()) {
+          const id = path.match(ROLLOUT_RE)?.[1];
+          if (id) index.set(id.toLowerCase(), path);
+        }
+      }
+      const path = index.get(sessionId.toLowerCase());
+      if (path) result = sessionMetaLineIsSubagent(reader.readFirstLine(path));
+    } catch {
+      result = false; // fail-open
+    }
+    cache.set(sessionId, result);
+    return result;
+  };
+}
+
+/** Drop sessions the predicate positively flags as subagent threads. Fail-open per session. */
+export function filterSubagentSessions(
+  result: AgentSessionListResult,
+  isSubagent: (sessionId: string) => boolean,
+): AgentSessionListResult {
+  return {
+    ...result,
+    sessions: result.sessions.filter((session) => {
+      try {
+        return !isSubagent(session.sessionId);
+      } catch {
+        return true; // fail-open: keep the session if detection throws
+      }
+    }),
+  };
+}
+
+/** Node-fs-backed reader rooted at `<home>/sessions`. Errors degrade to empty/undefined. */
+export function nodeRolloutReader(home: string): RolloutReader {
+  const root = join(home, "sessions");
+  return {
+    listRolloutPaths() {
+      const out: string[] = [];
+      const walk = (dir: string): void => {
+        let entries: import("node:fs").Dirent[];
+        try {
+          entries = readdirSync(dir, { withFileTypes: true });
+        } catch {
+          return;
+        }
+        for (const entry of entries) {
+          const full = join(dir, entry.name);
+          if (entry.isDirectory()) walk(full);
+          else if (entry.isFile() && entry.name.startsWith("rollout-") && entry.name.endsWith(".jsonl")) out.push(full);
+        }
+      };
+      walk(root);
+      return out;
+    },
+    readFirstLine(path) {
+      let fd: number | undefined;
+      try {
+        // Guard against a pathological huge first line: read in chunks up to a cap.
+        statSync(path);
+        fd = openSync(path, "r");
+        const buf = Buffer.alloc(READ_CHUNK);
+        let acc = "";
+        let total = 0;
+        for (;;) {
+          const bytes = readSync(fd, buf, 0, READ_CHUNK, total);
+          if (bytes <= 0) break;
+          acc += buf.toString("utf8", 0, bytes);
+          total += bytes;
+          const nl = acc.indexOf("\n");
+          if (nl !== -1) return acc.slice(0, nl);
+          if (total >= FIRST_LINE_READ_CAP) return undefined; // no newline within cap → fail-open
+        }
+        return acc.length ? acc : undefined; // single-line file with no trailing newline
+      } catch {
+        return undefined;
+      } finally {
+        if (fd !== undefined) {
+          try {
+            closeSync(fd);
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    },
+  };
+}
+
+/**
+ * Convenience predicate used by the transports for the Codex agent. Reads the
+ * real Codex rollout store under `resolveCodexHome()`.
+ */
+export function codexSubagentPredicate(env?: NodeJS.ProcessEnv): (sessionId: string) => boolean {
+  return createSubagentPredicate(nodeRolloutReader(resolveCodexHome(env)));
+}

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -111,6 +111,8 @@ export interface AgentSession {
 export interface AgentSessionListQuery {
   agent: string;
   agentCommand?: string;
+  /** Resolved acpx driver for `agent` (e.g. a custom `my-codex` agent has driver `codex`). Used to gate driver-specific list filtering. */
+  driver?: string;
   cwd: string;
   cursor?: string;
   filterCwd?: string;

--- a/tests/unit/commands/command-router-session.test.ts
+++ b/tests/unit/commands/command-router-session.test.ts
@@ -1058,6 +1058,7 @@ test("/ssn lists native sessions from the current session context", async () => 
   expect(reply.text).not.toContain("61456d60-b7e1-47e6-8641-72bbe8e552e7");
   expect(transport.listAgentSessions).toHaveBeenCalledWith({
     agent: "codex",
+    driver: "codex",
     cwd: "/tmp/project",
     filterCwd: "/tmp/project",
   });
@@ -1151,6 +1152,7 @@ test("/ssn preserves transport method this binding when listing native sessions"
   expect(transport.client.calls).toEqual([
     {
       agent: "codex",
+      driver: "codex",
       cwd: "/tmp/project",
       filterCwd: "/tmp/project",
     },
@@ -1338,6 +1340,7 @@ test("/ssn --all preserves all scope in next page commands", async () => {
   expect(reply.text).toContain("更多：/ssn codex --ws project --all --cursor cursor-2");
   expect(transport.listAgentSessions).toHaveBeenCalledWith({
     agent: "codex",
+    driver: "codex",
     cwd: "/tmp/project",
   });
 });

--- a/tests/unit/commands/handlers/native-session-pagination.test.ts
+++ b/tests/unit/commands/handlers/native-session-pagination.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+
+import { listFirstNonEmptyPage } from "../../../../src/commands/handlers/native-session-handler";
+import type { AgentSessionListQuery, AgentSessionListResult } from "../../../../src/transport/types";
+
+const baseQuery: AgentSessionListQuery = { agent: "codex", cwd: "/repo", filterCwd: "/repo" };
+const page = (ids: string[], nextCursor: string | null): AgentSessionListResult => ({
+  source: "agent",
+  nextCursor,
+  sessions: ids.map((sessionId) => ({ sessionId, cwd: "/repo" })),
+});
+
+test("listFirstNonEmptyPage: skips fully-filtered empty pages until one has sessions", async () => {
+  const pages = [page([], "c1"), page([], "c2"), page(["real"], null)];
+  const cursors: (string | undefined)[] = [];
+  const result = await listFirstNonEmptyPage(async (q) => {
+    cursors.push(q.cursor);
+    return pages.shift();
+  }, baseQuery);
+
+  expect(result?.sessions.map((s) => s.sessionId)).toEqual(["real"]);
+  // first call has no cursor, then it advances using each page's nextCursor
+  expect(cursors).toEqual([undefined, "c1", "c2"]);
+});
+
+test("listFirstNonEmptyPage: returns the first page unchanged when it already has sessions", async () => {
+  let calls = 0;
+  const result = await listFirstNonEmptyPage(async () => {
+    calls++;
+    return page(["a", "b"], "more");
+  }, baseQuery);
+
+  expect(calls).toBe(1);
+  expect(result?.sessions).toHaveLength(2);
+  expect(result?.nextCursor).toBe("more");
+});
+
+test("listFirstNonEmptyPage: stops at an empty page with no nextCursor (no infinite advance)", async () => {
+  let calls = 0;
+  const result = await listFirstNonEmptyPage(async () => {
+    calls++;
+    return page([], null);
+  }, baseQuery);
+
+  expect(calls).toBe(1);
+  expect(result?.sessions).toHaveLength(0);
+});
+
+test("listFirstNonEmptyPage: is bounded — never advances past the cap", async () => {
+  let calls = 0;
+  // Always empty but always has a nextCursor → must stop at the bound, not loop forever.
+  const result = await listFirstNonEmptyPage(async () => {
+    calls++;
+    return page([], `cursor-${calls}`);
+  }, baseQuery);
+
+  expect(result?.sessions).toHaveLength(0);
+  expect(calls).toBeLessThanOrEqual(26); // 1 initial + MAX_EMPTY_PAGE_ADVANCE (25)
+  expect(calls).toBeGreaterThan(1);
+});
+
+test("listFirstNonEmptyPage: propagates undefined (unsupported transport)", async () => {
+  const result = await listFirstNonEmptyPage(async () => undefined, baseQuery);
+  expect(result).toBeUndefined();
+});

--- a/tests/unit/transport/agent-session-list.test.ts
+++ b/tests/unit/transport/agent-session-list.test.ts
@@ -36,6 +36,25 @@ test("retries without --filter-cwd and filters locally when acpx rejects the opt
   expect(result).toEqual({ source: "agent", sessions: [{ sessionId: "thread-1", cwd: "/repo" }] });
 });
 
+test("drops sessions flagged by isSubagentSession after parsing", async () => {
+  const result = await runAgentSessionList({
+    runList: async () =>
+      ok(
+        JSON.stringify({
+          source: "agent",
+          sessions: [
+            { sessionId: "real", cwd: "/repo" },
+            { sessionId: "sub", cwd: "/repo" },
+          ],
+        }),
+      ),
+    formatError: () => "should not be called",
+    isSubagentSession: (id) => id === "sub",
+  });
+
+  expect(result).toEqual({ source: "agent", sessions: [{ sessionId: "real", cwd: "/repo" }] });
+});
+
 test("returns undefined when the agent does not advertise sessionCapabilities.list", async () => {
   const result = await runAgentSessionList({
     runList: async () => fail("Agent command does not advertise sessionCapabilities.list"),

--- a/tests/unit/transport/codex-subagent-filter.test.ts
+++ b/tests/unit/transport/codex-subagent-filter.test.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createSubagentPredicate,
+  filterSubagentSessions,
+  resolveCodexHome,
+  sessionMetaLineIsSubagent,
+  type RolloutReader,
+} from "../../../src/transport/codex-subagent-filter";
+import type { AgentSessionListResult } from "../../../src/transport/types";
+
+// --- sessionMetaLineIsSubagent --------------------------------------------------
+
+const subagentLine = JSON.stringify({
+  type: "session_meta",
+  payload: {
+    id: "019efcc9-4d20-74f1-a9e0-67f89ea2115f",
+    forked_from_id: "019edfcb-4f91-7b12-9777-d945f287c341",
+    source: { subagent: { thread_spawn: { parent_thread_id: "019edfcb-4f91-7b12-9777-d945f287c341", depth: 1, agent_nickname: "Bernoulli" } } },
+  },
+});
+
+test("sessionMetaLineIsSubagent: true for a subagent source object", () => {
+  expect(sessionMetaLineIsSubagent(subagentLine)).toBe(true);
+});
+
+test("sessionMetaLineIsSubagent: false for a real session (string source)", () => {
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: "unknown" } }))).toBe(false);
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: "vscode" } }))).toBe(false);
+});
+
+test("sessionMetaLineIsSubagent: false for missing source, non-subagent object, or array source", () => {
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: {} }))).toBe(false);
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: { cli: {} } } }))).toBe(false);
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: ["subagent"] } }))).toBe(false);
+});
+
+test("sessionMetaLineIsSubagent: false (fail-open) for malformed/empty input", () => {
+  expect(sessionMetaLineIsSubagent(undefined)).toBe(false);
+  expect(sessionMetaLineIsSubagent("")).toBe(false);
+  expect(sessionMetaLineIsSubagent("{not json")).toBe(false);
+});
+
+// --- resolveCodexHome -----------------------------------------------------------
+
+test("resolveCodexHome: prefers $CODEX_HOME, falls back to ~/.codex", () => {
+  expect(resolveCodexHome({ CODEX_HOME: "/custom/codex" } as NodeJS.ProcessEnv)).toBe("/custom/codex");
+  expect(resolveCodexHome({} as NodeJS.ProcessEnv)).toBe(join(homedir(), ".codex"));
+  expect(resolveCodexHome({ CODEX_HOME: "   " } as NodeJS.ProcessEnv)).toBe(join(homedir(), ".codex"));
+});
+
+// --- createSubagentPredicate (injected reader) ----------------------------------
+
+function reader(map: Record<string, string>, opts: { listThrows?: boolean } = {}): RolloutReader & { listCalls: number } {
+  let listCalls = 0;
+  const self = {
+    get listCalls() {
+      return listCalls;
+    },
+    listRolloutPaths() {
+      listCalls++;
+      if (opts.listThrows) throw new Error("boom");
+      // file names embed the session id, like Codex's rollout-<ts>-<id>.jsonl
+      return Object.keys(map).map((id) => `/c/sessions/2026/06/25/rollout-2026-06-25T11-18-31-${id}.jsonl`);
+    },
+    readFirstLine(path: string) {
+      const id = path.match(/rollout-.*-([0-9a-fA-F-]{36})\.jsonl$/)?.[1] ?? "";
+      return map[id];
+    },
+  };
+  return self as RolloutReader & { listCalls: number };
+}
+
+test("createSubagentPredicate: flags subagent ids, clears real ones, unknown is fail-open false", () => {
+  const isSub = createSubagentPredicate(
+    reader({
+      "019efcc9-4d20-74f1-a9e0-67f89ea2115f": subagentLine,
+      "019edfcb-4f91-7b12-9777-d945f287c341": JSON.stringify({ payload: { source: "unknown" } }),
+    }),
+  );
+  expect(isSub("019efcc9-4d20-74f1-a9e0-67f89ea2115f")).toBe(true);
+  expect(isSub("019edfcb-4f91-7b12-9777-d945f287c341")).toBe(false);
+  expect(isSub("ffffffff-0000-0000-0000-000000000000")).toBe(false); // no rollout → keep
+});
+
+test("createSubagentPredicate: matches session ids case-insensitively", () => {
+  const isSub = createSubagentPredicate(reader({ "019efcc9-4d20-74f1-a9e0-67f89ea2115f": subagentLine }));
+  expect(isSub("019EFCC9-4D20-74F1-A9E0-67F89EA2115F")).toBe(true);
+});
+
+test("createSubagentPredicate: builds the index once and memoizes per id", () => {
+  const r = reader({ "019efcc9-4d20-74f1-a9e0-67f89ea2115f": subagentLine });
+  const isSub = createSubagentPredicate(r);
+  isSub("019efcc9-4d20-74f1-a9e0-67f89ea2115f");
+  isSub("019efcc9-4d20-74f1-a9e0-67f89ea2115f");
+  isSub("other");
+  expect(r.listCalls).toBe(1);
+});
+
+test("createSubagentPredicate: fail-open false when the reader throws", () => {
+  const isSub = createSubagentPredicate(reader({}, { listThrows: true }));
+  expect(isSub("019efcc9-4d20-74f1-a9e0-67f89ea2115f")).toBe(false);
+});
+
+// --- filterSubagentSessions (pure) ----------------------------------------------
+
+const listResult = (ids: string[]): AgentSessionListResult => ({
+  source: "agent",
+  cursor: "c1",
+  cwd: "/repo",
+  sessions: ids.map((sessionId) => ({ sessionId, cwd: "/repo", title: "t" })),
+});
+
+test("filterSubagentSessions: drops flagged sessions, keeps the rest and other fields", () => {
+  const subs = new Set(["sub1", "sub2"]);
+  const out = filterSubagentSessions(listResult(["sub1", "real1", "sub2", "real2"]), (id) => subs.has(id));
+  expect(out.sessions.map((s) => s.sessionId)).toEqual(["real1", "real2"]);
+  expect(out.source).toBe("agent");
+  expect(out.cursor).toBe("c1");
+  expect(out.cwd).toBe("/repo");
+});
+
+test("filterSubagentSessions: keeps a session (fail-open) when the predicate throws", () => {
+  const out = filterSubagentSessions(listResult(["a", "b"]), (id) => {
+    if (id === "a") throw new Error("boom");
+    return false;
+  });
+  expect(out.sessions.map((s) => s.sessionId)).toEqual(["a", "b"]);
+});

--- a/tests/unit/transport/codex-subagent-filter.test.ts
+++ b/tests/unit/transport/codex-subagent-filter.test.ts
@@ -37,6 +37,20 @@ test("sessionMetaLineIsSubagent: false for missing source, non-subagent object, 
   expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: ["subagent"] } }))).toBe(false);
 });
 
+test("sessionMetaLineIsSubagent: true for non-thread_spawn subagent variants carrying parent_thread_id", () => {
+  // review/compact/… are sibling variants of thread_spawn under `subagent`.
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: { subagent: { review: { parent_thread_id: "p" } } } } }))).toBe(true);
+});
+
+test("sessionMetaLineIsSubagent: fail-open false on subagent format drift (no positive structure)", () => {
+  // Drift shapes must NOT be treated as subagents — fail-open keeps the session visible.
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: { subagent: null } } }))).toBe(false);
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: { subagent: "x" } } }))).toBe(false);
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: { subagent: {} } } }))).toBe(false);
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: { subagent: { thread_spawn: {} } } } }))).toBe(false);
+  expect(sessionMetaLineIsSubagent(JSON.stringify({ payload: { source: { subagent: { thread_spawn: { parent_thread_id: 123 } } } } }))).toBe(false);
+});
+
 test("sessionMetaLineIsSubagent: false (fail-open) for malformed/empty input", () => {
   expect(sessionMetaLineIsSubagent(undefined)).toBe(false);
   expect(sessionMetaLineIsSubagent("")).toBe(false);


### PR DESCRIPTION
## Problem

Codex's native `spawn_agent` runs subagents as their own threads. They leak into the dashboard's **native session browser** (and any consumer of `listAgentSessions`) right next to real user sessions:

- subagents **fork the parent's cwd**, so the cwd filter doesn't exclude them;
- acpx's `sessions list --format json` carries only `{sessionId, cwd, title, updatedAt}` — it **drops `parentThreadId`/source**, so there's no signal in the list payload to tell them apart.

Confirmed live: `acpx --format json codex sessions list --filter-cwd <repo>` returned **4 subagent threads among 12 entries**, indistinguishable from real sessions (same cwd, generic titles).

We can't fix this in the list payload (acpx is upstream, and its JSON has already dropped the discriminator). But the distinction survives in **Codex's own rollout store**: `$CODEX_HOME/sessions/**/rollout-<ts>-<sessionId>.jsonl`, whose first `session_meta` line has `payload.source` = `{subagent:{thread_spawn:{…}}}` for subagents vs a bare string (`"unknown"`, `"vscode"`, …) for real sessions.

## Fix

New `src/transport/codex-subagent-filter.ts`: resolve each listed `sessionId` → its rollout, read the first `session_meta` line, drop sessions whose source is a subagent object. Wired into the shared `runAgentSessionList` (covers **both** `acpx-cli` and `acpx-bridge`), **gated to the codex agent** by the callers.

### Design constraints
- **Fail-open.** Any missing / unreadable / unparseable rollout (or a Codex format change) leaves the session **visible** — degrades to "shows a phantom subagent session", never "hides a real session".
- **Codex-specific by nature** (reads `~/.codex/sessions`); not applied to other agents. Bounded first-line read; rollout index built once per call + memoized per id.
- **Does not touch acpx** (upstream). This is a downstream hack on data Codex already writes locally.

## Tests
- `codex-subagent-filter.test.ts`: pure `session_meta` parser (subagent / string-source / missing / malformed / array), `resolveCodexHome`, injected-reader predicate (flagging, case-insensitive ids, index-built-once memoization, fail-open on reader throw), pure `filterSubagentSessions` (drops flagged, fail-open on predicate throw, preserves other fields).
- `agent-session-list.test.ts`: wiring test that `isSubagentSession` filters after parse.
- Full suite green (typecheck + bun unit + relay-web vitest).
- **Live verification:** the predicate run against the real rollout store flagged exactly the 4 subagent threads and kept the 8 real sessions.

## Note
This is a **core** (`@ganglion/xacpx`) change. Related upstream issues filed for the real fix: agentclientprotocol/codex-acp#238 (surface spawn_agent over ACP) and #234 (drop subagent threads from `session/list`).