### PR TITLE
fix(control): harden relay-web workspace search against ReDoS

### DIFF
--- a/src/control/workspace-fs.ts
+++ b/src/control/workspace-fs.ts
@@ -33,6 +33,8 @@ const SEARCH_SKIP_DIRS = new Set([".git", "node_modules"]);
 const SEARCH_CONTENT_MAX_HITS = 500;
 const SEARCH_CONTENT_MAX_FILE = 1024 * 1024; // skip files > 1 MiB in the fallback walker
 const DOWNLOAD_MAX = 5 * 1024 * 1024; // 5 MiB cap for readFileBytes downloads
+const GIT_TIMEOUT_MS = 10_000; // kill any git subprocess that runs longer (slow repo / ReDoS via `git grep -E`)
+const SEARCH_DEADLINE_MS = 4_000; // abort an in-process JS walk that runs longer (best-effort ReDoS bound)
 
 export interface FsEntry {
   name: string;
@@ -277,9 +279,11 @@ export class WorkspaceFs {
       } catch {
         return resolvePromise(ignored);
       }
-      child.on("error", () => resolvePromise(ignored)); // git missing
+      const killer = setTimeout(() => { try { child!.kill("SIGKILL"); } catch { /* already gone */ } }, GIT_TIMEOUT_MS);
+      child.on("error", () => { clearTimeout(killer); resolvePromise(ignored); }); // git missing
       child.stdout.on("data", (b) => { out += b.toString(); });
       child.on("close", () => {
+        clearTimeout(killer);
         for (const p of out.split("\0")) { if (p) ignored.add(p); }
         resolvePromise(ignored);
       });
@@ -332,12 +336,15 @@ export class WorkspaceFs {
     const matches: string[] = [];
     let scanned = 0;
     let truncated = false;
+    const deadline = Date.now() + SEARCH_DEADLINE_MS;
     const queue: string[] = [base];
     while (queue.length) {
+      if (Date.now() > deadline) { truncated = true; break; }
       const dir = queue.shift()!;
       let dirents;
       try { dirents = await readdir(dir, { withFileTypes: true }); } catch { continue; }
       for (const d of dirents) {
+        if (Date.now() > deadline) { truncated = true; break; }
         if (++scanned > SEARCH_MAX_SCAN) { truncated = true; break; }
         if (d.isSymbolicLink()) continue; // never follow symlinks — keeps us contained
         if (d.isDirectory()) {
@@ -370,7 +377,7 @@ export class WorkspaceFs {
     const exc = opts.exclude ? globToRegExp(opts.exclude) : null;
 
     // Try git grep first: it's fast and respects .gitignore. Args are argv (never a shell).
-    const inGit = await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { maxBuffer: GIT_MAX_BUFFER })
+    const inGit = await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" })
       .then(() => true).catch(() => false);
     if (inGit) {
       const args = ["-C", root, "grep", "-n", "--column", "-I", "--no-color", "--untracked"];
@@ -380,7 +387,7 @@ export class WorkspaceFs {
       args.push("-e", query, "--", scopeRel || ".");
       let stdout = "";
       try {
-        stdout = (await execFileAsync("git", args, { maxBuffer: GIT_MAX_BUFFER })).stdout;
+        stdout = (await execFileAsync("git", args, { maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" })).stdout;
       } catch (e) {
         const code = (e as { code?: number }).code;
         if (code === 1) stdout = ""; // no matches
@@ -402,17 +409,62 @@ export class WorkspaceFs {
       return { workspace, query, matches: [], hits, truncated };
     }
 
-    // Fallback (non-git): bounded manual walk + per-line match.
+    // Not a git repo. Prefer `git grep --no-index` — same killable, timeout-bounded engine
+    // (no in-process user regex), just over on-disk files. Fall to the pure-JS walk only if
+    // the git binary is entirely absent.
+    try {
+      const args = ["grep", "--no-index", "-n", "--column", "-I", "--no-color"];
+      if (!opts.matchCase) args.push("-i");
+      if (opts.wholeWord) args.push("-w");
+      args.push(opts.regex ? "-E" : "-F");
+      args.push("-e", query, "--", ".");
+      let stdout = "";
+      try {
+        stdout = (await execFileAsync("git", args, { cwd: base, maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" })).stdout;
+      } catch (e) {
+        if ((e as { code?: string }).code === "ENOENT") throw e; // git missing → JS fallback below
+        const code = (e as { code?: number }).code;
+        if (code === 1) stdout = ""; // no matches
+        else { const out = (e as { stdout?: string }).stdout; stdout = typeof out === "string" ? out : ""; }
+      }
+      const hits: SearchHit[] = [];
+      let truncated = false;
+      for (const raw of stdout.split("\n")) {
+        if (!raw) continue;
+        const m = raw.match(/^(.*?):(\d+):(\d+):(.*)$/);
+        if (!m) continue;
+        // paths are relative to `base` (the scope dir); reconcile to root-relative like the repo path.
+        const relToBase = m[1]!.split(sep).join("/");
+        const p = scopeRel ? `${scopeRel}/${relToBase}` : relToBase;
+        if (inc && !inc.test(p)) continue;
+        if (exc && exc.test(p)) continue;
+        hits.push({ path: p, line: Number(m[2]), text: m[4]!.slice(0, 400) });
+        if (hits.length >= SEARCH_CONTENT_MAX_HITS) { truncated = true; break; }
+      }
+      return { workspace, query, matches: [], hits, truncated };
+    } catch (e) {
+      if ((e as { code?: string }).code !== "ENOENT") {
+        // Non-ENOENT unexpected error: degrade to empty rather than the (ReDoS-prone) JS walk.
+        return { workspace, query, matches: [], hits: [], truncated: false };
+      }
+      // else: git binary absent → pure-JS last-resort walk below.
+    }
+
+    // Fallback (git binary entirely absent): bounded manual walk + per-line match, with a
+    // wall-clock deadline so a catastrophic user regex can't hang the event loop forever.
     const matcher = buildLineMatcher(query, opts);
     const hits: SearchHit[] = [];
     let scanned = 0;
     let truncated = false;
+    const deadline = Date.now() + SEARCH_DEADLINE_MS;
     const queue: string[] = [base];
     while (queue.length) {
+      if (Date.now() > deadline) { truncated = true; break; }
       const dir = queue.shift()!;
       let dirents;
       try { dirents = await readdir(dir, { withFileTypes: true }); } catch { continue; }
       for (const d of dirents) {
+        if (Date.now() > deadline) { truncated = true; break; }
         if (++scanned > SEARCH_MAX_SCAN) { truncated = true; break; }
         if (d.isSymbolicLink()) continue;
         const full = resolve(dir, d.name);
@@ -443,7 +495,7 @@ export class WorkspaceFs {
   async gitDiff(workspace: string, relPath?: string): Promise<WorkspaceDiff> {
     const { root, rel } = await this.resolve(workspace, relPath);
     try {
-      await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { maxBuffer: GIT_MAX_BUFFER });
+      await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" });
     } catch {
       throw new Error("not-a-git-repo");
     }
@@ -456,7 +508,7 @@ export class WorkspaceFs {
       const { stdout } = await execFileAsync(
         "git",
         ["-C", root, "-c", "core.quotePath=false", "status", "--porcelain", "-z"],
-        { maxBuffer: GIT_MAX_BUFFER },
+        { maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" },
       );
       const fields = stdout.split("\0");
       for (let i = 0; i < fields.length; i++) {
@@ -478,10 +530,10 @@ export class WorkspaceFs {
     const diffArgs = (base: string[]) => ["-C", root, ...base, ...(rel ? ["--", rel] : [])];
     let diff = "";
     try {
-      diff = (await execFileAsync("git", diffArgs(["diff", "HEAD"]), { maxBuffer: GIT_MAX_BUFFER })).stdout;
+      diff = (await execFileAsync("git", diffArgs(["diff", "HEAD"]), { maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" })).stdout;
     } catch {
       try {
-        diff = (await execFileAsync("git", diffArgs(["diff"]), { maxBuffer: GIT_MAX_BUFFER })).stdout;
+        diff = (await execFileAsync("git", diffArgs(["diff"]), { maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" })).stdout;
       } catch {
         diff = "";
       }
@@ -495,7 +547,7 @@ export class WorkspaceFs {
         diff = (await execFileAsync(
           "git",
           ["-C", root, "-c", "core.quotePath=false", "diff", "--no-index", "--", "/dev/null", rel],
-          { maxBuffer: GIT_MAX_BUFFER },
+          { maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" },
         )).stdout;
       } catch (e) {
         const out = (e as { stdout?: string }).stdout;
@@ -512,7 +564,7 @@ export class WorkspaceFs {
   private async gitContext(root: string): Promise<Pick<WorkspaceDiff, "branch" | "detached" | "worktree">> {
     const run = async (...args: string[]): Promise<string | null> => {
       try {
-        return (await execFileAsync("git", ["-C", root, ...args], { maxBuffer: GIT_MAX_BUFFER })).stdout.trim();
+        return (await execFileAsync("git", ["-C", root, ...args], { maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" })).stdout.trim();
       } catch {
         return null;
       }

--- a/src/control/workspace-fs.ts
+++ b/src/control/workspace-fs.ts
@@ -32,6 +32,7 @@ const SEARCH_MAX_SCAN = 20000; // directory entries visited before giving up
 const SEARCH_SKIP_DIRS = new Set([".git", "node_modules"]);
 const SEARCH_CONTENT_MAX_HITS = 500;
 const SEARCH_CONTENT_MAX_FILE = 1024 * 1024; // skip files > 1 MiB in the fallback walker
+const LINE_MATCH_CAP = 2000; // cap chars fed to the in-process regex (git-absent last-resort ReDoS bound)
 const DOWNLOAD_MAX = 5 * 1024 * 1024; // 5 MiB cap for readFileBytes downloads
 const GIT_TIMEOUT_MS = 10_000; // kill any git subprocess that runs longer (slow repo / ReDoS via `git grep -E`)
 const SEARCH_DEADLINE_MS = 4_000; // abort an in-process JS walk that runs longer (best-effort ReDoS bound)
@@ -386,15 +387,17 @@ export class WorkspaceFs {
       args.push(opts.regex ? "-E" : "-F");
       args.push("-e", query, "--", scopeRel || ".");
       let stdout = "";
+      let killed = false;
       try {
         stdout = (await execFileAsync("git", args, { maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" })).stdout;
       } catch (e) {
+        killed = (e as { killed?: boolean }).killed === true || (e as { signal?: string }).signal === "SIGKILL";
         const code = (e as { code?: number }).code;
         if (code === 1) stdout = ""; // no matches
         else { const out = (e as { stdout?: string }).stdout; stdout = typeof out === "string" ? out : ""; }
       }
       const hits: SearchHit[] = [];
-      let truncated = false;
+      let truncated = killed;
       for (const raw of stdout.split("\n")) {
         if (!raw) continue;
         // format: <path>:<line>:<column>:<text>
@@ -417,18 +420,20 @@ export class WorkspaceFs {
       if (!opts.matchCase) args.push("-i");
       if (opts.wholeWord) args.push("-w");
       args.push(opts.regex ? "-E" : "-F");
-      args.push("-e", query, "--", ".");
+      args.push("-e", query, "--", ".", ":(exclude)node_modules/", ":(exclude).git/");
       let stdout = "";
+      let killed = false;
       try {
         stdout = (await execFileAsync("git", args, { cwd: base, maxBuffer: GIT_MAX_BUFFER, timeout: GIT_TIMEOUT_MS, killSignal: "SIGKILL" })).stdout;
       } catch (e) {
         if ((e as { code?: string }).code === "ENOENT") throw e; // git missing → JS fallback below
+        killed = (e as { killed?: boolean }).killed === true || (e as { signal?: string }).signal === "SIGKILL";
         const code = (e as { code?: number }).code;
         if (code === 1) stdout = ""; // no matches
         else { const out = (e as { stdout?: string }).stdout; stdout = typeof out === "string" ? out : ""; }
       }
       const hits: SearchHit[] = [];
-      let truncated = false;
+      let truncated = killed;
       for (const raw of stdout.split("\n")) {
         if (!raw) continue;
         const m = raw.match(/^(.*?):(\d+):(\d+):(.*)$/);
@@ -479,8 +484,9 @@ export class WorkspaceFs {
         if (text.includes("\0")) continue; // NUL byte ⇒ binary, skip
         const lines = text.split("\n");
         for (let i = 0; i < lines.length; i++) {
+          if (Date.now() > deadline) { truncated = true; break; }
           const line = lines[i]!;
-          if (matcher(line)) {
+          if (matcher(line.length > LINE_MATCH_CAP ? line.slice(0, LINE_MATCH_CAP) : line)) {
             hits.push({ path: rel, line: i + 1, text: line.slice(0, 400) });
             if (hits.length >= SEARCH_CONTENT_MAX_HITS) { truncated = true; break; }
           }

--- a/tests/unit/control/workspace-fs-redos.test.ts
+++ b/tests/unit/control/workspace-fs-redos.test.ts
@@ -62,6 +62,26 @@ describe("WorkspaceFs content search: ReDoS pattern in a git repo returns prompt
   });
 });
 
+describe("WorkspaceFs content search: `--no-index` skips node_modules/.git", () => {
+  let root: string;
+  let fs: WorkspaceFs;
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "wsfs-redos-skipdirs-"));
+    mkdirSync(join(root, "node_modules", "pkg"), { recursive: true });
+    writeFileSync(join(root, "node_modules", "pkg", "index.js"), "needle\n");
+    writeFileSync(join(root, "real.txt"), "needle\n");
+    fs = new WorkspaceFs(() => [{ name: "ws", cwd: root }]);
+  });
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  test("hits include real.txt but not any node_modules/ path", async () => {
+    const r = await fs.search("ws", { query: "needle", mode: "content" });
+    const paths = r.hits.map((h) => h.path);
+    expect(paths).toContain("real.txt");
+    expect(paths.some((p) => p.startsWith("node_modules/"))).toBe(false);
+  });
+});
+
 describe("WorkspaceFs search: regressions", () => {
   let root: string;
   let fs: WorkspaceFs;

--- a/tests/unit/control/workspace-fs-redos.test.ts
+++ b/tests/unit/control/workspace-fs-redos.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkspaceFs } from "../../../src/control/workspace-fs";
+
+// Hardening: user-supplied opts.regex reaches `git grep -E` (subprocess) and, previously,
+// an in-process RegExp fallback for non-git dirs. These tests verify the *observable*
+// behavior of the hardened paths (git-timeout backstop, --no-index routing + path
+// reconciliation, regression parity) — not timing internals, which are covered by review.
+
+describe("WorkspaceFs content search: non-git dir routes through `git grep --no-index`", () => {
+  let root: string;
+  let fs: WorkspaceFs;
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "wsfs-redos-noindex-"));
+    writeFileSync(join(root, "notes.txt"), "hello world\n");
+    mkdirSync(join(root, "sub"));
+    writeFileSync(join(root, "sub", "a.txt"), "needle\n");
+    fs = new WorkspaceFs(() => [{ name: "ws", cwd: root }]);
+  });
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  test("finds a hit at the workspace root with a root-relative path", async () => {
+    const r = await fs.search("ws", { query: "world", mode: "content" });
+    const hit = r.hits.find((h) => h.path === "notes.txt");
+    expect(hit).toBeDefined();
+    expect(hit!.line).toBe(1);
+  });
+
+  test("scoped search (opts.path) reconciles --no-index's base-relative path back to root-relative", async () => {
+    const r = await fs.search("ws", { query: "needle", mode: "content", path: "sub" });
+    expect(r.hits.map((h) => h.path)).toEqual(["sub/a.txt"]);
+  });
+});
+
+describe("WorkspaceFs content search: ReDoS pattern in a git repo returns promptly", () => {
+  let repo: string;
+  let fs: WorkspaceFs;
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), "wsfs-redos-git-"));
+    execFileSync("git", ["init", "-q"], { cwd: repo });
+    execFileSync("git", ["config", "user.email", "t@t"], { cwd: repo });
+    execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
+    // A long run of "a" with no trailing "b" is the classic (a+)+$ catastrophic-backtracking
+    // trigger for a naive backtracking engine; git's regex engine (and our timeout backstop)
+    // must not hang on it.
+    writeFileSync(join(repo, "evil.txt"), "a".repeat(100) + "\n");
+    execFileSync("git", ["add", "-A"], { cwd: repo });
+    fs = new WorkspaceFs(() => [{ name: "g", cwd: repo }]);
+  });
+  afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+  test("resolves within a few seconds instead of hanging", async () => {
+    const timeout = new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 8000));
+    const result = await Promise.race([
+      fs.search("g", { query: "(a+)+$", mode: "content", regex: true }),
+      timeout,
+    ]);
+    expect(result).not.toBe("timed-out");
+  });
+});
+
+describe("WorkspaceFs search: regressions", () => {
+  let root: string;
+  let fs: WorkspaceFs;
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "wsfs-redos-regress-"));
+    writeFileSync(join(root, "alpha.ts"), "export const alpha = 1;\n");
+    fs = new WorkspaceFs(() => [{ name: "ws", cwd: root }]);
+  });
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  test("name mode still finds files by path substring", async () => {
+    const r = await fs.search("ws", { query: "alpha.ts" });
+    expect(r.matches).toContain("alpha.ts");
+  });
+
+  test("an invalid regex still degrades to a substring match instead of throwing", async () => {
+    await expect(fs.search("ws", { query: "(", mode: "content", regex: true })).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Harden relay-web workspace search against ReDoS / runaway git

Follow-up to the file-tree browser (#108/#111). Both final reviews flagged that a user-supplied content-search regex (`opts.regex`) reached both `git grep -E` (a subprocess) and an in-process `RegExp.test` per line — a catastrophic pattern like `(a+)+$` against a long line could hang the connector's single-threaded event loop or spin a git process. Read-only and self-inflicted by an authenticated instance owner, but hardened regardless.

All changes are in `src/control/workspace-fs.ts` (+ `tests/unit/control/workspace-fs-redos.test.ts`). **No new dependencies.**

### Changes
1. **Timeout + SIGKILL on every git subprocess** (`GIT_TIMEOUT_MS = 10s`): all 9 `execFileAsync("git", …)` call sites (rev-parse ×2, `git grep`, `git grep --no-index`, `diff` ×2, `diff --no-index`, gitContext) plus a kill-timer on the `gitCheckIgnore` `spawn` (cleared on close/error). A killed grep now also returns `truncated: true` instead of mislabeling a partial result complete.
2. **Non-git content fallback routed through `git grep --no-index`** — the same killable, timeout-bounded engine over on-disk files, so there is no in-process user-regex on content for any workspace where git is installed (≈always). Hit paths are reconciled from `cwd:base`-relative back to workspace-root-relative via `scopeRel` (parity with the git-repo path, verified by a scoped-search test). Excludes `node_modules/` and `.git/` via negative pathspecs to match the old JS walk's skip behavior. The pure-JS walk remains only as a last resort when the git binary is entirely absent (ENOENT).
3. **Wall-clock deadline (`4s`) on the remaining in-process JS walks** (name-mode search + the git-absent content last-resort), plus a per-line input cap (`LINE_MATCH_CAP = 2000`) on the git-absent content matcher.

### Result
After this change, no git subprocess and no common-path in-process user regex is unbounded. The only residual is a single catastrophic regex on **name-mode** (bounded input = a file path) or in the **git-absent** content last-resort (bounded per-line input, deadline between lines) — both rare, self-inflicted, read-only, and best-effort-bounded. Fully eliminating them would need RE2/a worker thread (a native/heavier dependency), disproportionate to the risk.

### Verification
Reviewed by an independent security review (0 Critical / 0 Important). `bun test workspace-fs-redos` 6/6 (incl. non-git `--no-index` routing + path reconciliation + node_modules exclusion) · full `tests/unit/control` 0 fail · `tsc --noEmit` rc=0. No behavior change for normal queries.
