### PR TITLE
feat(relay-web): agent brand icons for chat avatar + session-list glyphs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.2",
+      "version": "0.9.7",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },
@@ -97,6 +97,7 @@
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
+        "@lobehub/icons-static-svg": "^1.91.0",
         "@shikijs/langs": "^3.20.0",
         "@shikijs/themes": "^3.20.0",
         "dompurify": "^3.4.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2749,7 +2749,6 @@
       "version": "1.91.0",
       "resolved": "https://registry.npmjs.org/@lobehub/icons-static-svg/-/icons-static-svg-1.91.0.tgz",
       "integrity": "sha512-ZDflEq0uUvAkH4WK4h3qNvvY09ts4OqUb5azD7A0xKfcuYhffGwB1Q/As2RguZYq4Gh4v925CJ8iodiClzc4zw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -11704,6 +11703,7 @@
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
+        "@lobehub/icons-static-svg": "^1.91.0",
         "@shikijs/langs": "^3.20.0",
         "@shikijs/themes": "^3.20.0",
         "dompurify": "^3.4.10",

--- a/packages/relay-web/package.json
+++ b/packages/relay-web/package.json
@@ -14,6 +14,7 @@
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@ganglion/xacpx-relay-protocol": "^0.1.0",
+    "@lobehub/icons-static-svg": "^1.91.0",
     "@shikijs/langs": "^3.20.0",
     "@shikijs/themes": "^3.20.0",
     "dompurify": "^3.4.10",

--- a/packages/relay-web/src/__tests__/agenticon.test.ts
+++ b/packages/relay-web/src/__tests__/agenticon.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { agentIconSvg } from "../lib/agent-icons";
+import AgentIcon from "../components/AgentIcon.vue";
+
+describe("agentIconSvg", () => {
+  it("returns brand SVG markup for known drivers", () => {
+    for (const driver of ["codex", "claude", "gemini", "copilot", "cursor", "qwen", "kimi", "opencode"]) {
+      const svg = agentIconSvg(driver);
+      expect(svg, driver).toBeTruthy();
+      expect(svg!).toContain("<svg");
+    }
+  });
+
+  it("is tolerant of casing and surrounding whitespace", () => {
+    expect(agentIconSvg("  CODEX ")).toBe(agentIconSvg("codex"));
+  });
+
+  it("returns null for unknown / empty drivers", () => {
+    expect(agentIconSvg("totally-made-up")).toBeNull();
+    expect(agentIconSvg("")).toBeNull();
+    expect(agentIconSvg(null)).toBeNull();
+    expect(agentIconSvg(undefined)).toBeNull();
+  });
+});
+
+describe("AgentIcon", () => {
+  it("renders the brand glyph for a known driver", () => {
+    const w = mount(AgentIcon, { props: { driver: "codex" } });
+    expect(w.find('[data-test="agent-icon"]').exists()).toBe(true);
+    expect(w.html()).toContain("<svg");
+    // The generic Bot fallback (an <svg> with the lucide class) must not appear.
+    expect(w.find(".lucide-bot").exists()).toBe(false);
+  });
+
+  it("falls back to the generic icon for an unknown driver", () => {
+    const w = mount(AgentIcon, { props: { driver: "nope" } });
+    expect(w.find('[data-test="agent-icon"]').exists()).toBe(true);
+    expect(w.find(".lucide-bot").exists()).toBe(true);
+  });
+
+  it("exposes the title for hover discoverability", () => {
+    const w = mount(AgentIcon, { props: { driver: "codex", title: "my-codex" } });
+    expect(w.find('[data-test="agent-icon"]').attributes("title")).toBe("my-codex");
+  });
+});

--- a/packages/relay-web/src/__tests__/instances.test.ts
+++ b/packages/relay-web/src/__tests__/instances.test.ts
@@ -30,6 +30,31 @@ test("loadSessions caches sessions under the instance", async () => {
   expect(store.instances[0]?.sessions.map((s) => s.alias)).toEqual(["backend"]);
 });
 
