### PR TITLE
feat: add comprehensive unit tests for core modules

### DIFF
--- a/tests/unit/commands/handlers/permission-handler.test.ts
+++ b/tests/unit/commands/handlers/permission-handler.test.ts
@@ -1,0 +1,78 @@
+import { expect, test, beforeEach } from "bun:test";
+import {
+  handlePermissionStatus,
+  handlePermissionAutoStatus,
+  renderPermissionStatus,
+  permissionHelp,
+} from "../../../../src/commands/handlers/permission-handler";
+import { setLocale } from "../../../../src/i18n";
+
+beforeEach(() => {
+  setLocale("zh");
+});
+
+test("permissionHelp returns correct help metadata", () => {
+  const help = permissionHelp();
+  expect(help.topic).toBe("permission");
+  expect(help.aliases).toContain("pm");
+  expect(help.summary).toBeDefined();
+  expect(help.commands.length).toBeGreaterThan(0);
+});
+
+test("handlePermissionStatus returns current permission status", () => {
+  const context = {
+    config: {
+      transport: {
+        permissionMode: "approve-reads",
+        nonInteractivePermissions: "deny",
+      },
+    },
+  } as any;
+
+  const result = handlePermissionStatus(context);
+  expect(result.text).toContain("approve-reads");
+  expect(result.text).toContain("deny");
+});
+
+test("handlePermissionStatus uses default values when config is undefined", () => {
+  const context = { config: undefined } as any;
+
+  const result = handlePermissionStatus(context);
+  expect(result.text).toContain("approve-all");
+  expect(result.text).toContain("deny");
+});
+
+test("renderPermissionStatus formats permission status correctly", () => {
+  const config = {
+    transport: {
+      permissionMode: "deny-all",
+      nonInteractivePermissions: "approve",
+    },
+  };
+
+  const result = renderPermissionStatus(config, "Test Title");
+  expect(result).toContain("Test Title");
+  expect(result).toContain("deny-all");
+  expect(result).toContain("approve");
+});
+
+test("renderPermissionStatus uses defaults when config is undefined", () => {
+  const result = renderPermissionStatus(undefined, "Test Title");
+  expect(result).toContain("Test Title");
+  expect(result).toContain("approve-all");
+  expect(result).toContain("deny");
+});
+
+test("handlePermissionAutoStatus returns current auto permission status", () => {
+  const context = {
+    config: {
+      transport: {
+        permissionMode: "approve-all",
+        nonInteractivePermissions: "approve",
+      },
+    },
+  } as any;
+
+  const result = handlePermissionAutoStatus(context);
+  expect(result.text).toContain("approve");
+});

