### PR TITLE
feat(relay-web): tab-strip edge fade, header session name, file-tree long-press

### DIFF
--- a/docs/superpowers/specs/2026-07-03-relay-web-strip-fade-header-longpress-design.md
+++ b/docs/superpowers/specs/2026-07-03-relay-web-strip-fade-header-longpress-design.md
@@ -1,0 +1,40 @@
+# Relay-web: tab-strip fade, header session name, file-tree long-press
+
+Date: 2026-07-03
+Status: design (on-device feedback batch, proceeding on stated assumptions)
+
+Four independent UX refinements from on-device feedback:
+
+## 1 & 2. Tab strip: hide the scrollbar, fade the overflow edges
+The center tab strip (`CenterTabStrip.vue`) is `overflow-x-auto`, so an OS scrollbar
+appears. Suppress it with the existing `no-scrollbar` utility (`style.css`). To keep the
+"there are more tabs" affordance, fade the content with a `mask-image` linear-gradient —
+but **only on the side(s) that actually overflow** (a static both-ends mask would dim the
+first/last tab even when nothing is clipped). `canLeft`/`canRight` refs track scroll
+position (scroll + resize listeners, re-checked when the tab count changes); `maskStyle`
+builds the gradient from them. jsdom has no layout, so both stay false → no mask → no test
+breakage.
+
+## 3. Session name at the front of the ChatPane chips row
+On mobile the top bar now shows tabs instead of the session name (prior change). Restore
+the name as the **leading chip** in the ChatPane header chips row (workspace / instance /
+agent / branch). Mobile-only (`lg:hidden`): on lg+ the header `<h1>` already shows the name
+at the front of that same row, so an always-on chip would duplicate it. `data-test="ctx-chip-session"`.
+
+## 4. File tree: drop the per-row ⋯; long-press for the menu on touch
+Remove the always-visible per-row ⋯ button (`data-test="row-menu"`) from `FileTreeNode`.
+Desktop keeps right-click (`@contextmenu`). Touch uses a **long-press** on the row via a new
+`useLongPress` composable (touch-only; 450ms hold; a >10px move before the hold is a scroll
+and cancels; the composable swallows the one synthesized click on lift so the press doesn't
+also toggle the row / close the just-opened menu). The row gets `select-none` +
+`[-webkit-touch-callout:none]` so the press doesn't highlight the name or pop the iOS callout.
+The workspace-root header ⋯ (in `FilesPanel`) is kept — it isn't a file/folder row and is the
+only root-create affordance.
+
+## Testing
+- New `use-long-press.ts` unit tests (hold-fires, mouse-ignored, slop-cancel, lift-cancel,
+  single-click-swallow).
+- `file-tree-writes.test.ts`: the ⋯-button test becomes a long-press test + a quick-tap
+  (no-menu) test; asserts `row-menu` is gone.
+- `centertabstrip.test.ts`: root carries `no-scrollbar`.
+- Full: `npx vitest run` + `npx vue-tsc --noEmit` in `packages/relay-web`.

--- a/packages/relay-web/src/__tests__/centertabstrip.test.ts
+++ b/packages/relay-web/src/__tests__/centertabstrip.test.ts
@@ -105,6 +105,15 @@ describe("CenterTabStrip", () => {
     expect(w.element.className).toContain("select-none");
   });
 
