### PR TITLE
fix(relay-web): fill the message-list agent avatar with its brand tile

### DIFF
--- a/packages/relay-web/src/__tests__/agenticon.test.ts
+++ b/packages/relay-web/src/__tests__/agenticon.test.ts
@@ -49,4 +49,24 @@ describe("AgentIcon", () => {
     const w = mount(AgentIcon, { props: { driver: "codex", title: "my-codex" } });
     expect(w.find('[data-test="agent-icon"]').attributes("title")).toBe("my-codex");
   });
+
+  it("fills its parent box (no fixed px) when fill is set", () => {
+    const w = mount(AgentIcon, { props: { driver: "codex", fill: true } });
+    const root = w.find('[data-test="agent-icon"]');
+    // Fill mode drops the fixed width/height so the brand tile bleeds to the parent's edges.
+    expect(root.classes()).toContain("h-full");
+    expect(root.classes()).toContain("w-full");
+    expect(root.attributes("style") ?? "").not.toContain("width");
+    // The brand SVG still fills + centers.
+    const inner = w.find('[data-test="agent-icon"] > span');
+    expect(inner.classes()).toContain("[&>svg]:h-full");
+    expect(inner.classes()).toContain("[&>svg]:w-full");
+  });
+
+  it("keeps a sized, inset glyph for the generic fallback even in fill mode", () => {
+    // The line-art Bot would look cramped bleeding edge-to-edge, so it stays at its px size,
+    // centered by the parent box's place-items-center.
+    const w = mount(AgentIcon, { props: { driver: "nope", fill: true, size: 15 } });
+    expect(w.find(".lucide-bot").exists()).toBe(true);
+  });
 });

--- a/packages/relay-web/src/components/AgentIcon.vue
+++ b/packages/relay-web/src/components/AgentIcon.vue
@@ -6,8 +6,12 @@ import { agentIconSvg } from "../lib/agent-icons";
 // A square brand glyph for an agent driver. Renders the @lobehub/icons SVG when one exists
 // for the driver, else a generic robot fallback. The SVG is a build-time bundled constant
 // (see agent-icons.ts), not user input, so v-html is safe here.
-const props = withDefaults(defineProps<{ driver?: string | null; size?: number; title?: string }>(), {
+// `fill` lets a tile-style brand mark bleed to the edges of its parent box (the avatar
+// container sets the size, border and rounding) instead of floating at a fixed px size.
+// The generic Bot fallback is line-art, so it stays at `size` even in fill mode.
+const props = withDefaults(defineProps<{ driver?: string | null; size?: number; title?: string; fill?: boolean }>(), {
   size: 16,
+  fill: false,
 });
 
 const svg = computed(() => agentIconSvg(props.driver));
@@ -25,8 +29,9 @@ const px = computed(() => `${props.size}px`);
     :title="title"
     role="img"
     :aria-label="title || driver || undefined"
-    class="inline-grid shrink-0 place-items-center [&>svg]:h-full [&>svg]:w-full"
-    :style="{ width: px, height: px }"
+    class="shrink-0 place-items-center [&>svg]:h-full [&>svg]:w-full"
+    :class="fill ? 'grid h-full w-full' : 'inline-grid'"
+    :style="fill ? undefined : { width: px, height: px }"
   >
     <span v-if="svg" class="grid h-full w-full place-items-center [&>svg]:block [&>svg]:h-full [&>svg]:w-full" v-html="svg" />
     <Bot v-else :size="size" class="text-fg-muted" />

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -176,7 +176,7 @@ watch(
           <!-- ASSISTANT row -->
           <div v-else class="cv-row group flex gap-2.5">
             <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden rounded-lg border border-border bg-surface">
-              <AgentIcon :driver="driver" :size="15" />
+              <AgentIcon :driver="driver" :size="15" fill />
             </div>
             <div data-test="msg-out" class="min-w-0 flex-1 space-y-2.5"
                  :class="m.failed ? 'rounded-lg ring-1 ring-danger/40' : ''">
@@ -202,7 +202,7 @@ watch(
         <!-- live streaming assistant row -->
         <div v-if="liveTurn && liveTurn.parts.length" class="flex gap-2.5">
           <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden rounded-lg border border-border bg-surface">
-            <AgentIcon :driver="driver" :size="15" />
+            <AgentIcon :driver="driver" :size="15" fill />
           </div>
           <div data-test="msg-streaming" class="min-w-0 flex-1">
             <TurnParts :parts="liveTurn.parts" :streaming="true" />


### PR DESCRIPTION
## Problem

In the conversation list, the agent avatar's brand icon looked off-center / small. The `@lobehub` brand marks (codex, claude, …) are **full-viewBox tile glyphs** (e.g. codex is a white rounded square bleeding 0–24), so floating one at 15px inside the 24px avatar box reads as a small glyph adrift in the box rather than a proper avatar tile.

## Fix

`AgentIcon` gains an opt-in `fill` prop: in fill mode the wrapper drops its fixed px size and becomes `h-full w-full`, so a brand tile bleeds to the parent box's edges (the avatar box already owns the size, `border`, `overflow-hidden` and `rounded-lg`). The conversation list's assistant row and live-streaming row pass `fill`, so the tiles render edge-to-edge like real app icons.

The generic line-art `Bot` fallback stays at its px `size` (centered by the box) even in fill mode — bleeding edge-to-edge would look cramped.

Scoped to the message-list avatars; the sidebar (`InstanceTree`) and chat-pane avatars are unchanged.

## Tests

`agenticon.test.ts`: fill mode drops the fixed px and keeps the brand-svg fill rule; the fallback stays a sized glyph in fill mode. Full relay-web suite green (64 files / 456 tests); `vue-tsc` clean.

> Ships in the next `@ganglion/xacpx-relay` release (bundled dashboard).