### PR TITLE
feat: 自动化测试缺口分析与补充

### DIFF
--- a/src/transport/acpx-session-index.ts
+++ b/src/transport/acpx-session-index.ts
@@ -28,7 +28,7 @@ export async function resolveSessionAgentCommandFromIndex(session: ResolvedSessi
     const targetCwd = resolve(session.cwd);
     const match = parsed.entries?.find((entry) =>
       entry.name === session.transportSession &&
-      resolve(entry.cwd ?? "") === targetCwd &&
+      typeof entry.cwd === "string" && resolve(entry.cwd) === targetCwd &&
       typeof entry.agentCommand === "string" &&
       entry.agentCommand.trim().length > 0
     );

--- a/src/transport/acpx-session-index.ts
+++ b/src/transport/acpx-session-index.ts
@@ -28,7 +28,7 @@ export async function resolveSessionAgentCommandFromIndex(session: ResolvedSessi
     const targetCwd = resolve(session.cwd);
     const match = parsed.entries?.find((entry) =>
       entry.name === session.transportSession &&
-      entry.cwd === targetCwd &&
+      resolve(entry.cwd ?? "") === targetCwd &&
       typeof entry.agentCommand === "string" &&
       entry.agentCommand.trim().length > 0
     );

--- a/tests/unit/transport/acpx-session-index.test.ts
+++ b/tests/unit/transport/acpx-session-index.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { writeFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { resolveSessionAgentCommandFromIndex } from "../../../src/transport/acpx-session-index";
+
+describe("resolveSessionAgentCommandFromIndex", () => {
+  let originalHome: string | undefined;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME;
+    tempDir = await mkdir(join(tmpdir(), `acpx-session-index-${Date.now()}`), { recursive: true });
+    process.env.HOME = tempDir;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = originalHome;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function createIndex(entries: Array<{ name?: string; cwd?: string; agentCommand?: string }>): Promise<void> {
+    const sessionsDir = join(tempDir, ".acpx", "sessions");
+    await mkdir(sessionsDir, { recursive: true });
+    await writeFile(join(sessionsDir, "index.json"), JSON.stringify({ entries }));
+  }
+
+  test("returns undefined when index file does not exist", async () => {
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBeUndefined();
+  });
+
+  test("returns undefined when index file contains invalid JSON", async () => {
+    const sessionsDir = join(tempDir, ".acpx", "sessions");
+    await mkdir(sessionsDir, { recursive: true });
+    await writeFile(join(sessionsDir, "index.json"), "not valid json");
+
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBeUndefined();
+  });
+
+  test("returns undefined when index has no entries", async () => {
+    await createIndex([]);
+
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBeUndefined();
+  });
+
+  test("returns agentCommand when exact session name and cwd match", async () => {
+    await createIndex([
+      { name: "ws:demo", cwd: "/home/user/project", agentCommand: "codex" },
+    ]);
+
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBe("codex");
+  });
+
+  test("returns agentCommand when cwd path is resolved (normalized)", async () => {
+    await createIndex([
+      { name: "ws:demo", cwd: "/home/user/project/sub/../", agentCommand: "codex" },
+    ]);
+
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBe("codex");
+  });
+
+  test("returns undefined when session name does not match", async () => {
+    await createIndex([
+      { name: "ws:other", cwd: "/home/user/project", agentCommand: "codex" },
+    ]);
+
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBeUndefined();
+  });
+
+  test("returns undefined when cwd does not match", async () => {
+    await createIndex([
+      { name: "ws:demo", cwd: "/home/user/other", agentCommand: "codex" },
+    ]);
+
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBeUndefined();
+  });
+
+  test("returns undefined when agentCommand is empty or whitespace", async () => {
+    await createIndex([
+      { name: "ws:demo", cwd: "/home/user/project", agentCommand: "" },
+      { name: "ws:demo2", cwd: "/home/user/project", agentCommand: "   " },
+    ]);
+
+    expect(await resolveSessionAgentCommandFromIndex({ transportSession: "ws:demo", cwd: "/home/user/project" } as never)).toBeUndefined();
+    expect(await resolveSessionAgentCommandFromIndex({ transportSession: "ws:demo2", cwd: "/home/user/project" } as never)).toBeUndefined();
+  });
+
+  test("returns undefined when HOME env is not set", async () => {
+    delete process.env.HOME;
+
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBeUndefined();
+  });
+
+  test("matches first entry when multiple entries have same name but different cwd", async () => {
+    await createIndex([
+      { name: "ws:demo", cwd: "/home/user/project", agentCommand: "codex" },
+      { name: "ws:demo", cwd: "/home/user/other", agentCommand: "claude" },
+    ]);
+
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBe("codex");
+  });
+
+  test("trims agentCommand before returning", async () => {
+    await createIndex([
+      { name: "ws:demo", cwd: "/home/user/project", agentCommand: "  codex  " },
+    ]);
+
+    const session = { transportSession: "ws:demo", cwd: "/home/user/project" };
+    expect(await resolveSessionAgentCommandFromIndex(session as never)).toBe("codex");
+  });
+});

--- a/tests/unit/transport/permission-mode-flag.test.ts
+++ b/tests/unit/transport/permission-mode-flag.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { permissionModeToFlag } from "../../../src/transport/permission-mode-flag";
+
+describe("permissionModeToFlag", () => {
+  test("maps 'approve-reads' to '--approve-reads'", () => {
+    expect(permissionModeToFlag("approve-reads")).toBe("--approve-reads");
+  });
+
+  test("maps 'deny-all' to '--deny-all'", () => {
+    expect(permissionModeToFlag("deny-all")).toBe("--deny-all");
+  });
+
+  test("maps 'approve-all' to '--approve-all'", () => {
+    expect(permissionModeToFlag("approve-all")).toBe("--approve-all");
+  });
+});

--- a/tests/unit/transport/tool-kind-emoji.test.ts
+++ b/tests/unit/transport/tool-kind-emoji.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { TOOL_KIND_EMOJI, DEFAULT_TOOL_EMOJI } from "../../../src/transport/tool-kind-emoji";
+
+describe("TOOL_KIND_EMOJI", () => {
+  test("maps 'read' to book emoji", () => {
+    expect(TOOL_KIND_EMOJI.read).toBe("\u{1F4D6}");
+  });
+
+  test("maps 'search' to magnifying glass emoji", () => {
+    expect(TOOL_KIND_EMOJI.search).toBe("\u{1F50D}");
+  });
+
+  test("maps 'execute' to computer emoji", () => {
+    expect(TOOL_KIND_EMOJI.execute).toBe("\u{1F4BB}");
+  });
+
+  test("maps 'edit' to pencil emoji", () => {
+    expect(TOOL_KIND_EMOJI.edit).toBe("\u{270F}\u{FE0F}");
+  });
+
+  test("maps 'think' to brain emoji", () => {
+    expect(TOOL_KIND_EMOJI.think).toBe("\u{1F9E0}");
+  });
+
+  test("maps 'other' to wrench emoji", () => {
+    expect(TOOL_KIND_EMOJI.other).toBe("\u{1F527}");
+  });
+});
+
+describe("DEFAULT_TOOL_EMOJI", () => {
+  test("equals TOOL_KIND_EMOJI.other", () => {
+    expect(DEFAULT_TOOL_EMOJI).toBe(TOOL_KIND_EMOJI.other);
+  });
+});


### PR DESCRIPTION
## 概述
自动化测试缺口分析，补充 transport 模块关键路径的回归测试覆盖。

## 风险行为覆盖
- **acpx-session-index 路径匹配缺陷修复**：修复 cwd 路径规范化问题，索引文件中包含 `..` 的相对路径现在能正确匹配
- **permission-mode-flag 完整映射验证**：覆盖 approve-reads、deny-all、approve-all 三种权限模式
- **tool-kind-emoji 全工具类型覆盖**：read、search、execute、edit、think、other

## 变更内容
- `src/transport/acpx-session-index.ts`：修复 entry.cwd 路径规范化（+1, -1）
- `tests/unit/transport/acpx-session-index.test.ts`：11 个测试用例
- `tests/unit/transport/permission-mode-flag.test.ts`：3 个测试用例
- `tests/unit/transport/tool-kind-emoji.test.ts`：7 个测试用例

## 验证
全部 21 个测试用例通过。修复了一个真实的 bug：原代码只对 `session.cwd` 调用 `resolve()`，但没有对索引文件中的 `entry.cwd` 做相同处理，导致相对路径无法正确匹配。