### PR TITLE
feat(relay-web): fold center tabs into mobile top bar + touch drag UX

### DIFF
--- a/docs/superpowers/specs/2026-07-03-relay-web-tab-strip-refinements-design.md
+++ b/docs/superpowers/specs/2026-07-03-relay-web-tab-strip-refinements-design.md
@@ -1,0 +1,71 @@
+# Relay-web center tab-strip refinements
+
+Date: 2026-07-03
+Status: design (proceeding on best judgment — user stepped away mid-clarification)
+
+## Context
+
+The center multi-tab strip (`CenterTabStrip.vue`, shipped in beta.10) is a standalone
+full-width row above the content pane: `💬Chat  file.ts✕  ⌗term✕`. On-device beta
+feedback surfaced three issues:
+
+1. **Mobile long-press selects the tab label text.** Tabs carry `touch-action: none`
+   but nothing suppresses text selection / the iOS long-press callout, so a press-hold
+   (the natural start of a drag on touch) highlights the label instead.
+2. **No drag feedback on the tab being moved.** `useTabDrag` already computes
+   `draggingId`, but the strip only styles the drop *target* (`overId` → ring). The
+   dragged tab itself gives no visual signal, so a touch drag feels unresponsive.
+3. **The tab strip is a separate row from the session name.** The user wants the tabs
+   to live in the same bar as the session name, horizontally scrollable when they
+   overflow, rather than consuming an extra full-width row.
+
+## Decision (revised after user feedback)
+
+An earlier draft merged the tabs and a pinned session label into one standalone row.
+The user chose instead to **fold the tabs into the mobile top bar** (`☰ … 📄📋`): on
+mobile the tab strip replaces the centered session-name text in that bar, so mobile
+spends one bar total instead of top-bar + a second tab-strip row. On desktop (which has
+no such top bar — it's `lg:hidden`) the tab strip keeps its standalone row above the
+content. Trade-off the user accepted: the session name no longer shows in the mobile top
+bar when a session is open (the sidebar still shows the active session).
+
+Chosen over the one-unified-row-with-pinned-label draft.
+
+## Changes
+
+### `CenterTabStrip.vue`
+- Single scroll-container root (`flex … overflow-x-auto`) holding the Chat button, tabs,
+  and the trailing `TAB_DROP_END` drop zone — same as before the refinement.
+- Add `select-none` + `[-webkit-touch-callout:none]` to the root so no descendant text
+  is selectable and iOS shows no callout on long-press.
+- Destructure `draggingId` from `useTabDrag` and, when `tab.id === draggingId`, apply a
+  "lifted" style (`scale-95 opacity-50`) to the dragged tab. Tab transition switched from
+  `transition-colors` to bare `transition` so the scale/opacity actually animate.
+- New optional prop `bare?: boolean`. When true the root drops its own chrome
+  (`shrink-0 border-b border-border bg-surface`) so it slots into a host row that already
+  owns those (the mobile top bar). Default (false) keeps the standalone chrome.
+
+### `DashboardView.vue`
+- Mobile top bar: replace the centered session-name `<span>` with
+  `<CenterTabStrip v-if="currentKey" bare :session-key="currentKey" class="min-w-0 flex-1" />`;
+  the `<span>` (app title / alias) remains as the `v-else` for when no session is open.
+- Center column: the standalone `<CenterTabStrip>` is wrapped in
+  `<div class="hidden lg:block">` so it renders on desktop only (mobile uses the top bar
+  copy). The wrapper — not a class on the strip — owns the responsive show/hide so the
+  strip's own `display:flex` never fights a `hidden`/`lg:flex` on the same node.
+
+### Out of scope (unchanged)
+- `use-tab-drag.ts` logic (threshold, reorder, hit-testing) — `draggingId` already
+  exists; we only start *consuming* it.
+- `ChatPane.vue` header (its `lg:`-only session-name h1 + workspace/agent chips are
+  untouched).
+
+## Testing
+
+Extend `centertabstrip.test.ts`:
+- Root carries `select-none`.
+- Default (standalone) root carries its `border-b` + `bg-surface` chrome.
+- `bare` root drops `border-b` + `bg-surface` yet still renders Chat + tabs.
+- Existing tabs still render (`data-test="tab"` / `tab-chat` / `tab-drop-end`).
+
+Full suite: `npx vitest run` + `npx vue-tsc --noEmit` in `packages/relay-web`.

--- a/packages/relay-web/src/__tests__/centertabstrip.test.ts
+++ b/packages/relay-web/src/__tests__/centertabstrip.test.ts
@@ -96,6 +96,64 @@ describe("CenterTabStrip", () => {
     }
   });
 
