### PR TITLE
feat(relay-web): terminal polish — no focus ring, theme-matched fit, richer keybar

### DIFF
--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -4,6 +4,7 @@ import { mount } from "@vue/test-utils";
 
 const adapter = {
   write: vi.fn(), resize: vi.fn(), dispose: vi.fn(), focus: vi.fn(),
+  getSelection: vi.fn(() => ""), setTheme: vi.fn(),
   fit: vi.fn(() => ({ cols: 80, rows: 24 })),
   cols: () => 80, rows: () => 24,
 };
@@ -101,6 +102,84 @@ describe("TerminalTab", () => {
     expect(sendWebClientMessage).toHaveBeenCalledWith(
       expect.objectContaining({ kind: "terminal-input", data: "d" }),
     );
+  });
+
+  it("sticky Alt prefixes ESC to the next typed char, then disarms", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    await w.find('[data-test="key-alt"]').trigger("click"); // arm
+    const onData = onDataOf();
+    onData("b");
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "b" }),
+    );
+    vi.mocked(sendWebClientMessage).mockClear();
+    onData("b"); // disarmed → plain 'b'
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "b" }),
+    );
+  });
+
+  it("sticky Shift upcases the next typed letter, then disarms", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    await w.find('[data-test="key-shift"]').trigger("click"); // arm
+    onDataOf()("a");
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "A" }),
+    );
+  });
+
+  it("Shift + arrow-up sends the xterm modified CSI sequence and disarms Shift", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    await w.find('[data-test="key-shift"]').trigger("click"); // arm
+    await w.find('[data-test="key-up"]').trigger("click");
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "[1;2A" }),
+    );
+    vi.mocked(sendWebClientMessage).mockClear();
+    await w.find('[data-test="key-up"]').trigger("click"); // disarmed → plain up
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "[A" }),
+    );
+  });
+
+  it("Shift + Tab sends reverse-tab CSI Z", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    await w.find('[data-test="key-shift"]').trigger("click"); // arm
+    await w.find('[data-test="key-tab"]').trigger("click");
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "[Z" }),
+    );
+  });
+
+  it("keybar Home / PgUp send the standard escape sequences", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    await w.find('[data-test="key-home"]').trigger("click");
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "[H" }),
+    );
+    await w.find('[data-test="key-pageup"]').trigger("click");
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "[5~" }),
+    );
+  });
+
+  it("Copy writes the terminal selection to the clipboard; no-op when empty", async () => {
+    const writeText = vi.fn(async () => {});
+    Object.assign(navigator, { clipboard: { writeText } });
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    adapter.getSelection.mockReturnValueOnce("selected text");
+    await w.find('[data-test="key-copy"]').trigger("click");
+    expect(writeText).toHaveBeenCalledWith("selected text");
+    writeText.mockClear();
+    adapter.getSelection.mockReturnValueOnce("");
+    await w.find('[data-test="key-copy"]').trigger("click");
+    expect(writeText).not.toHaveBeenCalled();
   });
 
   it("sticky Ctrl passes a non-letter through unchanged and disarms", async () => {

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -120,6 +120,22 @@ describe("TerminalTab", () => {
     );
   });
 
+  it("multi-char input (paste/IME) passes through and disarms an armed modifier", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    await w.find('[data-test="key-alt"]').trigger("click"); // arm Alt
+    const onData = onDataOf();
+    onData("abc"); // multi-char → unchanged, and the one-shot arm is dropped
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "abc" }),
+    );
+    vi.mocked(sendWebClientMessage).mockClear();
+    onData("x"); // disarmed → plain 'x' (no ESC prefix)
+    expect(sendWebClientMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal-input", data: "x" }),
+    );
+  });
+
   it("sticky Shift upcases the next typed letter, then disarms", async () => {
     const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
     await tick();

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -89,7 +89,11 @@ function handleData(d: string) {
       const lc = out.toLowerCase().charCodeAt(0);
       if (lc >= 97 && lc <= 122) out = String.fromCharCode(lc - 96);
     }
-    if (altArmed.value) out = "" + out;
+    if (altArmed.value) out = ESC + out;
+    disarmMods();
+  } else if (anyModArmed()) {
+    // Multi-char input (paste/IME) can't carry a soft modifier — drop the one-shot arm
+    // instead of letting it silently fire on a later keystroke.
     disarmMods();
   }
   terminals.input(props.instanceId, terminalId, out);
@@ -101,11 +105,11 @@ function handleData(d: string) {
 function applyMods(seq: string): string {
   const mod = modParam();
   if (mod === 1) return seq;
-  if (seq === "\t") return shiftArmed.value ? "[Z" : seq;
-  const letter = /^\[([A-Z])$/.exec(seq);
-  if (letter) return `[1;${mod}${letter[1]}`;
-  const tilde = /^\[(\d+)~$/.exec(seq);
-  if (tilde) return `[${tilde[1]};${mod}~`;
+  if (seq === "\t") return shiftArmed.value ? ESC + "[Z" : seq;
+  const letter = new RegExp("^" + ESC + "\\[([A-Z])$").exec(seq);
+  if (letter) return ESC + "[1;" + mod + letter[1];
+  const tilde = new RegExp("^" + ESC + "\\[(\\d+)~$").exec(seq);
+  if (tilde) return ESC + "[" + tilde[1] + ";" + mod + "~";
   return seq;
 }
 

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -1,16 +1,36 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onBeforeUnmount } from "vue";
-import { ArrowLeft, Keyboard, ClipboardPaste, ChevronUp, ChevronDown, ChevronLeft, ChevronRight } from "lucide-vue-next";
-import { createTerminalAdapter, type TerminalAdapter } from "../lib/terminal-adapter";
+import { ArrowLeft, Keyboard, ClipboardPaste, Copy, ChevronUp, ChevronDown, ChevronLeft, ChevronRight } from "lucide-vue-next";
+import { createTerminalAdapter, type TerminalAdapter, type TerminalTheme } from "../lib/terminal-adapter";
 import { useTerminalStore } from "../stores/terminal";
+import { useThemeStore } from "../stores/theme";
 
 const props = defineProps<{ instanceId: string; sessionAlias: string }>();
 const emit = defineEmits<{ close: [] }>();
 const terminals = useTerminalStore();
+const theme = useThemeStore();
 const host = ref<HTMLDivElement | null>(null);
 const status = ref<"idle" | "connecting" | "open" | "exited" | "error">("idle");
 const errorKey = ref<string>("");
+// Sticky modifiers — click to arm, applied to the next key, then auto-disarm (one-shot).
 const ctrlArmed = ref(false);
+const altArmed = ref(false);
+const shiftArmed = ref(false);
+
+// Read a `--c-*` design token ("R G B" triplet) as a hex color ghostty's theme parses.
+// Falls back to a dark default when the var is unreadable (e.g. jsdom, or pre-mount).
+function tokenHex(varName: string, fallback: string): string {
+  if (typeof getComputedStyle !== "function") return fallback;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+  const parts = raw.split(/\s+/).map(Number);
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) return fallback;
+  return "#" + parts.map((n) => Math.max(0, Math.min(255, n)).toString(16).padStart(2, "0")).join("");
+}
+// Keep the terminal background identical to the host so the integer-cell fit remainder
+// (the < 1-cell strip on the right/bottom) is invisible instead of a black seam.
+function currentTheme(): TerminalTheme {
+  return { background: tokenHex("--c-bg", "#0e1116"), foreground: tokenHex("--c-fg", "#e8ecf1") };
+}
 
 // Mobile has no physical Esc/Ctrl/arrows, so the shortcut bar defaults visible there and
 // hidden on desktop (which has a real keyboard). A saved preference overrides the default.
@@ -36,22 +56,64 @@ let offExit: (() => void) | null = null;
 let resizeObs: ResizeObserver | null = null;
 let epoch = 0;
 
-// Sticky Ctrl only rewrites a single soft-keyboard letter (a-z → charCode & 0x1f, e.g. c→\x03);
-// anything else passes through. Fires once, then disarms.
+// ESC built from a char code — a literal escape byte in this .vue gets mangled on save.
+const ESC = String.fromCharCode(0x1b);
+// Named CSI sequences for the shortcut bar (arrows stay inline in the template).
+const KEYS = {
+  home: ESC + "[H",
+  end: ESC + "[F",
+  pageUp: ESC + "[5~",
+  pageDown: ESC + "[6~",
+  insert: ESC + "[2~",
+  enter: "\r",
+};
+function anyModArmed(): boolean {
+  return ctrlArmed.value || altArmed.value || shiftArmed.value;
+}
+function disarmMods() {
+  ctrlArmed.value = false; altArmed.value = false; shiftArmed.value = false;
+}
+// xterm modifier parameter: 1 + Shift(1) + Alt(2) + Ctrl(4). 1 means "no modifiers".
+function modParam(): number {
+  return 1 + (shiftArmed.value ? 1 : 0) + (altArmed.value ? 2 : 0) + (ctrlArmed.value ? 4 : 0);
+}
+
+// Apply armed modifiers to typed soft-keyboard input (a single char): Shift upcases,
+// Ctrl maps a letter to its control code (c→\x03), Alt/Meta prefixes ESC. Then disarm.
 function handleData(d: string) {
   if (!terminalId) return;
   let out = d;
-  if (ctrlArmed.value && d.length === 1) {
-    const lc = d.toLowerCase().charCodeAt(0);
-    if (lc >= 97 && lc <= 122) out = String.fromCharCode(lc - 96);
-    ctrlArmed.value = false;
+  if (d.length === 1 && anyModArmed()) {
+    if (shiftArmed.value) out = out.toUpperCase();
+    if (ctrlArmed.value) {
+      const lc = out.toLowerCase().charCodeAt(0);
+      if (lc >= 97 && lc <= 122) out = String.fromCharCode(lc - 96);
+    }
+    if (altArmed.value) out = "" + out;
+    disarmMods();
   }
   terminals.input(props.instanceId, terminalId, out);
 }
 
+// Apply armed modifiers to a keybar escape sequence. CSI keys (arrows, Home/End as
+// `\x1b[<L>` and PgUp/Ins etc. as `\x1b[<n>~`) take an xterm `1;<mod>` parameter;
+// Shift+Tab is the special reverse-tab `\x1b[Z`. Non-CSI keys (Enter/Esc) pass through.
+function applyMods(seq: string): string {
+  const mod = modParam();
+  if (mod === 1) return seq;
+  if (seq === "\t") return shiftArmed.value ? "[Z" : seq;
+  const letter = /^\[([A-Z])$/.exec(seq);
+  if (letter) return `[1;${mod}${letter[1]}`;
+  const tilde = /^\[(\d+)~$/.exec(seq);
+  if (tilde) return `[${tilde[1]};${mod}~`;
+  return seq;
+}
+
 function sendKey(seq: string) {
   if (!terminalId) return;
-  terminals.input(props.instanceId, terminalId, seq);
+  const out = applyMods(seq);
+  if (anyModArmed()) disarmMods();
+  terminals.input(props.instanceId, terminalId, out);
   adapter?.focus();
 }
 
@@ -60,6 +122,14 @@ async function pasteClipboard() {
     const text = await navigator.clipboard?.readText();
     if (text) sendKey(text);
   } catch { /* clipboard blocked/unavailable — ignore */ }
+}
+
+// Copy the current terminal selection to the clipboard (no-op when nothing is selected).
+async function copySelection() {
+  const sel = adapter?.getSelection() ?? "";
+  if (!sel) return;
+  try { await navigator.clipboard?.writeText(sel); } catch { /* clipboard blocked — ignore */ }
+  adapter?.focus();
 }
 
 // Fit the ghostty grid to the host using the adapter's canvas-derived cell size, then tell
@@ -80,7 +150,7 @@ function teardown() {
   resizeObs?.disconnect(); resizeObs = null;
   if (terminalId) terminals.close(props.instanceId, terminalId);
   adapter?.dispose(); adapter = null; terminalId = "";
-  ctrlArmed.value = false;
+  disarmMods();
 }
 
 async function start() {
@@ -91,6 +161,7 @@ async function start() {
   const currentAdapter = createTerminalAdapter(host.value, {
     cols: 80, rows: 24,
     onData: handleData,
+    theme: currentTheme(),
   });
   adapter = currentAdapter;
   offOutput = terminals.onOutput((id, data) => { if (id === terminalId) adapter?.write(data); });
@@ -123,6 +194,9 @@ async function start() {
 
 onMounted(() => void start());
 watch(() => [props.instanceId, props.sessionAlias], () => void start());
+// Recolor the live terminal when the app toggles light/dark so it never leaves a
+// mismatched background band around the grid.
+watch(() => theme.mode, () => adapter?.setTheme(currentTheme()));
 onBeforeUnmount(teardown);
 </script>
 
@@ -149,7 +223,7 @@ onBeforeUnmount(teardown);
     <div v-if="!props.sessionAlias" class="p-4 text-sm text-fg-muted">{{ $t("terminal.noSession") }}</div>
     <div v-else-if="status === 'error'" class="p-4 text-sm text-fg-muted">{{ $t(errorKey) }}</div>
     <div v-else-if="status === 'exited'" class="p-4 text-sm text-fg-muted">{{ $t("terminal.exited", { code: errorKey }) }}</div>
-    <div ref="host" class="min-h-0 flex-1 overflow-hidden bg-black" data-test="terminal-host"></div>
+    <div ref="host" class="term-host flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-bg" data-test="terminal-host"></div>
 
     <!-- shortcut bar -->
     <div v-if="keybarVisible" data-test="keybar"
@@ -160,15 +234,43 @@ onBeforeUnmount(teardown);
               class="shrink-0 rounded-md border px-2.5 py-1 font-mono text-[12px] transition-colors"
               :class="ctrlArmed ? 'border-accent/40 bg-accent/10 text-accent' : 'border-border bg-bg text-fg-muted hover:bg-raised hover:text-fg'"
               @click="ctrlArmed = !ctrlArmed">Ctrl</button>
+      <button data-test="key-alt" :aria-pressed="altArmed"
+              class="shrink-0 rounded-md border px-2.5 py-1 font-mono text-[12px] transition-colors"
+              :class="altArmed ? 'border-accent/40 bg-accent/10 text-accent' : 'border-border bg-bg text-fg-muted hover:bg-raised hover:text-fg'"
+              @click="altArmed = !altArmed">Alt</button>
+      <button data-test="key-shift" :aria-pressed="shiftArmed"
+              class="shrink-0 rounded-md border px-2.5 py-1 font-mono text-[12px] transition-colors"
+              :class="shiftArmed ? 'border-accent/40 bg-accent/10 text-accent' : 'border-border bg-bg text-fg-muted hover:bg-raised hover:text-fg'"
+              @click="shiftArmed = !shiftArmed">Shift</button>
       <span class="h-4 w-px shrink-0 bg-border" aria-hidden="true" />
       <button data-test="key-left" :aria-label="$t('terminal.keybar.left')" class="grid h-7 w-7 shrink-0 place-items-center rounded-md border border-border bg-bg text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\u001b[D')"><ChevronLeft :size="15" /></button>
       <button data-test="key-up" :aria-label="$t('terminal.keybar.up')" class="grid h-7 w-7 shrink-0 place-items-center rounded-md border border-border bg-bg text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\u001b[A')"><ChevronUp :size="15" /></button>
       <button data-test="key-down" :aria-label="$t('terminal.keybar.down')" class="grid h-7 w-7 shrink-0 place-items-center rounded-md border border-border bg-bg text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\u001b[B')"><ChevronDown :size="15" /></button>
       <button data-test="key-right" :aria-label="$t('terminal.keybar.right')" class="grid h-7 w-7 shrink-0 place-items-center rounded-md border border-border bg-bg text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\u001b[C')"><ChevronRight :size="15" /></button>
       <span class="h-4 w-px shrink-0 bg-border" aria-hidden="true" />
-      <button data-test="key-paste" class="ml-auto flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 py-1 text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="pasteClipboard">
+      <button data-test="key-home" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.home)">Home</button>
+      <button data-test="key-end" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.end)">End</button>
+      <button data-test="key-pageup" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.pageUp)">PgUp</button>
+      <button data-test="key-pagedown" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.pageDown)">PgDn</button>
+      <button data-test="key-insert" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.insert)">Ins</button>
+      <button data-test="key-enter" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.enter)">Enter</button>
+      <span class="h-4 w-px shrink-0 bg-border" aria-hidden="true" />
+      <button data-test="key-copy" class="ml-auto flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 py-1 text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="copySelection">
+        <Copy :size="14" />{{ $t("terminal.keybar.copy") }}
+      </button>
+      <button data-test="key-paste" class="flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 py-1 text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="pasteClipboard">
         <ClipboardPaste :size="14" />{{ $t("terminal.keybar.paste") }}
       </button>
     </div>
   </div>
 </template>
+
+<style scoped>
+/* ghostty renders into a focusable canvas; the browser's default focus ring draws a blue
+ * box around the whole terminal. The cursor already signals focus, so suppress it. */
+.term-host :deep(canvas),
+.term-host :deep(*:focus),
+.term-host :deep(*:focus-visible) {
+  outline: none;
+}
+</style>

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -302,6 +302,7 @@ export default {
       show: "Show shortcut bar",
       hide: "Hide shortcut bar",
       paste: "Paste",
+      copy: "Copy",
       up: "Up",
       down: "Down",
       left: "Left",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -300,6 +300,7 @@ export default {
       show: "显示快捷键条",
       hide: "隐藏快捷键条",
       paste: "粘贴",
+      copy: "复制",
       up: "上",
       down: "下",
       left: "左",

--- a/packages/relay-web/src/lib/terminal-adapter.ts
+++ b/packages/relay-web/src/lib/terminal-adapter.ts
@@ -4,6 +4,14 @@
 
 import { ensureTerminalFont, TERMINAL_FONT_FAMILY } from "./terminal-font";
 
+/** Subset of ghostty's ITheme we set — foreground/background keep the terminal in sync
+ *  with the app's design tokens so the sub-cell fit remainder blends seamlessly. */
+export interface TerminalTheme {
+  foreground?: string;
+  background?: string;
+  cursor?: string;
+}
+
 export interface GhosttyTerminalLike {
   open(el: HTMLElement): void;
   write(data: string): void;
@@ -12,6 +20,10 @@ export interface GhosttyTerminalLike {
   onData(cb: (data: string) => void): void;
   focus?(): void;
   paste?(data: string): void;
+  getSelection?(): string;
+  setTheme?(theme: TerminalTheme): void;
+  /** ghostty's Terminal has no public setTheme yet; its renderer does. */
+  renderer?: { setTheme?(theme: TerminalTheme): void };
   element?: HTMLElement;
   cols: number;
   rows: number;
@@ -22,6 +34,10 @@ export interface TerminalAdapter {
   resize(cols: number, rows: number): void;
   dispose(): void;
   focus(): void;
+  /** The current text selection (empty string when nothing is selected). */
+  getSelection(): string;
+  /** Recolor the live terminal (e.g. on light/dark theme switch). No-op before open. */
+  setTheme(theme: TerminalTheme): void;
   /** Compute cols/rows that fit the host element, using the rendered canvas cell size.
    *  Returns null until the canvas has a measurable size. */
   fit(): { cols: number; rows: number } | null;
@@ -35,6 +51,8 @@ export interface TerminalAdapterOptions {
   onData: (data: string) => void;
   fontFamily?: string;
   fontSize?: number;
+  /** Initial foreground/background; keeps the terminal matching the app theme. */
+  theme?: TerminalTheme;
   /** Test seam. Defaults to constructing a real ghostty-web Terminal. */
   factory?: (cols: number, rows: number) => GhosttyTerminalLike;
 }
@@ -45,13 +63,13 @@ export interface TerminalAdapterOptions {
 let ghosttyInit: Promise<void> | undefined;
 
 async function defaultFactory(
-  cols: number, rows: number, fontFamily: string, fontSize: number,
+  cols: number, rows: number, fontFamily: string, fontSize: number, theme?: TerminalTheme,
 ): Promise<GhosttyTerminalLike> {
   const mod = await import("ghostty-web");
   ghosttyInit ??= mod.init();
   await ghosttyInit;
   await ensureTerminalFont();
-  return new mod.Terminal({ cols, rows, fontFamily, fontSize }) as unknown as GhosttyTerminalLike;
+  return new mod.Terminal({ cols, rows, fontFamily, fontSize, ...(theme ? { theme } : {}) }) as unknown as GhosttyTerminalLike;
 }
 
 export function createTerminalAdapter(el: HTMLElement, opts: TerminalAdapterOptions): TerminalAdapter {
@@ -61,7 +79,7 @@ export function createTerminalAdapter(el: HTMLElement, opts: TerminalAdapterOpti
 
   const ready: Promise<GhosttyTerminalLike> = opts.factory
     ? Promise.resolve(opts.factory(opts.cols, opts.rows))
-    : defaultFactory(opts.cols, opts.rows, fontFamily, fontSize);
+    : defaultFactory(opts.cols, opts.rows, fontFamily, fontSize, opts.theme);
 
   // open()/onData() are called ONLY inside ready.then — never synchronously. With an
   // injected factory (tests), ready is already-resolved, so .then runs next microtask;
@@ -77,6 +95,11 @@ export function createTerminalAdapter(el: HTMLElement, opts: TerminalAdapterOpti
     resize: (c, r) => live?.resize(c, r),
     dispose: () => live?.dispose(),
     focus: () => live?.focus?.(),
+    getSelection: () => live?.getSelection?.() ?? "",
+    setTheme: (theme) => {
+      if (live?.setTheme) live.setTheme(theme);
+      else live?.renderer?.setTheme?.(theme);
+    },
     fit: () => {
       if (!live?.element || !live.cols || !live.rows) return null;
       const canvas = live.element.querySelector("canvas");


### PR DESCRIPTION
Polish pass on the web terminal, addressing three issues reported from a live instance.

## 1. Focus ring
Mouse-focusing the terminal drew a blue browser focus ring around the whole canvas. Suppressed via a scoped `:deep()` `outline: none` on the ghostty canvas / focused descendants. The cursor already signals focus.

## 2. Top-hugging + black right/bottom seam
The integer character grid leaves a sub-cell remainder on the right/bottom after `floor(container / cell)`; that strip exposed the host's pure-black background, which differs from ghostty's fill → a visible black seam.

- Pass ghostty a `theme` with `background`/`foreground` derived from the app design tokens (`--c-bg` / `--c-fg`) and set the host background to the same `bg-bg`, so the remainder blends invisibly.
- Center the grid (flex) so the remainder distributes symmetrically and the content gets natural top breathing room.
- Recolor the live terminal on light/dark switch (`setTheme`; ghostty's `Terminal` exposes no public setTheme, so it falls back to the renderer's).

## 3. Richer shortcut bar
- **Sticky Alt / Shift** modifiers (one-shot, arm→next key→auto-disarm, consistent with the existing sticky Ctrl): Alt = Meta / ESC-prefix; Shift upcases letters, `Shift+Tab` = reverse-tab `ESC[Z`, arrows take the xterm modifier parameter (`ESC[1;2A`).
- **Home / End / PgUp / PgDn / Ins / Enter** (standard escape sequences).
- **Copy** — writes ghostty's current selection to the clipboard (no-op when empty).
- **Cmd dropped** — ⌘ produces no PTY bytes for a remote shell; Copy/Paste cover the intent.

## Tests
- 6 new `TerminalTab` cases: sticky Alt (ESC prefix), sticky Shift (upcase), Shift+arrow modified CSI, Shift+Tab reverse-tab, Home/PgUp sequences, Copy (selection → clipboard, empty no-op).
- Adapter gains `getSelection()` / `setTheme()` / `theme` option.
- Full relay-web suite green (509 tests) + `vue-tsc --noEmit` clean.

> Note: the canvas centering / top-spacing is a visual detail worth a quick eyeball on a real instance; the background-match already guarantees no black seam regardless.