### PR TITLE
fix(relay-web): stop terminal keyboard-inset from leaving a phantom bottom gap

### DIFF
--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -238,6 +238,46 @@ describe("TerminalTab", () => {
     expect(endStop).not.toHaveBeenCalled(); // tap reaches ghostty → focuses/raises keyboard
   });
 
+  it("keyboard inset applies only while focused and above the toolbar threshold", async () => {
+    const vv = { height: 400, offsetTop: 0, addEventListener: vi.fn(), removeEventListener: vi.fn() };
+    Object.defineProperty(window, "visualViewport", { value: vv, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 800, configurable: true }); // delta 400 > 120
+    try {
+      const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+      await tick();
+      const center = () => w.find('[data-test="terminal-center"]').attributes("style") ?? "";
+      const el = w.find('[data-test="terminal-host"]').element as HTMLElement;
+      // Unfocused: a large innerHeight−visualViewport delta is browser chrome, NOT a keyboard → no inset.
+      expect(center()).not.toContain("padding-bottom");
+      el.dispatchEvent(new Event("focusin", { bubbles: true }));
+      await tick();
+      expect(center()).toContain("padding-bottom: 400px");
+      el.dispatchEvent(new Event("focusout", { bubbles: true }));
+      await tick();
+      expect(center()).not.toContain("padding-bottom");
+    } finally {
+      Reflect.deleteProperty(window, "visualViewport");
+      Object.defineProperty(window, "innerHeight", { value: 768, configurable: true });
+    }
+  });
+
+  it("keyboard inset ignores a sub-threshold delta (browser toolbar) even when focused", async () => {
+    const vv = { height: 740, offsetTop: 0, addEventListener: vi.fn(), removeEventListener: vi.fn() };
+    Object.defineProperty(window, "visualViewport", { value: vv, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 800, configurable: true }); // delta 60 < 120
+    try {
+      const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+      await tick();
+      const el = w.find('[data-test="terminal-host"]').element as HTMLElement;
+      el.dispatchEvent(new Event("focusin", { bubbles: true }));
+      await tick();
+      expect(w.find('[data-test="terminal-center"]').attributes("style") ?? "").not.toContain("padding-bottom");
+    } finally {
+      Reflect.deleteProperty(window, "visualViewport");
+      Object.defineProperty(window, "innerHeight", { value: 768, configurable: true });
+    }
+  });
+
   it("Copy writes the terminal selection to the clipboard; no-op when empty", async () => {
     const writeText = vi.fn(async () => {});
     Object.assign(navigator, { clipboard: { writeText } });

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -148,17 +148,22 @@ function pageUp() { adapter?.scrollLines(-pageLines()); }
 function pageDown() { adapter?.scrollLines(pageLines()); }
 
 // --- Mobile: keep the shortcut bar above the on-screen keyboard ---------------------
-// The soft keyboard doesn't shrink the layout viewport on iOS, so a bottom-anchored bar
-// ends up hidden behind it. visualViewport tells us the covered height; we translate the
-// bar up by that much so it floats on top of the keyboard.
+// When the layout viewport doesn't shrink for the keyboard (iOS Safari ignores
+// interactive-widget), a bottom-anchored bar hides behind it. visualViewport tells us the
+// covered height, applied as pane padding. Two guards keep this from firing spuriously:
+//   1. Only while the terminal is focused — a keyboard can't be open otherwise, so a
+//      persistent browser-chrome gap (Safari's bottom toolbar) never leaves a phantom inset.
+//   2. Only above a keyboard-sized threshold — a toolbar (<=~90px) must not count; real
+//      keyboards are >=~150px. (When the browser DOES resize the layout, the raw delta is
+//      ~0 and this is a no-op, so it never double-applies.)
+const KEYBOARD_MIN_INSET = 120;
+const hostFocused = ref(false);
 const keyboardInset = ref(0);
 function updateKeyboardInset() {
   const vv = typeof window !== "undefined" ? window.visualViewport : null;
-  if (!vv) return;
+  if (!vv || !hostFocused.value) { keyboardInset.value = 0; return; }
   const raw = Math.round(window.innerHeight - vv.height - vv.offsetTop);
-  // Ignore small deltas (e.g. a desktop horizontal scrollbar makes innerHeight exceed
-  // visualViewport.height by ~15px); only a real on-screen keyboard clears this bar.
-  keyboardInset.value = raw > 60 ? raw : 0;
+  keyboardInset.value = raw > KEYBOARD_MIN_INSET ? raw : 0;
 }
 
 // --- Mobile: drag to scroll, tap to focus (raise the keyboard) ----------------------
@@ -250,6 +255,11 @@ async function start() {
   }
 }
 
+// focusin/focusout bubble from ghostty's focus target (the contenteditable host or its
+// textarea), so listening on the host catches both — gating the keyboard inset on focus.
+function onHostFocusIn() { hostFocused.value = true; updateKeyboardInset(); }
+function onHostFocusOut() { hostFocused.value = false; keyboardInset.value = 0; }
+
 // Touch listeners go on the host in CAPTURE phase so they run before ghostty's own
 // bubble-phase touchend — letting a drag stopPropagation() to suppress its tap-to-focus.
 function attachTouch() {
@@ -258,6 +268,8 @@ function attachTouch() {
   el.addEventListener("touchstart", onTouchStart, { capture: true, passive: true });
   el.addEventListener("touchmove", onTouchMove, { capture: true, passive: false });
   el.addEventListener("touchend", onTouchEnd, { capture: true });
+  el.addEventListener("focusin", onHostFocusIn);
+  el.addEventListener("focusout", onHostFocusOut);
 }
 function detachTouch() {
   const el = host.value;
@@ -265,6 +277,8 @@ function detachTouch() {
   el.removeEventListener("touchstart", onTouchStart, { capture: true });
   el.removeEventListener("touchmove", onTouchMove, { capture: true });
   el.removeEventListener("touchend", onTouchEnd, { capture: true });
+  el.removeEventListener("focusin", onHostFocusIn);
+  el.removeEventListener("focusout", onHostFocusOut);
 }
 
 onMounted(() => {


### PR DESCRIPTION
The beta.4 keyboard-inset (the `visualViewport` padding that lifts the shortcut bar above the soft keyboard, for browsers that ignore `interactive-widget=resizes-content`) fired **even with the keyboard closed**: on mobile Safari the persistent bottom toolbar makes `innerHeight − visualViewport.height` exceed the old 60px threshold, so the terminal pane kept a permanent `padding-bottom` gap that desktop never shows (reported: mobile keybar has an extra bottom margin).

## Fix
Two guards on the inset:
1. **Focus gate** — track `focusin`/`focusout` on the host; a keyboard can't be open unless the terminal is focused, so a persistent browser-chrome gap never leaves a phantom inset.
2. **Threshold 120px** — a browser toolbar (≤~90px) no longer counts; real keyboards (≥~150px) still do. And when the browser *does* resize the layout viewport for the keyboard, the raw delta is ~0, so this stays a no-op and never double-applies.

## About the composer's mobile bottom space (also asked)
That one is unrelated to this change and is **not a bug**: the chat composer uses `pb-[max(1rem, env(safe-area-inset-bottom))]` — the iOS home-indicator safe area (~34px on notched iPhones, 0 on desktop), so the Send button isn't under the home bar. Left as-is.

## Tests
- New `terminal-tab` cases: inset applies only while focused with a >120px delta; a sub-threshold delta (toolbar) is ignored even when focused.
- Full relay-web suite green (516) + `vue-tsc --noEmit` clean.

## Needs on-device verification
Whether the keybar still correctly lifts above the keyboard while typing on the reporter's iOS Safari (the 120px threshold and focus gate are derived, not device-measured).