### PR TITLE
fix(commands): don't stream chat-style reset progress into the web chat pane

### DIFF
--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -292,7 +292,15 @@ export class CommandRouter {
         case "cancel":
           return await handleCancel(this.createSessionHandlerContext(undefined, perfSpan), chatKey, command.alias);
         case "session.reset":
-          return await handleSessionReset(this.createSessionHandlerContext(reply, perfSpan), chatKey);
+          // The control channel is GUI-first: don't stream the chat-style "🚀 Starting…"
+          // progress pings into the web chat pane — they're mobile-oriented and clash with the
+          // web UI. The clean "Session … has been reset" confirmation is still returned as the
+          // turn result, and the dashboard refreshes the row via the sessions-changed event.
+          // Other channels (no GUI) keep the live progress feedback.
+          return await handleSessionReset(
+            this.createSessionHandlerContext(metadata?.channel === "control" ? undefined : reply, perfSpan),
+            chatKey,
+          );
         case "session.tail":
           return await handleSessionTail(this.createSessionHandlerContext(undefined, perfSpan), chatKey, command.lines);
         case "session.rm":

--- a/tests/unit/commands/command-router-interaction.test.ts
+++ b/tests/unit/commands/command-router-interaction.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, mock, test } from "bun:test";
 import { setLocale } from "../../../src/i18n";
 import { CommandRouter } from "../../../src/commands/command-router";
+import type { EnsureSessionProgress, ResolvedSession } from "../../../src/transport/types";
 import type { SessionAgentCommandResolver } from "./command-router-test-support";
 import {
   MemoryStateStore,
@@ -176,6 +177,54 @@ test("control-channel /clear keeps a native session native end-to-end", async ()
   expect(after?.agentSessionId).toBe("ses_fresh");
   expect(after?.transportSession).not.toBe(before?.transportSession);
   expect(after?.transportSession.startsWith("backend:resumed:reset-")).toBe(true);
+});
+
+test("control-channel /clear does not stream chat-style progress pings (web is GUI-first)", async () => {
+  const sessions = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  const transport = createTransport();
+  // Session (re)creation emits a spawn progress event; the chat progress handler would
+  // otherwise turn it into a "🚀 Starting…" ping streamed to the chat surface.
+  transport.ensureSession = mock(async (_s: ResolvedSession, onProgress?: (p: EnsureSessionProgress) => void) => {
+    onProgress?.("spawn");
+  });
+  const router = new CommandRouter(sessions, transport);
+  await router.handle("relay:acct", "/session new web --agent codex --ws backend");
+
+  const pings: string[] = [];
+  const reply = async (text: string) => {
+    pings.push(text);
+  };
+  const res = await router.handle(
+    "relay:acct", "/clear", reply, undefined, undefined, undefined,
+    { channel: "control", chatType: "direct" },
+  );
+
+  // No emoji progress dumped into the web chat pane — only the clean confirmation as the
+  // turn result; the dashboard refreshes the row via the sessions-changed event.
+  expect(pings).toEqual([]);
+  expect(res.text).toContain("已重置");
+});
+
+test("non-control /clear still streams the chat progress pings", async () => {
+  const sessions = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  const transport = createTransport();
+  transport.ensureSession = mock(async (_s: ResolvedSession, onProgress?: (p: EnsureSessionProgress) => void) => {
+    onProgress?.("spawn");
+  });
+  const router = new CommandRouter(sessions, transport);
+  await router.handle("wx:user", "/session new web --agent codex --ws backend");
+
+  const pings: string[] = [];
+  const reply = async (text: string) => {
+    pings.push(text);
+  };
+  await router.handle(
+    "wx:user", "/clear", reply, undefined, undefined, undefined,
+    { channel: "weixin", chatType: "direct" },
+  );
+
+  // Chat channels have no GUI, so they keep the live "🚀 Starting…" progress feedback.
+  expect(pings.some((p) => p.includes("🚀"))).toBe(true);
 });
 
 test("non-control channels still handle xacpx slash commands", async () => {


### PR DESCRIPTION
## Problem

After `/clear` was enabled on the web (control) channel, the reset's progress was streamed into the web chat pane as an assistant message:

> 🚀 Starting codex … ℹ️ [acpx] agent advertised auth methods … (waited 4s) Session "…" has been reset

These `🚀`/`ℹ️`/`(waited Ns)` pings are the chat-channel (WeChat/mobile) ensure-session progress messages. They clash with the web dashboard's visual language.

## Cause

`/clear` (session.reset) is handled by xacpx and runs `ensureTransportSession` through the chat **reply** callback. On the control channel that reply becomes web `turn-output` chunks, so the `createProgressHandler` pings (`router.agentSpawning` / `agentHeartbeat` / `acpxNoteElapsed`) get rendered in the chat pane.

## Fix

The control channel is GUI-first, so the `session.reset` case now passes **no chat reply** when `metadata.channel === "control"`:

- The `🚀 Starting…` progress pings are suppressed on web.
- The clean `Session … has been reset` confirmation is still returned as the turn result.
- The sidebar row still refreshes via the `sessions-changed` event (shipped earlier).
- Other (GUI-less) channels keep the live progress feedback unchanged.

## Tests

`command-router-interaction.test.ts`: control-channel `/clear` streams **no** progress pings (and still returns the confirmation); a non-control `/clear` still streams the `🚀` ping. `npx tsc --noEmit` clean; `tests/unit/commands` + `tests/unit/control` green.

> Core-side change (command-router) — reaches the dashboard once it ships in a core release.