### PR TITLE
fix(relay-web): keep tool-card chevron from shrinking on long titles

### DIFF
--- a/packages/relay-web/src/components/ReasoningPanel.vue
+++ b/packages/relay-web/src/components/ReasoningPanel.vue
@@ -15,8 +15,8 @@ const open = computed(() => localOpen.value);
 <template>
   <div class="overflow-hidden rounded-lg border border-border bg-surface text-xs shadow-e1">
     <button type="button" class="flex w-full items-center gap-1.5 px-3 py-2 text-left text-fg-muted" @click="localOpen = !localOpen">
-      <ChevronDown v-if="open" :size="13" />
-      <ChevronRight v-else :size="13" />
+      <ChevronDown v-if="open" :size="13" class="shrink-0" />
+      <ChevronRight v-else :size="13" class="shrink-0" />
       <Brain :size="13" :class="streaming ? 'text-accent' : ''" />
       <span class="text-[12px] font-medium" :class="streaming ? 'shimmer-text' : ''">{{ streaming ? $t("reasoning.reasoningStreaming") : $t("reasoning.reasoning") }}</span>
       <span v-if="streaming" data-test="reasoning-shimmer" class="ml-1 inline-block h-1.5 w-1.5 animate-pulse motion-reduce:animate-none rounded-full bg-fg-muted" aria-hidden="true" />

--- a/packages/relay-web/src/components/ToolCallPanel.vue
+++ b/packages/relay-web/src/components/ToolCallPanel.vue
@@ -48,8 +48,8 @@ function fmtDuration(ms?: number): string {
   <div class="overflow-hidden rounded-lg border border-border bg-surface text-xs shadow-e1">
     <button ref="header" type="button"
             class="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-bg" @click="onHeaderClick">
-      <ChevronDown v-if="open" :size="13" class="text-fg-muted" />
-      <ChevronRight v-else :size="13" class="text-fg-muted" />
+      <ChevronDown v-if="open" :size="13" class="shrink-0 text-fg-muted" />
+      <ChevronRight v-else :size="13" class="shrink-0 text-fg-muted" />
       <span class="inline-flex items-center gap-1.5 text-[11.5px] font-semibold text-fg-muted"><Wrench :size="13" /> {{ $t("tools.toolSteps") }}</span>
       <FueDot v-if="showFueDot" :pulsing="fue.status.value === 'unseen'" />
       <span v-else data-test="tool-count" class="font-mono text-[10.5px] text-fg-muted">{{ steps.length }}</span>

--- a/packages/relay-web/src/components/ToolStepCard.vue
+++ b/packages/relay-web/src/components/ToolStepCard.vue
@@ -47,10 +47,10 @@ function fmtDuration(ms?: number): string {
        :class="step.status === 'error' ? 'border-danger/40' : 'border-border'">
     <button type="button" data-test="tool-step-header"
             class="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-bg" @click="open = !open">
-      <ChevronDown v-if="open" :size="13" class="text-fg-muted" />
-      <ChevronRight v-else :size="13" class="text-fg-muted" />
+      <ChevronDown v-if="open" :size="13" class="shrink-0 text-fg-muted" />
+      <ChevronRight v-else :size="13" class="shrink-0 text-fg-muted" />
       <component :is="KIND_ICON[step.kind]" :size="13" class="shrink-0 text-fg-muted" />
-      <span class="truncate font-mono text-[11.5px] text-fg">{{ step.title }}</span>
+      <span class="min-w-0 truncate font-mono text-[11.5px] text-fg">{{ step.title }}</span>
       <span class="ml-auto flex shrink-0 items-center gap-2">
         <span v-if="step.durationMs !== undefined" class="font-mono text-[10.5px] text-fg-muted">{{ fmtDuration(step.durationMs) }}</span>
         <Check v-if="step.status === 'success'" data-test="step-status-success" :size="13" class="text-run" />


### PR DESCRIPTION
## What

工具卡片头部的折叠/展开 chevron 在标题较长时会被压扁成很小、且贴左上角；标题短的卡片则正常。根因是 `ToolStepCard`、`ToolCallPanel`、`ReasoningPanel` 三个组件里的 chevron 在 flex 头部里缺少 `shrink-0`，默认 `flex-shrink: 1`，横向空间不足时 SVG 跟着被压缩。read 类工具标题是长文件路径，所以最明显；`git status` 这类短标题不受影响。

## Changes

- 三处 `ChevronDown`/`ChevronRight` 补上 `shrink-0`，保持固定 13px、垂直居中
- `ToolStepCard` 标题 span 加 `min-w-0`，让长路径截断更干净

纯模板/样式改动，无逻辑变更。

## Test

无逻辑改动；视觉回归（长标题工具卡片折叠图标不再缩小）。