### PR TITLE
feat: acpx-cli 传输层新增 onUsage/onCommands 流式回调

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,7 +207,6 @@
       "integrity": "sha512-Ds16IyPm/dNJPCU8OzApo2gwGrgWT5BYHhE3NFwZbpCveqyvPDB9sZDDkJ5DsdOGT2aC+R3i0/M1OVXF2qdgPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.53.0",
         "@algolia/requester-browser-xhr": "5.53.0",
@@ -380,7 +379,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2054,7 +2052,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2078,7 +2075,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3534,7 +3530,6 @@
     "node_modules/@types/node": {
       "version": "25.5.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3785,7 +3780,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz",
       "integrity": "sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.35",
         "@vue/shared": "3.5.35"
@@ -4142,7 +4136,6 @@
     "node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4175,7 +4168,6 @@
       "integrity": "sha512-OGW1q6b91CRSSeiOnM8LxuR5NYJ2esvw66jUZ4IIvdv+ItNkx3pwLuyR+jaCdbGee4ov5WgUnyPryyh11xvByQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.19.0",
         "@algolia/client-abtesting": "5.53.0",
@@ -4479,7 +4471,6 @@
     "node_modules/bare-events": {
       "version": "2.8.2",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4657,7 +4648,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5692,7 +5682,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5895,7 +5884,6 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -6364,7 +6352,6 @@
     "node_modules/hono": {
       "version": "4.12.14",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7052,7 +7039,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7106,7 +7092,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -7636,6 +7621,8 @@
     },
     "node_modules/node-pty": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8035,7 +8022,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -8560,7 +8546,6 @@
       "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -9616,7 +9601,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9742,7 +9726,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -9863,7 +9846,6 @@
       "version": "6.0.2",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10133,7 +10115,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10792,7 +10773,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz",
       "integrity": "sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.35",
         "@vue/compiler-sfc": "3.5.35",
@@ -11579,7 +11559,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,6 +207,7 @@
       "integrity": "sha512-Ds16IyPm/dNJPCU8OzApo2gwGrgWT5BYHhE3NFwZbpCveqyvPDB9sZDDkJ5DsdOGT2aC+R3i0/M1OVXF2qdgPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.53.0",
         "@algolia/requester-browser-xhr": "5.53.0",
@@ -379,6 +380,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2052,6 +2054,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2075,6 +2078,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3530,6 +3534,7 @@
     "node_modules/@types/node": {
       "version": "25.5.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3780,6 +3785,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz",
       "integrity": "sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.35",
         "@vue/shared": "3.5.35"
@@ -4136,6 +4142,7 @@
     "node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4168,6 +4175,7 @@
       "integrity": "sha512-OGW1q6b91CRSSeiOnM8LxuR5NYJ2esvw66jUZ4IIvdv+ItNkx3pwLuyR+jaCdbGee4ov5WgUnyPryyh11xvByQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.19.0",
         "@algolia/client-abtesting": "5.53.0",
@@ -4471,6 +4479,7 @@
     "node_modules/bare-events": {
       "version": "2.8.2",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4648,6 +4657,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5682,6 +5692,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5884,6 +5895,7 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -6352,6 +6364,7 @@
     "node_modules/hono": {
       "version": "4.12.14",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7039,6 +7052,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7092,6 +7106,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -7621,8 +7636,6 @@
     },
     "node_modules/node-pty": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8022,6 +8035,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -8546,6 +8560,7 @@
       "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -9601,6 +9616,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9726,6 +9742,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -9846,6 +9863,7 @@
       "version": "6.0.2",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10115,6 +10133,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10773,6 +10792,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz",
       "integrity": "sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.35",
         "@vue/compiler-sfc": "3.5.35",
@@ -11559,6 +11579,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -7,11 +7,13 @@ import type { NonInteractivePermissions, PermissionMode } from "../../config/typ
 import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
 import { getLocale } from "../../i18n";
 import type {
+  AgentCommand,
   AgentSessionListQuery,
   AgentSessionListResult,
   EnsureSessionProgress,
   PermissionPolicy,
   PromptOptions,
+  PromptUsage,
   ReplyQuotaContext,
   ResolvedSession,
   SessionTransport,
@@ -291,7 +293,7 @@ export class AcpxCliTransport implements SessionTransport {
     const structuredPrompt = await createStructuredPromptFile(text, options?.media);
     const args = this.buildPromptArgs(session, text, structuredPrompt?.filePath);
     try {
-      if (reply || options?.onSegment || options?.onToolEvent || options?.onThought || options?.onPlan) {
+      if (reply || options?.onSegment || options?.onToolEvent || options?.onThought || options?.onPlan || options?.onUsage || options?.onCommands) {
         const effectiveReplyMode = session.effectiveReplyMode ?? session.replyMode;
         const formatToolCalls = (effectiveReplyMode ?? "verbose") === "verbose";
         // replyMode "stream" → raw token streaming (one live bubble, low latency).
@@ -314,6 +316,8 @@ export class AcpxCliTransport implements SessionTransport {
           options?.onToolEvent,
           options?.onThought,
           options?.onPlan,
+          options?.onUsage,
+          options?.onCommands,
           rawStream,
         );
         const baseText = getPromptText(result);
@@ -574,6 +578,8 @@ export class AcpxCliTransport implements SessionTransport {
     onToolEvent?: (event: ToolUseEvent) => void | Promise<void>,
     onThought?: (chunk: string) => void | Promise<void>,
     onPlan?: (entries: PlanEntry[]) => void | Promise<void>,
+    onUsage?: (usage: PromptUsage) => void | Promise<void>,
+    onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
     rawStream: boolean = false,
   ): Promise<{ result: CommandResult; overflowCount: number }> {
     const hooks = this.streamingHooks;
@@ -601,9 +607,15 @@ export class AcpxCliTransport implements SessionTransport {
       let thoughtError: unknown;
       let planChain = Promise.resolve();
       let planError: unknown;
+      let usageChain = Promise.resolve();
+      let usageError: unknown;
+      let commandsChain = Promise.resolve();
+      let commandsError: unknown;
       const userOnToolEvent = onToolEvent;
       const userOnThought = onThought;
       const userOnPlan = onPlan;
+      const userOnUsage = onUsage;
+      const userOnCommands = onCommands;
 
       const state = createStreamingPromptState(formatToolCalls, {
         mode: toolEventMode,
@@ -640,6 +652,30 @@ export class AcpxCliTransport implements SessionTransport {
                   .then(() => userOnPlan(entries))
                   .catch((error) => {
                     planError ??= error;
+                  });
+              },
+            }
+          : {}),
+        ...(userOnUsage
+          ? {
+              onUsage: (usage) => {
+                // Serialize handler invocations; first error wins.
+                usageChain = usageChain
+                  .then(() => userOnUsage(usage))
+                  .catch((error) => {
+                    usageError ??= error;
+                  });
+              },
+            }
+          : {}),
+        ...(userOnCommands
+          ? {
+              onCommands: (commands) => {
+                // Serialize handler invocations; first error wins.
+                commandsChain = commandsChain
+                  .then(() => userOnCommands(commands))
+                  .catch((error) => {
+                    commandsError ??= error;
                   });
               },
             }
@@ -720,6 +756,8 @@ export class AcpxCliTransport implements SessionTransport {
           toolEventChain,
           thoughtChain,
           planChain,
+          usageChain,
+          commandsChain,
         ]).then(() => {
           const deferred = sink?.getPendingError();
           if (deferred) {
@@ -740,6 +778,14 @@ export class AcpxCliTransport implements SessionTransport {
           }
           if (planError) {
             reject(planError);
+            return;
+          }
+          if (usageError) {
+            reject(usageError);
+            return;
+          }
+          if (commandsError) {
+            reject(commandsError);
             return;
           }
           resolve({

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
@@ -593,6 +593,162 @@ test("first onThought handler error wins when multiple handlers throw", async ()
   ).rejects.toThrow("error-1");
 });
 
+// ── onPlan chain semantics tests ─────────────────────────────────────────────
+
+test("forwards prompt.plan events to options.onPlan", async () => {
+  const plans: unknown[] = [];
+  const request = mock(async (_method: string, _params: unknown, onEvent?: (event: { type: string; entries?: unknown[] }) => void) => {
+    onEvent?.({ type: "prompt.plan", entries: [{ content: "step 1", status: "completed" }] });
+    return { text: "done" };
+  });
+  const transport = new AcpxBridgeTransport({ request });
+
+  await transport.prompt(session, "hi", undefined, undefined, {
+    onPlan: (entries) => { plans.push(entries); },
+  });
+
+  expect(plans).toEqual([[{ content: "step 1", status: "completed" }]]);
+});
+
+test("onPlan handler error rejects prompt", async () => {
+  const request = mock(async (_method: string, _params: unknown, onEvent?: (event: { type: string; entries?: unknown[] }) => void) => {
+    onEvent?.({ type: "prompt.plan", entries: [{ content: "boom", status: "completed" }] });
+    return { text: "done" };
+  });
+  const transport = new AcpxBridgeTransport({ request });
+
+  await expect(
+    transport.prompt(session, "hello", undefined, undefined, {
+      onPlan: () => {
+        throw new Error("handler blew up");
+      },
+    }),
+  ).rejects.toThrow("handler blew up");
+});
+
+test("first onPlan handler error wins when multiple handlers throw", async () => {
+  let callCount = 0;
+  const request = mock(async (_method: string, _params: unknown, onEvent?: (event: { type: string; entries?: unknown[] }) => void) => {
+    onEvent?.({ type: "prompt.plan", entries: [{ content: "e1", status: "completed" }] });
+    onEvent?.({ type: "prompt.plan", entries: [{ content: "e2", status: "completed" }] });
+    return { text: "done" };
+  });
+  const transport = new AcpxBridgeTransport({ request });
+
+  await expect(
+    transport.prompt(session, "hello", undefined, undefined, {
+      onPlan: () => {
+        callCount += 1;
+        throw new Error(`error-${callCount}`);
+      },
+    }),
+  ).rejects.toThrow("error-1");
+});
+
+// ── onUsage chain semantics tests ────────────────────────────────────────────
+
+test("forwards prompt.usage events to options.onUsage", async () => {
+  const usages: unknown[] = [];
+  const request = mock(async (_method: string, _params: unknown, onEvent?: (event: { type: string; used?: number; size?: number }) => void) => {
+    onEvent?.({ type: "prompt.usage", used: 1024, size: 16384 });
+    return { text: "done" };
+  });
+  const transport = new AcpxBridgeTransport({ request });
+
+  await transport.prompt(session, "hi", undefined, undefined, {
+    onUsage: (usage) => { usages.push(usage); },
+  });
+
+  expect(usages).toEqual([{ used: 1024, size: 16384 }]);
+});
+
+test("onUsage handler error rejects prompt", async () => {
+  const request = mock(async (_method: string, _params: unknown, onEvent?: (event: { type: string; used?: number; size?: number }) => void) => {
+    onEvent?.({ type: "prompt.usage", used: 100, size: 1000 });
+    return { text: "done" };
+  });
+  const transport = new AcpxBridgeTransport({ request });
+
+  await expect(
+    transport.prompt(session, "hello", undefined, undefined, {
+      onUsage: () => {
+        throw new Error("handler blew up");
+      },
+    }),
+  ).rejects.toThrow("handler blew up");
+});
+
+test("first onUsage handler error wins when multiple handlers throw", async () => {
+  let callCount = 0;
+  const request = mock(async (_method: string, _params: unknown, onEvent?: (event: { type: string; used?: number; size?: number }) => void) => {
+    onEvent?.({ type: "prompt.usage", used: 100, size: 1000 });
+    onEvent?.({ type: "prompt.usage", used: 200, size: 2000 });
+    return { text: "done" };
+  });
+  const transport = new AcpxBridgeTransport({ request });
+
+  await expect(
+    transport.prompt(session, "hello", undefined, undefined, {
+      onUsage: () => {
+        callCount += 1;
+        throw new Error(`error-${callCount}`);
+      },
+    }),
+  ).rejects.toThrow("error-1");
+});
+
+// ── onCommands chain semantics tests ────────────────────────────────────────
+
+test("forwards prompt.commands events to options.onCommands", async () => {
+  const commands: unknown[] = [];
+  const request = mock(async (_method: string, _params: unknown, onEvent?: (event: { type: string; commands?: unknown[] }) => void) => {
+    onEvent?.({ type: "prompt.commands", commands: [{ name: "compact", description: "Compact" }] });
+    return { text: "done" };
+  });
+  const transport = new AcpxBridgeTransport({ request });
+
+  await transport.prompt(session, "hi", undefined, undefined, {
+    onCommands: (cmds) => { commands.push(cmds); },
+  });
+
+  expect(commands).toEqual([[{ name: "compact", description: "Compact" }]]);
+});
+
+test("onCommands handler error rejects prompt", async () => {
+  const request = mock(async (_method: string, _params: unknown, onEvent?: (event: { type: string; commands?: unknown[] }) => void) => {
+    onEvent?.({ type: "prompt.commands", commands: [{ name: "boom" }] });
+    return { text: "done" };
+  });
+  const transport = new AcpxBridgeTransport({ request });
+
+  await expect(
+    transport.prompt(session, "hello", undefined, undefined, {
+      onCommands: () => {
+        throw new Error("handler blew up");
+      },
+    }),
+  ).rejects.toThrow("handler blew up");
+});
+
+test("first onCommands handler error wins when multiple handlers throw", async () => {
+  let callCount = 0;
+  const request = mock(async (_method: string, _params: unknown, onEvent?: (event: { type: string; commands?: unknown[] }) => void) => {
+    onEvent?.({ type: "prompt.commands", commands: [{ name: "cmd1" }] });
+    onEvent?.({ type: "prompt.commands", commands: [{ name: "cmd2" }] });
+    return { text: "done" };
+  });
+  const transport = new AcpxBridgeTransport({ request });
+
+  await expect(
+    transport.prompt(session, "hello", undefined, undefined, {
+      onCommands: () => {
+        callCount += 1;
+        throw new Error(`error-${callCount}`);
+      },
+    }),
+  ).rejects.toThrow("error-1");
+});
+
 
 test("bridge transport proxies native session methods", async () => {
   const requests: Array<{ method: string; params: Record<string, unknown> }> = [];

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -1918,6 +1918,217 @@ test("onThought: only the first handler error is surfaced", async () => {
   ).rejects.toThrow("thought error 1");
 });
 
+// --- onPlan wiring tests ---
+
+function makePlanLine(entries: unknown[]): string {
+  return JSON.stringify({
+    method: "session/update",
+    params: {
+      update: {
+        sessionUpdate: "plan",
+        entries,
+      },
+    },
+  });
+}
+
+test("onPlan: callback receives plan entries without bleeding into the reply stream", async () => {
+  const plans: unknown[] = [];
+  const segments: string[] = [];
+
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makePlanLine([{ content: "step 1", status: "completed" }, { content: "step 2", status: "in_progress" }]),
+        makeAgentChunkLine("final answer"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await transport.prompt(session, "hi", async (text) => {
+    segments.push(text);
+  }, undefined, {
+    onPlan: (entries) => {
+      plans.push(entries);
+    },
+  });
+
+  expect(plans).toEqual([[{ content: "step 1", status: "completed" }, { content: "step 2", status: "in_progress" }]]);
+  expect(segments).toEqual(["final answer"]);
+});
+
+test("onPlan: handler error rejects the prompt", async () => {
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makePlanLine([{ content: "boom", status: "completed" }]),
+        makeAgentChunkLine("done"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await expect(
+    transport.prompt(session, "hi", undefined, undefined, {
+      onPlan: () => {
+        throw new Error("plan handler boom");
+      },
+    }),
+  ).rejects.toThrow("plan handler boom");
+});
+
+// --- onUsage wiring tests ---
+
+function makeUsageLine(used: number, size: number): string {
+  return JSON.stringify({
+    method: "session/update",
+    params: {
+      update: {
+        sessionUpdate: "usage_update",
+        used,
+        size,
+      },
+    },
+  });
+}
+
+test("onUsage: callback receives usage data without bleeding into the reply stream", async () => {
+  const usages: unknown[] = [];
+  const segments: string[] = [];
+
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeUsageLine(1024, 16384),
+        makeAgentChunkLine("final answer"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await transport.prompt(session, "hi", async (text) => {
+    segments.push(text);
+  }, undefined, {
+    onUsage: (usage) => {
+      usages.push(usage);
+    },
+  });
+
+  expect(usages).toEqual([{ used: 1024, size: 16384 }]);
+  expect(segments).toEqual(["final answer"]);
+});
+
+test("onUsage: handler error rejects the prompt", async () => {
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeUsageLine(100, 1000),
+        makeAgentChunkLine("done"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await expect(
+    transport.prompt(session, "hi", undefined, undefined, {
+      onUsage: () => {
+        throw new Error("usage handler boom");
+      },
+    }),
+  ).rejects.toThrow("usage handler boom");
+});
+
+// --- onCommands wiring tests ---
+
+function makeCommandsLine(commands: unknown[]): string {
+  return JSON.stringify({
+    method: "session/update",
+    params: {
+      update: {
+        sessionUpdate: "available_commands_update",
+        availableCommands: commands,
+      },
+    },
+  });
+}
+
+test("onCommands: callback receives commands list without bleeding into the reply stream", async () => {
+  const commandsList: unknown[] = [];
+  const segments: string[] = [];
+
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeCommandsLine([{ name: "compact", description: "Compact context" }]),
+        makeAgentChunkLine("final answer"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await transport.prompt(session, "hi", async (text) => {
+    segments.push(text);
+  }, undefined, {
+    onCommands: (commands) => {
+      commandsList.push(commands);
+    },
+  });
+
+  expect(commandsList).toEqual([[{ name: "compact", description: "Compact context", hasInput: false }]]);
+  expect(segments).toEqual(["final answer"]);
+});
+
+test("onCommands: handler error rejects the prompt", async () => {
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeCommandsLine([{ name: "boom" }]),
+        makeAgentChunkLine("done"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await expect(
+    transport.prompt(session, "hi", undefined, undefined, {
+      onCommands: () => {
+        throw new Error("commands handler boom");
+      },
+    }),
+  ).rejects.toThrow("commands handler boom");
+});
+
 test("getAgentSessionId returns the agentSessionId from sessions show", async () => {
   const run = mock(async () => ({
     code: 0,

--- a/tests/unit/transport/streaming-prompt.test.ts
+++ b/tests/unit/transport/streaming-prompt.test.ts
@@ -672,3 +672,158 @@ test("interleaved stream: thoughts reach onThought in order, agent message lands
   expect(allText).not.toContain("first thought");
   expect(allText).not.toContain("second thought");
 });
+
+// --- onUsage tests ---
+
+test("onUsage receives usage_update with used/size and optional cost/breakdown", () => {
+  const usages: unknown[] = [];
+  const state = createStreamingPromptState(false, {
+    onUsage: (usage) => {
+      usages.push(usage);
+    },
+  });
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: {
+      sessionUpdate: "usage_update",
+      used: 1024,
+      size: 16384,
+      cost: { amount: 0.01, currency: "USD" },
+      _meta: { usage: { inputTokens: 512, outputTokens: 512 } },
+    } },
+  }));
+
+  expect(usages).toEqual([{
+    used: 1024,
+    size: 16384,
+    cost: { amount: 0.01, currency: "USD" },
+    breakdown: { inputTokens: 512, outputTokens: 512 },
+  }]);
+});
+
+test("onUsage ignores malformed usage_update with no used/size", () => {
+  let called = false;
+  const state = createStreamingPromptState(false, {
+    onUsage: () => { called = true; },
+  });
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "usage_update" } },
+  }));
+
+  expect(called).toBe(false);
+});
+
+test("onUsage ignores usage_update with zero or negative size", () => {
+  let called = false;
+  const state = createStreamingPromptState(false, {
+    onUsage: () => { called = true; },
+  });
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "usage_update", used: 100, size: 0 } },
+  }));
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "usage_update", used: 100, size: -1 } },
+  }));
+
+  expect(called).toBe(false);
+});
+
+test("onUsage receives partial usage_update with only used/size", () => {
+  const usages: unknown[] = [];
+  const state = createStreamingPromptState(false, {
+    onUsage: (usage) => { usages.push(usage); },
+  });
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "usage_update", used: 512, size: 8192 } },
+  }));
+
+  expect(usages).toEqual([{ used: 512, size: 8192 }]);
+});
+
+// --- onCommands tests ---
+
+test("onCommands receives available_commands_update with command list", () => {
+  const commandsList: unknown[] = [];
+  const state = createStreamingPromptState(false, {
+    onCommands: (commands) => { commandsList.push(commands); },
+  });
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: {
+      sessionUpdate: "available_commands_update",
+      availableCommands: [
+        { name: "compact", description: "Compact context" },
+        { name: "debug", input: "mode" },
+      ],
+    } },
+  }));
+
+  expect(commandsList).toEqual([[
+    { name: "compact", description: "Compact context", hasInput: false },
+    { name: "debug", hasInput: true },
+  ]]);
+});
+
+test("onCommands receives empty array as valid clear signal", () => {
+  const commandsList: unknown[] = [];
+  const state = createStreamingPromptState(false, {
+    onCommands: (commands) => { commandsList.push(commands); },
+  });
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "available_commands_update", availableCommands: [] } },
+  }));
+
+  expect(commandsList).toEqual([[]]);
+});
+
+test("onCommands ignores malformed available_commands_update without array", () => {
+  let called = false;
+  const state = createStreamingPromptState(false, {
+    onCommands: () => { called = true; },
+  });
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "available_commands_update" } },
+  }));
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "available_commands_update", availableCommands: "not array" } },
+  }));
+
+  expect(called).toBe(false);
+});
+
+// --- onPlan edge cases ---
+
+test("onPlan filters malformed plan entries", () => {
+  const plans: unknown[] = [];
+  const state = createStreamingPromptState(false, { onPlan: (entries) => plans.push(entries) });
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: { update: { sessionUpdate: "plan", entries: [
+      { content: "valid entry", status: "completed" },
+      { content: "no status" },
+      { status: "completed" },
+      "not an object",
+      null,
+      { content: 123, status: "completed" },
+      { content: "another valid", status: "in_progress" },
+    ] } },
+  }));
+  expect(plans).toEqual([[
+    { content: "valid entry", status: "completed" },
+    { content: "another valid", status: "in_progress" },
+  ]]);
+});


