### PR TITLE
relay-web file tree browser (sub-project A: read-only tree + search + gitignore)

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -153,6 +153,19 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   `TaskPanel.vue`、`ScheduledTasks.vue`、`OrchestrationTasks.vue`、`NoticeToast.vue`、`ConnectionBadge.vue`；
 - `src/router/index.ts`（含 `/settings` 路由）、`src/main.ts`、`src/App.vue`、`src/style.css`。
 
+## 文件树浏览器（Files 面板 / 子项目 A）
+
+`FilesPanel.vue` 的 **Files tab** 是懒加载**树视图**（`FileTreeNode.vue` 递归 + `ContextMenu.vue`）：
+
+- **树 / 懒加载**：根 = 会话 workspace 根；展开文件夹时按需调 `control.fs.list` 拉该层（`store.tree` 逐目录缓存，`store.expanded` 集合按 workspace 存 localStorage）。去掉了旧的面包屑 + 向上按钮。文件夹开/合图标（`FolderOpen`/`Folder`），文件按扩展名映射 lucide 图标（`src/lib/file-icons.ts`）。
+- **gitignore / 点文件**：`control.fs.list` 的每个条目带 `ignored`（后端 `git check-ignore`）；点文件按名判定。两个切换「显示点文件 / 显示 Git 忽略文件」默认关（存 localStorage），显示时以低透明度 + 斜体呈现（视觉「被忽略」）。默认隐藏使 `node_modules`/`.git` 不进树。
+- **git 状态点**：改动过的文件/含改动的目录在树节点上显示 M/A/D/? 状态点（复用 `store.changed`，由 `loadStatus()` 填充）。
+- **高级搜索**：主查询 + 三开关「精确大小写 / 匹配整词 / 正则」+「包含 / 排除」glob + 模式切换「文件名 / 内容」。内容模式为 grep（后端优先 `git grep`，非 git 回退手写走查；include/exclude 对返回路径后置过滤、`path` 限定作用域）。协议 `FsSearchPayload` 携带 `mode/matchCase/wholeWord/regex/include/exclude/path`，`FsSearchResult` 返回 `matches`(名字) / `hits`(内容 `{path,line,text}`)。
+- **右键菜单（只读子集）**：复制路径（**主机绝对路径** = `FsListResult.root + sep + relPath`）、复制相对路径（workspace 根相对）、（文件夹）在此文件夹搜索。写操作（新建/重命名/删除/下载/在 OS 打开）属**子项目 B**，本面板只搭右键菜单骨架。
+- **移动端**：右栏抽屉在 `<lg` 满屏宽（`w-full`）。
+
+后端只读、复用 `WorkspaceFs.resolve()` 三道闸（account-owns-instance → workspace 名白名单 → realpath 包含），无新增 config 门。
+
 ## 如何与 relay 通信
 
 - **REST**：`/api/*`（登录、实例列表、会话/历史快照），其中