--- a/tests/unit/commands/help/help-registry.test.ts
+++ b/tests/unit/commands/help/help-registry.test.ts
@@ -1,0 +1,71 @@
+import { expect, test, beforeEach } from "bun:test";
+import { getHelpTopic, listHelpTopics } from "../../../../src/commands/help/help-registry";
+import { setLocale } from "../../../../src/i18n";
+
+beforeEach(() => {
+  setLocale("zh");
+});
+
+test("listHelpTopics returns all registered help topics", () => {
+  const topics = listHelpTopics();
+  expect(topics.length).toBeGreaterThan(0);
+  expect(topics.some((t) => t.topic === "session")).toBe(true);
+  expect(topics.some((t) => t.topic === "workspace")).toBe(true);
+  expect(topics.some((t) => t.topic === "agent")).toBe(true);
+  expect(topics.some((t) => t.topic === "permission")).toBe(true);
+  expect(topics.some((t) => t.topic === "later")).toBe(true);
+});
+
+test("getHelpTopic finds topic by exact name", () => {
+  const topic = getHelpTopic("session");
+  expect(topic).not.toBeNull();
+  expect(topic?.topic).toBe("session");
+});
+
+test("getHelpTopic finds topic by alias", () => {
+  const topic = getHelpTopic("ws");
+  expect(topic).not.toBeNull();
+  expect(topic?.topic).toBe("workspace");
+});
+
+test("getHelpTopic returns null for unknown topic", () => {
+  const topic = getHelpTopic("nonexistent-topic");
+  expect(topic).toBeNull();
+});
+
+test("getHelpTopic is case-sensitive", () => {
+  const topic = getHelpTopic("Session");
+  expect(topic).toBeNull();
+});
+
+test("each help topic has required fields", () => {
+  const topics = listHelpTopics();
+  for (const topic of topics) {
+    expect(topic.topic).toBeDefined();
+    expect(topic.summary).toBeDefined();
+    expect(Array.isArray(topic.commands)).toBe(true);
+    expect(topic.commands.length).toBeGreaterThan(0);
+  }
+});
+
+test("help topics have valid command structures", () => {
+  const topics = listHelpTopics();
+  for (const topic of topics) {
+    for (const command of topic.commands) {
+      expect(command.usage).toBeDefined();
+      expect(command.description).toBeDefined();
+    }
+  }
+});
+
+test("permission help topic has correct metadata", () => {
+  const topic = getHelpTopic("permission");
+  expect(topic).not.toBeNull();
+  expect(topic?.aliases).toContain("pm");
+});
+
+test("later help topic has correct metadata", () => {
+  const topic = getHelpTopic("later");
+  expect(topic).not.toBeNull();
+  expect(topic?.aliases).toContain("lt");
+});

--- a/tests/unit/orchestration/endpoint-probe.test.ts
+++ b/tests/unit/orchestration/endpoint-probe.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import { createServer } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { canConnectToEndpoint } from "../../../src/orchestration/endpoint-probe";
+
+test("canConnectToEndpoint returns true when Unix socket accepts connections", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "xacpx-endpoint-probe-"));
+  const socketPath = join(dir, "test.sock");
+
+  const server = createServer();
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+  const result = await canConnectToEndpoint(socketPath);
+  expect(result).toBe(true);
+
+  server.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("canConnectToEndpoint returns false when socket path does not exist", async () => {
+  const result = await canConnectToEndpoint("/nonexistent/socket/path");
+  expect(result).toBe(false);
+});
+
+test("canConnectToEndpoint returns false when socket exists but has no listener", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "xacpx-endpoint-probe-"));
+  const socketPath = join(dir, "no-listener.sock");
+
+  const server = createServer();
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  server.close();
+
+  await new Promise((r) => setTimeout(r, 10));
+
+  const result = await canConnectToEndpoint(socketPath);
+  expect(result).toBe(false);
+
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("canConnectToEndpoint returns true when timeout occurs", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "xacpx-endpoint-probe-"));
+  const socketPath = join(dir, "timeout.sock");
+
+  const server = createServer();
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+  server.on("connection", (conn) => {
+  });
+
+  const result = await canConnectToEndpoint(socketPath, 10);
+  expect(result).toBe(true);
+
+  server.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("canConnectToEndpoint handles timeout parameter correctly", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "xacpx-endpoint-probe-"));
+  const socketPath = join(dir, "timeout2.sock");
+
+  const server = createServer();
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+  const result = await canConnectToEndpoint(socketPath, 5000);
+  expect(result).toBe(true);
+
+  server.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+

