### PR TITLE
fix(relay-web): touch swipe scrolls the tab strip; long-press to reorder

### DIFF
--- a/packages/relay-web/src/__tests__/use-tab-drag.test.ts
+++ b/packages/relay-web/src/__tests__/use-tab-drag.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { useTabDrag } from "../lib/use-tab-drag";
 
 // jsdom's PointerEvent support is inconsistent across versions; build one that
@@ -13,9 +13,14 @@ function pointerEvent(type: string, clientX: number, clientY = 0): PointerEvent 
 }
 
 function fakeStartEvent(clientX: number, clientY = 0): PointerEvent {
-  // `start` only reads clientX off the event it's given; a plain object cast is
-  // enough and sidesteps constructing a real PointerEvent for the initiating call.
+  // `start` only reads clientX/clientY/pointerType off the event it's given; a plain
+  // object cast is enough and sidesteps constructing a real PointerEvent. No
+  // pointerType ⇒ treated as mouse (immediate-threshold drag).
   return { clientX, clientY } as PointerEvent;
+}
+
+function fakeTouchStart(clientX: number, clientY = 0): PointerEvent {
+  return { clientX, clientY, pointerType: "touch" } as PointerEvent;
 }
 
 describe("useTabDrag", () => {
@@ -167,5 +172,90 @@ describe("useTabDrag", () => {
 
     delete (document as unknown as { elementFromPoint?: typeof stub }).elementFromPoint;
     document.body.removeChild(tab);
+  });
+});
+
+describe("useTabDrag (touch: long-press to drag, swipe to scroll)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    document.dispatchEvent(pointerEvent("pointercancel", 0, 0));
+    vi.useRealTimers();
+  });
+
+  it("does NOT arm a drag on a quick horizontal swipe — that stays a native scroll", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("b");
+    const { draggingId, start } = useTabDrag({ onReorder, resolveId });
+    start(fakeTouchStart(100, 100), "a");
+    // Finger travels past the slop before the hold timer fires ⇒ scroll intent.
+    document.dispatchEvent(pointerEvent("pointermove", 130, 102)); // dx=30 > 10px slop
+    expect(draggingId.value).toBeNull();
+    // Even after the hold interval elapses, the abandoned gesture must not arm.
+    vi.advanceTimersByTime(1000);
+    expect(draggingId.value).toBeNull();
+    document.dispatchEvent(pointerEvent("pointerup", 130, 102));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("arms a drag after the long-press hold, then reorders on move + up", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("b");
+    const { draggingId, overId, start } = useTabDrag({ onReorder, resolveId });
+    start(fakeTouchStart(100, 100), "a");
+    expect(draggingId.value).toBeNull(); // not armed yet — still within the hold
+    vi.advanceTimersByTime(320); // hold fires: tab is picked up
+    expect(draggingId.value).toBe("a");
+    document.dispatchEvent(pointerEvent("pointermove", 140, 100));
+    expect(overId.value).toBe("b");
+    document.dispatchEvent(pointerEvent("pointerup", 140, 100));
+    expect(onReorder).toHaveBeenCalledTimes(1);
+    expect(onReorder).toHaveBeenCalledWith("a", "b");
+  });
+
+  it("a small sub-slop wiggle during the press still lets the hold arm the drag", () => {
+    const onReorder = vi.fn();
+    const resolveId = vi.fn().mockReturnValue("b");
+    const { draggingId, start } = useTabDrag({ onReorder, resolveId });
+    start(fakeTouchStart(100, 100), "a");
+    document.dispatchEvent(pointerEvent("pointermove", 104, 103)); // hypot=5 < 10 slop
+    expect(draggingId.value).toBeNull();
+    vi.advanceTimersByTime(320);
+    expect(draggingId.value).toBe("a");
+    document.dispatchEvent(pointerEvent("pointerup", 104, 103));
+  });
+
+  it("suppresses native scroll (preventDefault touchmove) only once the drag is armed", () => {
+    const onReorder = vi.fn();
+    const { start } = useTabDrag({ onReorder, resolveId: () => "b" });
+    start(fakeTouchStart(100, 100), "a");
+
+    // Before the hold fires, a touchmove must NOT be prevented — native scroll runs.
+    const before = new Event("touchmove", { cancelable: true, bubbles: true });
+    document.dispatchEvent(before);
+    expect(before.defaultPrevented).toBe(false);
+
+    vi.advanceTimersByTime(320); // drag now armed
+
+    // Now an active drag must swallow the native pan so reorder isn't fighting scroll.
+    const during = new Event("touchmove", { cancelable: true, bubbles: true });
+    document.dispatchEvent(during);
+    expect(during.defaultPrevented).toBe(true);
+
+    document.dispatchEvent(pointerEvent("pointerup", 100, 100));
+  });
+
+  it("resets on pointercancel after the hold arms (browser reclaimed the gesture), without reordering", () => {
+    const onReorder = vi.fn();
+    const { draggingId, start } = useTabDrag({ onReorder, resolveId: () => "b" });
+    start(fakeTouchStart(100, 100), "a");
+    vi.advanceTimersByTime(320);
+    expect(draggingId.value).toBe("a");
+    document.dispatchEvent(pointerEvent("pointercancel", 100, 100));
+    expect(draggingId.value).toBeNull();
+    expect(onReorder).not.toHaveBeenCalled();
+    // A subsequent touchmove is a no-op and must not be prevented (listeners gone).
+    const after = new Event("touchmove", { cancelable: true, bubbles: true });
+    document.dispatchEvent(after);
+    expect(after.defaultPrevented).toBe(false);
   });
 });