--- a/docs/superpowers/plans/2026-07-01-relay-web-file-tree-browser.md
+++ b/docs/superpowers/plans/2026-07-01-relay-web-file-tree-browser.md
@@ -1,0 +1,1426 @@
+# relay-web 文件树浏览器（子项目 A）实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 relay-web Files 面板从"逐目录扁平列表"升级成懒加载树视图 + gitignore/点文件 感知（默认隐藏、显示时淡化+斜体）+ 高级搜索（文件名 + 内容 grep，含大小写/整词/正则/包含/排除）+ 右键复制路径/在此搜索 + 移动端满宽。全部只读。
+
+**Architecture:** relay-web 前端为主 + 少量只读后端扩展（`WorkspaceFs`：`git check-ignore` 标记 ignored、返回主机绝对 root/sep、`git grep` 内容搜索 + 非 git 回退）。数据路径不变（`control.fs.*` RPC → hub ownership 门 → connector → core → WorkspaceFs.resolve() 三道闸）。无写操作、无新 config 门。
+
+**Tech Stack:** Vue 3 `<script setup>` + Pinia + Tailwind + lucide-vue-next；core TypeScript + node:child_process git；bun test（后端）/ vitest（relay-web）。
+
+## Global Constraints
+
+- 只读子项目：不新增任何文件系统写操作、不新增 config 门。写/下载/在 OS 打开留给 B。
+- 后端新能力必须作为 `WorkspaceFs` 方法、复用现有 `resolve()`（workspace 名白名单 + realpath 包含），不另开路径。
+- git 相关全部 `execFile`/`spawn` 传 argv 数组，绝不走 shell。非 git 仓库/ git 缺失一律静默降级（不报错）。
+- 协议改动为**增量向后兼容**（新字段可选或有缺省），relay-protocol 保持 0.1.x，`^0.1.0` range 不变。
+- relay-protocol 构建用 `bun run build:relay-protocol`（bun build + tsc + assert，三步都要）。
+- relay-web 测试 cwd=`packages/relay-web`，`npx vitest run <file>`；**不要**用 bun test（缺 jsdom 假失败）。后端/连接器测试用 `bun test <file>`。
+- en/zh 两个 i18n catalog 必须键平价（`i18n-parity.test.ts` 自动校验）；无空串。
+- 复制路径="主机绝对路径"= `root + sep + relPath`（按主机 sep）；复制相对路径= workspace 根相对（内部 `/`）。
+- gitignore/点文件默认**隐藏**，两个 localStorage 开关显示；显示时行文字低透明度 + 斜体。
+
+---
+
+### Task 1: 后端 `WorkspaceFs.listDirectory` — ignored 标记 + 绝对 root/sep
+
+**Files:**
+- Modify: `src/control/workspace-fs.ts`（`FsEntry`/`DirListing` 接口 + `listDirectory` + 新增 `gitCheckIgnore` 私有方法）
+- Test: `tests/unit/control/workspace-fs.test.ts`（追加用例）
+
+**Interfaces:**
+- Produces:
+  - `FsEntry` 增 `ignored?: boolean`。
+  - `DirListing` 增 `root: string`（主机绝对 realpath 根）、`sep: "/" | "\\"`。
+  - `listDirectory(workspace, relPath?)` 返回值含上述字段；对本层被 gitignore 命中的条目标 `ignored:true`（非 git 仓库不标）。
+
+- [ ] **Step 1: 写失败测试（追加到 workspace-fs.test.ts）**
+
+在文件末尾追加一个 describe（用真实 git 仓库夹具）：
+
+```ts
+describe("WorkspaceFs listing: ignored flag + root/sep", () => {
+  let gitRoot: string;
+  let gfs: WorkspaceFs;
+  beforeAll(() => {
+    gitRoot = mkdtempSync(join(tmpdir(), "wsfs-git-"));
+    execFileSync("git", ["init", "-q"], { cwd: gitRoot });
+    execFileSync("git", ["config", "user.email", "t@t"], { cwd: gitRoot });
+    execFileSync("git", ["config", "user.name", "t"], { cwd: gitRoot });
+    writeFileSync(join(gitRoot, ".gitignore"), "ignored.log\ndist/\n");
+    writeFileSync(join(gitRoot, "keep.ts"), "export const x = 1;\n");
+    writeFileSync(join(gitRoot, "ignored.log"), "noise\n");
+    mkdirSync(join(gitRoot, "dist"));
+    writeFileSync(join(gitRoot, "dist", "out.js"), "1\n");
+    gfs = new WorkspaceFs(() => [{ name: "g", cwd: gitRoot }]);
+  });
+  afterAll(() => rmSync(gitRoot, { recursive: true, force: true }));
+
+  test("marks gitignored entries and returns absolute root + sep", async () => {
+    const r = await gfs.listDirectory("g", "");
+    const byName = Object.fromEntries(r.entries.map((e) => [e.name, e]));
+    expect(byName["ignored.log"].ignored).toBe(true);
+    expect(byName["dist"].ignored).toBe(true);
+    expect(byName["keep.ts"].ignored).toBeUndefined();
+    expect(r.root).toBe(require("node:fs").realpathSync(gitRoot));
+    expect(r.sep).toBe(require("node:path").sep);
+  });
+
+  test("non-git workspace lists without ignored flags and still returns root/sep", async () => {
+    const r = await fs.listDirectory("ws", "");
+    expect(r.entries.every((e) => e.ignored === undefined)).toBe(true);
+    expect(typeof r.root).toBe("string");
+    expect(r.sep).toBe(require("node:path").sep);
+  });
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `bun test tests/unit/control/workspace-fs.test.ts`
+Expected: FAIL — `r.root`/`r.sep` undefined、`ignored` 未标。
+
+- [ ] **Step 3: 实现**
+
+3a. 顶部 `import { sep } from "node:path";` 已存在；确认还导入了 `spawn`：把第 1 行改为
+```ts
+import { execFile, spawn } from "node:child_process";
+```
+
+3b. 接口加字段：
+```ts
+export interface FsEntry {
+  name: string;
+  type: "dir" | "file";
+  size?: number;
+  /** True when git check-ignore matches this entry (omitted in non-git workspaces). */
+  ignored?: boolean;
+}
+export interface DirListing {
+  workspace: string;
+  path: string;
+  entries: FsEntry[];
+  /** Absolute realpath'd workspace root on the connector host. */
+  root: string;
+  /** Host path separator, so the client can render an absolute host path. */
+  sep: "/" | "\\";
+}
+```
+
+3c. 新增私有方法（`git check-ignore` 批量，喂 stdin，退出码 1=无命中，其它错误=非 git→空集）：
+```ts
+  /** Return the subset of the given root-relative paths that git considers ignored.
+   *  Uses `check-ignore -z --stdin` (bounded by the caller's MAX_ENTRIES listing).
+   *  Any git error (not a repo, git missing) yields an empty set — callers degrade to
+   *  "nothing ignored". Never throws. */
+  private gitCheckIgnore(root: string, relPaths: string[]): Promise<Set<string>> {
+    return new Promise((resolvePromise) => {
+      if (!relPaths.length) return resolvePromise(new Set());
+      const ignored = new Set<string>();
+      let out = "";
+      let child;
+      try {
+        child = spawn("git", ["-C", root, "check-ignore", "-z", "--stdin"], { stdio: ["pipe", "pipe", "ignore"] });
+      } catch {
+        return resolvePromise(ignored);
+      }
+      child.on("error", () => resolvePromise(ignored)); // git missing
+      child.stdout.on("data", (b) => { out += b.toString(); });
+      child.on("close", () => {
+        for (const p of out.split("\0")) { if (p) ignored.add(p); }
+        resolvePromise(ignored);
+      });
+      child.stdin.on("error", () => {}); // ignore EPIPE if git bails early
+      child.stdin.end(relPaths.join("\0") + "\0");
+    });
+  }
+```
+
+3d. `listDirectory`：在排序后、返回前，计算 ignored 集并标注，返回 root/sep：
+```ts
+  async listDirectory(workspace: string, relPath?: string): Promise<DirListing> {
+    const { root, abs, rel } = await this.resolve(workspace, relPath);
+    const dirents = await readdir(abs, { withFileTypes: true });
+    const entries: FsEntry[] = [];
+    for (const d of dirents.slice(0, MAX_ENTRIES)) {
+      if (d.isDirectory()) {
+        entries.push({ name: d.name, type: "dir" });
+      } else if (d.isFile()) {
+        let size: number | undefined;
+        try {
+          size = (await stat(resolve(abs, d.name))).size;
+        } catch {
+          size = undefined;
+        }
+        entries.push({ name: d.name, type: "file", size });
+      }
+    }
+    entries.sort((a, b) => (a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name)));
+    // Mark gitignored entries (dirs are checked with a trailing slash so `dist/` rules match).
+    const relOf = (name: string, isDir: boolean) => (rel ? `${rel}/${name}` : name) + (isDir ? "/" : "");
+    const ignoredSet = await this.gitCheckIgnore(root, entries.map((e) => relOf(e.name, e.type === "dir")));
+    for (const e of entries) {
+      if (ignoredSet.has(relOf(e.name, e.type === "dir"))) e.ignored = true;
+    }
+    return { workspace, path: rel, entries, root, sep: sep as "/" | "\\" };
+  }
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `bun test tests/unit/control/workspace-fs.test.ts`
+Expected: PASS（原有用例 + 2 新用例全绿）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/control/workspace-fs.ts tests/unit/control/workspace-fs.test.ts
+git commit -m "feat(control): workspace-fs listing marks gitignored entries + returns host root/sep"
+```
+
+---
+
+### Task 2: 后端 `WorkspaceFs.search` — 模式/开关/include/exclude/path + 内容 grep
+
+**Files:**
+- Modify: `src/control/workspace-fs.ts`（`SearchResult` 接口 + `search` 签名与实现 + 新增 `contentGrep` 私有方法）
+- Test: `tests/unit/control/workspace-fs.test.ts`（追加用例）
+
+**Interfaces:**
+- Consumes: `resolve()`（Task 1 之前已存在）。
+- Produces:
+  - `SearchHit { path: string; line: number; text: string }`。
+  - `SearchResult` 增 `hits: SearchHit[]`（保留 `matches`）。
+  - `SearchOptions = { query: string; mode?: "name" | "content"; matchCase?: boolean; wholeWord?: boolean; regex?: boolean; include?: string; exclude?: string; path?: string }`。
+  - `search(workspace, opts: SearchOptions): Promise<SearchResult>`（**签名从 `(workspace, query)` 改为 `(workspace, opts)`**）。
+
+- [ ] **Step 1: 写失败测试（追加到 workspace-fs.test.ts）**
+
+复用上一个 describe 的 `gitRoot`/`gfs`（若在同文件）。追加：
+
+```ts
+describe("WorkspaceFs search: modes + flags", () => {
+  test("name mode: regex + include filter on relative path", async () => {
+    const r = await fs.search("ws", { query: "\\.ts$", mode: "name", regex: true });
+    expect(r.matches).toContain("src/a.ts");
+    expect(r.matches.every((m) => m.endsWith(".ts"))).toBe(true);
+    expect(r.hits).toEqual([]);
+  });
+
+  test("name mode: exclude glob drops matches", async () => {
+    const r = await fs.search("ws", { query: "a", mode: "name", exclude: "src/**" });
+    expect(r.matches.some((m) => m.startsWith("src/"))).toBe(false);
+  });
+
+  test("content mode: finds a line and returns path/line/text", async () => {
+    const r = await fs.search("ws", { query: "export const a", mode: "content" });
+    const hit = r.hits.find((h) => h.path === "src/a.ts");
+    expect(hit).toBeDefined();
+    expect(hit!.line).toBe(1);
+    expect(hit!.text).toContain("export const a");
+    expect(r.matches).toEqual([]);
+  });
+
+  test("content mode: case-sensitive miss vs case-insensitive hit", async () => {
+    const sensitive = await fs.search("ws", { query: "EXPORT", mode: "content", matchCase: true });
+    expect(sensitive.hits.length).toBe(0);
+    const insensitive = await fs.search("ws", { query: "EXPORT", mode: "content", matchCase: false });
+    expect(insensitive.hits.length).toBeGreaterThan(0);
+  });
+
+  test("empty query returns nothing", async () => {
+    const r = await fs.search("ws", { query: "   ", mode: "content" });
+    expect(r.hits).toEqual([]);
+    expect(r.matches).toEqual([]);
+  });
+});
+```
+
+> 说明：`ws` 夹具（非 git，来自文件顶部 beforeAll）走**内容 grep 的回退路径**（手写走查），正好覆盖非 git 分支。
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `bun test tests/unit/control/workspace-fs.test.ts`
+Expected: FAIL — `search` 不接受 opts 对象 / 无 `hits`。
+
+- [ ] **Step 3: 实现**
+
+3a. 顶部新增读取文件用的 import（已存在 `open`；新增 `readFile` 风格用现有 `open`+read，或直接用 `node:fs/promises` 的 `readFile`）。把第 4 行改为：
+```ts
+import { readdir, realpath, stat, open, readFile } from "node:fs/promises";
+```
+并新增常量（放在 SEARCH_* 附近）：
+```ts
+const SEARCH_CONTENT_MAX_HITS = 500;
+const SEARCH_CONTENT_MAX_FILE = 1024 * 1024; // skip files > 1 MiB in the fallback walker
+```
+
+3b. 接口：
+```ts
+export interface SearchHit {
+  path: string;
+  line: number;
+  text: string;
+}
+export interface SearchResult {
+  workspace: string;
+  query: string;
+  matches: string[];
+  hits: SearchHit[];
+  truncated: boolean;
+}
+export interface SearchOptions {
+  query: string;
+  mode?: "name" | "content";
+  matchCase?: boolean;
+  wholeWord?: boolean;
+  regex?: boolean;
+  /** Glob to restrict matches (relative to workspace root). */
+  include?: string;
+  /** Glob to drop matches. */
+  exclude?: string;
+  /** Base directory (relative) to scope the search; defaults to the whole workspace. */
+  path?: string;
+}
+```
+
+3c. 重写 `search`（名字模式=增强路径匹配；内容模式=git grep + 回退）：
+```ts
+  async search(workspace: string, opts: SearchOptions): Promise<SearchResult> {
+    const { root, abs: base } = await this.resolve(workspace, opts.path);
+    const query = opts.query.trim();
+    const empty: SearchResult = { workspace, query, matches: [], hits: [], truncated: false };
+    if (!query) return empty;
+
+    if ((opts.mode ?? "name") === "content") {
+      return this.contentGrep(workspace, root, base, opts, query);
+    }
+
+    // name mode: walk relative paths, apply matcher + include/exclude globs.
+    const matcher = buildMatcher(query, opts);
+    const inc = opts.include ? globToRegExp(opts.include) : null;
+    const exc = opts.exclude ? globToRegExp(opts.exclude) : null;
+    const matches: string[] = [];
+    let scanned = 0;
+    let truncated = false;
+    const queue: string[] = [base];
+    while (queue.length) {
+      const dir = queue.shift()!;
+      let dirents;
+      try { dirents = await readdir(dir, { withFileTypes: true }); } catch { continue; }
+      for (const d of dirents) {
+        if (++scanned > SEARCH_MAX_SCAN) { truncated = true; break; }
+        if (d.isSymbolicLink()) continue;
+        if (d.isDirectory()) {
+          if (!SEARCH_SKIP_DIRS.has(d.name)) queue.push(resolve(dir, d.name));
+        } else if (d.isFile()) {
+          const rel = relative(root, resolve(dir, d.name)).split(sep).join("/");
+          if (inc && !inc.test(rel)) continue;
+          if (exc && exc.test(rel)) continue;
+          if (matcher(rel)) {
+            matches.push(rel);
+            if (matches.length >= SEARCH_MAX_RESULTS) { truncated = true; break; }
+          }
+        }
+      }
+      if (truncated) break;
+    }
+    matches.sort();
+    return { workspace, query, matches, hits: [], truncated };
+  }
+```
+
+3d. 新增内容 grep（git grep 优先，非 git 回退手写走查）：
+```ts
+  private async contentGrep(workspace: string, root: string, base: string, opts: SearchOptions, query: string): Promise<SearchResult> {
+    // Try git grep first: it's fast and respects .gitignore. Args are argv (never a shell).
+    const inGit = await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { maxBuffer: GIT_MAX_BUFFER })
+      .then(() => true).catch(() => false);
+    if (inGit) {
+      const args = ["-C", root, "grep", "-n", "--column", "-I", "--no-color"];
+      if (!opts.matchCase) args.push("-i");
+      if (opts.wholeWord) args.push("-w");
+      args.push(opts.regex ? "-E" : "-F");
+      args.push("-e", query, "--");
+      const scope = opts.path ? opts.path : ".";
+      args.push(scope);
+      if (opts.include) args.push(`:(glob)${opts.include}`);
+      if (opts.exclude) args.push(`:(exclude,glob)${opts.exclude}`);
+      let stdout = "";
+      try {
+        stdout = (await execFileAsync("git", args, { maxBuffer: GIT_MAX_BUFFER })).stdout;
+      } catch (e) {
+        const code = (e as { code?: number }).code;
+        if (code === 1) stdout = ""; // no matches
+        else { const out = (e as { stdout?: string }).stdout; stdout = typeof out === "string" ? out : ""; }
+      }
+      const hits: SearchHit[] = [];
+      let truncated = false;
+      for (const raw of stdout.split("\n")) {
+        if (!raw) continue;
+        // format: <path>:<line>:<column>:<text>
+        const m = raw.match(/^(.*?):(\d+):(\d+):(.*)$/);
+        if (!m) continue;
+        hits.push({ path: m[1].split(sep).join("/"), line: Number(m[2]), text: m[4].slice(0, 400) });
+        if (hits.length >= SEARCH_CONTENT_MAX_HITS) { truncated = true; break; }
+      }
+      return { workspace, query, matches: [], hits, truncated };
+    }
+
+    // Fallback (non-git): bounded manual walk + per-line match.
+    const matcher = buildLineMatcher(query, opts);
+    const inc = opts.include ? globToRegExp(opts.include) : null;
+    const exc = opts.exclude ? globToRegExp(opts.exclude) : null;
+    const hits: SearchHit[] = [];
+    let scanned = 0;
+    let truncated = false;
+    const queue: string[] = [base];
+    while (queue.length) {
+      const dir = queue.shift()!;
+      let dirents;
+      try { dirents = await readdir(dir, { withFileTypes: true }); } catch { continue; }
+      for (const d of dirents) {
+        if (++scanned > SEARCH_MAX_SCAN) { truncated = true; break; }
+        if (d.isSymbolicLink()) continue;
+        const full = resolve(dir, d.name);
+        if (d.isDirectory()) { if (!SEARCH_SKIP_DIRS.has(d.name)) queue.push(full); continue; }
+        if (!d.isFile()) continue;
+        const rel = relative(root, full).split(sep).join("/");
+        if (inc && !inc.test(rel)) continue;
+        if (exc && exc.test(rel)) continue;
+        let info; try { info = await stat(full); } catch { continue; }
+        if (info.size > SEARCH_CONTENT_MAX_FILE) continue;
+        let text; try { text = await readFile(full, "utf8"); } catch { continue; }
+        if (text.includes(" ")) continue; // binary
+        const lines = text.split("\n");
+        for (let i = 0; i < lines.length; i++) {
+          if (matcher(lines[i])) {
+            hits.push({ path: rel, line: i + 1, text: lines[i].slice(0, 400) });
+            if (hits.length >= SEARCH_CONTENT_MAX_HITS) { truncated = true; break; }
+          }
+        }
+        if (truncated) break;
+      }
+      if (truncated) break;
+    }
+    return { workspace, query, matches: [], hits, truncated };
+  }
+```
+
+3e. 在文件底部（class 外）加纯函数辅助（matcher/glob）：
+```ts
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+/** Build a path/name matcher for name-mode search. */
+function buildMatcher(query: string, opts: SearchOptions): (s: string) => boolean {
+  return buildLineMatcher(query, opts, /*substringDefault*/ true);
+}
+/** Build a per-line/string matcher honoring regex/wholeWord/matchCase. In non-regex
+ *  mode it's a substring test; wholeWord wraps with \b boundaries. */
+function buildLineMatcher(query: string, opts: SearchOptions, _substringDefault = true): (s: string) => boolean {
+  const flags = opts.matchCase ? "" : "i";
+  let pattern: string;
+  if (opts.regex) pattern = query;
+  else pattern = escapeRe(query);
+  if (opts.wholeWord) pattern = `\\b${pattern}\\b`;
+  let re: RegExp | null = null;
+  try { re = new RegExp(pattern, flags); } catch { re = null; }
+  if (!re) {
+    // Invalid user regex → fall back to case-adjusted substring so search never throws.
+    const needle = opts.matchCase ? query : query.toLowerCase();
+    return (s) => (opts.matchCase ? s : s.toLowerCase()).includes(needle);
+  }
+  return (s) => re!.test(s);
+}
+/** Minimal glob → RegExp for include/exclude (supports **, *, ?). Anchored full-match. */
+function globToRegExp(glob: string): RegExp {
+  let re = "^";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === "*") {
+      if (glob[i + 1] === "*") { re += ".*"; i++; if (glob[i + 1] === "/") i++; }
+      else re += "[^/]*";
+    } else if (c === "?") re += "[^/]";
+    else re += escapeRe(c);
+  }
+  re += "$";
+  try { return new RegExp(re); } catch { return /$^/; }
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `bun test tests/unit/control/workspace-fs.test.ts`
+Expected: PASS（含新的 name/content/case/empty 用例；非 git `ws` 走回退路径）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/control/workspace-fs.ts tests/unit/control/workspace-fs.test.ts
+git commit -m "feat(control): workspace-fs search modes (name+content grep) with case/word/regex/include/exclude/path"
+```
+
+---
+
+### Task 3: 协议 DTO/message 扩展 + dist 重建
+
+**Files:**
+- Modify: `packages/relay-protocol/src/dtos.ts`（`FsEntryDto` + 新增 `FsSearchHitDto`）
+- Modify: `packages/relay-protocol/src/messages.ts`（`FsListResult` + `FsSearchPayload` + `FsSearchResult`）
+- Test: `tests/unit/packages/relay-protocol/web-dtos.test.ts` 或相邻 protocol 测试（若无针对 fs 的断言，则加最小断言）
+- Build: `bun run build:relay-protocol`
+
+**Interfaces:**
+- Consumes: Task 1/2 的后端返回形状（root/sep/ignored/hits）。
+- Produces: 供 connector（Task 4）与 relay-web（Task 6+）使用的类型。
+
+- [ ] **Step 1: 改 dtos.ts**
+
+`FsEntryDto` 加 `ignored?`；新增 `FsSearchHitDto`：
+```ts
+export interface FsEntryDto {
+  name: string;
+  type: "dir" | "file";
+  /** File size in bytes; omitted for directories. */
+  size?: number;
+  /** True when git considers the entry ignored (omitted in non-git workspaces). */
+  ignored?: boolean;
+}
+
+/** One content-search match line (mode:"content"). */
+export interface FsSearchHitDto {
+  path: string;
+  line: number;
+  text: string;
+}
+```
+
+- [ ] **Step 2: 改 messages.ts**
+
+2a. `FsListResult` 加 root/sep：
+```ts
+export interface FsListResult {
+  workspace: string;
+  path: string;
+  entries: FsEntryDto[];
+  /** Absolute realpath'd workspace root on the connector host. */
+  root: string;
+  /** Host path separator. */
+  sep: "/" | "\\";
+}
+```
+
+2b. `FsSearchPayload` 扩展（`query` 保留必填；其余可选，`mode` 缺省视为 "name"）：
+```ts
+export interface FsSearchPayload {
+  workspace: string;
+  query: string;
+  mode?: "name" | "content";
+  matchCase?: boolean;
+  wholeWord?: boolean;
+  regex?: boolean;
+  /** Glob to restrict matches (relative to workspace root). */
+  include?: string;
+  /** Glob to drop matches. */
+  exclude?: string;
+  /** Base directory (relative) to scope the search. */
+  path?: string;
+}
+```
+
+2c. `FsSearchResult` 加 hits，并把 import 行补上 `FsSearchHitDto`：
+```ts
+export interface FsSearchResult {
+  workspace: string;
+  query: string;
+  /** File paths (name mode). */
+  matches: string[];
+  /** Content matches (content mode). */
+  hits: FsSearchHitDto[];
+  truncated: boolean;
+}
+```
+messages.ts 第 1 行的 import 追加 `FsSearchHitDto`：
+```ts
+import type { AgentCatalogEntryDto, AgentDto, ControlEventDto, FsDiffFileDto, FsEntryDto, FsSearchHitDto, OrchestrationTaskDto, ScheduledTaskDto, SessionDto, WorkspaceDto } from "./dtos.js";
+```
+
+- [ ] **Step 3: 加/更新 protocol 断言测试**
+
+在 `tests/unit/packages/relay-protocol/web-dtos.test.ts` 追加一个编译期形状断言（该测试文件用 bun test）：
+```ts
+import { test, expect } from "bun:test";
+import type { FsListResult, FsSearchPayload, FsSearchResult, FsSearchHitDto, FsEntryDto } from "../../../../packages/relay-protocol/src/messages";
+
+test("fs DTOs carry the tree-browser additions", () => {
+  const entry: FsEntryDto = { name: "a", type: "file", ignored: true };
+  const list: FsListResult = { workspace: "w", path: "", entries: [entry], root: "/abs", sep: "/" };
+  const hit: FsSearchHitDto = { path: "a.ts", line: 3, text: "x" };
+  const payload: FsSearchPayload = { workspace: "w", query: "x", mode: "content", regex: true, include: "**/*.ts", path: "src" };
+  const result: FsSearchResult = { workspace: "w", query: "x", matches: [], hits: [hit], truncated: false };
+  expect(list.root).toBe("/abs");
+  expect(list.sep).toBe("/");
+  expect(payload.mode).toBe("content");
+  expect(result.hits[0].line).toBe(3);
+});
+```
+（若 `web-dtos.test.ts` 从 `messages` 导入路径不同，按同目录既有 import 风格对齐。）
+
+- [ ] **Step 4: 构建 dist + 跑测试 + 断言导出**
+
+Run:
+```bash
+bun run build:relay-protocol
+bun test tests/unit/packages/relay-protocol/web-dtos.test.ts
+```
+Expected: 构建成功（bun build + tsc + assert 三步 0 退出）；测试 PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add packages/relay-protocol/src/dtos.ts packages/relay-protocol/src/messages.ts packages/relay-protocol/dist tests/unit/packages/relay-protocol/web-dtos.test.ts
+git commit -m "feat(relay-protocol): fs tree-browser DTOs (ignored, root/sep, search modes+hits)"
+```
+
+---
+
+### Task 4: 连接器 + control-service 透传扩展搜索
+
+**Files:**
+- Modify: `src/control/control-service.ts`（`searchWorkspace` 签名）
+- Modify: `packages/channel-relay/src/control-bridge.ts`（`fsSearch` case 传新字段）
+- Test: `tests/unit/packages/channel-relay/control-bridge.test.ts`（若存在则加 fsSearch passthrough 用例；若不存在则新建最小文件）
+
+**Interfaces:**
+- Consumes: `WorkspaceFs.search(workspace, opts)`（Task 2）、`FsSearchPayload`（Task 3）。
+- Produces: `ControlService.searchWorkspace(workspace, opts: SearchOptions)`。
+
+- [ ] **Step 1: 改 control-service.ts**
+
+把 `searchWorkspace` 从 `(workspace, query)` 改为透传 opts。先在文件顶部的 `WorkspaceFs` 相关 import 里补 `SearchOptions` 类型导入（与 `DirListing`/`FileContent` 等同处）：
+```ts
+// 在现有 `import { ... } from "./workspace-fs";` 里追加 SearchOptions（若该文件用 type-only import 就放同一处）
+```
+然后：
+```ts
+  searchWorkspace(workspace: string, opts: import("./workspace-fs").SearchOptions): Promise<SearchResult> {
+    return this.workspaceFs.search(workspace, opts);
+  }
+```
+（若文件已具名导入 workspace-fs 类型，改为在那条 import 里加 `SearchOptions` 并写 `opts: SearchOptions`，避免 inline import。）
+
+- [ ] **Step 2: 改 control-bridge.ts 的 fsSearch case**
+
+```ts
+    case MSG.fsSearch: {
+      const input = payload as FsSearchPayload;
+      if (!input.workspace) return errorPayload("bad-request", "workspace is required");
+      return await control.searchWorkspace(input.workspace, {
+        query: input.query ?? "",
+        mode: input.mode,
+        matchCase: input.matchCase,
+        wholeWord: input.wholeWord,
+        regex: input.regex,
+        include: input.include,
+        exclude: input.exclude,
+        path: input.path,
+      }); // SearchResult ≅ FsSearchResult
+    }
+```
+
+- [ ] **Step 3: 写 passthrough 测试**
+
+若 `tests/unit/packages/channel-relay/control-bridge.test.ts` 存在，追加；否则新建：
+```ts
+import { test, expect } from "bun:test";
+import { dispatchControlRequest } from "../../../../packages/channel-relay/src/control-bridge";
+import { MSG } from "@ganglion/xacpx-relay-protocol";
+
+test("fsSearch passes advanced options through to control.searchWorkspace", async () => {
+  let received: unknown;
+  const control = {
+    searchWorkspace: async (_ws: string, opts: unknown) => { received = opts; return { workspace: "w", query: "x", matches: [], hits: [], truncated: false }; },
+  } as never;
+  await dispatchControlRequest(control, MSG.fsSearch, { workspace: "w", query: "x", mode: "content", regex: true, include: "**/*.ts", exclude: "dist/**", path: "src", matchCase: true, wholeWord: true });
+  expect(received).toEqual({ query: "x", mode: "content", matchCase: true, wholeWord: true, regex: true, include: "**/*.ts", exclude: "dist/**", path: "src" });
+});
+```
+> 若 `dispatchControlRequest` 的实际导出名/签名不同，按 control-bridge.ts 的真实导出对齐（explore 记录其为 `dispatchControlRequest(control, type, payload)`）。
+
+- [ ] **Step 4: 运行 + typecheck**
+
+Run:
+```bash
+bun test tests/unit/packages/channel-relay/control-bridge.test.ts
+npx tsc --noEmit
+```
+Expected: 测试 PASS；tsc 0 错误（含 control-service 新签名、connector 引用）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/control/control-service.ts packages/channel-relay/src/control-bridge.ts tests/unit/packages/channel-relay/control-bridge.test.ts
+git commit -m "feat(control,channel-relay): thread advanced fs search options through the bridge"
+```
+
+---
+
+### Task 5: i18n — 文件树/搜索/菜单/切换 文案（en + zh）
+
+**Files:**
+- Modify: `packages/relay-web/src/i18n/messages/en.ts`（`files` 块扩展）
+- Modify: `packages/relay-web/src/i18n/messages/zh-CN.ts`（`files` 块扩展）
+
+**Interfaces:**
+- Produces: 键 `files.tree.*`、`files.search.*`、`files.menu.*`、`files.toggle.*`（en/zh 平价）。
+
+- [ ] **Step 1: 基线平价绿**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/i18n-parity.test.ts`
+Expected: PASS。
+
+- [ ] **Step 2: 在 en.ts 的 `files` 对象内追加子块**
+
+在 `files: { ... }` 内（保留现有键）追加：
+```ts
+    tree: { expand: "Expand", collapse: "Collapse", emptyFolder: "Empty folder" },
+    search: {
+      matchCase: "Match case",
+      wholeWord: "Match whole word",
+      regex: "Use regular expression",
+      include: "files to include",
+      exclude: "files to exclude",
+      byName: "By name",
+      byContent: "By content",
+      noContentMatches: "No matches in files",
+    },
+    menu: {
+      copyPath: "Copy path",
+      copyRelativePath: "Copy relative path",
+      searchInFolder: "Search in this folder",
+    },
+    toggle: { showDotfiles: "Show dotfiles", showGitignored: "Show git-ignored" },
+```
+
+- [ ] **Step 3: 在 zh-CN.ts 的 `files` 对象内追加同结构**
+
+```ts
+    tree: { expand: "展开", collapse: "折叠", emptyFolder: "空文件夹" },
+    search: {
+      matchCase: "精确大小写",
+      wholeWord: "匹配整词",
+      regex: "使用正则",
+      include: "要包含的文件",
+      exclude: "要排除的文件",
+      byName: "按文件名",
+      byContent: "按内容",
+      noContentMatches: "文件中无匹配",
+    },
+    menu: {
+      copyPath: "复制路径",
+      copyRelativePath: "复制相对路径",
+      searchInFolder: "在此文件夹搜索",
+    },
+    toggle: { showDotfiles: "显示点文件", showGitignored: "显示 Git 忽略文件" },
+```
+
+- [ ] **Step 4: 平价校验**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/i18n-parity.test.ts`
+Expected: PASS（en/zh 键一致、无空串）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add packages/relay-web/src/i18n/messages/en.ts packages/relay-web/src/i18n/messages/zh-CN.ts
+git commit -m "i18n(relay-web): file tree browser strings (tree/search/menu/toggle, en+zh)"
+```
+
+---
+
+### Task 6: 前端 — `file-icons.ts` 扩展名→lucide 图标
+
+**Files:**
+- Create: `packages/relay-web/src/lib/file-icons.ts`
+- Test: `packages/relay-web/src/__tests__/file-icons.test.ts`
+
+**Interfaces:**
+- Produces: `iconForFile(name: string): Component`（lucide 组件）。
+
+- [ ] **Step 1: 写失败测试**
+
+Create `packages/relay-web/src/__tests__/file-icons.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { FileCode, FileJson, FileImage, File as FileIcon } from "lucide-vue-next";
+import { iconForFile } from "../lib/file-icons";
+
+describe("iconForFile", () => {
+  it("maps known extensions", () => {
+    expect(iconForFile("main.ts")).toBe(FileCode);
+    expect(iconForFile("data.json")).toBe(FileJson);
+    expect(iconForFile("logo.svg")).toBe(FileImage);
+    expect(iconForFile("photo.PNG")).toBe(FileImage); // case-insensitive
+  });
+  it("falls back to a generic file icon", () => {
+    expect(iconForFile("mystery.xyz")).toBe(FileIcon);
+    expect(iconForFile("noext")).toBe(FileIcon);
+  });
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/file-icons.test.ts`
+Expected: FAIL — 模块不存在。
+
+- [ ] **Step 3: 实现**
+
+Create `packages/relay-web/src/lib/file-icons.ts`:
+```ts
+import type { Component } from "vue";
+import {
+  File as FileIcon, FileCode, FileJson, FileText, FileImage, FileType,
+  FileCog, FileLock, FileTerminal, FileArchive,
+} from "lucide-vue-next";
+
+const EXT_ICON: Record<string, Component> = {
+  ts: FileCode, tsx: FileCode, js: FileCode, jsx: FileCode, mjs: FileCode, cjs: FileCode,
+  vue: FileCode, py: FileCode, rs: FileCode, go: FileCode, java: FileCode, rb: FileCode,
+  c: FileCode, h: FileCode, cpp: FileCode, cs: FileCode, php: FileCode, swift: FileCode,
+  html: FileCode, htm: FileCode,
+  json: FileJson,
+  md: FileText, mdx: FileText, txt: FileText, pdf: FileText,
+  png: FileImage, jpg: FileImage, jpeg: FileImage, gif: FileImage, svg: FileImage, webp: FileImage, ico: FileImage, avif: FileImage,
+  css: FileType, scss: FileType, sass: FileType, less: FileType,
+  yml: FileCog, yaml: FileCog, toml: FileCog, ini: FileCog, env: FileCog, conf: FileCog,
+  lock: FileLock,
+  sh: FileTerminal, bash: FileTerminal, zsh: FileTerminal, fish: FileTerminal,
+  zip: FileArchive, tar: FileArchive, gz: FileArchive, tgz: FileArchive, rar: FileArchive, "7z": FileArchive,
+};
+
+/** Pick a lucide icon component for a filename, by extension (case-insensitive). */
+export function iconForFile(name: string): Component {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) return FileIcon;
+  const ext = name.slice(dot + 1).toLowerCase();
+  return EXT_ICON[ext] ?? FileIcon;
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/file-icons.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add packages/relay-web/src/lib/file-icons.ts packages/relay-web/src/__tests__/file-icons.test.ts
+git commit -m "feat(relay-web): file-type icon map (lucide by extension)"
+```
+
+---
+
+### Task 7: 前端 — files store 树状态 + 搜索参数/hits + root/sep
+
+**Files:**
+- Modify: `packages/relay-web/src/stores/files.ts`
+- Test: `packages/relay-web/src/__tests__/files.test.ts`（追加用例）
+
+**Interfaces:**
+- Consumes: `control.fs.list`（返回 root/sep/entries[].ignored）、`control.fs.search`（新 payload/hits）。
+- Produces（store 新增）：
+  - `root: Ref<string>`、`sep: Ref<"/" | "\\">`。
+  - `tree: Ref<Record<string, FsEntryDto[]>>`（dir relPath → children，`""`=根）、`expanded: Ref<Set<string>>`、`loadingDirs: Ref<Set<string>>`。
+  - `listTree(dir: string): Promise<void>`（拉某目录一层进 `tree`，并写 root/sep）。
+  - `toggleExpand(dir: string): Promise<void>`（展开时若未缓存则 listTree；持久化 expanded）。
+  - 搜索：`searchOpts: Ref<{ mode; matchCase; wholeWord; regex; include; exclude; path }>`、`hits: Ref<FsSearchHitDto[]>`；`search(query, optsOverride?)` 用 searchOpts 组 payload，回填 `matches`/`hits`。
+  - `absPath(rel: string): string`（= root + sep + rel 按 sep）。
+
+- [ ] **Step 1: 写失败测试（追加到 files.test.ts）**
+
+```ts
+describe("files store: tree + advanced search", () => {
+  it("listTree caches a directory layer and records root/sep", async () => {
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [{ name: "src", type: "dir" }], root: "/abs/ws", sep: "/" });
+    const s = useFilesStore();
+    s.instanceId = "i1"; s.workspace = "ws";
+    await s.listTree("");
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.list", { workspace: "ws", path: "" });
+    expect(s.tree[""].map((e) => e.name)).toEqual(["src"]);
+    expect(s.root).toBe("/abs/ws");
+    expect(s.absPath("src/a.ts")).toBe("/abs/ws/src/a.ts");
+  });
+
+  it("toggleExpand lazy-loads then toggles without refetching", async () => {
+    const s = useFilesStore();
+    s.instanceId = "i1"; s.workspace = "ws";
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "src", entries: [{ name: "a.ts", type: "file", size: 3 }], root: "/abs/ws", sep: "/" });
+    await s.toggleExpand("src");
+    expect(s.expanded.has("src")).toBe(true);
+    expect(s.tree["src"].length).toBe(1);
+    rpc.mockClear();
+    await s.toggleExpand("src"); // collapse — no fetch
+    expect(s.expanded.has("src")).toBe(false);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("content search sends advanced options and fills hits", async () => {
+    const s = useFilesStore();
+    s.instanceId = "i1"; s.workspace = "ws";
+    s.searchOpts.mode = "content"; s.searchOpts.regex = true; s.searchOpts.include = "**/*.ts";
+    rpc.mockResolvedValueOnce({ workspace: "ws", query: "foo", matches: [], hits: [{ path: "a.ts", line: 2, text: "foo" }], truncated: false });
+    await s.search("foo");
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.search", { workspace: "ws", query: "foo", mode: "content", matchCase: false, wholeWord: false, regex: true, include: "**/*.ts", exclude: "", path: "" });
+    expect(s.hits[0].line).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/files.test.ts`
+Expected: FAIL — `listTree`/`toggleExpand`/`searchOpts`/`hits`/`absPath` 不存在。
+
+- [ ] **Step 3: 实现（在 files.ts 中新增，不破坏现有导出）**
+
+3a. import 增补类型：
+```ts
+import { isErrorPayload, type FsDiffResult, type FsEntryDto, type FsListResult, type FsReadResult, type FsSearchResult, type FsSearchHitDto } from "@ganglion/xacpx-relay-protocol";
+```
+
+3b. 新增 state（放在现有 ref 附近）：
+```ts
+  const root = ref("");
+  const sepChar = ref<"/" | "\\">("/");
+  const tree = ref<Record<string, FsEntryDto[]>>({});
+  const expanded = ref<Set<string>>(new Set());
+  const loadingDirs = ref<Set<string>>(new Set());
+  const hits = ref<FsSearchHitDto[]>([]);
+  const searchOpts = ref<{ mode: "name" | "content"; matchCase: boolean; wholeWord: boolean; regex: boolean; include: string; exclude: string; path: string }>({
+    mode: "name", matchCase: false, wholeWord: false, regex: false, include: "", exclude: "", path: "",
+  });
+```
+
+3c. 新增 actions：
+```ts
+  function expandedKey(): string { return `xacpx.fileTree.expanded.${workspace.value ?? ""}`; }
+
+  async function listTree(dir: string): Promise<void> {
+    if (!instanceId.value || !workspace.value) return;
+    loadingDirs.value = new Set(loadingDirs.value).add(dir);
+    try {
+      const r = unwrap(await api.rpc<FsListResult>(instanceId.value, "control.fs.list", { workspace: workspace.value, path: dir }));
+      root.value = r.root; sepChar.value = r.sep;
+      tree.value = { ...tree.value, [dir]: r.entries };
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "list-failed";
+    } finally {
+      const next = new Set(loadingDirs.value); next.delete(dir); loadingDirs.value = next;
+    }
+  }
+
+  async function toggleExpand(dir: string): Promise<void> {
+    const next = new Set(expanded.value);
+    if (next.has(dir)) {
+      next.delete(dir);
+    } else {
+      next.add(dir);
+      if (!tree.value[dir]) await listTree(dir);
+    }
+    expanded.value = next;
+    try { localStorage.setItem(expandedKey(), JSON.stringify([...next])); } catch { /* ignore */ }
+  }
+
+  function absPath(rel: string): string {
+    const s = sepChar.value;
+    return root.value + s + rel.split("/").join(s);
+  }
+```
+
+3d. `selectWorkspace`：重置树并恢复展开态、拉根层。把现有 `selectWorkspace` 体末尾的 `await list("");` 替换为：
+```ts
+    tree.value = {}; hits.value = [];
+    try { expanded.value = new Set(JSON.parse(localStorage.getItem(expandedKey()) ?? "[]") as string[]); } catch { expanded.value = new Set(); }
+    await listTree("");
+    // Re-hydrate previously expanded layers (best-effort).
+    for (const dir of [...expanded.value]) { if (dir && !tree.value[dir]) await listTree(dir).catch(() => {}); }
+```
+（保留其上方对 file/diff/changed/query/results 的清理不变。删除对旧 `list("")` 的调用。）
+
+3e. 重写 `search` 用 searchOpts 组 payload：
+```ts
+  async function search(q: string): Promise<void> {
+    query.value = q;
+    if (!instanceId.value || !workspace.value || !q.trim()) {
+      results.value = []; hits.value = []; searchTruncated.value = false; return;
+    }
+    searching.value = true; error.value = "";
+    try {
+      const o = searchOpts.value;
+      const r = unwrap(await api.rpc<FsSearchResult>(instanceId.value, "control.fs.search", {
+        workspace: workspace.value, query: q,
+        mode: o.mode, matchCase: o.matchCase, wholeWord: o.wholeWord, regex: o.regex,
+        include: o.include, exclude: o.exclude, path: o.path,
+      }));
+      results.value = r.matches; hits.value = r.hits ?? []; searchTruncated.value = r.truncated;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "search-failed";
+    } finally {
+      searching.value = false;
+    }
+  }
+```
+
+3f. `refresh`（Files tab 分支）改为清树缓存 + 重列已展开层：
+```ts
+    // 在 tab==="files" 分支里，替换 `await list(path.value); await loadStatus(); ...`：
+    tree.value = {};
+    await listTree("");
+    for (const dir of [...expanded.value]) { if (dir) await listTree(dir).catch(() => {}); }
+    await loadStatus();
+    await loadGitSummary(instanceId.value, workspace.value);
+```
+
+3g. `reset()` 里追加 `tree.value = {}; expanded.value = new Set(); hits.value = []; root.value = ""; `（保持原有清理）。
+
+3h. 导出追加：`return { ...(现有), root, sep: sepChar, tree, expanded, loadingDirs, hits, searchOpts, listTree, toggleExpand, absPath };`
+> 注意：对外键名用 `sep`（映射到 `sepChar`），避免与 node 无关；`return` 里写 `sep: sepChar`。
+
+> 旧的逐目录 `list`/`open(dir)`/`up` 保留（Changes tab 与 openFile 仍用；树视图改用 listTree/toggleExpand）。`open(file)` 打开文件的分支保持不变。
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/files.test.ts`
+Expected: PASS（现有 + 3 新用例）。若现有用例因 selectWorkspace 改动而依赖 `entries`，注意现有测试仍调用 `list`/`open`——它们不变；新树状态是并列新增。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add packages/relay-web/src/stores/files.ts packages/relay-web/src/__tests__/files.test.ts
+git commit -m "feat(relay-web): files store tree state + advanced search params/hits + absPath"
+```
+
+---
+
+### Task 8: 前端 — `ContextMenu.vue` + `FileTreeNode.vue`（递归树节点 + 右键菜单）
+
+**Files:**
+- Create: `packages/relay-web/src/components/ContextMenu.vue`
+- Create: `packages/relay-web/src/components/FileTreeNode.vue`
+- Test: `packages/relay-web/src/__tests__/filetree.test.ts`
+
+**Interfaces:**
+- Consumes: `useFilesStore()`（Task 7：tree/expanded/toggleExpand/absPath/open/searchOpts/search）、`iconForFile`（Task 6）、i18n（Task 5）。
+- Produces:
+  - `ContextMenu.vue`：props `{ x: number; y: number; items: { key: string; label: string }[] }`，emit `select(key)`、`close`。
+  - `FileTreeNode.vue`：props `{ entry: FsEntryDto; dir: string; depth: number; showDotfiles: boolean; showGitignored: boolean }`，递归渲染子节点；emit `openFile(rel)`。
+
+- [ ] **Step 1: 写失败测试**
+
+Create `packages/relay-web/src/__tests__/filetree.test.ts`:
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount } from "@vue/test-utils";
+
+const rpc = vi.fn();
+vi.mock("../api/client", () => ({ api: { rpc: (id: string, t: string, p?: unknown) => rpc(id, t, p) } }));
+
+import FileTreeNode from "../components/FileTreeNode.vue";
+import { useFilesStore } from "../stores/files";
+
+const g = { global: { mocks: { $t: (k: string) => k } } };
+
+beforeEach(() => { setActivePinia(createPinia()); rpc.mockReset(); Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } }); });
+
+describe("FileTreeNode", () => {
+  it("renders a dir row with a chevron and lazy-expands on click", async () => {
+    const s = useFilesStore(); s.instanceId = "i1"; s.workspace = "ws"; s.root = "/abs"; s.sep = "/";
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "src", entries: [{ name: "a.ts", type: "file", size: 3 }], root: "/abs", sep: "/" });
+    const w = mount(FileTreeNode, { props: { entry: { name: "src", type: "dir" }, dir: "", depth: 0, showDotfiles: false, showGitignored: false }, ...g });
+    await w.find('[data-test="tree-row"]').trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(rpc).toHaveBeenCalledWith("i1", "control.fs.list", { workspace: "ws", path: "src" });
+    expect(s.expanded.has("src")).toBe(true);
+  });
+
+  it("hides dotfiles and gitignored children unless toggled on", async () => {
+    const s = useFilesStore(); s.instanceId = "i1"; s.workspace = "ws"; s.root = "/abs"; s.sep = "/";
+    s.tree[""] = [
+      { name: "keep.ts", type: "file" },
+      { name: ".env", type: "file" },
+      { name: "dist", type: "dir", ignored: true },
+    ] as never;
+    // depth 0 rendered by a parent; here mount each child via a wrapper list is simpler:
+    const rows = (showDot: boolean, showIgn: boolean) => mount({
+      components: { FileTreeNode },
+      template: `<div><FileTreeNode v-for="e in entries" :key="e.name" :entry="e" dir="" :depth="0" :show-dotfiles="sd" :show-gitignored="si" /></div>`,
+      data: () => ({ entries: s.tree[""], sd: showDot, si: showIgn }),
+    }, g);
+    expect(rows(false, false).findAll('[data-test="tree-row"]').length).toBe(1); // only keep.ts
+    expect(rows(true, true).findAll('[data-test="tree-row"]').length).toBe(3);
+  });
+
+  it("context menu copy path writes the absolute host path", async () => {
+    const s = useFilesStore(); s.instanceId = "i1"; s.workspace = "ws"; s.root = "/abs/ws"; s.sep = "/";
+    const w = mount(FileTreeNode, { props: { entry: { name: "a.ts", type: "file" }, dir: "src", depth: 1, showDotfiles: true, showGitignored: true }, ...g });
+    await w.find('[data-test="tree-row"]').trigger("contextmenu");
+    await w.find('[data-test="menu-copyPath"]').trigger("click");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/abs/ws/src/a.ts");
+  });
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/filetree.test.ts`
+Expected: FAIL — 组件不存在。
+
+- [ ] **Step 3: 实现 ContextMenu.vue**
+
+Create `packages/relay-web/src/components/ContextMenu.vue`:
+```vue
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount } from "vue";
+defineProps<{ x: number; y: number; items: { key: string; label: string }[] }>();
+const emit = defineEmits<{ select: [key: string]; close: [] }>();
+function onDocClick() { emit("close"); }
+function onKey(e: KeyboardEvent) { if (e.key === "Escape") emit("close"); }
+onMounted(() => { document.addEventListener("click", onDocClick); document.addEventListener("keydown", onKey); });
+onBeforeUnmount(() => { document.removeEventListener("click", onDocClick); document.removeEventListener("keydown", onKey); });
+</script>
+<template>
+  <div data-test="context-menu" class="fixed z-50 min-w-40 rounded-md border border-border bg-surface py-1 text-[12.5px] shadow-lg"
+       :style="{ left: x + 'px', top: y + 'px' }" @click.stop>
+    <button v-for="it in items" :key="it.key" :data-test="`menu-${it.key}`"
+            class="block w-full px-3 py-1.5 text-left text-fg hover:bg-raised"
+            @click="emit('select', it.key); emit('close')">{{ it.label }}</button>
+  </div>
+</template>
+```
+
+- [ ] **Step 4: 实现 FileTreeNode.vue**
+
+Create `packages/relay-web/src/components/FileTreeNode.vue`:
+```vue
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { ChevronRight, ChevronDown, Folder, FolderOpen } from "lucide-vue-next";
+import type { FsEntryDto } from "@ganglion/xacpx-relay-protocol";
+import { useFilesStore } from "../stores/files";
+import { iconForFile } from "../lib/file-icons";
+import ContextMenu from "./ContextMenu.vue";
+
+const props = defineProps<{ entry: FsEntryDto; dir: string; depth: number; showDotfiles: boolean; showGitignored: boolean }>();
+const emit = defineEmits<{ openFile: [rel: string] }>();
+const files = useFilesStore();
+
+const rel = computed(() => (props.dir ? `${props.dir}/${props.entry.name}` : props.entry.name));
+const isDir = computed(() => props.entry.type === "dir");
+const isDot = computed(() => props.entry.name.startsWith("."));
+const dim = computed(() => isDot.value || props.entry.ignored === true);
+const isOpen = computed(() => files.expanded.has(rel.value));
+const children = computed(() => files.tree[rel.value] ?? []);
+
+// A child is visible when it passes both toggles.
+function visible(e: FsEntryDto): boolean {
+  if (e.ignored && !props.showGitignored) return false;
+  if (e.name.startsWith(".") && !props.showDotfiles) return false;
+  return true;
+}
+const visibleChildren = computed(() => children.value.filter(visible));
+
+function onRowClick() {
+  if (isDir.value) void files.toggleExpand(rel.value);
+  else emit("openFile", rel.value);
+}
+
+// context menu (items are built inline in the template via i18n — see :items below)
+const menu = ref<{ x: number; y: number } | null>(null);
+function openMenu(e: MouseEvent) { menu.value = { x: e.clientX, y: e.clientY }; }
+async function onMenuSelect(key: string) {
+  if (key === "copyPath") await navigator.clipboard?.writeText(files.absPath(rel.value)).catch(() => {});
+  else if (key === "copyRelativePath") await navigator.clipboard?.writeText(rel.value).catch(() => {});
+  else if (key === "searchInFolder") { files.searchOpts.path = rel.value; }
+  menu.value = null;
+}
+</script>
+
+<template>
+  <div>
+    <button data-test="tree-row"
+            class="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left hover:bg-raised"
+            :style="{ paddingLeft: depth * 12 + 4 + 'px' }"
+            @click="onRowClick" @contextmenu.prevent="openMenu">
+      <component :is="isOpen ? ChevronDown : ChevronRight" v-if="isDir" :size="12" class="shrink-0 text-fg-muted" />
+      <span v-else class="w-3 shrink-0" />
+      <component :is="isDir ? (isOpen ? FolderOpen : Folder) : iconForFile(entry.name)" :size="13"
+                 class="shrink-0" :class="isDir ? 'text-warn' : 'text-fg-muted'" />
+      <span class="flex-1 truncate text-[12px]" :class="[dim ? 'opacity-45 italic' : '', isDir ? 'text-fg font-medium' : 'text-fg-muted']">{{ entry.name }}</span>
+    </button>
+
+    <div v-if="isDir && isOpen">
+      <FileTreeNode v-for="c in visibleChildren" :key="c.name" :entry="c" :dir="rel" :depth="depth + 1"
+                    :show-dotfiles="showDotfiles" :show-gitignored="showGitignored" @open-file="emit('openFile', $event)" />
+      <div v-if="!visibleChildren.length && files.tree[rel]" class="py-0.5 text-[11px] text-fg-muted" :style="{ paddingLeft: (depth + 1) * 12 + 16 + 'px' }">{{ $t("files.tree.emptyFolder") }}</div>
+    </div>
+
+    <ContextMenu v-if="menu" :x="menu.x" :y="menu.y"
+                 :items="isDir
+                   ? [{ key: 'copyPath', label: $t('files.menu.copyPath') }, { key: 'copyRelativePath', label: $t('files.menu.copyRelativePath') }, { key: 'searchInFolder', label: $t('files.menu.searchInFolder') }]
+                   : [{ key: 'copyPath', label: $t('files.menu.copyPath') }, { key: 'copyRelativePath', label: $t('files.menu.copyRelativePath') }]"
+                 @select="onMenuSelect" @close="menu = null" />
+  </div>
+</template>
+```
+> 删除上面 `menuItems`/`base` 那段占位（它是误留），菜单项直接在模板里按 i18n 生成——实现时不要保留 `menuItems` computed。（见模板内 `:items`。）
+
+- [ ] **Step 5: 运行确认通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/filetree.test.ts`
+Expected: PASS。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add packages/relay-web/src/components/ContextMenu.vue packages/relay-web/src/components/FileTreeNode.vue packages/relay-web/src/__tests__/filetree.test.ts
+git commit -m "feat(relay-web): recursive file tree node + context menu (copy path/rel/search-in-folder)"
+```
+
+---
+
+### Task 9: 前端 — `FilesPanel.vue` 接入树 + 高级搜索 UI + 切换（去面包屑/向上）
+
+**Files:**
+- Modify: `packages/relay-web/src/components/FilesPanel.vue`
+- Test: `packages/relay-web/src/__tests__/filespanel.test.ts`（更新/追加用例）
+
+**Interfaces:**
+- Consumes: `FileTreeNode.vue`（Task 8）、files store（Task 7）、i18n（Task 5）。
+
+- [ ] **Step 1: 写/更新失败测试**
+
+在 `filespanel.test.ts` 追加（并移除对 `fs-up`/breadcrumb 的旧断言，若有）：
+```ts
+it("renders the tree root (no breadcrumb / up button)", async () => {
+  // mount FilesPanel with a stubbed store root layer
+  const s = useFilesStore(); s.instanceId = "i1"; s.workspace = "ws"; s.tree[""] = [{ name: "src", type: "dir" }] as never;
+  // ...mount per existing filespanel.test harness...
+  // expect no fs-up:
+  // expect(w.find('[data-test="fs-up"]').exists()).toBe(false);
+  // expect a tree row for src:
+  // expect(w.find('[data-test="tree-row"]').exists()).toBe(true);
+});
+it("search toggles drive searchOpts", async () => {
+  // click data-test="search-regex" → s.searchOpts.regex === true
+  // click data-test="search-mode-content" → s.searchOpts.mode === "content"
+});
+it("dotfile/gitignore toggles persist and filter", async () => {
+  // click data-test="toggle-dotfiles" → localStorage xacpx.files.showDotfiles === "1"
+});
+```
+> 按 `filespanel.test.ts` 现有挂载 harness（mock store 或真实 pinia）补全断言主体；关键断言：无 `fs-up`、有 `tree-row`、`search-regex`/`search-mode-content` 改 `searchOpts`、`toggle-dotfiles`/`toggle-gitignored` 改状态并写 localStorage。
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/filespanel.test.ts`
+Expected: FAIL。
+
+- [ ] **Step 3: 改 FilesPanel.vue（Files tab 部分）**
+
+3a. script：新增 import `FileTreeNode`；新增 dotfile/gitignore 切换（localStorage 持久化）+ 搜索开关处理；删除 `crumbs`/`atRoot`/`upOne`。
+```ts
+import FileTreeNode from "./FileTreeNode.vue";
+// dotfile / gitignore toggles
+const showDotfiles = ref(localStorage.getItem("xacpx.files.showDotfiles") === "1");
+const showGitignored = ref(localStorage.getItem("xacpx.files.showGitignored") === "1");
+watch(showDotfiles, (v) => localStorage.setItem("xacpx.files.showDotfiles", v ? "1" : "0"));
+watch(showGitignored, (v) => localStorage.setItem("xacpx.files.showGitignored", v ? "1" : "0"));
+// visible root children (same predicate as FileTreeNode)
+const rootChildren = computed(() => (files.tree[""] ?? []).filter((e) =>
+  (!e.ignored || showGitignored.value) && (!e.name.startsWith(".") || showDotfiles.value)));
+function openTreeFile(rel: string) { files.diffPath = null; void files.openFile(rel); }
+// re-run search when opts change while a query is active
+watch(() => ({ ...files.searchOpts }), () => { if (files.query.trim()) void files.search(files.query); }, { deep: true });
+```
+
+3b. template：把"browsing: 面包屑 + 目录 ul"整块（现 `<template v-else> ... </template>`，含 `fs-up` 按钮与 `<ul class="... file listing ...">`）替换为树：
+```html
+<template v-else>
+  <div class="flex shrink-0 items-center gap-3 border-b border-border px-2.5 py-1 text-[11px] text-fg-muted">
+    <label class="flex items-center gap-1 cursor-pointer"><input type="checkbox" data-test="toggle-dotfiles" v-model="showDotfiles" class="accent-accent" />{{ $t("files.toggle.showDotfiles") }}</label>
+    <label class="flex items-center gap-1 cursor-pointer"><input type="checkbox" data-test="toggle-gitignored" v-model="showGitignored" class="accent-accent" />{{ $t("files.toggle.showGitignored") }}</label>
+  </div>
+  <div class="min-h-0 flex-1 overflow-y-auto thin-scroll py-1 font-mono">
+    <FileTreeNode v-for="e in rootChildren" :key="e.name" :entry="e" dir="" :depth="0"
+                  :show-dotfiles="showDotfiles" :show-gitignored="showGitignored" @open-file="openTreeFile" />
+    <div v-if="!rootChildren.length && !files.loading" class="px-3 py-1 text-xs text-fg-muted">{{ $t("files.emptyDirectory") }}</div>
+  </div>
+</template>
+```
+
+3c. 搜索区：在现有搜索 input 行右侧加三个开关按钮 + 下方 include/exclude + 模式切换。把搜索 `<div class="... px-2 py-1">` 块扩展：
+```html
+<div class="shrink-0 border-b border-border px-2 py-1 space-y-1">
+  <div class="flex items-center gap-1">
+    <input v-model="searchInput" data-test="fs-search" :placeholder="$t('files.searchPlaceholder')"
+           class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-1 text-xs text-fg placeholder:text-fg-muted" @input="onSearchInput" />
+    <button data-test="search-matchcase" :title="$t('files.search.matchCase')" @click="files.searchOpts.matchCase = !files.searchOpts.matchCase"
+            class="grid h-6 w-6 place-items-center rounded text-[11px]" :class="files.searchOpts.matchCase ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">Aa</button>
+    <button data-test="search-wholeword" :title="$t('files.search.wholeWord')" @click="files.searchOpts.wholeWord = !files.searchOpts.wholeWord"
+            class="grid h-6 w-6 place-items-center rounded text-[11px]" :class="files.searchOpts.wholeWord ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">W</button>
+    <button data-test="search-regex" :title="$t('files.search.regex')" @click="files.searchOpts.regex = !files.searchOpts.regex"
+            class="grid h-6 w-6 place-items-center rounded font-mono text-[11px]" :class="files.searchOpts.regex ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">.*</button>
+    <button v-if="searchInput" :aria-label="$t('files.clearSearch')" class="text-fg-muted hover:text-fg" @click="clearSearch"><X :size="14" /></button>
+  </div>
+  <div class="flex items-center gap-1">
+    <input v-model="files.searchOpts.include" data-test="search-include" :placeholder="$t('files.search.include')" class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-0.5 text-[11px] text-fg placeholder:text-fg-muted" />
+    <input v-model="files.searchOpts.exclude" data-test="search-exclude" :placeholder="$t('files.search.exclude')" class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-0.5 text-[11px] text-fg placeholder:text-fg-muted" />
+  </div>
+  <div class="flex items-center gap-1 text-[11px]">
+    <button data-test="search-mode-name" @click="files.searchOpts.mode = 'name'" class="rounded px-2 py-0.5" :class="files.searchOpts.mode === 'name' ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">{{ $t("files.search.byName") }}</button>
+    <button data-test="search-mode-content" @click="files.searchOpts.mode = 'content'" class="rounded px-2 py-0.5" :class="files.searchOpts.mode === 'content' ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">{{ $t("files.search.byContent") }}</button>
+  </div>
+</div>
+```
+
+3d. 搜索结果：内容模式渲染 hits（按文件分组），名字模式沿用现有 results 列表。在现有 `fs-results` 块加内容分支：
+```html
+<div v-if="files.query.trim()" data-test="fs-results" class="min-h-0 flex-1 overflow-y-auto thin-scroll">
+  <template v-if="files.searchOpts.mode === 'content'">
+    <div v-if="!files.hits.length && !files.searching" class="px-3 py-1 text-xs text-fg-muted">{{ $t("files.search.noContentMatches") }}</div>
+    <ul class="p-2 text-[11px] font-mono leading-5">
+      <li v-for="(h, i) in files.hits" :key="i">
+        <button data-test="fs-hit" class="flex w-full items-baseline gap-2 rounded px-1.5 py-0.5 text-left hover:bg-raised" @click="openSearchResult(h.path)">
+          <span class="shrink-0 text-fg-muted/70">{{ h.path }}:{{ h.line }}</span>
+          <span class="truncate text-fg-muted">{{ h.text }}</span>
+        </button>
+      </li>
+    </ul>
+    <div v-if="files.searchTruncated" class="px-2.5 pb-1 text-xs text-warn">{{ $t("files.showingFirstMatches") }}</div>
+  </template>
+  <template v-else>
+    <!-- existing name-mode results list unchanged -->
+  </template>
+</div>
+```
+（保留现有名字模式 `<ul>` 结果块，移入 `v-else`。）
+
+- [ ] **Step 4: 运行确认通过 + typecheck**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/filespanel.test.ts && npx vue-tsc --noEmit -p tsconfig.json`
+Expected: PASS；tsc 干净（无 `crumbs`/`upOne`/`fs-up` 残留引用）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add packages/relay-web/src/components/FilesPanel.vue packages/relay-web/src/__tests__/filespanel.test.ts
+git commit -m "feat(relay-web): FilesPanel tree view + advanced search UI + dotfile/gitignore toggles (drop breadcrumb/up)"
+```
+
+---
+
+### Task 10: 前端 — 移动端右栏抽屉满宽
+
+**Files:**
+- Modify: `packages/relay-web/src/views/DashboardView.vue`（右栏 `data-drawer="right"` 的 class）
+- Test: `packages/relay-web/src/__tests__/dashboard-responsive.test.ts`（追加用例）
+
+- [ ] **Step 1: 写失败测试**
+
+追加：
+```ts
+test("right drawer is full-width on mobile (no 85% cap)", async () => {
+  const wrapper = mountDash();
+  await flushPromises();
+  const right = wrapper.find('[data-drawer="right"]');
+  expect(right.classes()).toContain("w-full");
+  expect(right.classes()).not.toContain("max-w-[85%]");
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/dashboard-responsive.test.ts`
+Expected: FAIL — 右栏仍是 `w-72 max-w-[85%]`。
+
+- [ ] **Step 3: 改 DashboardView.vue（第 331 行右栏 class）**
+
+把右栏 `data-drawer="right"` 的 class 中的 `w-72 max-w-[85%]` 改为 `w-full`（其余不变，`lg:w-[296px] lg:max-w-none` 保留）：
+```
+class="fixed inset-y-0 right-0 z-40 flex w-full shrink-0 transform flex-col overflow-hidden border-l border-border bg-surface shadow-lg transition-transform pt-[env(safe-area-inset-top)] lg:relative lg:z-auto lg:w-[296px] lg:max-w-none lg:translate-x-0 lg:transform-none lg:shadow-none lg:pt-0"
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/dashboard-responsive.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add packages/relay-web/src/views/DashboardView.vue packages/relay-web/src/__tests__/dashboard-responsive.test.ts
+git commit -m "feat(relay-web): right drawer full-width on mobile"
+```
+
+---
+
+### Task 11: 全量回归 + 构建验证 + 文档
+
+**Files:**
+- Modify: `docs/relay-web-module.md`（加"Files/文件树浏览器"小节）
+
+- [ ] **Step 1: 后端/连接器/协议回归**
+
+Run:
+```bash
+bun test tests/unit/control/workspace-fs.test.ts tests/unit/packages/relay-protocol/web-dtos.test.ts tests/unit/packages/channel-relay/control-bridge.test.ts
+npx tsc --noEmit
+```
+Expected: 全绿；tsc 0 错误。
+
+- [ ] **Step 2: relay-web 全量单测**
+
+Run: `cd packages/relay-web && npx vitest run`
+Expected: 全绿（含 file-icons/files/filetree/filespanel/dashboard-responsive/i18n-parity）。
+
+- [ ] **Step 3: 真实构建**
+
+Run: `bun run build:relay-web`
+Expected: 成功（vue-tsc 干净 + vite build）。
+
+- [ ] **Step 4: 文档小节**
+
+在 `docs/relay-web-module.md` 增加一节，说明 Files tab 现为懒加载树（`control.fs.list` 逐层）、gitignore/点文件 默认隐藏可切换、高级搜索（name/content、大小写/整词/正则/include/exclude/path）、右键复制路径/相对路径/在此搜索、移动端右栏满宽；并注明写操作在子项目 B。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add docs/relay-web-module.md
+git commit -m "docs(relay-web): document file tree browser (sub-project A)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage：**
+- 需求 1 树视图/图标/去面包屑 → Task 6（图标）/8（节点）/9（面板+去面包屑）✅
+- 需求 2 gitignore/点文件 淡化+斜体 → Task 1（后端 ignored）/8（节点淡化样式）✅
+- 需求 3 高级搜索（include/exclude/大小写/整词/正则 + 内容 grep）→ Task 2（后端）/3（协议）/4（透传）/7（store）/9（UI）✅
+- 需求 5 显示点文件/显示 gitignore 切换 → Task 9（切换 + 持久化）/8（过滤谓词）✅
+- 需求 6 移动端满宽 → Task 10 ✅
+- 需求 4 只读子集（复制路径/复制相对路径/在此文件夹搜索）→ Task 8（菜单）；复制路径=主机绝对路径依赖 Task 1 的 root/sep + Task 7 的 absPath ✅
+- 写操作/下载/在 OS 打开 → 明确留给 B（本计划非目标）✅
+
+**Placeholder scan：** 各 code 步给出完整代码；Task 8 的 `menuItems` 占位已移除（菜单项在模板 `:items` 内按 i18n 生成）。Task 9 的 filespanel 测试主体依赖现有 harness，已给出关键断言与 data-test 契约（挂载样板对齐现有文件），实现者按现有 filespanel.test.ts 的挂载方式补全测试体。
+
+**Type consistency：** `FsEntryDto.ignored`、`FsListResult.root/sep`、`FsSearchHitDto{path,line,text}`、`FsSearchPayload`/`FsSearchResult.hits`、`SearchOptions`、store 的 `searchOpts`/`hits`/`absPath`/`listTree`/`toggleExpand`、组件 props 跨任务一致。store 对外键 `sep`（内部 `sepChar`）已注明。`search(workspace, opts)` 新签名在 Task 2 定义、Task 4 消费一致。
+
+## 备注
+- gitignore 标记与内容 grep 都在非 git/ git 缺失时静默降级；内容 grep 默认（git grep）不搜被忽略文件，符合"忽略"语义。
+- 跳转到具体行为尽力（FileViewer 现不支持行定位），A 只保证打开文件。
+- B 子项目（写/下载/OS 打开）另开分支与 spec，复用本计划的 ContextMenu/树骨架与后端 resolve()。

