### PR TITLE
fix(relay-web): keybar sits flush on the keyboard (drop home-indicator inset when open)

### DIFF
--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -246,15 +246,20 @@ describe("TerminalTab", () => {
       const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
       await tick();
       const center = () => w.find('[data-test="terminal-center"]').attributes("style") ?? "";
+      const keybar = () => w.find('[data-test="keybar"]').attributes("style") ?? "";
       const el = w.find('[data-test="terminal-host"]').element as HTMLElement;
       // Unfocused: a large innerHeight−visualViewport delta is browser chrome, NOT a keyboard → no inset.
       expect(center()).not.toContain("padding-bottom");
       el.dispatchEvent(new Event("focusin", { bubbles: true }));
       await tick();
       expect(center()).toContain("padding-bottom: 400px");
+      // Keyboard open → the keybar drops its home-indicator safe-area padding so it sits
+      // flush on the keyboard instead of leaving a gap.
+      expect(keybar()).toContain("padding-bottom: 0.375rem");
       el.dispatchEvent(new Event("focusout", { bubbles: true }));
       await tick();
       expect(center()).not.toContain("padding-bottom");
+      expect(keybar()).not.toContain("padding-bottom");
     } finally {
       Reflect.deleteProperty(window, "visualViewport");
       Object.defineProperty(window, "innerHeight", { value: 768, configurable: true });

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -326,8 +326,12 @@ onBeforeUnmount(() => {
     <div ref="host" class="term-host flex min-h-0 flex-1 touch-none items-center justify-center overflow-hidden bg-bg" data-test="terminal-host"></div>
 
     <!-- shortcut bar — the root's padding-bottom (= keyboard height) lifts the whole pane,
-         so both this bar and the terminal's prompt row stay above the on-screen keyboard. -->
+         so both this bar and the terminal's prompt row stay above the on-screen keyboard.
+         The safe-area bottom padding (home-indicator inset) only applies when the keyboard
+         is CLOSED; while it's open the keyboard already covers the home indicator, so the
+         inset would just leave a gap between the buttons and the keyboard. -->
     <div v-if="keybarVisible" data-test="keybar"
+         :style="keyboardInset ? { paddingBottom: '0.375rem' } : undefined"
          class="flex shrink-0 items-center gap-1.5 overflow-x-auto border-t border-border bg-surface px-2 py-1.5 pb-[calc(0.375rem+env(safe-area-inset-bottom))] thin-scroll">
       <button data-test="key-esc" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\u001b')">Esc</button>
       <button data-test="key-tab" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="sendKey('\t')">Tab</button>


### PR DESCRIPTION
Follow-up to the mobile keyboard work. With the keyboard open the shortcut bar is now correctly lifted above it (beta.5's focus-gated inset works), but a black gap remained between the buttons and the iOS keyboard.

## Cause
The keybar carries `pb-[calc(0.375rem + env(safe-area-inset-bottom))]` — the ~34px iOS home-indicator inset. While the keyboard is open the home indicator is covered by the keyboard, so that inset is pure dead space: it pushes the buttons up inside the bar, leaving the gap.

## Fix
Drop the safe-area bottom padding when `keyboardInset > 0` (keyboard open) so the buttons sit flush on the keyboard; keep it when the keyboard is closed (so the buttons still clear the home indicator).

## Tests
- Extended the keyboard-inset test: keybar style has `padding-bottom: 0.375rem` when focused/open, and no inline padding when closed.
- `terminal-tab` suite green (25) + `vue-tsc --noEmit` clean.

## Needs on-device verification
Whether this fully closes the gap, or a small residual remains (which would be `keyboardInset` slightly over-measuring vs the real keyboard height — a separate follow-up if so).