### PR TITLE
fix(relay): persist context-usage meter across web refresh

### DIFF
--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -1,5 +1,5 @@
 import { RELAY_PROTOCOL_VERSION, type RelayEnvelope } from "./envelope.js";
-import type { ControlEventDto, ScheduledOriginDto, ToolStepDto, TurnPartDto } from "./dtos.js";
+import type { ControlEventDto, ScheduledOriginDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto } from "./dtos.js";
 import type { InstanceNoticePayload } from "./messages.js";
 
 /** Envelope `type` for every relay→web push. */
@@ -46,6 +46,18 @@ export interface LiveTurnSnapshotDto {
   status: "working" | "streaming";
   /** Epoch ms the turn began on the hub, so the elapsed-time HUD stays accurate. */
   startedAt: number;
+}
+
+/** The latest context-usage meter retained per session, handed to a (re)connecting web
+ *  client so the context-usage bar survives a page refresh. Mirrors the `turn-usage`
+ *  control event (replace-latest); absent for agents/sessions that never reported usage. */
+export interface SessionUsageSnapshotDto {
+  instanceId: string;
+  sessionAlias: string;
+  used: number;
+  size: number;
+  cost?: UsageCostDto;
+  breakdown?: UsageBreakdownDto;
 }
 
 /** Server→web push payloads (tagged with the originating instance). */

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -182,6 +182,25 @@ test("loadActiveTurns fetches the in-flight snapshot and seeds it", async () => 
   expect(store.streaming).toBe("live");
 });
 
