### PR TITLE
fix(relay): retain agent-advertised commands per session so web '/' hints survive a refresh

### DIFF
--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -1,5 +1,5 @@
 import { RELAY_PROTOCOL_VERSION, type RelayEnvelope } from "./envelope.js";
-import type { ControlEventDto, ScheduledOriginDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto } from "./dtos.js";
+import type { AgentCommandDto, ControlEventDto, ScheduledOriginDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto } from "./dtos.js";
 import type { InstanceNoticePayload } from "./messages.js";
 
 /** Envelope `type` for every relay→web push. */
@@ -58,6 +58,16 @@ export interface SessionUsageSnapshotDto {
   size: number;
   cost?: UsageCostDto;
   breakdown?: UsageBreakdownDto;
+}
+
+/** The latest agent-advertised slash commands retained per session, handed to a
+ *  (re)connecting web client so the composer's "/" command hints survive a page
+ *  refresh. Mirrors the `agent-commands` control event (replace-latest); absent for
+ *  agents/sessions that never advertised any. */
+export interface SessionCommandsSnapshotDto {
+  instanceId: string;
+  sessionAlias: string;
+  commands: AgentCommandDto[];
 }
 
 /** Server→web push payloads (tagged with the originating instance). */

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -190,8 +190,10 @@ function onInput() {
         @drop.prevent="onDrop" @dragover.prevent>
     <!-- hidden file picker -->
     <input ref="fileInput" type="file" multiple class="hidden" data-test="attach-input" @change="onFilesPicked" />
-    <!-- COMPOSER — single elevated card: textarea on top, controls row below. -->
-    <div class="rounded-lg border border-border bg-surface shadow-e2 focus-within:border-accent/50 transition-colors">
+    <!-- COMPOSER — single elevated card: textarea on top, controls row below.
+         `relative` so the slash-command menu can float above the card (bottom-full)
+         instead of pushing the textarea down. -->
+    <div class="relative rounded-lg border border-border bg-surface shadow-e2 focus-within:border-accent/50 transition-colors">
       <!-- Pending attachment chips -->
       <div v-if="composer.pending.length" class="flex flex-wrap gap-2 px-2.5 pt-2.5 pb-1">
         <div v-for="p in composer.pending" :key="p.id"
@@ -208,9 +210,10 @@ function onInput() {
       <span v-if="composer.rejection" data-test="attach-rejected" class="block px-3 pt-2 text-xs text-danger">
         {{ composer.rejection.reason === 'too-many' ? $t('chat.attach.tooMany') : $t('chat.attach.tooLarge', { name: composer.rejection.filename }) }}
       </span>
-      <!-- Agent slash-command autocomplete -->
+      <!-- Agent slash-command autocomplete: floats above the composer card (bottom-full)
+           so it never grows the input box; pinned to the card's horizontal edges. -->
       <ul v-if="cmdMenuOpen && cmdMatches.length" data-test="cmd-menu" role="listbox"
-          class="mx-2.5 mt-2 max-h-56 overflow-auto rounded-md border border-border bg-raised py-1 shadow-e2">
+          class="absolute bottom-full inset-x-2.5 z-20 mb-2 max-h-56 overflow-auto rounded-md border border-border bg-raised py-1 shadow-e2">
         <li v-for="(c, i) in cmdMatches" :key="c.name"
             data-test="cmd-item" role="option" :aria-selected="i === cmdActiveIdx"
             class="flex cursor-pointer items-baseline gap-2 px-3 py-1.5 text-[13px]"

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
-import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, ScheduledOriginDto, SessionUsageSnapshotDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
+import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, ScheduledOriginDto, SessionCommandsSnapshotDto, SessionUsageSnapshotDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 
 // Remember which session was open so a page refresh returns to it (selection is not
@@ -258,10 +258,20 @@ export const useChatStore = defineStore("chat", () => {
     }
   }
 
+  /** Seed the per-session agent command list from the hub's snapshot (after a
+   *  refresh/reconnect), so the composer's "/" hints reappear without waiting for the
+   *  agent to re-advertise (which it typically only does at session start). */
+  function seedCommands(snapshots: SessionCommandsSnapshotDto[]): void {
+    for (const s of snapshots) {
+      agentCommands.value[bufKey(s.instanceId, s.sessionAlias)] = s.commands;
+    }
+  }
+
   async function loadActiveTurns(): Promise<void> {
-    const { turns, usage: usageSnapshot } = await api.get<{ turns: LiveTurnSnapshotDto[]; usage?: SessionUsageSnapshotDto[] }>("/api/active-turns");
+    const { turns, usage: usageSnapshot, commands: commandsSnapshot } = await api.get<{ turns: LiveTurnSnapshotDto[]; usage?: SessionUsageSnapshotDto[]; commands?: SessionCommandsSnapshotDto[] }>("/api/active-turns");
     seedActiveTurns(turns);
     if (usageSnapshot) seedUsage(usageSnapshot);
+    if (commandsSnapshot) seedCommands(commandsSnapshot);
   }
 
   function applyEvent(event: WebServerEvent): void {

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { serveStatic } from "@hono/node-server/serve-static";
 
-import { MSG, type LiveTurnSnapshotDto, type SessionUsageSnapshotDto } from "@ganglion/xacpx-relay-protocol";
+import { MSG, type LiveTurnSnapshotDto, type SessionCommandsSnapshotDto, type SessionUsageSnapshotDto } from "@ganglion/xacpx-relay-protocol";
 
 import type { AccountRow, AccountStore } from "../stores/accounts.js";
 import type { InstanceStore } from "../stores/instances.js";
@@ -24,6 +24,8 @@ export interface AppDeps {
   activeTurns?: (instanceId: string) => LiveTurnSnapshotDto[];
   /** Snapshot the latest per-session context-usage for an instance (for the active-turns endpoint). */
   sessionUsage?: (instanceId: string) => SessionUsageSnapshotDto[];
+  /** Snapshot the latest per-session agent-advertised commands for an instance (for the active-turns endpoint). */
+  sessionCommands?: (instanceId: string) => SessionCommandsSnapshotDto[];
   webRoot?: string;
   sessionTtlMs?: number;
   pairingTtlMs?: number;
@@ -257,11 +259,13 @@ export function createApp(deps: AppDeps): Hono<Vars> {
     const account = c.get("account");
     const turns: LiveTurnSnapshotDto[] = [];
     const usage: SessionUsageSnapshotDto[] = [];
+    const commands: SessionCommandsSnapshotDto[] = [];
     for (const inst of deps.instances.listByAccount(account.id)) {
       for (const t of deps.activeTurns?.(inst.id) ?? []) turns.push(t);
       for (const u of deps.sessionUsage?.(inst.id) ?? []) usage.push(u);
+      for (const cmd of deps.sessionCommands?.(inst.id) ?? []) commands.push(cmd);
     }
-    return c.json({ turns, usage });
+    return c.json({ turns, usage, commands });
   });
 
   app.get("/api/instances/:id/sessions/:alias/messages", (c) => {

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -4,8 +4,8 @@ import { serve, type ServerType } from "@hono/node-server";
 import { WebSocketServer } from "ws";
 
 import {
-  MSG, type ControlEventDto, type InstanceEventPayload, type InstanceNoticePayload, type LiveTurnSnapshotDto, type RelayEnvelope,
-  type SessionUsageSnapshotDto, type ToolStepDto, type TurnPartDto, type UsageBreakdownDto, type UsageCostDto,
+  MSG, type AgentCommandDto, type ControlEventDto, type InstanceEventPayload, type InstanceNoticePayload, type LiveTurnSnapshotDto, type RelayEnvelope,
+  type SessionCommandsSnapshotDto, type SessionUsageSnapshotDto, type ToolStepDto, type TurnPartDto, type UsageBreakdownDto, type UsageCostDto,
 } from "@ganglion/xacpx-relay-protocol";
 
 import { createSqlDriver, initSchema, type SqlDriver } from "./db.js";
@@ -71,6 +71,21 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     }
     return out;
   };
+  // Latest agent-advertised slash commands per (instance, session). Like sessionUsage this
+  // is session-scoped (replace-latest) so a (re)connecting web client can restore the
+  // composer's "/" command hints after a refresh (see GET /api/active-turns). Agents
+  // typically advertise once at session start, so without this the hints vanish on reload.
+  // Cleared when the instance goes offline. Absent for sessions that advertised none.
+  const sessionCommands = new Map<string, AgentCommandDto[]>();
+  const listSessionCommands = (instanceId: string): SessionCommandsSnapshotDto[] => {
+    const prefix = `${instanceId}\0`;
+    const out: SessionCommandsSnapshotDto[] = [];
+    for (const [k, commands] of sessionCommands) {
+      if (!k.startsWith(prefix)) continue;
+      out.push({ instanceId, sessionAlias: k.slice(prefix.length), commands });
+    }
+    return out;
+  };
   // Snapshot the in-flight turns for one instance so a (re)connecting web client can
   // rebuild the live view after a refresh (see GET /api/active-turns). `parts` is the
   // live array — fine to hand out by reference since the route serializes it at once.
@@ -118,6 +133,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
         const prefix = `${instanceId}\0`;
         for (const k of turnBuffers.keys()) if (k.startsWith(prefix)) turnBuffers.delete(k);
         for (const k of sessionUsage.keys()) if (k.startsWith(prefix)) sessionUsage.delete(k);
+        for (const k of sessionCommands.keys()) if (k.startsWith(prefix)) sessionCommands.delete(k);
       }
       webGateway.broadcast(accountId, { kind: "instance-status", instanceId, online });
     },
@@ -168,6 +184,11 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
           // restore the context-usage bar from the active-turns snapshot. Already
           // broadcast above; this is the persistence the snapshot reads back.
           sessionUsage.set(key(instanceId, event.sessionAlias), { used: event.used, size: event.size, ...(event.cost ? { cost: event.cost } : {}), ...(event.breakdown ? { breakdown: event.breakdown } : {}) });
+        } else if (event.type === "agent-commands") {
+          // Retain the latest advertised command list per session (replace) so a refreshed
+          // web client can restore the composer's "/" hints from the active-turns snapshot.
+          // Already broadcast above; this is the persistence the snapshot reads back.
+          sessionCommands.set(key(instanceId, event.sessionAlias), event.commands);
         } else if (event.type === "session-history") {
           // Seed a freshly-attached native session's recovered prior conversation into
           // history (one-time). Guard against re-seeding an already-populated session so a
@@ -191,6 +212,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     maxMessagesPerSession: MAX_MESSAGES_PER_SESSION,
     activeTurns: listActiveTurns,
     sessionUsage: listSessionUsage,
+    sessionCommands: listSessionCommands,
     trustProxy: options.trustProxy,
     checkUpdate: createRelayUpdateChecker({ current: readRelayVersion() }),
   });