--- a/docs/superpowers/specs/2026-07-01-relay-web-file-tree-browser-design.md
+++ b/docs/superpowers/specs/2026-07-01-relay-web-file-tree-browser-design.md
@@ -1,0 +1,119 @@
+# relay-web 文件树浏览器（子项目 A：只读树 + 高级搜索 + gitignore 感知）
+
+状态：设计已确认，待评审
+日期：2026-07-01
+分支：feat/relay-web-file-tree（off main ff05dae）
+
+## 范围拆分
+
+原始需求（6 条）拆成两份 spec，本 spec 只覆盖 **A（只读浏览体验）**：
+
+- **A（本 spec）**：树视图、gitignore/点文件 样式+切换、高级搜索（文件名 + 内容 grep）、移动端满宽、右键菜单里**无副作用**的项（复制路径/复制相对路径/在此文件夹搜索）。全部**只读**，无文件系统写入，不新增 config 门。
+- **B（另开 spec）**：写/执行能力——新建文件、新建文件夹、复制(副本)、重命名、删除、下载、在 OS 文件浏览器打开。安全门控（默认关）。A 把右键菜单骨架搭好，B 往里加项。
+
+## 背景
+
+当前 Files 面板（`FilesPanel.vue` + `stores/files.ts`）是**逐目录扁平列表** + 面包屑 + 向上按钮；搜索是相对路径子串扁平匹配；无 gitignore/点文件 感知；整条 `control.fs.*` 链只读。后端 `WorkspaceFs.resolve()` 是唯一收口（workspace 名白名单 + realpath 包含检查，符号链接安全），所有方法都走它。
+
+## 目标 / 非目标
+
+**目标**
+- Files tab 改为懒加载**树视图**（去面包屑/向上按钮），文件夹展开/折叠图标 + 按扩展名的多类型文件图标。
+- gitignore 命中项与点文件：默认隐藏，两个切换可显示；显示时以**低透明度 + 斜体**呈现（视觉"被忽略"感）。
+- 高级搜索：**精确大小写 / 匹配整词 / 正则** 三开关 + **包含/排除 glob** 两字段 + **[文件名 | 内容]** 模式切换；内容模式为 grep。
+- 右键菜单（A 子集）：复制路径（主机绝对路径）、复制相对路径（workspace 根相对）、在此文件夹搜索（文件夹）。
+- 移动端右栏抽屉满屏宽。
+
+**非目标（留给 B）**
+- 任何文件系统写入（新建/重命名/删除/复制副本）、下载、在 OS 打开。
+- 内容搜索命中的语法高亮、跨文件替换。
+- 跳转到具体行（FileViewer 若不支持行定位，A 只负责打开该文件，跳行尽力而非必须）。
+
+## 架构
+
+relay-web 前端为主 + 少量**只读**后端扩展。数据路径不变：relay-web `files` store → `control.fs.*` RPC → hub `/rpc`（ownership 门）→ connector `control-bridge` → core `ControlService` → `WorkspaceFs`。安全模型三道闸沿用（account-owns-instance → workspace 名白名单 → realpath 包含）。**本子项目只读，不加 config 门。**
+
+新增/变化的后端能力全部作为 `WorkspaceFs` 上的新逻辑或现有方法的扩展，复用同一 `resolve()`，不另开路径。
+
+## 组件与数据流
+
+### 1. 树视图（需求 1）
+
+- **前端**：`FilesPanel.vue` 的 Files tab 用递归树组件（新增 `FileTree.vue` + 递归 `FileTreeNode.vue`，或 `FilesPanel` 内递归渲染）。根 = workspace 根目录（进入即列根层）。展开一个文件夹时，若其子项未加载，调用现有 `control.fs.list({workspace, path})` 拉该目录一层，缓存到节点。折叠只隐藏、不丢缓存。
+- 去掉面包屑区块与 `data-test="fs-up"` 向上按钮及 `upOne()`。保留顶部 workspace 标签 + 刷新按钮（刷新=清树缓存并重列已展开层）。Changes tab 完全不动。
+- **图标**：文件夹展开态 `FolderOpen`、折叠态 `Folder`，前置 `ChevronDown`/`ChevronRight`。文件按扩展名映射 lucide 图标，新增 `src/lib/file-icons.ts`（纯函数 `iconForFile(name) → Component`），覆盖约 18 类：ts/js/tsx/jsx→FileCode、json→FileJson、md→FileText、png/jpg/svg/gif/webp→FileImage、css/scss→FileType、html/vue→FileCode、yml/yaml/toml/ini/env→FileCog、lock→FileLock、sh→FileTerminal、zip/tar/gz→FileArchive、pdf→FileText、默认→File。零新依赖（全来自 lucide-vue-next）。
+- **展开态持久化**：按 workspace 存 `localStorage["xacpx.fileTree.expanded.<ws>"]`（展开目录相对路径集合）。挂载时恢复并预拉这些层。
+- 点文件 → 仍走 `files.open(entry)` 在中间 FileViewer 打开（不变）。选中项高亮沿用现有 accent 样式；git 状态点徽标沿用现有 `changed` 逻辑，按树节点相对路径匹配。
+
+### 2. gitignore / 点文件（需求 2、5）
+
+- **后端**：`FsEntryDto` 增加可选 `ignored?: boolean`。`WorkspaceFs.listDirectory` 在 readdir 后，对本层条目批量跑 `git check-ignore -z --stdin`（cwd = workspace 根），命中者标 `ignored:true`；workspace 非 git 仓库或 git 缺失 → 全部 `ignored` 省略（视为未忽略），不报错。dotfile **不**由后端标记——前端按 `name.startsWith(".")` 判定。
+- **前端**：两个切换 `showDotfiles`、`showGitignored`，**默认关**，各存 localStorage。过滤规则：`ignored` 项在 `showGitignored=false` 时隐藏；dotfile 在 `showDotfiles=false` 时隐藏（两条件独立，一个项可能既是 dotfile 又 ignored，任一开关关闭即隐藏其对应维度——实现为"要显示该项，需满足 (非 ignored 或 showGitignored) 且 (非 dotfile 或 showDotfiles)"）。
+- **样式**：显示出来的 ignored 或 dotfile 项，行文字用**低透明度**（如 `opacity-45` / `text-fg-muted/50`，视觉融入背景）**+ 斜体**（`italic`）。两类可共用同一"淡化"样式类。
+- 默认隐藏使 `node_modules`（通常 gitignored）与 `.git`（dotfile）自然不出现在树里，避免大目录卡顿。
+
+### 3. 高级搜索（需求 3）
+
+- **UI**（Files tab 顶部搜索区扩展）：主查询输入框 + 三个可点亮开关按钮 **Aa（精确大小写）/ ￧（匹配整词）/ .\*（正则）**（沿 VSCode 惯例，放输入框右侧），下方两个小输入 **包含(glob)** / **排除(glob)**，以及一个模式切换 **[文件名 | 内容]**。开关/模式状态存 localStorage。查询 250ms 防抖。
+- **协议**：`FsSearchPayload` 扩展为 `{ workspace, query, mode: "name" | "content", matchCase?: boolean, wholeWord?: boolean, regex?: boolean, include?: string, exclude?: string, path?: string }`（`path` = 作用域基目录，供"在此文件夹搜索"；缺省=整个 workspace）。`FsSearchResult` 扩展为 `{ workspace, query, matches: string[], hits: FsSearchHitDto[], truncated: boolean }`，其中 `FsSearchHitDto = { path: string; line: number; text: string }`；名字模式只填 `matches`，内容模式只填 `hits`。
+- **后端**（`WorkspaceFs.search`）：
+  - `mode:"name"`：现有 BFS 路径匹配的增强——支持 `matchCase`/`wholeWord`/`regex` 应用于路径，`include`/`exclude` 作为 glob 过滤，`path` 限定起始目录。上限沿用（扫描/结果 cap）。
+  - `mode:"content"`：优先 `git grep`（`git grep -n --column -I --no-color`，`-i` ←!matchCase 时加、`-w` ←wholeWord、`-E`/`-F` ←regex 与否，pathspec 追加 `-- <path 或 .>` 及 include/exclude 转成的 `:(glob)`/`:(exclude,glob)`）；非 git 仓库或 git 缺失时**回退**手写走查（复用现有 BFS + 逐行匹配，跳过 `.git`/`node_modules`、不跟符号链接、尊重 read cap）。结果 cap（如 ≤200 文件、≤500 命中，超出置 `truncated`）。
+  - 两模式都不返回 ignored/大二进制文件的内容命中（`-I` 跳二进制；回退路径按现有 binary 判定跳过）。
+- **前端渲染**：名字模式=现有扁平列表（复用）。内容模式=按文件分组，组内列出 `行号: 行预览`，点某命中 → `files.openFile(path)` 打开该文件（跳行尽力）。`truncated` 时显示"仅显示前 N 条"。
+- **在此文件夹搜索**（右键项）：设 `path` = 该目录相对路径 + 聚焦搜索框（默认内容模式），把作用域限定到该子树。
+
+### 4. 右键菜单骨架（需求 4 的只读子集）
+
+- 新增通用右键菜单组件（`ContextMenu.vue`，绝对定位、点击外部/Esc 关闭、贴边翻转防溢出），供树节点使用；设计成可注入菜单项数组，B 复用同一组件追加写操作项。
+- **A 的菜单项**：
+  - 文件 & 文件夹：**复制路径**（主机绝对路径）、**复制相对路径**（workspace 根相对路径）。
+  - 文件夹另加：**在此文件夹搜索**。
+- **复制路径 = 主机绝对路径**：需要主机绝对根。`FsListResult` 增加 `root: string`（`resolve()` 已 realpath 的工作区绝对根）与 `sep: "/" | "\\"`（主机分隔符）。前端"复制路径" = `root + sep + relPath.split("/").join(sep)`；"复制相对路径" = `relPath`（workspace 根相对，内部用 `/`）。二者经 `navigator.clipboard.writeText`，失败静默。
+  - **安全说明**：这会向已通过 ownership 的属主暴露 connector 主机的绝对目录布局。属主本就能浏览该 workspace 内容，风险等同现状 + 主机路径前缀；用户明确要此行为。不改变任何写能力。
+
+### 5. 移动端满宽（需求 6）
+
+- `DashboardView.vue` 右栏抽屉（`data-drawer="right"`）在 `<lg`（移动端抽屉态）宽度从 `w-72 max-w-[85%]` 改为**满屏宽**（`w-full`，去掉 `max-w-[85%]` 上限；`lg:` 静态列宽度与拖拽逻辑不变）。左栏与 backdrop 不动。
+
+## 协议变更汇总（relay-protocol）
+
+- `dtos.ts`：`FsEntryDto` 增 `ignored?: boolean`；新增 `FsSearchHitDto { path: string; line: number; text: string }`。
+- `messages.ts`：`FsListResult` 增 `root: string`、`sep: "/" | "\\"`；`FsSearchPayload` 增 `mode/matchCase/wholeWord/regex/include/exclude/path`（除 `mode` 外均可选；`mode` 缺省视为 `"name"` 以兼容）；`FsSearchResult` 增 `hits: FsSearchHitDto[]`（`matches` 保留）。
+- 全部**向后兼容增量**（新字段可选/有缺省），protocol 保持 0.1.x（沿用 `^0.1.0` range，见 [[reference_release_version_coupling]]）。
+
+## 边界与文件结构
+
+- `src/lib/file-icons.ts`（新）：`iconForFile(name)` 纯函数，单一职责=扩展名→lucide 组件。
+- `FileTree.vue` / `FileTreeNode.vue`（新）：递归树渲染 + 展开/折叠 + 懒加载调用；节点样式（选中/ignored/dotfile 淡化/git 徽标）。
+- `ContextMenu.vue`（新）：通用菜单，菜单项由父组件注入。
+- `FilesPanel.vue`（改）：Files tab 换成树 + 新搜索区；去面包屑/向上；Changes tab 不动。
+- `stores/files.ts`（改）：树节点缓存与展开态、搜索参数与 hits、`root`/`sep`。保持 store 为唯一数据/RPC 入口。
+- `src/control/workspace-fs.ts`（改）：listDirectory 加 ignored 标记 + 返回 root/sep；search 加 mode/flags/include/exclude/path 与内容 grep。
+- `packages/channel-relay/src/control-bridge.ts`（改）：透传扩展后的 search payload 字段（list 无需改签名）。
+
+## 测试计划
+
+- **后端（bun，tests/unit/control/workspace-fs.test.ts 扩展）**：
+  - listDirectory 在 git 仓库里对 gitignored 条目标 `ignored:true`；非 git 仓库不标、不报错；返回的 `root` 为绝对 realpath、`sep` 合理。
+  - search name 模式：matchCase/wholeWord/regex/include/exclude/path 各自生效；content 模式：git grep 命中返回 {path,line,text}，非 git 回退走查命中，二进制跳过，超限置 truncated。
+  - path-traversal 守卫对新 search path 仍生效（`..`/符号链接不越界）。
+- **前端（vitest，cwd=packages/relay-web）**：
+  - 树：展开触发懒加载 list、折叠保留缓存、展开态持久化恢复；文件夹开/合图标切换；`iconForFile` 映射若干扩展名。
+  - ignored/dotfile：默认隐藏；开关打开后出现且带淡化+斜体类；组合过滤逻辑正确。
+  - 搜索：三开关 + include/exclude + 模式切换驱动正确的 `control.fs.search` payload；内容 hits 分组渲染；名字 matches 渲染；truncated 提示。
+  - 右键菜单：复制路径=`root+sep+relpath`、复制相对路径=relpath（mock clipboard 断言写入值）；文件夹"在此文件夹搜索"设置作用域 path。
+  - DashboardView：移动端右栏抽屉满宽（`w-full`、无 `max-w-[85%]`）。
+- i18n：新增 en/zh 键（树/搜索开关/菜单项/切换标签），`i18n-parity` 守卫。
+
+## 风险与缓解
+
+- **git check-ignore 每次展开一调**：懒加载下每目录一次，可接受；结果随该层缓存，折叠再展开不重调（除非刷新）。非 git/无 git 静默跳过。
+- **内容 grep 体量**：`git grep` 天然尊重 gitignore、快；回退走查有扫描/结果 cap + 二进制/大文件跳过，避免拉爆。命中 cap + truncated 提示。
+- **主机绝对路径暴露**：属主可见、经 ownership 门，用户明确要；不引入任何写能力。
+- **大目录**：默认隐藏 gitignored+dotfiles 使 node_modules/.git 不进树；单层仍受 `MAX_ENTRIES=2000` 保护。
+- **跳转到行**：FileViewer 现不支持行定位，A 只保证打开文件，跳行为尽力（不阻塞）。
+
+## 版本 / 发布
+
+随下一个 core/relay 版本发布（web 静态资源由 hub 提供）。协议增量兼容、保持 0.1.x。B 子项目另开分支/spec。

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -211,7 +211,16 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
     case MSG.fsSearch: {
       const input = payload as FsSearchPayload;
       if (!input.workspace) return errorPayload("bad-request", "workspace is required");
-      return await control.searchWorkspace(input.workspace, input.query ?? ""); // SearchResult ≅ FsSearchResult
+      return await control.searchWorkspace(input.workspace, {
+        query: input.query ?? "",
+        mode: input.mode,
+        matchCase: input.matchCase,
+        wholeWord: input.wholeWord,
+        regex: input.regex,
+        include: input.include,
+        exclude: input.exclude,
+        path: input.path,
+      }); // SearchResult ≅ FsSearchResult
     }
     case MSG.sessionModelGet: {
       const input = payload as SessionModelGetPayload;

--- a/packages/relay-protocol/dist/dtos.d.ts
+++ b/packages/relay-protocol/dist/dtos.d.ts
@@ -43,6 +43,14 @@ export interface FsEntryDto {
     type: "dir" | "file";
     /** File size in bytes; omitted for directories. */
     size?: number;
+    /** True when git considers the entry ignored (omitted in non-git workspaces). */
+    ignored?: boolean;
+}
+/** One content-search match line (mode:"content"). */
+export interface FsSearchHitDto {
+    path: string;
+    line: number;
+    text: string;
 }
 /** A changed file in a workspace's git working tree. `status` is the porcelain XY
  *  code (e.g. " M", "A ", "??", "D "). */

--- a/packages/relay-protocol/dist/messages.d.ts
+++ b/packages/relay-protocol/dist/messages.d.ts
@@ -1,4 +1,4 @@
-import type { AgentCatalogEntryDto, AgentDto, ControlEventDto, FsDiffFileDto, FsEntryDto, OrchestrationTaskDto, ScheduledTaskDto, SessionDto, WorkspaceDto } from "./dtos.js";
+import type { AgentCatalogEntryDto, AgentDto, ControlEventDto, FsDiffFileDto, FsEntryDto, FsSearchHitDto, OrchestrationTaskDto, ScheduledTaskDto, SessionDto, WorkspaceDto } from "./dtos.js";
 export declare const MSG: {
     readonly instanceRegister: "instance.register";
     readonly instanceAuth: "instance.auth";
@@ -282,6 +282,10 @@ export interface FsListResult {
     /** Normalized path relative to the workspace root ("" = root). */
     path: string;
     entries: FsEntryDto[];
+    /** Absolute realpath'd workspace root on the connector host. */
+    root: string;
+    /** Host path separator. */
+    sep: "/" | "\\";
 }
 export interface FsReadPayload {
     workspace: string;
@@ -324,14 +328,28 @@ export interface FsDiffResult {
 }
 export interface FsSearchPayload {
     workspace: string;
-    /** Case-insensitive substring matched against each file's relative path. */
+    /** Case-insensitive substring matched against each file's relative path (name mode)
+     *  or file content (content mode). */
     query: string;
+    /** Search target; defaults to "name" when omitted. */
+    mode?: "name" | "content";
+    matchCase?: boolean;
+    wholeWord?: boolean;
+    regex?: boolean;
+    /** Glob to restrict matches (relative to workspace root). */
+    include?: string;
+    /** Glob to drop matches. */
+    exclude?: string;
+    /** Base directory (relative) to scope the search. */
+    path?: string;
 }
 export interface FsSearchResult {
     workspace: string;
     query: string;
-    /** Matching file paths relative to the workspace root. */
+    /** Matching file paths relative to the workspace root (name mode). */
     matches: string[];
+    /** Content matches (content mode). */
+    hits: FsSearchHitDto[];
     /** True when the result cap was hit. */
     truncated: boolean;
 }

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -47,6 +47,15 @@ export interface FsEntryDto {
   type: "dir" | "file";
   /** File size in bytes; omitted for directories. */
   size?: number;
+  /** True when git considers the entry ignored (omitted in non-git workspaces). */
+  ignored?: boolean;
+}
+
+/** One content-search match line (mode:"content"). */
+export interface FsSearchHitDto {
+  path: string;
+  line: number;
+  text: string;
 }
 
 /** A changed file in a workspace's git working tree. `status` is the porcelain XY

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -1,4 +1,4 @@
-import type { AgentCatalogEntryDto, AgentDto, ControlEventDto, FsDiffFileDto, FsEntryDto, OrchestrationTaskDto, ScheduledTaskDto, SessionDto, WorkspaceDto } from "./dtos.js";
+import type { AgentCatalogEntryDto, AgentDto, ControlEventDto, FsDiffFileDto, FsEntryDto, FsSearchHitDto, OrchestrationTaskDto, ScheduledTaskDto, SessionDto, WorkspaceDto } from "./dtos.js";
 
 // Instance <-> relay message types. Convention: chatKey for relay-driven chats
 // is `relay:<accountId>`; the relay server stamps chatKey/senderId/isOwner on
@@ -307,6 +307,10 @@ export interface FsListResult {
   /** Normalized path relative to the workspace root ("" = root). */
   path: string;
   entries: FsEntryDto[];
+  /** Absolute realpath'd workspace root on the connector host. */
+  root: string;
+  /** Host path separator. */
+  sep: "/" | "\\";
 }
 export interface FsReadPayload {
   workspace: string;
@@ -346,14 +350,28 @@ export interface FsDiffResult {
 }
 export interface FsSearchPayload {
   workspace: string;
-  /** Case-insensitive substring matched against each file's relative path. */
+  /** Case-insensitive substring matched against each file's relative path (name mode)
+   *  or file content (content mode). */
   query: string;
+  /** Search target; defaults to "name" when omitted. */
+  mode?: "name" | "content";
+  matchCase?: boolean;
+  wholeWord?: boolean;
+  regex?: boolean;
+  /** Glob to restrict matches (relative to workspace root). */
+  include?: string;
+  /** Glob to drop matches. */
+  exclude?: string;
+  /** Base directory (relative) to scope the search. */
+  path?: string;
 }
 export interface FsSearchResult {
   workspace: string;
   query: string;
-  /** Matching file paths relative to the workspace root. */
+  /** Matching file paths relative to the workspace root (name mode). */
   matches: string[];
+  /** Content matches (content mode). */
+  hits: FsSearchHitDto[];
   /** True when the result cap was hit. */
   truncated: boolean;
 }

--- a/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
@@ -294,3 +294,11 @@ test("opening the terminal closes an already-open right drawer (rightOpen mutual
   await flushPromises();
   expect(right.classes()).toContain("translate-x-full");
 });
+
+test("right drawer is full-width on mobile (no 85% cap)", async () => {
+  const wrapper = mountDash();
+  await flushPromises();
+  const right = wrapper.find('[data-drawer="right"]');
+  expect(right.classes()).toContain("w-full");
+  expect(right.classes()).not.toContain("max-w-[85%]");
+});

--- a/packages/relay-web/src/__tests__/file-icons.test.ts
+++ b/packages/relay-web/src/__tests__/file-icons.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { FileCode, FileJson, FileImage, File as FileIcon } from "lucide-vue-next";
+import { iconForFile } from "../lib/file-icons";
+
+describe("iconForFile", () => {
+  it("maps known extensions", () => {
+    expect(iconForFile("main.ts")).toBe(FileCode);
+    expect(iconForFile("data.json")).toBe(FileJson);
+    expect(iconForFile("logo.svg")).toBe(FileImage);
+    expect(iconForFile("photo.PNG")).toBe(FileImage); // case-insensitive
+  });
+  it("falls back to a generic file icon", () => {
+    expect(iconForFile("mystery.xyz")).toBe(FileIcon);
+    expect(iconForFile("noext")).toBe(FileIcon);
+  });
+});

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -57,7 +57,7 @@ describe("files store", () => {
     await s.selectWorkspace("i1", "ws");
     rpc.mockResolvedValueOnce({ workspace: "ws", query: "a.ts", matches: ["src/a.ts"], truncated: false });
     await s.search("a.ts");
-    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.search", { workspace: "ws", query: "a.ts" });
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.search", { workspace: "ws", query: "a.ts", mode: "name", matchCase: false, wholeWord: false, regex: false, include: "", exclude: "", path: "" });
     expect(s.results).toEqual(["src/a.ts"]);
     rpc.mockResolvedValueOnce({ workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false });
     await s.openFile("src/a.ts");
@@ -195,5 +195,41 @@ describe("files store", () => {
     const s = useFilesStore();
     await s.selectWorkspace("i1", "ws");
     expect(s.error).toBe("path-escapes-workspace");
+  });
+});
+
+describe("files store: tree + advanced search", () => {
+  it("listTree caches a directory layer and records root/sep", async () => {
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [{ name: "src", type: "dir" }], root: "/abs/ws", sep: "/" });
+    const s = useFilesStore();
+    s.instanceId = "i1"; s.workspace = "ws";
+    await s.listTree("");
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.list", { workspace: "ws", path: "" });
+    expect(s.tree[""].map((e) => e.name)).toEqual(["src"]);
+    expect(s.root).toBe("/abs/ws");
+    expect(s.absPath("src/a.ts")).toBe("/abs/ws/src/a.ts");
+  });
+
+  it("toggleExpand lazy-loads then toggles without refetching", async () => {
+    const s = useFilesStore();
+    s.instanceId = "i1"; s.workspace = "ws";
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "src", entries: [{ name: "a.ts", type: "file", size: 3 }], root: "/abs/ws", sep: "/" });
+    await s.toggleExpand("src");
+    expect(s.expanded.has("src")).toBe(true);
+    expect(s.tree["src"].length).toBe(1);
+    rpc.mockClear();
+    await s.toggleExpand("src"); // collapse — no fetch
+    expect(s.expanded.has("src")).toBe(false);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("content search sends advanced options and fills hits", async () => {
+    const s = useFilesStore();
+    s.instanceId = "i1"; s.workspace = "ws";
+    s.searchOpts.mode = "content"; s.searchOpts.regex = true; s.searchOpts.include = "**/*.ts";
+    rpc.mockResolvedValueOnce({ workspace: "ws", query: "foo", matches: [], hits: [{ path: "a.ts", line: 2, text: "foo" }], truncated: false });
+    await s.search("foo");
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.search", { workspace: "ws", query: "foo", mode: "content", matchCase: false, wholeWord: false, regex: true, include: "**/*.ts", exclude: "", path: "" });
+    expect(s.hits[0].line).toBe(2);
   });
 });

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -232,4 +232,11 @@ describe("files store: tree + advanced search", () => {
     expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.search", { workspace: "ws", query: "foo", mode: "content", matchCase: false, wholeWord: false, regex: true, include: "**/*.ts", exclude: "", path: "" });
     expect(s.hits[0].line).toBe(2);
   });
+
+  it("reset() clears the directory search scope (searchOpts.path) to avoid cross-workspace leak", () => {
+    const s = useFilesStore();
+    s.searchOpts.path = "src";
+    s.reset();
+    expect(s.searchOpts.path).toBe("");
+  });
 });

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
   pinia = createPinia();
   setActivePinia(pinia);
   rpc.mockClear();
