### PR TITLE
feat(relay-web): center multi-tab interface + session-list cap

### DIFF
--- a/docs/superpowers/plans/2026-07-03-relay-web-center-tabs.md
+++ b/docs/superpowers/plans/2026-07-03-relay-web-center-tabs.md
@@ -1,0 +1,406 @@
+# relay-web center multi-tab + session-list cap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the dashboard center column into a per-session tab strip (pinned Chat + closable, drag-reorderable file/diff/terminal tabs) and cap the left-rail session list at 10 per instance with show-more/collapse.
+
+**Architecture:** A new `center-tabs` Pinia store holds per-session `{ tabs, activeId }`. `DashboardView` renders a `CenterTabStrip` plus panes: one always-mounted `ChatPane` (current session), one `FileViewer` per open file/diff tab, one `TerminalTab` per open terminal tab — all mounted while open, `v-show` only the current session's active tab (so terminals/scroll survive session and tab switches). `FileViewer` is decoupled from the single global `files.file` slot to per-instance props + return-based store reads. Tab reorder is pointer-based (mouse+touch).
+
+**Tech Stack:** Vue 3 `<script setup>`, Pinia (setup stores), vue-i18n, Tailwind, lucide-vue-next, vitest + @vue/test-utils (jsdom). Tests run with `cd packages/relay-web && npx vitest run` (NOT bun test). Test files live in `packages/relay-web/src/__tests__/`.
+
+## Global Constraints
+
+- **No new dependencies.** Drag-reorder is vanilla Pointer Events (mirror `lib/use-swipe-actions.ts` / `lib/edge-swipe.ts`); relay-web artifacts must stay self-contained (no CDNs).
+- **Typecheck must pass:** `cd packages/relay-web && npx vue-tsc --noEmit` rc=0.
+- **Tests:** `cd packages/relay-web && npx vitest run` — all green. Add tests in `src/__tests__/`.
+- **i18n parity:** every new key exists in BOTH `src/i18n/messages/en.ts` and `src/i18n/messages/zh-CN.ts` with identical placeholder names.
+- **Chat is implicit** — never stored as a tab; `activeId === "chat"` means the chat pane shows. The chat tab is pinned first, non-closable, non-draggable; reorder never moves a tab before it.
+- **One terminal per session** (tab id `"terminal"`); opening again focuses it.
+- **Session key** is always `` `${instanceId}::${alias}` `` via a shared `sessionKey()` helper exported from the store.
+- Keep existing behavior for anything not explicitly changed (session ordering, swipe actions, right-rail Files/Changes tab, mobile drawers).
+
+---
+
+### Task 1: `center-tabs` store
+
+**Files:**
+- Create: `packages/relay-web/src/stores/center-tabs.ts`
+- Test: `packages/relay-web/src/__tests__/center-tabs.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type CenterTab =
+    | { kind: "file"; id: string; path: string }
+    | { kind: "diff"; id: string; path: string }
+    | { kind: "terminal"; id: string };
+  export function sessionKey(instanceId: string, alias: string): string; // `${instanceId}::${alias}`
+  export const useCenterTabsStore: // setup store, returns:
+  //   tabsFor(key): CenterTab[]        activeFor(key): string  (default "chat")
+  //   openFile(key, path)   -> id = path,          activate
+  //   openDiff(key, path)   -> id = "diff:"+path,  activate
+  //   openTerminal(key)     -> id = "terminal",    activate
+  //   setActive(key, id)
+  //   closeTab(key, id)     -> remove; if it was active, activate left neighbor or "chat"
+  //   reorder(key, draggedId, targetId) -> move dragged before target within the tab list
+  //   clearSession(key)     -> delete the session's entry
+  //   allOpenTabs(): { key: string; tab: CenterTab }[]  // flattened, for mounting every pane
+  ```
+
+**Behavior details:**
+- `bySession = ref<Record<string, { tabs: CenterTab[]; activeId: string }>>({})`.
+- `openFile/openDiff/openTerminal`: if a tab with that id exists, just activate it; else push a new tab and activate it. Never duplicate an id.
+- `closeTab`: find index; remove it; if the removed tab was active, set active to `tabs[index-1]?.id ?? tabs[index]?.id ?? "chat"` (left neighbor, else the new tab at that index, else chat). If not active, leave active unchanged.
+- `reorder(key, draggedId, targetId)`: no-op if either missing or equal; remove dragged, insert it at the current index of target (before it). All tabs are file/diff/terminal (chat isn't in the list), so no chat-guard needed here.
+- Reactivity: mutate via reassigning `bySession.value = { ...bySession.value, [key]: next }` OR mutate nested arrays with `.value` writes that Vue tracks — prefer replacing the session object so getters recompute.
+- `allOpenTabs()`: `Object.entries(bySession.value).flatMap(([key, s]) => s.tabs.map(tab => ({ key, tab })))`.
+
+- [ ] **Step 1: Write failing tests** (`center-tabs.test.ts`, `import { setActivePinia, createPinia } from "pinia"`, `beforeEach(() => setActivePinia(createPinia()))`):
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
+
+beforeEach(() => setActivePinia(createPinia()));
+const K = sessionKey("i1", "s1");
+
+describe("center-tabs store", () => {
+  it("opens a file tab, dedupes by path, and activates it", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts");
+    s.openFile(K, "a.ts"); // dedupe
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["a.ts"]);
+    expect(s.activeFor(K)).toBe("a.ts");
+  });
+
+  it("diff and terminal ids are namespaced/fixed", () => {
+    const s = useCenterTabsStore();
+    s.openDiff(K, "a.ts");
+    s.openTerminal(K);
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["diff:a.ts", "terminal"]);
+    s.openTerminal(K); // one terminal per session
+    expect(s.tabsFor(K).filter(t => t.kind === "terminal").length).toBe(1);
+  });
+
+  it("closing the active tab activates the left neighbor, else chat", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); // active = b.ts
+    s.closeTab(K, "b.ts");
+    expect(s.activeFor(K)).toBe("a.ts");
+    s.closeTab(K, "a.ts");
+    expect(s.activeFor(K)).toBe("chat");
+    expect(s.tabsFor(K)).toEqual([]);
+  });
+
+  it("closing a non-active tab keeps the active one", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); s.setActive(K, "chat");
+    s.closeTab(K, "a.ts");
+    expect(s.activeFor(K)).toBe("chat");
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["b.ts"]);
+  });
+
+  it("reorder moves the dragged tab before the target", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); s.openFile(K, "c.ts");
+    s.reorder(K, "c.ts", "a.ts"); // c before a
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["c.ts", "a.ts", "b.ts"]);
+  });
+
+  it("tabs are isolated per session and clearSession removes them", () => {
+    const s = useCenterTabsStore();
+    const K2 = sessionKey("i1", "s2");
+    s.openFile(K, "a.ts"); s.openTerminal(K2);
+    expect(s.tabsFor(K).length).toBe(1);
+    expect(s.tabsFor(K2).length).toBe(1);
+    expect(s.allOpenTabs().length).toBe(2);
+    s.clearSession(K);
+    expect(s.tabsFor(K)).toEqual([]);
+    expect(s.allOpenTabs().length).toBe(1);
+  });
+
+  it("activeFor defaults to chat for an unknown session", () => {
+    const s = useCenterTabsStore();
+    expect(s.activeFor(sessionKey("x", "y"))).toBe("chat");
+    expect(s.tabsFor(sessionKey("x", "y"))).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2:** Run `npx vitest run src/__tests__/center-tabs.test.ts` → FAIL (module missing).
+- [ ] **Step 3:** Implement `center-tabs.ts` per the interface + behavior above.
+- [ ] **Step 4:** Run the test → PASS. `npx vue-tsc --noEmit` → rc=0.
+- [ ] **Step 5:** Commit `feat(relay-web): center-tabs store (per-session tab sets)`.
+
+---
+
+### Task 2: Session-list cap in `InstanceTree.vue` (Feature 1)
+
+**Files:**
+- Modify: `packages/relay-web/src/components/InstanceTree.vue` (session `v-for` ~line 222; `orderedSessions` ~line 70)
+- Modify: `packages/relay-web/src/i18n/messages/en.ts`, `zh-CN.ts` (add `instance.showMoreSessions`, `instance.collapseSessions`)
+- Test: `packages/relay-web/src/__tests__/instancetree-session-cap.test.ts`
+
+**Interfaces:**
+- Consumes: existing `orderedSessions(inst.sessions)` (active first, archived last).
+- Produces: nothing external.
+
+**Behavior:**
+- `const SESSION_CAP = 10;`
+- Per-instance expand set: `const sessionsExpanded = ref<Set<string>>(new Set());` + `toggleSessions(id)`.
+- `visibleSessions(inst)`: `const all = orderedSessions(inst.sessions); return sessionsExpanded.value.has(inst.id) ? all : all.slice(0, SESSION_CAP);`
+- Below the session rows, when `orderedSessions(inst.sessions).length > SESSION_CAP`, render a button:
+  - collapsed → `{{ $t("instance.showMoreSessions", { n: total - SESSION_CAP }) }}` (data-test `sessions-show-more`)
+  - expanded → `{{ $t("instance.collapseSessions") }}` (data-test `sessions-collapse`)
+  - `@click.stop="toggleSessions(inst.id)"`.
+- Change the session `v-for` to iterate `visibleSessions(inst)` instead of `orderedSessions(inst.sessions)`.
+
+**i18n:**
+```
+// en.ts  (instance: { ... })
+showMoreSessions: "Show {n} more",
+collapseSessions: "Collapse",
+// zh-CN.ts
+showMoreSessions: "再显示 {n} 个",
+collapseSessions: "收起",
+```
+
+- [ ] **Step 1: Write failing test** (`instancetree-session-cap.test.ts`): mount `InstanceTree` with one instance of 13 sessions (expand the instance so rows show). Assert exactly 10 `[data-test="session-row"]` render and a `[data-test="sessions-show-more"]` exists whose text contains "3". Click it → 13 rows + `[data-test="sessions-collapse"]`. Click collapse → back to 10.
+  - Check the actual session-row `data-test` in `InstanceTree.vue` and reuse it; if rows have no stable `data-test`, add `data-test="session-row"` to the row element in this task.
+  - Mount pattern: follow the existing `src/__tests__/instancetree.test.ts` for store setup (`useInstancesStore`, set `instances`, `sessionsLoaded: true`, expand the instance).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement the cap + button + i18n.
+- [ ] **Step 4:** Run → PASS; `npx vue-tsc --noEmit` rc=0; also run `src/__tests__/instancetree.test.ts` + `instancetree-rename.test.ts` to confirm no regression.
+- [ ] **Step 5:** Commit `feat(relay-web): cap session list at 10 per instance with show-more/collapse`.
+
+---
+
+### Task 3: Return-based file/diff reads in `files.ts`
+
+**Files:**
+- Modify: `packages/relay-web/src/stores/files.ts`
+- Test: extend `packages/relay-web/src/__tests__/files.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  readFile(instanceId: string, workspace: string, path: string): Promise<FsReadResult>
+  readDiff(instanceId: string, workspace: string, path?: string): Promise<FsDiffResult>
+  ```
+  Both call `api.rpc` (`control.fs.read` / `control.fs.diff`) and RETURN the unwrapped result (throw on error payload) WITHOUT mutating any global store field (`file`, `diff`, `diffPath`, `error`, `loading`). These are for the tab panes to load their own content independently.
+
+- [ ] **Step 1: Write failing tests** in `files.test.ts`:
+```ts
+it("readFile returns content without touching the global file slot", async () => {
+  const s = useFilesStore();
+  rpc.mockResolvedValueOnce({ workspace: "ws", path: "a.ts", content: "x", size: 1, truncated: false, binary: false });
+  const r = await s.readFile("i1", "ws", "a.ts");
+  expect(r.content).toBe("x");
+  expect(s.file).toBeNull(); // global slot untouched
+});
+it("readDiff returns a diff without touching global diff state", async () => {
+  const s = useFilesStore();
+  rpc.mockResolvedValueOnce({ workspace: "ws", files: [], diff: "@@", truncated: false });
+  const r = await s.readDiff("i1", "ws", "a.ts");
+  expect(r.diff).toBe("@@");
+  expect(s.diff).toBeNull();
+  expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.diff", { workspace: "ws", path: "a.ts" });
+});
+```
+(Match the existing `files.test.ts` rpc-mock harness — it uses a module `rpc` mock.)
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement `readFile`/`readDiff` (thin: `unwrap(await api.rpc(...))`, omit `path` from the diff payload when undefined, mirroring `loadDiff`). Add both to the store's returned object.
+- [ ] **Step 4:** Run → PASS; `npx vue-tsc --noEmit` rc=0.
+- [ ] **Step 5:** Commit `feat(relay-web): return-based readFile/readDiff (no global slot mutation)`.
+
+---
+
+### Task 4: Decouple `FileViewer.vue` to props + own content
+
+**Files:**
+- Modify: `packages/relay-web/src/components/FileViewer.vue`
+- Test: `packages/relay-web/src/__tests__/fileviewer.test.ts` (extend) + keep `files-i18n.test.ts` green
+
+**Interfaces:**
+- Consumes: `files.readFile`, `files.readDiff` (Task 3).
+- Produces (props):
+  ```ts
+  defineProps<{ instanceId: string; workspace: string; path?: string; diffPath?: string }>()
+  // exactly one of path / diffPath is set. Emits: (e: "close") and (e: "back").
+  ```
+
+**Behavior:**
+- Replace reads of `files.file`/`files.diff`/`files.diffPath` with LOCAL refs `file`, `diff`, `loading`, `error`.
+- On mount and when `[instanceId, workspace, path, diffPath]` change: if `path` → `file.value = await files.readFile(...)`, `diff.value = null`; else if `diffPath` → `diff.value = await files.readDiff(instanceId, workspace, diffPath)`, `file.value = null`. Guard against races (capture a local token / check the props still match after await).
+- Keep the existing rendering (binary notice, truncated, diff rendering, back/close buttons, i18n keys) but sourced from local refs.
+- `files-i18n.test.ts` currently mounts `FileViewer` and sets `files.file` directly — it MUST be updated in THIS task to pass props instead (e.g. mount with `props: { instanceId:'i1', workspace:'ws', path:'src/a.ts' }` and stub `files.readFile` to resolve the fixture). Update it so it still asserts the same zh-CN affordances.
+
+- [ ] **Step 1:** Update `fileviewer.test.ts` + `files-i18n.test.ts` to the props API (stub `files.readFile`/`readDiff` via `vi.spyOn`), asserting: renders file content from `path` prop; renders diff from `diffPath` prop; emits `close`. Run → FAIL.
+- [ ] **Step 2:** Refactor `FileViewer.vue` to props + local loading.
+- [ ] **Step 3:** Run `fileviewer.test.ts` + `files-i18n.test.ts` → PASS; `npx vue-tsc --noEmit` rc=0.
+- [ ] **Step 4:** Commit `refactor(relay-web): FileViewer loads its own content from props`.
+
+**Note for integrator (Task 7):** any current single-slot usage of `FileViewer` in `DashboardView` is replaced there; `files.file`/`diff`/`diffPath` global fields may remain for other readers (Changes-tab badges) but the center no longer drives `FileViewer` off them.
+
+---
+
+### Task 5: `lib/use-tab-drag.ts` — pointer-based reorder
+
+**Files:**
+- Create: `packages/relay-web/src/lib/use-tab-drag.ts`
+- Test: `packages/relay-web/src/__tests__/use-tab-drag.test.ts`
+
+**Interfaces:**
+- Produces a composable that, given callbacks, tracks a horizontal pointer drag over tab elements and reports the drag source id and a live target id, committing on pointerup. Keep it framework-light and unit-testable:
+  ```ts
+  export interface TabDragHandlers {
+    onReorder: (draggedId: string, targetId: string) => void;
+  }
+  export function useTabDrag(opts: TabDragHandlers): {
+    draggingId: Ref<string | null>;
+    overId: Ref<string | null>;
+    start: (e: PointerEvent, id: string) => void;   // pointerdown on a tab
+    // internal move/up handlers are wired on the element via returned bindings or attached to document
+  };
+  ```
+- Behavior: `start` records `id`, `startX`, sets nothing dragging yet. On `pointermove` past ~4px threshold, set `draggingId=id`; determine `overId` from `document.elementFromPoint(x, y)` walking to the nearest `[data-tab-id]`. On `pointerup`, if `draggingId && overId && overId !== draggingId`, call `onReorder(draggingId, overId)`; reset. `pointercancel` resets.
+- Because layout/hit-testing isn't available in jsdom, the unit test covers the *logic* you can exercise: threshold gating (a move < threshold does NOT set `draggingId`; a move ≥ threshold does), and that a synthetic pointerup with a known `overId` (inject via a test seam — e.g. accept an `elementIdAt(x,y)` function param defaulting to the DOM lookup) calls `onReorder`. Design the composable to accept an optional `resolveId?: (x: number, y: number) => string | null` so tests can inject hit-testing.
+
+- [ ] **Step 1: Write failing tests** exercising: (a) move below threshold → `draggingId` stays null, no reorder; (b) move above threshold with injected `resolveId` → `overId` updates; (c) pointerup commits `onReorder(dragged, over)`; (d) pointercancel resets without calling `onReorder`. Run → FAIL.
+- [ ] **Step 2:** Implement `use-tab-drag.ts` with the `resolveId` seam (default uses `document.elementFromPoint(...).closest('[data-tab-id]')?.getAttribute('data-tab-id')`).
+- [ ] **Step 3:** Run → PASS; `npx vue-tsc --noEmit` rc=0.
+- [ ] **Step 4:** Commit `feat(relay-web): pointer-based tab drag-reorder utility`.
+
+---
+
+### Task 6: `CenterTabStrip.vue`
+
+**Files:**
+- Create: `packages/relay-web/src/components/CenterTabStrip.vue`
+- Modify: `packages/relay-web/src/i18n/messages/en.ts`, `zh-CN.ts` (add `center.chat`, `center.terminal`, `center.closeTab`)
+- Test: `packages/relay-web/src/__tests__/centertabstrip.test.ts`
+
+**Interfaces:**
+- Consumes: `useCenterTabsStore` (Task 1), `useTabDrag` (Task 5), `iconForFile` (`lib/file-icons`), lucide `MessageSquare`/`SquareTerminal`/`X`.
+- Props: `defineProps<{ sessionKey: string }>()`.
+- Renders: a horizontal, `overflow-x-auto` strip.
+  - First: the pinned chat tab — `data-test="tab-chat"`, active when `activeFor(key)==='chat'`, `@click="setActive(key,'chat')"`, no ✕, not draggable.
+  - Then `tabsFor(key)`: each tab `data-test="tab"` `:data-tab-id="tab.id"`, `draggable`-like via `@pointerdown="drag.start($event, tab.id)"`, `touch-action: none`, active styling when `tab.id===activeFor(key)`, click → `setActive`, a ✕ button (`data-test="tab-close"`, `@click.stop="closeTab(key, tab.id)"`, `:aria-label="$t('center.closeTab')"`). Icon: terminal → `SquareTerminal`; file/diff → `iconForFile(tab.path)`; diff shows a small "Δ"/diff hint. Label: basename of `tab.path` (file/diff) or `$t('center.terminal')`.
+  - Drag visual: apply an "over" ring when `drag.overId === tab.id`.
+- The strip's `onReorder` → `store.reorder(props.sessionKey, dragged, target)`.
+
+**i18n:** `center: { chat: "Chat"/"会话", terminal: "Terminal"/"终端", closeTab: "Close tab"/"关闭标签" }`.
+
+- [ ] **Step 1: Write failing test** (`centertabstrip.test.ts`): pinia; open a file + terminal on the key; mount with `props:{ sessionKey:K }` and `$t` mock. Assert: a `tab-chat` element exists; two `tab` elements; clicking a `tab` calls `setActive`; clicking its `tab-close` calls `closeTab`; the active tab has the active class. (Drag is covered by Task 5; here just assert `@pointerdown` is wired by triggering `pointerdown` and checking `drag.start` isn't throwing / the element has `data-tab-id`.)
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement `CenterTabStrip.vue` + i18n.
+- [ ] **Step 4:** Run → PASS; `npx vue-tsc --noEmit` rc=0.
+- [ ] **Step 5:** Commit `feat(relay-web): CenterTabStrip (pinned chat + closable, drag-reorderable tabs)`.
+
+---
+
+### Task 7: `DashboardView.vue` center integration
+
+**Files:**
+- Modify: `packages/relay-web/src/views/DashboardView.vue` (center region ~lines 314-325; watchers ~131-140; terminal toggle button)
+- Test: `packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts` (new; keep existing dashboard tests green)
+
+**Interfaces:**
+- Consumes: `useCenterTabsStore`, `sessionKey`, `CenterTabStrip`, decoupled `FileViewer` (Task 4), `TerminalTab`, `ChatPane`.
+
+**Behavior:**
+- `currentKey = computed(() => chat.instanceId && chat.sessionAlias ? sessionKey(chat.instanceId, chat.sessionAlias) : null)`.
+- Replace the center block:
+  ```
+  <div class="center column">
+    <CenterTabStrip v-if="currentKey" :session-key="currentKey" />
+    <div class="relative flex-1 min-h-0">
+      <ChatPane ... :inert="currentKey && centerTabs.activeFor(currentKey) !== 'chat'"
+                v-show="!currentKey || centerTabs.activeFor(currentKey) === 'chat'" />
+      <!-- one pane per open tab across ALL sessions, mounted while open -->
+      <template v-for="{ key, tab } in centerTabs.allOpenTabs()" :key="key + '|' + tab.id">
+        <FileViewer v-if="tab.kind === 'file' || tab.kind === 'diff'"
+          v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
+          :instance-id="keyInstance(key)" :workspace="keyWorkspace(key)"
+          :path="tab.kind==='file' ? tab.path : undefined"
+          :diff-path="tab.kind==='diff' ? tab.path : undefined"
+          @close="centerTabs.closeTab(key, tab.id)" @back="backToFileList" />
+        <TerminalTab v-else-if="tab.kind === 'terminal'"
+          v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
+          :instance-id="keyInstance(key)" :session-alias="keyAlias(key)" />
+      </template>
+    </div>
+  </div>
+  ```
+  - Add helpers `keyInstance(key)`/`keyAlias(key)` that split on `"::"`. `keyWorkspace(key)` = the workspace for that session (look it up via instances store by instanceId+alias, mirroring the existing `activeWorkspace` logic); if not resolvable, pass the current `files.workspace` for the current session only. Since panes only *show* for the current session, resolving workspace for the current key is sufficient; for hidden non-current panes, workspace can be resolved the same way (they don't need to be visible to hold state).
+- **Terminal button:** the existing terminal toggle now calls `centerTabs.openTerminal(currentKey)` (and, if desired, toggles back to chat if the terminal is already active — acceptable to just always open/focus).
+- **Remove** the `viewingFile`/`terminalOpen` refs/computed and the mutual-exclusion watchers (131-140) that are now handled by the tab model. Preserve: on mobile, opening a tab may still close the right drawer overlay (`rightOpen=false`) — keep a minimal watcher on `currentKey`'s active tab if needed, else drop.
+- Keep `ChatPane` a single instance bound to the current session (unchanged props).
+
+- [ ] **Step 1: Write failing test** (`dashboard-center-tabs.test.ts`): mount `DashboardView` with a selected session (reuse existing dashboard test setup for `chat.select`), then:
+  - initially the chat pane shows and `CenterTabStrip` shows only the chat tab;
+  - `centerTabs.openFile(currentKey, "a.ts")` → a `FileViewer` becomes visible and the strip shows a file tab;
+  - `centerTabs.openTerminal(currentKey)` → a `TerminalTab` mounts.
+  Use shallow/stubbed child components where full mount is heavy (stub `FileViewer`/`TerminalTab`/`ChatPane` with `{ template: '<div data-test="...">' }` via `global.stubs`) and assert on the stubs' presence/visibility. Run → FAIL.
+- [ ] **Step 2:** Implement the integration; delete dead overlay state/watchers.
+- [ ] **Step 3:** Run the new test + existing `filespanel`/dashboard tests → PASS; `npx vue-tsc --noEmit` rc=0.
+- [ ] **Step 4:** Commit `feat(relay-web): render center as a per-session tab strip`.
+
+---
+
+### Task 8: Route file/diff opening through center-tabs
+
+**Files:**
+- Modify: `packages/relay-web/src/components/FilesPanel.vue` (`openTreeFile`, `openSearchResult`, `openDiff`)
+- Test: `packages/relay-web/src/__tests__/filespanel.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `useCenterTabsStore`, `sessionKey`, `useChatStore` (already imported for `activeWorkspace`).
+
+**Behavior:**
+- `currentKey`: `chat.instanceId && chat.sessionAlias ? sessionKey(chat.instanceId, chat.sessionAlias) : null`.
+- `openTreeFile(rel)` / `openSearchResult(m)`: if `currentKey`, call `centerTabs.openFile(currentKey, rel)`; keep clearing `files.diffPath = null` if still used elsewhere, but do NOT call `files.openFile` (which mutates the global slot the center no longer reads). If no `currentKey`, no-op.
+- `openDiff(path)`: if `currentKey`, `centerTabs.openDiff(currentKey, path)`.
+- Leave the Changes/Files right-rail listing and search UI otherwise unchanged.
+
+- [ ] **Step 1: Update/extend `filespanel.test.ts`**: with a selected session (set `chat.instanceId`/`sessionAlias`), clicking a tree file / search result / changed file calls the corresponding `centerTabs.openFile`/`openDiff` with `sessionKey(...)` and the path. (Spy on the center-tabs store methods.) Run → FAIL.
+- [ ] **Step 2:** Implement the routing.
+- [ ] **Step 3:** Run → PASS; `npx vue-tsc --noEmit` rc=0.
+- [ ] **Step 4:** Commit `feat(relay-web): open files/diffs as center tabs from the Files rail`.
+
+---
+
+### Task 9: Clear a session's tabs on archive/delete
+
+**Files:**
+- Modify: wherever a session is archived/deleted and its center state should drop — most likely `DashboardView.vue` (it already reacts to session removal / alias clear) or the archive handler path from `InstanceTree`.
+- Test: extend `dashboard-center-tabs.test.ts` (or a focused test)
+
+**Behavior:**
+- When a session is archived or deleted (its `alias` no longer exists / is cleared), call `centerTabs.clearSession(sessionKey(instanceId, alias))` so its tabs (and thus mounted terminal/file panes) unmount and its PTY tears down.
+- Verify the terminal pane actually unmounts (its `onBeforeUnmount`/`teardown` runs) when `clearSession` removes the tab — this is the orphan-PTY safeguard.
+
+- [ ] **Step 1: Write failing test:** open a terminal on a session, then simulate archive/delete of that session → the terminal pane is gone (`allOpenTabs()` no longer lists it / the stub unmounts). Run → FAIL.
+- [ ] **Step 2:** Wire `clearSession` into the archive/delete path.
+- [ ] **Step 3:** Run → PASS; `npx vue-tsc --noEmit` rc=0.
+- [ ] **Step 4:** Commit `fix(relay-web): drop a session's center tabs (and PTYs) on archive/delete`.
+
+---
+
+### Task 10: Full-suite gate + i18n parity sweep
+
+**Files:** none new (verification + any parity fix)
+
+- [ ] **Step 1:** `cd packages/relay-web && npx vue-tsc --noEmit` → rc=0.
+- [ ] **Step 2:** `npx vitest run` → all green (full suite).
+- [ ] **Step 3:** Grep both i18n files for the new keys (`showMoreSessions`, `collapseSessions`, `center.chat`, `center.terminal`, `center.closeTab`) — confirm present in BOTH with matching placeholders. Fix any gap.
+- [ ] **Step 4:** Commit only if a fix was needed: `test(relay-web): center-tabs full-suite + i18n parity`.
+
+---
+
+## Notes for the executor
+
+- **Task order / dependencies:** 1 → (3 → 4), 5 → 6 → 7 → 8 → 9 → 10. Task 2 (session cap) is independent and can go anytime. Tasks 3/4 and 5/6 are two independent chains feeding Task 7.
+- The heaviest, riskiest task is **7** (center integration + deleting the old overlay/watcher logic). Give it extra review attention: verify ChatPane still preserves scroll (single instance, `v-show` + `inert`), the mobile right-drawer behavior, and that hidden panes don't error when their session isn't current (workspace resolution).
+- Terminal orphan-PTY safety: the only way a terminal's `teardown()` runs is component unmount — which now happens on `closeTab` (tab removed → `v-for` drops the pane) and on `clearSession`. Confirm both unmount paths in review.

--- a/docs/superpowers/specs/2026-07-03-relay-web-center-tabs.md
+++ b/docs/superpowers/specs/2026-07-03-relay-web-center-tabs.md
@@ -1,0 +1,99 @@
+# relay-web: center multi-tab + session-list cap — design
+
+Two dashboard UX features for `packages/relay-web`.
+
+## Feature 1 — Session list per-instance cap (small)
+
+**Today:** `InstanceTree.vue` renders every session under an expanded instance (`v-for="s in orderedSessions(inst.sessions)"`), no cap.
+
+**Change:** cap the visible sessions per instance at **10** (of the already-ordered list — active first, archived last). When an instance has more:
+- Show a **"再显示 N 个 / Show N more"** button at the bottom of that instance's list (`N` = remaining count).
+- When expanded, show **"收起 / Collapse"** to return to 10.
+
+**State:** a reactive `Set<string>` of instanceIds whose session list is expanded, local to `InstanceTree.vue` (ephemeral — resets on reload; no persistence). Default collapsed.
+
+**i18n:** `instance.showMoreSessions` ("再显示 {n} 个" / "Show {n} more"), `instance.collapseSessions` ("收起" / "Collapse"). Both en + zh.
+
+Selection, ordering, swipe-actions, and the existing per-instance expand/collapse (which hides the whole instance) are unchanged; this cap is a second, inner level that only limits how many rows render.
+
+## Feature 2 — Center area as a tab strip (large)
+
+**Today** (`DashboardView.vue:319-325`): the center column is `ChatPane` (always mounted, `inert` when covered) plus `FileViewer` and `TerminalTab` as **mutually-exclusive overlays** driven by `viewingFile` (`files.file || files.diffPath`) and `terminalOpen`. Watchers enforce the mutual exclusion. `FileViewer` reads the single global `files.file`/`files.diff` slot.
+
+**Change:** the center gets a **tab strip** at the top. Tabs:
+- **Chat** is the pinned first tab (💬), **non-closable, non-draggable**, always present.
+- **File / diff / terminal** tabs follow, each **closable (✕)** and **draggable to reorder** (among themselves — chat stays first).
+
+Confirmed decisions:
+- **Per-session tab sets.** Each session (`instanceId::alias`) has its own tab list + active tab. Switching sessions shows that session's tabs and active tab.
+- **One terminal per session** — clicking the terminal button opens the session's terminal tab, or focuses it if already open.
+- **Terminals survive session switches** — a terminal tab's component stays mounted (hidden) when you switch away, so its PTY isn't torn down; switching back reveals it live.
+
+### New store: `stores/center-tabs.ts`
+
+```ts
+type CenterTab =
+  | { kind: "file";     id: string; path: string }   // id = path
+  | { kind: "diff";     id: string; path: string }   // id = "diff:" + path
+  | { kind: "terminal"; id: string };                // id = "terminal"
+
+interface SessionTabs { tabs: CenterTab[]; activeId: string } // activeId = "chat" | tab.id
+```
+
+- `bySession: Record<string /* instanceId::alias */, SessionTabs>` (ref).
+- `sessionKey(instanceId, alias)` helper.
+- Actions (all take an explicit `key`): `openFile(key, path)`, `openDiff(key, path)`, `openTerminal(key)` — add if absent (dedup by id) then activate; `closeTab(key, id)` — remove and, if it was active, activate the left neighbor or `"chat"`; `setActive(key, id)`; `reorder(key, fromId, toId)` — move within the non-chat list; `clearSession(key)` (on session archive/delete).
+- Getters: `tabsFor(key)`, `activeFor(key)`.
+- **Chat is implicit** — never stored as a tab; `activeId === "chat"` means the chat pane is showing.
+
+### Center rendering (`DashboardView.vue`)
+
+Replace the overlay block with:
+1. A **`CenterTabStrip`** component: renders the chat tab + `tabsFor(currentKey)`, marks the active one, handles click-to-activate, close (✕), and HTML5 drag-reorder (`draggable`, `@dragstart`/`@dragover.prevent`/`@drop`; chat tab not draggable and not a drop-after target before index 0). Mirrors the file-icon + a terminal icon.
+2. The panes:
+   - **`ChatPane`** — single instance, current session (as today); `v-show` when `activeFor(currentKey) === "chat"`, else `inert`/hidden.
+   - **File/diff tabs** — render **one `FileViewer` per open file/diff tab across all sessions**, keyed by `key+tab.id`, `v-show` only when its session is current **and** it's the active tab. Kept mounted while open → preserves scroll and avoids reload on tab switch.
+   - **Terminal tabs** — render **one `TerminalTab` per open terminal tab across all sessions**, keyed by `key`, `v-show` when current+active. Kept mounted across session switches → PTY survives.
+
+Mounting every open tab's component (not just the current one) is what makes terminals survive session switches and file scroll persist; file content is lightweight text, and there's at most one terminal per session, so the cost is bounded by what the user opened.
+
+### `FileViewer` decoupling
+
+`FileViewer` currently reads the global `files.file`/`files.diff` slot, so only one can exist. Refactor it to take a **prop** (`{ instanceId, workspace, path?, diffPath? }`) and load + hold its **own** content in local refs, via new **return-based** store reads that do not mutate global state:
+- `files.readFile(instanceId, workspace, path): Promise<FsReadResult>`
+- `files.readDiff(instanceId, workspace, path?): Promise<FsDiffResult>`
+
+Keep the existing global `openFile`/`loadDiff` for any remaining single-slot callers, but the tab panes use the return-based reads. Back/close affordances: **close (✕)** now closes the tab (via `closeTab`); the mobile "back to file list" affordance still reopens the right Files drawer.
+
+### Wiring the openers
+
+- Right-rail Files tree / search-result click (`openTreeFile`, `openSearchResult`) → `centerTabs.openFile(currentKey, path)` instead of `files.openFile`.
+- Changes-tab file click (`openDiff`) → `centerTabs.openDiff(currentKey, path)`.
+- Terminal toggle button → `centerTabs.openTerminal(currentKey)` (focus if open); the button can also close/return-to-chat.
+- Remove the `viewingFile`/`terminalOpen` overlay state and the mutual-exclusion watchers (superseded by the tab model). Preserve the mobile right-drawer auto-close where it still makes sense (opening a tab on mobile closes the right drawer overlay).
+- On session archive/delete, call `centerTabs.clearSession(key)`.
+
+### Drag-reorder (mouse + touch)
+
+Greenfield, but **pointer-based** (Pointer Events) so it works on both desktop and touch in one implementation — matching the codebase's existing pointer-based drag utilities (`lib/use-swipe-actions.ts`, `lib/edge-swipe.ts`) rather than the HTML5 drag API (which does not fire on touch).
+
+New utility `lib/use-tab-drag.ts` (or inline in `CenterTabStrip`):
+- `pointerdown` on a non-chat tab records the tab id + start X and sets `pointer-capture`; a small movement threshold (~4px) distinguishes a drag from a tap so click-to-activate and the ✕ close still work.
+- `pointermove` past the threshold enters drag mode: track the pointer X, compute the target insertion slot from the tab elements' midpoints, and show a live drop indicator (or live-reorder).
+- `pointerup` commits `reorder(key, draggedId, targetId)` and releases capture; `pointercancel` aborts.
+- Chat tab is not a drag source and reorder never moves a tab before the chat slot (index 0).
+- `touch-action: none` on draggable tabs so the browser doesn't scroll/select mid-drag; the strip itself still scrolls horizontally when not dragging.
+
+## Testing
+
+- **center-tabs store:** open/dedup/activate, close-activates-neighbor-or-chat, reorder within non-chat list, per-session isolation, clearSession.
+- **CenterTabStrip:** renders chat + tabs, active marking, close emits, drag-reorder calls store.
+- **FileViewer (decoupled):** loads its own content from props (file + diff), independent instances don't clash.
+- **InstanceTree cap:** ≤10 shown; "show N more" reveals the rest; "collapse" returns to 10; count correct; isolated per instance.
+- i18n parity for new keys.
+
+## Out of scope
+
+- Multiple terminals per session.
+- Persisting tab sets across page reloads (tabs are in-memory; a reload returns to chat).
+- Tab overflow scrolling beyond what flex-wrap/scroll gives (basic horizontal scroll of the strip is fine).

--- a/packages/relay-web/src/__tests__/center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/center-tabs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
-import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
+import { useCenterTabsStore, sessionKey, TAB_DROP_END } from "../stores/center-tabs";
 
 beforeEach(() => setActivePinia(createPinia()));
 const K = sessionKey("i1", "s1");
@@ -10,8 +10,8 @@ describe("center-tabs store", () => {
     const s = useCenterTabsStore();
     s.openFile(K, "a.ts");
     s.openFile(K, "a.ts"); // dedupe
-    expect(s.tabsFor(K).map(t => t.id)).toEqual(["a.ts"]);
-    expect(s.activeFor(K)).toBe("a.ts");
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["file:a.ts"]);
+    expect(s.activeFor(K)).toBe("file:a.ts");
   });
 
   it("diff and terminal ids are namespaced/fixed", () => {
@@ -23,12 +23,28 @@ describe("center-tabs store", () => {
     expect(s.tabsFor(K).filter(t => t.kind === "terminal").length).toBe(1);
   });
 
+  it("file ids are namespaced so they can't collide with the terminal tab or a diff tab", () => {
+    const s = useCenterTabsStore();
+    // A root file literally named "terminal" must not collide with the fixed terminal id.
+    s.openFile(K, "terminal");
+    s.openTerminal(K);
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["file:terminal", "terminal"]);
+    expect(s.tabsFor(K).length).toBe(2);
+
+    // A file whose path is literally "diff:x" must not collide with the diff tab of "x".
+    const K2 = sessionKey("i1", "s2");
+    s.openFile(K2, "diff:x");
+    s.openDiff(K2, "x");
+    expect(s.tabsFor(K2).map(t => t.id)).toEqual(["file:diff:x", "diff:x"]);
+    expect(s.tabsFor(K2).length).toBe(2);
+  });
+
   it("closing the active tab activates the left neighbor, else chat", () => {
     const s = useCenterTabsStore();
     s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); // active = b.ts
-    s.closeTab(K, "b.ts");
-    expect(s.activeFor(K)).toBe("a.ts");
-    s.closeTab(K, "a.ts");
+    s.closeTab(K, "file:b.ts");
+    expect(s.activeFor(K)).toBe("file:a.ts");
+    s.closeTab(K, "file:a.ts");
     expect(s.activeFor(K)).toBe("chat");
     expect(s.tabsFor(K)).toEqual([]);
   });
@@ -36,16 +52,30 @@ describe("center-tabs store", () => {
   it("closing a non-active tab keeps the active one", () => {
     const s = useCenterTabsStore();
     s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); s.setActive(K, "chat");
-    s.closeTab(K, "a.ts");
+    s.closeTab(K, "file:a.ts");
     expect(s.activeFor(K)).toBe("chat");
-    expect(s.tabsFor(K).map(t => t.id)).toEqual(["b.ts"]);
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["file:b.ts"]);
   });
 
   it("reorder moves the dragged tab before the target", () => {
     const s = useCenterTabsStore();
     s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); s.openFile(K, "c.ts");
-    s.reorder(K, "c.ts", "a.ts"); // c before a
-    expect(s.tabsFor(K).map(t => t.id)).toEqual(["c.ts", "a.ts", "b.ts"]);
+    s.reorder(K, "file:c.ts", "file:a.ts"); // c before a
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["file:c.ts", "file:a.ts", "file:b.ts"]);
+  });
+
+  it("reorder moves the dragged tab to the end when the target is the END sentinel", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); s.openFile(K, "c.ts");
+    s.reorder(K, "file:a.ts", TAB_DROP_END);
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["file:b.ts", "file:c.ts", "file:a.ts"]);
+  });
+
+  it("reorder to END is a no-op when the dragged tab is missing", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts");
+    s.reorder(K, "file:missing.ts", TAB_DROP_END);
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["file:a.ts", "file:b.ts"]);
   });
 
   it("tabs are isolated per session and clearSession removes them", () => {

--- a/packages/relay-web/src/__tests__/center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/center-tabs.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
+
+beforeEach(() => setActivePinia(createPinia()));
+const K = sessionKey("i1", "s1");
+
+describe("center-tabs store", () => {
+  it("opens a file tab, dedupes by path, and activates it", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts");
+    s.openFile(K, "a.ts"); // dedupe
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["a.ts"]);
+    expect(s.activeFor(K)).toBe("a.ts");
+  });
+
+  it("diff and terminal ids are namespaced/fixed", () => {
+    const s = useCenterTabsStore();
+    s.openDiff(K, "a.ts");
+    s.openTerminal(K);
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["diff:a.ts", "terminal"]);
+    s.openTerminal(K); // one terminal per session
+    expect(s.tabsFor(K).filter(t => t.kind === "terminal").length).toBe(1);
+  });
+
+  it("closing the active tab activates the left neighbor, else chat", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); // active = b.ts
+    s.closeTab(K, "b.ts");
+    expect(s.activeFor(K)).toBe("a.ts");
+    s.closeTab(K, "a.ts");
+    expect(s.activeFor(K)).toBe("chat");
+    expect(s.tabsFor(K)).toEqual([]);
+  });
+
+  it("closing a non-active tab keeps the active one", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); s.setActive(K, "chat");
+    s.closeTab(K, "a.ts");
+    expect(s.activeFor(K)).toBe("chat");
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["b.ts"]);
+  });
+
+  it("reorder moves the dragged tab before the target", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); s.openFile(K, "c.ts");
+    s.reorder(K, "c.ts", "a.ts"); // c before a
+    expect(s.tabsFor(K).map(t => t.id)).toEqual(["c.ts", "a.ts", "b.ts"]);
+  });
+
+  it("tabs are isolated per session and clearSession removes them", () => {
+    const s = useCenterTabsStore();
+    const K2 = sessionKey("i1", "s2");
+    s.openFile(K, "a.ts"); s.openTerminal(K2);
+    expect(s.tabsFor(K).length).toBe(1);
+    expect(s.tabsFor(K2).length).toBe(1);
+    expect(s.allOpenTabs().length).toBe(2);
+    s.clearSession(K);
+    expect(s.tabsFor(K)).toEqual([]);
+    expect(s.allOpenTabs().length).toBe(1);
+  });
+
+  it("activeFor defaults to chat for an unknown session", () => {
+    const s = useCenterTabsStore();
+    expect(s.activeFor(sessionKey("x", "y"))).toBe("chat");
+    expect(s.tabsFor(sessionKey("x", "y"))).toEqual([]);
+  });
+});

