### PR TITLE
fix(relay-web): chat composer sits flush on the keyboard (drop home-indicator inset when open)

### DIFF
--- a/packages/relay-web/src/__tests__/use-virtual-keyboard.test.ts
+++ b/packages/relay-web/src/__tests__/use-virtual-keyboard.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, h, type Ref } from "vue";
+import { useVirtualKeyboardInset } from "../lib/use-virtual-keyboard";
+
+function harness() {
+  let inset!: Ref<number>;
+  const Comp = defineComponent({ setup() { inset = useVirtualKeyboardInset(); return () => h("div"); } });
+  const w = mount(Comp);
+  return { w, get: () => inset.value };
+}
+
+function setViewport(innerHeight: number, vvHeight: number) {
+  Object.defineProperty(window, "visualViewport", {
+    value: { height: vvHeight, offsetTop: 0, addEventListener() {}, removeEventListener() {} },
+    configurable: true,
+  });
+  Object.defineProperty(window, "innerHeight", { value: innerHeight, configurable: true });
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "visualViewport");
+  Object.defineProperty(window, "innerHeight", { value: 768, configurable: true });
+});
+
+describe("useVirtualKeyboardInset", () => {
+  it("reports the covered height only while an editable element is focused", () => {
+    setViewport(800, 400); // delta 400 > 120
+    const { get } = harness();
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    expect(get()).toBe(0); // nothing focused yet
+    ta.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(get()).toBe(400);
+    ta.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    expect(get()).toBe(0);
+    ta.remove();
+  });
+
+  it("ignores focus on a non-editable element (no keyboard)", () => {
+    setViewport(800, 400);
+    const { get } = harness();
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    div.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(get()).toBe(0);
+    div.remove();
+  });
+
+  it("ignores a sub-threshold delta (browser toolbar) even when focused", () => {
+    setViewport(800, 720); // delta 80 < 120
+    const { get } = harness();
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    ta.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(get()).toBe(0);
+    ta.remove();
+  });
+});

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -4,6 +4,7 @@ import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
 import { useFilesStore } from "../stores/files";
 import { useComposerStore } from "../stores/composer";
+import { useVirtualKeyboardInset } from "../lib/use-virtual-keyboard";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import MessageList from "./MessageList.vue";
 import PromptInput from "./PromptInput.vue";
@@ -17,6 +18,9 @@ const chat = useChatStore();
 const instances = useInstancesStore();
 const files = useFilesStore();
 const composer = useComposerStore();
+// While the soft keyboard is open it already covers the iOS home indicator, so the
+// composer's safe-area bottom padding is just a gap — drop it then (see the template).
+const keyboardInset = useVirtualKeyboardInset();
 
 function onSend(text: string, media: PromptAttachmentRef[] = []) {
   void chat.send(text, media);
@@ -173,7 +177,9 @@ const verb = computed(() => {
       <!-- composer area. pb uses max(1rem, safe-area-inset-bottom) so the iOS home-indicator
            inset is applied ONCE here (the bottommost element) and never stacks on top of the
            composer's own padding — env() is 0 off-PWA, so desktop stays at 1rem. -->
-      <div class="shrink-0 space-y-2 bg-gradient-to-t from-bg to-transparent px-2 lg:px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-1.5">
+      <div class="shrink-0 space-y-2 bg-gradient-to-t from-bg to-transparent px-2 lg:px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-1.5"
+           :style="keyboardInset ? { paddingBottom: '0.5rem' } : undefined"
+           data-test="composer-area">
         <!-- TURN HUD -->
         <div v-if="chat.busy" data-test="turn-hud"
              class="flex items-center gap-2 rounded-lg border border-run/20 bg-run/8 px-3 py-1.5">

--- a/packages/relay-web/src/lib/use-virtual-keyboard.ts
+++ b/packages/relay-web/src/lib/use-virtual-keyboard.ts
@@ -1,0 +1,46 @@
+import { ref, onMounted, onBeforeUnmount, type Ref } from "vue";
+
+// True when `t` is a text-editing element the on-screen keyboard would open for.
+function isEditable(t: EventTarget | null): boolean {
+  const el = t as HTMLElement | null;
+  if (!el || !el.tagName) return false;
+  return el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable === true;
+}
+
+// Reactive height (px) the on-screen keyboard covers at the bottom of the viewport; 0 when
+// closed. Detected via visualViewport, gated two ways so browser chrome never counts:
+//   1. Only while an editable element is focused — a keyboard can't be open otherwise, so a
+//      persistent mobile browser toolbar never leaves a phantom inset.
+//   2. Only above a keyboard-sized threshold (a toolbar is <=~90px; real keyboards >=~150px).
+// When the browser resizes the layout viewport for the keyboard the raw delta is ~0, so this
+// stays a no-op and never double-applies. Callers typically use it to drop a bottom
+// safe-area inset (which the keyboard already covers) so content sits flush on the keyboard.
+export function useVirtualKeyboardInset(): Ref<number> {
+  const KEYBOARD_MIN_INSET = 120;
+  const inset = ref(0);
+  let focused = false;
+
+  function update() {
+    const vv = typeof window !== "undefined" ? window.visualViewport : null;
+    if (!vv || !focused) { inset.value = 0; return; }
+    const raw = Math.round(window.innerHeight - vv.height - vv.offsetTop);
+    inset.value = raw > KEYBOARD_MIN_INSET ? raw : 0;
+  }
+  function onFocusIn(e: FocusEvent) { focused = isEditable(e.target); update(); }
+  function onFocusOut() { focused = false; inset.value = 0; }
+
+  onMounted(() => {
+    window.visualViewport?.addEventListener("resize", update);
+    window.visualViewport?.addEventListener("scroll", update);
+    window.addEventListener("focusin", onFocusIn);
+    window.addEventListener("focusout", onFocusOut);
+  });
+  onBeforeUnmount(() => {
+    window.visualViewport?.removeEventListener("resize", update);
+    window.visualViewport?.removeEventListener("scroll", update);
+    window.removeEventListener("focusin", onFocusIn);
+    window.removeEventListener("focusout", onFocusOut);
+  });
+
+  return inset;
+}


### PR DESCRIPTION
Same fix as the terminal keybar (#109), applied to the chat composer per follow-up feedback ("消息输入框也一样").

## Cause
The composer area carries `pb-[max(1rem, env(safe-area-inset-bottom))]` — the ~34px iOS home-indicator inset. iOS Safari already scrolls the focused textarea above the keyboard, but that bottom inset then sits between the composer and the keyboard as dead space (the keyboard already covers the home indicator).

## Fix
Extract keyboard-open detection into a small `useVirtualKeyboardInset()` composable (visualViewport delta, gated on an editable element being focused + a 120px keyboard threshold, so mobile browser chrome never counts), and drop the composer's bottom padding to `0.5rem` while the keyboard is open. When the keyboard is closed the full safe-area inset applies (composer clears the home indicator); desktop is unaffected (env() = 0).

## Tests
- New `use-virtual-keyboard` unit tests: reports covered height only while an editable element is focused; ignores non-editable focus and sub-threshold (toolbar) deltas.
- Full relay-web suite green (519) + `vue-tsc --noEmit` clean.

## Note
The terminal keybar (#109) still uses its own host-focus-gated copy of this logic; it could be migrated onto the composable later, but that touches shipped/tested behavior so it's left as a follow-up.