### PR TITLE
fix(relay-web): stop iOS focus auto-zoom + hub 0.9.12-beta.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [relay 0.9.12-beta.14] - 2026-07-03
+
+A `@ganglion/xacpx-relay` (hub) beta stopping iOS focus auto-zoom. UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.
+
+### Fixed
+
+- **No more zoom-on-focus on iOS.** Tapping into an input on mobile Safari no longer zooms the page toward the field (iOS auto-zooms any control with font-size < 16px, and the dashboard's inputs are intentionally compact). The viewport now sets `maximum-scale=1` / `user-scalable=no`. Trade-off: pinch-to-zoom is disabled.
+
 ## [relay 0.9.12-beta.13] - 2026-07-03
 
 A `@ganglion/xacpx-relay` (hub) beta with a batch of center-panel and file-tree UX refinements (#123). UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11682,7 +11682,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.13",
+      "version": "0.9.12-beta.14",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/packages/relay-web/index.html
+++ b/packages/relay-web/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
+    <!-- maximum-scale=1 + user-scalable=no: stop iOS Safari from auto-zooming toward a
+         focused input (it does this for any form control with font-size < 16px, and the
+         dashboard's inputs are intentionally compact). Trade-off: also disables pinch-zoom. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>XACPX HUB</title>
     <meta name="theme-color" content="#0E1116" />
     <meta name="description" content="Self-hosted relay dashboard for xacpx — remote-control acpx sessions." />

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.13",
+  "version": "0.9.12-beta.14",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
On mobile Safari, tapping into an input zoomed the page toward the field. iOS auto-zooms any focused form control whose font-size is < 16px, and the dashboard's inputs are intentionally compact (11–13px).

## Fix
Viewport meta gains `maximum-scale=1, user-scalable=no` — the page can't zoom past 1×, so focus no longer zooms.

**Trade-off (chosen by the user):** pinch-to-zoom is disabled globally. The alternative (forcing every mobile input to 16px) was rejected to keep the compact layout.

## Release
- Hub-only beta: `@ganglion/xacpx-relay` → **0.9.12-beta.14** (UI-only, bundled `relay-web`).
- `package-lock.json` synced; CHANGELOG entry (English); `npm run verify:publish` passed.

On merge, tag `relay-v0.9.12-beta.14` triggers `publish-relay.yml` → npm `next`.