+test("loadActiveTurns seeds the per-session usage meter so the context bar survives a refresh", async () => {
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    turns: [],
+    usage: [{ instanceId: "i1", sessionAlias: "backend", used: 1200, size: 8000, cost: { totalUsd: 0.5 } }],
+  }), { status: 200 })));
+  const store = useChatStore();
+  await store.loadActiveTurns();
+  store.select("i1", "backend");
+  expect(store.sessionUsage).toEqual({ used: 1200, size: 8000, cost: { totalUsd: 0.5 } });
+});
+
+test("loadActiveTurns tolerates a snapshot without a usage field (older hub)", async () => {
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ turns: [] }), { status: 200 })));
+  const store = useChatStore();
+  await store.loadActiveTurns();
+  store.select("i1", "backend");
+  expect(store.sessionUsage).toBeNull();
+});
+
 test("loadHistory records hasMore; loadOlder prepends the older page and updates the cursor", async () => {
   const calls: string[] = [];
   vi.stubGlobal("fetch", vi.fn(async (path: string) => {

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
-import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, ScheduledOriginDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
+import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, ScheduledOriginDto, SessionUsageSnapshotDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 
 // Remember which session was open so a page refresh returns to it (selection is not
@@ -250,9 +250,18 @@ export const useChatStore = defineStore("chat", () => {
     }
   }
 
+  /** Seed the per-session context-usage meter from the hub's snapshot (after a
+   *  refresh/reconnect), so the usage bar reappears without waiting for the next turn. */
+  function seedUsage(snapshots: SessionUsageSnapshotDto[]): void {
+    for (const u of snapshots) {
+      usage.value[bufKey(u.instanceId, u.sessionAlias)] = { used: u.used, size: u.size, ...(u.cost ? { cost: u.cost } : {}), ...(u.breakdown ? { breakdown: u.breakdown } : {}) };
+    }
+  }
+
   async function loadActiveTurns(): Promise<void> {
-    const { turns } = await api.get<{ turns: LiveTurnSnapshotDto[] }>("/api/active-turns");
+    const { turns, usage: usageSnapshot } = await api.get<{ turns: LiveTurnSnapshotDto[]; usage?: SessionUsageSnapshotDto[] }>("/api/active-turns");
     seedActiveTurns(turns);
+    if (usageSnapshot) seedUsage(usageSnapshot);
   }
 
   function applyEvent(event: WebServerEvent): void {

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { serveStatic } from "@hono/node-server/serve-static";
 
-import { MSG, type LiveTurnSnapshotDto } from "@ganglion/xacpx-relay-protocol";
+import { MSG, type LiveTurnSnapshotDto, type SessionUsageSnapshotDto } from "@ganglion/xacpx-relay-protocol";
 
 import type { AccountRow, AccountStore } from "../stores/accounts.js";
 import type { InstanceStore } from "../stores/instances.js";
@@ -22,6 +22,8 @@ export interface AppDeps {
   messages: MessageStore;
   /** Snapshot the in-flight turns for an instance (for the active-turns endpoint). */
   activeTurns?: (instanceId: string) => LiveTurnSnapshotDto[];
+  /** Snapshot the latest per-session context-usage for an instance (for the active-turns endpoint). */
+  sessionUsage?: (instanceId: string) => SessionUsageSnapshotDto[];
   webRoot?: string;
   sessionTtlMs?: number;
   pairingTtlMs?: number;
@@ -254,10 +256,12 @@ export function createApp(deps: AppDeps): Hono<Vars> {
   app.get("/api/active-turns", (c) => {
     const account = c.get("account");
     const turns: LiveTurnSnapshotDto[] = [];
+    const usage: SessionUsageSnapshotDto[] = [];
     for (const inst of deps.instances.listByAccount(account.id)) {
       for (const t of deps.activeTurns?.(inst.id) ?? []) turns.push(t);
+      for (const u of deps.sessionUsage?.(inst.id) ?? []) usage.push(u);
     }
-    return c.json({ turns });
+    return c.json({ turns, usage });
   });
 
   app.get("/api/instances/:id/sessions/:alias/messages", (c) => {

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -4,7 +4,8 @@ import { serve, type ServerType } from "@hono/node-server";
 import { WebSocketServer } from "ws";
 
 import {
-  MSG, type ControlEventDto, type InstanceEventPayload, type InstanceNoticePayload, type LiveTurnSnapshotDto, type RelayEnvelope, type ToolStepDto, type TurnPartDto,
+  MSG, type ControlEventDto, type InstanceEventPayload, type InstanceNoticePayload, type LiveTurnSnapshotDto, type RelayEnvelope,
+  type SessionUsageSnapshotDto, type ToolStepDto, type TurnPartDto, type UsageBreakdownDto, type UsageCostDto,
 } from "@ganglion/xacpx-relay-protocol";
 
 import { createSqlDriver, initSchema, type SqlDriver } from "./db.js";
@@ -55,6 +56,21 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reasoning: string; parts: TurnPartDto[]; startedAt: number }
   const turnBuffers = new Map<string, TurnAccumulator>();
   const key = (instanceId: string, alias: string) => `${instanceId}\0${alias}`;
+  // Latest context-usage meter per (instance, session). Unlike turnBuffers this is
+  // session-scoped — it survives turn-finished (replace-latest) so a (re)connecting web
+  // client can restore the usage bar after a refresh (see GET /api/active-turns). Cleared
+  // when the instance goes offline. Absent for agents/sessions that never report usage.
+  interface UsageSnapshot { used: number; size: number; cost?: UsageCostDto; breakdown?: UsageBreakdownDto }
+  const sessionUsage = new Map<string, UsageSnapshot>();
+  const listSessionUsage = (instanceId: string): SessionUsageSnapshotDto[] => {
+    const prefix = `${instanceId}\0`;
+    const out: SessionUsageSnapshotDto[] = [];
+    for (const [k, u] of sessionUsage) {
+      if (!k.startsWith(prefix)) continue;
+      out.push({ instanceId, sessionAlias: k.slice(prefix.length), used: u.used, size: u.size, ...(u.cost ? { cost: u.cost } : {}), ...(u.breakdown ? { breakdown: u.breakdown } : {}) });
+    }
+    return out;
+  };
   // Snapshot the in-flight turns for one instance so a (re)connecting web client can
   // rebuild the live view after a refresh (see GET /api/active-turns). `parts` is the
   // live array — fine to hand out by reference since the route serializes it at once.
@@ -101,6 +117,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
       if (!online) {
         const prefix = `${instanceId}\0`;
         for (const k of turnBuffers.keys()) if (k.startsWith(prefix)) turnBuffers.delete(k);
+        for (const k of sessionUsage.keys()) if (k.startsWith(prefix)) sessionUsage.delete(k);
       }
       webGateway.broadcast(accountId, { kind: "instance-status", instanceId, online });
     },
@@ -146,6 +163,11 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
               : undefined;
             messages.append(instanceId, event.sessionAlias, "out", a.text, structured);
           }
+        } else if (event.type === "turn-usage") {
+          // Retain the latest usage per session (replace) so a refreshed web client can
+          // restore the context-usage bar from the active-turns snapshot. Already
+          // broadcast above; this is the persistence the snapshot reads back.
+          sessionUsage.set(key(instanceId, event.sessionAlias), { used: event.used, size: event.size, ...(event.cost ? { cost: event.cost } : {}), ...(event.breakdown ? { breakdown: event.breakdown } : {}) });
         } else if (event.type === "session-history") {
           // Seed a freshly-attached native session's recovered prior conversation into
           // history (one-time). Guard against re-seeding an already-populated session so a
@@ -168,6 +190,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     historyRetentionDays: options.historyRetentionDays ?? 30,
     maxMessagesPerSession: MAX_MESSAGES_PER_SESSION,
     activeTurns: listActiveTurns,
+    sessionUsage: listSessionUsage,
     trustProxy: options.trustProxy,
     checkUpdate: createRelayUpdateChecker({ current: readRelayVersion() }),
   });

--- a/tests/unit/packages/relay/web-dashboard-e2e.test.ts
+++ b/tests/unit/packages/relay/web-dashboard-e2e.test.ts
@@ -58,24 +58,34 @@ test("instance event flows to web client and is cached as history", async () => 
   // instance emits a streamed turn (turn-started opens the accumulator)
   listeners.forEach((l) => l({ type: "turn-started", chatKey: "relay:x", sessionAlias: "backend" }));
   listeners.forEach((l) => l({ type: "turn-output", chatKey: "relay:x", sessionAlias: "backend", chunk: "done" }));
+  // Context-usage meter: retained per session (replace-latest), must survive turn-finished.
+  listeners.forEach((l) => l({ type: "turn-usage", chatKey: "relay:x", sessionAlias: "backend", used: 1200, size: 8000 }));
   await new Promise((r) => setTimeout(r, 50));
 
   // Mid-turn (before turn-finished): the in-flight snapshot is exposed so a refreshed
   // web client can rebuild the live view instead of losing the running task.
   const activeRes = await fetch(`${base}/api/active-turns`, { headers: { cookie } });
-  const { turns } = (await activeRes.json()) as { turns: Array<{ instanceId: string; sessionAlias: string; status: string; parts: Array<{ type: string; text?: string }> }> };
+  const { turns, usage } = (await activeRes.json()) as {
+    turns: Array<{ instanceId: string; sessionAlias: string; status: string; parts: Array<{ type: string; text?: string }> }>;
+    usage: Array<{ instanceId: string; sessionAlias: string; used: number; size: number }>;
+  };
   expect(turns).toHaveLength(1);
   expect(turns[0]!.sessionAlias).toBe("backend");
   expect(turns[0]!.instanceId).toBe(instId0);
   expect(turns[0]!.status).toBe("streaming");
   expect(turns[0]!.parts).toEqual([{ type: "text", text: "done" }]);
+  // The usage meter is exposed in the same snapshot so a refresh restores the bar.
+  expect(usage).toEqual([{ instanceId: instId0, sessionAlias: "backend", used: 1200, size: 8000 }]);
 
   listeners.forEach((l) => l({ type: "turn-finished", chatKey: "relay:x", sessionAlias: "backend", ok: true }));
   await new Promise((r) => setTimeout(r, 200));
 
-  // After the turn settles, the snapshot is empty (it flushed to persisted history).
+  // After the turn settles, the turn snapshot is empty (flushed to history) — but the
+  // usage meter is session-scoped and PERSISTS, so the context bar survives a refresh.
   const activeAfter = await fetch(`${base}/api/active-turns`, { headers: { cookie } });
-  expect(((await activeAfter.json()) as { turns: unknown[] }).turns).toHaveLength(0);
+  const afterJson = (await activeAfter.json()) as { turns: unknown[]; usage: Array<{ sessionAlias: string; used: number }> };
+  expect(afterJson.turns).toHaveLength(0);
+  expect(afterJson.usage).toEqual([{ instanceId: instId0, sessionAlias: "backend", used: 1200, size: 8000 }]);
 
   const kinds = events
     .map((raw) => { const d = decodeEnvelope(raw); return d.ok ? parseWebServerEvent(d.envelope) : null; })


### PR DESCRIPTION
## Problem

The dashboard's context-usage bar (the `N%` meter in the composer) disappears after a page refresh. It's driven only by live `turn-usage` control events held in the web store's memory; on refresh the store resets and nothing replays the last usage, so the bar is gone until the next turn emits usage.

## Root cause

The hub broadcasts `turn-usage` to web clients but **retains nothing** per session — only in-flight turn buffers, which are deleted on `turn-finished`. The reconnect snapshot (`GET /api/active-turns`) carries turns only. So a refreshed client has no source for the last usage.

## Fix

Retain the usage where the reconnect snapshot can serve it:

- **relay-protocol:** add `SessionUsageSnapshotDto`.
- **relay hub:** keep a `sessionUsage` map per `(instance, session)` — session-scoped, replace-latest, **surviving `turn-finished`** and cleared when the instance goes offline. Include `usage[]` in the `/api/active-turns` response.
- **relay-web:** `loadActiveTurns` seeds the usage meter from the snapshot (`seedUsage`), tolerant of an older hub that omits the field.

The meter is unchanged for live turns; this only adds restore-on-refresh.

## Tests
- Hub e2e (`web-dashboard-e2e`): `turn-usage` appears in the snapshot mid-turn **and survives `turn-finished`** (turns snapshot empties, usage persists).
- Chat store: `loadActiveTurns` seeds usage (incl. cost); tolerates a snapshot with no `usage` field.
- Full suite green (typecheck + bun unit + relay-web vitest).

## Note
Relay hub + relay-web change → ships in `@ganglion/xacpx-relay`. The new DTO is type-only and additive; `@ganglion/xacpx-relay-protocol` needs no runtime change (the hub uses it as a type and relay-web bundles it).