### PR TITLE
release(relay): hub 0.9.12-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [relay 0.9.12-beta.11] - 2026-07-03
+
+A `@ganglion/xacpx-relay` (hub) beta folding in on-device feedback on the center tab strip (#119). UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.
+
+### Changed
+
+- **Center tabs fold into the mobile top bar.** On mobile the tab strip now lives in the existing `☰ … 📄📋` bar in place of the centered session name (horizontally scrollable when tabs overflow), so mobile spends one bar instead of the top bar plus a second full-width tab-strip row. Desktop keeps the standalone strip row. Trade-off: on mobile the session alias no longer shows in the top bar while a session is open (the sidebar still highlights it).
+
+### Fixed
+
+- **Mobile long-press starts a drag instead of selecting text.** The tab strip suppresses text selection and the iOS long-press callout, so a press-hold begins a tab drag rather than highlighting the label.
+- **The dragged tab now has visual feedback** — it lifts (slight shrink + fade) while being dragged.
+
 ## [relay 0.9.12-beta.10] - 2026-07-03
 
 A `@ganglion/xacpx-relay` (hub) beta adding a multi-tab center area and a session-list cap (#117). UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11682,7 +11682,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.10",
+      "version": "0.9.12-beta.11",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.10",
+  "version": "0.9.12-beta.11",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Hub-only beta release bundling the relay-web center tab-strip refinements from #119.

- Bumps `@ganglion/xacpx-relay` → **0.9.12-beta.11** (UI-only; no core/protocol/connector change).
- `package-lock.json` synced (`npm install --package-lock-only`).
- CHANGELOG entry added (English).
- `npm run verify:publish` passed locally — the built `relay-web` dashboard is bundled into the hub tarball (`dist/relay-web/index.html`).

On merge, tag `relay-v0.9.12-beta.11` triggers `publish-relay.yml` → npm `next` dist-tag.