--- a/tests/unit/state/debounced-state-store.test.ts
+++ b/tests/unit/state/debounced-state-store.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "bun:test";
+import { DebouncedStateStore } from "../../../src/state/debounced-state-store";
+
+test("DebouncedStateStore saves state after debounce interval", async () => {
+  const savedStates: any[] = [];
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async (state) => {
+        savedStates.push(state);
+      },
+    },
+    intervalMs: 10,
+  });
+
+  await store.save({ sessions: {}, chat_contexts: {} });
+  await new Promise((r) => setTimeout(r, 50));
+
+  expect(savedStates.length).toBe(1);
+  await store.dispose();
+});
+
+test("DebouncedStateStore batches multiple saves within interval", async () => {
+  const savedStates: any[] = [];
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async (state) => {
+        savedStates.push(state);
+      },
+    },
+    intervalMs: 10,
+  });
+
+  await Promise.all([
+    store.save({ sessions: { a: 1 }, chat_contexts: {} }),
+    store.save({ sessions: { b: 2 }, chat_contexts: {} }),
+    store.save({ sessions: { c: 3 }, chat_contexts: {} }),
+  ]);
+  await new Promise((r) => setTimeout(r, 50));
+
+  expect(savedStates.length).toBe(1);
+  expect(savedStates[0].sessions).toEqual({ c: 3 });
+  await store.dispose();
+});
+
+test("DebouncedStateStore flushes pending saves immediately", async () => {
+  const savedStates: any[] = [];
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async (state) => {
+        savedStates.push(state);
+      },
+    },
+    intervalMs: 1000,
+  });
+
+  await store.save({ sessions: { test: 1 }, chat_contexts: {} });
+  await store.flush();
+
+  expect(savedStates.length).toBe(1);
+  await store.dispose();
+});
+
+test("DebouncedStateStore rejects save after dispose", async () => {
+  const store = new DebouncedStateStore({
+    delegate: { save: async () => {} },
+    intervalMs: 10,
+  });
+
+  await store.dispose();
+
+  await expect(store.save({ sessions: {}, chat_contexts: {} })).rejects.toThrow("DebouncedStateStore is disposed");
+});
+
+test("DebouncedStateStore handles concurrent saves with flush", async () => {
+  const savedStates: any[] = [];
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async (state) => {
+        savedStates.push(state);
+        await new Promise((r) => setTimeout(r, 5));
+      },
+    },
+    intervalMs: 10,
+  });
+
+  store.save({ sessions: { a: 1 }, chat_contexts: {} });
+  store.save({ sessions: { b: 2 }, chat_contexts: {} });
+  await store.flush();
+
+  expect(savedStates.length).toBe(1);
+  await store.dispose();
+});
+
+test("DebouncedStateStore calls onError when save fails", async () => {
+  const errors: unknown[] = [];
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async () => {
+        throw new Error("save failed");
+      },
+    },
+    intervalMs: 10,
+    onError: (error) => {
+      errors.push(error);
+    },
+  });
+
+  await expect(store.save({ sessions: {}, chat_contexts: {} })).rejects.toThrow("save failed");
+  await new Promise((r) => setTimeout(r, 50));
+
+  expect(errors.length).toBe(1);
+  await store.dispose();
+});
+
+test("DebouncedStateStore schedules another flush after current flush completes", async () => {
+  let saveCount = 0;
+  let inSave = false;
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async () => {
+        inSave = true;
+        saveCount++;
+        await new Promise((r) => setTimeout(r, 20));
+        inSave = false;
+      },
+    },
+    intervalMs: 10,
+  });
+
+  await store.save({ sessions: { a: 1 }, chat_contexts: {} });
+  await new Promise((r) => setTimeout(r, 5));
+  await store.save({ sessions: { b: 2 }, chat_contexts: {} });
+  await new Promise((r) => setTimeout(r, 50));
+
+  expect(saveCount).toBe(2);
+  await store.dispose();
+});