+  it("hides the native scrollbar on the strip (edge fade stands in for it)", () => {
+    const store = useCenterTabsStore();
+    const K = sessionKey("i1", "s1");
+    store.openFile(K, "src/a.ts");
+
+    const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
+    expect(w.element.className).toContain("no-scrollbar");
+  });
+
   it("renders its own border/background chrome when standalone (default)", () => {
     const store = useCenterTabsStore();
     const K = sessionKey("i1", "s1");

--- a/packages/relay-web/src/__tests__/file-tree-writes.test.ts
+++ b/packages/relay-web/src/__tests__/file-tree-writes.test.ts
@@ -74,14 +74,36 @@ describe("FileTreeNode write menu", () => {
     expect(w.find('[data-test="menu-newFile"]').exists()).toBe(false);
   });
 
-  it("the ⋯ row button opens the same context menu (touch-reachable)", async () => {
+  it("a touch long-press on the row opens the same context menu (no ⋯ button)", async () => {
+    vi.useFakeTimers();
     const store = useFilesStore();
     store.instanceId = "i1"; store.workspace = "ws"; store.root = "/abs"; store.sep = "/";
     const w = mount(FileTreeNode, { props: { entry: { name: "a.ts", type: "file" }, dir: "", depth: 0, showDotfiles: true, showGitignored: true }, ...g });
+    expect(w.find('[data-test="row-menu"]').exists()).toBe(false); // the per-row ⋯ button is gone
     expect(w.find('[data-test="context-menu"]').exists()).toBe(false);
-    await w.find('[data-test="row-menu"]').trigger("click");
+
+    await w.find('[data-test="tree-row"]').trigger("pointerdown", { pointerType: "touch", clientX: 40, clientY: 50 });
+    vi.advanceTimersByTime(450); // hold elapses → menu opens at the finger
+    await w.vm.$nextTick();
     expect(w.find('[data-test="context-menu"]').exists()).toBe(true);
     expect(w.find('[data-test="menu-rename"]').exists()).toBe(true);
+
+    document.dispatchEvent(new MouseEvent("pointerup", { clientX: 40, clientY: 50 })); // lift ends the gesture
+    vi.advanceTimersByTime(500); // disarm the click-swallow backstop so no document listener leaks
+    vi.useRealTimers();
+  });
+
+  it("a quick tap (no hold) does NOT open the menu — it stays a normal row click", async () => {
+    vi.useFakeTimers();
+    const store = useFilesStore();
+    store.instanceId = "i1"; store.workspace = "ws"; store.root = "/abs"; store.sep = "/";
+    const w = mount(FileTreeNode, { props: { entry: { name: "a.ts", type: "file" }, dir: "", depth: 0, showDotfiles: true, showGitignored: true }, ...g });
+    await w.find('[data-test="tree-row"]').trigger("pointerdown", { pointerType: "touch", clientX: 40, clientY: 50 });
+    document.dispatchEvent(new MouseEvent("pointerup", { clientX: 40, clientY: 50 })); // lift before the hold
+    vi.advanceTimersByTime(450);
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="context-menu"]').exists()).toBe(false);
+    vi.useRealTimers();
   });
 
   it("searchInFolder fills the include field with a folder glob, not a hidden scope", async () => {

--- a/packages/relay-web/src/__tests__/use-long-press.test.ts
+++ b/packages/relay-web/src/__tests__/use-long-press.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useLongPress } from "../lib/use-long-press";
+
+function ev(type: string, clientX: number, clientY = 0): PointerEvent {
+  try {
+    return new PointerEvent(type, { clientX, clientY, bubbles: true });
+  } catch {
+    return new MouseEvent(type, { clientX, clientY, bubbles: true }) as unknown as PointerEvent;
+  }
+}
+function touchStart(clientX: number, clientY = 0): PointerEvent {
+  return { clientX, clientY, pointerType: "touch" } as PointerEvent;
+}
+function mouseStart(clientX: number, clientY = 0): PointerEvent {
+  return { clientX, clientY, pointerType: "mouse" } as PointerEvent;
+}
+
+describe("useLongPress", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    document.dispatchEvent(ev("pointercancel", 0, 0));
+    vi.useRealTimers();
+  });
+
+  it("fires after the hold on touch, with the press coordinates", () => {
+    const cb = vi.fn();
+    const { start } = useLongPress(cb);
+    start(touchStart(30, 40));
+    expect(cb).not.toHaveBeenCalled(); // still within the hold
+    vi.advanceTimersByTime(450);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(30, 40);
+  });
+
+  it("ignores mouse/pen — those use the native right-click contextmenu", () => {
+    const cb = vi.fn();
+    const { start } = useLongPress(cb);
+    start(mouseStart(30, 40));
+    vi.advanceTimersByTime(1000);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("cancels when the finger moves past the slop before the hold (it's a scroll)", () => {
+    const cb = vi.fn();
+    const { start } = useLongPress(cb);
+    start(touchStart(30, 40));
+    document.dispatchEvent(ev("pointermove", 50, 40)); // dx=20 > 10px slop
+    vi.advanceTimersByTime(450);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("cancels when the finger lifts before the hold", () => {
+    const cb = vi.fn();
+    const { start } = useLongPress(cb);
+    start(touchStart(30, 40));
+    document.dispatchEvent(ev("pointerup", 30, 40));
+    vi.advanceTimersByTime(450);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("swallows exactly the one trailing click (armed at lift, so hold duration doesn't matter)", () => {
+    const cb = vi.fn();
+    const { start } = useLongPress(cb);
+    start(touchStart(30, 40));
+    vi.advanceTimersByTime(450); // fired
+    // No swallow is armed until the finger lifts — so even an arbitrarily long hold works.
+    const early = new MouseEvent("click", { cancelable: true, bubbles: true });
+    document.dispatchEvent(early);
+    expect(early.defaultPrevented).toBe(false); // nothing armed yet
+
+    document.dispatchEvent(ev("pointerup", 30, 40)); // lift arms the one-shot swallow
+    const lift = new MouseEvent("click", { cancelable: true, bubbles: true });
+    document.dispatchEvent(lift);
+    expect(lift.defaultPrevented).toBe(true);
+
+    // Only that one is swallowed; a later unrelated click passes through.
+    const later = new MouseEvent("click", { cancelable: true, bubbles: true });
+    document.dispatchEvent(later);
+    expect(later.defaultPrevented).toBe(false);
+  });
+});

--- a/packages/relay-web/src/components/CenterTabStrip.vue
+++ b/packages/relay-web/src/components/CenterTabStrip.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from "vue";
 import { useI18n } from "vue-i18n";
 import { MessageSquare, SquareTerminal, X } from "lucide-vue-next";
 import { useCenterTabsStore, type CenterTab, TAB_DROP_END } from "../stores/center-tabs";
@@ -39,11 +40,57 @@ function iconFor(tab: CenterTab) {
 function labelFor(tab: CenterTab): string {
   return tab.kind === "terminal" ? t("center.terminal") : basename(tab.path);
 }
+
+// Edge-fade + hidden scrollbar. The scrollbar is suppressed (`no-scrollbar`); to signal
+// that tabs continue off-screen we fade the strip's content with a mask, but ONLY on the
+// side(s) that actually have hidden tabs — a static both-ends mask would dim the first/last
+// tab even when nothing is clipped. `canLeft`/`canRight` track the scroll position.
+const scroller = ref<HTMLElement | null>(null);
+const canLeft = ref(false);
+const canRight = ref(false);
+
+function updateFades() {
+  const el = scroller.value;
+  if (!el) {
+    canLeft.value = false;
+    canRight.value = false;
+    return;
+  }
+  canLeft.value = el.scrollLeft > 1;
+  canRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
+}
+
+const FADE = "1.25rem";
+const maskStyle = computed(() => {
+  const l = canLeft.value;
+  const r = canRight.value;
+  if (!l && !r) return {};
+  const stops = [l ? "transparent 0" : "#000 0"];
+  if (l) stops.push(`#000 ${FADE}`);
+  if (r) stops.push(`#000 calc(100% - ${FADE})`);
+  stops.push(r ? "transparent 100%" : "#000 100%");
+  const g = `linear-gradient(to right, ${stops.join(", ")})`;
+  return { maskImage: g, WebkitMaskImage: g };
+});
+
+onMounted(() => {
+  updateFades();
+  scroller.value?.addEventListener("scroll", updateFades, { passive: true });
+  window.addEventListener("resize", updateFades);
+});
+onBeforeUnmount(() => {
+  scroller.value?.removeEventListener("scroll", updateFades);
+  window.removeEventListener("resize", updateFades);
+});
+// A tab added/closed changes scrollWidth ⇒ re-evaluate which side overflows.
+watch(() => store.tabsFor(props.sessionKey).length, () => nextTick(updateFades));
 </script>
 
 <template>
   <div
-    class="flex select-none items-center gap-0.5 overflow-x-auto px-1 py-1 [-webkit-touch-callout:none]"
+    ref="scroller"
+    :style="maskStyle"
+    class="no-scrollbar flex select-none items-center gap-0.5 overflow-x-auto px-1 py-1 [-webkit-touch-callout:none]"
     :class="props.bare ? '' : 'shrink-0 border-b border-border bg-surface'"
   >
     <!-- Pinned chat tab: never closable, never draggable, always first. -->

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -121,6 +121,10 @@ const verb = computed(() => {
              stay fully readable instead of truncating — title tooltips don't work on touch.
              Each chip is shrink-0 (natural width); the strip overflows and scrolls. -->
         <div v-if="currentSession || instance" class="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto no-scrollbar">
+          <!-- Session name as the leading chip. Mobile only: on lg+ the <h1> above already
+               shows it at the front of this row, so showing it here too would duplicate. -->
+          <span data-test="ctx-chip-session"
+                class="flex shrink-0 items-center whitespace-nowrap rounded-md border border-border bg-surface px-2 py-0.5 text-[10.5px] font-semibold text-fg lg:hidden">{{ currentSession?.displayName || chat.sessionAlias }}</span>
           <button v-if="currentSession?.workspace" data-test="ctx-chip-workspace"
                   class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-surface py-0.5 pl-1.5 pr-2 text-[10.5px] font-medium text-fg-muted hover:bg-fg/5"
                   :title='$t("chat.browseFiles")'

--- a/packages/relay-web/src/components/FileTreeNode.vue
+++ b/packages/relay-web/src/components/FileTreeNode.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { ChevronRight, ChevronDown, Folder, FolderOpen, MoreHorizontal } from "lucide-vue-next";
+import { ChevronRight, ChevronDown, Folder, FolderOpen } from "lucide-vue-next";
 import type { FsEntryDto } from "@ganglion/xacpx-relay-protocol";
 import { useFilesStore } from "../stores/files";
 import { iconForFile } from "../lib/file-icons";
 import { openMenuKey } from "../lib/tree-menu";
+import { useLongPress } from "../lib/use-long-press";
 import ContextMenu from "./ContextMenu.vue";
 
 // Local directive: focus + select an element on mount (the rename input).
@@ -63,16 +64,25 @@ function onRowClick() {
 // `openMenuKey` (shared across all rows + the root header) enforces one menu at a time:
 // this row's menu renders only while it's the active key, so opening another closes ours.
 const menu = ref<{ x: number; y: number } | null>(null);
+function openMenuAt(x: number, y: number) {
+  menu.value = { x, y };
+  openMenuKey.value = rel.value;
+}
+// Desktop: right-click. Real coords from the contextmenu event; fall back to the row's
+// rect if a synthesized event has clientX/Y = 0.
 function openMenu(e: MouseEvent) {
-  // Right-click / mouse-click gives real coords; keyboard-activating the ⋯ button yields a
-  // click with clientX/Y = 0, so fall back to the trigger's rect to place the menu.
   let x = e.clientX, y = e.clientY;
   if (!x && !y) {
     const r = (e.currentTarget as HTMLElement | null)?.getBoundingClientRect();
     if (r) { x = r.left; y = r.bottom; }
   }
-  menu.value = { x, y };
-  openMenuKey.value = rel.value;
+  openMenuAt(x, y);
+}
+// Touch has no right-click, so a long-press on the row opens the same menu at the finger.
+const longPress = useLongPress((x, y) => openMenuAt(x, y));
+function onRowPointerDown(e: PointerEvent) {
+  if (inlineMode.value?.kind === "rename") return; // holding to place the caret must not pop the menu
+  longPress.start(e);
 }
 function closeMenu() { menu.value = null; if (openMenuKey.value === rel.value) openMenuKey.value = null; }
 
@@ -122,32 +132,27 @@ async function onMenuSelect(key: string) {
 
 <template>
   <div v-if="selfVisible">
-    <!-- Row = clickable label button + a sibling ⋯ button + status dot. The ⋯ is a real
-         button (not nested in the row button) so it's keyboard-activatable and valid ARIA. -->
-    <div class="flex w-full items-center rounded pr-1 hover:bg-raised">
+    <!-- Row = clickable label button + status dot. The "more actions" menu opens via
+         right-click on desktop and a long-press on touch (no per-row ⋯ button). select-none
+         + no iOS callout so the long-press doesn't highlight the name or pop the callout. -->
+    <div class="flex w-full select-none items-center rounded pr-1 hover:bg-raised [-webkit-touch-callout:none]">
       <button data-test="tree-row"
               class="flex min-w-0 flex-1 items-center gap-1 py-0.5 pl-1 text-left"
               :style="{ paddingLeft: depth * 12 + 4 + 'px' }"
-              @click="onRowClick" @contextmenu.prevent="openMenu">
+              @click="onRowClick" @contextmenu.prevent="openMenu" @pointerdown="onRowPointerDown">
         <component :is="isOpen ? ChevronDown : ChevronRight" v-if="isDir" :size="12" class="shrink-0 text-fg-muted" />
         <span v-else class="w-3 shrink-0" />
         <component :is="isDir ? (isOpen ? FolderOpen : Folder) : iconForFile(entry.name)" :size="13"
                    class="shrink-0" :class="isDir ? 'text-warn' : 'text-fg-muted'" />
         <span v-if="inlineMode?.kind !== 'rename'" class="flex-1 truncate text-[12px]" :class="[dim ? 'opacity-45 italic' : '', isDir ? 'text-fg font-medium' : 'text-fg-muted']">{{ entry.name }}</span>
-        <!-- rename: replace the label with an input in-place -->
+        <!-- rename: replace the label with an input in-place. select-text re-enables caret
+             placement/selection that the row's select-none would otherwise inherit-block. -->
         <input v-else v-focus data-test="inline-name" v-model="inlineName" @click.stop
                @keyup.enter="submitInline" @keyup.esc="cancelInline" @blur="cancelInline"
-               class="flex-1 rounded border border-border bg-raised px-1 text-[12px]" />
+               class="flex-1 select-text rounded border border-border bg-raised px-1 text-[12px]" />
       </button>
-      <span v-if="gitDot" data-test="fs-status" class="ml-1 h-1.5 w-1.5 shrink-0 rounded-full" :class="gitDot"
+      <span v-if="gitDot" data-test="fs-status" class="mx-1 h-1.5 w-1.5 shrink-0 rounded-full" :class="gitDot"
             :title="entry.type === 'file' ? (files.changed[rel] || '') : $t('files.containsChanges')" />
-      <!-- Always-visible ⋯ trigger, pinned at the far right: opens the same context menu, so
-           touch devices (no right-click) can reach every action. -->
-      <button data-test="row-menu" type="button" :aria-label="$t('files.menu.more')"
-              class="ml-1 grid h-5 w-5 shrink-0 place-items-center rounded text-fg-muted opacity-60 hover:bg-surface hover:text-fg hover:opacity-100"
-              @click.stop="openMenu($event)">
-        <MoreHorizontal :size="13" />
-      </button>
     </div>
 
     <div v-if="isDir && isOpen">

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -191,7 +191,6 @@ export default {
       rename: "Rename",
       delete: "Delete",
       download: "Download",
-      more: "More actions",
       confirmDelete: 'Delete "{name}"? This cannot be undone.',
       writeDisabled: "File writes are disabled. Enable `files.writeEnabled` in the instance config.",
     },

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -189,7 +189,6 @@ export default {
       rename: "重命名",
       delete: "删除",
       download: "下载",
-      more: "更多操作",
       confirmDelete: "确定删除「{name}」？此操作不可撤销。",
       writeDisabled: "文件写入未启用，请在实例 config 中开启 `files.writeEnabled`。",
     },

--- a/packages/relay-web/src/lib/use-long-press.ts
+++ b/packages/relay-web/src/lib/use-long-press.ts
@@ -1,0 +1,111 @@
+import { getCurrentScope, onScopeDispose } from "vue";
+
+/** Touch long-press → callback, for surfaces whose primary "more actions" gesture on
+ *  desktop is right-click (which touch devices lack). Mouse/pen are ignored here — they
+ *  use the native contextmenu event. Mirrors the attach/detach-on-document style of
+ *  `use-tab-drag.ts`: a hold timer arms on pointerdown and fires only if the finger
+ *  stays roughly still; any movement past `slop` (i.e. a scroll) cancels it. */
+
+const HOLD_MS = 450;
+const SLOP = 10;
+
+export interface LongPressOptions {
+  holdMs?: number;
+  slop?: number;
+}
+
+export interface LongPressHandlers {
+  /** Call from a target's `pointerdown` handler. */
+  start: (e: PointerEvent) => void;
+}
+
+export function useLongPress(
+  onLongPress: (x: number, y: number) => void,
+  opts: LongPressOptions = {},
+): LongPressHandlers {
+  const holdMs = opts.holdMs ?? HOLD_MS;
+  const slop = opts.slop ?? SLOP;
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let swallowCleanup: ReturnType<typeof setTimeout> | null = null;
+  let fired = false;
+  let startX = 0;
+  let startY = 0;
+
+  function removeDocListeners() {
+    document.removeEventListener("pointermove", onMove);
+    document.removeEventListener("pointerup", onUp);
+    document.removeEventListener("pointercancel", onCancel);
+  }
+
+  // The browser synthesizes a `click` when the finger lifts after the press. Swallow
+  // exactly that one (capture phase) so the long-press doesn't ALSO activate the row or
+  // immediately close the menu it just opened. Armed AT lift (not from `fire()`), so the
+  // window is right before the click regardless of how long the finger stayed down.
+  // Self-removes on the first click, with a short timeout backstop if none arrives.
+  function armClickSwallow() {
+    document.addEventListener("click", swallowClick, true);
+    swallowCleanup = setTimeout(disarmClickSwallow, 500);
+  }
+  function disarmClickSwallow() {
+    document.removeEventListener("click", swallowClick, true);
+    if (swallowCleanup !== null) {
+      clearTimeout(swallowCleanup);
+      swallowCleanup = null;
+    }
+  }
+  function swallowClick(e: MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    disarmClickSwallow();
+  }
+
+  function reset() {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    fired = false;
+    removeDocListeners();
+  }
+
+  function fire() {
+    timer = null;
+    fired = true;
+    document.removeEventListener("pointermove", onMove); // movement no longer matters
+    onLongPress(startX, startY);
+  }
+
+  function onMove(e: PointerEvent) {
+    // Movement past the slop means the finger is scrolling, not pressing — bail so the
+    // native scroll runs and no menu opens.
+    if (Math.hypot(e.clientX - startX, e.clientY - startY) > slop) reset();
+  }
+  function onUp() {
+    // Lift after a fired long-press: swallow the immediately-following synthesized click.
+    if (fired) armClickSwallow();
+    reset();
+  }
+  function onCancel() {
+    // The system reclaimed the gesture (e.g. a pan took over) — no click follows, so
+    // don't arm the swallow.
+    reset();
+  }
+
+  function start(e: PointerEvent) {
+    if (e.pointerType !== "touch") return; // mouse/pen use the contextmenu (right-click) event
+    reset();
+    startX = e.clientX;
+    startY = e.clientY;
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+    document.addEventListener("pointercancel", onCancel);
+    timer = setTimeout(fire, holdMs);
+  }
+
+  // Clean up if the host component unmounts mid-gesture (e.g. the tree row is removed
+  // while its hold timer is pending), so a stray timer can't fire against a gone row.
+  if (getCurrentScope()) onScopeDispose(reset);
+
+  return { start };
+}


### PR DESCRIPTION
Four on-device UX refinements (relay-web dashboard).

## Changes
1. **Tab strip:** hide the OS scrollbar (`no-scrollbar`) and fade the overflowing edge(s) with a **dynamic** `mask-image` — only the side(s) that actually have off-screen tabs (a static both-ends fade would dim the first/last tab even when nothing is clipped).
2. **Session name in the header row:** added as the leading chip in the ChatPane workspace/instance/agent/branch row, **mobile-only** (`lg:hidden`) — desktop already shows it in the `<h1>` at the front of that row. Restores the name mobile lost when tabs moved into the top bar.
3. **File tree — long-press menu:** removed the per-row ⋯ button. Desktop keeps right-click; **touch opens the menu via a long-press** (new `useLongPress` composable: 450 ms hold, cancels on a >10 px scroll or early lift, ignores mouse/pen). The lift-click is swallowed (armed at lift, so a long hold can't defeat it) so the press doesn't also toggle the row / close the menu. Row gets `select-none` + no iOS callout; the rename input keeps `select-text`; a long-press while renaming is suppressed; the composable disposes on unmount. The workspace-root header ⋯ is kept (root-create affordance).

## Testing
- `npx vitest run` → **620 passed** (new `useLongPress` unit tests; file-tree long-press + quick-tap tests; `no-scrollbar` assertion).
- `npx vue-tsc --noEmit` → clean.

Independent review: **LGTM-with-nits**; the impactful nits (long-hold swallow timing, `select-none` vs the rename input, long-press-during-rename, unmount cleanup, orphaned i18n key) are all addressed here.

Spec: `docs/superpowers/specs/2026-07-03-relay-web-strip-fade-header-longpress-design.md`.