### PR TITLE
test(commands): verify /clear keeps a native session native end-to-end

### DIFF
--- a/tests/unit/commands/command-router-interaction.test.ts
+++ b/tests/unit/commands/command-router-interaction.test.ts
@@ -144,6 +144,40 @@ test("control-channel /clear still resets the session instead of passing through
   expect(reply.text).not.toContain("agent:web:/clear");
 });
 
+test("control-channel /clear keeps a native session native end-to-end", async () => {
+  const sessions = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  const transport = createTransport();
+  // The fresh transport session created by the reset advertises a new agent rollout id;
+  // the reset handler reads it back to keep the logical session native.
+  (transport as { getAgentSessionId?: unknown }).getAgentSessionId = mock(async () => "ses_fresh");
+  const router = new CommandRouter(sessions, transport);
+
+  // Seed a native (agent-side) session bound to the chat — as if attached from a codex rollout.
+  await sessions.attachNativeSession({
+    alias: "resumed",
+    agent: "codex",
+    workspace: "backend",
+    transportSession: "backend:resumed",
+    agentSessionId: "ses_orig",
+  });
+  await sessions.useSession("relay:acct", "resumed");
+  const before = await sessions.getCurrentSession("relay:acct");
+  expect(before?.source).toBe("agent-side");
+
+  await router.handle(
+    "relay:acct", "/clear", undefined, undefined, undefined, undefined,
+    { channel: "control", chatType: "direct" },
+  );
+  const after = await sessions.getCurrentSession("relay:acct");
+
+  // Reset recreated the transport session but the logical session stays native, re-bound to
+  // the fresh rollout id — so the dashboard's "native" badge survives /clear.
+  expect(after?.source).toBe("agent-side");
+  expect(after?.agentSessionId).toBe("ses_fresh");
+  expect(after?.transportSession).not.toBe(before?.transportSession);
+  expect(after?.transportSession.startsWith("backend:resumed:reset-")).toBe(true);
+});
+
 test("non-control channels still handle xacpx slash commands", async () => {
   const sessions = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
   const transport = createTransport();


### PR DESCRIPTION
## Why

Follow-up to #90, closing the review's Nice-to-have gap. The handler-level native-preservation is already covered (`session-reset-handler.test.ts`), but nothing exercised the **full control-channel path**: that `/clear` on a native (agent-side) session both survives the GUI-first passthrough exemption AND re-binds the fresh rollout id so the session stays native.

## What

Adds one integration test at the `CommandRouter` level (`command-router-interaction.test.ts`):

1. Seeds an `agent-side` session bound to the chat (as if attached from a codex rollout).
2. Gives the transport a `getAgentSessionId` that returns a fresh id (`ses_fresh`).
3. Sends `/clear` on the control channel (`channel: "control"`).
4. Asserts the logical session is **still `source: "agent-side"`**, re-bound to `ses_fresh`, with a recreated transport session (`backend:resumed:reset-…`).

This proves the relay-web "native" badge survives `/clear`.

## Tests

Test-only change. `bun test … command-router-interaction` → 72 pass / 0 fail; `npx tsc --noEmit` clean; `tests/unit/commands` green.