+  localStorage.clear();
 });
 
 describe("FilesPanel navigation rail", () => {
@@ -40,58 +41,47 @@ describe("FilesPanel navigation rail", () => {
     expect(label.text()).toContain("backend");
   });
 
-  it("badges directory entries with git status", async () => {
-    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
-    const files = useFilesStore();
-    files.path = "";
-    files.entries = [
-      { name: "src", type: "dir" },
-      { name: "clean.ts", type: "file", size: 1 },
-      { name: "new.ts", type: "file", size: 1 },
-    ];
-    files.changed = { "src/a.ts": " M", "new.ts": "??" };
-    await w.vm.$nextTick();
-    const badges = w.findAll('[data-test="fs-status"]');
-    // src (dir, nested change) + new.ts (untracked) badge; clean.ts has none.
-    expect(badges.length).toBe(2);
-    const titles = badges.map((b) => b.attributes("title"));
-    expect(titles.some((t) => t?.startsWith("•"))).toBe(true); // src directory contains a change
-    expect(titles.some((t) => t?.startsWith("U"))).toBe(true); // new.ts is untracked
-    expect(badges.every((b) => b.classes().includes("bg-warn"))).toBe(true);
-  });
-
-  it("opening a directory entry that is a file routes it to the center viewer (clears any diff)", async () => {
+  it("opening a tree file routes it to the center viewer (clears any diff)", async () => {
     const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
     const files = useFilesStore();
     files.diffPath = "old/diff.ts"; // a stale diff selection
-    files.entries = [{ name: "a.ts", type: "file", size: 1 }];
+    files.tree[""] = [{ name: "a.ts", type: "file", size: 1 }] as never;
     await w.vm.$nextTick();
-    await w.find('[data-test="fs-entry"]').trigger("click");
+    await w.find('[data-test="tree-row"]').trigger("click");
     // The diff selection is cleared so the center shows the freshly opened file, not a mix.
     expect(files.diffPath).toBeNull();
   });
 
-  it("up button is disabled at the workspace root and goes up one level from a nested dir", async () => {
+  it("renders the tree root (no breadcrumb / up button)", async () => {
     const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
     const files = useFilesStore();
-    const up = vi.spyOn(files, "up").mockImplementation(() => {});
-
-    // At the root: no path segments → the button is present but disabled.
-    files.path = "";
+    files.tree[""] = [{ name: "src", type: "dir" }] as never;
     await w.vm.$nextTick();
-    const btnRoot = w.find('[data-test="fs-up"]');
-    expect(btnRoot.exists()).toBe(true);
-    expect(btnRoot.attributes("disabled")).toBeDefined();
-    await btnRoot.trigger("click");
-    expect(up).not.toHaveBeenCalled();
+    expect(w.find('[data-test="fs-up"]').exists()).toBe(false);
+    expect(w.find('[data-test="tree-row"]').exists()).toBe(true);
+  });
 
-    // Two levels deep (src/lib): up one level keeps the first segment → up(0) ("src").
-    files.path = "src/lib";
+  it("search toggles drive searchOpts", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
     await w.vm.$nextTick();
-    const btn = w.find('[data-test="fs-up"]');
-    expect(btn.attributes("disabled")).toBeUndefined();
-    await btn.trigger("click");
-    expect(up).toHaveBeenCalledWith(0);
+    await w.find('[data-test="search-regex"]').trigger("click");
+    expect(files.searchOpts.regex).toBe(true);
+    await w.find('[data-test="search-mode-content"]').trigger("click");
+    expect(files.searchOpts.mode).toBe("content");
+  });
+
+  it("dotfile/gitignore toggles persist and filter", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    files.tree[""] = [{ name: "src", type: "dir" }, { name: ".env", type: "file" }] as never;
+    await w.vm.$nextTick();
+    // .env is a dotfile, hidden by default.
+    expect(w.findAll('[data-test="tree-row"]').length).toBe(1);
+    await w.find('[data-test="toggle-dotfiles"]').setValue(true);
+    expect(localStorage.getItem("xacpx.files.showDotfiles")).toBe("1");
+    await w.vm.$nextTick();
+    expect(w.findAll('[data-test="tree-row"]').length).toBe(2);
   });
 
   it("has a refresh button that re-fetches the current view via the store", async () => {

--- a/packages/relay-web/src/__tests__/filetree.test.ts
+++ b/packages/relay-web/src/__tests__/filetree.test.ts
@@ -47,4 +47,15 @@ describe("FileTreeNode", () => {
     await w.find('[data-test="menu-copyPath"]').trigger("click");
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/abs/ws/src/a.ts");
   });
+
+  it("renders a git-status dot for a changed file and a dir containing changes, not for clean files", async () => {
+    const s = useFilesStore(); s.instanceId = "i1"; s.workspace = "ws"; s.root = "/abs"; s.sep = "/";
+    s.changed = { "src/a.ts": " M" };
+    const changedFile = mount(FileTreeNode, { props: { entry: { name: "a.ts", type: "file" }, dir: "src", depth: 1, showDotfiles: true, showGitignored: true }, ...g });
+    expect(changedFile.find('[data-test="fs-status"]').exists()).toBe(true);
+    const dirWithChange = mount(FileTreeNode, { props: { entry: { name: "src", type: "dir" }, dir: "", depth: 0, showDotfiles: true, showGitignored: true }, ...g });
+    expect(dirWithChange.find('[data-test="fs-status"]').exists()).toBe(true);
+    const cleanFile = mount(FileTreeNode, { props: { entry: { name: "clean.ts", type: "file" }, dir: "", depth: 0, showDotfiles: true, showGitignored: true }, ...g });
+    expect(cleanFile.find('[data-test="fs-status"]').exists()).toBe(false);
+  });
 });

--- a/packages/relay-web/src/__tests__/filetree.test.ts
+++ b/packages/relay-web/src/__tests__/filetree.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount } from "@vue/test-utils";
+
+const rpc = vi.fn();
+vi.mock("../api/client", () => ({ api: { rpc: (id: string, t: string, p?: unknown) => rpc(id, t, p) } }));
+
+import FileTreeNode from "../components/FileTreeNode.vue";
+import { useFilesStore } from "../stores/files";
+
+const g = { global: { mocks: { $t: (k: string) => k } } };
+
+beforeEach(() => { setActivePinia(createPinia()); rpc.mockReset(); Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } }); });
+
+describe("FileTreeNode", () => {
+  it("renders a dir row with a chevron and lazy-expands on click", async () => {
+    const s = useFilesStore(); s.instanceId = "i1"; s.workspace = "ws"; s.root = "/abs"; s.sep = "/";
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "src", entries: [{ name: "a.ts", type: "file", size: 3 }], root: "/abs", sep: "/" });
+    const w = mount(FileTreeNode, { props: { entry: { name: "src", type: "dir" }, dir: "", depth: 0, showDotfiles: false, showGitignored: false }, ...g });
+    await w.find('[data-test="tree-row"]').trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(rpc).toHaveBeenCalledWith("i1", "control.fs.list", { workspace: "ws", path: "src" });
+    expect(s.expanded.has("src")).toBe(true);
+  });
+
+  it("hides dotfiles and gitignored children unless toggled on", async () => {
+    const s = useFilesStore(); s.instanceId = "i1"; s.workspace = "ws"; s.root = "/abs"; s.sep = "/";
+    s.tree[""] = [
+      { name: "keep.ts", type: "file" },
+      { name: ".env", type: "file" },
+      { name: "dist", type: "dir", ignored: true },
+    ] as never;
+    // depth 0 rendered by a parent; here mount each child via a wrapper list is simpler:
+    const rows = (showDot: boolean, showIgn: boolean) => mount({
+      components: { FileTreeNode },
+      template: `<div><FileTreeNode v-for="e in entries" :key="e.name" :entry="e" dir="" :depth="0" :show-dotfiles="sd" :show-gitignored="si" /></div>`,
+      data: () => ({ entries: s.tree[""], sd: showDot, si: showIgn }),
+    }, g);
+    expect(rows(false, false).findAll('[data-test="tree-row"]').length).toBe(1); // only keep.ts
+    expect(rows(true, true).findAll('[data-test="tree-row"]').length).toBe(3);
+  });
+
+  it("context menu copy path writes the absolute host path", async () => {
+    const s = useFilesStore(); s.instanceId = "i1"; s.workspace = "ws"; s.root = "/abs/ws"; s.sep = "/";
+    const w = mount(FileTreeNode, { props: { entry: { name: "a.ts", type: "file" }, dir: "src", depth: 1, showDotfiles: true, showGitignored: true }, ...g });
+    await w.find('[data-test="tree-row"]').trigger("contextmenu");
+    await w.find('[data-test="menu-copyPath"]').trigger("click");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/abs/ws/src/a.ts");
+  });
+});