--- a/packages/relay-web/src/__tests__/centertabstrip.test.ts
+++ b/packages/relay-web/src/__tests__/centertabstrip.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import CenterTabStrip from "../components/CenterTabStrip.vue";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
+
+const g = { global: { mocks: { $t: (k: string) => k } } };
+
+beforeEach(() => setActivePinia(createPinia()));
+
+describe("CenterTabStrip", () => {
+  it("renders the pinned chat tab plus one tab per open file/terminal", () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+    store.openTerminal(K);
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+
+    expect(w.find('[data-test="tab-chat"]').exists()).toBe(true);
+    expect(w.findAll('[data-test="tab"]')).toHaveLength(2);
+  });
+
+  it("shows the basename of the file path as the tab label", () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+    store.openTerminal(K);
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "src/a.ts")!;
+    expect(fileTab.exists()).toBe(true);
+    expect(fileTab.text()).toContain("a.ts");
+    expect(fileTab.text()).not.toContain("src/a.ts");
+  });
+
+  it("marks the active tab with the accent styling", () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+    store.openTerminal(K); // now terminal is active
+    store.setActive(K, "src/a.ts"); // reactivate the file tab
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "src/a.ts")!;
+    const terminalTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "terminal")!;
+    expect(fileTab.classes().join(" ")).toContain("accent");
+    expect(terminalTab.classes().join(" ")).not.toContain("accent");
+    expect(w.find('[data-test="tab-chat"]').classes().join(" ")).not.toContain("accent");
+  });
+
+  it("clicking a tab activates it via the store", async () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+    store.openTerminal(K);
+    const setActive = vi.spyOn(store, "setActive");
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "src/a.ts")!;
+    await fileTab.trigger("click");
+    expect(setActive).toHaveBeenCalledWith(K, "src/a.ts");
+
+    await w.find('[data-test="tab-chat"]').trigger("click");
+    expect(setActive).toHaveBeenLastCalledWith(K, "chat");
+  });
+
+  it("clicking a tab's close button closes it via the store without also activating it", async () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+    store.openTerminal(K);
+    store.setActive(K, "chat");
+    const setActive = vi.spyOn(store, "setActive");
+    const closeTab = vi.spyOn(store, "closeTab");
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "src/a.ts")!;
+    await fileTab.find('[data-test="tab-close"]').trigger("click");
+
+    expect(closeTab).toHaveBeenCalledWith(K, "src/a.ts");
+    expect(setActive).not.toHaveBeenCalled(); // @click.stop must not also bubble into activation
+  });
+
+  it("wires pointerdown for drag without throwing, and each tab carries data-tab-id", () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+    store.openTerminal(K);
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    const tabs = w.findAll('[data-test="tab"]');
+    expect(tabs.map((t) => t.attributes("data-tab-id")).sort()).toEqual(["src/a.ts", "terminal"]);
+    for (const t of tabs) {
+      expect(() => t.trigger("pointerdown")).not.toThrow();
+    }
+  });
+});