--- a/tests/unit/util/async.test.ts
+++ b/tests/unit/util/async.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import { settleWithinTimeout } from "../../../src/util/async";
+
+test("settleWithinTimeout resolves when work completes before timeout", async () => {
+  let resolved = false;
+  const promise = settleWithinTimeout(
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolved = true;
+        resolve();
+      }, 10);
+    }),
+    1000,
+  );
+
+  await promise;
+  expect(resolved).toBe(true);
+});
+
+test("settleWithinTimeout resolves when work rejects before timeout", async () => {
+  let rejected = false;
+  const promise = settleWithinTimeout(
+    new Promise<void>((_, reject) => {
+      setTimeout(() => {
+        rejected = true;
+        reject(new Error("test error"));
+      }, 10);
+    }),
+    1000,
+  );
+
+  await promise;
+  expect(rejected).toBe(true);
+});
+
+test("settleWithinTimeout resolves after timeout when work is still pending", async () => {
+  let completed = false;
+  const promise = settleWithinTimeout(
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        completed = true;
+        resolve();
+      }, 1000);
+    }),
+    10,
+  );
+
+  await promise;
+  expect(completed).toBe(false);
+});
+
+test("settleWithinTimeout handles immediate resolution", async () => {
+  await settleWithinTimeout(Promise.resolve(), 1000);
+});
+
+test("settleWithinTimeout handles immediate rejection", async () => {
+  await settleWithinTimeout(Promise.reject(new Error("immediate")), 1000);
+});

--- a/tests/unit/util/sanitize.test.ts
+++ b/tests/unit/util/sanitize.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { sanitizeString } from "../../../src/util/sanitize";
+
+test("sanitizeString with allow pattern keeps allowed characters", () => {
+  expect(sanitizeString("hello_world", { allow: /[a-z_]/ })).toBe("hello_world");
+});
+
+test("sanitizeString with allow pattern replaces disallowed characters", () => {
+  expect(sanitizeString("hello world!", { allow: /[a-z_]/ })).toBe("hello-world-");
+});
+
+test("sanitizeString with deny pattern replaces denied characters", () => {
+  expect(sanitizeString("hello world!", { deny: /\s/ })).toBe("hello-world!");
+});
+
+test("sanitizeString collapses multiple replacements", () => {
+  expect(sanitizeString("hello   world", { deny: /\s/, collapse: true })).toBe("hello-world");
+});
+
+test("sanitizeString trims replacements from start and end", () => {
+  expect(sanitizeString("  hello world  ", { deny: /\s/, trim: true })).toBe("hello-world");
+});
+
+test("sanitizeString lowercases when requested", () => {
+  expect(sanitizeString("Hello World", { lowercase: true })).toBe("hello world");
+});
+
+test("sanitizeString returns fallback for empty result", () => {
+  expect(sanitizeString("!!!", { deny: /[^a-z]/, fallback: "default" })).toBe("default");
+});
+
+test("sanitizeString uses custom replacement", () => {
+  expect(sanitizeString("hello world", { deny: /\s/, replacement: "_" })).toBe("hello_world");
+});
+
+test("sanitizeString combines multiple options", () => {
+  expect(sanitizeString("  Hello World!!!  ", {
+    deny: /[^a-z]/,
+    replacement: "-",
+    lowercase: true,
+    collapse: true,
+    trim: true,
+  })).toBe("hello-world");
+});
+
+test("sanitizeString returns empty string when all characters are stripped", () => {
+  expect(sanitizeString("!!!", { deny: /[^a-z]/ })).toBe("");
+});

