### PR TITLE
feat(relay-web): badge native (agent-side) sessions in the sidebar

### DIFF
--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -6,6 +6,10 @@ export interface SessionDto {
   transportSession: string;
   running: boolean;
   archived: boolean;
+  /** True when this logical session was attached to an existing agent-side (native) rollout
+   *  — e.g. a resumed codex session — rather than freshly created via `/session new`. Lets
+   *  the web badge native sessions distinctly. Omitted (not `false`) for fresh sessions. */
+  native?: boolean;
   /** The agent adapter command this session actually runs (acpx-recorded, or the agent's
    *  resolved default). Lets the web avoid seeding a new session's model picker from a
    *  session running a different adapter version — those advertise model ids in

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -90,6 +90,18 @@ describe("InstanceTree session management", () => {
     expect(chat.sessionAlias).toBe("backend");
   });
 
+  it("badges a native session and leaves a fresh one unbadged", () => {
+    const store = useInstancesStore();
+    store.instances = [instance([
+      { alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false },
+      { alias: "resumed", agent: "codex", workspace: "home", transportSession: "ses_abc", running: false, archived: false, native: true },
+    ])] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const badges = w.findAll('[data-test="native-badge"]');
+    expect(badges).toHaveLength(1);
+    expect(badges[0]!.text()).toBe("native");
+  });
+
   it("shows a spinner on an optimistic 'creating' session row", () => {
     const store = useInstancesStore();
     store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "", running: false, archived: false, creating: true }])] as never;

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -235,6 +235,9 @@ const rowSwipes = computed(() => {
                 <AgentIcon :driver="driverFor(inst, s.agent)" :title="s.agent" :size="14"
                            :class="s.archived ? 'opacity-60' : ''" />
                 <span v-if="s.archived" data-test="archived-badge" class="shrink-0 rounded bg-bg px-1 py-px text-[9px] text-fg-muted">{{ $t("instance.sessionArchivedBadge") }}</span>
+                <span v-if="s.native" data-test="native-badge" :title="$t('instance.sessionNativeBadgeTitle')"
+                      class="shrink-0 rounded bg-info/15 px-1 py-px text-[9px] text-info"
+                      :class="s.archived ? 'opacity-60' : ''">{{ $t("instance.sessionNativeBadge") }}</span>
                 <span v-if="!s.archived && elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
                       class="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-run">{{ elapsedLabel(inst.id, s.alias) }}</span>
               </button>

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -172,6 +172,8 @@ export default {
     deleteSession: "Delete session",
     archiveSession: "Archive session",
     sessionArchivedBadge: "archived",
+    sessionNativeBadge: "native",
+    sessionNativeBadgeTitle: "Resumed from an existing agent-side session",
     sessionArchivedToast: "Archived \"{alias}\"",
     undo: "Undo",
     manage: "Manage instance",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -170,6 +170,8 @@ export default {
     deleteSession: "删除会话",
     archiveSession: "归档会话",
     sessionArchivedBadge: "已归档",
+    sessionNativeBadge: "原生",
+    sessionNativeBadgeTitle: "从已有的 agent 原生会话续接",
     sessionArchivedToast: "已归档「{alias}」",
     undo: "撤销",
     manage: "管理实例",

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -182,7 +182,9 @@ export const useInstancesStore = defineStore("instances", () => {
     const inst = byId(instanceId);
     if (!inst || inst.sessions.some((s) => s.alias === alias)) return false;
     inst.sessions = [
-      { alias, agent, workspace, transportSession: "", running: false, archived: false, creating: true, creatingSince: Date.now() },
+      // A native attach (agentSessionId set) yields a native session — badge the optimistic
+      // row immediately so the marker doesn't pop in only once the server row lands.
+      { alias, agent, workspace, transportSession: "", running: false, archived: false, creating: true, creatingSince: Date.now(), ...(agentSessionId ? { native: true } : {}) },
       ...inst.sessions,
     ];
     void createSession(instanceId, alias, agent, workspace, agentSessionId, model).catch((e) => {

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -34,6 +34,10 @@ export interface ControlSessionInfo {
   transportSession: string;
   running: boolean;
   archived: boolean;
+  /** True when this logical session was attached to an existing agent-side (native) rollout
+   *  rather than freshly created. Mirrors LogicalSession.source === "agent-side"; omitted for
+   *  fresh xacpx sessions so the wire stays minimal. */
+  native?: boolean;
   /** The agent adapter command this session runs (acpx-recorded, or the agent's resolved
    *  default). Surfaced so the web can avoid seeding a new session's model picker from a
    *  session on a different adapter version (whose advertised model ids may be in an
@@ -222,6 +226,7 @@ export class ControlService {
         transportSession: session.transportSession,
         running: this.deps.activeTurns.isActiveAnywhere(session.alias),
         archived: session.archived === true,
+        ...(session.source === "agent-side" ? { native: true } : {}),
         ...(session.agentCommand ? { agentCommand: session.agentCommand } : {}),
       }));
   }

--- a/tests/unit/control/control-service-sessions.test.ts
+++ b/tests/unit/control/control-service-sessions.test.ts
@@ -73,6 +73,23 @@ test("listSessions maps resolved sessions with running flag", () => {
   ]);
 });
 
+test("listSessions marks an agent-side (native) session with native: true", () => {
+  const { deps } = makeDeps();
+  // A native-attached session carries source "agent-side"; a fresh xacpx session does not.
+  deps.sessions.listAllResolvedSessions = () => [
+    { alias: "backend", agent: "claude", workspace: "/ws/backend", transportSession: "xacpx-backend" },
+    { alias: "resumed", agent: "codex", workspace: "/ws/docs", transportSession: "ses_abc", source: "agent-side" },
+  ];
+  const control = new ControlService(deps as never);
+
+  const sessions = control.listSessions("relay:acct");
+  const fresh = sessions.find((s) => s.alias === "backend")!;
+  const native = sessions.find((s) => s.alias === "resumed")!;
+  // Fresh sessions omit the flag entirely; only native ones carry native: true.
+  expect("native" in fresh).toBe(false);
+  expect(native.native).toBe(true);
+});
+
 test("createSession runs the transport lifecycle and emits sessions-changed", async () => {
   const { deps, seen, calls } = makeDeps();
   const control = new ControlService(deps as never);


### PR DESCRIPTION
## What

Surface in the relay-web sidebar whether a logical session was **attached to an existing agent-side (native) rollout** (e.g. a resumed codex session) vs **freshly created** via `/session new`.

The backend already tracks this as `LogicalSession.source === "agent-side"` (and on `ResolvedSession.source`), but the discriminator was stripped at the wire boundary, so native and acpx-created sessions looked identical in the web.

## Changes

- **Wire**: add `native?: boolean` to `SessionDto` (relay-protocol) and `ControlSessionInfo` (control). `listSessions` sets `native: true` only when `source === "agent-side"`; omitted otherwise so the wire stays minimal and the two types remain field-identical for the connector pass-through.
- **Web**: render a `native` badge in `InstanceTree.vue` next to the archived badge (info color, with tooltip). The optimistic native-attach row carries the flag so the badge shows immediately rather than popping in once the server row lands.
- **i18n**: add `sessionNativeBadge` + `sessionNativeBadgeTitle` to both `en` and `zh-CN`.

## Tests

- Backend: `listSessions` marks an agent-side session `native: true` and omits the field for fresh sessions.
- Web: the badge renders only for native rows, not fresh ones.

## Verification

- `tsc --noEmit` ✅ / `vue-tsc --noEmit` ✅
- Backend control session tests ✅
- Full relay-web vitest suite (64 files / 454 tests) ✅, including i18n key-parity smoke test

Independently reviewed by a subagent: no blockers; the one actionable nit (optimistic row badge timing) is applied in this PR.

> Note: `packages/relay-protocol/dist` is gitignored and regenerated at build time — `native` lands in the dist via `bun run build:relay-protocol`.