### PR TITLE
fix(commands): let /clear reset the session on the control channel

### DIFF
--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -78,6 +78,21 @@ turn 结束时无论成功或失败都发出 `turn-finished`（失败时含 `err
 直接将 reply 分片与最终文本以换行连接后返回字符串。适用于不需要会话状态切换和事件流的
 一次性命令执行场景。
 
+### 斜杠命令透传（GUI-first）
+
+control 通道是 GUI-first 的：relay-web 通过看板按钮驱动会话操作，所以用户在 web
+聊天框里输入的任何 `/` 前缀文本都会被 `command-router` **原样转成 prompt 发给 agent**，
+而不是当作 xacpx 命令解释（微信/飞书等无 GUI 的频道不受影响，仍走正常命令解析）。
+
+**例外**：`session.reset`（`/clear`、`/session reset`）即使在 control 通道也仍由 xacpx
+处理。web 端没有别的「清空/重置会话」入口，且 codex 等 ACP agent 不认识 `/clear`，原样转发
+只会静默 no-op；而 reset 对 xacpx 会话模型是有副作用的（重建 transport 会话，并保持
+native 标记），不能当作文本发给 agent。见 `src/commands/command-router.ts` 的透传分支。
+
+reset 在回合内重建了 transport 会话，但 reset handler 不发事件，所以 `control.prompt`
+会在回合结束后比较 `transportSession` 前后值，若变化则补发 `sessions-changed`（与 archived
+徽标的兜底刷新同理），否则看板会一直显示旧的 transport id / native 绑定直到下次无关刷新。
+
 ### 事件总线覆盖范围
 
 事件总线只保证「`ControlService` 自身发起的变更」会发事件；其它入口

--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -154,7 +154,13 @@ export class CommandRouter {
     // other chat channels have no GUI and still depend on xacpx commands, so this
     // passthrough is scoped to the control channel (set by the control service for
     // every structured-control turn; see docs/control-module.md).
-    if (metadata?.channel === "control" && command.kind !== "prompt") {
+    //
+    // Exception: `session.reset` (`/clear`, `/session reset`) stays xacpx-handled even on
+    // the control channel. The web GUI has no other "clear/reset session" entry, and codex
+    // (and other ACP agents) don't interpret `/clear` themselves — forwarding it verbatim
+    // would silently no-op. Reset is side-effecting on the xacpx session model (recreates
+    // the transport session, preserving native), so it must not be sent to the agent as text.
+    if (metadata?.channel === "control" && command.kind !== "prompt" && command.kind !== "session.reset") {
       command = { kind: "prompt", text: input.trim() };
     }
     await this.logger.debug("command.parsed", "parsed inbound command", {

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -451,14 +451,20 @@ export class ControlService {
     let resolveSettled!: () => void;
     const settled = new Promise<void>((resolve) => { resolveSettled = resolve; });
     this.inFlight.set(key, { controller, settled });
-    // Sending to an archived session restores it (useSession clears `archived`), but
-    // useSession emits no event — so detect the transition here and emit
-    // `sessions-changed` after, otherwise the dashboard keeps showing a stale
-    // "archived" badge on the row until the next unrelated refresh.
+    // Sending to an archived session restores it (useSession clears `archived`), and
+    // `/clear` (session.reset) recreates the transport session under the same alias — both
+    // mutate the session row, but neither useSession nor the reset handler emits an event.
+    // Capture the pre-turn state here so we can detect the transition afterwards and emit
+    // `sessions-changed`, otherwise the dashboard keeps showing a stale archived badge /
+    // transport+native binding on the row until the next unrelated refresh.
+    let internalAlias: string | undefined;
     let wasArchived = false;
+    let priorTransportSession: string | undefined;
     try {
-      const internalAlias = await this.deps.sessions.resolveAliasForChat(params.chatKey, params.sessionAlias);
-      wasArchived = (await this.deps.sessions.getSession(internalAlias))?.archived === true;
+      internalAlias = await this.deps.sessions.resolveAliasForChat(params.chatKey, params.sessionAlias);
+      const prior = await this.deps.sessions.getSession(internalAlias);
+      wasArchived = prior?.archived === true;
+      priorTransportSession = prior?.transportSession;
     } catch {
       /* best-effort: a detection failure just means no badge refresh */
     }
@@ -618,6 +624,19 @@ export class ControlService {
     } finally {
       this.inFlight.delete(key);
       resolveSettled();
+      // `/clear` (session.reset) recreated the transport session during the turn (and may
+      // have re-bound a fresh native agentSessionId). Emit `sessions-changed` so the
+      // dashboard refreshes the row; best-effort, and only when the binding actually moved.
+      if (internalAlias && priorTransportSession) {
+        try {
+          const after = await this.deps.sessions.getSession(internalAlias);
+          if (after && after.transportSession !== priorTransportSession) {
+            this.deps.events.emit({ type: "sessions-changed" });
+          }
+        } catch {
+          /* best-effort: no refresh on detection failure */
+        }
+      }
     }
   }
 

--- a/tests/unit/commands/command-router-interaction.test.ts
+++ b/tests/unit/commands/command-router-interaction.test.ts
@@ -120,6 +120,30 @@ test("control-channel slash commands pass through to the agent (web is GUI-first
   expect(reply.text).toContain("agent:web:/status"); // agent echoed it, not the xacpx status card
 });
 
+test("control-channel /clear still resets the session instead of passing through", async () => {
+  const sessions = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  const transport = createTransport();
+  const router = new CommandRouter(sessions, transport);
+
+  await router.handle("relay:acct", "/session new web --agent codex --ws backend");
+  const before = await sessions.getCurrentSession("relay:acct");
+  const promptsBefore = getPromptMock(transport).mock.calls.length;
+
+  // `/clear` is a session-reset alias. The web GUI has no other reset entry, so even on the
+  // control channel it must be handled by xacpx (recreate the transport session) rather than
+  // forwarded to the agent verbatim like other slash commands.
+  const reply = await router.handle(
+    "relay:acct", "/clear", undefined, undefined, undefined, undefined,
+    { channel: "control", chatType: "direct" },
+  );
+  const after = await sessions.getCurrentSession("relay:acct");
+
+  expect(getPromptMock(transport).mock.calls.length).toBe(promptsBefore); // never sent to the agent
+  expect(after?.transportSession).not.toBe(before?.transportSession);
+  expect(after?.transportSession.startsWith("backend:web:reset-")).toBe(true);
+  expect(reply.text).not.toContain("agent:web:/clear");
+});
+
 test("non-control channels still handle xacpx slash commands", async () => {
   const sessions = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
   const transport = createTransport();

--- a/tests/unit/control/control-service-prompt.test.ts
+++ b/tests/unit/control/control-service-prompt.test.ts
@@ -101,6 +101,49 @@ test("prompting a non-archived session does NOT emit sessions-changed (no needle
   expect(seen.some((e) => e.type === "sessions-changed")).toBe(false);
 });
 
+function makeControlWithTransportChange(opts: { changes: boolean }) {
+  const events = createControlEventBus();
+  const seen: ControlEvent[] = [];
+  events.subscribe((event) => seen.push(event));
+  // Model `/clear`: the turn (agent.chat) recreates the transport session under the same
+  // alias, so getSession returns a new transportSession on the post-turn read.
+  let reads = 0;
+  const control = new ControlService({
+    agent: { chat: async () => ({ text: "会话已重置" }) },
+    sessions: {
+      listAllResolvedSessions: () => [],
+      createSession: async () => { throw new Error("unused"); },
+      removeSession: async () => ({ wasActive: false }),
+      useSession: async () => ({ alias: "backend", agent: "claude", workspace: "/ws" }),
+      resolveAliasForChat: async (_chatKey: string, alias: string) => `relay:${alias}`,
+      getSession: async () => {
+        reads += 1;
+        const transportSession = opts.changes && reads > 1 ? "/ws:backend:reset-2" : "/ws:backend";
+        return { alias: "relay:backend", agent: "claude", workspace: "/ws", transportSession };
+      },
+    },
+    activeTurns: { isActiveAnywhere: () => false },
+    scheduled: {} as never,
+    orchestration: {} as never,
+    events,
+  } as never);
+  return { control, seen };
+}
+
+test("a control-channel /clear (transport session recreated) emits sessions-changed", async () => {
+  // session.reset rebuilds the transport session mid-turn; without this the dashboard row
+  // keeps showing the stale transport id / native binding until an unrelated refresh.
+  const { control, seen } = makeControlWithTransportChange({ changes: true });
+  await control.prompt({ chatKey: "relay:acct-1", sessionAlias: "backend", text: "/clear", senderId: "acct-1" });
+  expect(seen.some((e) => e.type === "sessions-changed")).toBe(true);
+});
+
+test("an ordinary prompt (transport session unchanged) does NOT emit sessions-changed", async () => {
+  const { control, seen } = makeControlWithTransportChange({ changes: false });
+  await control.prompt({ chatKey: "relay:acct-1", sessionAlias: "backend", text: "hi", senderId: "acct-1" });
+  expect(seen.some((e) => e.type === "sessions-changed")).toBe(false);
+});
+
 test("multi-paragraph reply: each segment after the first restores the \\n\\n break", async () => {
   // Regression: the transport strips paragraph boundaries when splitting into
   // trimmed segments. Concatenating bare segments ran paragraphs together; the


### PR DESCRIPTION
## Problem

In the relay-web chat box, typing `/clear` (or `/session reset`) on a **codex** session did nothing — for both native and non-native sessions.

Root cause is the GUI-first passthrough in `command-router.ts`: for `metadata.channel === "control"`, **any** non-prompt slash command is rewritten to a prompt and forwarded verbatim to the agent. So `/clear` (which parses to `session.reset`) was sent to codex as literal text, which it ignores. In WeChat/Feishu (non-control channels) `/clear` is correctly handled by xacpx's `handleSessionResetCommand`.

## Fix

Exempt `session.reset` from the control-channel passthrough so xacpx handles it normally — recreating the transport session and **preserving native** (agent-side) sessions across the reset. Both `/clear` and `/session reset` parse to the same kind, so one check covers both. All other slash commands still pass through to the agent (the web GUI owns those actions).

### Follow-up from review: dashboard staleness

`session.reset` rebuilds the transport session mid-turn but emits no event, so the relay-web session row would show a stale transport id / native binding until an unrelated refresh. The control prompt path now snapshots `transportSession` before the turn and, in `finally`, emits `sessions-changed` when it moved — mirroring the existing archived-badge refresh. It only fires when the binding actually changed (no needless refresh on ordinary prompts).

## Tests

- `command-router-interaction.test.ts`: control-channel `/clear` resets the session (not sent to the agent; transport session recreated as `…:reset-<ts>`).
- `control-service-prompt.test.ts`: a transport-session change mid-turn emits `sessions-changed`; an unchanged one does not.
- `npx tsc --noEmit` clean; `tests/unit/commands` + `tests/unit/control` green.

Docs: documented the carve-out and the refresh in `docs/control-module.md`.