+  it("suppresses text selection on the strip so a touch press-hold starts a drag instead of highlighting a label", () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    expect(w.element.className).toContain("select-none");
+  });
+
+  it("renders its own border/background chrome when standalone (default)", () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    const cls = w.element.className;
+    expect(cls).toContain("border-b");
+    expect(cls).toContain("bg-surface");
+  });
+
+  it("drops its own border/background chrome when bare, so it slots into a host row", () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K, bare: true }, ...g });
+    const cls = w.element.className;
+    expect(cls).not.toContain("border-b");
+    expect(cls).not.toContain("bg-surface");
+    // Still a working strip: chat + the open file tab both render.
+    expect(w.find('[data-test="tab-chat"]').exists()).toBe(true);
+    expect(w.findAll('[data-test="tab"]')).toHaveLength(1);
+  });
+
+  it("lifts the dragged tab (scale/opacity) once a pointer drag crosses the threshold", async () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+    // jsdom has no elementFromPoint; stub it so the drag composable's default
+    // resolveId doesn't throw. Returning null keeps overId null — draggingId (which
+    // drives the lift class) is set from the armed tab before resolveId runs.
+    (document as unknown as { elementFromPoint: () => null }).elementFromPoint = () => null;
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "file:src/a.ts")!;
+    expect(fileTab.classes()).not.toContain("scale-95"); // not lifted at rest
+
+    await fileTab.trigger("pointerdown", { clientX: 100 });
+    document.dispatchEvent(new MouseEvent("pointermove", { clientX: 120, clientY: 0, bubbles: true })); // dx=20 >= 4px
+    await w.vm.$nextTick();
+
+    expect(fileTab.classes()).toContain("scale-95");
+    expect(fileTab.classes()).toContain("opacity-50");
+
+    document.dispatchEvent(new MouseEvent("pointerup", { clientX: 120, bubbles: true })); // end gesture, remove listeners
+    delete (document as unknown as { elementFromPoint?: () => null }).elementFromPoint;
+  });
+
   it("renders a trailing end-of-strip drop zone carrying the END sentinel id, after the last tab", () => {
     const store = useCenterTabsStore();
     const K = sessionKey("i1", "s1");

--- a/packages/relay-web/src/components/CenterTabStrip.vue
+++ b/packages/relay-web/src/components/CenterTabStrip.vue
@@ -5,13 +5,24 @@ import { useCenterTabsStore, type CenterTab, TAB_DROP_END } from "../stores/cent
 import { useTabDrag } from "../lib/use-tab-drag";
 import { iconForFile } from "../lib/file-icons";
 
-const props = defineProps<{ sessionKey: string }>();
+// The center tab strip: pinned Chat button + closable, drag-reorderable file/diff/
+// terminal tabs, horizontally scrollable when they overflow. Rendered in two places:
+// a standalone row above the content on desktop, and (with `bare`) inside the mobile
+// top bar where it replaces the session-name text. `bare` drops the strip's own chrome
+// (border/background/shrink-0) so it slots into a host row that already owns those.
+//
+// `select-none` + `[-webkit-touch-callout:none]` on the root stop a touch press-hold
+// (the natural start of a drag) from highlighting a tab's label or popping the iOS
+// callout menu. Keep the root <div> the FIRST node in <template>: a leading sibling
+// comment would make the component a fragment root, so tests' `w.element` would resolve
+// to the comment instead of the div.
+const props = defineProps<{ sessionKey: string; bare?: boolean }>();
 const store = useCenterTabsStore();
 const { t } = useI18n();
 
-// Destructure so Vue's template compiler auto-unwraps `overId` (a top-level ref
-// binding); `drag.overId` (member access on a plain object) would NOT be unwrapped.
-const { overId, start } = useTabDrag({
+// Destructure so Vue's template compiler auto-unwraps the refs (top-level bindings);
+// `drag.overId` (member access on a plain object) would NOT be unwrapped.
+const { draggingId, overId, start } = useTabDrag({
   onReorder: (draggedId, targetId) => store.reorder(props.sessionKey, draggedId, targetId),
 });
 
@@ -31,7 +42,10 @@ function labelFor(tab: CenterTab): string {
 </script>
 
 <template>
-  <div class="flex shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border bg-surface px-1 py-1">
+  <div
+    class="flex select-none items-center gap-0.5 overflow-x-auto px-1 py-1 [-webkit-touch-callout:none]"
+    :class="props.bare ? '' : 'shrink-0 border-b border-border bg-surface'"
+  >
     <!-- Pinned chat tab: never closable, never draggable, always first. -->
     <button
       type="button"
@@ -49,10 +63,11 @@ function labelFor(tab: CenterTab): string {
       data-test="tab"
       :data-tab-id="tab.id"
       style="touch-action: none"
-      class="flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11.5px] transition-colors cursor-pointer"
+      class="flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11.5px] transition cursor-pointer"
       :class="[
         tab.id === store.activeFor(props.sessionKey) ? 'bg-accent/10 text-accent font-semibold' : 'text-fg-muted font-medium hover:bg-raised',
         overId === tab.id ? 'ring-1 ring-inset ring-accent' : '',
+        tab.id === draggingId ? 'scale-95 opacity-50' : '',
       ]"
       @click="store.setActive(props.sessionKey, tab.id)"
       @pointerdown="start($event, tab.id)"

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -307,11 +307,16 @@ onUnmounted(() => {
       </div>
     </header>
 
-    <!-- Mobile top bar: hamburger opens the instance tree, Tasks opens the task panel. -->
+    <!-- Mobile top bar: hamburger opens the instance tree, Tasks opens the task panel.
+         When a session is open the center tab strip lives HERE (bare, so it borrows this
+         bar's border/background) in place of the session-name text — folding tabs into the
+         one bar mobile already spends, instead of a second full-width row. The standalone
+         strip below is desktop-only. Falls back to the app title when no session is open. -->
     <div class="flex items-center gap-2 border-b border-border bg-surface px-2 py-1.5 lg:hidden">
       <button data-test="open-instances" :aria-label='$t("nav.openInstances")'
               class="rounded p-1 leading-none text-fg-muted hover:bg-fg/5" @click="leftOpen = true"><Menu :size="20" /></button>
-      <span class="min-w-0 flex-1 truncate text-center text-sm font-medium">{{ chat.sessionAlias ?? "xacpx relay" }}</span>
+      <CenterTabStrip v-if="currentKey" bare :session-key="currentKey" class="min-w-0 flex-1" />
+      <span v-else class="min-w-0 flex-1 truncate text-center text-sm font-medium">{{ chat.sessionAlias ?? "xacpx relay" }}</span>
       <div class="flex shrink-0 items-center gap-0.5">
         <button data-test="open-files" :aria-label='$t("nav.openFiles")' :title='$t("nav.files")'
                 class="grid h-8 w-8 place-items-center rounded text-fg-muted hover:bg-fg/5"
@@ -365,7 +370,10 @@ onUnmounted(() => {
            pane only ever unmounts when its tab is closed (closeTab) or its session is
            cleared (clearSession). -->
       <div data-test="column" class="relative flex min-w-0 flex-1 flex-col">
-        <CenterTabStrip v-if="currentKey" :session-key="currentKey" />
+        <!-- Desktop-only standalone strip (mobile renders it in the top bar above). The
+             wrapper — not a class on the strip — owns the responsive show/hide so the
+             strip's own `display:flex` never fights a `hidden`/`lg:flex` on the same node. -->
+        <div v-if="currentKey" class="hidden shrink-0 lg:block"><CenterTabStrip :session-key="currentKey" /></div>
         <div class="relative min-h-0 flex-1">
           <ChatPane class="absolute inset-0"
                     :inert="!!currentKey && centerTabs.activeFor(currentKey) !== 'chat'"


### PR DESCRIPTION
On-device beta feedback on the center multi-tab strip (shipped in `@ganglion/xacpx-relay` beta.10).

## Changes
- **Mobile long-press no longer selects the tab label.** Added `select-none` +
  `[-webkit-touch-callout:none]` to the strip root, so a press-hold starts a drag instead
  of highlighting text / popping the iOS callout.
- **The dragged tab now has visual feedback.** Consume the drag composable's already-computed
  `draggingId` to lift the dragged tab (`scale-95 opacity-50`); switched the tab transition
  from `transition-colors` to bare `transition` so scale/opacity actually animate.
- **Tabs folded into the mobile top bar.** On mobile the tab strip replaces the centered
  session-name text in the existing `☰ … 📄📋` bar (horizontally scrollable), so mobile
  spends one bar instead of top-bar + a second full-width tab-strip row. Desktop keeps the
  standalone strip row (no such top bar there).

## Implementation
- `CenterTabStrip.vue`: new `bare?: boolean` prop drops the strip's own chrome
  (`shrink-0 border-b border-border bg-surface`) so it slots into a host row that already
  owns those.
- `DashboardView.vue`: mobile top bar renders `<CenterTabStrip bare … class="min-w-0 flex-1">`
  (the session-name `<span>` stays as the `v-else` no-session fallback); the desktop
  standalone strip is wrapped in `hidden shrink-0 lg:block`.

## Trade-off
When a session is open, the mobile top bar no longer shows the session alias (tabs take that
space); the sidebar still highlights the active session. This is the layout that was chosen.

## Testing
- `npx vitest run` → **608 passed** (added: select-none on root, standalone vs `bare` chrome,
  and a pointer-drag test asserting the dragged tab gets the lift class).
- `npx vue-tsc --noEmit` → clean.

Two independent subagent reviews (one per layout iteration); final verdict **LGTM** with only
cosmetic nits, both addressed (wrapper `shrink-0`; drag-lift test added).

Spec: `docs/superpowers/specs/2026-07-03-relay-web-tab-strip-refinements-design.md`.