--- a/packages/relay-web/src/__tests__/centertabstrip.test.ts
+++ b/packages/relay-web/src/__tests__/centertabstrip.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import CenterTabStrip from "../components/CenterTabStrip.vue";
-import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
+import { useCenterTabsStore, sessionKey, TAB_DROP_END } from "../stores/center-tabs";
 
 const g = { global: { mocks: { $t: (k: string) => k } } };
 
@@ -28,7 +28,7 @@ describe("CenterTabStrip", () => {
     store.openTerminal(K);
 
     const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
-    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "src/a.ts")!;
+    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "file:src/a.ts")!;
     expect(fileTab.exists()).toBe(true);
     expect(fileTab.text()).toContain("a.ts");
     expect(fileTab.text()).not.toContain("src/a.ts");
@@ -39,10 +39,10 @@ describe("CenterTabStrip", () => {
     const K = sessionKey("i1", "s1");
     store.openFile(K, "src/a.ts");
     store.openTerminal(K); // now terminal is active
-    store.setActive(K, "src/a.ts"); // reactivate the file tab
+    store.setActive(K, "file:src/a.ts"); // reactivate the file tab
 
     const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
-    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "src/a.ts")!;
+    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "file:src/a.ts")!;
     const terminalTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "terminal")!;
     expect(fileTab.classes().join(" ")).toContain("accent");
     expect(terminalTab.classes().join(" ")).not.toContain("accent");
@@ -57,9 +57,9 @@ describe("CenterTabStrip", () => {
     const setActive = vi.spyOn(store, "setActive");
 
     const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
-    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "src/a.ts")!;
+    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "file:src/a.ts")!;
     await fileTab.trigger("click");
-    expect(setActive).toHaveBeenCalledWith(K, "src/a.ts");
+    expect(setActive).toHaveBeenCalledWith(K, "file:src/a.ts");
 
     await w.find('[data-test="tab-chat"]').trigger("click");
     expect(setActive).toHaveBeenLastCalledWith(K, "chat");
@@ -75,10 +75,10 @@ describe("CenterTabStrip", () => {
     const closeTab = vi.spyOn(store, "closeTab");
 
     const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
-    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "src/a.ts")!;
+    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "file:src/a.ts")!;
     await fileTab.find('[data-test="tab-close"]').trigger("click");
 
-    expect(closeTab).toHaveBeenCalledWith(K, "src/a.ts");
+    expect(closeTab).toHaveBeenCalledWith(K, "file:src/a.ts");
     expect(setActive).not.toHaveBeenCalled(); // @click.stop must not also bubble into activation
   });
 
@@ -90,9 +90,23 @@ describe("CenterTabStrip", () => {
 
     const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
     const tabs = w.findAll('[data-test="tab"]');
-    expect(tabs.map((t) => t.attributes("data-tab-id")).sort()).toEqual(["src/a.ts", "terminal"]);
+    expect(tabs.map((t) => t.attributes("data-tab-id")).sort()).toEqual(["file:src/a.ts", "terminal"]);
     for (const t of tabs) {
       expect(() => t.trigger("pointerdown")).not.toThrow();
     }
+  });
+
+  it("renders a trailing end-of-strip drop zone carrying the END sentinel id, after the last tab", () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+    store.openTerminal(K);
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    const endZone = w.find(`[data-tab-id="${TAB_DROP_END}"]`);
+    expect(endZone.exists()).toBe(true);
+    // Not a tab: no [data-test="tab"] marker, no visible label/close button.
+    expect(endZone.attributes("data-test")).not.toBe("tab");
+    expect(endZone.find('[data-test="tab-close"]').exists()).toBe(false);
   });
 });

--- a/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
@@ -1,0 +1,127 @@
+// packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+import { setActivePinia, createPinia } from "pinia";
+import { beforeEach, expect, test, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// Stub the WS client so jsdom needs no real socket.
+vi.mock("../api/events", () => ({
+  connectEvents: () => vi.fn(),
+}));
+// DashboardView uses useRouter()/<router-link>; mock to avoid a real router.
+vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+import DashboardView from "../views/DashboardView.vue";
+import { useChatStore } from "../stores/chat";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
+
+const stubs = {
+  ChatPane: { template: '<div data-test="stub-chat"/>' },
+  FileViewer: { template: '<div data-test="stub-file"/>' },
+  TerminalTab: { template: '<div data-test="stub-term"/>' },
+  CenterTabStrip: { template: '<div data-test="stub-strip"/>' },
+  InstanceTree: true,
+  TaskPanel: true,
+  FilesPanel: true,
+  "router-link": true,
+};
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ instances: [] }), { status: 200 })));
+});
+
+function mountDash() {
+  return mount(DashboardView, { global: { stubs } });
+}
+
+function selectSession(): string {
+  const chat = useChatStore();
+  chat.instanceId = "i1";
+  chat.sessionAlias = "demo";
+  return sessionKey("i1", "demo");
+}
+
+test("with a selected session, chat shows and no file/terminal panes are mounted", async () => {
+  const wrapper = mountDash();
+  await flushPromises();
+  selectSession();
+  await flushPromises();
+
+  expect(wrapper.find('[data-test="stub-chat"]').exists()).toBe(true);
+  expect(wrapper.find('[data-test="stub-file"]').exists()).toBe(false);
+  expect(wrapper.find('[data-test="stub-term"]').exists()).toBe(false);
+  // The tab strip only renders once a session is selected.
+  expect(wrapper.find('[data-test="stub-strip"]').exists()).toBe(true);
+});
+
+test("opening a file via center-tabs mounts a FileViewer pane", async () => {
+  const wrapper = mountDash();
+  await flushPromises();
+  const key = selectSession();
+  await flushPromises();
+
+  const centerTabs = useCenterTabsStore();
+  centerTabs.openFile(key, "a.ts");
+  await flushPromises();
+
+  const file = wrapper.find('[data-test="stub-file"]');
+  expect(file.exists()).toBe(true);
+  // Visible (v-show), not display:none, since it's the active tab for the current session.
+  expect(file.attributes("style") ?? "").not.toContain("display: none");
+  // Chat pane is still mounted underneath but hidden.
+  const chat = wrapper.find('[data-test="stub-chat"]');
+  expect(chat.exists()).toBe(true);
+  expect(chat.attributes("style") ?? "").toContain("display: none");
+});
+
+test("opening a terminal via center-tabs mounts a TerminalTab pane", async () => {
+  const wrapper = mountDash();
+  await flushPromises();
+  const key = selectSession();
+  await flushPromises();
+
+  const centerTabs = useCenterTabsStore();
+  centerTabs.openTerminal(key);
+  await flushPromises();
+
+  const term = wrapper.find('[data-test="stub-term"]');
+  expect(term.exists()).toBe(true);
+  expect(term.attributes("style") ?? "").not.toContain("display: none");
+});
+
+test("the header terminal button opens/focuses the current session's terminal tab", async () => {
+  const wrapper = mountDash();
+  await flushPromises();
+  const key = selectSession();
+  await flushPromises();
+
+  const centerTabs = useCenterTabsStore();
+  const spy = vi.spyOn(centerTabs, "openTerminal");
+
+  await wrapper.find('[data-test="toggle-terminal"]').trigger("click");
+  await flushPromises();
+
+  expect(spy).toHaveBeenCalledWith(key);
+  expect(wrapper.find('[data-test="stub-term"]').exists()).toBe(true);
+});
+
+test("hidden panes for a non-current session don't error (workspace resolution)", async () => {
+  const wrapper = mountDash();
+  await flushPromises();
+  const key = selectSession();
+  await flushPromises();
+
+  const centerTabs = useCenterTabsStore();
+  // Open a file tab in a DIFFERENT (unresolvable) session — not the current one.
+  const otherKey = sessionKey("i2", "other");
+  centerTabs.openFile(otherKey, "b.ts");
+  await flushPromises();
+
+  // It mounts (allOpenTabs spans all sessions) but stays hidden since it isn't current.
+  const files = wrapper.findAll('[data-test="stub-file"]');
+  expect(files.length).toBe(1);
+  expect(files[0].attributes("style") ?? "").toContain("display: none");
+  // The current session's chat is unaffected.
+  expect(wrapper.find('[data-test="stub-chat"]').attributes("style") ?? "").not.toContain("display: none");
+  void key; // currentKey unaffected by the other session's tab
+});

--- a/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
@@ -13,6 +13,7 @@ vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 import DashboardView from "../views/DashboardView.vue";
 import { useChatStore } from "../stores/chat";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
+import { useInstancesStore, type InstanceView } from "../stores/instances";
 
 const stubs = {
   ChatPane: { template: '<div data-test="stub-chat"/>' },
@@ -124,4 +125,52 @@ test("hidden panes for a non-current session don't error (workspace resolution)"
   // The current session's chat is unaffected.
   expect(wrapper.find('[data-test="stub-chat"]').attributes("style") ?? "").not.toContain("display: none");
   void key; // currentKey unaffected by the other session's tab
+});
+
+function makeInstance(overrides: Partial<InstanceView> & { id: string }): InstanceView {
+  return {
+    name: overrides.id, online: true, lastSeenAt: null,
+    sessions: [], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [],
+    ...overrides,
+  };
+}
+
+test("out-of-band session removal prunes that session's center-tabs, but leaves other sessions and still-loading instances alone", async () => {
+  const wrapper = mountDash();
+  await flushPromises();
+
+  const instances = useInstancesStore();
+  instances.instances = [
+    makeInstance({ id: "i1", sessions: [{ alias: "demo", agent: "a", workspace: "w", transportSession: "t", running: true, archived: false }] }),
+    makeInstance({ id: "i2", sessions: [{ alias: "keep", agent: "a", workspace: "w", transportSession: "t", running: true, archived: false }] }),
+    // Sessions never fetched for this instance — a key referencing it must never be pruned
+    // just because it isn't (yet) in an empty `sessions` list.
+    makeInstance({ id: "i3", sessions: [], sessionsLoaded: false }),
+  ];
+  await flushPromises();
+
+  const chat = useChatStore();
+  chat.instanceId = "i1";
+  chat.sessionAlias = "demo";
+  const goneKey = sessionKey("i1", "demo");
+  const keepKey = sessionKey("i2", "keep");
+  const loadingKey = sessionKey("i3", "ghost");
+
+  const centerTabs = useCenterTabsStore();
+  centerTabs.openFile(goneKey, "a.ts");
+  centerTabs.openTerminal(goneKey);
+  centerTabs.openFile(keepKey, "b.ts");
+  centerTabs.openFile(loadingKey, "c.ts");
+  await flushPromises();
+  expect(centerTabs.tabsFor(goneKey).length).toBe(2);
+
+  // Simulate a SERVER-driven removal (deleted from the CLI / WeChat / another browser):
+  // the session vanishes from i1's list, but sessionsLoaded stays true — exactly what a
+  // real `applyEvent` -> `loadSessions` reload leaves behind.
+  instances.instances[0].sessions = [];
+  await flushPromises();
+
+  expect(centerTabs.tabsFor(goneKey)).toEqual([]); // reconciled away
+  expect(centerTabs.tabsFor(keepKey).length).toBe(1); // untouched — still a valid session
+  expect(centerTabs.tabsFor(loadingKey).length).toBe(1); // guarded — instance still loading
 });

