### PR TITLE
release: relay hub 0.9.12-beta.8 — file-tree browser UX refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [relay 0.9.12-beta.8] - 2026-07-03
+
+A `@ganglion/xacpx-relay` (hub) beta bundling file-tree browser UX refinements (#114). UI-only (bundled `relay-web`); no core/protocol/connector change. Published to the npm `next` dist-tag. Update with `xacpx-relay update` (then restart the hub and hard-reload the dashboard).
+
+### Added
+
+- **Per-row ⋯ menu button.** Every file-tree row and the workspace-root header now expose an always-visible ⋯ button that opens the same context menu, so touch devices (no right-click) can reach every action. Root-level new file / new folder moved into the header menu (the two standalone root buttons are gone).
+- **Global toast system.** File operations (create / rename / delete / download) now report success and failure through a unified, top-center toast host that stacks, auto-dismisses, and can be closed by hand — replacing the sticky, non-dismissible error banner for write ops.
+
+### Changed
+
+- **"Search in this folder" is now visible and editable.** It writes a `<folder>/**` glob into the "files to include" field (VSCode-style) instead of a hidden scope; the field is cleared on a workspace switch so a folder scope never leaks across workspaces.
+- **Search placeholder tracks the active mode** (by name vs by content).
+- Only one file-tree context menu is open at a time (repeated right-clicks no longer stack menus).
+
+### Removed
+
+- The **Duplicate** action from the file/folder context menu.
+
 ## [file-tree browser] - 2026-07-03
 
 A coordinated pre-release across the full relay stack adding the relay-web **file-tree browser** (read + write) and hardening its search. All four packages go out together — the write/search backend spans core + connector + protocol, so the hub UI alone would not work. Pre-releases publish to the npm `next` dist-tag. Update the daemon with `xacpx update` (core + connector) and the hub with `xacpx-relay update`, then restart both and hard-reload the dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11682,7 +11682,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.7",
+      "version": "0.9.12-beta.8",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.7",
+  "version": "0.9.12-beta.8",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Hub-only beta bumping `@ganglion/xacpx-relay` to **0.9.12-beta.8** to ship the file-tree browser UX refinements from #114. UI-only (bundled `relay-web`) — no core / protocol / connector change.

## Contents (from #114)
- Per-row ⋯ menu button on every tree row + workspace header (touch-reachable); root new file/folder moved into the header menu.
- Unified global toast host (top-center, stacking, auto-dismiss + closable) for file-op results, replacing the sticky error banner for write ops.
- "Search in this folder" writes a `<folder>/**` glob into the visible "files to include" field (cleared on workspace switch).
- Mode-aware search placeholder; single-open context menu; removed the Duplicate action.

## Release mechanics
- `packages/relay/package.json` → 0.9.12-beta.8; `package-lock.json` synced.
- CHANGELOG entry added.
- `bun run verify:publish` passes (dashboard `dist/relay-web/index.html` confirmed packed into the hub tarball).
- After merge, tag `relay-v0.9.12-beta.8` triggers the hub publish workflow → npm `next` dist-tag.

Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.