### PR TITLE
feat(relay-web): declutter the session row and avatar

### DIFF
--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -294,8 +294,10 @@ describe("InstanceTree session management", () => {
     expect(archivedRow.text()).toContain("arch"); // archived sunk to bottom
     // Archived state reads from the greyed name; its dedicated text badge was removed to keep
     // the row uncluttered once the native marker landed.
-    expect(archivedRow.find(".truncate").classes()).toContain("text-fg-muted");
+    expect(archivedRow.find('[data-test="session-name"]').classes()).toContain("text-fg-muted");
     expect(w.find('[data-test="archived-badge"]').exists()).toBe(false);
+    // …but a visually-hidden label keeps the archived state announced to screen readers.
+    expect(archivedRow.find('[data-test="archived-label"]').classes()).toContain("sr-only");
   });
 
   it("hides row actions when the instance is offline", () => {

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -90,16 +90,17 @@ describe("InstanceTree session management", () => {
     expect(chat.sessionAlias).toBe("backend");
   });
 
-  it("badges a native session and leaves a fresh one unbadged", () => {
+  it("marks a native session with the link icon and leaves a fresh one unmarked", () => {
     const store = useInstancesStore();
     store.instances = [instance([
       { alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false },
       { alias: "resumed", agent: "codex", workspace: "home", transportSession: "ses_abc", running: false, archived: false, native: true },
     ])] as never;
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
-    const badges = w.findAll('[data-test="native-badge"]');
-    expect(badges).toHaveLength(1);
-    expect(badges[0]!.text()).toBe("native");
+    // Native sessions now carry a compact link glyph (not a text badge) to keep the row tidy.
+    const marks = w.findAll('[data-test="native-badge"]');
+    expect(marks).toHaveLength(1);
+    expect(marks[0]!.attributes("title")).toBe("Resumed from an existing agent-side session");
   });
 
   it("shows a spinner on an optimistic 'creating' session row", () => {
@@ -289,8 +290,12 @@ describe("InstanceTree session management", () => {
     ])] as never;
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
     const rows = w.findAll('[data-test="session-row"]');
-    expect(rows[rows.length - 1].text()).toContain("arch"); // archived sunk to bottom
-    expect(w.find('[data-test="archived-badge"]').exists()).toBe(true);
+    const archivedRow = rows[rows.length - 1];
+    expect(archivedRow.text()).toContain("arch"); // archived sunk to bottom
+    // Archived state reads from the greyed name; its dedicated text badge was removed to keep
+    // the row uncluttered once the native marker landed.
+    expect(archivedRow.find(".truncate").classes()).toContain("text-fg-muted");
+    expect(w.find('[data-test="archived-badge"]').exists()).toBe(false);
   });
 
   it("hides row actions when the instance is offline", () => {

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { Archive, ChevronDown, ChevronRight, Loader2, MoreHorizontal, Pencil, Plus, Settings2, Trash2 } from "lucide-vue-next";
+import { Archive, ChevronDown, ChevronRight, Link2, Loader2, MoreHorizontal, Pencil, Plus, Settings2, Trash2 } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { confirm } from "../lib/use-confirm";
@@ -252,6 +252,10 @@ const rowSwipes = computed(() => {
                 <span v-else-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'unread'" data-test="attention-dot" data-attention="unread"
                       class="h-2 w-2 shrink-0 rounded-full bg-info" />
                 <span v-else-if="!s.archived && s.running" data-test="attention-dot" data-attention="running" class="h-2 w-2 shrink-0 rounded-full bg-run" />
+                <!-- Agent brand glyph (driver icon) BEFORE the name, in place of a text badge —
+                     saves horizontal space; the agent name stays available on hover. -->
+                <AgentIcon :driver="driverFor(inst, s.agent)" :title="s.agent" :size="14"
+                           :class="s.archived ? 'opacity-60' : ''" />
                 <input v-if="renamingFor === `${inst.id}:${s.alias}`" data-test="rename-input"
                        v-model="renameDraft" :maxlength="60" :placeholder="$t('instance.sessionRenamePlaceholder')"
                        class="min-w-0 flex-1 rounded border border-accent bg-bg px-1 py-px text-[13px] text-fg outline-none"
@@ -260,14 +264,12 @@ const rowSwipes = computed(() => {
                        v-focus />
                 <span v-else class="truncate text-[12.5px] font-medium"
                       :class="s.archived ? 'text-fg-muted' : (isSelected(inst.id, s.alias) ? 'font-semibold text-accent' : 'text-fg')">{{ s.displayName || s.alias }}</span>
-                <!-- Agent shown as its brand glyph (driver icon) instead of a text badge to
-                     save horizontal space; the agent name stays available on hover. -->
-                <AgentIcon :driver="driverFor(inst, s.agent)" :title="s.agent" :size="14"
-                           :class="s.archived ? 'opacity-60' : ''" />
-                <span v-if="s.archived" data-test="archived-badge" class="shrink-0 rounded bg-bg px-1 py-px text-[9px] text-fg-muted">{{ $t("instance.sessionArchivedBadge") }}</span>
-                <span v-if="s.native" data-test="native-badge" :title="$t('instance.sessionNativeBadgeTitle')"
-                      class="shrink-0 rounded bg-info/15 px-1 py-px text-[9px] text-info"
-                      :class="s.archived ? 'opacity-60' : ''">{{ $t("instance.sessionNativeBadge") }}</span>
+                <!-- Native (agent-side / resumed) sessions get a small link glyph instead of a text
+                     badge to keep the row uncluttered. Archived state reads from the dimmed name, so
+                     it no longer carries its own badge. -->
+                <Link2 v-if="s.native" data-test="native-badge" :size="12"
+                       :aria-label="$t('instance.sessionNativeBadgeTitle')" :title="$t('instance.sessionNativeBadgeTitle')"
+                       class="shrink-0 text-info" :class="s.archived ? 'opacity-60' : ''" />
                 <span v-if="!s.archived && elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
                       class="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-run">{{ elapsedLabel(inst.id, s.alias) }}</span>
               </button>

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -262,11 +262,14 @@ const rowSwipes = computed(() => {
                        @click.stop @keydown.enter.prevent="commitRename(inst.id, s.alias)"
                        @keydown.escape.prevent="cancelRename" @blur="commitRename(inst.id, s.alias)"
                        v-focus />
-                <span v-else class="truncate text-[12.5px] font-medium"
+                <span v-else data-test="session-name" class="min-w-0 truncate text-[12.5px] font-medium"
                       :class="s.archived ? 'text-fg-muted' : (isSelected(inst.id, s.alias) ? 'font-semibold text-accent' : 'text-fg')">{{ s.displayName || s.alias }}</span>
+                <!-- Archived state is shown visually by the dimmed name (no text badge), but that
+                     greying carries no signal for screen readers — keep a visually-hidden label so
+                     archived status is still announced. -->
+                <span v-if="s.archived" data-test="archived-label" class="sr-only">{{ $t("instance.sessionArchivedLabel") }}</span>
                 <!-- Native (agent-side / resumed) sessions get a small link glyph instead of a text
-                     badge to keep the row uncluttered. Archived state reads from the dimmed name, so
-                     it no longer carries its own badge. -->
+                     badge to keep the row uncluttered. -->
                 <Link2 v-if="s.native" data-test="native-badge" :size="12"
                        :aria-label="$t('instance.sessionNativeBadgeTitle')" :title="$t('instance.sessionNativeBadgeTitle')"
                        class="shrink-0 text-info" :class="s.archived ? 'opacity-60' : ''" />

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -175,7 +175,7 @@ watch(
           </div>
           <!-- ASSISTANT row -->
           <div v-else class="cv-row group flex gap-2.5">
-            <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden rounded-lg border border-border bg-surface">
+            <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden">
               <AgentIcon :driver="driver" :size="15" fill />
             </div>
             <div data-test="msg-out" class="min-w-0 flex-1 space-y-2.5"
@@ -201,7 +201,7 @@ watch(
 
         <!-- live streaming assistant row -->
         <div v-if="liveTurn && liveTurn.parts.length" class="flex gap-2.5">
-          <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden rounded-lg border border-border bg-surface">
+          <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden">
             <AgentIcon :driver="driver" :size="15" fill />
           </div>
           <div data-test="msg-streaming" class="min-w-0 flex-1">

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -171,6 +171,7 @@ export default {
     newSession: "New session",
     deleteSession: "Delete session",
     archiveSession: "Archive session",
+    sessionArchivedLabel: "archived",
     sessionNativeBadgeTitle: "Resumed from an existing agent-side session",
     sessionArchivedToast: "Archived \"{alias}\"",
     undo: "Undo",

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -171,8 +171,6 @@ export default {
     newSession: "New session",
     deleteSession: "Delete session",
     archiveSession: "Archive session",
-    sessionArchivedBadge: "archived",
-    sessionNativeBadge: "native",
     sessionNativeBadgeTitle: "Resumed from an existing agent-side session",
     sessionArchivedToast: "Archived \"{alias}\"",
     undo: "Undo",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -169,6 +169,7 @@ export default {
     newSession: "新建会话",
     deleteSession: "删除会话",
     archiveSession: "归档会话",
+    sessionArchivedLabel: "已归档",
     sessionNativeBadgeTitle: "从已有的 agent 原生会话续接",
     sessionArchivedToast: "已归档「{alias}」",
     undo: "撤销",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -169,8 +169,6 @@ export default {
     newSession: "新建会话",
     deleteSession: "删除会话",
     archiveSession: "归档会话",
-    sessionArchivedBadge: "已归档",
-    sessionNativeBadge: "原生",
     sessionNativeBadgeTitle: "从已有的 agent 原生会话续接",
     sessionArchivedToast: "已归档「{alias}」",
     undo: "撤销",


### PR DESCRIPTION
Follows #93 (display-name rename) — builds on its row structure.

## Why

Once the native badge landed beside the agent glyph and the archived badge, the sidebar row got visibly cramped (see the company-PC group in the report: `agent-icon 原生`, `已归档 原生`, …).

## Changes

**Sidebar row (`InstanceTree.vue`):**
- **Agent brand glyph moves before the session name** (was trailing) → the row reads `icon → name` like a normal list item.
- **Drop the "archived" text badge.** Archived state already reads from the greyed-out name, so the badge was redundant.
- **Native badge → a compact `Link2` glyph** (info-colored, tooltip retained) instead of the "原生"/"native" text — signals an agent-side / resumed session without eating horizontal space.

**Conversation list avatar (`MessageList.vue`):**
- Remove the rounded border + surface background wrapping the agent avatar. Now that the brand tile fills the box (#92), the frame just boxed it in.

**i18n:** drop the now-unused `sessionArchivedBadge` / `sessionNativeBadge` strings (the native tooltip key stays).

## Tests

`instancetree.test.ts` updated: native sessions now assert the icon marker (tooltip) not text; the archived row asserts the greyed name + no badge. Full relay-web suite green (67 files / 466 tests); `vue-tsc` clean (after rebuilding relay-protocol dist for #93's `displayName`).

> Ships in the next `@ganglion/xacpx-relay` release (bundled dashboard).