--- a/tests/unit/packages/relay/web-dashboard-e2e.test.ts
+++ b/tests/unit/packages/relay/web-dashboard-e2e.test.ts
@@ -60,14 +60,18 @@ test("instance event flows to web client and is cached as history", async () => 
   listeners.forEach((l) => l({ type: "turn-output", chatKey: "relay:x", sessionAlias: "backend", chunk: "done" }));
   // Context-usage meter: retained per session (replace-latest), must survive turn-finished.
   listeners.forEach((l) => l({ type: "turn-usage", chatKey: "relay:x", sessionAlias: "backend", used: 1200, size: 8000 }));
+  // Agent-advertised slash commands: also retained per session (replace-latest), so the
+  // composer's "/" hints survive a refresh (agents typically advertise once at start).
+  listeners.forEach((l) => l({ type: "agent-commands", chatKey: "relay:x", sessionAlias: "backend", commands: [{ name: "compact", description: "Compact" }] }));
   await new Promise((r) => setTimeout(r, 50));
 
   // Mid-turn (before turn-finished): the in-flight snapshot is exposed so a refreshed
   // web client can rebuild the live view instead of losing the running task.
   const activeRes = await fetch(`${base}/api/active-turns`, { headers: { cookie } });
-  const { turns, usage } = (await activeRes.json()) as {
+  const { turns, usage, commands } = (await activeRes.json()) as {
     turns: Array<{ instanceId: string; sessionAlias: string; status: string; parts: Array<{ type: string; text?: string }> }>;
     usage: Array<{ instanceId: string; sessionAlias: string; used: number; size: number }>;
+    commands: Array<{ instanceId: string; sessionAlias: string; commands: Array<{ name: string; description?: string }> }>;
   };
   expect(turns).toHaveLength(1);
   expect(turns[0]!.sessionAlias).toBe("backend");
@@ -76,6 +80,8 @@ test("instance event flows to web client and is cached as history", async () => 
   expect(turns[0]!.parts).toEqual([{ type: "text", text: "done" }]);
   // The usage meter is exposed in the same snapshot so a refresh restores the bar.
   expect(usage).toEqual([{ instanceId: instId0, sessionAlias: "backend", used: 1200, size: 8000 }]);
+  // The advertised command list rides along too so a refresh restores the "/" hints.
+  expect(commands).toEqual([{ instanceId: instId0, sessionAlias: "backend", commands: [{ name: "compact", description: "Compact" }] }]);
 
   listeners.forEach((l) => l({ type: "turn-finished", chatKey: "relay:x", sessionAlias: "backend", ok: true }));
   await new Promise((r) => setTimeout(r, 200));
@@ -83,9 +89,11 @@ test("instance event flows to web client and is cached as history", async () => 
   // After the turn settles, the turn snapshot is empty (flushed to history) — but the
   // usage meter is session-scoped and PERSISTS, so the context bar survives a refresh.
   const activeAfter = await fetch(`${base}/api/active-turns`, { headers: { cookie } });
-  const afterJson = (await activeAfter.json()) as { turns: unknown[]; usage: Array<{ sessionAlias: string; used: number }> };
+  const afterJson = (await activeAfter.json()) as { turns: unknown[]; usage: Array<{ sessionAlias: string; used: number }>; commands: Array<{ sessionAlias: string; commands: Array<{ name: string }> }> };
   expect(afterJson.turns).toHaveLength(0);
   expect(afterJson.usage).toEqual([{ instanceId: instId0, sessionAlias: "backend", used: 1200, size: 8000 }]);
+  // Like the usage meter, the advertised command list is session-scoped and PERSISTS.
+  expect(afterJson.commands).toEqual([{ instanceId: instId0, sessionAlias: "backend", commands: [{ name: "compact", description: "Compact" }] }]);
 
   const kinds = events
     .map((raw) => { const d = decodeEnvelope(raw); return d.ok ? parseWebServerEvent(d.envelope) : null; })


### PR DESCRIPTION
## Problem

When using a **codex** agent in relay-web, the composer's `/` command autocomplete (e.g. `/compact`) disappears after a page refresh.

Root cause is the same class of reconnect-retention gap we fixed for the context-usage bar in relay 0.9.7 — but for `agent-commands` this time:

- The web is GUI-first: xacpx forwards all `/`-text to the agent verbatim and surfaces only the commands the agent **advertises** via the ACP `available_commands_update` frame (`agent-commands` control event).
- codex advertises its command list (`init`, `compact`, `undo`, `review`, `logout`, `opsx-*` — note: **no `/clear`**) typically **once at session start**.
- The hub broadcast that event live but **did not retain it**, so a refreshed/reconnected web client got no replay → `sessionCommands` went empty → the `/compact` hint vanished.

(`/clear` is intentionally untouched — codex has no such command; that's expected. The xacpx `session.reset` mapping only exists on the WeChat/Feishu chat channels, not the GUI passthrough path.)

## Fix

Mirror the existing `turn-usage` retention end-to-end:

| File | Change |
|---|---|
| `relay-protocol/src/web-dtos.ts` | New `SessionCommandsSnapshotDto` |
| `relay/src/server.ts` | `sessionCommands` map + `listSessionCommands`; retain on `agent-commands` (replace-latest), clear on instance offline, wire into `createApp` |
| `relay/src/http/app.ts` | `GET /api/active-turns` now also returns a `commands` array |
| `relay-web/src/stores/chat.ts` | `seedCommands()`; `loadActiveTurns` reads `commands` (tolerant of a missing field for older hubs) |
| `tests/unit/packages/relay/web-dashboard-e2e.test.ts` | e2e assertions: command list is exposed in the snapshot and persists across `turn-finished` |

## Verification

- `tsc` (relay) + `vue-tsc` (relay-web): clean
- relay package unit tests (incl. web-dashboard e2e): pass
- relay-web vitest: **416/416**
- relay-protocol unit tests: pass