### PR TITLE
release(relay): hub 0.9.12-beta.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [relay 0.9.12-beta.13] - 2026-07-03
+
+A `@ganglion/xacpx-relay` (hub) beta with a batch of center-panel and file-tree UX refinements (#123). UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.
+
+### Changed
+
+- **Tab strip: no scrollbar, edge fade instead.** The center tab strip no longer shows an OS scrollbar; overflowing tabs fade out at whichever edge(s) actually have more tabs off-screen.
+- **Session name back in view.** The session name now leads the workspace / instance / agent / branch chip row on mobile (desktop already shows it in the header title) — restoring the name that moved out of the mobile top bar when tabs took its place.
+- **File tree: long-press for the menu.** The always-visible per-row ⋯ button is gone. On desktop the actions menu opens with right-click; on touch it opens with a **long-press** on the row (a swipe still scrolls the tree). The workspace-root ⋯ (new file / folder in root) is unchanged.
+
 ## [relay 0.9.12-beta.12] - 2026-07-03
 
 A `@ganglion/xacpx-relay` (hub) beta fixing a touch-gesture conflict in the center tab strip (#121). UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11682,7 +11682,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.12",
+      "version": "0.9.12-beta.13",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.12",
+  "version": "0.9.12-beta.13",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Hub-only beta bundling the relay-web center-panel + file-tree UX refinements from #123.

- Bumps `@ganglion/xacpx-relay` → **0.9.12-beta.13** (UI-only).
- `package-lock.json` synced; CHANGELOG entry added (English).
- `npm run verify:publish` passed — built `relay-web` bundled into the hub tarball.

On merge, tag `relay-v0.9.12-beta.13` triggers `publish-relay.yml` → npm `next`.