### PR TITLE
feat(channel-feishu): usage footer + plan panel in streaming card

### DIFF
--- a/packages/channel-feishu/src/card/card-builder.ts
+++ b/packages/channel-feishu/src/card/card-builder.ts
@@ -191,7 +191,8 @@ export function formatUsageSegment(usage: PromptUsage): string {
     parts.push(`↓${formatTokenCount(breakdown.outputTokens)}`);
   }
   if (typeof usage.size === "number" && usage.size > 0 && typeof usage.used === "number" && usage.used >= 0) {
-    const percent = Math.round((usage.used / usage.size) * 100);
+    // Clamp: agents can transiently report used > size; never show >100%.
+    const percent = Math.min(100, Math.round((usage.used / usage.size) * 100));
     parts.push(`ctx ${formatTokenCount(usage.used)}/${formatTokenCount(usage.size)} ${percent}%`);
   }
   return parts.join(" · ");
@@ -199,9 +200,15 @@ export function formatUsageSegment(usage: PromptUsage): string {
 
 function formatTokenCount(value: number): string {
   if (!Number.isFinite(value) || value < 0) return "0";
-  if (value >= 1_000_000) return formatScaled(value, 1_000_000, "m");
-  if (value >= 1_000) return formatScaled(value, 1_000, "k");
-  return String(Math.round(value));
+  const rounded = Math.round(value);
+  if (rounded >= 1_000_000) return formatScaled(rounded, 1_000_000, "m");
+  if (rounded >= 1_000) {
+    // Promote to the next unit when the k-rounding would read "1000k"
+    // (e.g. 999_999 → "1m", not "1000k").
+    if (Math.round(rounded / 1_000) >= 1_000) return formatScaled(rounded, 1_000_000, "m");
+    return formatScaled(rounded, 1_000, "k");
+  }
+  return String(rounded);
 }
 
 function formatScaled(value: number, factor: number, suffix: string): string {

--- a/packages/channel-feishu/src/card/card-builder.ts
+++ b/packages/channel-feishu/src/card/card-builder.ts
@@ -1,3 +1,4 @@
+import type { PlanEntry, PromptUsage } from "xacpx/plugin-api";
 import { t } from "../i18n/index.js";
 import { en } from "../i18n/en.js";
 import { zh } from "../i18n/zh.js";
@@ -13,6 +14,7 @@ export type CardState = "thinking" | "streaming" | "complete" | "aborted" | "err
 export const CARD_BODY_MAX_CHARS = 28000;
 const TRUNCATION_MARKER = "\n\n…(truncated)";
 const TOOL_PANEL_MAX_STEPS = 50;
+const PLAN_PANEL_MAX_STEPS = 30;
 
 export function truncateForCardBody(text: string, maxChars: number = CARD_BODY_MAX_CHARS): string {
   if (text.length <= maxChars) return text;
@@ -31,6 +33,10 @@ export interface BuildCardInput {
   reasoningText?: string;
   reasoningElapsedMs?: number;
   toolSteps?: ToolUseStep[];
+  /** Agent live plan/todo list (ACP `plan`); rendered as a collapsible panel. */
+  planEntries?: PlanEntry[];
+  /** Context-usage side-channel; rendered into the footer (tokens + window %). */
+  usage?: PromptUsage;
   /** Per-call override of {@link CARD_BODY_MAX_CHARS}. */
   maxBodyChars?: number;
 }
@@ -46,6 +52,12 @@ export function buildCard(input: BuildCardInput): Record<string, unknown> {
   };
 
   const elements: Array<Record<string, unknown>> = [];
+
+  const planPanel = buildPlanPanel(input.planEntries);
+  if (planPanel) {
+    elements.push(planPanel);
+    elements.push({ tag: "hr" });
+  }
 
   const toolPanel = buildToolUsePanel(input.toolSteps);
   if (toolPanel) {
@@ -90,7 +102,8 @@ export function buildCard(input: BuildCardInput): Record<string, unknown> {
     text_size: "normal_v2",
   });
 
-  const footer = footerForState(input.state, input.elapsedMs);
+  const usageText = input.usage ? formatUsageSegment(input.usage) : "";
+  const footer = footerForState(input.state, input.elapsedMs, usageText || undefined);
   if (footer) elements.push(footer);
 
   return {
@@ -124,9 +137,22 @@ function summaryForState(state: CardState): Record<string, unknown> {
   }
 }
 
-function footerForState(state: CardState, elapsedMs?: number): Record<string, unknown> | null {
+function footerElement(content: string): Record<string, unknown> {
+  return { tag: "markdown", content, text_size: "notation", text_align: "left" };
+}
+
+function footerForState(
+  state: CardState,
+  elapsedMs?: number,
+  usageText?: string,
+): Record<string, unknown> | null {
   const elapsedLabel = typeof elapsedMs === "number" ? formatElapsedMs(elapsedMs) : "";
   const elapsedSuffix = elapsedLabel ? ` · ${elapsedLabel}` : "";
+  // Usage rides as a trailing ` · <tokens · ctx %>` segment on whatever the
+  // state's footer already shows. It can be present without elapsed (e.g. a
+  // usage_update lands before the first footer tick), so complete/streaming
+  // render their footer when EITHER elapsed or usage is available.
+  const usageSuffix = usageText ? ` · ${usageText}` : "";
   switch (state) {
     // Live states (thinking/streaming) embed the elapsed inline as
     // `处理中... <elapsed>` rather than appending it via ` · <elapsed>`
@@ -135,43 +161,94 @@ function footerForState(state: CardState, elapsedMs?: number): Record<string, un
     // states (complete/aborted/error) use the ` · ` separator because the
     // label is a final outcome and the elapsed is supplementary.
     case "thinking":
-      return {
-        tag: "markdown",
-        content: elapsedLabel ? t().footerThinkingElapsed(elapsedLabel) : t().footerThinking,
-        text_size: "notation",
-        text_align: "left",
-      };
+      return footerElement((elapsedLabel ? t().footerThinkingElapsed(elapsedLabel) : t().footerThinking) + usageSuffix);
     case "aborted":
-      return {
-        tag: "markdown",
-        content: t().footerAborted(elapsedSuffix),
-        text_size: "notation",
-        text_align: "left",
-      };
+      return footerElement(t().footerAborted(elapsedSuffix) + usageSuffix);
     case "error":
-      return {
-        tag: "markdown",
-        content: t().footerError(elapsedSuffix),
-        text_size: "notation",
-        text_align: "left",
-      };
+      return footerElement(t().footerError(elapsedSuffix) + usageSuffix);
     case "complete":
-      if (!elapsedLabel) return null;
-      return {
-        tag: "markdown",
-        content: t().footerComplete(elapsedLabel),
-        text_size: "notation",
-        text_align: "left",
-      };
+      if (!elapsedLabel && !usageText) return null;
+      return footerElement(elapsedLabel ? t().footerComplete(elapsedLabel) + usageSuffix : (usageText ?? ""));
     case "streaming":
-      if (!elapsedLabel) return null;
-      return {
-        tag: "markdown",
-        content: t().footerStreaming(elapsedLabel),
-        text_size: "notation",
-        text_align: "left",
-      };
+      if (!elapsedLabel && !usageText) return null;
+      return footerElement(elapsedLabel ? t().footerStreaming(elapsedLabel) + usageSuffix : (usageText ?? ""));
   }
+}
+
+/**
+ * Render the usage side-channel as a compact footer segment, e.g.
+ * `↑1.2k · ↓800 · ctx 12k/200k 6%`. Each piece is independent: token counts
+ * come from the per-turn breakdown (codex may omit them) and the context part
+ * from the window fill. Returns "" when nothing usable is present.
+ */
+export function formatUsageSegment(usage: PromptUsage): string {
+  const parts: string[] = [];
+  const breakdown = usage.breakdown;
+  if (breakdown && typeof breakdown.inputTokens === "number" && breakdown.inputTokens > 0) {
+    parts.push(`↑${formatTokenCount(breakdown.inputTokens)}`);
+  }
+  if (breakdown && typeof breakdown.outputTokens === "number" && breakdown.outputTokens > 0) {
+    parts.push(`↓${formatTokenCount(breakdown.outputTokens)}`);
+  }
+  if (typeof usage.size === "number" && usage.size > 0 && typeof usage.used === "number" && usage.used >= 0) {
+    const percent = Math.round((usage.used / usage.size) * 100);
+    parts.push(`ctx ${formatTokenCount(usage.used)}/${formatTokenCount(usage.size)} ${percent}%`);
+  }
+  return parts.join(" · ");
+}
+
+function formatTokenCount(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return "0";
+  if (value >= 1_000_000) return formatScaled(value, 1_000_000, "m");
+  if (value >= 1_000) return formatScaled(value, 1_000, "k");
+  return String(Math.round(value));
+}
+
+function formatScaled(value: number, factor: number, suffix: string): string {
+  const scaled = value / factor;
+  if (scaled >= 100 || Number.isInteger(scaled)) return `${Math.round(scaled)}${suffix}`;
+  return `${scaled.toFixed(1).replace(/\.0$/, "")}${suffix}`;
+}
+
+const PLAN_STATUS_ICON: Record<string, string> = {
+  completed: "✅",
+  in_progress: "⏳",
+  pending: "⬜",
+};
+
+function buildPlanPanel(entries: PlanEntry[] | undefined): Record<string, unknown> | null {
+  if (!entries || entries.length === 0) return null;
+  const done = entries.filter((entry) => entry.status === "completed").length;
+  const visible = entries.slice(0, PLAN_PANEL_MAX_STEPS);
+  const lines = visible.map((entry) => {
+    const icon = PLAN_STATUS_ICON[entry.status] ?? PLAN_STATUS_ICON.pending;
+    const text = truncateInline(entry.content, 120);
+    // Strike completed items so the remaining work reads at a glance.
+    return entry.status === "completed" ? `${icon} ~~${text}~~` : `${icon} ${text}`;
+  });
+  const omitted = entries.length - visible.length;
+  if (omitted > 0) {
+    lines.push(t().planPanelOmitted(omitted));
+  }
+  return {
+    tag: "collapsible_panel",
+    // Expanded by default: the live plan is the headline "what's happening".
+    expanded: true,
+    header: {
+      title: {
+        tag: "markdown",
+        content: t().planPanelHeader(done, entries.length),
+      },
+    },
+    elements: [
+      {
+        tag: "markdown",
+        content: lines.join("\n"),
+        text_align: "left",
+        text_size: "notation",
+      },
+    ],
+  };
 }
 
 const TOOL_KIND_ICON: Record<string, string> = {

--- a/packages/channel-feishu/src/card/streaming-card-controller.ts
+++ b/packages/channel-feishu/src/card/streaming-card-controller.ts
@@ -1,12 +1,14 @@
 import { isMessageUnavailable, markIfUnavailableError } from "../message-unavailable.js";
 import { resolveFeishuReceiveIdType, normalizeFeishuTarget } from "../send.js";
 import { t } from "../i18n/index.js";
+import type { PlanEntry, PromptUsage } from "xacpx/plugin-api";
 import {
   CARD_BODY_MAX_CHARS,
   STREAMING_ELEMENT_ID,
   buildCard,
   buildCardMessageContent,
   formatElapsedMs,
+  formatUsageSegment,
   truncateForCardBody,
   type CardState,
 } from "./card-builder.js";
@@ -143,6 +145,13 @@ export class StreamingCardController {
   private lastFooterText: string | null = null;
   private readonly toolUseStore: ToolUseStore;
   private lastPushedToolRevision = -1;
+  // Latest usage side-channel (replace, not accumulate — each update is the
+  // current window/turn snapshot). Folded into the footer text key so a change
+  // forces the full card.update path off the streaming fast-path.
+  private lastUsage: PromptUsage | undefined = undefined;
+  // Latest plan/todo list (ACP `plan` re-sends the WHOLE list → replace).
+  private planEntries: PlanEntry[] = [];
+  private lastPushedPlanKey = "";
   private terminated = false;
   private seededAtMs = 0;
   private degraded = false;
@@ -277,6 +286,26 @@ export class StreamingCardController {
     // Ensure the next push goes through the full card.update path so the
     // tool-use panel actually renders (the fast-path only touches the
     // streaming_content element).
+    this.flush.requestFlush(() => this.pushUpdate());
+  }
+
+  recordUsage(usage: PromptUsage): void {
+    if (this.terminated) return;
+    this.lastUsage = usage;
+    if (!this.cardId) return;
+    // Usage lives in the footer, not streaming_content — pushUpdate detects the
+    // footer-text change and takes the full card.update path.
+    this.flush.requestFlush(() => this.pushUpdate());
+  }
+
+  recordPlan(entries: PlanEntry[]): void {
+    if (this.terminated) return;
+    // Replace, don't append — the agent re-sends the whole list each update.
+    this.planEntries = entries;
+    if (!this.cardId) return;
+    // Plan renders as a separate collapsible panel, so it can't ride the
+    // streaming_content fast-path — pushUpdate detects the change and takes
+    // the full card.update path.
     this.flush.requestFlush(() => this.pushUpdate());
   }
 
@@ -466,12 +495,16 @@ export class StreamingCardController {
     const reasoningChanged = reasoningRendered !== this.lastPushedReasoning;
 
     const elapsedMs = this.seededAtMs > 0 ? this.now() - this.seededAtMs : undefined;
-    const currentFooterText = computeFooterText(this.state, elapsedMs);
+    const usageText = this.lastUsage ? formatUsageSegment(this.lastUsage) : "";
+    const currentFooterText = computeFooterText(this.state, elapsedMs, usageText);
     const footerChanged = currentFooterText !== this.lastFooterText;
 
     const toolSteps = this.toolUseStore.steps();
     const toolRevision = this.toolUseStore.getRevision();
     const toolStepsChanged = toolRevision !== this.lastPushedToolRevision;
+
+    const planKey = this.planEntries.length > 0 ? planStateKey(this.planEntries) : "";
+    const planChanged = planKey !== this.lastPushedPlanKey;
 
     const elementApi = this.client.cardkit.v1.cardElement;
     if (
@@ -480,6 +513,7 @@ export class StreamingCardController {
       !reasoningChanged &&
       !footerChanged &&
       !toolStepsChanged &&
+      !planChanged &&
       elementApi
     ) {
       const seq = this.sequence++;
@@ -503,6 +537,8 @@ export class StreamingCardController {
       ...(reasoningRendered ? { reasoningText: reasoningRendered } : {}),
       ...(reasoningElapsedMs !== undefined ? { reasoningElapsedMs } : {}),
       ...(toolSteps.length > 0 ? { toolSteps } : {}),
+      ...(this.planEntries.length > 0 ? { planEntries: this.planEntries } : {}),
+      ...(this.lastUsage ? { usage: this.lastUsage } : {}),
       ...(this.cardBodyMaxChars !== undefined ? { maxBodyChars: this.cardBodyMaxChars } : {}),
     });
     const seq = this.sequence++;
@@ -515,6 +551,7 @@ export class StreamingCardController {
       this.lastPushedReasoning = reasoningRendered;
       this.lastFooterText = currentFooterText;
       this.lastPushedToolRevision = toolRevision;
+      this.lastPushedPlanKey = planKey;
     } catch (error) {
       // 230011/231003 mean the message is gone — that's a terminal "success"
       // for our purposes; don't count it as a failure (the user couldn't see
@@ -527,7 +564,11 @@ export class StreamingCardController {
   }
 }
 
-function computeFooterText(state: CardState, elapsedMs: number | undefined): string {
-  if (elapsedMs === undefined) return state;
-  return `${state}|${formatElapsedMs(elapsedMs)}`;
+function computeFooterText(state: CardState, elapsedMs: number | undefined, usageText: string): string {
+  if (elapsedMs === undefined && !usageText) return state;
+  return `${state}|${elapsedMs === undefined ? "" : formatElapsedMs(elapsedMs)}|${usageText}`;
+}
+
+function planStateKey(entries: PlanEntry[]): string {
+  return entries.map((entry) => `${entry.status}:${entry.content}`).join("\n");
 }

--- a/packages/channel-feishu/src/channel.ts
+++ b/packages/channel-feishu/src/channel.ts
@@ -251,6 +251,14 @@ export class FeishuChannel implements MessageChannelRuntime {
             if (input.abortSignal?.aborted) return;
             cardController.appendReasoning(chunk);
           },
+          onPlan: (entries) => {
+            if (input.abortSignal?.aborted) return;
+            cardController.recordPlan(entries);
+          },
+          onUsage: (usage) => {
+            if (input.abortSignal?.aborted) return;
+            cardController.recordUsage(usage);
+          },
         } : {}),
       });
 
@@ -644,6 +652,14 @@ export class FeishuChannel implements MessageChannelRuntime {
             onThought: (chunk) => {
               if (active.suppressed) return;
               active.cardController?.appendReasoning(chunk);
+            },
+            onPlan: (entries) => {
+              if (active.suppressed) return;
+              active.cardController?.recordPlan(entries);
+            },
+            onUsage: (usage) => {
+              if (active.suppressed) return;
+              active.cardController?.recordUsage(usage);
             },
           } : {}),
           abortSignal: abortController.signal,

--- a/packages/channel-feishu/src/i18n/en.ts
+++ b/packages/channel-feishu/src/i18n/en.ts
@@ -23,6 +23,8 @@ export const en: FeishuMessages = {
   reasoningHeaderElapsed: (elapsed) => `🧠 Thought for ${elapsed}`,
   toolPanelOmitted: (count) => `… ${count} more tool call${count === 1 ? "" : "s"} not shown`,
   toolPanelHeader: (count) => `🔧 Tool calls (${count})`,
+  planPanelHeader: (done, total) => `📋 Plan (${done}/${total})`,
+  planPanelOmitted: (count) => `… ${count} more item${count === 1 ? "" : "s"} not shown`,
 
   // ---- channel ----
   taskCompleted: "Task completed.",

--- a/packages/channel-feishu/src/i18n/messages.ts
+++ b/packages/channel-feishu/src/i18n/messages.ts
@@ -47,6 +47,10 @@ export interface FeishuMessages {
   toolPanelOmitted: (count: number) => string;
   /** Collapsible panel header for the tool-use section. */
   toolPanelHeader: (count: number) => string;
+  /** Collapsible panel header for the plan/todo section (done / total). */
+  planPanelHeader: (done: number, total: number) => string;
+  /** Text appended to the plan panel when entries are omitted. */
+  planPanelOmitted: (count: number) => string;
 
   // ---- channel ----
   /** Fallback text sent when an orchestration task completes with no result text. */

--- a/packages/channel-feishu/src/i18n/zh.ts
+++ b/packages/channel-feishu/src/i18n/zh.ts
@@ -38,6 +38,8 @@ export const zh: FeishuMessages = {
   reasoningHeaderElapsed: (elapsed) => `🧠 已思考 ${elapsed}`,
   toolPanelOmitted: (count) => `… 还有 ${count} 个工具调用未显示`,
   toolPanelHeader: (count) => `🔧 工具调用 (${count})`,
+  planPanelHeader: (done, total) => `📋 任务清单 (${done}/${total})`,
+  planPanelOmitted: (count) => `… 还有 ${count} 项未显示`,
 
   // ---- channel ----
   taskCompleted: "任务已完成。",

--- a/src/plugin-api.ts
+++ b/src/plugin-api.ts
@@ -10,10 +10,21 @@ export type {
   ScheduledChannelMessageInput,
   OrchestrationDeliveryCallbacks,
   OutboundQuota,
+  PlanEntry,
+  PlanEntryStatus,
   ToolUseEvent,
   ToolUseKind,
   ToolUseStatus,
 } from "./channels/types.js";
+// Streaming side-channel payloads (context usage + advertised commands) so
+// channel plugins can render token/context footers and command hints. These
+// originate in the transport layer; surfaced here as the public plugin contract.
+export type {
+  AgentCommand,
+  PromptUsage,
+  UsageBreakdown,
+  UsageCost,
+} from "./transport/types.js";
 export type {
   ChannelCliInput,
   ChannelCliIo,

--- a/tests/unit/packages/channel-feishu/feishu-card-builder.test.ts
+++ b/tests/unit/packages/channel-feishu/feishu-card-builder.test.ts
@@ -8,6 +8,7 @@ import {
   buildCard,
   buildCardMessageContent,
   formatElapsedMs,
+  formatUsageSegment,
   truncateForCardBody,
 } from "../../../../packages/channel-feishu/src/card/card-builder";
 
@@ -248,6 +249,122 @@ test("buildCard reasoning header omits elapsed when reasoningElapsedMs is absent
   const headerJson = JSON.stringify(panel.header);
   expect(headerJson).toContain(t().reasoningHeader);
   expect(headerJson).not.toContain(t().reasoningHeaderElapsed(""));
+});
+
+// ---- usage footer (P0) ----
+
+test("formatUsageSegment renders token breakdown and context fill", () => {
+  const seg = formatUsageSegment({
+    used: 12_000,
+    size: 200_000,
+    breakdown: { inputTokens: 1234, outputTokens: 800 },
+  });
+  expect(seg).toBe("↑1.2k · ↓800 · ctx 12k/200k 6%");
+});
+
+test("formatUsageSegment shows only context when breakdown is absent (codex)", () => {
+  const seg = formatUsageSegment({ used: 50_000, size: 100_000 });
+  expect(seg).toBe("ctx 50k/100k 50%");
+});
+
+test("formatUsageSegment omits zero token fields", () => {
+  const seg = formatUsageSegment({ used: 0, size: 128_000, breakdown: { inputTokens: 0, outputTokens: 42 } });
+  expect(seg).toBe("↓42 · ctx 0/128k 0%");
+});
+
+test("formatUsageSegment returns empty string when nothing usable", () => {
+  expect(formatUsageSegment({ used: 0, size: 0 })).toBe("");
+});
+
+test("buildCard 'complete' appends usage segment to the footer", () => {
+  const card = buildCard({
+    state: "complete",
+    text: "answer",
+    elapsedMs: 3400,
+    usage: { used: 12_000, size: 200_000, breakdown: { inputTokens: 1234, outputTokens: 800 } },
+  }) as { body: { elements: Array<{ content: string }> } };
+  const footer = card.body.elements[card.body.elements.length - 1];
+  expect(footer.content).toContain(t().summaryComplete);
+  expect(footer.content).toContain("3.4s");
+  expect(footer.content).toContain("↑1.2k");
+  expect(footer.content).toContain("ctx 12k/200k 6%");
+});
+
+test("buildCard 'complete' renders footer from usage even without elapsed", () => {
+  const card = buildCard({
+    state: "complete",
+    text: "answer",
+    usage: { used: 50_000, size: 100_000 },
+  }) as { body: { elements: Array<{ content: string; element_id?: string }> } };
+  const last = card.body.elements[card.body.elements.length - 1];
+  expect(last.element_id).not.toBe(STREAMING_ELEMENT_ID);
+  expect(last.content).toContain("ctx 50k/100k 50%");
+});
+
+test("buildCard streaming footer carries usage alongside elapsed", () => {
+  const card = buildCard({
+    state: "streaming",
+    text: "abc",
+    elapsedMs: 4000,
+    usage: { used: 8_000, size: 200_000 },
+  }) as { body: { elements: Array<{ content: string }> } };
+  const footer = card.body.elements[card.body.elements.length - 1];
+  expect(footer.content).toContain("4.0s");
+  expect(footer.content).toContain("ctx 8k/200k 4%");
+});
+
+// ---- plan panel (P1) ----
+
+test("buildCard with planEntries renders an expanded plan panel above the tool panel", () => {
+  const card = buildCard({
+    state: "streaming",
+    text: "working",
+    elapsedMs: 1000,
+    planEntries: [
+      { content: "Read the spec", status: "completed" },
+      { content: "Write the code", status: "in_progress" },
+      { content: "Add tests", status: "pending" },
+    ],
+    toolSteps: [
+      { toolCallId: "t1", toolName: "Bash", kind: "execute", status: "running", startedAt: 0 },
+    ],
+  });
+  const elements = (card.body as { elements: Array<Record<string, unknown>> }).elements;
+  const panel = elements[0];
+  expect(panel.tag).toBe("collapsible_panel");
+  expect(panel.expanded).toBe(true);
+  const json = JSON.stringify(panel);
+  expect(json).toContain(t().planPanelHeader(1, 3));
+  expect(json).toContain("Read the spec");
+  expect(json).toContain("~~Read the spec~~"); // completed struck through
+  expect(json).toContain("Write the code");
+  // Plan panel precedes the tool panel.
+  expect(JSON.stringify(elements[2])).toContain(t().toolPanelHeader(1));
+});
+
+test("buildCard with no planEntries omits the plan panel", () => {
+  const card = buildCard({ state: "streaming", text: "hi", elapsedMs: 1000 });
+  const elements = (card.body as { elements: Array<Record<string, unknown>> }).elements;
+  const planHeaderPresent = elements.some((el) => JSON.stringify(el).includes(t().planPanelHeader(0, 0)));
+  expect(planHeaderPresent).toBe(false);
+});
+
+test("buildCard caps the plan panel rows while preserving the total in the header", () => {
+  const card = buildCard({
+    state: "streaming",
+    text: "hi",
+    elapsedMs: 1000,
+    planEntries: Array.from({ length: 35 }, (_, i) => ({
+      content: `Step ${i}`,
+      status: "pending" as const,
+    })),
+  });
+  const panel = (card.body as { elements: Array<Record<string, unknown>> }).elements[0];
+  const json = JSON.stringify(panel);
+  expect(json).toContain(t().planPanelHeader(0, 35));
+  expect(json).toContain("Step 29");
+  expect(json).not.toContain("Step 30");
+  expect(json).toContain(t().planPanelOmitted(5));
 });
 
 test("buildCard reasoning header omits elapsed when reasoningElapsedMs is zero", () => {

--- a/tests/unit/packages/channel-feishu/feishu-card-builder.test.ts
+++ b/tests/unit/packages/channel-feishu/feishu-card-builder.test.ts
@@ -276,6 +276,16 @@ test("formatUsageSegment returns empty string when nothing usable", () => {
   expect(formatUsageSegment({ used: 0, size: 0 })).toBe("");
 });
 
+test("formatUsageSegment clamps context percent to 100 when used exceeds size", () => {
+  const seg = formatUsageSegment({ used: 250_000, size: 200_000 });
+  expect(seg).toBe("ctx 250k/200k 100%");
+});
+
+test("formatUsageSegment promotes 999_999 tokens to 1m instead of 1000k", () => {
+  const seg = formatUsageSegment({ used: 999_999, size: 1_000_000 });
+  expect(seg).toBe("ctx 1m/1m 100%");
+});
+
 test("buildCard 'complete' appends usage segment to the footer", () => {
   const card = buildCard({
     state: "complete",

--- a/tests/unit/packages/channel-feishu/feishu-streaming-card-controller.test.ts
+++ b/tests/unit/packages/channel-feishu/feishu-streaming-card-controller.test.ts
@@ -1071,38 +1071,52 @@ test("recordUsage surfaces the usage segment in the terminal card footer", async
 
 test("recordUsage forces a full card.update off the streaming fast-path", async () => {
   const { client, calls } = createFakeClient();
-  const controller = new StreamingCardController({ client, flushIntervalMs: 10 });
+  // Pin the clock so the elapsed footer label can't change between pushes —
+  // that isolates usage as the ONLY thing that can force a full card.update
+  // (same technique as "subsequent streaming pushes use cardElement.content").
+  const controller = new StreamingCardController({ client, flushIntervalMs: 10, now: () => 1_000 });
   await controller.seed({ to: "oc_chat" });
-
-  // Get into streaming state with one full update so subsequent text would
-  // normally take the element-content fast-path.
   controller.appendStream("first");
-  await new Promise((r) => setTimeout(r, 25));
-  const updatesBefore = calls.cardUpdate.length;
+  await new Promise((r) => setTimeout(r, 30));
+  const fullBefore = calls.cardUpdate.length;
 
   controller.recordUsage({ used: 5_000, size: 100_000 });
-  await new Promise((r) => setTimeout(r, 25));
+  controller.appendStream("second");
+  await new Promise((r) => setTimeout(r, 30));
 
-  // A usage change must go through card.update (footer lives there), not the
-  // element-content fast-path.
-  expect(calls.cardUpdate.length).toBeGreaterThan(updatesBefore);
+  // Usage lives in the footer, not streaming_content — it must take the full
+  // card.update path, not the element-content fast-path.
+  expect(calls.cardUpdate.length).toBeGreaterThan(fullBefore);
   const last = calls.cardUpdate[calls.cardUpdate.length - 1];
-  const elements = (last.cardJson.body as { elements: Array<{ content?: string }> }).elements;
-  expect(JSON.stringify(elements)).toContain("ctx 5k/100k 5%");
+  expect(JSON.stringify(last.cardJson)).toContain("ctx 5k/100k 5%");
+
+  // Control: with usage now stable and the clock pinned, a further pure-text
+  // change rides the element-content fast-path — proving the increment above
+  // was caused by the usage change, not an unconditional full update.
+  const fastBefore = calls.elementContent.length;
+  controller.appendStream("third");
+  await new Promise((r) => setTimeout(r, 30));
+  expect(calls.elementContent.length).toBeGreaterThan(fastBefore);
 });
 
-test("recordPlan renders an expanded plan panel that replaces on each update", async () => {
+test("recordPlan forces a full update and replaces the whole list", async () => {
   const { client, calls } = createFakeClient();
-  const controller = new StreamingCardController({ client, flushIntervalMs: 10 });
+  const controller = new StreamingCardController({ client, flushIntervalMs: 10, now: () => 1_000 });
   await controller.seed({ to: "oc_chat" });
+  controller.appendStream("first");
+  await new Promise((r) => setTimeout(r, 30));
+  const fullBefore = calls.cardUpdate.length;
 
   controller.recordPlan([
     { content: "Investigate", status: "completed" },
     { content: "Implement", status: "in_progress" },
   ]);
-  await new Promise((r) => setTimeout(r, 25));
+  controller.appendStream("second");
+  await new Promise((r) => setTimeout(r, 30));
+  // Plan renders as its own panel (not streaming_content): forces full update.
+  expect(calls.cardUpdate.length).toBeGreaterThan(fullBefore);
 
-  // Re-send the WHOLE list (replace semantics) — second item now done.
+  // Re-send the WHOLE list (replace, not append) — second item now done.
   controller.recordPlan([
     { content: "Investigate", status: "completed" },
     { content: "Implement", status: "completed" },
@@ -1114,5 +1128,10 @@ test("recordPlan renders an expanded plan panel that replaces on each update", a
   const panel = elements.find((el) => el.tag === "collapsible_panel" && JSON.stringify(el).includes(feishuT().planPanelHeader(2, 2)));
   expect(panel).toBeDefined();
   expect(panel!.expanded).toBe(true);
-  expect(JSON.stringify(panel)).toContain("~~Implement~~");
+  const panelJson = JSON.stringify(panel);
+  // Replace semantics: both prior entries present and completed, header reads
+  // 2/2 — an append would have produced 4 entries (and a 2/4 header).
+  expect(panelJson).toContain("~~Investigate~~");
+  expect(panelJson).toContain("~~Implement~~");
+  expect(panelJson).toContain(feishuT().planPanelHeader(2, 2));
 });

--- a/tests/unit/packages/channel-feishu/feishu-streaming-card-controller.test.ts
+++ b/tests/unit/packages/channel-feishu/feishu-streaming-card-controller.test.ts
@@ -1052,3 +1052,67 @@ test("reasoning panel renders while the card is still in the thinking state", as
   const body = elements.find((el) => el.element_id === "streaming_content");
   expect(body?.content ?? "").toBe("");
 });
+
+test("recordUsage surfaces the usage segment in the terminal card footer", async () => {
+  const { client, calls } = createFakeClient();
+  const controller = new StreamingCardController({ client, flushIntervalMs: 10 });
+  await controller.seed({ to: "oc_chat" });
+
+  controller.appendStream("the answer");
+  controller.recordUsage({ used: 12_000, size: 200_000, breakdown: { inputTokens: 1234, outputTokens: 800 } });
+  await controller.complete();
+
+  const last = calls.cardUpdate[calls.cardUpdate.length - 1];
+  const elements = (last.cardJson.body as { elements: Array<{ content?: string }> }).elements;
+  const footer = elements[elements.length - 1];
+  expect(footer.content).toContain("↑1.2k");
+  expect(footer.content).toContain("ctx 12k/200k 6%");
+});
+
+test("recordUsage forces a full card.update off the streaming fast-path", async () => {
+  const { client, calls } = createFakeClient();
+  const controller = new StreamingCardController({ client, flushIntervalMs: 10 });
+  await controller.seed({ to: "oc_chat" });
+
+  // Get into streaming state with one full update so subsequent text would
+  // normally take the element-content fast-path.
+  controller.appendStream("first");
+  await new Promise((r) => setTimeout(r, 25));
+  const updatesBefore = calls.cardUpdate.length;
+
+  controller.recordUsage({ used: 5_000, size: 100_000 });
+  await new Promise((r) => setTimeout(r, 25));
+
+  // A usage change must go through card.update (footer lives there), not the
+  // element-content fast-path.
+  expect(calls.cardUpdate.length).toBeGreaterThan(updatesBefore);
+  const last = calls.cardUpdate[calls.cardUpdate.length - 1];
+  const elements = (last.cardJson.body as { elements: Array<{ content?: string }> }).elements;
+  expect(JSON.stringify(elements)).toContain("ctx 5k/100k 5%");
+});
+
+test("recordPlan renders an expanded plan panel that replaces on each update", async () => {
+  const { client, calls } = createFakeClient();
+  const controller = new StreamingCardController({ client, flushIntervalMs: 10 });
+  await controller.seed({ to: "oc_chat" });
+
+  controller.recordPlan([
+    { content: "Investigate", status: "completed" },
+    { content: "Implement", status: "in_progress" },
+  ]);
+  await new Promise((r) => setTimeout(r, 25));
+
+  // Re-send the WHOLE list (replace semantics) — second item now done.
+  controller.recordPlan([
+    { content: "Investigate", status: "completed" },
+    { content: "Implement", status: "completed" },
+  ]);
+  await controller.complete();
+
+  const last = calls.cardUpdate[calls.cardUpdate.length - 1];
+  const elements = (last.cardJson.body as { elements: Array<Record<string, unknown>> }).elements;
+  const panel = elements.find((el) => el.tag === "collapsible_panel" && JSON.stringify(el).includes(feishuT().planPanelHeader(2, 2)));
+  expect(panel).toBeDefined();
+  expect(panel!.expanded).toBe(true);
+  expect(JSON.stringify(panel)).toContain("~~Implement~~");
+});


### PR DESCRIPTION
## What

The Feishu streaming CardKit card already consumed `onToolEvent`/`onThought` but **dropped the `onUsage` and `onPlan` side-channels** even though both flow end-to-end from the transport (`onUsage` wired in #98; `onPlan` long-present). This wires both into the card.

### P0 — usage footer
Render token breakdown + context-window fill as a trailing footer segment, e.g.:

```
_已完成 · 3.4s_ · ↑1.2k · ↓800 · ctx 12k/200k 6%
```

Each piece is independent — codex omits the per-turn breakdown, so it degrades to context-only (`ctx …%`). Percent is clamped to 100; token counts roll `999_999 → 1m` (not `1000k`).

### P1 — plan panel
Render the agent's live plan/todo (ACP `plan`, **replace-on-update** semantics) as an **expanded** `collapsible_panel` above the tool panel, with status icons (✅/⏳/⬜), struck-through completed items, `📋 任务清单 (done/total)` header, and a 30-row cap.

## How it behaves
Both fold into the change-detection in `pushUpdate`: usage joins the footer-text key, plan gets its own `planChanged` flag. A usage/plan change therefore **forces the full `card.update` path** and bypasses the `streaming_content` element-content fast-path (the footer/panels are not that element). Bookkeeping (`lastFooterText`, `lastPushedPlanKey`) is written only on the successful full-update path. Both `recordUsage`/`recordPlan` are guarded against firing after the card terminates.

## Plumbing
- `src/plugin-api.ts` now exports `PromptUsage`/`UsageBreakdown`/`UsageCost`/`AgentCommand` (from transport) and `PlanEntry`/`PlanEntryStatus` (from channels), so the channel package can type the new callbacks.
- Both `agent.chat` call sites in `channel.ts` (scheduled + realtime) wire `onUsage`/`onPlan`.
- New bilingual i18n keys `planPanelHeader`/`planPanelOmitted`.

## Tests
- `feishu-card-builder.test.ts`: `formatUsageSegment` (full breakdown, codex context-only, zero fields, empty, clamp, k→m rollover); usage footer composition; plan panel (order above tool panel, done/total header, strikethrough, 30-row cap).
- `feishu-streaming-card-controller.test.ts`: `recordUsage`/`recordPlan` **isolate the fast-path bypass** with a pinned clock + a pure-text control push, and assert plan **replace** (2/2 header, not append).

Verification: `npm test` green (core bun tests + 466 relay-web + root typecheck); `bun run build:channel-feishu` typechecks clean.

## Review
Dispatched a review subagent → **approve-with-nits**, no must-fix. Applied the Should-fix (test isolation) and two cheap correctness nits (percent clamp, token rollover).