--- a/packages/relay-web/src/components/CenterTabStrip.vue
+++ b/packages/relay-web/src/components/CenterTabStrip.vue
@@ -57,12 +57,18 @@ function labelFor(tab: CenterTab): string {
       <MessageSquare :size="13" />{{ $t("center.chat") }}
     </button>
 
+    <!-- `touch-action: pan-x`: let a horizontal swipe scroll the strip natively; the
+         drag-reorder is gated behind a long-press instead (see use-tab-drag). pan-x also
+         forbids the browser from vertically panning from a tab — fine because the strip
+         only ever lives in the fixed mobile top bar / the desktop row, neither of which is
+         inside vertically-scrollable content. Revisit pan-x if the strip is ever placed
+         somewhere a vertical scroll must start on a tab. -->
     <div
       v-for="tab in store.tabsFor(props.sessionKey)"
       :key="tab.id"
       data-test="tab"
       :data-tab-id="tab.id"
-      style="touch-action: none"
+      style="touch-action: pan-x"
       class="flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11.5px] transition cursor-pointer"
       :class="[
         tab.id === store.activeFor(props.sessionKey) ? 'bg-accent/10 text-accent font-semibold' : 'text-fg-muted font-medium hover:bg-raised',

--- a/packages/relay-web/src/lib/use-tab-drag.ts
+++ b/packages/relay-web/src/lib/use-tab-drag.ts
@@ -1,9 +1,20 @@
 import { ref, type Ref } from "vue";
 
-/** Px of pointer movement before a pointerdown on a tab commits to a drag
+/** Px of pointer movement before a MOUSE pointerdown on a tab commits to a drag
  *  rather than staying a click. Mirrors the `intent` threshold in
- *  `use-swipe-actions.ts`. */
+ *  `use-swipe-actions.ts`. Touch uses a hold instead (see below). */
 const THRESHOLD = 4;
+
+/** Touch only: how long the finger must stay pressed on a tab before the gesture
+ *  becomes a drag-reorder. A shorter press-and-swipe is left to the browser as a
+ *  native horizontal scroll of the strip — otherwise dragging and scrolling (both
+ *  horizontal finger travel) are indistinguishable and the strip can never scroll.
+ *  This is the standard "long-press to pick up" pattern. */
+const TOUCH_HOLD_MS = 320;
+
+/** Touch only: if the finger travels more than this before the hold fires, the
+ *  gesture is a scroll, not a drag — abandon arming and let the browser scroll. */
+const TOUCH_SLOP = 10;
 
 export interface TabDragOptions {
   onReorder: (draggedId: string, targetId: string) => void;
@@ -26,10 +37,18 @@ function defaultResolveId(x: number, y: number): string | null {
   return el?.closest("[data-tab-id]")?.getAttribute("data-tab-id") ?? null;
 }
 
-/** Vanilla Pointer Events tab drag-reorder (mouse + touch), mirroring the
- *  attach/detach-on-document style of `use-swipe-actions.ts` / `edge-swipe.ts`.
- *  `start` arms the gesture but does not mark it dragging until the pointer
- *  has moved past `THRESHOLD`, so a plain tap/click never flags a drag. */
+/** Vanilla Pointer Events tab drag-reorder, mirroring the attach/detach-on-document
+ *  style of `use-swipe-actions.ts` / `edge-swipe.ts`.
+ *
+ *  Mouse/pen: `start` arms the gesture and it becomes a drag once the pointer moves
+ *  past `THRESHOLD`, so a plain click never flags a drag. A mouse can't scroll by
+ *  dragging, so there's nothing to disambiguate.
+ *
+ *  Touch: `start` arms a `TOUCH_HOLD_MS` timer instead. If the finger stays put the
+ *  timer fires and the drag begins (the tab lifts as feedback); if it travels past
+ *  `TOUCH_SLOP` first, we bail and let the browser scroll the strip natively. While a
+ *  touch drag is active a non-passive `touchmove` `preventDefault` suppresses the
+ *  native pan so the reorder isn't fighting a scroll. */
 export function useTabDrag(opts: TabDragOptions): TabDragHandlers {
   const draggingId = ref<string | null>(null);
   const overId = ref<string | null>(null);
@@ -37,20 +56,60 @@ export function useTabDrag(opts: TabDragOptions): TabDragHandlers {
 
   let armedId: string | null = null;
   let startX = 0;
+  let startY = 0;
+  let isTouch = false;
+  let holdTimer: ReturnType<typeof setTimeout> | null = null;
 
-  function reset() {
-    armedId = null;
-    draggingId.value = null;
-    overId.value = null;
+  function clearHold() {
+    if (holdTimer !== null) {
+      clearTimeout(holdTimer);
+      holdTimer = null;
+    }
+  }
+
+  function removeListeners() {
     document.removeEventListener("pointermove", pointermove);
     document.removeEventListener("pointerup", pointerup);
     document.removeEventListener("pointercancel", pointercancel);
+    document.removeEventListener("touchmove", touchmoveBlockScroll);
+  }
+
+  function reset() {
+    clearHold();
+    armedId = null;
+    isTouch = false;
+    draggingId.value = null;
+    overId.value = null;
+    removeListeners();
+  }
+
+  // The long-press fired while the finger was still pressed: pick up the tab. overId
+  // is resolved on the next move; the lift style keyed off draggingId also serves as
+  // "drag armed" feedback.
+  function activateHold() {
+    holdTimer = null;
+    if (armedId !== null) draggingId.value = armedId;
+  }
+
+  // Suppress the native horizontal pan ONLY while a touch drag is active, so pre-hold
+  // swipes still scroll the strip. Must be a non-passive listener to be cancelable.
+  function touchmoveBlockScroll(e: TouchEvent) {
+    if (draggingId.value !== null && e.cancelable) e.preventDefault();
   }
 
   function pointermove(e: PointerEvent) {
     if (armedId === null) return;
     if (draggingId.value === null) {
-      if (Math.abs(e.clientX - startX) < THRESHOLD) return;
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      if (isTouch) {
+        // Hold hasn't fired yet (it would have set draggingId). Movement past the
+        // slop means the user is scrolling, not picking up a tab — bail so the
+        // browser's native scroll (still permitted by `touch-action: pan-x`) runs.
+        if (Math.hypot(dx, dy) > TOUCH_SLOP) reset();
+        return;
+      }
+      if (Math.abs(dx) < THRESHOLD) return;
       draggingId.value = armedId;
     }
     overId.value = resolveId(e.clientX, e.clientY);
@@ -70,19 +129,24 @@ export function useTabDrag(opts: TabDragOptions): TabDragHandlers {
   }
 
   function start(e: PointerEvent, id: string) {
-    // Defensive: drop any listeners from a prior gesture that never reached
-    // pointerup/pointercancel (e.g. a second pointerdown mid-drag) before
-    // re-adding, so listeners never accumulate across gestures.
-    document.removeEventListener("pointermove", pointermove);
-    document.removeEventListener("pointerup", pointerup);
-    document.removeEventListener("pointercancel", pointercancel);
+    // Defensive: drop any listeners/timer from a prior gesture that never reached
+    // pointerup/pointercancel (e.g. a second pointerdown mid-drag) before re-adding,
+    // so nothing accumulates across gestures.
+    clearHold();
+    removeListeners();
     armedId = id;
     startX = e.clientX;
+    startY = e.clientY;
+    isTouch = e.pointerType === "touch";
     draggingId.value = null;
     overId.value = null;
     document.addEventListener("pointermove", pointermove);
     document.addEventListener("pointerup", pointerup);
     document.addEventListener("pointercancel", pointercancel);
+    if (isTouch) {
+      document.addEventListener("touchmove", touchmoveBlockScroll, { passive: false });
+      holdTimer = setTimeout(activateHold, TOUCH_HOLD_MS);
+    }
   }
 
   return { draggingId, overId, start };


### PR DESCRIPTION
Follow-up to #119 (beta.11): on-device, the mobile top-bar tab strip **couldn't be scrolled** — every tab had `touch-action: none` and the drag armed on any 4px move, so a horizontal swipe always became a reorder and an overflowing strip never scrolled.

## Fix
- Tabs use `touch-action: pan-x` → a horizontal swipe scrolls the strip natively.
- `useTabDrag` disambiguates by `pointerType`:
  - **mouse/pen**: unchanged (immediate 4px threshold drag).
  - **touch**: a **320ms long-press** picks up the tab (standard mobile pattern). A pre-hold move past a 10px slop is treated as a scroll and abandons the drag.
  - While a touch drag is active, a non-passive `touchmove` `preventDefault` suppresses the native pan so reorder and scroll don't fight.

Documented that `pan-x` depends on the strip only living in non-vertically-scrollable placements (mobile top bar / desktop row).

## Testing
- `npx vitest run` → **613 passed** (5 new touch tests: scroll-bail, long-press-arm, sub-slop-wiggle, active-drag preventDefault, pointercancel-mid-hold reset).
- `npx vue-tsc --noEmit` → clean.

Independent review: **LGTM-with-nits**; both nits (two untested behaviors + the pan-x placement note) addressed here.