--- a/packages/relay-web/src/components/ContextMenu.vue
+++ b/packages/relay-web/src/components/ContextMenu.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount } from "vue";
+defineProps<{ x: number; y: number; items: { key: string; label: string }[] }>();
+const emit = defineEmits<{ select: [key: string]; close: [] }>();
+function onDocClick() { emit("close"); }
+function onKey(e: KeyboardEvent) { if (e.key === "Escape") emit("close"); }
+onMounted(() => { document.addEventListener("click", onDocClick); document.addEventListener("keydown", onKey); });
+onBeforeUnmount(() => { document.removeEventListener("click", onDocClick); document.removeEventListener("keydown", onKey); });
+</script>
+<template>
+  <div data-test="context-menu" class="fixed z-50 min-w-40 rounded-md border border-border bg-surface py-1 text-[12.5px] shadow-lg"
+       :style="{ left: x + 'px', top: y + 'px' }" @click.stop>
+    <button v-for="it in items" :key="it.key" :data-test="`menu-${it.key}`"
+            class="block w-full px-3 py-1.5 text-left text-fg hover:bg-raised"
+            @click="emit('select', it.key); emit('close')">{{ it.label }}</button>
+  </div>
+</template>

--- a/packages/relay-web/src/components/FileTreeNode.vue
+++ b/packages/relay-web/src/components/FileTreeNode.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { ChevronRight, ChevronDown, Folder, FolderOpen } from "lucide-vue-next";
+import type { FsEntryDto } from "@ganglion/xacpx-relay-protocol";
+import { useFilesStore } from "../stores/files";
+import { iconForFile } from "../lib/file-icons";
+import ContextMenu from "./ContextMenu.vue";
+
+const props = defineProps<{ entry: FsEntryDto; dir: string; depth: number; showDotfiles: boolean; showGitignored: boolean }>();
+const emit = defineEmits<{ openFile: [rel: string] }>();
+const files = useFilesStore();
+
+const rel = computed(() => (props.dir ? `${props.dir}/${props.entry.name}` : props.entry.name));
+const isDir = computed(() => props.entry.type === "dir");
+const isDot = computed(() => props.entry.name.startsWith("."));
+const dim = computed(() => isDot.value || props.entry.ignored === true);
+const isOpen = computed(() => files.expanded.has(rel.value));
+const children = computed(() => files.tree[rel.value] ?? []);
+
+// A child is visible when it passes both toggles.
+function visible(e: FsEntryDto): boolean {
+  if (e.ignored && !props.showGitignored) return false;
+  if (e.name.startsWith(".") && !props.showDotfiles) return false;
+  return true;
+}
+const visibleChildren = computed(() => children.value.filter(visible));
+const selfVisible = computed(() => visible(props.entry));
+
+function onRowClick() {
+  if (isDir.value) void files.toggleExpand(rel.value);
+  else emit("openFile", rel.value);
+}
+
+// context menu (items are built inline in the template via i18n — see :items below)
+const menu = ref<{ x: number; y: number } | null>(null);
+function openMenu(e: MouseEvent) { menu.value = { x: e.clientX, y: e.clientY }; }
+async function onMenuSelect(key: string) {
+  if (key === "copyPath") await navigator.clipboard?.writeText(files.absPath(rel.value)).catch(() => {});
+  else if (key === "copyRelativePath") await navigator.clipboard?.writeText(rel.value).catch(() => {});
+  else if (key === "searchInFolder") { files.searchOpts.path = rel.value; }
+  menu.value = null;
+}
+</script>
+
+<template>
+  <div v-if="selfVisible">
+    <button data-test="tree-row"
+            class="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left hover:bg-raised"
+            :style="{ paddingLeft: depth * 12 + 4 + 'px' }"
+            @click="onRowClick" @contextmenu.prevent="openMenu">
+      <component :is="isOpen ? ChevronDown : ChevronRight" v-if="isDir" :size="12" class="shrink-0 text-fg-muted" />
+      <span v-else class="w-3 shrink-0" />
+      <component :is="isDir ? (isOpen ? FolderOpen : Folder) : iconForFile(entry.name)" :size="13"
+                 class="shrink-0" :class="isDir ? 'text-warn' : 'text-fg-muted'" />
+      <span class="flex-1 truncate text-[12px]" :class="[dim ? 'opacity-45 italic' : '', isDir ? 'text-fg font-medium' : 'text-fg-muted']">{{ entry.name }}</span>
+    </button>
+
+    <div v-if="isDir && isOpen">
+      <FileTreeNode v-for="c in visibleChildren" :key="c.name" :entry="c" :dir="rel" :depth="depth + 1"
+                    :show-dotfiles="showDotfiles" :show-gitignored="showGitignored" @open-file="emit('openFile', $event)" />
+      <div v-if="!visibleChildren.length && files.tree[rel]" class="py-0.5 text-[11px] text-fg-muted" :style="{ paddingLeft: (depth + 1) * 12 + 16 + 'px' }">{{ $t("files.tree.emptyFolder") }}</div>
+    </div>
+
+    <ContextMenu v-if="menu" :x="menu.x" :y="menu.y"
+                 :items="isDir
+                   ? [{ key: 'copyPath', label: $t('files.menu.copyPath') }, { key: 'copyRelativePath', label: $t('files.menu.copyRelativePath') }, { key: 'searchInFolder', label: $t('files.menu.searchInFolder') }]
+                   : [{ key: 'copyPath', label: $t('files.menu.copyPath') }, { key: 'copyRelativePath', label: $t('files.menu.copyRelativePath') }]"
+                 @select="onMenuSelect" @close="menu = null" />
+  </div>
+</template>

