### PR TITLE
release(relay): hub 0.9.12-beta.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [relay 0.9.12-beta.12] - 2026-07-03
+
+A `@ganglion/xacpx-relay` (hub) beta fixing a touch-gesture conflict in the center tab strip (#121). UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.
+
+### Fixed
+
+- **The mobile tab strip can be scrolled again.** With several tabs open, a horizontal swipe was always captured as a drag-reorder, so the overflowing strip could never scroll. Tabs now scroll natively on a swipe; **reordering is a long-press-then-drag** on touch (the standard mobile pattern), while mouse drag is unchanged. An active drag suppresses the native scroll so the two no longer fight.
+
 ## [relay 0.9.12-beta.11] - 2026-07-03
 
 A `@ganglion/xacpx-relay` (hub) beta folding in on-device feedback on the center tab strip (#119). UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11682,7 +11682,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.11",
+      "version": "0.9.12-beta.12",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.11",
+  "version": "0.9.12-beta.12",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Hub-only beta bundling the relay-web tab-strip touch-gesture fix from #121.

- Bumps `@ganglion/xacpx-relay` → **0.9.12-beta.12** (UI-only; no core/protocol/connector change).
- `package-lock.json` synced; CHANGELOG entry added (English).
- `npm run verify:publish` passed — built `relay-web` bundled into the hub tarball.

On merge, tag `relay-v0.9.12-beta.12` triggers `publish-relay.yml` → npm `next`.