### PR TITLE
release: file edit & save — protocol 0.1.10 + core/relay/channel-relay betas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [file edit & save] - 2026-07-04
+
+Edit and save file content from the relay-web dashboard's file viewer (#128). This is a **four-package** release, not a UI-only hub bump — it adds a new gated wire RPC `control.fs.write`:
+
+- `@ganglion/xacpx-relay-protocol` **0.1.10** (stable) — new `control.fs.write` message + `FsWritePayload`/`FsWriteResult`, and an `mtimeMs` field on `FsReadResult` (the stale-write token).
+- `@ganglion/xacpx` **0.17.0-beta.3** (`next`) — `WorkspaceFs.writeFile` (realpath containment, atomic write, binary/size/truncated-target guards, `{mtimeMs,size}` stale-write check) and gated `ControlService.fsWrite`.
+- `@ganglion/xacpx-channel-relay` **0.3.3-beta.3** (`next`) — connector dispatch for `control.fs.write`.
+- `@ganglion/xacpx-relay` **0.9.12-beta.16** (`next`, bundled `relay-web`) — the editor UI.
+
+### Added
+
+- **Edit & save files.** The file viewer's header has a pencil that opens a CodeMirror 6 editor in place, with **Save** / **Cancel**, a dirty indicator, and **⌘/Ctrl-S** to save. Syntax highlighting for common languages, plain-text fallback otherwise.
+- **Stale-write protection.** A save is rejected (`stale-write`) if the file changed on disk since you opened it — an inline banner offers **Reload** while preserving your draft, so an agent's concurrent edit is never silently overwritten.
+- **Unsaved-changes guard.** Closing a tab with unsaved edits prompts before discarding.
+
+### Safety
+
+- Editing is gated by the same `filesWriteEnabled()` policy as create/rename/delete, strictly before any filesystem I/O; writes stay contained to the workspace root (realpath) and are atomic. Binary, truncated-on-read, and oversized files can't be edited or saved.
+
+> Release order: protocol → core → (relay, channel-relay). The connector must be repacked, reinstalled into the plugin home, and the console restarted to serve `control.fs.write` live.
+
 ## [relay 0.9.12-beta.15] - 2026-07-03
 
 A `@ganglion/xacpx-relay` (hub) beta adding file-viewer search (#126). UI-only (bundled `relay-web`). Published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.2",
+  "version": "0.17.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.2",
+      "version": "0.17.0-beta.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -11972,7 +11972,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.2",
+      "version": "0.3.3-beta.3",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -12014,7 +12014,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.15",
+      "version": "0.9.12-beta.16",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -12031,7 +12031,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT"
     },
     "packages/relay-web": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.2",
+  "version": "0.17.0-beta.3",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/channel-relay/package.json
+++ b/packages/channel-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-relay",
-  "version": "0.3.3-beta.2",
+  "version": "0.3.3-beta.3",
   "description": "Relay hub connector channel plugin for xacpx.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay-protocol/package.json
+++ b/packages/relay-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay-protocol",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Shared wire protocol types and codecs for the xacpx relay hub.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.15",
+  "version": "0.9.12-beta.16",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.2", () => {
+test("root package version is 0.17.0-beta.3", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.2");
+  expect(pkg.version).toBe("0.17.0-beta.3");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.2",
+  "version": "0.17.0-beta.3",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.2"
+    "@ganglion/xacpx": "^0.17.0-beta.3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Version bumps for the file edit & save feature (#128). Four-package coordinated release.

| Package | Version | dist-tag |
|---|---|---|
| `@ganglion/xacpx-relay-protocol` | 0.1.9 → **0.1.10** | latest (additive, backward-compatible) |
| `@ganglion/xacpx` (core) | 0.17.0-beta.2 → **0.17.0-beta.3** | next |
| `@ganglion/xacpx-relay` (hub) | 0.9.12-beta.15 → **0.9.12-beta.16** | next |
| `@ganglion/xacpx-channel-relay` | 0.3.3-beta.2 → **0.3.3-beta.3** | next |

Protocol goes to a **stable** 0.1.10 (not a beta) because the `^0.1.0` consumer ranges don't resolve prereleases — the additive `control.fs.write` message + `FsReadResult.mtimeMs` are backward-compatible.

Coupling updated: `package-metadata.test.ts` version assertion → beta.3; `weacpx-compat` shim version + `^0.17.0-beta.3` dep; root `package-lock.json` synced.

`bun run verify:publish` passes (all four tarballs; `relay-protocol dist exports OK`; dashboard bundled into the hub).

Tag order after merge: `relay-protocol-v0.1.10` → `v0.17.0-beta.3` → `relay-v0.9.12-beta.16` → `channel-relay-v0.3.3-beta.3`.