--- a/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
@@ -95,13 +95,13 @@ test("file viewer Back opens the file list drawer (the tab stays open); Close re
   centerTabs.openFile(key, "a.ts");
   await flushPromises();
   expect(wrapper.findComponent(FileViewer).exists()).toBe(true);
-  expect(centerTabs.activeFor(key)).toBe("a.ts");
+  expect(centerTabs.activeFor(key)).toBe("file:a.ts");
 
   // Back -> file list: right drawer opens on files, but the tab is untouched (still
   // open/active) — the drawer just overlays it on mobile.
   wrapper.findComponent(FileViewer).vm.$emit("back");
   await flushPromises();
-  expect(centerTabs.activeFor(key)).toBe("a.ts");
+  expect(centerTabs.activeFor(key)).toBe("file:a.ts");
   expect(right.classes()).toContain("translate-x-0");
   expect(right.classes()).not.toContain("translate-x-full");
 
@@ -259,7 +259,7 @@ test("toggling the terminal activates the terminal tab and is mutually exclusive
   const key = sessionKey("i1", "demo");
   centerTabs.openFile(key, "a.ts");
   await flushPromises();
-  expect(centerTabs.activeFor(key)).toBe("a.ts");
+  expect(centerTabs.activeFor(key)).toBe("file:a.ts");
 
   await wrapper.find('[data-test="toggle-terminal"]').trigger("click");
   await flushPromises();
@@ -268,7 +268,7 @@ test("toggling the terminal activates the terminal tab and is mutually exclusive
   // ...and it becomes the sole active tab (mutual exclusion) — the file tab is untouched
   // (still open in the strip, just no longer active).
   expect(centerTabs.activeFor(key)).toBe("terminal");
-  expect(centerTabs.tabsFor(key).map((t) => t.id)).toEqual(["a.ts", "terminal"]);
+  expect(centerTabs.tabsFor(key).map((t) => t.id)).toEqual(["file:a.ts", "terminal"]);
 });
 
 test("the right rail no longer exposes a Terminal tab", async () => {

--- a/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
@@ -13,7 +13,7 @@ import DashboardView from "../views/DashboardView.vue";
 import ChatPane from "../components/ChatPane.vue";
 import FileViewer from "../components/FileViewer.vue";
 import { useChatStore } from "../stores/chat";
-import { useFilesStore } from "../stores/files";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 
 const stubs = { ChatPane: true, FileViewer: true, TaskPanel: true, TerminalTab: true, "router-link": true };
 
@@ -75,8 +75,12 @@ test("the mobile bar exposes a discoverable Files button that opens the Files dr
   expect(filesTab.classes()).toContain("font-semibold");
 });
 
-test("file viewer Back returns to the file list (drawer reopens) and Close returns to the conversation", async () => {
-  const files = useFilesStore();
+test("file viewer Back opens the file list drawer (the tab stays open); Close removes the tab and returns to chat", async () => {
+  const chat = useChatStore();
+  chat.instanceId = "i1";
+  chat.sessionAlias = "demo";
+  const centerTabs = useCenterTabsStore();
+  const key = sessionKey("i1", "demo");
   // Replace the FileViewer stub with a minimal one that re-emits back/close so we can
   // exercise DashboardView's nav handlers (rightTab/rightOpen are internal refs, so we
   // assert via observable drawer DOM).
@@ -87,25 +91,25 @@ test("file viewer Back returns to the file list (drawer reopens) and Close retur
   await flushPromises();
   const right = wrapper.find('[data-drawer="right"]');
 
-  // Open a file so the (stubbed) FileViewer renders.
-  files.file = { workspace: "ws", path: "a.ts", content: "x", size: 1, truncated: false, binary: false };
+  // Open a file tab so the (stubbed) FileViewer renders.
+  centerTabs.openFile(key, "a.ts");
   await flushPromises();
   expect(wrapper.findComponent(FileViewer).exists()).toBe(true);
+  expect(centerTabs.activeFor(key)).toBe("a.ts");
 
-  // Back -> file list: file cleared AND right drawer open on files.
+  // Back -> file list: right drawer opens on files, but the tab is untouched (still
+  // open/active) — the drawer just overlays it on mobile.
   wrapper.findComponent(FileViewer).vm.$emit("back");
   await flushPromises();
-  expect(files.file).toBeNull();
+  expect(centerTabs.activeFor(key)).toBe("a.ts");
   expect(right.classes()).toContain("translate-x-0");
   expect(right.classes()).not.toContain("translate-x-full");
 
-  // Re-open a file, then Close -> conversation: file cleared AND right drawer NOT open.
-  files.file = { workspace: "ws", path: "b.ts", content: "y", size: 1, truncated: false, binary: false };
-  await flushPromises();
+  // Close -> the tab is actually removed and active falls back to chat.
   wrapper.findComponent(FileViewer).vm.$emit("close");
   await flushPromises();
-  expect(files.file).toBeNull();
-  expect(right.classes()).toContain("translate-x-full");
+  expect(centerTabs.tabsFor(key)).toEqual([]);
+  expect(centerTabs.activeFor(key)).toBe("chat");
 });
 
 test("tasks drawer opens via the Tasks button", async () => {
@@ -143,27 +147,33 @@ test("selecting a session closes the instance drawer and routes to chat", async 
   expect(wrapper.find('[data-drawer="left"]').classes()).toContain("-translate-x-full");
 });
 
-test("opening a file overlays the viewer but keeps the chat mounted+laid out (inert) so scroll is preserved without re-layout jank", async () => {
+test("opening a file overlays the viewer but keeps the chat mounted (inert) so scroll is preserved without re-layout jank", async () => {
+  const chat0 = useChatStore();
+  chat0.instanceId = "i1";
+  chat0.sessionAlias = "demo";
+  const centerTabs = useCenterTabsStore();
+  const key = sessionKey("i1", "demo");
   const wrapper = mountDash();
   await flushPromises();
   const chatBefore = wrapper.findComponent(ChatPane);
   expect(chatBefore.exists()).toBe(true);
-  // Bound inert is false when no file is open (the stub surfaces the raw bound value; on the
-  // real single-root ChatPane Vue drops the attribute entirely when false).
+  // Bound inert is false when no tab is active (the stub surfaces the raw bound value; on
+  // the real single-root ChatPane Vue drops the attribute entirely when false).
   expect(chatBefore.attributes("inert")).toBe("false");
   expect(wrapper.findComponent(FileViewer).exists()).toBe(false);
-  // Opening a file overlays the FileViewer on top. ChatPane is NOT unmounted or hidden via
-  // display:none — it stays laid out underneath (just `inert`), so its scroll position is
-  // preserved and returning is a cheap repaint, not a full re-layout.
-  const files = useFilesStore();
-  files.file = { workspace: "ws", path: "a.ts", content: "x", size: 1, truncated: false, binary: false };
+  // Opening a file tab mounts a FileViewer pane. ChatPane is NOT unmounted or hidden via
+  // display:none in the sense of losing layout — v-show only toggles CSS display, so its
+  // scroll position is preserved and returning is a cheap repaint, not a full re-layout.
+  centerTabs.openFile(key, "a.ts");
   await flushPromises();
-  expect(wrapper.findComponent(FileViewer).exists()).toBe(true);
+  const file = wrapper.findComponent(FileViewer);
+  expect(file.exists()).toBe(true);
+  expect(file.attributes("style") ?? "").not.toContain("display: none"); // the active tab is visible
   const chat = wrapper.findComponent(ChatPane);
   expect(chat.exists()).toBe(true);
   expect(chat.attributes("inert")).toBe("true"); // occluded → disabled for focus/interaction
-  // Not hidden via display:none (that's what caused the reveal jank).
-  expect(chat.attributes("style") ?? "").not.toContain("display: none");
+  // Hidden via v-show (display:none) while a tab is active — NOT unmounted (still findable).
+  expect(chat.attributes("style") ?? "").toContain("display: none");
 });
 
 test("the sidebar header toggle collapses the instances column, and the edge handle restores it", async () => {
@@ -239,22 +249,26 @@ test("terminal toggle is disabled without a session and enabled with one", async
   expect(wrapper.find('[data-test="toggle-terminal"]').attributes("disabled")).toBeUndefined();
 });
 
-test("toggling the terminal opens a center overlay and is mutually exclusive with the file viewer", async () => {
+test("toggling the terminal activates the terminal tab and is mutually exclusive with the file tab (only one active at a time)", async () => {
   const wrapper = mountDash();
   await flushPromises();
   const chat = useChatStore();
   chat.instanceId = "i1";
   chat.sessionAlias = "demo";
-  const files = useFilesStore();
-  files.file = { workspace: "ws", path: "a.ts", content: "x", size: 1, truncated: false, binary: false };
+  const centerTabs = useCenterTabsStore();
+  const key = sessionKey("i1", "demo");
+  centerTabs.openFile(key, "a.ts");
   await flushPromises();
+  expect(centerTabs.activeFor(key)).toBe("a.ts");
 
   await wrapper.find('[data-test="toggle-terminal"]').trigger("click");
   await flushPromises();
   // Terminal overlay is mounted (VTU renders a `true` stub as <terminal-tab-stub>)...
   expect(wrapper.find("terminal-tab-stub").exists()).toBe(true);
-  // ...and opening it cleared the file viewer (mutual exclusion).
-  expect(files.file).toBeNull();
+  // ...and it becomes the sole active tab (mutual exclusion) — the file tab is untouched
+  // (still open in the strip, just no longer active).
+  expect(centerTabs.activeFor(key)).toBe("terminal");
+  expect(centerTabs.tabsFor(key).map((t) => t.id)).toEqual(["a.ts", "terminal"]);
 });
 
 test("the right rail no longer exposes a Terminal tab", async () => {
@@ -265,7 +279,7 @@ test("the right rail no longer exposes a Terminal tab", async () => {
   expect(wrapper.find('[data-test="right-tab-tasks"]').exists()).toBe(true);
 });
 
-test("clearing the session auto-closes the terminal overlay", async () => {
+test("deselecting the session hides (but keeps mounted) its terminal — it stays warm in the background and reappears on reselect", async () => {
   const wrapper = mountDash();
   await flushPromises();
   const chat = useChatStore();
@@ -275,9 +289,19 @@ test("clearing the session auto-closes the terminal overlay", async () => {
   await wrapper.find('[data-test="toggle-terminal"]').trigger("click");
   await flushPromises();
   expect(wrapper.find("terminal-tab-stub").exists()).toBe(true);
+
+  // Deselecting the session (not archiving/removing it) must NOT tear down the terminal's
+  // PTY — the pane just hides. Unmounting only happens via closeTab/clearSession.
   chat.sessionAlias = null;
   await flushPromises();
-  expect(wrapper.find("terminal-tab-stub").exists()).toBe(false);
+  const hiddenTerm = wrapper.find("terminal-tab-stub");
+  expect(hiddenTerm.exists()).toBe(true);
+  expect(hiddenTerm.attributes("style") ?? "").toContain("display: none");
+
+  // Reselecting the same session reveals the same (still-open) terminal tab again.
+  chat.sessionAlias = "demo";
+  await flushPromises();
+  expect(wrapper.find("terminal-tab-stub").attributes("style") ?? "").not.toContain("display: none");
 });
 
 test("opening the terminal closes an already-open right drawer (rightOpen mutual exclusion)", async () => {

--- a/packages/relay-web/src/__tests__/files-i18n.test.ts
+++ b/packages/relay-web/src/__tests__/files-i18n.test.ts
@@ -1,6 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises } from "@vue/test-utils";
 import { i18n } from "../i18n";
 import FileViewer from "../components/FileViewer.vue";
 import { useFilesStore } from "../stores/files";
@@ -16,9 +17,10 @@ afterEach(() => { i18n.global.locale.value = "en"; });
 describe("files browser i18n", () => {
   it("renders Chinese affordances in FileViewer when locale is zh-CN", async () => {
     i18n.global.locale.value = "zh-CN";
-    const w = mount(FileViewer, { global: { plugins: [pinia] } });
     const files = useFilesStore();
-    files.file = { workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false };
+    vi.spyOn(files, "readFile").mockResolvedValue({ workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "src/a.ts" }, global: { plugins: [pinia] } });
+    await flushPromises();
     await w.vm.$nextTick();
     // Back-to-list affordance shows "文件" (Files); desktop Back shows "返回".
     expect(w.find('[data-test="fv-back-list"]').text()).toContain("文件");
@@ -28,9 +30,10 @@ describe("files browser i18n", () => {
 
   it("localizes the binary-file notice in zh-CN", async () => {
     i18n.global.locale.value = "zh-CN";
-    const w = mount(FileViewer, { global: { plugins: [pinia] } });
     const files = useFilesStore();
-    files.file = { workspace: "ws", path: "bin.dat", content: "", size: 4, truncated: false, binary: true };
+    vi.spyOn(files, "readFile").mockResolvedValue({ workspace: "ws", path: "bin.dat", content: "", size: 4, truncated: false, binary: true });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "bin.dat" }, global: { plugins: [pinia] } });
+    await flushPromises();
     await w.vm.$nextTick();
     expect(w.text()).toContain("不显示二进制文件");
   });

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -196,6 +196,23 @@ describe("files store", () => {
     await s.selectWorkspace("i1", "ws");
     expect(s.error).toBe("path-escapes-workspace");
   });
+
+  it("readFile returns content without touching the global file slot", async () => {
+    const s = useFilesStore();
+    rpc.mockResolvedValueOnce({ workspace: "ws", path: "a.ts", content: "x", size: 1, truncated: false, binary: false });
+    const r = await s.readFile("i1", "ws", "a.ts");
+    expect(r.content).toBe("x");
+    expect(s.file).toBeNull(); // global slot untouched
+  });
+
+  it("readDiff returns a diff without touching global diff state", async () => {
+    const s = useFilesStore();
+    rpc.mockResolvedValueOnce({ workspace: "ws", files: [], diff: "@@", truncated: false });
+    const r = await s.readDiff("i1", "ws", "a.ts");
+    expect(r.diff).toBe("@@");
+    expect(s.diff).toBeNull();
+    expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.diff", { workspace: "ws", path: "a.ts" });
+  });
 });
 
 describe("files store: tree + advanced search", () => {

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -12,6 +12,7 @@ import FilesPanel from "../components/FilesPanel.vue";
 import { useFilesStore } from "../stores/files";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 
 let pinia: ReturnType<typeof createPinia>;
 beforeEach(() => {
@@ -226,6 +227,112 @@ describe("FilesPanel navigation rail", () => {
     await flushPromises();
 
     expect(loadDiff).not.toHaveBeenCalled();
+  });
+});
+
+describe("FilesPanel center-tab routing", () => {
+  it("opening a tree file with a selected session opens a center file tab", async () => {
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    const centerTabs = useCenterTabsStore();
+    const openFile = vi.spyOn(centerTabs, "openFile");
+    files.tree[""] = [{ name: "a.ts", type: "file", size: 1 }] as never;
+    await w.vm.$nextTick();
+    await w.find('[data-test="tree-row"]').trigger("click");
+    expect(openFile).toHaveBeenCalledWith(sessionKey("i1", "s1"), "a.ts");
+    // The tree still renders (listing behavior unchanged).
+    expect(w.find('[data-test="tree-row"]').exists()).toBe(true);
+  });
+
+  it("opening a tree file with no selected session is a no-op for the center-tabs store", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    const centerTabs = useCenterTabsStore();
+    const openFile = vi.spyOn(centerTabs, "openFile");
+    files.tree[""] = [{ name: "a.ts", type: "file", size: 1 }] as never;
+    await w.vm.$nextTick();
+    await w.find('[data-test="tree-row"]').trigger("click");
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it("clicking a name-mode search result opens a center file tab", async () => {
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    const centerTabs = useCenterTabsStore();
+    vi.spyOn(files, "search").mockResolvedValue();
+    const openFile = vi.spyOn(centerTabs, "openFile");
+    files.query = "foo";
+    files.results = ["src/foo.ts"] as never;
+    await w.vm.$nextTick();
+    await w.find('[data-test="fs-result"]').trigger("click");
+    expect(openFile).toHaveBeenCalledWith(sessionKey("i1", "s1"), "src/foo.ts");
+    expect(w.find('[data-test="fs-result"]').exists()).toBe(true);
+  });
+
+  it("clicking a content-mode search hit opens a center file tab", async () => {
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    const centerTabs = useCenterTabsStore();
+    vi.spyOn(files, "search").mockResolvedValue();
+    const openFile = vi.spyOn(centerTabs, "openFile");
+    files.searchOpts.mode = "content";
+    files.query = "foo";
+    files.hits = [{ path: "src/a.ts", line: 3, text: "const foo = 1" }] as never;
+    await w.vm.$nextTick();
+    await w.find('[data-test="fs-hit"]').trigger("click");
+    expect(openFile).toHaveBeenCalledWith(sessionKey("i1", "s1"), "src/a.ts");
+  });
+
+  it("clicking a changed file opens a center diff tab, keeps the listing, and highlights the row", async () => {
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    const centerTabs = useCenterTabsStore();
+    files.tab = "changes";
+    files.diff = {
+      workspace: "ws",
+      files: [{ path: "src/a.ts", status: " M" }],
+      diff: "+x\n-y\n",
+      truncated: false,
+    } as never;
+    await w.vm.$nextTick();
+    const loadDiff = vi.spyOn(files, "loadDiff").mockResolvedValue();
+    const openDiff = vi.spyOn(centerTabs, "openDiff");
+    await w.find('[data-test="diff-file"]').trigger("click");
+    expect(openDiff).toHaveBeenCalledWith(sessionKey("i1", "s1"), "src/a.ts");
+    // The panel-data listing itself must not be reloaded by the click-to-view action.
+    expect(loadDiff).not.toHaveBeenCalled();
+    // The changed-files list is still there (panel data untouched).
+    expect(w.findAll('[data-test="diff-file"]').length).toBe(1);
+    expect(w.find('[data-test="diff-file"]').classes().join(" ")).toContain("bg-accent/10");
+  });
+
+  it("clicking a changed file with no selected session is a no-op for the center-tabs store", async () => {
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    const centerTabs = useCenterTabsStore();
+    const openDiff = vi.spyOn(centerTabs, "openDiff");
+    files.tab = "changes";
+    files.diff = {
+      workspace: "ws",
+      files: [{ path: "src/a.ts", status: " M" }],
+      diff: "+x\n-y\n",
+      truncated: false,
+    } as never;
+    await w.vm.$nextTick();
+    await w.find('[data-test="diff-file"]').trigger("click");
+    expect(openDiff).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -42,15 +42,33 @@ describe("FilesPanel navigation rail", () => {
     expect(label.text()).toContain("backend");
   });
 
-  it("opening a tree file routes it to the center viewer (clears any diff)", async () => {
+  it("opening a tree file clears the changed-file row highlight, not files.diffPath", async () => {
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
     const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
     const files = useFilesStore();
-    files.diffPath = "old/diff.ts"; // a stale diff selection
+    // Select a changed-file row first (sets the local highlight, per this component).
+    files.tab = "changes";
+    files.diff = { workspace: "ws", files: [{ path: "src/a.ts", status: " M" }], diff: "+x\n-y\n", truncated: false } as never;
+    await w.vm.$nextTick();
+    await w.find('[data-test="diff-file"]').trigger("click");
+    expect(w.find('[data-test="diff-file"]').classes().join(" ")).toContain("bg-accent/10");
+    // `files.diffPath` (the loaded-diff scope) is untouched by row selection — it's still
+    // whatever loadDiff() set it to (null here, since loadDiff was never actually called).
+    const diffPathBefore = files.diffPath;
+
+    files.tab = "files";
     files.tree[""] = [{ name: "a.ts", type: "file", size: 1 }] as never;
     await w.vm.$nextTick();
     await w.find('[data-test="tree-row"]').trigger("click");
-    // The diff selection is cleared so the center shows the freshly opened file, not a mix.
-    expect(files.diffPath).toBeNull();
+
+    // files.diffPath (load-scope) is untouched by opening a tree file.
+    expect(files.diffPath).toBe(diffPathBefore);
+    // The local row highlight is cleared — back on the Changes tab, the row is no longer highlighted.
+    files.tab = "changes";
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="diff-file"]').classes().join(" ")).not.toContain("bg-accent/10");
   });
 
   it("renders the tree root (no breadcrumb / up button)", async () => {
@@ -315,6 +333,62 @@ describe("FilesPanel center-tab routing", () => {
     expect(loadDiff).not.toHaveBeenCalled();
     // The changed-files list is still there (panel data untouched).
     expect(w.findAll('[data-test="diff-file"]').length).toBe(1);
+    expect(w.find('[data-test="diff-file"]').classes().join(" ")).toContain("bg-accent/10");
+  });
+
+  it("refreshing the Changes tab after selecting a changed-file row reloads the whole-tree diff, not the selected file", async () => {
+    // Regression for: openDiff() used to write files.diffPath purely to drive the row
+    // highlight, but files.diffPath doubles as the SCOPE of the loaded files.diff — so a
+    // later refresh() would rescope the whole-tree diff down to just the clicked file.
+    const chat = useChatStore();
+    chat.instanceId = "i1";
+    chat.sessionAlias = "s1";
+    const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    files.instanceId = "i1";
+    files.workspace = "ws";
+    files.tab = "changes";
+    const wholeTreeDiff = {
+      workspace: "ws",
+      files: [
+        { path: "a.ts", status: " M" },
+        { path: "b.ts", status: " M" },
+        { path: "c.ts", status: " M" },
+      ],
+      diff: "+x\n-y\n+z\n",
+      truncated: false,
+    };
+    files.diff = wholeTreeDiff;
+    await w.vm.$nextTick();
+
+    // Note: vi.spyOn(files, "loadDiff") would NOT observe refresh()'s internal call —
+    // Pinia setup-store actions call sibling actions via the closure reference, not the
+    // store's public property, so the spy is only triggered by external callers (verified
+    // empirically: a spy here sees 0 calls even though the real RPC call fires correctly).
+    // Assert on the actual RPC call args instead, which is what the bug really breaks.
+    rpc.mockClear();
+    rpc.mockResolvedValue(wholeTreeDiff);
+
+    // Click a changed-file row: opens a center diff tab + highlights it, but must not
+    // touch files.diffPath (the loaded-diff scope) or trigger a reload by itself.
+    await w.find('[data-test="diff-file"]').trigger("click");
+    expect(files.diffPath).toBeNull();
+    expect(w.find('[data-test="diff-file"]').classes().join(" ")).toContain("bg-accent/10");
+
+    // Refresh: the reviewer's bug scenario — must reload the WHOLE tree, not rescope to
+    // whichever changed-file row was last clicked.
+    await w.find('[data-test="refresh-files"]').trigger("click");
+    await flushPromises();
+
+    const diffCalls = rpc.mock.calls.filter((c) => c[1] === "control.fs.diff");
+    expect(diffCalls.length).toBe(1);
+    // No `path` param on the diff RPC call — whole-tree, not scoped to the clicked file.
+    expect(diffCalls[0][2]).toEqual({ workspace: "ws" });
+    // The Changes list stays whole-tree (3 files), not narrowed down to the clicked one.
+    expect(files.diff?.files.length).toBe(3);
+
+    // The row highlight still reflects the previously clicked file (local view state
+    // survives the refresh, since it's independent of the reloaded files.diff).
     expect(w.find('[data-test="diff-file"]').classes().join(" ")).toContain("bg-accent/10");
   });
 

--- a/packages/relay-web/src/__tests__/fileviewer.test.ts
+++ b/packages/relay-web/src/__tests__/fileviewer.test.ts
@@ -20,12 +20,14 @@ beforeEach(() => {
 });
 
 describe("FileViewer", () => {
-  it("renders the file content and upgrades it to highlighted HTML", async () => {
+  it("renders the file content (loaded via readFile from the path prop) and upgrades it to highlighted HTML", async () => {
     vi.useFakeTimers();
-    const w = mount(FileViewer, { global: { plugins: [pinia] } });
     const files = useFilesStore();
-    files.file = { workspace: "ws", path: "src/a.ts", content: "one\ntwo\nthree", size: 13, truncated: false, binary: false };
+    vi.spyOn(files, "readFile").mockResolvedValue({ workspace: "ws", path: "src/a.ts", content: "one\ntwo\nthree", size: 13, truncated: false, binary: false });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "src/a.ts" }, global: { plugins: [pinia] } });
+    await flushPromises();
     await w.vm.$nextTick();
+    expect(files.readFile).toHaveBeenCalledWith("i1", "ws", "src/a.ts");
     // immediate plain fallback shows the content before highlighting resolves
     const body = w.find('[data-test="fv-file-body"]');
     expect(body.exists()).toBe(true);
@@ -40,9 +42,10 @@ describe("FileViewer", () => {
   });
 
   it("offers a copy button that copies the file content", async () => {
-    const w = mount(FileViewer, { global: { plugins: [pinia] } });
     const files = useFilesStore();
-    files.file = { workspace: "ws", path: "src/a.ts", content: "hello", size: 5, truncated: false, binary: false };
+    vi.spyOn(files, "readFile").mockResolvedValue({ workspace: "ws", path: "src/a.ts", content: "hello", size: 5, truncated: false, binary: false });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "src/a.ts" }, global: { plugins: [pinia] } });
+    await flushPromises();
     await w.vm.$nextTick();
     await w.find('[data-test="copy-button"]').trigger("click");
     await Promise.resolve();
@@ -50,9 +53,10 @@ describe("FileViewer", () => {
   });
 
   it("hides the gutter and copy button for a binary file", async () => {
-    const w = mount(FileViewer, { global: { plugins: [pinia] } });
     const files = useFilesStore();
-    files.file = { workspace: "ws", path: "bin.dat", content: "", size: 4, truncated: false, binary: true };
+    vi.spyOn(files, "readFile").mockResolvedValue({ workspace: "ws", path: "bin.dat", content: "", size: 4, truncated: false, binary: true });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "bin.dat" }, global: { plugins: [pinia] } });
+    await flushPromises();
     await w.vm.$nextTick();
     expect(w.find('[data-test="fv-file-body"]').exists()).toBe(false);
     expect(w.find('[data-test="copy-button"]').exists()).toBe(false);
@@ -60,38 +64,42 @@ describe("FileViewer", () => {
   });
 
   it("the mobile Files affordance emits back (return to the file list)", async () => {
-    const w = mount(FileViewer, { global: { plugins: [pinia] } });
     const files = useFilesStore();
-    files.file = { workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false };
+    vi.spyOn(files, "readFile").mockResolvedValue({ workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "src/a.ts" }, global: { plugins: [pinia] } });
+    await flushPromises();
     await w.vm.$nextTick();
     await w.find('[data-test="fv-back-list"]').trigger("click");
     expect(w.emitted("back")).toBeTruthy();
   });
 
   it("the mobile Close affordance emits close (return to the conversation)", async () => {
-    const w = mount(FileViewer, { global: { plugins: [pinia] } });
     const files = useFilesStore();
-    files.file = { workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false };
+    vi.spyOn(files, "readFile").mockResolvedValue({ workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "src/a.ts" }, global: { plugins: [pinia] } });
+    await flushPromises();
     await w.vm.$nextTick();
     await w.find('[data-test="fv-close"]').trigger("click");
     expect(w.emitted("close")).toBeTruthy();
   });
 
   it("the desktop Back affordance emits close (desktop has the list always visible)", async () => {
-    const w = mount(FileViewer, { global: { plugins: [pinia] } });
     const files = useFilesStore();
-    files.file = { workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false };
+    vi.spyOn(files, "readFile").mockResolvedValue({ workspace: "ws", path: "src/a.ts", content: "x", size: 1, truncated: false, binary: false });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "src/a.ts" }, global: { plugins: [pinia] } });
+    await flushPromises();
     await w.vm.$nextTick();
     await w.find('[data-test="fv-back"]').trigger("click");
     expect(w.emitted("close")).toBeTruthy();
   });
 
-  it("renders a single-file diff as structured rows", async () => {
-    const w = mount(FileViewer, { global: { plugins: [pinia] } });
+  it("renders a single-file diff (loaded via readDiff from the diffPath prop) as structured rows", async () => {
     const files = useFilesStore();
-    files.diffPath = "src/a.ts";
-    files.diff = { workspace: "ws", files: [{ path: "src/a.ts", status: " M" }], diff: "@@ -1 +1 @@\n-old\n+new", truncated: false };
+    vi.spyOn(files, "readDiff").mockResolvedValue({ workspace: "ws", files: [{ path: "src/a.ts", status: " M" }], diff: "@@ -1 +1 @@\n-old\n+new", truncated: false });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", diffPath: "src/a.ts" }, global: { plugins: [pinia] } });
+    await flushPromises();
     await w.vm.$nextTick();
+    expect(files.readDiff).toHaveBeenCalledWith("i1", "ws", "src/a.ts");
     const body = w.find('[data-test="fv-diff-body"]');
     expect(body.exists()).toBe(true);
     const rows = w.findAll('[data-test="fv-diff-row"]');
@@ -99,5 +107,26 @@ describe("FileViewer", () => {
     expect(rows.length).toBe(3);
     expect(body.text()).toContain("old");
     expect(body.text()).toContain("new");
+  });
+
+  it("ignores a stale readFile response when props change before it resolves (race guard)", async () => {
+    const files = useFilesStore();
+    let resolveFirst!: (v: { workspace: string; path: string; content: string; size: number; truncated: boolean; binary: boolean }) => void;
+    const first = new Promise((resolve) => { resolveFirst = resolve; });
+    const readFileSpy = vi.spyOn(files, "readFile").mockImplementationOnce(() => first as Promise<{ workspace: string; path: string; content: string; size: number; truncated: boolean; binary: boolean }>);
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "a.ts" }, global: { plugins: [pinia] } });
+    await w.vm.$nextTick();
+    readFileSpy.mockResolvedValueOnce({ workspace: "ws", path: "b.ts", content: "second", size: 6, truncated: false, binary: false });
+    // switch to a second file before the first load resolves
+    await w.setProps({ path: "b.ts" });
+    await flushPromises();
+    await w.vm.$nextTick();
+    // now let the stale first response resolve — it must NOT clobber the second file's content
+    resolveFirst({ workspace: "ws", path: "a.ts", content: "first (stale)", size: 14, truncated: false, binary: false });
+    await flushPromises();
+    await w.vm.$nextTick();
+    const body = w.find('[data-test="fv-file-body"]');
+    expect(body.text()).toContain("second");
+    expect(body.text()).not.toContain("stale");
   });
 });

--- a/packages/relay-web/src/__tests__/fileviewer.test.ts
+++ b/packages/relay-web/src/__tests__/fileviewer.test.ts
@@ -129,4 +129,47 @@ describe("FileViewer", () => {
     expect(body.text()).toContain("second");
     expect(body.text()).not.toContain("stale");
   });
+
+  it("ignores a stale readFile rejection when props change before it rejects (race guard)", async () => {
+    const files = useFilesStore();
+    let rejectFirst!: (e: Error) => void;
+    const first = new Promise<{ workspace: string; path: string; content: string; size: number; truncated: boolean; binary: boolean }>((_resolve, reject) => { rejectFirst = reject; });
+    const readFileSpy = vi.spyOn(files, "readFile").mockImplementationOnce(() => first);
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "a.ts" }, global: { plugins: [pinia] } });
+    await w.vm.$nextTick();
+    readFileSpy.mockResolvedValueOnce({ workspace: "ws", path: "b.ts", content: "second", size: 6, truncated: false, binary: false });
+    // switch to a second file before the first load rejects
+    await w.setProps({ path: "b.ts" });
+    await flushPromises();
+    await w.vm.$nextTick();
+    // second file's content is showing
+    expect(w.find('[data-test="fv-file-body"]').text()).toContain("second");
+    // now let the stale first load reject — it must NOT clobber the second file's content
+    // nor surface an error for a selection that's no longer current
+    rejectFirst(new Error("deleted"));
+    await flushPromises();
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="fv-file-body"]').text()).toContain("second");
+    expect(w.find('[data-test="fv-error"]').exists()).toBe(false);
+  });
+
+  it("shows an error (and clears stale content) when a load rejects with no newer selection pending", async () => {
+    const files = useFilesStore();
+    vi.spyOn(files, "readFile").mockResolvedValueOnce({ workspace: "ws", path: "a.ts", content: "first", size: 5, truncated: false, binary: false });
+    const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "a.ts" }, global: { plugins: [pinia] } });
+    await flushPromises();
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="fv-file-body"]').text()).toContain("first");
+    // switch to a file whose load rejects (deleted file, permission error, etc.)
+    vi.spyOn(files, "readFile").mockRejectedValueOnce(new Error("deleted"));
+    await w.setProps({ path: "gone.ts" });
+    await flushPromises();
+    await w.vm.$nextTick();
+    const err = w.find('[data-test="fv-error"]');
+    expect(err.exists()).toBe(true);
+    expect(err.text()).toContain("deleted");
+    // the previous selection's content must not still be shown as if it were the new one
+    expect(w.find('[data-test="fv-file-body"]').exists()).toBe(false);
+    expect(w.text()).not.toContain("first");
+  });
 });

--- a/packages/relay-web/src/__tests__/instancetree-session-cap.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree-session-cap.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import InstanceTree from "../components/InstanceTree.vue";
+import { useInstancesStore } from "../stores/instances";
+
+function makeSessions(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    alias: `s${i}`,
+    agent: "claude",
+    workspace: "home",
+    transportSession: `t${i}`,
+    running: false,
+    archived: false,
+  }));
+}
+
+const instance = (sessions: unknown[]) => ({
+  id: "i1", name: "pc", online: true, lastSeenAt: null, sessions, sessionsLoaded: true, agents: [], workspaces: [],
+});
+
+describe("InstanceTree session-list cap", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it("caps the session list at 10 with a show-more/collapse toggle", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance(makeSessions(13))] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+
+    // Capped to 10 rows by default.
+    expect(w.findAll('[data-test="session-row"]')).toHaveLength(10);
+    const showMore = w.find('[data-test="sessions-show-more"]');
+    expect(showMore.exists()).toBe(true);
+    expect(showMore.text()).toContain("3");
+    expect(w.find('[data-test="sessions-collapse"]').exists()).toBe(false);
+
+    // Expand: all 13 rows show, button flips to collapse.
+    await showMore.trigger("click");
+    expect(w.findAll('[data-test="session-row"]')).toHaveLength(13);
+    expect(w.find('[data-test="sessions-show-more"]').exists()).toBe(false);
+    const collapse = w.find('[data-test="sessions-collapse"]');
+    expect(collapse.exists()).toBe(true);
+
+    // Collapse: back to 10.
+    await collapse.trigger("click");
+    expect(w.findAll('[data-test="session-row"]')).toHaveLength(10);
+    expect(w.find('[data-test="sessions-show-more"]').exists()).toBe(true);
+  });
+
+  it("does not render a show-more/collapse toggle when at or under the cap", () => {
+    const store = useInstancesStore();
+    store.instances = [instance(makeSessions(10))] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.findAll('[data-test="session-row"]')).toHaveLength(10);
+    expect(w.find('[data-test="sessions-show-more"]').exists()).toBe(false);
+    expect(w.find('[data-test="sessions-collapse"]').exists()).toBe(false);
+  });
+
+  it("isolates expand state per instance", async () => {
+    const store = useInstancesStore();
+    store.instances = [
+      { ...instance(makeSessions(13)), id: "i1", name: "pc1" },
+      { ...instance(makeSessions(13)), id: "i2", name: "pc2" },
+    ] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+
+    // 10 + 10 rows initially, two show-more buttons.
+    expect(w.findAll('[data-test="session-row"]')).toHaveLength(20);
+    const showMores = w.findAll('[data-test="sessions-show-more"]');
+    expect(showMores).toHaveLength(2);
+
+    // Expanding the first instance only affects its own rows.
+    await showMores[0]!.trigger("click");
+    expect(w.findAll('[data-test="session-row"]')).toHaveLength(23); // 13 + 10
+    expect(w.findAll('[data-test="sessions-show-more"]')).toHaveLength(1);
+    expect(w.findAll('[data-test="sessions-collapse"]')).toHaveLength(1);
+  });
+
+  it("preserves session ordering (active first, archived last) under the cap", () => {
+    const store = useInstancesStore();
+    const sessions = [
+      ...makeSessions(9).map((s) => ({ ...s, archived: true })),
+      { alias: "z-active", agent: "claude", workspace: "home", transportSession: "tz", running: false, archived: false },
+      { alias: "y-active", agent: "claude", workspace: "home", transportSession: "ty", running: false, archived: false },
+    ];
+    store.instances = [instance(sessions)] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const rows = w.findAll('[data-test="session-row"]');
+    expect(rows).toHaveLength(10);
+    // Active sessions sink to the top even though they were appended last in source order.
+    const names = rows.map((r) => r.find('[data-test="session-name"]').text());
+    expect(names[0]).toBe("z-active");
+    expect(names[1]).toBe("y-active");
+  });
+});

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -4,6 +4,7 @@ import { createPinia, setActivePinia } from "pinia";
 import InstanceTree from "../components/InstanceTree.vue";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { settleConfirm, useConfirmState } from "../lib/use-confirm";
 
 const instance = (sessions: unknown[] = [], sessionsLoaded = true) => ({
@@ -305,5 +306,47 @@ describe("InstanceTree session management", () => {
     store.instances = [{ ...instance([{ alias: "a", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }]), online: false }] as never;
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
     expect(w.find('[data-test="session-actions"]').exists()).toBe(false);
+  });
+
+  // Archiving/deleting a session must drop its center-tabs entry so any mounted
+  // terminal/file panes unmount (and the terminal's PTY tears down) — otherwise
+  // an archived/deleted session leaks a live terminal pane forever.
+  it("clears the session's center tabs when it is archived", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    vi.spyOn(store, "archiveSession").mockResolvedValue();
+    const centerTabs = useCenterTabsStore();
+    const key = sessionKey("i1", "backend");
+    centerTabs.openTerminal(key);
+    expect(centerTabs.tabsFor(key)).toHaveLength(1);
+    const clearSession = vi.spyOn(centerTabs, "clearSession");
+    const w = mount(InstanceTree, { attachTo: document.body, global: { stubs: { NewSessionDialog: true } } });
+    await w.find('[data-test="session-menu"]').trigger("mousedown");
+    await w.find('[data-test="session-menu"]').trigger("click");
+    const item = w.find('[data-test="action-archive"]');
+    await item.trigger("mousedown");
+    await item.trigger("click");
+    await flushPromises();
+    expect(clearSession).toHaveBeenCalledWith(key);
+    expect(centerTabs.tabsFor(key)).toEqual([]);
+    w.unmount();
+  });
+
+  it("clears the session's center tabs when it is deleted", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    vi.spyOn(store, "removeSession").mockResolvedValue();
+    const centerTabs = useCenterTabsStore();
+    const key = sessionKey("i1", "backend");
+    centerTabs.openTerminal(key);
+    expect(centerTabs.tabsFor(key)).toHaveLength(1);
+    const clearSession = vi.spyOn(centerTabs, "clearSession");
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    await w.find('[data-test="session-menu"]').trigger("click");
+    await w.find('[data-test="delete-session"]').trigger("click");
+    settleConfirm(true);
+    await flushPromises();
+    expect(clearSession).toHaveBeenCalledWith(key);
+    expect(centerTabs.tabsFor(key)).toEqual([]);
   });
 });

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -5,7 +5,7 @@ import { mount } from "@vue/test-utils";
 const adapter = {
   write: vi.fn(), resize: vi.fn(), dispose: vi.fn(), focus: vi.fn(),
   getSelection: vi.fn(() => ""), setTheme: vi.fn(), scrollLines: vi.fn(),
-  fit: vi.fn(() => ({ cols: 80, rows: 24 })),
+  fit: vi.fn((): { cols: number; rows: number } | null => ({ cols: 80, rows: 24 })),
   cols: () => 80, rows: () => 24,
 };
 vi.mock("../lib/terminal-adapter", () => ({ createTerminalAdapter: vi.fn(() => adapter) }));
@@ -328,5 +328,20 @@ describe("TerminalTab", () => {
     expect(sendWebClientMessage).toHaveBeenCalledWith(
       expect.objectContaining({ kind: "terminal-resize", cols: 80, rows: 24 }),
     );
+  });
+
+  // Non-active terminal tabs now stay mounted under v-show (display:none -> the host is
+  // 0×0). fit() returning null used to unconditionally reschedule via requestAnimationFrame,
+  // which would self-perpetuate a 60fps rAF loop forever for a backgrounded terminal. The
+  // guard must bail instead when the host isn't actually laid out (jsdom's div clientWidth
+  // defaults to 0, same as a real display:none host) — it self-heals via the ResizeObserver
+  // once the terminal is revealed again.
+  it("applyFit does not reschedule an rAF when the host is hidden (0 width)", async () => {
+    const rafSpy = vi.spyOn(globalThis, "requestAnimationFrame");
+    adapter.fit.mockReturnValue(null); // host can't be measured — as when display:none
+    mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    expect(rafSpy).not.toHaveBeenCalled();
+    rafSpy.mockRestore();
   });
 });

--- a/packages/relay-web/src/__tests__/use-tab-drag.test.ts
+++ b/packages/relay-web/src/__tests__/use-tab-drag.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { useTabDrag } from "../lib/use-tab-drag";
+
+// jsdom's PointerEvent support is inconsistent across versions; build one that
+// definitely carries clientX/clientY regardless of what the runtime provides.
+function pointerEvent(type: string, clientX: number, clientY = 0): PointerEvent {
+  try {
+    return new PointerEvent(type, { clientX, clientY, bubbles: true });
+  } catch {
+    const e = new MouseEvent(type, { clientX, clientY, bubbles: true });
+    return e as unknown as PointerEvent;
+  }
+}
+
+function fakeStartEvent(clientX: number, clientY = 0): PointerEvent {
+  // `start` only reads clientX off the event it's given; a plain object cast is
+  // enough and sidesteps constructing a real PointerEvent for the initiating call.
+  return { clientX, clientY } as PointerEvent;
+}
+
+describe("useTabDrag", () => {
+  afterEach(() => {
+    // Belt-and-suspenders: any leaked listener from a failing test must not leak
+    // into the next test's assertions (which dispatch on document too).
+    document.dispatchEvent(pointerEvent("pointercancel", 0, 0));
+  });
+
+  it("does not start a drag when movement stays below the 4px threshold", () => {
+    const onReorder = vi.fn();
+    const { draggingId, overId, start } = useTabDrag({ onReorder });
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 102)); // dx=2 < 4
+    expect(draggingId.value).toBeNull();
+    expect(overId.value).toBeNull();
+    document.dispatchEvent(pointerEvent("pointerup", 102));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("starts a drag once movement reaches the threshold and resolves overId via the injected seam", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("b");
+    const { draggingId, overId, start } = useTabDrag({ onReorder, resolveId });
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 105, 7)); // dx=5 >= 4
+    expect(draggingId.value).toBe("a");
+    expect(overId.value).toBe("b");
+    expect(resolveId).toHaveBeenCalledWith(105, 7);
+    document.dispatchEvent(pointerEvent("pointerup", 105, 7));
+  });
+
+  it("commits onReorder exactly once on pointerup when over differs from dragged, then resets", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("b");
+    const { draggingId, overId, start } = useTabDrag({ onReorder, resolveId });
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 110));
+    document.dispatchEvent(pointerEvent("pointerup", 110));
+    expect(onReorder).toHaveBeenCalledTimes(1);
+    expect(onReorder).toHaveBeenCalledWith("a", "b");
+    expect(draggingId.value).toBeNull();
+    expect(overId.value).toBeNull();
+  });
+
+  it("does not call onReorder when the target is the dragged tab itself", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("a");
+    const { start } = useTabDrag({ onReorder, resolveId });
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 110));
+    document.dispatchEvent(pointerEvent("pointerup", 110));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("does not call onReorder when no drop target resolves", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue(null);
+    const { start } = useTabDrag({ onReorder, resolveId });
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 110));
+    document.dispatchEvent(pointerEvent("pointerup", 110));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("resets without calling onReorder on pointercancel", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("b");
+    const { draggingId, overId, start } = useTabDrag({ onReorder, resolveId });
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 110));
+    expect(draggingId.value).toBe("a");
+    document.dispatchEvent(pointerEvent("pointercancel", 110));
+    expect(draggingId.value).toBeNull();
+    expect(overId.value).toBeNull();
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("removes document listeners after pointerup so a later stray move/up is a no-op", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("b");
+    const { draggingId, start } = useTabDrag({ onReorder, resolveId });
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 110));
+    document.dispatchEvent(pointerEvent("pointerup", 110));
+    expect(onReorder).toHaveBeenCalledTimes(1);
+    // Stray events after the gesture ended must not resurrect state or refire.
+    document.dispatchEvent(pointerEvent("pointermove", 200));
+    document.dispatchEvent(pointerEvent("pointerup", 200));
+    expect(draggingId.value).toBeNull();
+    expect(onReorder).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes document listeners after pointercancel so a later stray move/up is a no-op", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("b");
+    const { draggingId, start } = useTabDrag({ onReorder, resolveId });
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 110));
+    document.dispatchEvent(pointerEvent("pointercancel", 110));
+    document.dispatchEvent(pointerEvent("pointermove", 200));
+    document.dispatchEvent(pointerEvent("pointerup", 200));
+    expect(draggingId.value).toBeNull();
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("falls back to document.elementFromPoint + closest('[data-tab-id]') when resolveId is omitted", () => {
+    // jsdom does not implement elementFromPoint at all (property is undefined),
+    // so vi.spyOn has nothing to wrap — stub it directly and remove it after.
+    const tab = document.createElement("div");
+    tab.setAttribute("data-tab-id", "c");
+    document.body.appendChild(tab);
+    const stub = vi.fn().mockReturnValue(tab);
+    (document as unknown as { elementFromPoint: typeof stub }).elementFromPoint = stub;
+
+    const onReorder = vi.fn();
+    const { overId, start } = useTabDrag({ onReorder });
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 110, 20));
+    expect(stub).toHaveBeenCalledWith(110, 20);
+    expect(overId.value).toBe("c");
+    document.dispatchEvent(pointerEvent("pointerup", 110, 20));
+
+    delete (document as unknown as { elementFromPoint?: typeof stub }).elementFromPoint;
+    document.body.removeChild(tab);
+  });
+});

