### PR TITLE
fix(transport,relay-web): tolerate cross-adapter model ids on session create

### DIFF
--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -6,6 +6,12 @@ export interface SessionDto {
   transportSession: string;
   running: boolean;
   archived: boolean;
+  /** The agent adapter command this session actually runs (acpx-recorded, or the agent's
+   *  resolved default). Lets the web avoid seeding a new session's model picker from a
+   *  session running a different adapter version — those advertise model ids in
+   *  incompatible formats (e.g. codex `gpt-5.5[high]` vs `gpt-5.5/high`). Omitted when
+   *  unknown. */
+  agentCommand?: string;
 }
 
 /** Wire DTO for a configured agent on an instance. */

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -169,4 +169,60 @@ describe("FilesPanel navigation rail", () => {
     expect(cjk).toBeTruthy();
     expect(cjk!.text()).toContain("草稿.md");
   });
+
+  it("auto-loads the diff when switching sessions while the Changes tab is active", async () => {
+    const instances = useInstancesStore();
+    instances.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      sessions: [
+        { alias: "s1", agent: "codex", workspace: "backend" },
+        { alias: "s2", agent: "codex", workspace: "frontend" },
+      ],
+      agents: [], workspaces: [{ name: "backend", cwd: "/b" }, { name: "frontend", cwd: "/f" }], agentCatalog: [],
+    }] as never;
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    await flushPromises();
+
+    const files = useFilesStore();
+    // Changes tab already active with a diff loaded — so the tab watcher's `!files.diff`
+    // guard would NOT fire on its own; only the session-switch path should reload.
+    files.tab = "changes";
+    files.diff = { workspace: "backend", files: [], diff: "", truncated: false } as never;
+    await flushPromises();
+
+    const loadDiff = vi.spyOn(files, "loadDiff").mockResolvedValue();
+    // Switch to a session in a different workspace while the Changes tab stays active.
+    chat.sessionAlias = "s2";
+    await flushPromises();
+
+    expect(loadDiff).toHaveBeenCalled();
+  });
+
+  it("does not auto-load the diff on a session switch when the Files tab is active", async () => {
+    const instances = useInstancesStore();
+    instances.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      sessions: [
+        { alias: "s1", agent: "codex", workspace: "backend" },
+        { alias: "s2", agent: "codex", workspace: "frontend" },
+      ],
+      agents: [], workspaces: [{ name: "backend", cwd: "/b" }, { name: "frontend", cwd: "/f" }], agentCatalog: [],
+    }] as never;
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    await flushPromises();
+
+    const files = useFilesStore();
+    files.tab = "files";
+    const loadDiff = vi.spyOn(files, "loadDiff").mockResolvedValue();
+    chat.sessionAlias = "s2";
+    await flushPromises();
+
+    expect(loadDiff).not.toHaveBeenCalled();
+  });
 });

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -187,18 +187,19 @@ describe("FilesPanel navigation rail", () => {
     await flushPromises();
 
     const files = useFilesStore();
-    // Changes tab already active with a diff loaded — so the tab watcher's `!files.diff`
-    // guard would NOT fire on its own; only the session-switch path should reload.
     files.tab = "changes";
     files.diff = { workspace: "backend", files: [], diff: "", truncated: false } as never;
     await flushPromises();
 
+    // Spy installed after any initial load, so a call here can only come from the
+    // session-switch path (the tab watcher keys on `files.tab`, which doesn't change).
     const loadDiff = vi.spyOn(files, "loadDiff").mockResolvedValue();
     // Switch to a session in a different workspace while the Changes tab stays active.
     chat.sessionAlias = "s2";
     await flushPromises();
 
-    expect(loadDiff).toHaveBeenCalled();
+    // Loaded exactly once via this path — guards against an accidental double-load.
+    expect(loadDiff).toHaveBeenCalledTimes(1);
   });
 
   it("does not auto-load the diff on a session switch when the Files tab is active", async () => {

--- a/packages/relay-web/src/__tests__/instances.test.ts
+++ b/packages/relay-web/src/__tests__/instances.test.ts
@@ -220,6 +220,72 @@ describe("agent catalog + management actions", () => {
   });
 });
 
