### PR TITLE
fix(relay-web): mobile terminal — keybar above keyboard, PgUp/PgDn scroll, touch scroll

### DIFF
--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -201,22 +201,41 @@ describe("TerminalTab", () => {
     expect(sendWebClientMessage).not.toHaveBeenCalled(); // local scroll, nothing sent to PTY
   });
 
-  it("touch drag scrolls the viewport (finger up -> toward newer) without focusing", async () => {
+  // The mount uses a mocked adapter (no real ghostty), so tap-to-focus suppression is
+  // asserted via stopPropagation on the touchend — the actual mechanism that prevents
+  // ghostty's canvas touchend handler (an ancestor-capture vs descendant-bubble race) from
+  // focusing and popping the keyboard on a drag.
+  function touchOn(el: HTMLElement, type: string, y: number) {
+    const e = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(e, "touches", { value: [{ clientX: 0, clientY: y }], configurable: true });
+    const stop = vi.spyOn(e, "stopPropagation");
+    el.dispatchEvent(e);
+    return stop;
+  }
+
+  it("touch drag scrolls (finger up -> toward newer) and stops propagation to suppress focus", async () => {
     const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
     await tick();
     const el = w.find('[data-test="terminal-host"]').element as HTMLElement;
     Object.defineProperty(el, "clientHeight", { value: 240, configurable: true }); // rows 24 -> lineH 10
-    adapter.scrollLines.mockClear(); adapter.focus.mockClear();
-    const touch = (type: string, y: number) => {
-      const e = new Event(type, { bubbles: true, cancelable: true });
-      Object.defineProperty(e, "touches", { value: [{ clientX: 0, clientY: y }], configurable: true });
-      el.dispatchEvent(e);
-    };
-    touch("touchstart", 100);
-    touch("touchmove", 60); // dy=-40, lineH=10 -> 4 lines toward newer
-    touch("touchend", 60);
+    adapter.scrollLines.mockClear();
+    touchOn(el, "touchstart", 100);
+    touchOn(el, "touchmove", 60); // dy=-40, lineH=10 -> 4 lines toward newer
+    const endStop = touchOn(el, "touchend", 60);
     expect(adapter.scrollLines).toHaveBeenCalledWith(4);
-    expect(adapter.focus).not.toHaveBeenCalled(); // a drag must not raise the keyboard
+    expect(endStop).toHaveBeenCalled(); // drag suppresses ghostty's tap-to-focus
+  });
+
+  it("a plain touch tap does NOT stop propagation (falls through to focus/keyboard)", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    const el = w.find('[data-test="terminal-host"]').element as HTMLElement;
+    Object.defineProperty(el, "clientHeight", { value: 240, configurable: true });
+    adapter.scrollLines.mockClear();
+    touchOn(el, "touchstart", 100);
+    const endStop = touchOn(el, "touchend", 100); // no movement → tap
+    expect(adapter.scrollLines).not.toHaveBeenCalled();
+    expect(endStop).not.toHaveBeenCalled(); // tap reaches ghostty → focuses/raises keyboard
   });
 
   it("Copy writes the terminal selection to the clipboard; no-op when empty", async () => {

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -4,7 +4,7 @@ import { mount } from "@vue/test-utils";
 
 const adapter = {
   write: vi.fn(), resize: vi.fn(), dispose: vi.fn(), focus: vi.fn(),
-  getSelection: vi.fn(() => ""), setTheme: vi.fn(),
+  getSelection: vi.fn(() => ""), setTheme: vi.fn(), scrollLines: vi.fn(),
   fit: vi.fn(() => ({ cols: 80, rows: 24 })),
   cols: () => 80, rows: () => 24,
 };
@@ -177,17 +177,46 @@ describe("TerminalTab", () => {
     );
   });
 
-  it("keybar Home / PgUp send the standard escape sequences", async () => {
+  it("keybar Home / End send Ctrl-A / Ctrl-E (bound in default zsh/bash)", async () => {
     const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
     await tick();
     await w.find('[data-test="key-home"]').trigger("click");
     expect(sendWebClientMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "terminal-input", data: "[H" }),
+      expect.objectContaining({ kind: "terminal-input", data: "" }),
     );
-    await w.find('[data-test="key-pageup"]').trigger("click");
+    await w.find('[data-test="key-end"]').trigger("click");
     expect(sendWebClientMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "terminal-input", data: "[5~" }),
+      expect.objectContaining({ kind: "terminal-input", data: "" }),
     );
+  });
+
+  it("keybar PgUp / PgDn scroll the viewport locally (rows-1 lines), not send keys", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    vi.mocked(sendWebClientMessage).mockClear();
+    await w.find('[data-test="key-pageup"]').trigger("click");
+    expect(adapter.scrollLines).toHaveBeenCalledWith(-23); // rows(24) - 1, toward older
+    await w.find('[data-test="key-pagedown"]').trigger("click");
+    expect(adapter.scrollLines).toHaveBeenCalledWith(23); // toward newer
+    expect(sendWebClientMessage).not.toHaveBeenCalled(); // local scroll, nothing sent to PTY
+  });
+
+  it("touch drag scrolls the viewport (finger up -> toward newer) without focusing", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    const el = w.find('[data-test="terminal-host"]').element as HTMLElement;
+    Object.defineProperty(el, "clientHeight", { value: 240, configurable: true }); // rows 24 -> lineH 10
+    adapter.scrollLines.mockClear(); adapter.focus.mockClear();
+    const touch = (type: string, y: number) => {
+      const e = new Event(type, { bubbles: true, cancelable: true });
+      Object.defineProperty(e, "touches", { value: [{ clientX: 0, clientY: y }], configurable: true });
+      el.dispatchEvent(e);
+    };
+    touch("touchstart", 100);
+    touch("touchmove", 60); // dy=-40, lineH=10 -> 4 lines toward newer
+    touch("touchend", 60);
+    expect(adapter.scrollLines).toHaveBeenCalledWith(4);
+    expect(adapter.focus).not.toHaveBeenCalled(); // a drag must not raise the keyboard
   });
 
   it("Copy writes the terminal selection to the clipboard; no-op when empty", async () => {

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -155,7 +155,10 @@ const keyboardInset = ref(0);
 function updateKeyboardInset() {
   const vv = typeof window !== "undefined" ? window.visualViewport : null;
   if (!vv) return;
-  keyboardInset.value = Math.max(0, Math.round(window.innerHeight - vv.height - vv.offsetTop));
+  const raw = Math.round(window.innerHeight - vv.height - vv.offsetTop);
+  // Ignore small deltas (e.g. a desktop horizontal scrollbar makes innerHeight exceed
+  // visualViewport.height by ~15px); only a real on-screen keyboard clears this bar.
+  keyboardInset.value = raw > 60 ? raw : 0;
 }
 
 // --- Mobile: drag to scroll, tap to focus (raise the keyboard) ----------------------
@@ -175,6 +178,7 @@ function onTouchMove(e: TouchEvent) {
   touchMoved = true;
   e.preventDefault(); e.stopPropagation(); // suppress page scroll + ghostty's tap-to-focus
   const lineH = host.value.clientHeight / Math.max(1, adapter.rows());
+  if (!(lineH > 0)) return; // not laid out yet — avoid div-by-zero → Infinity scroll
   touchResidual += t.clientY - touchLastY;
   touchLastY = t.clientY;
   const lines = Math.trunc(touchResidual / lineH);
@@ -282,7 +286,8 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="flex h-full flex-col bg-bg" data-test="terminal-center">
+  <div class="flex h-full flex-col bg-bg" data-test="terminal-center"
+       :style="keyboardInset ? { paddingBottom: `${keyboardInset}px` } : undefined">
     <!-- header -->
     <div class="flex h-11 shrink-0 items-center gap-2 border-b border-border bg-surface/60 px-3 backdrop-blur-md">
       <button data-test="term-close" :aria-label="$t('terminal.close')"
@@ -306,10 +311,10 @@ onBeforeUnmount(() => {
     <div v-else-if="status === 'exited'" class="p-4 text-sm text-fg-muted">{{ $t("terminal.exited", { code: errorKey }) }}</div>
     <div ref="host" class="term-host flex min-h-0 flex-1 touch-none items-center justify-center overflow-hidden bg-bg" data-test="terminal-host"></div>
 
-    <!-- shortcut bar — translated up by the on-screen keyboard height so it stays visible -->
+    <!-- shortcut bar — the root's padding-bottom (= keyboard height) lifts the whole pane,
+         so both this bar and the terminal's prompt row stay above the on-screen keyboard. -->
     <div v-if="keybarVisible" data-test="keybar"
-         :style="keyboardInset ? { transform: `translateY(-${keyboardInset}px)` } : undefined"
-         class="relative z-10 flex shrink-0 items-center gap-1.5 overflow-x-auto border-t border-border bg-surface px-2 py-1.5 pb-[calc(0.375rem+env(safe-area-inset-bottom))] thin-scroll">
+         class="flex shrink-0 items-center gap-1.5 overflow-x-auto border-t border-border bg-surface px-2 py-1.5 pb-[calc(0.375rem+env(safe-area-inset-bottom))] thin-scroll">
       <button data-test="key-esc" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\u001b')">Esc</button>
       <button data-test="key-tab" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\t')">Tab</button>
       <button data-test="key-ctrl" :aria-pressed="ctrlArmed"

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -58,12 +58,14 @@ let epoch = 0;
 
 // ESC built from a char code — a literal escape byte in this .vue gets mangled on save.
 const ESC = String.fromCharCode(0x1b);
-// Named CSI sequences for the shortcut bar (arrows stay inline in the template).
+// Named sequences for the shortcut bar (arrows stay inline in the template).
+// Home/End are sent as Ctrl-A / Ctrl-E (emacs beginning/end-of-line): a bare zsh/bash
+// line editor leaves the raw Home/End escape sequences (ESC[H / ESC[F) unbound, but binds
+// Ctrl-A/Ctrl-E by default, so these actually move the cursor on the command line.
+// PgUp/PgDn are NOT here — they scroll the viewport locally (pageUp/pageDown below).
 const KEYS = {
-  home: ESC + "[H",
-  end: ESC + "[F",
-  pageUp: ESC + "[5~",
-  pageDown: ESC + "[6~",
+  home: String.fromCharCode(1),
+  end: String.fromCharCode(5),
   insert: ESC + "[2~",
   enter: "\r",
 };
@@ -136,6 +138,54 @@ async function copySelection() {
   adapter?.focus();
 }
 
+// PgUp/PgDn scroll the local viewport by ~one screen (ghostty scrollLines: + = toward the
+// newest/bottom rows). This is what "page up/down" means for a scrollback pager, rather
+// than sending ESC[5~/ESC[6~ which a shell ignores. No-op in alt-screen (no scrollback).
+function pageLines(): number {
+  return Math.max(1, (adapter?.rows() ?? 24) - 1);
+}
+function pageUp() { adapter?.scrollLines(-pageLines()); }
+function pageDown() { adapter?.scrollLines(pageLines()); }
+
+// --- Mobile: keep the shortcut bar above the on-screen keyboard ---------------------
+// The soft keyboard doesn't shrink the layout viewport on iOS, so a bottom-anchored bar
+// ends up hidden behind it. visualViewport tells us the covered height; we translate the
+// bar up by that much so it floats on top of the keyboard.
+const keyboardInset = ref(0);
+function updateKeyboardInset() {
+  const vv = typeof window !== "undefined" ? window.visualViewport : null;
+  if (!vv) return;
+  keyboardInset.value = Math.max(0, Math.round(window.innerHeight - vv.height - vv.offsetTop));
+}
+
+// --- Mobile: drag to scroll, tap to focus (raise the keyboard) ----------------------
+// ghostty only wires wheel (desktop) + a touchend that focuses; there's no touch scroll,
+// and every tap raises the keyboard. We add touch scrolling and only focus on a real tap.
+let touchStartY = 0, touchStartX = 0, touchLastY = 0, touchResidual = 0, touchMoved = false;
+function onTouchStart(e: TouchEvent) {
+  if (e.touches.length !== 1) return;
+  const t = e.touches[0];
+  touchStartY = touchLastY = t.clientY; touchStartX = t.clientX;
+  touchResidual = 0; touchMoved = false;
+}
+function onTouchMove(e: TouchEvent) {
+  if (e.touches.length !== 1 || !adapter || !host.value) return;
+  const t = e.touches[0];
+  if (!touchMoved && Math.hypot(t.clientX - touchStartX, t.clientY - touchStartY) < 8) return;
+  touchMoved = true;
+  e.preventDefault(); e.stopPropagation(); // suppress page scroll + ghostty's tap-to-focus
+  const lineH = host.value.clientHeight / Math.max(1, adapter.rows());
+  touchResidual += t.clientY - touchLastY;
+  touchLastY = t.clientY;
+  const lines = Math.trunc(touchResidual / lineH);
+  if (lines !== 0) { adapter.scrollLines(-lines); touchResidual -= lines * lineH; }
+}
+function onTouchEnd(e: TouchEvent) {
+  // A drag already scrolled — stop ghostty's touchend from focusing (which pops the
+  // keyboard). A plain tap falls through to ghostty and focuses as expected.
+  if (touchMoved) { e.preventDefault(); e.stopPropagation(); }
+}
+
 // Fit the ghostty grid to the host using the adapter's canvas-derived cell size, then tell
 // the PTY. Retries via rAF until the canvas has a measurable size. Epoch-guarded so a
 // teardown/supersede stops the retry loop.
@@ -196,12 +246,39 @@ async function start() {
   }
 }
 
-onMounted(() => void start());
+// Touch listeners go on the host in CAPTURE phase so they run before ghostty's own
+// bubble-phase touchend — letting a drag stopPropagation() to suppress its tap-to-focus.
+function attachTouch() {
+  const el = host.value;
+  if (!el) return;
+  el.addEventListener("touchstart", onTouchStart, { capture: true, passive: true });
+  el.addEventListener("touchmove", onTouchMove, { capture: true, passive: false });
+  el.addEventListener("touchend", onTouchEnd, { capture: true });
+}
+function detachTouch() {
+  const el = host.value;
+  if (!el) return;
+  el.removeEventListener("touchstart", onTouchStart, { capture: true });
+  el.removeEventListener("touchmove", onTouchMove, { capture: true });
+  el.removeEventListener("touchend", onTouchEnd, { capture: true });
+}
+
+onMounted(() => {
+  void start();
+  attachTouch();
+  window.visualViewport?.addEventListener("resize", updateKeyboardInset);
+  window.visualViewport?.addEventListener("scroll", updateKeyboardInset);
+});
 watch(() => [props.instanceId, props.sessionAlias], () => void start());
 // Recolor the live terminal when the app toggles light/dark so it never leaves a
 // mismatched background band around the grid.
 watch(() => theme.mode, () => adapter?.setTheme(currentTheme()));
-onBeforeUnmount(teardown);
+onBeforeUnmount(() => {
+  detachTouch();
+  window.visualViewport?.removeEventListener("resize", updateKeyboardInset);
+  window.visualViewport?.removeEventListener("scroll", updateKeyboardInset);
+  teardown();
+});
 </script>
 
 <template>
@@ -227,11 +304,12 @@ onBeforeUnmount(teardown);
     <div v-if="!props.sessionAlias" class="p-4 text-sm text-fg-muted">{{ $t("terminal.noSession") }}</div>
     <div v-else-if="status === 'error'" class="p-4 text-sm text-fg-muted">{{ $t(errorKey) }}</div>
     <div v-else-if="status === 'exited'" class="p-4 text-sm text-fg-muted">{{ $t("terminal.exited", { code: errorKey }) }}</div>
-    <div ref="host" class="term-host flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-bg" data-test="terminal-host"></div>
+    <div ref="host" class="term-host flex min-h-0 flex-1 touch-none items-center justify-center overflow-hidden bg-bg" data-test="terminal-host"></div>
 
-    <!-- shortcut bar -->
+    <!-- shortcut bar — translated up by the on-screen keyboard height so it stays visible -->
     <div v-if="keybarVisible" data-test="keybar"
-         class="flex shrink-0 items-center gap-1.5 overflow-x-auto border-t border-border bg-surface px-2 py-1.5 pb-[calc(0.375rem+env(safe-area-inset-bottom))] thin-scroll">
+         :style="keyboardInset ? { transform: `translateY(-${keyboardInset}px)` } : undefined"
+         class="relative z-10 flex shrink-0 items-center gap-1.5 overflow-x-auto border-t border-border bg-surface px-2 py-1.5 pb-[calc(0.375rem+env(safe-area-inset-bottom))] thin-scroll">
       <button data-test="key-esc" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\u001b')">Esc</button>
       <button data-test="key-tab" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\t')">Tab</button>
       <button data-test="key-ctrl" :aria-pressed="ctrlArmed"
@@ -254,8 +332,8 @@ onBeforeUnmount(teardown);
       <span class="h-4 w-px shrink-0 bg-border" aria-hidden="true" />
       <button data-test="key-home" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.home)">Home</button>
       <button data-test="key-end" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.end)">End</button>
-      <button data-test="key-pageup" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.pageUp)">PgUp</button>
-      <button data-test="key-pagedown" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.pageDown)">PgDn</button>
+      <button data-test="key-pageup" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="pageUp">PgUp</button>
+      <button data-test="key-pagedown" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="pageDown">PgDn</button>
       <button data-test="key-insert" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.insert)">Ins</button>
       <button data-test="key-enter" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey(KEYS.enter)">Enter</button>
       <span class="h-4 w-px shrink-0 bg-border" aria-hidden="true" />