### PR DESCRIPTION
## 🎯 Changes

### 1. acpx-cli 传输层新增 onUsage/onCommands 回调
- 引入 `AgentCommand` 和 `PromptUsage` 类型。
- 在 prompt 触发条件中增加 `onUsage` 和 `onCommands` 选项判断。
- 将 `onUsage` 和 `onCommands` 回调透传至流式 prompt 处理函数。
- 新增 usage 和 commands 的串行化调用链及错误捕获逻辑，与现有 `toolEvent`/`thought`/`plan` 链保持一致。
- 在 Promise 汇总阶段加入 usage 和 commands 链的等待，并在出错时拒绝 prompt。

### 2. 补充单元测试
- **acpx-bridge-transport**: 新增 `onPlan`、`onUsage`、`onCommands` 链路语义测试，覆盖事件转发、处理函数错误拒绝 prompt、首个错误优先等场景。
- **acpx-cli-transport**: 新增 `onUsage`、`onCommands`、`onPlan` 接线测试，验证回调接收数据且不污染回复流，以及处理函数错误拒绝 prompt 的行为。
- **streaming-prompt**: 新增 `onUsage` 解析测试（接收 `usage_update`，忽略畸形事件）、`onCommands` 解析测试（接收 `available_commands_update`，处理空数组和畸形数据），以及 `onPlan` 边界测试（过滤畸形计划条目）。

### 3. 清理 package-lock.json
- 移除了约 23 个依赖项上多余的 `"peer": true` 标记。
- 为 `node-pty` 包补充了 `resolved` 和 `integrity` 字段。

## 💡 Technical Highlights

- **一致性回调机制**: `onUsage` 和 `onCommands` 采用与 `onPlan` 等回调相同的串行化与错误传播机制，确保传输层行为统一。
- **健壮性增强**: 详细的单元测试覆盖了事件转发、错误处理和畸形数据解析等边界情况，提高了系统的稳定性。
- **依赖清理**: 优化 `package-lock.json`，减少不必要的元数据，使依赖管理更清晰。