### PR TITLE
release: relay stack beta — file-tree browser + writes + ReDoS hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [file-tree browser] - 2026-07-03
+
+A coordinated pre-release across the full relay stack adding the relay-web **file-tree browser** (read + write) and hardening its search. All four packages go out together — the write/search backend spans core + connector + protocol, so the hub UI alone would not work. Pre-releases publish to the npm `next` dist-tag. Update the daemon with `xacpx update` (core + connector) and the hub with `xacpx-relay update`, then restart both and hard-reload the dashboard.
+
+Versions: `@ganglion/xacpx` 0.17.0-beta.2 · `@ganglion/xacpx-relay-protocol` 0.1.9 · `@ganglion/xacpx-channel-relay` 0.3.3-beta.2 · `@ganglion/xacpx-relay` 0.9.12-beta.7.
+
+### Added
+
+- **File-tree browser (read-only, sub-project A / #108).** Lazy per-directory tree replacing the flat listing; folder open/closed and per-extension file icons; gitignored + dotfiles dimmed/italic and hidden behind toggles; advanced search over file names or content (`git grep`, with a non-git fallback) with match-case / whole-word / regex toggles, include/exclude globs, and search-in-folder scoping; git-status dots; full-width mobile drawer.
+- **File writes (sub-project B / #111), off by default.** New file / new folder / rename / duplicate / delete (permanent, with confirmation) / download (≤5 MiB), gated by a new `files.writeEnabled` config flag (default `false`). Download is a read and is not gated. All writes reuse the `WorkspaceFs` containment choke point (new `resolveParent()` for not-yet-existing targets); the workspace root cannot be renamed/duplicated/deleted.
+
+### Security
+
+- **Search ReDoS / runaway-subprocess hardening (#112).** Every `git` subprocess now runs under a 10s timeout + SIGKILL; the non-git content fallback routes through `git grep --no-index` (a killable, timeout-bounded engine) so no user-supplied regex runs in-process for content search when git is present; the remaining in-process JS walks carry a wall-clock deadline. Closes the event-loop-hang risk from a catastrophic content-search regex.
+
 ## [relay 0.9.12-beta.6] - 2026-07-02
 
 A `@ganglion/xacpx-relay` (hub) beta closing the mobile keyboard gap on both the terminal shortcut bar and the chat composer. UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update` (then restart the hub and hard-reload the dashboard).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.1",
+  "version": "0.17.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.1",
+      "version": "0.17.0-beta.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -11640,7 +11640,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.1",
+      "version": "0.3.3-beta.2",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -11682,7 +11682,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.6",
+      "version": "0.9.12-beta.7",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -11699,7 +11699,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT"
     },
     "packages/relay-web": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.1",
+  "version": "0.17.0-beta.2",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/channel-relay/package.json
+++ b/packages/channel-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-relay",
-  "version": "0.3.3-beta.1",
+  "version": "0.3.3-beta.2",
   "description": "Relay hub connector channel plugin for xacpx.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay-protocol/package.json
+++ b/packages/relay-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay-protocol",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Shared wire protocol types and codecs for the xacpx relay hub.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.6",
+  "version": "0.9.12-beta.7",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.1", () => {
+test("root package version is 0.17.0-beta.2", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.1");
+  expect(pkg.version).toBe("0.17.0-beta.2");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.1",
+  "version": "0.17.0-beta.2",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.1"
+    "@ganglion/xacpx": "^0.17.0-beta.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Coordinated pre-release of the relay stack for the **file-tree browser** (read + write) and its search hardening. All four packages bump together — the write/search backend spans core + connector + protocol, so the hub UI alone would not function.

| Package | old (npm `next`) | new |
|---|---|---|
| `@ganglion/xacpx` (core) | 0.17.0-beta.1 | **0.17.0-beta.2** |
| `@ganglion/xacpx-relay-protocol` | 0.1.8 | **0.1.9** |
| `@ganglion/xacpx-channel-relay` | 0.3.3-beta.1 | **0.3.3-beta.2** |
| `@ganglion/xacpx-relay` (hub) | 0.9.12-beta.6 | **0.9.12-beta.7** |

Ships: file-tree browser (#108), file writes behind `files.writeEnabled` default-off (#111), search ReDoS hardening (#112).

Coupling handled: root version + `weacpx-compat` shim (version + `^dep`) + `package-metadata.test.ts` assertion synced; `package-lock.json` synced (`--package-lock-only`). Protocol stays 0.1.x (`^0.1.0` deps unaffected); channel-relay peer `xacpx >=0.11.0-0` satisfied by the core beta.

Verified: `package-metadata` 4/4 · `bun run verify:publish` pass (builds all packages, bundles relay-web into the hub, asserts `dist/relay-web/index.html` + protocol dist exports) · `tsc --noEmit` rc=0 · no dist drift.

After merge + green CI, tags are pushed in topological order to trigger the per-package publish workflows (`next` dist-tag): `v0.17.0-beta.2` → `relay-protocol-v0.1.9` → `relay-v0.9.12-beta.7` + `channel-relay-v0.3.3-beta.2`.