+test("loadSessions also loads the instance's agents so driver→icon mapping works in the normal flow", async () => {
+  const store = useInstancesStore();
+  store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: false, agents: [], workspaces: [], agentCatalog: [] }];
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc").mockImplementation(async (_id: string, type: string) => {
+    if (type === "control.agents.list") return { agents: [{ name: "my-codex", driver: "codex" }] } as never;
+    return { sessions: [{ alias: "backend", agent: "my-codex", workspace: "/w", transportSession: "t", running: false }] } as never;
+  });
+  await store.loadSessions("i1");
+  expect(rpc).toHaveBeenCalledWith("i1", "control.agents.list");
+  expect(store.byId("i1")!.agents).toEqual([{ name: "my-codex", driver: "codex" }]);
+  vi.restoreAllMocks();
+});
+
+test("loadSessions skips the agents fetch once agents are already loaded", async () => {
+  const store = useInstancesStore();
+  store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: true, agents: [{ name: "a", driver: "codex" }], workspaces: [], agentCatalog: [] }];
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [] } as never);
+  await store.loadSessions("i1");
+  expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.list");
+  expect(rpc).not.toHaveBeenCalledWith("i1", "control.agents.list");
+  vi.restoreAllMocks();
+});
+
 test("loadInstances eagerly loads sessions for online instances", async () => {
   vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo) => {
     const url = typeof input === "string" ? input : String(input);

--- a/packages/relay-web/src/components/AgentIcon.vue
+++ b/packages/relay-web/src/components/AgentIcon.vue
@@ -21,6 +21,8 @@ const px = computed(() => `${props.size}px`);
     data-test="agent-icon"
     :data-driver="driver || ''"
     :title="title"
+    role="img"
+    :aria-label="title || driver || undefined"
     class="inline-grid shrink-0 place-items-center [&>svg]:h-full [&>svg]:w-full"
     :style="{ width: px, height: px }"
   >

--- a/packages/relay-web/src/components/AgentIcon.vue
+++ b/packages/relay-web/src/components/AgentIcon.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Bot } from "lucide-vue-next";
+import { agentIconSvg } from "../lib/agent-icons";
+
+// A square brand glyph for an agent driver. Renders the @lobehub/icons SVG when one exists
+// for the driver, else a generic robot fallback. The SVG is a build-time bundled constant
+// (see agent-icons.ts), not user input, so v-html is safe here.
+const props = withDefaults(defineProps<{ driver?: string | null; size?: number; title?: string }>(), {
+  size: 16,
+});
+
+const svg = computed(() => agentIconSvg(props.driver));
+const px = computed(() => `${props.size}px`);
+</script>
+
+<template>
+  <!-- The wrapper fixes the box; the inner SVG (which ships with its own width/height) is
+       forced to fill it so every brand mark lands at the same size. -->
+  <span
+    data-test="agent-icon"
+    :data-driver="driver || ''"
+    :title="title"
+    class="inline-grid shrink-0 place-items-center [&>svg]:h-full [&>svg]:w-full"
+    :style="{ width: px, height: px }"
+  >
+    <span v-if="svg" class="grid h-full w-full place-items-center" v-html="svg" />
+    <Bot v-else :size="size" class="text-fg-muted" />
+  </span>
+</template>

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -41,6 +41,12 @@ const instance = computed(() => (chat.instanceId ? instances.byId(chat.instanceI
 const currentSession = computed(() =>
   instance.value?.sessions.find((s) => s.alias === chat.sessionAlias),
 );
+// The session's acpx driver (codex/claude/…), resolved from the instance's configured
+// agents (session carries the agent NAME; AgentDto maps name→driver). Drives the
+// assistant avatar glyph. Undefined until agents load → AgentIcon shows its fallback.
+const currentDriver = computed(() =>
+  instance.value?.agents.find((a) => a.name === currentSession.value?.agent)?.driver,
+);
 
 // Keep a read-only git summary loaded for the current session's workspace so the
 // header chip reflects changes without the user opening the Files panel first.
@@ -117,7 +123,7 @@ const verb = computed(() => {
         {{ chat.error }}
         <button class="ml-2 text-danger underline" @click="chat.error = ''">{{ $t("common.dismiss") }}</button>
       </div>
-      <MessageList :messages="chat.messages" :live-turn="chat.liveTurn"
+      <MessageList :messages="chat.messages" :live-turn="chat.liveTurn" :driver="currentDriver"
                    :session-key="`${chat.instanceId}\0${chat.sessionAlias}`"
                    :scroll-to-scheduled="chat.scrollRequest"
                    :has-more-older="chat.hasMoreOlder" :loading-older="chat.loadingOlder"

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -9,10 +9,18 @@ import { showActionToast } from "../lib/use-action-toast";
 import { useSwipeActions } from "../lib/use-swipe-actions";
 import NewSessionDialog from "./NewSessionDialog.vue";
 import ManageInstanceDialog from "./ManageInstanceDialog.vue";
+import AgentIcon from "./AgentIcon.vue";
+import type { InstanceView } from "../stores/instances";
 
 const store = useInstancesStore();
 const chat = useChatStore();
 const { t } = useI18n();
+
+// A session row carries the agent NAME; the brand glyph keys on its driver. Resolve via the
+// instance's configured agents (AgentDto maps name→driver). Undefined → AgentIcon falls back.
+function driverFor(inst: InstanceView, agentName: string): string | undefined {
+  return inst.agents.find((a) => a.name === agentName)?.driver;
+}
 const emit = defineEmits<{ select: [instanceId: string, alias: string] }>();
 const dialogFor = ref<{ id: string; name: string } | null>(null);
 const manageFor = ref<{ id: string; name: string } | null>(null);
@@ -209,8 +217,10 @@ const rowSwipes = computed(() => {
                 <span v-else-if="!s.archived && s.running" data-test="attention-dot" data-attention="running" class="h-2 w-2 shrink-0 rounded-full bg-run" />
                 <span class="truncate text-[12.5px] font-medium"
                       :class="s.archived ? 'text-fg-muted' : (isSelected(inst.id, s.alias) ? 'font-semibold text-accent' : 'text-fg')">{{ s.alias }}</span>
-                <span class="shrink-0 rounded px-1 py-px font-mono text-[9.5px]"
-                      :class="isSelected(inst.id, s.alias) ? 'bg-accent/15 text-accent' : 'bg-bg text-fg-muted'">{{ s.agent }}</span>
+                <!-- Agent shown as its brand glyph (driver icon) instead of a text badge to
+                     save horizontal space; the agent name stays available on hover. -->
+                <AgentIcon :driver="driverFor(inst, s.agent)" :title="s.agent" :size="14"
+                           :class="s.archived ? 'opacity-60' : ''" />
                 <span v-if="s.archived" data-test="archived-badge" class="shrink-0 rounded bg-bg px-1 py-px text-[9px] text-fg-muted">{{ $t("instance.sessionArchivedBadge") }}</span>
                 <span v-if="!s.archived && elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
                       class="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-run">{{ elapsedLabel(inst.id, s.alias) }}</span>

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -6,11 +6,12 @@ import ToolCallPanel from "./ToolCallPanel.vue";
 import ReasoningPanel from "./ReasoningPanel.vue";
 import TurnParts from "./TurnParts.vue";
 import CopyButton from "./CopyButton.vue";
-import { Bot, CircleStop, Clock, Loader2, RotateCcw } from "lucide-vue-next";
+import { CircleStop, Clock, Loader2, RotateCcw } from "lucide-vue-next";
+import AgentIcon from "./AgentIcon.vue";
 import MessageAttachments from "./MessageAttachments.vue";
 import { fmtTime, fmtDateTime } from "../lib/format";
 
-const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; hasMoreOlder?: boolean; loadingOlder?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null }>();
+const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; driver?: string | null; hasMoreOlder?: boolean; loadingOlder?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null }>();
 const emit = defineEmits<{ resend: [message: ChatMessage]; loadOlder: [] }>();
 
 import type { ScheduledOriginDto } from "@ganglion/xacpx-relay-protocol";
@@ -173,8 +174,8 @@ watch(
           </div>
           <!-- ASSISTANT row -->
           <div v-else class="cv-row group flex gap-2.5">
-            <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-lg border border-border bg-surface">
-              <Bot :size="13" class="text-accent" />
+            <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden rounded-lg border border-border bg-surface">
+              <AgentIcon :driver="driver" :size="15" />
             </div>
             <div data-test="msg-out" class="min-w-0 flex-1 space-y-2.5"
                  :class="m.failed ? 'rounded-lg ring-1 ring-danger' : ''">
@@ -199,8 +200,8 @@ watch(
 
         <!-- live streaming assistant row -->
         <div v-if="liveTurn && liveTurn.parts.length" class="flex gap-2.5">
-          <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-lg border border-border bg-surface">
-            <Bot :size="13" class="text-accent" />
+          <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden rounded-lg border border-border bg-surface">
+            <AgentIcon :driver="driver" :size="15" />
           </div>
           <div data-test="msg-streaming" class="min-w-0 flex-1">
             <TurnParts :parts="liveTurn.parts" :streaming="true" />

--- a/packages/relay-web/src/lib/agent-icons.ts
+++ b/packages/relay-web/src/lib/agent-icons.ts
@@ -1,0 +1,45 @@
+// Brand glyphs for agent drivers, sourced from @lobehub/icons-static-svg (same library
+// the docs site uses). Each entry is the raw SVG markup, imported at build time via Vite's
+// `?raw` loader — bundled as a trusted string constant, never user input, so AgentIcon can
+// render it with v-html. Colour variants are used where the library ships one; the rest
+// fall back to the monochrome mark. Drivers with no brand icon resolve to null and the
+// caller shows a generic fallback.
+import codex from "@lobehub/icons-static-svg/icons/codex-color.svg?raw";
+import claude from "@lobehub/icons-static-svg/icons/claudecode-color.svg?raw";
+import gemini from "@lobehub/icons-static-svg/icons/gemini-color.svg?raw";
+import copilot from "@lobehub/icons-static-svg/icons/copilot-color.svg?raw";
+import cursor from "@lobehub/icons-static-svg/icons/cursor.svg?raw";
+import qwen from "@lobehub/icons-static-svg/icons/qwen-color.svg?raw";
+import kimi from "@lobehub/icons-static-svg/icons/kimi-color.svg?raw";
+import opencode from "@lobehub/icons-static-svg/icons/opencode.svg?raw";
+import openclaw from "@lobehub/icons-static-svg/icons/openclaw-color.svg?raw";
+import kilocode from "@lobehub/icons-static-svg/icons/kilocode.svg?raw";
+import kiro from "@lobehub/icons-static-svg/icons/kiro-color.svg?raw";
+import qoder from "@lobehub/icons-static-svg/icons/qoder-color.svg?raw";
+import trae from "@lobehub/icons-static-svg/icons/trae-color.svg?raw";
+
+// Keyed by acpx driver (src/config/agent-templates.ts). A custom agent ("my-codex")
+// resolves to driver "codex" upstream, so keying on driver — not the agent name — keeps
+// the mapping small and stable.
+const ICONS: Record<string, string> = {
+  codex,
+  claude,
+  gemini,
+  copilot,
+  cursor,
+  qwen,
+  kimi,
+  opencode,
+  openclaw,
+  kilocode,
+  kiro,
+  qoder,
+  trae,
+};
+
+/** Raw brand SVG for an agent driver, or null when the library ships none (the caller
+ *  then renders a generic fallback). Tolerant of casing/whitespace drift in the driver. */
+export function agentIconSvg(driver: string | null | undefined): string | null {
+  if (!driver) return null;
+  return ICONS[driver.trim().toLowerCase()] ?? null;
+}

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -55,11 +55,24 @@ export const useInstancesStore = defineStore("instances", () => {
   }
 
   async function loadSessions(instanceId: string): Promise<void> {
-    const { sessions } = await api.rpc<{ sessions: SessionDto[] }>(instanceId, "control.sessions.list");
+    // Pull the configured agents alongside the session list (once) so the sidebar and chat
+    // can map each session's agent NAME → driver for the brand icon. Agents otherwise only
+    // load when a create/manage dialog opens (loadFormOptions), so in the normal
+    // login→browse→chat flow inst.agents would stay empty and every icon would fall back to
+    // the generic glyph. Tolerant + fire-alongside: an agents failure must never block the
+    // session list, and it self-heals on the next loadSessions since `agents` stays empty.
+    const needAgents = (byId(instanceId)?.agents.length ?? 0) === 0;
+    const [{ sessions }, agentsRes] = await Promise.all([
+      api.rpc<{ sessions: SessionDto[] }>(instanceId, "control.sessions.list"),
+      needAgents
+        ? api.rpc<{ agents: AgentDto[] }>(instanceId, "control.agents.list").catch(() => null)
+        : Promise.resolve(null),
+    ]);
     const inst = byId(instanceId);
     if (inst) {
       inst.sessions = sessions;
       inst.sessionsLoaded = true;
+      if (agentsRes && !isErrorPayload(agentsRes) && Array.isArray(agentsRes.agents)) inst.agents = agentsRes.agents;
     }
   }
 


### PR DESCRIPTION
Render each agent's **brand mark by acpx driver**, using `@lobehub/icons-static-svg` — the same library the docs site uses.

## What changes

- **Chat assistant avatar**: the generic lucide `Bot` becomes the session's driver glyph (codex / claude / gemini / copilot / cursor / qwen / kimi / opencode / …). Resolved in `ChatPane` from the instance's configured agents (session carries the agent *name*; `AgentDto` maps name→driver).
- **Sidebar session list**: the text agent badge (`{{ s.agent }}`) becomes the driver icon, saving horizontal space. The agent name stays available on hover (`title`).

## How

| File | Role |
|---|---|
| `lib/agent-icons.ts` | driver → raw brand SVG (Vite `?raw`, build-time constants), null for unknown drivers |
| `components/AgentIcon.vue` | renders the bundled SVG (v-html on a trusted constant) or a `Bot` fallback |
| `MessageList.vue` | new `driver` prop; both avatar slots use `<AgentIcon>` |
| `ChatPane.vue` | resolves the current session's driver, passes it down |
| `InstanceTree.vue` | per-row driver resolution; badge → `<AgentIcon>` with `title` |

Color variants are used where the library ships one; cursor/opencode/kilocode fall back to the monochrome mark. Drivers with no brand icon (pi, droid, iflow, …) show the generic `Bot`.

## Dependency

Adds `@lobehub/icons-static-svg@^1.91.0` to `packages/relay-web` (already a docs dep). Root `package-lock.json` + `bun.lock` synced so CI `npm ci` passes.

## Verification

- `vue-tsc`: clean
- relay-web vitest: **422/422** (incl. new `agenticon.test.ts` — mapping + render + fallback + title)
- `vite build` (relay-web): succeeds — confirms the `?raw` icon imports bundle