--- a/tests/unit/util/sanitize.test.ts
+++ b/tests/unit/util/sanitize.test.ts
@@ -14,11 +14,12 @@ test("sanitizeString with deny pattern replaces denied characters", () => {
 });
 
 test("sanitizeString collapses multiple replacements", () => {
-  expect(sanitizeString("hello   world", { deny: /\s/, collapse: true })).toBe("hello-world");
+  // deny needs the global flag to replace every match
+  expect(sanitizeString("hello   world", { deny: /\s/g, collapse: true })).toBe("hello-world");
 });
 
 test("sanitizeString trims replacements from start and end", () => {
-  expect(sanitizeString("  hello world  ", { deny: /\s/, trim: true })).toBe("hello-world");
+  expect(sanitizeString("  hello world  ", { deny: /\s/g, trim: true })).toBe("hello-world");
 });
 
 test("sanitizeString lowercases when requested", () => {
@@ -26,7 +27,8 @@ test("sanitizeString lowercases when requested", () => {
 });
 
 test("sanitizeString returns fallback for empty result", () => {
-  expect(sanitizeString("!!!", { deny: /[^a-z]/, fallback: "default" })).toBe("default");
+  // empty replacement strips characters entirely, so an all-denied input becomes ""
+  expect(sanitizeString("!!!", { deny: /[^a-z]/g, replacement: "", fallback: "default" })).toBe("default");
 });
 
 test("sanitizeString uses custom replacement", () => {
@@ -35,7 +37,7 @@ test("sanitizeString uses custom replacement", () => {
 
 test("sanitizeString combines multiple options", () => {
   expect(sanitizeString("  Hello World!!!  ", {
-    deny: /[^a-z]/,
+    deny: /[^a-z]/g,
     replacement: "-",
     lowercase: true,
     collapse: true,
@@ -44,5 +46,5 @@ test("sanitizeString combines multiple options", () => {
 });
 
 test("sanitizeString returns empty string when all characters are stripped", () => {
-  expect(sanitizeString("!!!", { deny: /[^a-z]/ })).toBe("");
+  expect(sanitizeString("!!!", { deny: /[^a-z]/g, replacement: "" })).toBe("");
 });

--- a/tests/unit/util/text.test.ts
+++ b/tests/unit/util/text.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { truncateText, escapeForDoubleQuotes, quoteIfNeeded } from "../../../src/util/text";
+
+test("truncateText returns unchanged text when within limit", () => {
+  expect(truncateText("hello", 10)).toBe("hello");
+});
+
+test("truncateText truncates and adds ellipsis when over limit", () => {
+  expect(truncateText("hello world", 8)).toBe("hello…");
+});
+
+test("truncateText handles empty string", () => {
+  expect(truncateText("", 10)).toBe("");
+});
+
+test("truncateText uses custom ellipsis", () => {
+  expect(truncateText("hello world", 8, "---")).toBe("hel---");
+});
+
+test("truncateText handles exact limit", () => {
+  expect(truncateText("hello", 5)).toBe("hello");
+});
+
+test("truncateText handles text shorter than ellipsis", () => {
+  expect(truncateText("hi", 1)).toBe("h");
+});
+
+test("escapeForDoubleQuotes escapes backslashes and quotes", () => {
+  expect(escapeForDoubleQuotes('hello "world"')).toBe('hello \\"world\\"');
+  expect(escapeForDoubleQuotes("hello \\ world")).toBe("hello \\\\ world");
+  expect(escapeForDoubleQuotes('hello "world" \\')).toBe('hello \\"world\\" \\\\');
+});
+
+test("quoteIfNeeded wraps text in escaped double quotes", () => {
+  expect(quoteIfNeeded('hello "world"')).toBe('"hello \\"world\\""');
+  expect(quoteIfNeeded("simple")).toBe('"simple"');
+});

--- a/tests/unit/util/text.test.ts
+++ b/tests/unit/util/text.test.ts
@@ -6,7 +6,8 @@ test("truncateText returns unchanged text when within limit", () => {
 });
 
 test("truncateText truncates and adds ellipsis when over limit", () => {
-  expect(truncateText("hello world", 8)).toBe("hello…");
+  // slices to maxLength - ellipsis.length, then appends the ellipsis
+  expect(truncateText("hello world", 8)).toBe("hello w…");
 });
 
 test("truncateText handles empty string", () => {
@@ -14,7 +15,7 @@ test("truncateText handles empty string", () => {
 });
 
 test("truncateText uses custom ellipsis", () => {
-  expect(truncateText("hello world", 8, "---")).toBe("hel---");
+  expect(truncateText("hello world", 8, "---")).toBe("hello---");
 });
 
 test("truncateText handles exact limit", () => {
@@ -22,7 +23,8 @@ test("truncateText handles exact limit", () => {
 });
 
 test("truncateText handles text shorter than ellipsis", () => {
-  expect(truncateText("hi", 1)).toBe("h");
+  // maxLength < ellipsis length: slice(0, negative) is empty, leaving just the ellipsis
+  expect(truncateText("hi", 1)).toBe("…");
 });
 
 test("escapeForDoubleQuotes escapes backslashes and quotes", () => {


### PR DESCRIPTION
## 🎯 Changes

### 1. 新增权限处理器 (Permission Handler) 单元测试
- 验证 `permissionHelp()` 返回的帮助元数据包含正确的话题、别名、摘要和命令列表。
- 验证 `handlePermissionStatus()` 返回当前权限状态，并在配置未定义时使用默认值。
- 验证 `renderPermissionStatus()` 权限状态格式化正确，并在配置未定义时使用默认值。
- 验证 `handlePermissionAutoStatus()` 返回当前自动权限状态。

### 2. 新增帮助注册表 (Help Registry) 单元测试
- 验证 `listHelpTopics()` 返回所有已注册帮助话题，包括 session、workspace、agent、permission、later 等。
- 验证 `getHelpTopic()` 按精确名称和别名查找话题，未知话题返回 null，并测试大小写敏感行为。
- 验证帮助话题结构，确保每个话题包含必填字段且命令结构合法。
- 验证 permission 和 later 话题元数据，检查别名配置正确。

### 3. 新增端点探测 (Endpoint Probe) 单元测试
- 验证 `canConnectToEndpoint()` 在 Unix 套接字接受连接时返回 true。
- 验证套接字路径不存在时返回 false。
- 验证套接字存在但无监听器时返回 false。
- 验证超时参数处理，包括连接超时时返回 true 及不同超时值的正确行为。

### 4. 新增防抖状态存储 (Debounced State Store) 单元测试
- 验证防抖间隔后保存状态。
- 验证多个保存在间隔内被批量合并为一次保存。
- 验证 `flush()` 立即刷新待保存状态。
- 验证 dispose 后保存操作被拒绝。
- 验证并发保存与 flush 配合使用。
- 验证保存失败时触发 `onError` 回调。
- 验证当前 flush 完成后自动调度下一次 flush。

### 5. 新增异步工具 (Async Utilities) 单元测试
- 验证 `settleWithinTimeout()` 在超时前完成时正常解决。
- 验证在超时前拒绝时正常解决。
- 验证工作仍在进行中时超时后解决。
- 验证立即解决和立即拒绝场景。

### 6. 新增字符串清理工具 (String Sanitize Utilities) 单元测试
- 验证 `sanitizeString()` 使用 allow 模式保留允许字符。
- 验证使用 deny 模式替换禁止字符。
- 验证折叠多个替换和首尾修剪替换。
- 验证小写转换和空结果返回回退值。
- 验证自定义替换字符及多选项组合使用。
- 验证所有字符被移除时返回空字符串。

### 7. 新增文本处理工具 (Text Utilities) 单元测试
- 验证 `truncateText()` 在限制内返回原文及超出限制时截断并添加省略号。
- 验证处理空字符串、自定义省略符、精确限制及文本短于省略符。
- 验证 `escapeForDoubleQuotes()` 转义反斜杠和双引号。
- 验证 `quoteIfNeeded()` 用转义双引号包裹文本。

## 💡 Technical Highlights

- **测试框架统一**: 所有新增测试均基于 `bun:test` 框架编写，确保测试环境一致性。
- **高覆盖率**: 针对核心功能模块的边界条件、默认值回退及异常处理逻辑进行了全面测试。
- **代码质量保障**: 通过增加单元测试，提升了代码的健壮性和可维护性，降低了潜在缺陷的风险。
- **模块化测试**: 每个测试文件专注于一个特定模块，确保测试的独立性和可读性。