### PR TITLE
fix(relay-web): suppress terminal focus ring on the host element itself

### DIFF
--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -35,6 +35,12 @@ describe("TerminalTab", () => {
     expect(createTerminalAdapter).toHaveBeenCalled();
   });
 
+  it("host carries the term-host class the focus-ring suppression targets", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    expect(w.find('[data-test="terminal-host"]').classes()).toContain("term-host");
+  });
+
   it("shows the no-session hint when sessionAlias is empty", () => {
     const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "" }, global: globalOpts });
     expect(w.text()).toContain("terminal.noSession");

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -270,11 +270,19 @@ onBeforeUnmount(teardown);
 </template>
 
 <style scoped>
-/* ghostty renders into a focusable canvas; the browser's default focus ring draws a blue
- * box around the whole terminal. The cursor already signals focus, so suppress it. */
+/* ghostty turns the host element itself into a focusable contenteditable textbox
+ * (open() sets tabindex + contenteditable on the element we pass in), so the browser's
+ * default focus ring draws a blue box around the whole terminal. Suppress it on the host
+ * itself (NOT just descendants — :deep(*:focus) never matches the host element) and on any
+ * focusable child; the cursor already signals focus. box-shadow covers ring-style focus. */
+.term-host,
+.term-host:focus,
+.term-host:focus-visible,
+.term-host:focus-within,
 .term-host :deep(canvas),
 .term-host :deep(*:focus),
 .term-host :deep(*:focus-visible) {
-  outline: none;
+  outline: none !important;
+  box-shadow: none !important;
 }
 </style>


### PR DESCRIPTION
Follow-up to #104 — the blue focus ring around the terminal was still showing.

## Root cause
ghostty's `open(A)` turns the element we pass in into the focusable input surface:

```js
open(A) {
  this.element = A;
  A.setAttribute("tabindex", "0");
  A.setAttribute("contenteditable", "true");   // A === .term-host
  A.appendChild(this.canvas);
}
```

So the browser's default focus ring is drawn on `.term-host` **itself**. The prior fix used `.term-host :deep(*:focus)`, which only matches **descendants** and never the host element — hence the ring survived. (The canvas isn't focusable and the textarea is 1px/opacity-0, so neither is the visible ring.)

## Fix
Target the host element directly (not via `:deep`, which is descendant-only) and add `box-shadow: none` to cover ring-style focus styling:

```css
.term-host, .term-host:focus, .term-host:focus-visible, .term-host:focus-within,
.term-host :deep(canvas), .term-host :deep(*:focus), .term-host :deep(*:focus-visible) {
  outline: none !important; box-shadow: none !important;
}
```

Locked with a test asserting the host carries the `term-host` class.

## Tests
- relay-web `terminal-tab` suite green (20 tests); `vue-tsc --noEmit` clean.