--- a/packages/relay-web/src/lib/terminal-adapter.ts
+++ b/packages/relay-web/src/lib/terminal-adapter.ts
@@ -22,6 +22,8 @@ export interface GhosttyTerminalLike {
   paste?(data: string): void;
   getSelection?(): string;
   setTheme?(theme: TerminalTheme): void;
+  /** Scroll the viewport by N lines (positive = toward the newest/bottom rows). */
+  scrollLines?(amount: number): void;
   /** ghostty's Terminal has no public setTheme yet; its renderer does. */
   renderer?: { setTheme?(theme: TerminalTheme): void };
   element?: HTMLElement;
@@ -38,6 +40,8 @@ export interface TerminalAdapter {
   getSelection(): string;
   /** Recolor the live terminal (e.g. on light/dark theme switch). No-op before open. */
   setTheme(theme: TerminalTheme): void;
+  /** Scroll the viewport by N lines (positive = toward the newest/bottom rows). */
+  scrollLines(amount: number): void;
   /** Compute cols/rows that fit the host element, using the rendered canvas cell size.
    *  Returns null until the canvas has a measurable size. */
   fit(): { cols: number; rows: number } | null;
@@ -100,6 +104,7 @@ export function createTerminalAdapter(el: HTMLElement, opts: TerminalAdapterOpti
       if (live?.setTheme) live.setTheme(theme);
       else live?.renderer?.setTheme?.(theme);
     },
+    scrollLines: (n) => live?.scrollLines?.(n),
     fit: () => {
       if (!live?.element || !live.cols || !live.rows) return null;
       const canvas = live.element.querySelector("canvas");


### PR DESCRIPTION
Addresses the mobile terminal issues reported from a live device. **#1 (Chinese IME) is deferred** — it's a ghostty-web (0.4.0) upstream limitation: it `preventDefault()`s `beforeinput` on the contenteditable host, which breaks mobile CJK composition; fixing it cleanly means patching the library, not our layer.

## Fixes

### Keybar hidden behind the on-screen keyboard (#2)
The soft keyboard doesn't shrink the layout viewport on iOS, so the bottom-anchored shortcut bar sat behind it. Now we track `window.visualViewport` (resize/scroll) and translate the bar up by the covered height (`innerHeight − vv.height − vv.offsetTop`), so it floats on top of the keyboard.

### Home/End no-op, PgUp/PgDn behaved like arrows (#3)
- **Home/End** now send **Ctrl-A / Ctrl-E** (emacs beginning/end-of-line). A bare zsh/bash line editor leaves the raw `ESC[H`/`ESC[F` unbound (why they did nothing — ghostty's own physical Home/End send those too), but binds Ctrl-A/E by default.
- **PgUp/PgDn** now **scroll the viewport locally one page** via ghostty's `scrollLines` (`+` = toward newest), matching the "page up/down" intent, instead of sending `ESC[5~`/`ESC[6~` (which the shell ignores; ghostty also maps wheel→arrows in alt-screen, which is what made them look like arrow keys).

### No touch scrolling; tap always raised the keyboard (#4)
ghostty only wires `wheel` (desktop) + a `touchend` that focuses — no touch scroll. Added capture-phase touch handlers on the host:
- **Drag** scrolls the viewport (finger up → toward newer rows), `preventDefault` + `stopPropagation` to suppress page scroll and ghostty's tap-to-focus.
- **Tap** falls through to ghostty and focuses (raises the keyboard).
- Host gets `touch-action: none` so we own the gesture. Adapter gains `scrollLines()`.

## Tests
- New `terminal-tab` cases: Home/End → Ctrl-A/E, PgUp/PgDn → `scrollLines(∓23)` (rows−1) with nothing sent to the PTY, and a touch-drag → `scrollLines` with no focus.
- Full relay-web suite green (513) + `vue-tsc --noEmit` clean.

## Needs on-device verification (can't be exercised in jsdom)
- Scroll **direction** feel for PgUp/PgDn and touch drag (sign derived from ghostty's `scrollLines`/wheel source, but confirm on a real device).
- Keybar sits exactly above the keyboard across iOS/Android.
- Drag-vs-tap: ghostty's `touchend` is assumed bubble-phase so our capture-phase `stopPropagation` suppresses focus on drag — verify a drag doesn't pop the keyboard.