### PR TITLE
fix(relay-web): auto-load the diff on session switch when the Changes tab is active

### DIFF
--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -169,4 +169,60 @@ describe("FilesPanel navigation rail", () => {
     expect(cjk).toBeTruthy();
     expect(cjk!.text()).toContain("草稿.md");
   });
+
+  it("auto-loads the diff when switching sessions while the Changes tab is active", async () => {
+    const instances = useInstancesStore();
+    instances.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      sessions: [
+        { alias: "s1", agent: "codex", workspace: "backend" },
+        { alias: "s2", agent: "codex", workspace: "frontend" },
+      ],
+      agents: [], workspaces: [{ name: "backend", cwd: "/b" }, { name: "frontend", cwd: "/f" }], agentCatalog: [],
+    }] as never;
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    await flushPromises();
+
+    const files = useFilesStore();
+    // Changes tab already active with a diff loaded — so the tab watcher's `!files.diff`
+    // guard would NOT fire on its own; only the session-switch path should reload.
+    files.tab = "changes";
+    files.diff = { workspace: "backend", files: [], diff: "", truncated: false } as never;
+    await flushPromises();
+
+    const loadDiff = vi.spyOn(files, "loadDiff").mockResolvedValue();
+    // Switch to a session in a different workspace while the Changes tab stays active.
+    chat.sessionAlias = "s2";
+    await flushPromises();
+
+    expect(loadDiff).toHaveBeenCalled();
+  });
+
+  it("does not auto-load the diff on a session switch when the Files tab is active", async () => {
+    const instances = useInstancesStore();
+    instances.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      sessions: [
+        { alias: "s1", agent: "codex", workspace: "backend" },
+        { alias: "s2", agent: "codex", workspace: "frontend" },
+      ],
+      agents: [], workspaces: [{ name: "backend", cwd: "/b" }, { name: "frontend", cwd: "/f" }], agentCatalog: [],
+    }] as never;
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    await flushPromises();
+
+    const files = useFilesStore();
+    files.tab = "files";
+    const loadDiff = vi.spyOn(files, "loadDiff").mockResolvedValue();
+    chat.sessionAlias = "s2";
+    await flushPromises();
+
+    expect(loadDiff).not.toHaveBeenCalled();
+  });
 });

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -187,18 +187,19 @@ describe("FilesPanel navigation rail", () => {
     await flushPromises();
 
     const files = useFilesStore();
-    // Changes tab already active with a diff loaded — so the tab watcher's `!files.diff`
-    // guard would NOT fire on its own; only the session-switch path should reload.
     files.tab = "changes";
     files.diff = { workspace: "backend", files: [], diff: "", truncated: false } as never;
     await flushPromises();
 
+    // Spy installed after any initial load, so a call here can only come from the
+    // session-switch path (the tab watcher keys on `files.tab`, which doesn't change).
     const loadDiff = vi.spyOn(files, "loadDiff").mockResolvedValue();
     // Switch to a session in a different workspace while the Changes tab stays active.
     chat.sessionAlias = "s2";
     await flushPromises();
 
-    expect(loadDiff).toHaveBeenCalled();
+    // Loaded exactly once via this path — guards against an accidental double-load.
+    expect(loadDiff).toHaveBeenCalledTimes(1);
   });
 
   it("does not auto-load the diff on a session switch when the Files tab is active", async () => {

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -154,7 +154,13 @@ watch(
     await instances.loadWorkspaces(id).catch(() => {});
     // Default to the active session's workspace; fall back to the first configured one.
     const target = ws ?? instances.byId(id)?.workspaces?.[0]?.name;
-    if (target) void files.selectWorkspace(id, target);
+    if (!target) return;
+    await files.selectWorkspace(id, target);
+    // selectWorkspace cleared the diff, but the files.tab watcher below won't refire on a
+    // session switch (the tab value is unchanged), so the Changes tab would sit on the
+    // "no diff loaded" placeholder until a manual refresh. Load it here when it's the
+    // active view so switching sessions auto-shows the new workspace's changes.
+    if (files.tab === "changes") void files.loadDiff();
   },
   { immediate: true },
 );


### PR DESCRIPTION
## Problem

With the right rail's **Changes (改动)** tab active, switching sessions showed **未加载差异 (no diff loaded)** until you manually clicked the refresh button.

## Root cause

`FilesPanel` loads the diff lazily in two places:
- the workspace-change watcher (session switch) → calls `files.reset()` + `selectWorkspace()`, which **clears** `files.diff`;
- a `files.tab` watcher → loads the diff, but only fires when the **tab value changes**.

On a session switch the tab value is unchanged (still `changes`), so neither path reloads the diff — it just sits on the placeholder.

## Fix

In the workspace-change watcher, after `selectWorkspace`, load the diff when the Changes tab is the active view:

```ts
await files.selectWorkspace(id, target);
if (files.tab === "changes") void files.loadDiff();
```

## Verification

- `vue-tsc`: clean
- `filespanel.test.ts`: **11/11** — added two cases:
  - switching sessions while the Changes tab is active (with a diff already loaded, so the tab watcher's `!files.diff` guard wouldn't fire) **does** reload the diff;
  - switching sessions while the Files tab is active does **not** load the diff.