+describe("listModelSuggestions adapter-consensus gate", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  function seedSessions(sessions: unknown[]) {
+    const store = useInstancesStore();
+    store.instances = [{ id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: sessions as never, sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] }];
+    return store;
+  }
+
+  test("reuses a single same-agent+workspace session's advertised models", async () => {
+    const store = seedSessions([
+      { alias: "a", agent: "codex", workspace: "w", transportSession: "t", running: true, archived: false, agentCommand: "npx codex-acp@new" },
+    ]);
+    const { api } = await import("../api/client");
+    vi.spyOn(api, "rpc").mockResolvedValue({ current: "gpt-5.5[high]", available: ["gpt-5.5[high]", "gpt-5.5[low]"] });
+    await expect(store.listModelSuggestions("i1", "codex", "w")).resolves.toEqual(["gpt-5.5[high]", "gpt-5.5[low]"]);
+    vi.restoreAllMocks();
+  });
+
+  test("suppresses suggestions when same-agent sessions run different adapters", async () => {
+    const store = seedSessions([
+      { alias: "old", agent: "codex", workspace: "w", transportSession: "t1", running: true, archived: false, agentCommand: "npx @zed-industries/codex-acp@0.10.0" },
+      { alias: "new", agent: "codex", workspace: "w", transportSession: "t2", running: true, archived: false, agentCommand: "npx @agentclientprotocol/codex-acp@^0.0.44" },
+    ]);
+    const { api } = await import("../api/client");
+    const rpc = vi.spyOn(api, "rpc");
+    await expect(store.listModelSuggestions("i1", "codex", "w")).resolves.toEqual([]);
+    // Ambiguous adapter → never query a live session for its (wrong-adapter) models.
+    expect(rpc).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  test("reuses when same-agent sessions share one adapter", async () => {
+    const store = seedSessions([
+      { alias: "a", agent: "codex", workspace: "w", transportSession: "t1", running: true, archived: false, agentCommand: "npx codex-acp@new" },
+      { alias: "b", agent: "codex", workspace: "w", transportSession: "t2", running: false, archived: false, agentCommand: "npx codex-acp@new" },
+    ]);
+    const { api } = await import("../api/client");
+    vi.spyOn(api, "rpc").mockResolvedValue({ current: "gpt-5.5[high]", available: ["gpt-5.5[high]"] });
+    await expect(store.listModelSuggestions("i1", "codex", "w")).resolves.toEqual(["gpt-5.5[high]"]);
+    vi.restoreAllMocks();
+  });
+
+  test("ignores archived sessions when judging adapter consensus", async () => {
+    const store = seedSessions([
+      { alias: "live", agent: "codex", workspace: "w", transportSession: "t1", running: true, archived: false, agentCommand: "npx codex-acp@new" },
+      { alias: "old", agent: "codex", workspace: "w", transportSession: "t2", running: false, archived: true, agentCommand: "npx @zed-industries/codex-acp@0.10.0" },
+    ]);
+    const { api } = await import("../api/client");
+    vi.spyOn(api, "rpc").mockResolvedValue({ current: "gpt-5.5[high]", available: ["gpt-5.5[high]"] });
+    await expect(store.listModelSuggestions("i1", "codex", "w")).resolves.toEqual(["gpt-5.5[high]"]);
+    vi.restoreAllMocks();
+  });
+
+  test("reuses when adapter is unknown on all sessions (legacy state, no field)", async () => {
+    const store = seedSessions([
+      { alias: "a", agent: "codex", workspace: "w", transportSession: "t1", running: true, archived: false },
+      { alias: "b", agent: "codex", workspace: "w", transportSession: "t2", running: false, archived: false },
+    ]);
+    const { api } = await import("../api/client");
+    vi.spyOn(api, "rpc").mockResolvedValue({ current: "gpt-5.5[high]", available: ["gpt-5.5[high]"] });
+    await expect(store.listModelSuggestions("i1", "codex", "w")).resolves.toEqual(["gpt-5.5[high]"]);
+    vi.restoreAllMocks();
+  });
+});
+
 import { mount } from "@vue/test-utils";
 import InstanceTree from "../components/InstanceTree.vue";
 

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -154,7 +154,13 @@ watch(
     await instances.loadWorkspaces(id).catch(() => {});
     // Default to the active session's workspace; fall back to the first configured one.
     const target = ws ?? instances.byId(id)?.workspaces?.[0]?.name;
-    if (target) void files.selectWorkspace(id, target);
+    if (!target) return;
+    await files.selectWorkspace(id, target);
+    // selectWorkspace cleared the diff, but the files.tab watcher below won't refire on a
+    // session switch (the tab value is unchanged), so the Changes tab would sit on the
+    // "no diff loaded" placeholder until a manual refresh. Load it here when it's the
+    // active view so switching sessions auto-shows the new workspace's changes.
+    if (files.tab === "changes") void files.loadDiff();
   },
   { immediate: true },
 );

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -149,13 +149,27 @@ export const useInstancesStore = defineStore("instances", () => {
 
   // Best-effort model suggestions for the new-session form's datalist. acpx can't list
   // an agent's models without a live session, so we reuse the advertised `available`
-  // list from any EXISTING session of the same agent + workspace. Returns [] when there
+  // list from an EXISTING session of the same agent + workspace. Returns [] when there
   // is no such session (e.g. a brand-new agent) or on any failure — the form then falls
   // back to a plain free-text input defaulting to "default".
   async function listModelSuggestions(instanceId: string, agent: string, workspace: string): Promise<string[]> {
     const inst = byId(instanceId);
-    const match = (inst?.sessions ?? []).find((s) => s.agent === agent && s.workspace === workspace);
-    if (!match) return [];
+    // Only consider live (non-archived) same-agent+workspace sessions — a fresh session
+    // resembles a live one, not an archived rollout.
+    const candidates = (inst?.sessions ?? []).filter((s) => s.agent === agent && s.workspace === workspace && !s.archived);
+    if (candidates.length === 0) return [];
+    // Different adapter versions of the same agent advertise model ids in incompatible
+    // formats (e.g. codex: `gpt-5.5[high]` vs `gpt-5.5/high`). Seeding a NEW session's
+    // picker from a session running a DIFFERENT adapter would propose ids the new adapter
+    // rejects. We can't know the new session's adapter ahead of creation, so this is a
+    // best-effort gate: only reuse when every candidate shares ONE resolved adapter
+    // command; suppress (→ free-text default) when they visibly diverge. It can't catch
+    // every case — `agentCommand` is undefined whenever acpx didn't record the session's
+    // adapter (so two such sessions collapse to one value and still reuse) — but the
+    // transport's model-not-advertised fallback (drop the rejected `--model`, use the
+    // agent default) is the actual guarantee that a bad pick never bricks creation.
+    if (new Set(candidates.map((s) => s.agentCommand ?? "")).size > 1) return [];
+    const match = candidates[0];
     try {
       const r = unwrap(await api.rpc<SessionModelResult>(instanceId, "control.session.model.get", { sessionAlias: match.alias }));
       const seen = new Set<string>();

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -11,6 +11,7 @@ import type { AgentCommand, UsageBreakdown, UsageCost } from "../transport/types
 import { createStructuredPromptFile } from "../transport/prompt-media";
 import { createStreamingPromptState, parseStreamingDataChunk } from "../transport/streaming-prompt";
 import { parseMissingOptionalDep } from "./parse-missing-optional-dep";
+import { isModelNotAdvertisedError } from "../transport/model-not-advertised";
 import { deriveParentPackageName } from "../recovery/discover-parent-package-paths";
 import { AcpxQueueOwnerLauncher } from "../transport/acpx-queue-owner-launcher";
 import { permissionModeToFlag } from "../transport/permission-mode-flag";
@@ -278,6 +279,34 @@ export class BridgeRuntime {
   }
 
   async ensureSession(
+    input: BridgeSessionInput,
+    onProgress?: (progress: EnsureSessionProgress) => void,
+  ): Promise<Record<string, never>> {
+    try {
+      return await this.attemptEnsureSession(input, onProgress);
+    } catch (error) {
+      // Different agent adapters advertise model ids in different formats (e.g. the two
+      // codex adapters disagree: `gpt-5.5[high]` vs `gpt-5.5/high`), so a model valid for
+      // one adapter is rejected by another and acpx hard-fails session creation. A stale /
+      // cross-adapter / mistyped model override must never make a session uncreatable —
+      // drop it and retry once, falling back to the agent adapter's default model.
+      const requestedModel = input.model?.trim();
+      if (
+        requestedModel &&
+        error instanceof EnsureSessionFailedError &&
+        isModelNotAdvertisedError(error.message)
+      ) {
+        onProgress?.({
+          kind: "note",
+          text: `agent did not advertise model "${requestedModel}"; retrying with the agent's default model`,
+        });
+        return await this.attemptEnsureSession({ ...input, model: undefined }, onProgress);
+      }
+      throw error;
+    }
+  }
+
+  private async attemptEnsureSession(
     input: BridgeSessionInput,
     onProgress?: (progress: EnsureSessionProgress) => void,
   ): Promise<Record<string, never>> {

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -34,6 +34,11 @@ export interface ControlSessionInfo {
   transportSession: string;
   running: boolean;
   archived: boolean;
+  /** The agent adapter command this session runs (acpx-recorded, or the agent's resolved
+   *  default). Surfaced so the web can avoid seeding a new session's model picker from a
+   *  session on a different adapter version (whose advertised model ids may be in an
+   *  incompatible format). Omitted when unknown. */
+  agentCommand?: string;
 }
 
 export interface ControlAgentInfo {
@@ -217,6 +222,7 @@ export class ControlService {
         transportSession: session.transportSession,
         running: this.deps.activeTurns.isActiveAnywhere(session.alias),
         archived: session.archived === true,
+        ...(session.agentCommand ? { agentCommand: session.agentCommand } : {}),
       }));
   }
 

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -17,6 +17,7 @@ import type {
   SessionTransport,
 } from "../types";
 import { getPromptText, normalizeCommandError } from "../prompt-output";
+import { isModelNotAdvertisedError } from "../model-not-advertised";
 import { createStructuredPromptFile } from "../prompt-media";
 import { createStreamingPromptState, parseStreamingDataChunk } from "../streaming-prompt";
 import {
@@ -205,6 +206,24 @@ export class AcpxCliTransport implements SessionTransport {
   // is never emitted. Users on this transport still see the initial "spawn" hint from
   // CommandRouter (emitted before the call) but will not receive mid-flight updates.
   async ensureSession(session: ResolvedSession, _onProgress?: (progress: EnsureSessionProgress) => void): Promise<void> {
+    try {
+      await this.runEnsureSession(session);
+    } catch (error) {
+      // Different agent adapters advertise model ids in different formats (e.g. the two
+      // codex adapters disagree: `gpt-5.5[high]` vs `gpt-5.5/high`), so a model valid for
+      // one adapter is rejected by another and acpx hard-fails session creation. A stale /
+      // cross-adapter / mistyped model override must never make a session uncreatable —
+      // drop it and retry once, falling back to the agent adapter's default model.
+      const requestedModel = session.model?.trim();
+      if (requestedModel && isModelNotAdvertisedError(error instanceof Error ? error.message : null)) {
+        await this.runEnsureSession({ ...session, model: undefined });
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private async runEnsureSession(session: ResolvedSession): Promise<void> {
     const args = this.buildArgs(session, [
       "sessions",
       "new",

--- a/src/transport/model-not-advertised.ts
+++ b/src/transport/model-not-advertised.ts
@@ -1,0 +1,20 @@
+// Different agent adapters advertise model ids in different formats — e.g. the two codex
+// adapters disagree on reasoning-effort suffixes (`gpt-5.5[high]` vs `gpt-5.5/high`). A model
+// id that is valid under one adapter is therefore rejected by another, and acpx hard-fails
+// session creation when a `--model` (or a replayed saved model) is not advertised.
+//
+// Transports use this to recognize that specific failure and retry session creation WITHOUT
+// the model — falling back to the agent adapter's default — so a stale / cross-adapter /
+// mistyped model override can never make a session uncreatable.
+//
+// Matched acpx messages (see ../../acpx/src/acp/model-support.ts):
+//   Cannot apply --model "<id>": the ACP agent did not advertise that model. Available models: …
+//   Cannot apply --model "<id>": the ACP agent did not advertise model support through …
+//   Cannot replay saved model "<id>": the ACP agent did not advertise that model. …
+export function isModelNotAdvertisedError(text: string | undefined | null): boolean {
+  if (!text) return false;
+  return (
+    /Cannot (?:apply --model|replay saved model)\b/i.test(text) ||
+    /did not advertise (?:that model|model support)/i.test(text)
+  );
+}

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -670,6 +670,54 @@ test("ensureSession falls back to generic kind when stderr does not match", asyn
   expect((caught as { kind?: string }).kind).toBe("generic");
 });
 
+test("ensureSession retries without --model when the agent does not advertise the requested model", async () => {
+  const calls: string[][] = [];
+  const modelRejection = {
+    code: 1,
+    stdout: "",
+    stderr:
+      '[acpx] initialized protocol version 1\nCannot apply --model "gpt-5.5/high": the ACP agent did not advertise that model. Available models: gpt-5.5[high].',
+  };
+  // First attempt carries --model and is rejected at every step; the model-less retry
+  // succeeds at the `ensure` step.
+  const runner = async (_command: string, args: string[]) => {
+    calls.push(args);
+    if (args.includes("--model")) return modelRejection;
+    return { code: 0, stdout: "ok", stderr: "" };
+  };
+  const runtime = new BridgeRuntime("acpx", runner, runner);
+  const notes: string[] = [];
+  await expect(
+    runtime.ensureSession(
+      { agent: "codex", cwd: "/repo", name: "demo", model: "gpt-5.5/high" },
+      (progress) => {
+        if (typeof progress === "object" && progress.kind === "note") notes.push(progress.text);
+      },
+    ),
+  ).resolves.toEqual({});
+
+  // The first attempt actually tried the requested model...
+  expect(calls.some((a) => a.includes("--model"))).toBe(true);
+  // ...and a later attempt dropped it to fall back to the agent default.
+  expect(calls.some((a) => a.includes("ensure") && !a.includes("--model"))).toBe(true);
+  // The fallback is surfaced to the user with the offending model id.
+  expect(notes.join(" ")).toContain("gpt-5.5/high");
+});
+
+test("ensureSession does not retry for failures unrelated to the model", async () => {
+  let attempts = 0;
+  const runner = async () => {
+    attempts += 1;
+    return { code: 1, stdout: "", stderr: "unrelated boom" };
+  };
+  const runtime = new BridgeRuntime("acpx", runner, runner);
+  await expect(
+    runtime.ensureSession({ agent: "codex", cwd: "/repo", name: "demo", model: "gpt-5.5[high]" }),
+  ).rejects.toThrow("unrelated boom");
+  // ensure + show + new from a single attempt — no second (model-less) attempt.
+  expect(attempts).toBe(3);
+});
+
 // ── toolEventMode wiring tests ───────────────────────────────────────────────
 
 function makeSpawnPrompt(dataHandler: { current?: (chunk: string) => void }, closeHandler: { current?: (code: number | null) => void }) {

--- a/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
@@ -46,6 +46,38 @@ test("ensureSession omits --model when the session has none", async () => {
   expect(args).not.toContain("--model");
 });
 
+test("ensureSession retries without --model when the agent does not advertise the requested model", async () => {
+  const calls: string[][] = [];
+  const run = mock(async (_command: string, args: string[]) => {
+    calls.push(args);
+    if (args.includes("--model")) {
+      return {
+        code: 1,
+        stdout: "",
+        stderr:
+          'Cannot apply --model "gpt-5.2[high]": the ACP agent did not advertise that model. Available models: gpt-5.2/high.',
+      };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const transport = new AcpxCliTransport({ command: "acpx" }, run, okRunner());
+  // Resolves instead of throwing: the stale model is dropped, not fatal.
+  await transport.ensureSession(modelSession);
+  expect(calls.some((a) => a.includes("--model"))).toBe(true);
+  expect(calls.some((a) => !a.includes("--model"))).toBe(true);
+});
+
+test("ensureSession surfaces non-model failures without retrying", async () => {
+  let attempts = 0;
+  const run = mock(async () => {
+    attempts += 1;
+    return { code: 1, stdout: "", stderr: "unrelated boom" };
+  });
+  const transport = new AcpxCliTransport({ command: "acpx" }, run, okRunner());
+  await expect(transport.ensureSession(modelSession)).rejects.toThrow("unrelated boom");
+  expect(attempts).toBe(1);
+});
+
 test("setModel issues `set ... model <id>` with the new model consistently", async () => {
   const run = okRunner();
   const transport = new AcpxCliTransport({ command: "acpx" }, run, okRunner());

--- a/tests/unit/transport/model-not-advertised.test.ts
+++ b/tests/unit/transport/model-not-advertised.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+
+import { isModelNotAdvertisedError } from "../../../src/transport/model-not-advertised";
+
+test("matches acpx 'did not advertise that model' rejection", () => {
+  const msg =
+    'Cannot apply --model "gpt-5.5/high": the ACP agent did not advertise that model. ' +
+    "Available models: gpt-5.5[low], gpt-5.5[medium], gpt-5.5[high].";
+  expect(isModelNotAdvertisedError(msg)).toBe(true);
+});
+
+test("matches acpx 'did not advertise model support' rejection", () => {
+  const msg =
+    'Cannot apply --model "gpt-5.5/high": the ACP agent did not advertise model support ' +
+    "through a session config option or legacy models metadata, and the adapter does not " +
+    "support a startup model flag.";
+  expect(isModelNotAdvertisedError(msg)).toBe(true);
+});
+
+test("matches the replay-saved-model variant", () => {
+  const msg = 'Cannot replay saved model "gpt-5.5/high": the ACP agent did not advertise that model.';
+  expect(isModelNotAdvertisedError(msg)).toBe(true);
+});
+
+test("matches even when interleaved with [acpx] log lines", () => {
+  const msg = [
+    "[acpx] spawning built-in agent @agentclientprotocol/codex-acp@^0.0.44",
+    "[acpx] initialized protocol version 1",
+    'Cannot apply --model "gpt-5.5/high": the ACP agent did not advertise that model. Available models: gpt-5.5[high].',
+  ].join("\n");
+  expect(isModelNotAdvertisedError(msg)).toBe(true);
+});
+
+test("does not match unrelated session-creation failures", () => {
+  expect(isModelNotAdvertisedError("session initialization timed out after 120s")).toBe(false);
+  expect(isModelNotAdvertisedError("EPERM: rename index.json.tmp failed")).toBe(false);
+  expect(isModelNotAdvertisedError("failed to create session")).toBe(false);
+});
+
+test("is null/undefined safe", () => {
+  expect(isModelNotAdvertisedError(undefined)).toBe(false);
+  expect(isModelNotAdvertisedError(null)).toBe(false);
+  expect(isModelNotAdvertisedError("")).toBe(false);
+});


### PR DESCRIPTION
## Problem

Different agent adapters advertise model ids in different formats. The two codex adapters disagree on reasoning-effort suffixes: old `@zed-industries/codex-acp@0.10.0` uses **slash** form (`gpt-5.5/high`), the new default `@agentclientprotocol/codex-acp@^0.0.44` uses **bracket** form (`gpt-5.5[high]`).

A model id valid under one adapter is rejected by another, and acpx **hard-fails session creation** when `--model` isn't advertised:

```
Cannot apply --model "gpt-5.5/high": the ACP agent did not advertise that model.
Available models: gpt-5.5[low], gpt-5.5[medium], gpt-5.5[high], ...
```

Trigger: the relay-web **New Session** dialog seeded its model suggestions (`listModelSuggestions`) from an existing same-agent+workspace session that could run a *different* adapter. Picking a suggested id then bricked creation.

(acpx is upstream / not ours to edit, so the fix lives on the xacpx side.)

## Fix — two layers

**1. Transport resilience (the guarantee — covers web / WeChat / restore alike)**
When acpx rejects `--model` as not advertised, drop it and retry session creation once, falling back to the agent adapter's default model.
- New `isModelNotAdvertisedError` matcher (`src/transport/model-not-advertised.ts`)
- Wired into the acpx-bridge `ensureSession` (surfaces a `note` progress) and the acpx-cli `ensureSession`

**2. relay-web prevention (best-effort — don't propose a cross-adapter id)**
- Expose each session's resolved adapter command on `SessionDto` (via control `listSessions`)
- `listModelSuggestions` only reuses suggestions when all live same-agent+workspace sessions share one adapter; suppresses on divergence (→ free-text default)

## Tests / verification
- New unit tests for the matcher, both transports' retry + no-retry paths, and the relay-web consensus gate (single / shared / divergent / archived-ignored / all-unknown)
- `npm test` (core full suite + typecheck) green; relay-web vitest 423 passed; protocol + connector tsc clean; relay-web vue-tsc clean

## Deploy note
`SessionDto` changed, so `bun run build:relay-protocol` is required (done locally; dist is gitignored). Rebuild + restart daemon / connector / relay-web for the fix to take effect.