--- a/packages/relay-web/src/__tests__/use-tab-drag.test.ts
+++ b/packages/relay-web/src/__tests__/use-tab-drag.test.ts
@@ -122,6 +122,32 @@ describe("useTabDrag", () => {
     expect(onReorder).not.toHaveBeenCalled();
   });
 
+  it("resets stale drag state from an abandoned gesture when start() re-fires mid-drag", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("x");
+    const { draggingId, overId, start } = useTabDrag({ onReorder, resolveId });
+
+    // Gesture 1: crosses the threshold, so draggingId/overId become non-null.
+    start(fakeStartEvent(100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 110));
+    expect(draggingId.value).toBe("a");
+    expect(overId.value).toBe("x");
+
+    // Gesture 2: a second pointerdown fires before gesture 1's pointerup/cancel
+    // (e.g. a second touch point). Re-arming must clear the stale drag refs.
+    start(fakeStartEvent(500), "c");
+    expect(draggingId.value).toBeNull();
+    expect(overId.value).toBeNull();
+
+    // Sub-threshold movement for gesture 2 must not cross into dragging.
+    document.dispatchEvent(pointerEvent("pointermove", 502)); // dx=2 < 4
+    expect(draggingId.value).toBeNull();
+    expect(overId.value).toBeNull();
+
+    document.dispatchEvent(pointerEvent("pointerup", 502));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
   it("falls back to document.elementFromPoint + closest('[data-tab-id]') when resolveId is omitted", () => {
     // jsdom does not implement elementFromPoint at all (property is undefined),
     // so vi.spyOn has nothing to wrap — stub it directly and remove it after.

--- a/packages/relay-web/src/components/CenterTabStrip.vue
+++ b/packages/relay-web/src/components/CenterTabStrip.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 import { MessageSquare, SquareTerminal, X } from "lucide-vue-next";
-import { useCenterTabsStore, type CenterTab } from "../stores/center-tabs";
+import { useCenterTabsStore, type CenterTab, TAB_DROP_END } from "../stores/center-tabs";
 import { useTabDrag } from "../lib/use-tab-drag";
 import { iconForFile } from "../lib/file-icons";
 
@@ -70,5 +70,16 @@ function labelFor(tab: CenterTab): string {
         <X :size="11" />
       </button>
     </div>
+
+    <!-- Trailing drop zone: not a tab (no label/close), just extends the drop target past
+         the last tab so a drag released in the empty strip area moves it to the end.
+         `flex-1` fills remaining strip width; `min-w-3` keeps it hit-testable even when
+         tabs already fill/overflow the strip. -->
+    <div
+      data-test="tab-drop-end"
+      :data-tab-id="TAB_DROP_END"
+      class="min-w-3 flex-1 self-stretch rounded-md"
+      :class="overId === TAB_DROP_END ? 'ring-1 ring-inset ring-accent' : ''"
+    />
   </div>
 </template>

--- a/packages/relay-web/src/components/CenterTabStrip.vue
+++ b/packages/relay-web/src/components/CenterTabStrip.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import { MessageSquare, SquareTerminal, X } from "lucide-vue-next";
+import { useCenterTabsStore, type CenterTab } from "../stores/center-tabs";
+import { useTabDrag } from "../lib/use-tab-drag";
+import { iconForFile } from "../lib/file-icons";
+
+const props = defineProps<{ sessionKey: string }>();
+const store = useCenterTabsStore();
+const { t } = useI18n();
+
+// Destructure so Vue's template compiler auto-unwraps `overId` (a top-level ref
+// binding); `drag.overId` (member access on a plain object) would NOT be unwrapped.
+const { overId, start } = useTabDrag({
+  onReorder: (draggedId, targetId) => store.reorder(props.sessionKey, draggedId, targetId),
+});
+
+/** Last "/"-segment of a path, or the whole string when there's no separator. */
+function basename(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx === -1 ? path : path.slice(idx + 1);
+}
+
+function iconFor(tab: CenterTab) {
+  return tab.kind === "terminal" ? SquareTerminal : iconForFile(tab.path);
+}
+
+function labelFor(tab: CenterTab): string {
+  return tab.kind === "terminal" ? t("center.terminal") : basename(tab.path);
+}
+</script>
+
+<template>
+  <div class="flex shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border bg-surface px-1 py-1">
+    <!-- Pinned chat tab: never closable, never draggable, always first. -->
+    <button
+      type="button"
+      data-test="tab-chat"
+      class="flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11.5px] transition-colors cursor-pointer"
+      :class="store.activeFor(props.sessionKey) === 'chat' ? 'bg-accent/10 text-accent font-semibold' : 'text-fg-muted font-medium hover:bg-raised'"
+      @click="store.setActive(props.sessionKey, 'chat')"
+    >
+      <MessageSquare :size="13" />{{ $t("center.chat") }}
+    </button>
+
+    <div
+      v-for="tab in store.tabsFor(props.sessionKey)"
+      :key="tab.id"
+      data-test="tab"
+      :data-tab-id="tab.id"
+      style="touch-action: none"
+      class="flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11.5px] transition-colors cursor-pointer"
+      :class="[
+        tab.id === store.activeFor(props.sessionKey) ? 'bg-accent/10 text-accent font-semibold' : 'text-fg-muted font-medium hover:bg-raised',
+        overId === tab.id ? 'ring-1 ring-inset ring-accent' : '',
+      ]"
+      @click="store.setActive(props.sessionKey, tab.id)"
+      @pointerdown="start($event, tab.id)"
+    >
+      <component :is="iconFor(tab)" :size="13" class="shrink-0" />
+      <span v-if="tab.kind === 'diff'" class="shrink-0 text-[10px] font-semibold opacity-80">Δ</span>
+      <span class="max-w-[10rem] truncate">{{ labelFor(tab) }}</span>
+      <button
+        type="button"
+        data-test="tab-close"
+        :aria-label="$t('center.closeTab')"
+        class="ml-0.5 grid h-4 w-4 shrink-0 place-items-center rounded text-fg-muted opacity-60 hover:bg-surface hover:text-fg hover:opacity-100"
+        @click.stop="store.closeTab(props.sessionKey, tab.id)"
+      >
+        <X :size="11" />
+      </button>
+    </div>
+  </div>
+</template>

--- a/packages/relay-web/src/components/FileViewer.vue
+++ b/packages/relay-web/src/components/FileViewer.vue
@@ -55,6 +55,10 @@ async function load(): Promise<void> {
     }
   } catch (e) {
     if (token !== loadToken) return;
+    // Clear stale content on a real failure — otherwise the pane would keep showing the
+    // previous selection's file/diff as if it were the (failed) new one.
+    file.value = null;
+    diff.value = null;
     error.value = e instanceof Error ? e.message : "read-failed";
   } finally {
     if (token === loadToken) loading.value = false;
@@ -140,6 +144,13 @@ function fmtSize(n?: number): string {
 
     <!-- body -->
     <div class="min-h-0 flex-1 overflow-auto thin-scroll">
+      <!-- load failed: a rejected load clears file/diff (see `load()`'s catch), so this only
+           shows in place of — never on top of — stale content from a previous selection. -->
+      <div v-if="error" data-test="fv-error" class="m-3 rounded-lg border border-danger/25 bg-danger/10 px-3 py-2 text-sm text-danger">{{ error }}</div>
+      <!-- loading affordance: only while nothing is on screen yet (first load, or after an
+           error-cleared retry) — a load-in-progress for an already-shown file keeps that
+           file visible instead of flashing this. -->
+      <div v-else-if="loading && !file && !diff" data-test="fv-loading" class="p-6 text-sm text-fg-muted">{{ $t("files.loading") }}</div>
       <!-- file content -->
       <template v-if="file">
         <div v-if="!file.binary && fileLines.length <= LINE_GUTTER_LIMIT" data-test="fv-file-body">

--- a/packages/relay-web/src/components/FileViewer.vue
+++ b/packages/relay-web/src/components/FileViewer.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from "vue";
 import { ArrowLeft, FileText, FileDiff, X } from "lucide-vue-next";
 import { useFilesStore } from "../stores/files";
+import type { FsDiffResult, FsReadResult } from "@ganglion/xacpx-relay-protocol";
 // NOTE: ../lib/shiki is imported DYNAMICALLY inside the highlight callback below — never
 // statically — so the Shiki core + JS engine stay out of FileViewer's (eagerly-loaded)
 // chunk and the entry bundle, per the lazy-load size constraint. parseUnifiedDiff is a
@@ -12,14 +13,60 @@ import CopyButton from "./CopyButton.vue";
 // Roomy file/diff viewer that takes over the center column (the chat area) so file
 // content isn't squeezed into the narrow right rail. The rail keeps navigation; this
 // shows the selected file or single-file diff full-width, with a Back affordance.
+//
+// Content is instance-owned, not global: the caller passes instance/workspace/path (or
+// diffPath) via props and this component loads (and owns) its own copy via the store's
+// return-based readFile/readDiff — so multiple open tabs (e.g. two files, or a file and a
+// terminal, across sessions) never clobber each other's content the way the old single
+// `files.file`/`files.diff` slot did.
+const props = defineProps<{ instanceId: string; workspace: string; path?: string; diffPath?: string }>();
 const emit = defineEmits<{ back: []; close: [] }>();
 const files = useFilesStore();
+
+const file = ref<FsReadResult | null>(null);
+const diff = ref<FsDiffResult | null>(null);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+// Load this pane's own content whenever what it should show changes (mount included, via
+// `immediate: true`). Race-guard: a fast tab/prop switch can start a second load before the
+// first settles — each call stamps a token and bails on apply if a newer call has since
+// started, so a stale response can never overwrite fresher content.
+let loadToken = 0;
+async function load(): Promise<void> {
+  const token = ++loadToken;
+  const { instanceId, workspace, path, diffPath } = props;
+  loading.value = true;
+  error.value = null;
+  try {
+    if (path) {
+      const result = await files.readFile(instanceId, workspace, path);
+      if (token !== loadToken) return; // props changed while awaiting — discard
+      file.value = result;
+      diff.value = null;
+    } else if (diffPath) {
+      const result = await files.readDiff(instanceId, workspace, diffPath);
+      if (token !== loadToken) return;
+      diff.value = result;
+      file.value = null;
+    } else {
+      file.value = null;
+      diff.value = null;
+    }
+  } catch (e) {
+    if (token !== loadToken) return;
+    error.value = e instanceof Error ? e.message : "read-failed";
+  } finally {
+    if (token === loadToken) loading.value = false;
+  }
+}
+watch(() => [props.instanceId, props.workspace, props.path, props.diffPath] as const, load, { immediate: true });
 
 // Above this many lines we skip Shiki and render a plain <pre> so a huge file doesn't
 // stall the highlighter or emit an enormous DOM.
 const LINE_GUTTER_LIMIT = 5000;
 const fileLines = computed(() => {
-  const f = files.file;
+  const f = file.value;
   if (!f || f.binary) return [];
   return f.content.split("\n");
 });
@@ -29,11 +76,11 @@ const fileLines = computed(() => {
 const fileHtml = ref("");
 let hlTimer: ReturnType<typeof setTimeout> | null = null;
 watch(
-  () => [files.file?.path, files.file?.content, files.file?.binary] as const,
+  () => [file.value?.path, file.value?.content, file.value?.binary] as const,
   ([path, content, binary]) => {
     if (hlTimer) clearTimeout(hlTimer);
     fileHtml.value = "";
-    if (!files.file || binary || content === undefined) return;
+    if (!file.value || binary || content === undefined) return;
     if (fileLines.value.length > LINE_GUTTER_LIMIT) return; // plain fallback for huge files
     const code = content;
     hlTimer = setTimeout(() => {
@@ -43,7 +90,7 @@ watch(
         const { resolveLang, highlightToHtml } = await import("../lib/shiki");
         const html = await highlightToHtml(code, resolveLang(path));
         // ignore a stale result if the file changed while we were highlighting
-        if (files.file?.content === code) fileHtml.value = html;
+        if (file.value?.content === code) fileHtml.value = html;
       })();
     }, 150);
   },
@@ -51,7 +98,7 @@ watch(
 );
 
 // Structured rows for the single-file diff (HAPI-style tinted rows; not syntax-highlighted).
-const parsedDiff = computed(() => (files.diff?.diff ? parseUnifiedDiff(files.diff.diff) : null));
+const parsedDiff = computed(() => (diff.value?.diff ? parseUnifiedDiff(diff.value.diff) : null));
 
 function fmtSize(n?: number): string {
   if (n === undefined) return "";
@@ -72,19 +119,19 @@ function fmtSize(n?: number): string {
               class="hidden lg:flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2 py-1 text-[12px] font-medium text-fg-muted transition-colors hover:bg-raised hover:text-fg"
               @click="emit('close')"><ArrowLeft :size="14" class="shrink-0" />{{ $t("files.back") }}</button>
       <span class="h-4 w-px bg-border" aria-hidden="true" />
-      <template v-if="files.file">
+      <template v-if="file">
         <FileText :size="14" class="shrink-0 text-accent" />
-        <span class="truncate font-mono text-[12.5px] text-fg">{{ files.file.path }}</span>
-        <span class="shrink-0 text-[11px] text-fg-muted">{{ fmtSize(files.file.size) }}</span>
-        <span v-if="files.file.truncated" class="shrink-0 rounded bg-warn/10 px-1 text-[10.5px] text-warn">{{ $t("files.truncated") }}</span>
-        <span v-if="files.file.binary" class="shrink-0 rounded bg-fg/5 px-1 text-[10.5px] text-fg-muted">{{ $t("files.binary") }}</span>
+        <span class="truncate font-mono text-[12.5px] text-fg">{{ file.path }}</span>
+        <span class="shrink-0 text-[11px] text-fg-muted">{{ fmtSize(file.size) }}</span>
+        <span v-if="file.truncated" class="shrink-0 rounded bg-warn/10 px-1 text-[10.5px] text-warn">{{ $t("files.truncated") }}</span>
+        <span v-if="file.binary" class="shrink-0 rounded bg-fg/5 px-1 text-[10.5px] text-fg-muted">{{ $t("files.binary") }}</span>
       </template>
-      <template v-else-if="files.diffPath">
+      <template v-else-if="props.diffPath">
         <FileDiff :size="14" class="shrink-0 text-accent" />
-        <span class="truncate font-mono text-[12.5px] text-fg">{{ files.diffPath }}</span>
+        <span class="truncate font-mono text-[12.5px] text-fg">{{ props.diffPath }}</span>
       </template>
       <div class="ml-auto flex shrink-0 items-center gap-1">
-        <CopyButton v-if="files.file && !files.file.binary" :text="files.file.content" />
+        <CopyButton v-if="file && !file.binary" :text="file.content" />
         <button data-test="fv-close" :aria-label="$t('files.closeFile')"
                 class="grid h-7 w-7 place-items-center rounded text-fg-muted transition-colors hover:bg-raised hover:text-fg lg:hidden"
                 @click="emit('close')"><X :size="16" /></button>
@@ -94,16 +141,16 @@ function fmtSize(n?: number): string {
     <!-- body -->
     <div class="min-h-0 flex-1 overflow-auto thin-scroll">
       <!-- file content -->
-      <template v-if="files.file">
-        <div v-if="!files.file.binary && fileLines.length <= LINE_GUTTER_LIMIT" data-test="fv-file-body">
+      <template v-if="file">
+        <div v-if="!file.binary && fileLines.length <= LINE_GUTTER_LIMIT" data-test="fv-file-body">
           <div v-if="fileHtml" v-html="fileHtml"></div>
-          <pre v-else class="overflow-x-auto p-4 font-mono text-[12.5px] leading-relaxed text-fg whitespace-pre">{{ files.file.content }}</pre>
+          <pre v-else class="overflow-x-auto p-4 font-mono text-[12.5px] leading-relaxed text-fg whitespace-pre">{{ file.content }}</pre>
         </div>
-        <pre v-else-if="!files.file.binary" data-test="fv-file-body" class="overflow-x-auto p-4 font-mono text-[12.5px] leading-relaxed text-fg whitespace-pre">{{ files.file.content }}</pre>
+        <pre v-else-if="!file.binary" data-test="fv-file-body" class="overflow-x-auto p-4 font-mono text-[12.5px] leading-relaxed text-fg whitespace-pre">{{ file.content }}</pre>
         <div v-else class="p-6 text-sm text-fg-muted">{{ $t("files.binaryNotShown") }}</div>
       </template>
       <!-- single-file diff: structured tinted rows with dual line numbers (no syntax highlight) -->
-      <template v-else-if="files.diffPath && files.diff">
+      <template v-else-if="props.diffPath && diff">
         <div v-if="parsedDiff && parsedDiff.rows.length" data-test="fv-diff-body" class="font-mono text-[12.5px] leading-relaxed">
           <div v-for="(r, i) in parsedDiff.rows" :key="i" data-test="fv-diff-row" class="flex"
                :class="r.type === 'add' ? 'bg-run/10' : r.type === 'del' ? 'bg-danger/10' : r.type === 'hunk' ? 'bg-info/5' : ''">
@@ -114,7 +161,7 @@ function fmtSize(n?: number): string {
           </div>
         </div>
         <div v-else class="p-6 text-sm text-fg-muted">{{ $t("files.noDiffContent") }}</div>
-        <div v-if="files.diff.truncated" class="px-4 py-1 text-xs text-warn">{{ $t("files.diffTruncated") }}</div>
+        <div v-if="diff.truncated" class="px-4 py-1 text-xs text-warn">{{ $t("files.diffTruncated") }}</div>
       </template>
     </div>
   </div>

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -38,8 +38,14 @@ watch(showGitignored, (v) => localStorage.setItem("xacpx.files.showGitignored", 
 // Root-layer children, filtered by the same predicate FileTreeNode applies to its own children.
 const rootChildren = computed(() => (files.tree[""] ?? []).filter((e) =>
   (!e.ignored || showGitignored.value) && (!e.name.startsWith(".") || showDotfiles.value)));
+// Purely local view state for the Changes-tab row highlight — distinct from
+// `files.diffPath`, which is the SCOPE of the currently loaded `files.diff` (whole-tree
+// vs one file) and must only ever be written by `files.loadDiff()`. Conflating the two
+// used to cause `refresh()` to rescope the loaded diff to whatever row was last clicked.
+const selectedDiff = ref<string | null>(null);
+
 function openTreeFile(rel: string) {
-  files.diffPath = null; // clear any Changes-tab row highlight in favor of the freshly opened file
+  selectedDiff.value = null; // clear any Changes-tab row highlight in favor of the freshly opened file
   if (currentKey.value) centerTabs.openFile(currentKey.value, rel);
 }
 
@@ -196,14 +202,16 @@ function statusBadge(code: string): { label: string; cls: string; dot: string } 
 }
 
 function openSearchResult(m: string) {
-  files.diffPath = null; // clear any Changes-tab row highlight in favor of the freshly opened file
+  selectedDiff.value = null; // clear any Changes-tab row highlight in favor of the freshly opened file
   if (currentKey.value) centerTabs.openFile(currentKey.value, m);
 }
 function openDiff(path: string) {
   // Keep the Changes-tab row highlighted without re-fetching (that would rescope the
   // panel's loaded `diff` to this one file and skew the +/- summary counts above the
-  // list) — the diff VIEW itself now loads its own content in a center diff tab.
-  files.diffPath = path;
+  // list) — the diff VIEW itself now loads its own content in a center diff tab. The
+  // highlight is purely local view state (`selectedDiff`); `files.diffPath` stays
+  // untouched here so it keeps meaning "scope of the loaded diff", not "last-clicked row".
+  selectedDiff.value = path;
   if (currentKey.value) centerTabs.openDiff(currentKey.value, path);
 }
 
@@ -214,6 +222,7 @@ watch(
   async ([id, ws]) => {
     files.reset();
     searchInput.value = "";
+    selectedDiff.value = null;
     if (!id) return;
     files.instanceId = id;
     await instances.loadWorkspaces(id).catch(() => {});
@@ -413,11 +422,11 @@ watch(
                 <li v-for="f in s.items" :key="f.path">
                   <button data-test="diff-file" :title="f.path"
                           class="flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left cursor-pointer"
-                          :class="files.diffPath === f.path ? 'bg-accent/10' : 'hover:bg-raised'" @click="openDiff(f.path)">
+                          :class="selectedDiff === f.path ? 'bg-accent/10' : 'hover:bg-raised'" @click="openDiff(f.path)">
                     <span class="w-3 shrink-0 text-center font-mono text-[10.5px] uppercase" :class="statusBadge(f.status).cls">{{ statusBadge(f.status).label }}</span>
                     <span class="flex min-w-0 flex-1 items-baseline truncate font-mono text-[11px]">
                       <span v-if="splitPath(f.path).dir" class="truncate text-fg-muted/70">{{ splitPath(f.path).dir }}</span>
-                      <span class="shrink-0" :class="files.diffPath === f.path ? 'text-accent' : 'text-fg'">{{ splitPath(f.path).name }}</span>
+                      <span class="shrink-0" :class="selectedDiff === f.path ? 'text-accent' : 'text-fg'">{{ splitPath(f.path).name }}</span>
                     </span>
                   </button>
                 </li>

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -4,6 +4,7 @@ import { ChevronRight, File, FileText, Folder, FolderGit2, GitBranch, List, More
 import { useFilesStore } from "../stores/files";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { groupChanges, splitPath } from "../lib/change-groups";
 import { openMenuKey, ROOT_MENU_KEY } from "../lib/tree-menu";
 import FileTreeNode from "./FileTreeNode.vue";
@@ -21,6 +22,13 @@ const props = defineProps<{ instanceId: string | null }>();
 const files = useFilesStore();
 const instances = useInstancesStore();
 const chat = useChatStore();
+const centerTabs = useCenterTabsStore();
+
+// The session whose center tabs a click here should open a tab on — null when no
+// session is selected, in which case opening a file/diff from the rail is a no-op.
+const currentKey = computed(() =>
+  chat.instanceId && chat.sessionAlias ? sessionKey(chat.instanceId, chat.sessionAlias) : null,
+);
 
 // dotfile / gitignore toggles for the Files-tab tree, persisted across sessions.
 const showDotfiles = ref(localStorage.getItem("xacpx.files.showDotfiles") === "1");
@@ -31,8 +39,8 @@ watch(showGitignored, (v) => localStorage.setItem("xacpx.files.showGitignored", 
 const rootChildren = computed(() => (files.tree[""] ?? []).filter((e) =>
   (!e.ignored || showGitignored.value) && (!e.name.startsWith(".") || showDotfiles.value)));
 function openTreeFile(rel: string) {
-  files.diffPath = null;
-  void files.openFile(rel);
+  files.diffPath = null; // clear any Changes-tab row highlight in favor of the freshly opened file
+  if (currentKey.value) centerTabs.openFile(currentKey.value, rel);
 }
 
 // Root-level "new file / new folder" — the workspace root has no parent tree row to
@@ -188,12 +196,15 @@ function statusBadge(code: string): { label: string; cls: string; dot: string } 
 }
 
 function openSearchResult(m: string) {
-  files.diffPath = null;
-  void files.openFile(m);
+  files.diffPath = null; // clear any Changes-tab row highlight in favor of the freshly opened file
+  if (currentKey.value) centerTabs.openFile(currentKey.value, m);
 }
 function openDiff(path: string) {
-  files.file = null;
-  void files.loadDiff(path);
+  // Keep the Changes-tab row highlighted without re-fetching (that would rescope the
+  // panel's loaded `diff` to this one file and skew the +/- summary counts above the
+  // list) — the diff VIEW itself now loads its own content in a center diff tab.
+  files.diffPath = path;
+  if (currentKey.value) centerTabs.openDiff(currentKey.value, path);
 }
 
 // Follow the instance + active session's workspace. Re-selects (and resets navigation)

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -71,6 +71,22 @@ function orderedSessions<T extends { archived?: boolean }>(sessions: T[]): T[] {
   return [...sessions].sort((a, b) => Number(a.archived ?? false) - Number(b.archived ?? false));
 }
 
+// Long session lists get noisy fast — cap the rendered rows per instance and let the
+// user opt into the rest via "show N more" (mirrors the instance collapse/expand
+// pattern above, but keyed independently since either can toggle without the other).
+const SESSION_CAP = 10;
+const sessionsExpanded = ref<Set<string>>(new Set());
+function toggleSessions(id: string) {
+  const next = new Set(sessionsExpanded.value);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  sessionsExpanded.value = next;
+}
+function visibleSessions(inst: InstanceView): InstanceView["sessions"] {
+  const all = orderedSessions(inst.sessions);
+  return sessionsExpanded.value.has(inst.id) ? all : all.slice(0, SESSION_CAP);
+}
+
 // Desktop overflow (⋯) menu open-state, keyed by `${instanceId}:${alias}`.
 const openMenuFor = ref<string | null>(null);
 
@@ -219,7 +235,7 @@ const rowSwipes = computed(() => {
       <!-- Indented session rows under an accent-able left rule. -->
       <div v-show="isExpanded(inst.id)" class="ml-2.5 mt-px space-y-px border-l border-border pl-2.5">
         <div
-          v-for="s in orderedSessions(inst.sessions)"
+          v-for="s in visibleSessions(inst)"
           :key="s.alias"
           data-test="session-row"
           class="group relative rounded-md"
@@ -308,6 +324,19 @@ const rowSwipes = computed(() => {
             <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
           </div>
         </div>
+
+        <button v-if="orderedSessions(inst.sessions).length > SESSION_CAP && !sessionsExpanded.has(inst.id)"
+                data-test="sessions-show-more"
+                class="w-full py-1 pl-2.5 text-left text-[11px] font-medium text-fg-muted hover:text-fg"
+                @click.stop="toggleSessions(inst.id)">
+          {{ $t("instance.showMoreSessions", { n: orderedSessions(inst.sessions).length - SESSION_CAP }) }}
+        </button>
+        <button v-else-if="orderedSessions(inst.sessions).length > SESSION_CAP"
+                data-test="sessions-collapse"
+                class="w-full py-1 pl-2.5 text-left text-[11px] font-medium text-fg-muted hover:text-fg"
+                @click.stop="toggleSessions(inst.id)">
+          {{ $t("instance.collapseSessions") }}
+        </button>
 
         <div v-if="inst.online && !inst.sessionsLoaded && !inst.sessions.length" data-test="sessions-loading"
              class="py-1 pl-2.5 text-[11px] text-fg-muted">{{ $t("instance.loading") }}</div>

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -4,6 +4,7 @@ import { useI18n } from "vue-i18n";
 import { Archive, ChevronDown, ChevronRight, Link2, Loader2, MoreHorizontal, Pencil, Plus, Settings2, Trash2 } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { confirm } from "../lib/use-confirm";
 import { showActionToast } from "../lib/use-action-toast";
 import { useSwipeActions } from "../lib/use-swipe-actions";
@@ -19,6 +20,7 @@ const vFocus = {
 
 const store = useInstancesStore();
 const chat = useChatStore();
+const centerTabs = useCenterTabsStore();
 const { t } = useI18n();
 
 // A session row carries the agent NAME; the brand glyph keys on its driver. Resolve via the
@@ -148,6 +150,9 @@ function onRowTap(id: string, alias: string) {
 async function onArchive(id: string, alias: string) {
   openMenuFor.value = null;
   openSwipeFor.value = null;
+  // Drop this session's center tabs (terminal/file panes) right away — the ephemeral
+  // tabs/PTY are freed on archive; unarchive (via the undo toast) does not restore them.
+  centerTabs.clearSession(sessionKey(id, alias));
   await store.archiveSession(id, alias).catch(() => {});
   showUndoToast(id, alias);
 }
@@ -173,6 +178,8 @@ async function askDelete(id: string, alias: string) {
   // Deleting the session you're viewing drops the view back to the empty "no session"
   // state rather than leaving a stale, now-broken selection pointed at it.
   const wasActive = isSelected(id, alias);
+  // Drop this session's center tabs (terminal/file panes) so they unmount along with it.
+  centerTabs.clearSession(sessionKey(id, alias));
   void store.removeSession(id, alias).catch(() => {});
   if (wasActive) chat.clearSelection();
 }

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -201,7 +201,16 @@ function onTouchEnd(e: TouchEvent) {
 function applyFit(myEpoch = epoch) {
   if (myEpoch !== epoch || !terminalId || !adapter) return;
   const dim = adapter.fit();
-  if (!dim) { requestAnimationFrame(() => applyFit(myEpoch)); return; }
+  if (!dim) {
+    // fit() also returns null when the host is hidden (v-show="false" -> display:none ->
+    // 0x0), which non-active terminal tabs now stay mounted as. Rescheduling unconditionally
+    // there would self-perpetuate this rAF loop at 60fps forever for every backgrounded
+    // terminal. Only retry while the host is actually laid out (non-zero size); once it's
+    // hidden, bail — the ResizeObserver below re-invokes applyFit when it's revealed again
+    // (display change -> size change), so this self-heals without polling.
+    if (host.value && host.value.clientWidth > 0) requestAnimationFrame(() => applyFit(myEpoch));
+    return;
+  }
   adapter.resize(dim.cols, dim.rows);
   terminals.resize(props.instanceId, terminalId, dim.cols, dim.rows);
 }

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -326,6 +326,11 @@ export default {
   taskPanel: {
     noSession: "No session selected.",
   },
+  center: {
+    chat: "Chat",
+    terminal: "Terminal",
+    closeTab: "Close tab",
+  },
   terminal: {
     title: "Terminal",
     disabled: "Terminal is disabled. Enable `terminal.enabled` in the instance config.",

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -219,6 +219,8 @@ export default {
     offline: "offline",
     loading: "loading…",
     noSessions: "no sessions yet",
+    showMoreSessions: "Show {n} more",
+    collapseSessions: "Collapse",
     deleteSessionTitle: "Delete session?",
     deleteSessionBody: "\"{alias}\" will be permanently removed. This can't be undone.",
     manageTitle: "Manage · {name}",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -324,6 +324,11 @@ export default {
   taskPanel: {
     noSession: "未选择会话。",
   },
+  center: {
+    chat: "会话",
+    terminal: "终端",
+    closeTab: "关闭标签",
+  },
   terminal: {
     title: "终端",
     disabled: "终端未启用。请在实例 config 中开启 `terminal.enabled`。",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -217,6 +217,8 @@ export default {
     offline: "离线",
     loading: "加载中…",
     noSessions: "暂无会话",
+    showMoreSessions: "再显示 {n} 个",
+    collapseSessions: "收起",
     deleteSessionTitle: "删除会话？",
     deleteSessionBody: "“{alias}” 将被永久删除，此操作无法撤销。",
     manageTitle: "管理 · {name}",

--- a/packages/relay-web/src/lib/use-tab-drag.ts
+++ b/packages/relay-web/src/lib/use-tab-drag.ts
@@ -78,6 +78,8 @@ export function useTabDrag(opts: TabDragOptions): TabDragHandlers {
     document.removeEventListener("pointercancel", pointercancel);
     armedId = id;
     startX = e.clientX;
+    draggingId.value = null;
+    overId.value = null;
     document.addEventListener("pointermove", pointermove);
     document.addEventListener("pointerup", pointerup);
     document.addEventListener("pointercancel", pointercancel);

--- a/packages/relay-web/src/lib/use-tab-drag.ts
+++ b/packages/relay-web/src/lib/use-tab-drag.ts
@@ -1,0 +1,87 @@
+import { ref, type Ref } from "vue";
+
+/** Px of pointer movement before a pointerdown on a tab commits to a drag
+ *  rather than staying a click. Mirrors the `intent` threshold in
+ *  `use-swipe-actions.ts`. */
+const THRESHOLD = 4;
+
+export interface TabDragOptions {
+  onReorder: (draggedId: string, targetId: string) => void;
+  /** Hit-test seam: given viewport coords, return the `data-tab-id` of the tab
+   *  underneath, or null. Defaults to a real DOM lookup via
+   *  `document.elementFromPoint`, which jsdom can't lay out — tests inject
+   *  this to control `overId` deterministically. */
+  resolveId?: (x: number, y: number) => string | null;
+}
+
+export interface TabDragHandlers {
+  draggingId: Ref<string | null>;
+  overId: Ref<string | null>;
+  /** Call from a tab's `pointerdown` handler. */
+  start: (e: PointerEvent, id: string) => void;
+}
+
+function defaultResolveId(x: number, y: number): string | null {
+  const el = document.elementFromPoint(x, y);
+  return el?.closest("[data-tab-id]")?.getAttribute("data-tab-id") ?? null;
+}
+
+/** Vanilla Pointer Events tab drag-reorder (mouse + touch), mirroring the
+ *  attach/detach-on-document style of `use-swipe-actions.ts` / `edge-swipe.ts`.
+ *  `start` arms the gesture but does not mark it dragging until the pointer
+ *  has moved past `THRESHOLD`, so a plain tap/click never flags a drag. */
+export function useTabDrag(opts: TabDragOptions): TabDragHandlers {
+  const draggingId = ref<string | null>(null);
+  const overId = ref<string | null>(null);
+  const resolveId = opts.resolveId ?? defaultResolveId;
+
+  let armedId: string | null = null;
+  let startX = 0;
+
+  function reset() {
+    armedId = null;
+    draggingId.value = null;
+    overId.value = null;
+    document.removeEventListener("pointermove", pointermove);
+    document.removeEventListener("pointerup", pointerup);
+    document.removeEventListener("pointercancel", pointercancel);
+  }
+
+  function pointermove(e: PointerEvent) {
+    if (armedId === null) return;
+    if (draggingId.value === null) {
+      if (Math.abs(e.clientX - startX) < THRESHOLD) return;
+      draggingId.value = armedId;
+    }
+    overId.value = resolveId(e.clientX, e.clientY);
+  }
+
+  function pointerup() {
+    const dragged = draggingId.value;
+    const over = overId.value;
+    if (dragged && over && over !== dragged) {
+      opts.onReorder(dragged, over);
+    }
+    reset();
+  }
+
+  function pointercancel() {
+    reset();
+  }
+
+  function start(e: PointerEvent, id: string) {
+    // Defensive: drop any listeners from a prior gesture that never reached
+    // pointerup/pointercancel (e.g. a second pointerdown mid-drag) before
+    // re-adding, so listeners never accumulate across gestures.
+    document.removeEventListener("pointermove", pointermove);
+    document.removeEventListener("pointerup", pointerup);
+    document.removeEventListener("pointercancel", pointercancel);
+    armedId = id;
+    startX = e.clientX;
+    document.addEventListener("pointermove", pointermove);
+    document.addEventListener("pointerup", pointerup);
+    document.addEventListener("pointercancel", pointercancel);
+  }
+
+  return { draggingId, overId, start };
+}

--- a/packages/relay-web/src/stores/center-tabs.ts
+++ b/packages/relay-web/src/stores/center-tabs.ts
@@ -16,6 +16,10 @@ export function sessionKey(instanceId: string, alias: string): string {
   return `${instanceId}::${alias}`;
 }
 
+/** Sentinel `targetId` for `reorder()`: drop past the last tab moves the
+ *  dragged tab to the end of the list instead of before a real tab. */
+export const TAB_DROP_END = "__end__";
+
 export const useCenterTabsStore = defineStore("center-tabs", () => {
   const bySession = ref<Record<string, SessionTabs>>({});
 
@@ -36,7 +40,7 @@ export const useCenterTabsStore = defineStore("center-tabs", () => {
   }
 
   function openFile(key: string, path: string): void {
-    upsertAndActivate(key, { kind: "file", id: path, path });
+    upsertAndActivate(key, { kind: "file", id: `file:${path}`, path });
   }
 
   function openDiff(key: string, path: string): void {
@@ -63,17 +67,26 @@ export const useCenterTabsStore = defineStore("center-tabs", () => {
     bySession.value = { ...bySession.value, [key]: { tabs, activeId } };
   }
 
+  /** Moves `draggedId` before `targetId`, or to the end of the list when
+   *  `targetId` is `TAB_DROP_END` (a drop past the last tab). No-op if
+   *  `draggedId` isn't open, or `targetId` is neither `TAB_DROP_END` nor an
+   *  open tab. */
   function reorder(key: string, draggedId: string, targetId: string): void {
     if (draggedId === targetId) return;
     const current = bySession.value[key];
     if (!current) return;
     const draggedIndex = current.tabs.findIndex((t) => t.id === draggedId);
-    const targetIndex = current.tabs.findIndex((t) => t.id === targetId);
-    if (draggedIndex === -1 || targetIndex === -1) return;
+    if (draggedIndex === -1) return;
+    const isEnd = targetId === TAB_DROP_END;
+    if (!isEnd && !current.tabs.some((t) => t.id === targetId)) return;
     const tabs = [...current.tabs];
     const [dragged] = tabs.splice(draggedIndex, 1);
-    const insertAt = tabs.findIndex((t) => t.id === targetId);
-    tabs.splice(insertAt, 0, dragged);
+    if (isEnd) {
+      tabs.push(dragged);
+    } else {
+      const insertAt = tabs.findIndex((t) => t.id === targetId);
+      tabs.splice(insertAt, 0, dragged);
+    }
     bySession.value = { ...bySession.value, [key]: { tabs, activeId: current.activeId } };
   }
 

--- a/packages/relay-web/src/stores/center-tabs.ts
+++ b/packages/relay-web/src/stores/center-tabs.ts
@@ -1,0 +1,96 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+export type CenterTab =
+  | { kind: "file"; id: string; path: string }
+  | { kind: "diff"; id: string; path: string }
+  | { kind: "terminal"; id: string };
+
+interface SessionTabs {
+  tabs: CenterTab[];
+  activeId: string;
+}
+
+/** Stable per-session key: `${instanceId}::${alias}`. */
+export function sessionKey(instanceId: string, alias: string): string {
+  return `${instanceId}::${alias}`;
+}
+
+export const useCenterTabsStore = defineStore("center-tabs", () => {
+  const bySession = ref<Record<string, SessionTabs>>({});
+
+  function tabsFor(key: string): CenterTab[] {
+    return bySession.value[key]?.tabs ?? [];
+  }
+
+  function activeFor(key: string): string {
+    return bySession.value[key]?.activeId ?? "chat";
+  }
+
+  /** Insert-or-activate a tab by id: existing id just activates; new id is appended and activated. */
+  function upsertAndActivate(key: string, tab: CenterTab): void {
+    const current = bySession.value[key] ?? { tabs: [], activeId: "chat" };
+    const exists = current.tabs.some((t) => t.id === tab.id);
+    const tabs = exists ? current.tabs : [...current.tabs, tab];
+    bySession.value = { ...bySession.value, [key]: { tabs, activeId: tab.id } };
+  }
+
+  function openFile(key: string, path: string): void {
+    upsertAndActivate(key, { kind: "file", id: path, path });
+  }
+
+  function openDiff(key: string, path: string): void {
+    upsertAndActivate(key, { kind: "diff", id: `diff:${path}`, path });
+  }
+
+  function openTerminal(key: string): void {
+    upsertAndActivate(key, { kind: "terminal", id: "terminal" });
+  }
+
+  function setActive(key: string, id: string): void {
+    const current = bySession.value[key] ?? { tabs: [], activeId: "chat" };
+    bySession.value = { ...bySession.value, [key]: { tabs: current.tabs, activeId: id } };
+  }
+
+  function closeTab(key: string, id: string): void {
+    const current = bySession.value[key];
+    if (!current) return;
+    const index = current.tabs.findIndex((t) => t.id === id);
+    if (index === -1) return;
+    const tabs = current.tabs.filter((t) => t.id !== id);
+    const wasActive = current.activeId === id;
+    const activeId = wasActive ? (current.tabs[index - 1]?.id ?? tabs[index]?.id ?? "chat") : current.activeId;
+    bySession.value = { ...bySession.value, [key]: { tabs, activeId } };
+  }
+
+  function reorder(key: string, draggedId: string, targetId: string): void {
+    if (draggedId === targetId) return;
+    const current = bySession.value[key];
+    if (!current) return;
+    const draggedIndex = current.tabs.findIndex((t) => t.id === draggedId);
+    const targetIndex = current.tabs.findIndex((t) => t.id === targetId);
+    if (draggedIndex === -1 || targetIndex === -1) return;
+    const tabs = [...current.tabs];
+    const [dragged] = tabs.splice(draggedIndex, 1);
+    const insertAt = tabs.findIndex((t) => t.id === targetId);
+    tabs.splice(insertAt, 0, dragged);
+    bySession.value = { ...bySession.value, [key]: { tabs, activeId: current.activeId } };
+  }
+
+  function clearSession(key: string): void {
+    if (!(key in bySession.value)) return;
+    const next = { ...bySession.value };
+    delete next[key];
+    bySession.value = next;
+  }
+
+  function allOpenTabs(): { key: string; tab: CenterTab }[] {
+    return Object.entries(bySession.value).flatMap(([key, s]) => s.tabs.map((tab) => ({ key, tab })));
+  }
+
+  return {
+    tabsFor, activeFor,
+    openFile, openDiff, openTerminal,
+    setActive, closeTab, reorder, clearSession, allOpenTabs,
+  };
+});

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -365,11 +365,24 @@ export const useFilesStore = defineStore("files", () => {
     }
   }
 
+  /** Read a file's content without touching the global `file` slot — for tab
+   *  panes that hold their own local content independent of the file browser. */
+  async function readFile(id: string, ws: string, filePath: string): Promise<FsReadResult> {
+    return unwrap(await api.rpc<FsReadResult>(id, "control.fs.read", { workspace: ws, path: filePath }));
+  }
+
+  /** Read a git diff (whole-tree or one file) without touching the global `diff`/`diffPath`
+   *  slots — for tab panes that hold their own local diff content. */
+  async function readDiff(id: string, ws: string, filePath?: string): Promise<FsDiffResult> {
+    return unwrap(await api.rpc<FsDiffResult>(id, "control.fs.diff", { workspace: ws, ...(filePath ? { path: filePath } : {}) }));
+  }
+
   return {
     instanceId, workspace, path, entries, file, diff, diffPath, notGit, changed, gitSummary, tab, query, results, searchTruncated, searching, loading, error,
     root, sep: sepChar, tree, expanded, loadingDirs, hits, searchOpts,
     reset, selectWorkspace, list, open, openFile, up, search, loadDiff, loadStatus, loadGitSummary, refresh,
     listTree, toggleExpand, absPath,
     createEntry, renameEntry, deleteEntry, downloadEntry,
+    readFile, readDiff,
   };
 });

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -147,6 +147,32 @@ function keyWorkspace(key: string): string {
   return inst?.sessions.find((s) => s.alias === keyAlias(key))?.workspace ?? "";
 }
 
+// Prune center-tabs whose session has disappeared OUT-OF-BAND (deleted from the CLI /
+// WeChat / another browser tab). `InstanceTree` prunes on local archive/delete, but a
+// server-driven removal only reloads `instances` (via applyEvent → loadSessions) — nothing
+// else tells centerTabs, so that session's FileViewer/TerminalTab panes above would stay
+// mounted (and any PTY alive) forever. Only consider an instance's session list authoritative
+// once it has actually loaded (`sessionsLoaded`): while a fetch is still in flight, a key
+// that isn't in `sessions` yet hasn't necessarily been removed, it just hasn't arrived —
+// pruning then would race the load and drop a still-valid tab.
+const validSessionKeys = computed(() => {
+  const keys = new Set<string>();
+  for (const inst of instances.instances) {
+    if (!inst.sessionsLoaded) continue;
+    for (const s of inst.sessions) keys.add(sessionKey(inst.id, s.alias));
+  }
+  return keys;
+});
+function reconcileCenterTabs() {
+  const valid = validSessionKeys.value;
+  const openKeys = new Set(centerTabs.allOpenTabs().map((t) => t.key));
+  for (const key of openKeys) {
+    const inst = instances.byId(keyInstance(key));
+    if (inst?.sessionsLoaded && !valid.has(key)) centerTabs.clearSession(key);
+  }
+}
+watch(() => instances.instances, reconcileCenterTabs, { deep: true });
+
 // A file/diff/terminal tab opened for the current session takes over the center column.
 // On mobile, opening one also closes the right drawer so the pane is actually visible.
 watch(

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -318,7 +318,10 @@ onUnmounted(() => {
            disables the occluded conversation for focus/interaction. -->
       <div data-test="column" class="relative flex min-w-0 flex-1 flex-col">
         <ChatPane class="absolute inset-0" :inert="viewingFile || terminalOpen" @show-files="rightTab = 'files'" />
-        <FileViewer v-if="viewingFile" class="absolute inset-0 z-10" @back="backToFileList" @close="closeFileViewer" />
+        <FileViewer v-if="viewingFile" class="absolute inset-0 z-10"
+                    :instance-id="files.instanceId ?? ''" :workspace="files.workspace ?? ''"
+                    :path="files.file?.path" :diff-path="files.diffPath ?? undefined"
+                    @back="backToFileList" @close="closeFileViewer" />
         <TerminalTab v-if="terminalOpen" class="absolute inset-0 z-20"
                      :instance-id="chat.instanceId ?? ''" :session-alias="chat.sessionAlias ?? ''"
                      @close="terminalOpen = false" />

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -6,7 +6,7 @@ import { useChatStore, loadPersistedSelection } from "../stores/chat";
 import { useTasksStore } from "../stores/tasks";
 import { useNoticesStore } from "../stores/notices";
 import { useConnectionStore } from "../stores/connection";
-import { useFilesStore } from "../stores/files";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { useTerminalStore } from "../stores/terminal";
 import InstanceTree from "../components/InstanceTree.vue";
 import ChatPane from "../components/ChatPane.vue";
@@ -14,6 +14,7 @@ import FileViewer from "../components/FileViewer.vue";
 import TaskPanel from "../components/TaskPanel.vue";
 import FilesPanel from "../components/FilesPanel.vue";
 import TerminalTab from "../components/TerminalTab.vue";
+import CenterTabStrip from "../components/CenterTabStrip.vue";
 import NoticeToast from "../components/NoticeToast.vue";
 import ActionToast from "../components/ActionToast.vue";
 import ToastHost from "../components/ToastHost.vue";
@@ -28,11 +29,11 @@ import { Search, Moon, Sun, Settings, X, Menu, FileText, List, PanelLeftClose, P
 const theme = useThemeStore();
 const instances = useInstancesStore();
 const chat = useChatStore();
-const files = useFilesStore();
 const tasks = useTasksStore();
 const terminals = useTerminalStore();
 const notices = useNoticesStore();
 const conn = useConnectionStore();
+const centerTabs = useCenterTabsStore();
 let disconnect: (() => void) | null = null;
 
 // Mobile-only drawer state. On desktop (lg:) both panels are static columns and
@@ -40,7 +41,6 @@ let disconnect: (() => void) | null = null;
 const leftOpen = ref(false);
 const rightOpen = ref(false);
 const rightTab = ref<"tasks" | "files">("tasks");
-const terminalOpen = ref(false);
 function closeDrawers() {
   leftOpen.value = false;
   rightOpen.value = false;
@@ -65,10 +65,10 @@ const swipe = createEdgeSwipe({
   closeLeft: () => { leftOpen.value = false; },
   closeRight: () => { rightOpen.value = false; },
 });
-// Mobile: "Back" from the file viewer returns to the FILE LIST (reopen the Files drawer),
-// not the conversation. Clearing the open file reverts the center to ChatPane underneath.
+// Mobile: "Back" from the file viewer returns to the FILE LIST (reopen the Files drawer)
+// so the user can pick another file. It does NOT close the underlying file/diff tab — the
+// tab stays open (and active) in the per-session tab strip; the drawer just overlays it.
 function backToFileList() {
-  closeFileViewer();
   openRight("files");
 }
 
@@ -125,18 +125,34 @@ function onDesktopChange(e: MediaQueryListEvent | MediaQueryList) {
   isDesktop.value = e.matches;
 }
 
-// A file/diff opened from the rail takes over the center column (FileViewer); Back
-// returns to the conversation. On mobile, opening one also closes the right drawer so
-// the viewer is actually visible.
-const viewingFile = computed(() => !!(files.file || files.diffPath));
-function closeFileViewer() {
-  files.file = null;
-  files.diffPath = null;
+// Per-session center tab strip: the session key the tab strip / panes below key off.
+// Both instanceId and sessionAlias must be set (a fresh/deselected pane has neither).
+const currentKey = computed(() => (chat.instanceId && chat.sessionAlias ? sessionKey(chat.instanceId, chat.sessionAlias) : null));
+
+/** Split a `${instanceId}::${alias}` session key back into its parts. */
+function keyInstance(key: string): string {
+  const idx = key.indexOf("::");
+  return idx === -1 ? key : key.slice(0, idx);
 }
-watch(viewingFile, (v) => { if (v) { rightOpen.value = false; terminalOpen.value = false; } });
-watch(terminalOpen, (v) => { if (v) { files.file = null; files.diffPath = null; rightOpen.value = false; } });
-// 会话被清空时自动收起终端（否则会显示无会话态且开关已禁用）。
-watch(() => chat.sessionAlias, (a) => { if (!a) terminalOpen.value = false; });
+function keyAlias(key: string): string {
+  const idx = key.indexOf("::");
+  return idx === -1 ? "" : key.slice(idx + 2);
+}
+// Resolve a session key's workspace via the instances store — mirrors FilesPanel's
+// `activeWorkspace` lookup, generalized to any (not just the current) session so hidden
+// panes for other sessions can still load their own content. "" when unresolvable (e.g.
+// the instance hasn't loaded its session list yet).
+function keyWorkspace(key: string): string {
+  const inst = instances.byId(keyInstance(key));
+  return inst?.sessions.find((s) => s.alias === keyAlias(key))?.workspace ?? "";
+}
+
+// A file/diff/terminal tab opened for the current session takes over the center column.
+// On mobile, opening one also closes the right drawer so the pane is actually visible.
+watch(
+  () => (currentKey.value ? centerTabs.activeFor(currentKey.value) : "chat"),
+  (active) => { if (active !== "chat") rightOpen.value = false; },
+);
 
 // Cmd/Ctrl+K command palette.
 const paletteOpen = ref(false);
@@ -240,8 +256,8 @@ onUnmounted(() => {
           :title='$t("terminal.title")'
           :disabled="!chat.sessionAlias"
           class="grid h-7 w-7 place-items-center rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
-          :class="terminalOpen ? 'border-accent/40 bg-accent/10 text-accent' : 'border-border text-fg-muted hover:bg-raised'"
-          @click="terminalOpen = !terminalOpen"
+          :class="currentKey && centerTabs.activeFor(currentKey) === 'terminal' ? 'border-accent/40 bg-accent/10 text-accent' : 'border-border text-fg-muted hover:bg-raised'"
+          @click="currentKey && centerTabs.openTerminal(currentKey)"
         >
           <SquareTerminal :size="15" />
         </button>
@@ -307,24 +323,41 @@ onUnmounted(() => {
               class="hidden w-5 shrink-0 items-center justify-center border-r border-border bg-surface/60 text-fg-muted transition-colors hover:bg-raised hover:text-fg lg:flex"
               @click="leftCollapsed = false"><PanelLeftOpen :size="15" /></button>
 
-      <!-- Center: chat, always full width of the remaining space. -->
+      <!-- Center: per-session tab strip (pinned Chat + closable file/diff/terminal tabs),
+           always full width of the remaining space. -->
       <!-- min-w-0: let this flex child shrink to its share instead of growing to its
            widest content (a tool card's command/diff line), which would otherwise push
            the right panel off-screen. Wide tool content scrolls/wraps within instead. -->
-      <!-- ChatPane stays mounted AND laid out (never display:none) — a file viewer just
-           overlays it. v-if/v-show would unmount or display:none the conversation, which
-           loses its scroll position and forces a full re-layout on return (visible jank).
-           Overlaying keeps the scroller warm, so Back is an instant repaint. `inert`
-           disables the occluded conversation for focus/interaction. -->
+      <!-- ChatPane is a SINGLE always-mounted instance bound to the current session,
+           toggled with `v-show` (never `v-if`) — so switching tabs only flips CSS
+           display, it never destroys/recreates the component, which is what preserves
+           its scroll position and message-list state across a tab switch. `inert`
+           additionally disables the occluded conversation for focus/interaction while a
+           tab is active. Every OPEN file/diff/terminal tab across ALL sessions gets its
+           own always-mounted pane too (so a background session's terminal PTY / a file's
+           scroll stay warm); `v-show` reveals only the current session's active tab. A
+           pane only ever unmounts when its tab is closed (closeTab) or its session is
+           cleared (clearSession). -->
       <div data-test="column" class="relative flex min-w-0 flex-1 flex-col">
-        <ChatPane class="absolute inset-0" :inert="viewingFile || terminalOpen" @show-files="rightTab = 'files'" />
-        <FileViewer v-if="viewingFile" class="absolute inset-0 z-10"
-                    :instance-id="files.instanceId ?? ''" :workspace="files.workspace ?? ''"
-                    :path="files.file?.path" :diff-path="files.diffPath ?? undefined"
-                    @back="backToFileList" @close="closeFileViewer" />
-        <TerminalTab v-if="terminalOpen" class="absolute inset-0 z-20"
-                     :instance-id="chat.instanceId ?? ''" :session-alias="chat.sessionAlias ?? ''"
-                     @close="terminalOpen = false" />
+        <CenterTabStrip v-if="currentKey" :session-key="currentKey" />
+        <div class="relative min-h-0 flex-1">
+          <ChatPane class="absolute inset-0"
+                    :inert="!!currentKey && centerTabs.activeFor(currentKey) !== 'chat'"
+                    v-show="!currentKey || centerTabs.activeFor(currentKey) === 'chat'"
+                    @show-files="rightTab = 'files'" />
+          <template v-for="{ key, tab } in centerTabs.allOpenTabs()" :key="key + '|' + tab.id">
+            <FileViewer v-if="tab.kind === 'file' || tab.kind === 'diff'" class="absolute inset-0 z-10"
+                        v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
+                        :instance-id="keyInstance(key)" :workspace="keyWorkspace(key)"
+                        :path="tab.kind === 'file' ? tab.path : undefined"
+                        :diff-path="tab.kind === 'diff' ? tab.path : undefined"
+                        @close="centerTabs.closeTab(key, tab.id)" @back="backToFileList" />
+            <TerminalTab v-else-if="tab.kind === 'terminal'" class="absolute inset-0 z-20"
+                         v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
+                         :instance-id="keyInstance(key)" :session-alias="keyAlias(key)"
+                         @close="centerTabs.closeTab(key, tab.id)" />
+          </template>
+        </div>
       </div>
 
       <!-- Right: tasks. Off-canvas drawer < lg, static column ≥ lg. On desktop its


### PR DESCRIPTION
Two dashboard UX features, built via subagent-driven development (fresh implementer + review per task, final whole-branch review).

## 1. Session-list cap (left rail)
Each instance shows at most **10** sessions (of the ordered list — active first, archived last). More → a **"再显示 N 个 / Show N more"** button; expanded → **"收起 / Collapse"**. Per-instance, ephemeral. Ordering/selection/swipe-actions unchanged.

## 2. Center area → per-session tab strip
The center column is now a tab strip instead of mutually-exclusive overlays.
- **💬 Chat** is the pinned first tab (non-closable, non-draggable); **file / diff / terminal** tabs follow, each **closable** and **drag-reorderable** (pointer-based → mouse **and** touch).
- **Per-session tab sets** (`stores/center-tabs.ts`, keyed `instanceId::alias`; chat is implicit). Switching sessions shows that session's tabs.
- **All open tabs stay mounted** (`v-show` only the current session's active tab) → **terminals survive session switches** (PTY not torn down) and file scroll persists. One terminal per session (re-click focuses it).
- **`FileViewer` decoupled** from the single global slot → loads its own content from props via return-based `files.readFile`/`readDiff`, so multiple viewers coexist.
- **`FilesPanel`** routes tree/search/changed-file clicks to open center tabs; **archive/delete** and **out-of-band session removal** prune a session's tabs (and its PTY).

## Architecture notes
- New: `stores/center-tabs.ts`, `components/CenterTabStrip.vue`, `lib/use-tab-drag.ts` (vanilla Pointer Events, no dependency). Rewrote the `DashboardView` center block (removed the old `viewingFile`/`terminalOpen` overlay + mutual-exclusion watchers).
- Reorder is pointer-based to match the codebase's existing `use-swipe-actions`/`edge-swipe` utilities and to cover touch.

## Review & correctness
Each of the 10 tasks was individually reviewed; the final whole-branch review ran on the strongest model. Real bugs caught and fixed in-flight:
- FileViewer silently kept stale content on a failed load → now surfaces error/loading and clears stale content.
- Pointer-drag re-entrant `start()` leaked drag state (multi-touch) → reset on re-arm.
- `openDiff` dual-wrote `files.diffPath`, breaking the Changes-tab Refresh scope → decoupled the row highlight into local state.
- **Out-of-band session removal** (deleted from CLI/another client) didn't prune tabs → orphan panes/PTYs; now reconciled against the loaded session list.
- **Backgrounded terminal** spun a permanent 60fps `requestAnimationFrame` loop (0×0 hidden host) → bails until laid out, self-heals on reveal.

Deferred Minors (non-blocking, logged): tab elements are `<div>` not `<button role=tab>` for keyboard a11y (forced by the nested close button — follow-up), plus a couple of micro-perf nits.

## Tests
`vue-tsc --noEmit` clean. Full relay-web suite: **600 passing (84 files)**, including new tests for the center-tabs store, session cap, `readFile`/`readDiff`, FileViewer race/error handling, pointer drag-reorder, CenterTabStrip, the DashboardView tab integration, FilesPanel routing, clearSession, and the two final-review fixes.