--- a/packages/relay-web/src/components/FileTreeNode.vue
+++ b/packages/relay-web/src/components/FileTreeNode.vue
@@ -26,6 +26,26 @@ function visible(e: FsEntryDto): boolean {
 const visibleChildren = computed(() => children.value.filter(visible));
 const selfVisible = computed(() => visible(props.entry));
 
+// Git-status dot: a file gets its own porcelain status color; a dir gets a generic
+// dot if any changed path lives under it. Mirrors the old FilesPanel `statusBadge` colors.
+const gitDot = computed<string | null>(() => {
+  if (props.entry.type === "file") {
+    const code = files.changed[rel.value];
+    return code ? dotClass(code) : null;
+  }
+  const prefix = rel.value + "/";
+  return Object.keys(files.changed).some((p) => p.startsWith(prefix)) ? "bg-warn" : null;
+});
+function dotClass(code: string): string {
+  const c = code.trim();
+  if (c.includes("?")) return "bg-warn";
+  if (c.includes("A")) return "bg-run";
+  if (c.includes("D")) return "bg-danger";
+  if (c.includes("R")) return "bg-accent";
+  if (c.includes("M")) return "bg-warn";
+  return "bg-warn";
+}
+
 function onRowClick() {
   if (isDir.value) void files.toggleExpand(rel.value);
   else emit("openFile", rel.value);
@@ -53,6 +73,8 @@ async function onMenuSelect(key: string) {
       <component :is="isDir ? (isOpen ? FolderOpen : Folder) : iconForFile(entry.name)" :size="13"
                  class="shrink-0" :class="isDir ? 'text-warn' : 'text-fg-muted'" />
       <span class="flex-1 truncate text-[12px]" :class="[dim ? 'opacity-45 italic' : '', isDir ? 'text-fg font-medium' : 'text-fg-muted']">{{ entry.name }}</span>
+      <span v-if="gitDot" data-test="fs-status" class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full" :class="gitDot"
+            :title="entry.type === 'file' ? (files.changed[rel] || '') : $t('files.containsChanges')" />
     </button>
 
     <div v-if="isDir && isOpen">

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { ChevronRight, CornerLeftUp, File, FileText, Folder, FolderGit2, GitBranch, List, RefreshCw, X } from "lucide-vue-next";
-import type { FsEntryDto } from "@ganglion/xacpx-relay-protocol";
+import { ChevronRight, File, FileText, Folder, FolderGit2, GitBranch, List, RefreshCw, X } from "lucide-vue-next";
 import { useFilesStore } from "../stores/files";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { groupChanges, splitPath } from "../lib/change-groups";
+import FileTreeNode from "./FileTreeNode.vue";
 
 // Navigation-only file rail: a file tree (Files) and a changed-files list (Changes).
 // Opening a file or a single-file diff shows it full-width in the center column (see
@@ -15,13 +15,20 @@ const files = useFilesStore();
 const instances = useInstancesStore();
 const chat = useChatStore();
 
-const crumbs = computed(() => (files.path ? files.path.split("/") : []));
-const atRoot = computed(() => crumbs.value.length === 0);
-// Go up one directory level. `up(i)` keeps the first i+1 path segments, so the parent of
-// the current dir is `up(crumbs.length - 2)` (and `up(-1)` lands on the workspace root).
-function upOne() {
-  if (!atRoot.value) files.up(crumbs.value.length - 2);
+// dotfile / gitignore toggles for the Files-tab tree, persisted across sessions.
+const showDotfiles = ref(localStorage.getItem("xacpx.files.showDotfiles") === "1");
+const showGitignored = ref(localStorage.getItem("xacpx.files.showGitignored") === "1");
+watch(showDotfiles, (v) => localStorage.setItem("xacpx.files.showDotfiles", v ? "1" : "0"));
+watch(showGitignored, (v) => localStorage.setItem("xacpx.files.showGitignored", v ? "1" : "0"));
+// Root-layer children, filtered by the same predicate FileTreeNode applies to its own children.
+const rootChildren = computed(() => (files.tree[""] ?? []).filter((e) =>
+  (!e.ignored || showGitignored.value) && (!e.name.startsWith(".") || showDotfiles.value)));
+function openTreeFile(rel: string) {
+  files.diffPath = null;
+  void files.openFile(rel);
 }
+// Re-run the active search when its options change (toggles, include/exclude, mode).
+watch(() => ({ ...files.searchOpts }), () => { if (files.query.trim()) void files.search(files.query); }, { deep: true });
 
 // The panel follows the ACTIVE session's workspace — there's no manual picker, since the
 // workspace is a fixed property of the session you're chatting with.
@@ -92,17 +99,7 @@ function clearSearch() {
   void files.search("");
 }
 
-// Format a byte size compactly.
-function fmtSize(n?: number): string {
-  if (n === undefined) return "";
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  return `${(n / 1024 / 1024).toFixed(1)} MB`;
-}
-// Git-status badge for a directory entry, derived from the quietly-loaded status map.
-function entryRel(name: string): string {
-  return files.path ? `${files.path}/${name}` : name;
-}
+// Git-status badge for a Changes-tab row, derived from the porcelain status code.
 function statusBadge(code: string): { label: string; cls: string; dot: string } {
   const c = code.trim();
   if (c.includes("?")) return { label: "U", cls: "text-warn", dot: "bg-warn" }; // untracked
@@ -112,27 +109,7 @@ function statusBadge(code: string): { label: string; cls: string; dot: string } 
   if (c.includes("M")) return { label: "M", cls: "text-info", dot: "bg-warn" };
   return { label: c[0] ?? "•", cls: "text-fg-muted", dot: "bg-warn" };
 }
-function entryStatus(e: { name: string; type: string }): { label: string; cls: string; dot: string } | null {
-  const rel = entryRel(e.name);
-  if (e.type === "file") {
-    const code = files.changed[rel];
-    return code ? statusBadge(code) : null;
-  }
-  const prefix = `${rel}/`;
-  return Object.keys(files.changed).some((p) => p.startsWith(prefix)) ? { label: "•", cls: "text-warn", dot: "bg-warn" } : null;
-}
 
-// `true` when this entry is the file currently shown in the center viewer.
-function isOpen(name: string): boolean {
-  return !!files.file && files.file.path === entryRel(name);
-}
-
-// Open helpers: clear the counterpart so the center viewer shows exactly one thing —
-// a file or a single-file diff, never a stale mix.
-function openEntry(e: FsEntryDto) {
-  if (e.type === "file") files.diffPath = null;
-  void files.open(e);
-}
 function openSearchResult(m: string) {
   files.diffPath = null;
   void files.openFile(m);
@@ -215,62 +192,71 @@ watch(
 
       <!-- Files tab: pinned search (+ breadcrumb when browsing); only the listing scrolls. -->
       <div v-if="files.tab === 'files'" class="flex min-h-0 flex-1 flex-col">
-        <!-- search (pinned) -->
-        <div class="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
-          <input v-model="searchInput" data-test="fs-search" :placeholder="$t('files.searchPlaceholder')"
-                 class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-1 text-xs text-fg placeholder:text-fg-muted" @input="onSearchInput" />
-          <button v-if="searchInput" :aria-label="$t('files.clearSearch')" class="text-fg-muted hover:text-fg" @click="clearSearch"><X :size="14" /></button>
+        <!-- search (pinned): query + match-case/whole-word/regex + include/exclude + name/content mode -->
+        <div class="shrink-0 border-b border-border px-2 py-1 space-y-1">
+          <div class="flex items-center gap-1">
+            <input v-model="searchInput" data-test="fs-search" :placeholder="$t('files.searchPlaceholder')"
+                   class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-1 text-xs text-fg placeholder:text-fg-muted" @input="onSearchInput" />
+            <button data-test="search-matchcase" :title="$t('files.search.matchCase')" @click="files.searchOpts.matchCase = !files.searchOpts.matchCase"
+                    class="grid h-6 w-6 place-items-center rounded text-[11px]" :class="files.searchOpts.matchCase ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">Aa</button>
+            <button data-test="search-wholeword" :title="$t('files.search.wholeWord')" @click="files.searchOpts.wholeWord = !files.searchOpts.wholeWord"
+                    class="grid h-6 w-6 place-items-center rounded text-[11px]" :class="files.searchOpts.wholeWord ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">W</button>
+            <button data-test="search-regex" :title="$t('files.search.regex')" @click="files.searchOpts.regex = !files.searchOpts.regex"
+                    class="grid h-6 w-6 place-items-center rounded font-mono text-[11px]" :class="files.searchOpts.regex ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">.*</button>
+            <button v-if="searchInput" :aria-label="$t('files.clearSearch')" class="text-fg-muted hover:text-fg" @click="clearSearch"><X :size="14" /></button>
+          </div>
+          <div class="flex items-center gap-1">
+            <input v-model="files.searchOpts.include" data-test="search-include" :placeholder="$t('files.search.include')" class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-0.5 text-[11px] text-fg placeholder:text-fg-muted" />
+            <input v-model="files.searchOpts.exclude" data-test="search-exclude" :placeholder="$t('files.search.exclude')" class="min-w-0 flex-1 rounded border border-border bg-bg px-2 py-0.5 text-[11px] text-fg placeholder:text-fg-muted" />
+          </div>
+          <div class="flex items-center gap-1 text-[11px]">
+            <button data-test="search-mode-name" @click="files.searchOpts.mode = 'name'" class="rounded px-2 py-0.5" :class="files.searchOpts.mode === 'name' ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">{{ $t("files.search.byName") }}</button>
+            <button data-test="search-mode-content" @click="files.searchOpts.mode = 'content'" class="rounded px-2 py-0.5" :class="files.searchOpts.mode === 'content' ? 'bg-accent/15 text-accent' : 'text-fg-muted hover:bg-raised'">{{ $t("files.search.byContent") }}</button>
+          </div>
         </div>
 
-        <!-- search results (the list scrolls) -->
+        <!-- search results (the list scrolls): content mode groups hits by file, name mode keeps the flat list -->
         <div v-if="files.query.trim()" data-test="fs-results" class="min-h-0 flex-1 overflow-y-auto thin-scroll">
-          <ul class="p-2.5 text-[11px] font-mono leading-5 space-y-px">
-            <li v-for="m in files.results" :key="m">
-              <button data-test="fs-result"
-                      class="flex w-full items-center gap-1.5 rounded-md px-1.5 py-1 text-left hover:bg-raised cursor-pointer" @click="openSearchResult(m)">
-                <File :size="13" class="shrink-0 text-fg-muted" />
-                <span class="truncate font-sans text-[12px] text-fg-muted">{{ m }}</span>
-              </button>
-            </li>
-            <li v-if="!files.results.length && !files.searching" class="px-1.5 py-1 text-xs text-fg-muted">{{ $t("palette.noMatches") }}</li>
-          </ul>
-          <div v-if="files.searchTruncated" class="px-2.5 pb-1 text-xs text-warn">{{ $t("files.showingFirstMatches") }}</div>
-        </div>
-
-        <!-- browsing: pinned breadcrumb, then the directory listing scrolls -->
-        <template v-else>
-        <div class="flex shrink-0 flex-wrap items-center gap-1 border-b border-border px-2.5 py-1.5 font-mono text-[11px] text-fg-muted">
-          <button data-test="fs-up" :title="$t('files.upOneLevel')" :aria-label="$t('files.upOneLevel')"
-                  class="grid h-5 w-5 shrink-0 place-items-center rounded text-fg-muted hover:bg-raised hover:text-fg disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
-                  :disabled="atRoot || files.loading" @click="upOne">
-            <CornerLeftUp :size="13" />
-          </button>
-          <button class="hover:text-fg" @click="files.up(-1)">{{ files.workspace ?? $t("files.root") }}</button>
-          <template v-for="(c, i) in crumbs" :key="i">
-            <span>/</span><button class="hover:text-fg" @click="files.up(i)">{{ c }}</button>
+          <template v-if="files.searchOpts.mode === 'content'">
+            <div v-if="!files.hits.length && !files.searching" class="px-3 py-1 text-xs text-fg-muted">{{ $t("files.search.noContentMatches") }}</div>
+            <ul class="p-2 text-[11px] font-mono leading-5">
+              <li v-for="(h, i) in files.hits" :key="i">
+                <button data-test="fs-hit" class="flex w-full items-baseline gap-2 rounded px-1.5 py-0.5 text-left hover:bg-raised" @click="openSearchResult(h.path)">
+                  <span class="shrink-0 text-fg-muted/70">{{ h.path }}:{{ h.line }}</span>
+                  <span class="truncate text-fg-muted">{{ h.text }}</span>
+                </button>
+              </li>
+            </ul>
+            <div v-if="files.searchTruncated" class="px-2.5 pb-1 text-xs text-warn">{{ $t("files.showingFirstMatches") }}</div>
+          </template>
+          <template v-else>
+            <ul class="p-2.5 text-[11px] font-mono leading-5 space-y-px">
+              <li v-for="m in files.results" :key="m">
+                <button data-test="fs-result"
+                        class="flex w-full items-center gap-1.5 rounded-md px-1.5 py-1 text-left hover:bg-raised cursor-pointer" @click="openSearchResult(m)">
+                  <File :size="13" class="shrink-0 text-fg-muted" />
+                  <span class="truncate font-sans text-[12px] text-fg-muted">{{ m }}</span>
+                </button>
+              </li>
+              <li v-if="!files.results.length && !files.searching" class="px-1.5 py-1 text-xs text-fg-muted">{{ $t("palette.noMatches") }}</li>
+            </ul>
+            <div v-if="files.searchTruncated" class="px-2.5 pb-1 text-xs text-warn">{{ $t("files.showingFirstMatches") }}</div>
           </template>
         </div>
 
-        <!-- directory listing: tree-styled rows (chevron + folder/file icon) -->
-        <ul class="min-h-0 flex-1 overflow-y-auto thin-scroll p-2.5 text-[11px] font-mono leading-5 space-y-px">
-          <li v-for="e in files.entries" :key="e.name">
-            <button data-test="fs-entry"
-                    class="flex w-full items-center gap-1.5 rounded-md px-1.5 py-1 text-left cursor-pointer"
-                    :class="isOpen(e.name) ? 'bg-accent/15' : (entryStatus(e) ? 'bg-accent/10' : 'hover:bg-raised')" @click="openEntry(e)">
-              <ChevronRight v-if="e.type === 'dir'" :size="11" class="shrink-0 text-fg-muted" />
-              <span v-else class="w-[11px] shrink-0" />
-              <Folder v-if="e.type === 'dir'" :size="13" class="shrink-0" :class="entryStatus(e) ? 'text-accent' : 'text-fg-muted'" />
-              <File v-else :size="13" class="shrink-0" :class="isOpen(e.name) || entryStatus(e) ? 'text-accent' : 'text-fg-muted'" />
-              <span class="flex-1 truncate font-sans text-[12px]"
-                    :class="isOpen(e.name) || entryStatus(e) ? 'text-accent font-medium' : (e.type === 'dir' ? 'text-fg font-medium' : 'text-fg-muted')">{{ e.name }}</span>
-              <span v-if="entryStatus(e)" data-test="fs-status" class="w-1.5 h-1.5 shrink-0 rounded-full"
-                    :class="entryStatus(e)!.dot"
-                    :title="`${entryStatus(e)!.label} — ${files.changed[entryRel(e.name)] || $t('files.containsChanges')}`" />
-              <span v-if="e.type === 'file' && !entryStatus(e)" class="shrink-0 font-mono text-[10.5px] text-fg-muted tabular-nums">{{ fmtSize(e.size) }}</span>
-            </button>
-          </li>
-          <li v-if="!files.entries.length && !files.loading" class="px-1.5 py-1 text-xs text-fg-muted">{{ $t("files.emptyDirectory") }}</li>
-        </ul>
+        <!-- browsing: dotfile/gitignore toggles, then the tree scrolls -->
+        <template v-else>
+        <div class="flex shrink-0 items-center gap-3 border-b border-border px-2.5 py-1 text-[11px] text-fg-muted">
+          <label class="flex items-center gap-1 cursor-pointer"><input type="checkbox" data-test="toggle-dotfiles" v-model="showDotfiles" class="accent-accent" />{{ $t("files.toggle.showDotfiles") }}</label>
+          <label class="flex items-center gap-1 cursor-pointer"><input type="checkbox" data-test="toggle-gitignored" v-model="showGitignored" class="accent-accent" />{{ $t("files.toggle.showGitignored") }}</label>
+        </div>
+
+        <!-- directory tree: recursive rows (chevron + folder/file icon), lazy-expanded -->
+        <div class="min-h-0 flex-1 overflow-y-auto thin-scroll py-1 font-mono">
+          <FileTreeNode v-for="e in rootChildren" :key="e.name" :entry="e" dir="" :depth="0"
+                        :show-dotfiles="showDotfiles" :show-gitignored="showGitignored" @open-file="openTreeFile" />
+          <div v-if="!rootChildren.length && !files.loading" class="px-3 py-1 text-xs text-fg-muted">{{ $t("files.emptyDirectory") }}</div>
+        </div>
         </template>
       </div>
 

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -168,6 +168,23 @@ export default {
     detached: "detached",
     linked: "linked",
     worktree: "worktree",
+    tree: { expand: "Expand", collapse: "Collapse", emptyFolder: "Empty folder" },
+    search: {
+      matchCase: "Match case",
+      wholeWord: "Match whole word",
+      regex: "Use regular expression",
+      include: "files to include",
+      exclude: "files to exclude",
+      byName: "By name",
+      byContent: "By content",
+      noContentMatches: "No matches in files",
+    },
+    menu: {
+      copyPath: "Copy path",
+      copyRelativePath: "Copy relative path",
+      searchInFolder: "Search in this folder",
+    },
+    toggle: { showDotfiles: "Show dotfiles", showGitignored: "Show git-ignored" },
   },
   instance: {
     newSession: "New session",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -166,6 +166,23 @@ export default {
     detached: "分离 HEAD",
     linked: "链接",
     worktree: "工作树",
+    tree: { expand: "展开", collapse: "折叠", emptyFolder: "空文件夹" },
+    search: {
+      matchCase: "精确大小写",
+      wholeWord: "匹配整词",
+      regex: "使用正则",
+      include: "要包含的文件",
+      exclude: "要排除的文件",
+      byName: "按文件名",
+      byContent: "按内容",
+      noContentMatches: "文件中无匹配",
+    },
+    menu: {
+      copyPath: "复制路径",
+      copyRelativePath: "复制相对路径",
+      searchInFolder: "在此文件夹搜索",
+    },
+    toggle: { showDotfiles: "显示点文件", showGitignored: "显示 Git 忽略文件" },
   },
   instance: {
     newSession: "新建会话",

--- a/packages/relay-web/src/lib/file-icons.ts
+++ b/packages/relay-web/src/lib/file-icons.ts
@@ -1,0 +1,28 @@
+import type { Component } from "vue";
+import {
+  File as FileIcon, FileCode, FileJson, FileText, FileImage, FileType,
+  FileCog, FileLock, FileTerminal, FileArchive,
+} from "lucide-vue-next";
+
+const EXT_ICON: Record<string, Component> = {
+  ts: FileCode, tsx: FileCode, js: FileCode, jsx: FileCode, mjs: FileCode, cjs: FileCode,
+  vue: FileCode, py: FileCode, rs: FileCode, go: FileCode, java: FileCode, rb: FileCode,
+  c: FileCode, h: FileCode, cpp: FileCode, cs: FileCode, php: FileCode, swift: FileCode,
+  html: FileCode, htm: FileCode,
+  json: FileJson,
+  md: FileText, mdx: FileText, txt: FileText, pdf: FileText,
+  png: FileImage, jpg: FileImage, jpeg: FileImage, gif: FileImage, svg: FileImage, webp: FileImage, ico: FileImage, avif: FileImage,
+  css: FileType, scss: FileType, sass: FileType, less: FileType,
+  yml: FileCog, yaml: FileCog, toml: FileCog, ini: FileCog, env: FileCog, conf: FileCog,
+  lock: FileLock,
+  sh: FileTerminal, bash: FileTerminal, zsh: FileTerminal, fish: FileTerminal,
+  zip: FileArchive, tar: FileArchive, gz: FileArchive, tgz: FileArchive, rar: FileArchive, "7z": FileArchive,
+};
+
+/** Pick a lucide icon component for a filename, by extension (case-insensitive). */
+export function iconForFile(name: string): Component {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) return FileIcon;
+  const ext = name.slice(dot + 1).toLowerCase();
+  return EXT_ICON[ext] ?? FileIcon;
+}

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -64,6 +64,10 @@ export const useFilesStore = defineStore("files", () => {
     expanded.value = new Set();
     hits.value = [];
     root.value = "";
+    // The folder scope is workspace-bound (a relPath in the outgoing workspace) — the
+    // other searchOpts (mode/matchCase/wholeWord/regex/include/exclude) are user
+    // preferences and survive a workspace switch on purpose.
+    searchOpts.value.path = "";
   }
 
   async function selectWorkspace(id: string, ws: string): Promise<void> {

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -7,6 +7,7 @@ import {
   type FsListResult,
   type FsReadResult,
   type FsSearchResult,
+  type FsSearchHitDto,
 } from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
 
@@ -35,6 +36,17 @@ export const useFilesStore = defineStore("files", () => {
   const searching = ref(false);
   const loading = ref(false);
   const error = ref("");
+  // Lazy tree state for the file-tree browser — parallel to the flat path/entries
+  // above, which the Changes tab and openFile() still rely on.
+  const root = ref("");
+  const sepChar = ref<"/" | "\\">("/");
+  const tree = ref<Record<string, FsEntryDto[]>>({});
+  const expanded = ref<Set<string>>(new Set());
+  const loadingDirs = ref<Set<string>>(new Set());
+  const hits = ref<FsSearchHitDto[]>([]);
+  const searchOpts = ref<{ mode: "name" | "content"; matchCase: boolean; wholeWord: boolean; regex: boolean; include: string; exclude: string; path: string }>({
+    mode: "name", matchCase: false, wholeWord: false, regex: false, include: "", exclude: "", path: "",
+  });
 
   function reset(): void {
     workspace.value = null;
@@ -48,6 +60,10 @@ export const useFilesStore = defineStore("files", () => {
     query.value = "";
     results.value = [];
     error.value = "";
+    tree.value = {};
+    expanded.value = new Set();
+    hits.value = [];
+    root.value = "";
   }
 
   async function selectWorkspace(id: string, ws: string): Promise<void> {
@@ -60,7 +76,15 @@ export const useFilesStore = defineStore("files", () => {
     changed.value = {};
     query.value = "";
     results.value = [];
-    await list("");
+    tree.value = {}; hits.value = [];
+    try { expanded.value = new Set(JSON.parse(localStorage.getItem(expandedKey()) ?? "[]") as string[]); } catch { expanded.value = new Set(); }
+    await listTree("");
+    // Mirror the root layer into the flat path/entries state — the Changes tab and
+    // any surviving flat-view consumers read those, not `tree`, after selectWorkspace.
+    path.value = "";
+    entries.value = tree.value[""] ?? [];
+    // Re-hydrate previously expanded layers (best-effort).
+    for (const dir of [...expanded.value]) { if (dir && !tree.value[dir]) await listTree(dir).catch(() => {}); }
     void loadStatus();
   }
 
@@ -127,6 +151,42 @@ export const useFilesStore = defineStore("files", () => {
     }
   }
 
+  function expandedKey(): string { return `xacpx.fileTree.expanded.${workspace.value ?? ""}`; }
+
+  /** Fetch one directory layer into the tree cache, recording root/sep along the way. */
+  async function listTree(dir: string): Promise<void> {
+    if (!instanceId.value || !workspace.value) return;
+    loadingDirs.value = new Set(loadingDirs.value).add(dir);
+    try {
+      const r = unwrap(await api.rpc<FsListResult>(instanceId.value, "control.fs.list", { workspace: workspace.value, path: dir }));
+      root.value = r.root; sepChar.value = r.sep;
+      tree.value = { ...tree.value, [dir]: r.entries };
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "list-failed";
+    } finally {
+      const next = new Set(loadingDirs.value); next.delete(dir); loadingDirs.value = next;
+    }
+  }
+
+  /** Expand/collapse a tree node, lazily fetching its children on first expand. */
+  async function toggleExpand(dir: string): Promise<void> {
+    const next = new Set(expanded.value);
+    if (next.has(dir)) {
+      next.delete(dir);
+    } else {
+      next.add(dir);
+      if (!tree.value[dir]) await listTree(dir);
+    }
+    expanded.value = next;
+    try { localStorage.setItem(expandedKey(), JSON.stringify([...next])); } catch { /* ignore */ }
+  }
+
+  /** Resolve a workspace-relative path to an absolute path using the workspace root/sep. */
+  function absPath(rel: string): string {
+    const s = sepChar.value;
+    return root.value + s + rel.split("/").join(s);
+  }
+
   /** Descend into a child dir or open a file, relative to the current path. */
   async function open(entry: FsEntryDto): Promise<void> {
     const child = path.value ? `${path.value}/${entry.name}` : entry.name;
@@ -167,6 +227,11 @@ export const useFilesStore = defineStore("files", () => {
       return;
     }
     await list(path.value);
+    // Also drop the stale tree cache and re-pull the root plus any expanded layers,
+    // so the tree browser reflects the same post-write state as the flat view above.
+    tree.value = {};
+    await listTree("");
+    for (const dir of [...expanded.value]) { if (dir) await listTree(dir).catch(() => {}); }
     await loadStatus();
     await loadGitSummary(instanceId.value, workspace.value);
   }
@@ -181,14 +246,21 @@ export const useFilesStore = defineStore("files", () => {
     query.value = q;
     if (!instanceId.value || !workspace.value || !q.trim()) {
       results.value = [];
+      hits.value = [];
       searchTruncated.value = false;
       return;
     }
     searching.value = true;
     error.value = "";
     try {
-      const r = unwrap(await api.rpc<FsSearchResult>(instanceId.value, "control.fs.search", { workspace: workspace.value, query: q }));
+      const o = searchOpts.value;
+      const r = unwrap(await api.rpc<FsSearchResult>(instanceId.value, "control.fs.search", {
+        workspace: workspace.value, query: q,
+        mode: o.mode, matchCase: o.matchCase, wholeWord: o.wholeWord, regex: o.regex,
+        include: o.include, exclude: o.exclude, path: o.path,
+      }));
       results.value = r.matches;
+      hits.value = r.hits ?? [];
       searchTruncated.value = r.truncated;
     } catch (e) {
       error.value = e instanceof Error ? e.message : "search-failed";
@@ -221,5 +293,10 @@ export const useFilesStore = defineStore("files", () => {
     }
   }
 
-  return { instanceId, workspace, path, entries, file, diff, diffPath, notGit, changed, gitSummary, tab, query, results, searchTruncated, searching, loading, error, reset, selectWorkspace, list, open, openFile, up, search, loadDiff, loadStatus, loadGitSummary, refresh };
+  return {
+    instanceId, workspace, path, entries, file, diff, diffPath, notGit, changed, gitSummary, tab, query, results, searchTruncated, searching, loading, error,
+    root, sep: sepChar, tree, expanded, loadingDirs, hits, searchOpts,
+    reset, selectWorkspace, list, open, openFile, up, search, loadDiff, loadStatus, loadGitSummary, refresh,
+    listTree, toggleExpand, absPath,
+  };
 });

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -328,7 +328,7 @@ onUnmounted(() => {
            which stays as a no-JS fallback); on mobile no inline width is set so the
            fixed `w-72` drawer width applies. -->
       <div data-test="column" data-drawer="right"
-           class="fixed inset-y-0 right-0 z-40 flex w-72 max-w-[85%] shrink-0 transform flex-col overflow-hidden border-l border-border bg-surface shadow-lg transition-transform pt-[env(safe-area-inset-top)] lg:relative lg:z-auto lg:w-[296px] lg:max-w-none lg:translate-x-0 lg:transform-none lg:shadow-none lg:pt-0"
+           class="fixed inset-y-0 right-0 z-40 flex w-full shrink-0 transform flex-col overflow-hidden border-l border-border bg-surface shadow-lg transition-transform pt-[env(safe-area-inset-top)] lg:relative lg:z-auto lg:w-[296px] lg:max-w-none lg:translate-x-0 lg:transform-none lg:shadow-none lg:pt-0"
            :class="rightOpen ? 'translate-x-0' : 'translate-x-full'"
            :style="isDesktop ? { width: rightWidth + 'px' } : undefined">
         <!-- Resize handle: a thin grab strip on the panel's left edge (desktop only).

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -24,7 +24,7 @@ import {
 import type { ControlEventBus, ScheduledOrigin } from "./control-event-bus";
 import { readNativeSessionHistory, type NativeHistoryMessage } from "../transport/native-session-history";
 import type { AgentCatalogEntry } from "../config/agent-catalog";
-import { WorkspaceFs, type DirListing, type FileContent, type SearchResult, type WorkspaceDiff } from "./workspace-fs";
+import { WorkspaceFs, type DirListing, type FileContent, type SearchOptions, type SearchResult, type WorkspaceDiff } from "./workspace-fs";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import type { UploadStore } from "./upload-store.js";
 
@@ -199,8 +199,8 @@ export class ControlService {
     return this.workspaceFs.gitDiff(workspace, path);
   }
 
-  searchWorkspace(workspace: string, query: string): Promise<SearchResult> {
-    return this.workspaceFs.search(workspace, query);
+  searchWorkspace(workspace: string, opts: SearchOptions): Promise<SearchResult> {
+    return this.workspaceFs.search(workspace, opts);
   }
 
   async uploadFile(input: { filename: string; content: string; mimeType: string }): Promise<{ id: string; path: string; filename: string; mimeType: string; size: number }> {

--- a/src/control/workspace-fs.ts
+++ b/src/control/workspace-fs.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { homedir } from "node:os";
 import { readdir, realpath, stat, open } from "node:fs/promises";
@@ -35,11 +35,17 @@ export interface FsEntry {
   name: string;
   type: "dir" | "file";
   size?: number;
+  /** True when git check-ignore matches this entry (omitted in non-git workspaces). */
+  ignored?: boolean;
 }
 export interface DirListing {
   workspace: string;
   path: string;
   entries: FsEntry[];
+  /** Absolute realpath'd workspace root on the connector host. */
+  root: string;
+  /** Host path separator, so the client can render an absolute host path. */
+  sep: "/" | "\\";
 }
 export interface FileContent {
   workspace: string;
@@ -106,7 +112,7 @@ export class WorkspaceFs {
   }
 
   async listDirectory(workspace: string, relPath?: string): Promise<DirListing> {
-    const { abs, rel } = await this.resolve(workspace, relPath);
+    const { root, abs, rel } = await this.resolve(workspace, relPath);
     const dirents = await readdir(abs, { withFileTypes: true });
     const entries: FsEntry[] = [];
     for (const d of dirents.slice(0, MAX_ENTRIES)) {
@@ -124,7 +130,39 @@ export class WorkspaceFs {
       // symlinks / sockets / devices are skipped (not browsable read targets)
     }
     entries.sort((a, b) => (a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name)));
-    return { workspace, path: rel, entries };
+    // Mark gitignored entries (dirs are checked with a trailing slash so `dist/` rules match).
+    const relOf = (name: string, isDir: boolean) => (rel ? `${rel}/${name}` : name) + (isDir ? "/" : "");
+    const ignoredSet = await this.gitCheckIgnore(root, entries.map((e) => relOf(e.name, e.type === "dir")));
+    for (const e of entries) {
+      if (ignoredSet.has(relOf(e.name, e.type === "dir"))) e.ignored = true;
+    }
+    return { workspace, path: rel, entries, root, sep: sep as "/" | "\\" };
+  }
+
+  /** Return the subset of the given root-relative paths that git considers ignored.
+   *  Uses `check-ignore -z --stdin` (bounded by the caller's MAX_ENTRIES listing).
+   *  Any git error (not a repo, git missing) yields an empty set — callers degrade to
+   *  "nothing ignored". Never throws. */
+  private gitCheckIgnore(root: string, relPaths: string[]): Promise<Set<string>> {
+    return new Promise((resolvePromise) => {
+      if (!relPaths.length) return resolvePromise(new Set());
+      const ignored = new Set<string>();
+      let out = "";
+      let child;
+      try {
+        child = spawn("git", ["-C", root, "check-ignore", "-z", "--stdin"], { stdio: ["pipe", "pipe", "ignore"] });
+      } catch {
+        return resolvePromise(ignored);
+      }
+      child.on("error", () => resolvePromise(ignored)); // git missing
+      child.stdout.on("data", (b) => { out += b.toString(); });
+      child.on("close", () => {
+        for (const p of out.split("\0")) { if (p) ignored.add(p); }
+        resolvePromise(ignored);
+      });
+      child.stdin.on("error", () => {}); // ignore EPIPE if git bails early
+      child.stdin.end(relPaths.join("\0") + "\0");
+    });
   }
 
   async readFile(workspace: string, relPath: string): Promise<FileContent> {

--- a/src/control/workspace-fs.ts
+++ b/src/control/workspace-fs.ts
@@ -1,7 +1,7 @@
 import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { homedir } from "node:os";
-import { readdir, realpath, stat, open } from "node:fs/promises";
+import { readdir, realpath, stat, open, readFile } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 
 const execFileAsync = promisify(execFile);
@@ -30,6 +30,8 @@ const GIT_MAX_BUFFER = 32 * 1024 * 1024;
 const SEARCH_MAX_RESULTS = 200;
 const SEARCH_MAX_SCAN = 20000; // directory entries visited before giving up
 const SEARCH_SKIP_DIRS = new Set([".git", "node_modules"]);
+const SEARCH_CONTENT_MAX_HITS = 500;
+const SEARCH_CONTENT_MAX_FILE = 1024 * 1024; // skip files > 1 MiB in the fallback walker
 
 export interface FsEntry {
   name: string;
@@ -59,11 +61,30 @@ export interface DiffFile {
   path: string;
   status: string;
 }
+export interface SearchHit {
+  path: string;
+  line: number;
+  text: string;
+}
 export interface SearchResult {
   workspace: string;
   query: string;
   matches: string[];
+  hits: SearchHit[];
   truncated: boolean;
+}
+export interface SearchOptions {
+  query: string;
+  mode?: "name" | "content";
+  matchCase?: boolean;
+  wholeWord?: boolean;
+  regex?: boolean;
+  /** Glob to restrict matches (relative to workspace root). */
+  include?: string;
+  /** Glob to drop matches. */
+  exclude?: string;
+  /** Base directory (relative) to scope the search; defaults to the whole workspace. */
+  path?: string;
 }
 export interface WorkspaceDiff {
   workspace: string;
@@ -188,26 +209,32 @@ export class WorkspaceFs {
     }
   }
 
-  /** Find files whose relative path contains `query` (case-insensitive). Walks the
-   *  tree breadth-first, skipping `.git`/`node_modules` and never following symlinks
-   *  (so it stays contained), bounded by a scan budget and a result cap. */
-  async search(workspace: string, query: string): Promise<SearchResult> {
-    const { root } = await this.resolve(workspace, undefined);
-    const needle = query.trim().toLowerCase();
-    const matches: string[] = [];
-    if (!needle) return { workspace, query, matches, truncated: false };
+  /** Find files by name (default) or content. Name mode walks relative paths
+   *  breadth-first, skipping `.git`/`node_modules` and never following symlinks (so it
+   *  stays contained), applying the query plus any include/exclude globs. Content mode
+   *  delegates to `contentGrep`. Both are bounded by a scan budget and a result cap. */
+  async search(workspace: string, opts: SearchOptions): Promise<SearchResult> {
+    const { root, abs: base } = await this.resolve(workspace, opts.path);
+    const query = opts.query.trim();
+    const empty: SearchResult = { workspace, query, matches: [], hits: [], truncated: false };
+    if (!query) return empty;
 
+    if ((opts.mode ?? "name") === "content") {
+      return this.contentGrep(workspace, root, base, opts, query);
+    }
+
+    // name mode: walk relative paths, apply matcher + include/exclude globs.
+    const matcher = buildMatcher(query, opts);
+    const inc = opts.include ? globToRegExp(opts.include) : null;
+    const exc = opts.exclude ? globToRegExp(opts.exclude) : null;
+    const matches: string[] = [];
     let scanned = 0;
     let truncated = false;
-    const queue: string[] = [root];
+    const queue: string[] = [base];
     while (queue.length) {
       const dir = queue.shift()!;
       let dirents;
-      try {
-        dirents = await readdir(dir, { withFileTypes: true });
-      } catch {
-        continue;
-      }
+      try { dirents = await readdir(dir, { withFileTypes: true }); } catch { continue; }
       for (const d of dirents) {
         if (++scanned > SEARCH_MAX_SCAN) { truncated = true; break; }
         if (d.isSymbolicLink()) continue; // never follow symlinks — keeps us contained
@@ -215,7 +242,9 @@ export class WorkspaceFs {
           if (!SEARCH_SKIP_DIRS.has(d.name)) queue.push(resolve(dir, d.name));
         } else if (d.isFile()) {
           const rel = relative(root, resolve(dir, d.name)).split(sep).join("/");
-          if (rel.toLowerCase().includes(needle)) {
+          if (inc && !inc.test(rel)) continue;
+          if (exc && exc.test(rel)) continue;
+          if (matcher(rel)) {
             matches.push(rel);
             if (matches.length >= SEARCH_MAX_RESULTS) { truncated = true; break; }
           }
@@ -224,7 +253,85 @@ export class WorkspaceFs {
       if (truncated) break;
     }
     matches.sort();
-    return { workspace, query, matches, truncated };
+    return { workspace, query, matches, hits: [], truncated };
+  }
+
+  /** Content grep: `git grep` when the workspace root is a git repo (fast, respects
+   *  .gitignore), else a bounded manual walk that scans each file line by line. Never
+   *  throws on git absence/failure or an invalid user regex — both degrade gracefully. */
+  private async contentGrep(workspace: string, root: string, base: string, opts: SearchOptions, query: string): Promise<SearchResult> {
+    // Try git grep first: it's fast and respects .gitignore. Args are argv (never a shell).
+    const inGit = await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { maxBuffer: GIT_MAX_BUFFER })
+      .then(() => true).catch(() => false);
+    if (inGit) {
+      const args = ["-C", root, "grep", "-n", "--column", "-I", "--no-color"];
+      if (!opts.matchCase) args.push("-i");
+      if (opts.wholeWord) args.push("-w");
+      args.push(opts.regex ? "-E" : "-F");
+      args.push("-e", query, "--");
+      const scope = opts.path ? opts.path : ".";
+      args.push(scope);
+      if (opts.include) args.push(`:(glob)${opts.include}`);
+      if (opts.exclude) args.push(`:(exclude,glob)${opts.exclude}`);
+      let stdout = "";
+      try {
+        stdout = (await execFileAsync("git", args, { maxBuffer: GIT_MAX_BUFFER })).stdout;
+      } catch (e) {
+        const code = (e as { code?: number }).code;
+        if (code === 1) stdout = ""; // no matches
+        else { const out = (e as { stdout?: string }).stdout; stdout = typeof out === "string" ? out : ""; }
+      }
+      const hits: SearchHit[] = [];
+      let truncated = false;
+      for (const raw of stdout.split("\n")) {
+        if (!raw) continue;
+        // format: <path>:<line>:<column>:<text>
+        const m = raw.match(/^(.*?):(\d+):(\d+):(.*)$/);
+        if (!m) continue;
+        hits.push({ path: m[1]!.split(sep).join("/"), line: Number(m[2]), text: m[4]!.slice(0, 400) });
+        if (hits.length >= SEARCH_CONTENT_MAX_HITS) { truncated = true; break; }
+      }
+      return { workspace, query, matches: [], hits, truncated };
+    }
+
+    // Fallback (non-git): bounded manual walk + per-line match.
+    const matcher = buildLineMatcher(query, opts);
+    const inc = opts.include ? globToRegExp(opts.include) : null;
+    const exc = opts.exclude ? globToRegExp(opts.exclude) : null;
+    const hits: SearchHit[] = [];
+    let scanned = 0;
+    let truncated = false;
+    const queue: string[] = [base];
+    while (queue.length) {
+      const dir = queue.shift()!;
+      let dirents;
+      try { dirents = await readdir(dir, { withFileTypes: true }); } catch { continue; }
+      for (const d of dirents) {
+        if (++scanned > SEARCH_MAX_SCAN) { truncated = true; break; }
+        if (d.isSymbolicLink()) continue;
+        const full = resolve(dir, d.name);
+        if (d.isDirectory()) { if (!SEARCH_SKIP_DIRS.has(d.name)) queue.push(full); continue; }
+        if (!d.isFile()) continue;
+        const rel = relative(root, full).split(sep).join("/");
+        if (inc && !inc.test(rel)) continue;
+        if (exc && exc.test(rel)) continue;
+        let info; try { info = await stat(full); } catch { continue; }
+        if (info.size > SEARCH_CONTENT_MAX_FILE) continue;
+        let text; try { text = await readFile(full, "utf8"); } catch { continue; }
+        if (text.includes("\0")) continue; // NUL byte ⇒ binary, skip
+        const lines = text.split("\n");
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i]!;
+          if (matcher(line)) {
+            hits.push({ path: rel, line: i + 1, text: line.slice(0, 400) });
+            if (hits.length >= SEARCH_CONTENT_MAX_HITS) { truncated = true; break; }
+          }
+        }
+        if (truncated) break;
+      }
+      if (truncated) break;
+    }
+    return { workspace, query, matches: [], hits, truncated };
   }
 
   async gitDiff(workspace: string, relPath?: string): Promise<WorkspaceDiff> {
@@ -319,4 +426,43 @@ export class WorkspaceFs {
     }
     return ctx;
   }
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+/** Build a path/name matcher for name-mode search. */
+function buildMatcher(query: string, opts: SearchOptions): (s: string) => boolean {
+  return buildLineMatcher(query, opts);
+}
+/** Build a per-line/string matcher honoring regex/wholeWord/matchCase. In non-regex
+ *  mode it's a substring test; wholeWord wraps with \b boundaries. */
+function buildLineMatcher(query: string, opts: SearchOptions): (s: string) => boolean {
+  const flags = opts.matchCase ? "" : "i";
+  let pattern: string;
+  if (opts.regex) pattern = query;
+  else pattern = escapeRe(query);
+  if (opts.wholeWord) pattern = `\\b${pattern}\\b`;
+  let re: RegExp | null = null;
+  try { re = new RegExp(pattern, flags); } catch { re = null; }
+  if (!re) {
+    // Invalid user regex → fall back to case-adjusted substring so search never throws.
+    const needle = opts.matchCase ? query : query.toLowerCase();
+    return (s) => (opts.matchCase ? s : s.toLowerCase()).includes(needle);
+  }
+  return (s) => re!.test(s);
+}
+/** Minimal glob → RegExp for include/exclude (supports **, *, ?). Anchored full-match. */
+function globToRegExp(glob: string): RegExp {
+  let re = "^";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === "*") {
+      if (glob[i + 1] === "*") { re += ".*"; i++; if (glob[i + 1] === "/") i++; }
+      else re += "[^/]*";
+    } else if (c === "?") re += "[^/]";
+    else re += escapeRe(c!);
+  }
+  re += "$";
+  try { return new RegExp(re); } catch { return /$^/; }
 }

--- a/src/control/workspace-fs.ts
+++ b/src/control/workspace-fs.ts
@@ -214,13 +214,13 @@ export class WorkspaceFs {
    *  stays contained), applying the query plus any include/exclude globs. Content mode
    *  delegates to `contentGrep`. Both are bounded by a scan budget and a result cap. */
   async search(workspace: string, opts: SearchOptions): Promise<SearchResult> {
-    const { root, abs: base } = await this.resolve(workspace, opts.path);
+    const { root, abs: base, rel: scopeRel } = await this.resolve(workspace, opts.path);
     const query = opts.query.trim();
     const empty: SearchResult = { workspace, query, matches: [], hits: [], truncated: false };
     if (!query) return empty;
 
     if ((opts.mode ?? "name") === "content") {
-      return this.contentGrep(workspace, root, base, opts, query);
+      return this.contentGrep(workspace, root, base, scopeRel, opts, query);
     }
 
     // name mode: walk relative paths, apply matcher + include/exclude globs.
@@ -258,21 +258,24 @@ export class WorkspaceFs {
 
   /** Content grep: `git grep` when the workspace root is a git repo (fast, respects
    *  .gitignore), else a bounded manual walk that scans each file line by line. Never
-   *  throws on git absence/failure or an invalid user regex — both degrade gracefully. */
-  private async contentGrep(workspace: string, root: string, base: string, opts: SearchOptions, query: string): Promise<SearchResult> {
+   *  throws on git absence/failure or an invalid user regex — both degrade gracefully.
+   *  `scopeRel` is the already-resolved (canonicalized, containment-checked) scope from
+   *  `resolve()`; include/exclude are applied as a post-filter on the parsed hits rather
+   *  than as extra git pathspecs — git ORs multiple positive pathspecs together, so a
+   *  scope pathspec plus an include pathspec would leak matches from outside the scope. */
+  private async contentGrep(workspace: string, root: string, base: string, scopeRel: string, opts: SearchOptions, query: string): Promise<SearchResult> {
+    const inc = opts.include ? globToRegExp(opts.include) : null;
+    const exc = opts.exclude ? globToRegExp(opts.exclude) : null;
+
     // Try git grep first: it's fast and respects .gitignore. Args are argv (never a shell).
     const inGit = await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { maxBuffer: GIT_MAX_BUFFER })
       .then(() => true).catch(() => false);
     if (inGit) {
-      const args = ["-C", root, "grep", "-n", "--column", "-I", "--no-color"];
+      const args = ["-C", root, "grep", "-n", "--column", "-I", "--no-color", "--untracked"];
       if (!opts.matchCase) args.push("-i");
       if (opts.wholeWord) args.push("-w");
       args.push(opts.regex ? "-E" : "-F");
-      args.push("-e", query, "--");
-      const scope = opts.path ? opts.path : ".";
-      args.push(scope);
-      if (opts.include) args.push(`:(glob)${opts.include}`);
-      if (opts.exclude) args.push(`:(exclude,glob)${opts.exclude}`);
+      args.push("-e", query, "--", scopeRel || ".");
       let stdout = "";
       try {
         stdout = (await execFileAsync("git", args, { maxBuffer: GIT_MAX_BUFFER })).stdout;
@@ -288,7 +291,10 @@ export class WorkspaceFs {
         // format: <path>:<line>:<column>:<text>
         const m = raw.match(/^(.*?):(\d+):(\d+):(.*)$/);
         if (!m) continue;
-        hits.push({ path: m[1]!.split(sep).join("/"), line: Number(m[2]), text: m[4]!.slice(0, 400) });
+        const p = m[1]!.split(sep).join("/");
+        if (inc && !inc.test(p)) continue;
+        if (exc && exc.test(p)) continue;
+        hits.push({ path: p, line: Number(m[2]), text: m[4]!.slice(0, 400) });
         if (hits.length >= SEARCH_CONTENT_MAX_HITS) { truncated = true; break; }
       }
       return { workspace, query, matches: [], hits, truncated };
@@ -296,8 +302,6 @@ export class WorkspaceFs {
 
     // Fallback (non-git): bounded manual walk + per-line match.
     const matcher = buildLineMatcher(query, opts);
-    const inc = opts.include ? globToRegExp(opts.include) : null;
-    const exc = opts.exclude ? globToRegExp(opts.exclude) : null;
     const hits: SearchHit[] = [];
     let scanned = 0;
     let truncated = false;

--- a/tests/unit/control/workspace-fs.test.ts
+++ b/tests/unit/control/workspace-fs.test.ts
@@ -220,3 +220,38 @@ describe("WorkspaceFs git diff", () => {
     rmSync(repo, { recursive: true, force: true });
   });
 });
+
+describe("WorkspaceFs listing: ignored flag + root/sep", () => {
+  let gitRoot: string;
+  let gfs: WorkspaceFs;
+  beforeAll(() => {
+    gitRoot = mkdtempSync(join(tmpdir(), "wsfs-git-"));
+    execFileSync("git", ["init", "-q"], { cwd: gitRoot });
+    execFileSync("git", ["config", "user.email", "t@t"], { cwd: gitRoot });
+    execFileSync("git", ["config", "user.name", "t"], { cwd: gitRoot });
+    writeFileSync(join(gitRoot, ".gitignore"), "ignored.log\ndist/\n");
+    writeFileSync(join(gitRoot, "keep.ts"), "export const x = 1;\n");
+    writeFileSync(join(gitRoot, "ignored.log"), "noise\n");
+    mkdirSync(join(gitRoot, "dist"));
+    writeFileSync(join(gitRoot, "dist", "out.js"), "1\n");
+    gfs = new WorkspaceFs(() => [{ name: "g", cwd: gitRoot }]);
+  });
+  afterAll(() => rmSync(gitRoot, { recursive: true, force: true }));
+
+  test("marks gitignored entries and returns absolute root + sep", async () => {
+    const r = await gfs.listDirectory("g", "");
+    const byName = Object.fromEntries(r.entries.map((e) => [e.name, e]));
+    expect(byName["ignored.log"].ignored).toBe(true);
+    expect(byName["dist"].ignored).toBe(true);
+    expect(byName["keep.ts"].ignored).toBeUndefined();
+    expect(r.root).toBe(require("node:fs").realpathSync(gitRoot));
+    expect(r.sep).toBe(require("node:path").sep);
+  });
+
+  test("non-git workspace lists without ignored flags and still returns root/sep", async () => {
+    const r = await fs.listDirectory("ws", "");
+    expect(r.entries.every((e) => e.ignored === undefined)).toBe(true);
+    expect(typeof r.root).toBe("string");
+    expect(r.sep).toBe(require("node:path").sep);
+  });
+});

--- a/tests/unit/control/workspace-fs.test.ts
+++ b/tests/unit/control/workspace-fs.test.ts
@@ -134,6 +134,49 @@ describe("WorkspaceFs search: modes + flags", () => {
   });
 });
 
+describe("WorkspaceFs search: content grep in a git repo (include/exclude/path narrowing)", () => {
+  let repo: string;
+  let rfs: WorkspaceFs;
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), "wsfs-grep-"));
+    execFileSync("git", ["init", "-q"], { cwd: repo });
+    execFileSync("git", ["config", "user.email", "t@t"], { cwd: repo });
+    execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
+    mkdirSync(join(repo, "src"));
+    mkdirSync(join(repo, "other"));
+    writeFileSync(join(repo, "src", "a.ts"), "const needle = 1;\n");
+    writeFileSync(join(repo, "other", "b.ts"), "const needle = 2;\n");
+    execFileSync("git", ["add", "-A"], { cwd: repo }); // tracked; --untracked also covers unadded files
+    rfs = new WorkspaceFs(() => [{ name: "g", cwd: repo }]);
+  });
+  afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+  test("finds hits across both files with no scoping", async () => {
+    const r = await rfs.search("g", { query: "needle", mode: "content" });
+    expect(r.hits.map((h) => h.path).sort()).toEqual(["other/b.ts", "src/a.ts"]);
+  });
+
+  test("include narrows to matching files only (no leak from outside the glob)", async () => {
+    const r = await rfs.search("g", { query: "needle", mode: "content", include: "src/**" });
+    expect(r.hits.map((h) => h.path)).toEqual(["src/a.ts"]);
+  });
+
+  test("path scopes the search (no leak from outside the base dir)", async () => {
+    const r = await rfs.search("g", { query: "needle", mode: "content", path: "src" });
+    expect(r.hits.map((h) => h.path)).toEqual(["src/a.ts"]);
+  });
+
+  test("exclude drops matching files", async () => {
+    const r = await rfs.search("g", { query: "needle", mode: "content", exclude: "other/**" });
+    expect(r.hits.some((h) => h.path === "other/b.ts")).toBe(false);
+    expect(r.hits.some((h) => h.path === "src/a.ts")).toBe(true);
+  });
+
+  test("path containment still applies to search scoping", async () => {
+    await expect(rfs.search("g", { query: "x", mode: "content", path: "../.." })).rejects.toThrow(/escapes-workspace|not-found/);
+  });
+});
+
 describe("WorkspaceFs git diff", () => {
   test("throws on a non-git workspace", async () => {
     await expect(fs.gitDiff("ws")).rejects.toThrow("not-a-git-repo");

--- a/tests/unit/control/workspace-fs.test.ts
+++ b/tests/unit/control/workspace-fs.test.ts
@@ -81,19 +81,55 @@ describe("WorkspaceFs listing & reading", () => {
 
 describe("WorkspaceFs search", () => {
   test("finds files by case-insensitive path substring", async () => {
-    const r = await fs.search("ws", "A.TS");
+    const r = await fs.search("ws", { query: "A.TS" });
     expect(r.matches).toContain("src/a.ts");
     expect(r.truncated).toBe(false);
   });
 
   test("returns no matches for an empty or unmatched query", async () => {
-    expect((await fs.search("ws", "")).matches).toEqual([]);
-    expect((await fs.search("ws", "zzz-nope")).matches).toEqual([]);
+    expect((await fs.search("ws", { query: "" })).matches).toEqual([]);
+    expect((await fs.search("ws", { query: "zzz-nope" })).matches).toEqual([]);
   });
 
   test("does not follow a symlink that escapes the root", async () => {
     // `escape` points outside; its `secret.txt` must never appear in results.
-    const r = await fs.search("ws", "secret");
+    const r = await fs.search("ws", { query: "secret" });
+    expect(r.matches).toEqual([]);
+  });
+});
+
+describe("WorkspaceFs search: modes + flags", () => {
+  test("name mode: regex + include filter on relative path", async () => {
+    const r = await fs.search("ws", { query: "\\.ts$", mode: "name", regex: true });
+    expect(r.matches).toContain("src/a.ts");
+    expect(r.matches.every((m) => m.endsWith(".ts"))).toBe(true);
+    expect(r.hits).toEqual([]);
+  });
+
+  test("name mode: exclude glob drops matches", async () => {
+    const r = await fs.search("ws", { query: "a", mode: "name", exclude: "src/**" });
+    expect(r.matches.some((m) => m.startsWith("src/"))).toBe(false);
+  });
+
+  test("content mode: finds a line and returns path/line/text", async () => {
+    const r = await fs.search("ws", { query: "export const a", mode: "content" });
+    const hit = r.hits.find((h) => h.path === "src/a.ts");
+    expect(hit).toBeDefined();
+    expect(hit!.line).toBe(1);
+    expect(hit!.text).toContain("export const a");
+    expect(r.matches).toEqual([]);
+  });
+
+  test("content mode: case-sensitive miss vs case-insensitive hit", async () => {
+    const sensitive = await fs.search("ws", { query: "EXPORT", mode: "content", matchCase: true });
+    expect(sensitive.hits.length).toBe(0);
+    const insensitive = await fs.search("ws", { query: "EXPORT", mode: "content", matchCase: false });
+    expect(insensitive.hits.length).toBeGreaterThan(0);
+  });
+
+  test("empty query returns nothing", async () => {
+    const r = await fs.search("ws", { query: "   ", mode: "content" });
+    expect(r.hits).toEqual([]);
     expect(r.matches).toEqual([]);
   });
 });

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -223,6 +223,41 @@ test("sessions.rename dispatches to setSessionDisplayName and returns ok", async
   expect(calls).toEqual([["relay:acc", "backend", "My label"]]);
 });
 
+test("fs.search passes advanced search options through to control.searchWorkspace", async () => {
+  const calls: unknown[] = [];
+  const { control } = makeFakeControl({
+    searchWorkspace: async (workspace: string, opts: unknown) => {
+      calls.push([workspace, opts]);
+      return { workspace, query: "x", matches: [], hits: [], truncated: false };
+    },
+  });
+  const bridge = createControlBridge(control as never);
+  const result = await dispatch(bridge, req(MSG.fsSearch, {
+    workspace: "w", query: "x", mode: "content", regex: true,
+    include: "**/*.ts", exclude: "dist/**", path: "src", matchCase: true, wholeWord: true,
+  }));
+  expect(result).toEqual({ workspace: "w", query: "x", matches: [], hits: [], truncated: false });
+  expect(calls).toEqual([["w", {
+    query: "x", mode: "content", matchCase: true, wholeWord: true, regex: true,
+    include: "**/*.ts", exclude: "dist/**", path: "src",
+  }]]);
+});
+
+test("fs.search returns bad-request when workspace is missing", async () => {
+  const { control, calls } = makeFakeControl({
+    searchWorkspace: async (workspace: string, opts: unknown) => {
+      calls.searchWorkspace ??= [];
+      calls.searchWorkspace.push([workspace, opts]);
+      return { workspace, query: "x", matches: [], hits: [], truncated: false };
+    },
+  });
+  const bridge = createControlBridge(control as never);
+  expect(await dispatch(bridge, req(MSG.fsSearch, { query: "x" }))).toEqual({
+    error: { code: "bad-request", message: "workspace is required" },
+  });
+  expect(calls.searchWorkspace).toBeUndefined();
+});
+
 test("sessions.rename returns bad-request when alias is missing", async () => {
   const { control } = makeFakeControl({
     setSessionDisplayName: async () => {},

--- a/tests/unit/packages/relay-protocol/web-dtos.test.ts
+++ b/tests/unit/packages/relay-protocol/web-dtos.test.ts
@@ -6,6 +6,11 @@ import {
   encodeEnvelope,
   parseWebServerEvent,
   webEventEnvelope,
+  type FsEntryDto,
+  type FsListResult,
+  type FsSearchHitDto,
+  type FsSearchPayload,
+  type FsSearchResult,
   type WebServerEvent,
 } from "../../../../packages/relay-protocol/src/index";
 
@@ -199,4 +204,16 @@ test("accepts well-formed per-variant tool details", () => {
   expect(roundtrip(step({ type: "search", query: "rg x" }))).not.toBeNull();
   expect(roundtrip(step({ type: "text", text: "thinking" }))).not.toBeNull();
   expect(roundtrip(step({ type: "fields", fields: [{ label: "a", value: "b" }], output: "o" }))).not.toBeNull();
+});
+
+test("fs DTOs carry the tree-browser additions", () => {
+  const entry: FsEntryDto = { name: "a", type: "file", ignored: true };
+  const list: FsListResult = { workspace: "w", path: "", entries: [entry], root: "/abs", sep: "/" };
+  const hit: FsSearchHitDto = { path: "a.ts", line: 3, text: "x" };
+  const payload: FsSearchPayload = { workspace: "w", query: "x", mode: "content", regex: true, include: "**/*.ts", path: "src" };
+  const result: FsSearchResult = { workspace: "w", query: "x", matches: [], hits: [hit], truncated: false };
+  expect(list.root).toBe("/abs");
+  expect(list.sep).toBe("/");
+  expect(payload.mode).toBe("content");
+  expect(result.hits[0].line).toBe(3);
 });


### PR DESCRIPTION
## relay-web file tree browser (sub-project A: read-only)

Turns the relay-web **Files** panel from a flat per-directory list into a lazy **tree** with gitignore-awareness, advanced search, git-status dots, a read-only right-click menu, and a mobile full-width drawer. Backend additions are **read-only** — no filesystem writes, no new config gate. Writes/download/OS-open are **sub-project B** (separate spec/branch).

### What & why
The old Files tab was a flat listing with a breadcrumb + up button; you couldn't see structure at a glance, and browsing surfaced `node_modules`/dotfiles noise.

- **Lazy tree view** — root = the session's workspace; expanding a folder fetches that layer via the existing `control.fs.list` (per-dir cache, expand-state persisted per workspace). Breadcrumb + up button removed. Folder open/closed icons + per-extension file icons (lucide).
- **gitignore / dotfiles** — each listing entry carries `ignored` (backend `git check-ignore`); dotfiles detected by name. Two toggles (show dotfiles / show git-ignored), **default off**, render those entries dimmed + italic when shown. Keeps `node_modules`/`.git` out of the tree by default.
- **git-status dots** — changed files / dirs-with-changes show M/A/D/? dots in the tree (reuses the git status map).
- **Advanced search** — match-case / whole-word / regex toggles + include/exclude globs + a **name | content** mode switch. Content mode is grep (backend prefers `git grep --untracked`, respecting `.gitignore`; non-git fallback walk). include/exclude/path narrow correctly (single scoped pathspec + post-filter).
- **Right-click menu (read-only subset)** — copy path (**absolute host path**), copy relative path, and (folders) "search in this folder". Menu scaffold reused by sub-project B.
- **Mobile** — the right drawer is full-width (`w-full`) on mobile.

### Security
All new fs/search paths route through the single `WorkspaceFs.resolve()` choke point (workspace-name allowlist + symlink-safe realpath containment). git is always argv (never shelled). The absolute-host-path disclosure (copy path) is owner-only, behind the existing ownership gate — an intentional, requested behavior. No write capability added.

### Tests & build
- backend/protocol/connector bun: **74 pass / 0 fail**; full `tsc --noEmit`: clean; relay-web vitest: **76 files / 515 pass**; real `bun run build:relay-web`: success (vue-tsc clean + vite).

### Process
11 tasks implemented subagent-driven, each spec+quality reviewed (all Approved; one included a real git-grep include/intersection bug caught + fixed in review), plus a whole-branch review (0 Critical / 1 Important) whose lone gate — a cross-workspace search-scope leak — is fixed with a test.

### Protocol
Additive & backward-compatible (`FsEntryDto.ignored`, `FsListResult.root/sep`, `FsSearchHitDto`, extended `FsSearchPayload`, `FsSearchResult.hits`); relay-protocol stays 0.1.x.
