### PR TITLE
feat(relay-web): restore center tabs + edit drafts on refresh (layer 1+2)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-relay-web-refresh-restore.md
+++ b/docs/superpowers/plans/2026-07-04-relay-web-refresh-restore.md
@@ -1,0 +1,715 @@
+# relay-web 刷新恢复(第 1+2 层)Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 浏览器刷新后还原刷新前的中置 tab 集(文件/diff/终端)+ 激活 tab + 未保存编辑草稿,纯前端 sessionStorage 实现。
+
+**Architecture:** 四个解耦单元:① `lib/file-drafts.ts` 草稿库(照抄 composer-drafts);② `stores/center-tabs.ts` 加 hydrate+deep-watch 持久化,终端 tab 引入 `autostart`(恢复一律 false);③ `TerminalTab.vue` 按 `autostart` 懒启动(false 显占位);④ `FileViewer.vue` 接线草稿(恢复进编辑态、靠既有 mtime 陈旧写保护兑底)。全部只动 `packages/relay-web`。
+
+**Tech Stack:** Vue 3 setup SFC、Pinia setup store、vue-i18n、sessionStorage;测试 Vitest(jsdom)+ @vue/test-utils。
+
+## Global Constraints
+
+- 纯前端,只改 `packages/relay-web/`;不动后端 / 协议 / 其它包。UI-only → 只 bump hub 一个 beta。
+- 持久化一律 **sessionStorage**(与 `lib/composer-drafts.ts` 同寿命),读写全 try/catch 吞异常,写失败静默降级。
+- 测试跑法:`cd packages/relay-web && npx vitest run`(**绝不用 bun test**);类型 `cd packages/relay-web && npx vue-tsc --noEmit`。
+- 持久盘持久化 shell 的 cwd 会在 `cd repo && git …` 后漂回仓库根;每次跑 vitest/vue-tsc 前必须重新 `cd packages/relay-web`。
+- storage key 用 kebab + `.v1` 版本后缀:草稿 `xacpx.file-drafts.v1`、tab 集 `xacpx.center-tabs.v1`。
+- 新增/删除 i18n 键必须 en.ts + zh-CN.ts 同步,过 `src/__tests__/i18n-parity.test.ts`。
+- CodeMirror 在 jsdom 报 `getClientRects is not a function`,已在 `src/__tests__/setup.ts` stub,勿重复处理。
+- 每个改动单元结束时:`npx vue-tsc --noEmit` 必须 0 报错。
+
+---
+
+### Task 1: 文件草稿库 `lib/file-drafts.ts`
+
+纯函数模块,sessionStorage 读写文件编辑草稿。照抄 `packages/relay-web/src/lib/composer-drafts.ts` 的 read/write/try-catch 结构,独立 KEY。
+
+**Files:**
+- Create: `packages/relay-web/src/lib/file-drafts.ts`
+- Test: `packages/relay-web/src/__tests__/file-drafts.test.ts`
+
+**Interfaces:**
+- Consumes: 浏览器 `sessionStorage`。
+- Produces:
+  - `draftKey(sessionKey: string, path: string): string` → `` `${sessionKey}::${path}` ``
+  - `loadFileDraft(key: string): string | null`(无草稿返 `null`;空串 `""` 是合法草稿)
+  - `saveFileDraft(key: string, text: string): void`(有 text 写、空则删键;写失败静默)
+  - `clearFileDraft(key: string): void`
+
+- [ ] **Step 1: 写失败的测试**
+
+Create `packages/relay-web/src/__tests__/file-drafts.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { draftKey, loadFileDraft, saveFileDraft, clearFileDraft } from "../lib/file-drafts";
+
+beforeEach(() => sessionStorage.clear());
+afterEach(() => vi.restoreAllMocks());
+
+describe("file-drafts", () => {
+  it("draftKey composes sessionKey and path", () => {
+    expect(draftKey("i1::s1", "a/b.ts")).toBe("i1::s1::a/b.ts");
+  });
+
+  it("save then load round-trips the text", () => {
+    const k = draftKey("i1::s1", "a.ts");
+    saveFileDraft(k, "hello");
+    expect(loadFileDraft(k)).toBe("hello");
+  });
+
+  it("empty string is a valid draft (distinct from absent)", () => {
+    const k = draftKey("i1::s1", "a.ts");
+    saveFileDraft(k, "x");
+    saveFileDraft(k, ""); // deleting all content is a real draft-clear, so key is removed
+    expect(loadFileDraft(k)).toBeNull();
+  });
+
+  it("returns null when no draft exists", () => {
+    expect(loadFileDraft(draftKey("i1::s1", "none.ts"))).toBeNull();
+  });
+
+  it("clearFileDraft removes the key", () => {
+    const k = draftKey("i1::s1", "a.ts");
+    saveFileDraft(k, "hi");
+    clearFileDraft(k);
+    expect(loadFileDraft(k)).toBeNull();
+  });
+
+  it("tolerates corrupt storage without throwing", () => {
+    sessionStorage.setItem("xacpx.file-drafts.v1", "{not json");
+    expect(loadFileDraft(draftKey("i1::s1", "a.ts"))).toBeNull();
+  });
+
+  it("swallows setItem quota errors", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+    expect(() => saveFileDraft(draftKey("i1::s1", "a.ts"), "big")).not.toThrow();
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/file-drafts.test.ts`
+Expected: FAIL — `Failed to resolve import "../lib/file-drafts"`.
+
+- [ ] **Step 3: 实现模块**
+
+Create `packages/relay-web/src/lib/file-drafts.ts`:
+
+```ts
+/** Per-session file edit-draft persistence (mirrors composer-drafts). An unsaved edit buffer
+ *  survives a browser reload. Stored in sessionStorage (tab-scoped — dies with the tab) keyed
+ *  by `${sessionKey}::${path}`, matching the center-tab's per-session identity. */
+const KEY = "xacpx.file-drafts.v1";
+
+type Drafts = Record<string, string>;
+
+function read(): Drafts {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as Drafts) : {};
+  } catch {
+    return {};
+  }
+}
+
+function write(drafts: Drafts): void {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify(drafts));
+  } catch {
+    /* storage full / disabled — drafts are best-effort */
+  }
+}
+
+export function draftKey(sessionKey: string, path: string): string {
+  return `${sessionKey}::${path}`;
+}
+
+export function loadFileDraft(key: string): string | null {
+  if (!key) return null;
+  const v = read()[key];
+  return v ?? null; // null = absent; "" = a real (emptied) draft
+}
+
+export function saveFileDraft(key: string, text: string): void {
+  if (!key) return;
+  const drafts = read();
+  if (text) drafts[key] = text;
+  else delete drafts[key];
+  write(drafts);
+}
+
+export function clearFileDraft(key: string): void {
+  if (!key) return;
+  const drafts = read();
+  delete drafts[key];
+  write(drafts);
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/file-drafts.test.ts`
+Expected: PASS(7 个用例全绿)。
+
+- [ ] **Step 5: 类型检查 + 提交**
+
+```bash
+cd packages/relay-web && npx vue-tsc --noEmit
+cd /Users/maijiazhen/Projects/workspace-a
+git add packages/relay-web/src/lib/file-drafts.ts packages/relay-web/src/__tests__/file-drafts.test.ts
+git commit -m "feat(relay-web): file-drafts sessionStorage lib for edit-buffer persistence"
+```
+
+---
+
+### Task 2: center-tabs 持久化 + 终端 `autostart`
+
+在 `stores/center-tabs.ts` 内加 hydrate(初始化读回)+ persist(deep watch 写回),终端 tab 类型加 `autostart?: boolean`;`openTerminal` 置 `autostart:true`;hydrate 把读回的终端 tab `autostart` 强制为 `false`。
+
+**Files:**
+- Modify: `packages/relay-web/src/stores/center-tabs.ts`
+- Test: `packages/relay-web/src/__tests__/center-tabs.test.ts`(扩充,已存在)
+
+**Interfaces:**
+- Consumes: `sessionStorage`、`vue` 的 `ref`/`watch`。
+- Produces:`CenterTab` 终端变体新增 `autostart?: boolean`。现有 mutator 签名全不变(`openFile/openDiff/openTerminal/setActive/closeTab/reorder/clearSession/setDirty/isDirty/closeTabGuarded/tabsFor/activeFor/allOpenTabs`)。
+
+- [ ] **Step 1: 写失败的测试**
+
+在 `packages/relay-web/src/__tests__/center-tabs.test.ts` 顶部把 `beforeEach` 改成同时清 sessionStorage:
+
+```ts
+beforeEach(() => { setActivePinia(createPinia()); sessionStorage.clear(); });
+```
+
+并在文件末尾 `describe("center-tabs store", () => { ... })` 内追加以下用例(注意:`useCenterTabsStore` 已在文件顶部 import):
+
+```ts
+  it("openTerminal marks the tab autostart:true (fresh user action spawns)", () => {
+    const s = useCenterTabsStore();
+    s.openTerminal(K);
+    const term = s.tabsFor(K).find((t) => t.kind === "terminal");
+    expect(term && term.kind === "terminal" ? term.autostart : undefined).toBe(true);
+  });
+
+  it("persists tab state to sessionStorage on mutation", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts");
+    const raw = sessionStorage.getItem("xacpx.center-tabs.v1");
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)[K].tabs.map((t: { id: string }) => t.id)).toEqual(["file:a.ts"]);
+    expect(JSON.parse(raw!)[K].activeId).toBe("file:a.ts");
+  });
+
+  it("hydrates tab state from sessionStorage on a fresh store", () => {
+    sessionStorage.setItem(
+      "xacpx.center-tabs.v1",
+      JSON.stringify({ [K]: { tabs: [{ kind: "file", id: "file:a.ts", path: "a.ts" }], activeId: "file:a.ts" } }),
+    );
+    const s = useCenterTabsStore(); // fresh pinia from beforeEach ran BEFORE we set storage? see note
+    expect(s.tabsFor(K).map((t) => t.id)).toEqual(["file:a.ts"]);
+    expect(s.activeFor(K)).toBe("file:a.ts");
+  });
+
+  it("forces restored terminal tabs to autostart:false", () => {
+    sessionStorage.setItem(
+      "xacpx.center-tabs.v1",
+      JSON.stringify({ [K]: { tabs: [{ kind: "terminal", id: "terminal", autostart: true }], activeId: "terminal" } }),
+    );
+    const s = useCenterTabsStore();
+    const term = s.tabsFor(K).find((t) => t.kind === "terminal");
+    expect(term && term.kind === "terminal" ? term.autostart : undefined).toBe(false);
+  });
+
+  it("discards corrupt storage and bad session entries without throwing", () => {
+    sessionStorage.setItem("xacpx.center-tabs.v1", "{not json");
+    expect(() => useCenterTabsStore()).not.toThrow();
+    expect(useCenterTabsStore().tabsFor(K)).toEqual([]);
+
+    sessionStorage.setItem(
+      "xacpx.center-tabs.v1",
+      JSON.stringify({ [K]: { tabs: "nope", activeId: 5 }, "i1::s2": { tabs: [{ kind: "file", id: "file:b.ts", path: "b.ts" }], activeId: "file:b.ts" } }),
+    );
+    const s2 = useCenterTabsStore();
+    expect(s2.tabsFor(K)).toEqual([]); // bad entry dropped
+    expect(s2.tabsFor(sessionKey("i1", "s2")).map((t) => t.id)).toEqual(["file:b.ts"]); // good entry kept
+  });
+```
+
+> 注意 hydrate 用例:`useCenterTabsStore()` 在 `setActivePinia` 后首次调用时读 sessionStorage。`beforeEach` 先跑(清空 + 新 pinia),用例体内再 `setItem` 然后首次 `useCenterTabsStore()` —— 因 pinia 惰性实例化 store,首次调用即触发工厂里的 hydrate,能读到刚 set 的值。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/center-tabs.test.ts`
+Expected: FAIL — 新增用例失败(`autostart` undefined、sessionStorage 无 `xacpx.center-tabs.v1`、hydrate 未还原)。既有用例仍应通过。
+
+- [ ] **Step 3: 改 store**
+
+在 `packages/relay-web/src/stores/center-tabs.ts` 做四处改动:
+
+**(a)** import 加 `watch`:
+
+```ts
+import { ref, watch } from "vue";
+```
+
+**(b)** 终端变体类型加 `autostart`(第 9 行附近):
+
+```ts
+export type CenterTab =
+  | { kind: "file"; id: string; path: string; targetLine?: number; targetRev?: number; dirty?: boolean }
+  | { kind: "diff"; id: string; path: string }
+  | { kind: "terminal"; id: string; autostart?: boolean };
+```
+
+**(c)** 在 `export function sessionKey(...)` 之后、`useCenterTabsStore` 之前加 STORAGE_KEY + hydrate/persist:
+
+```ts
+const STORAGE_KEY = "xacpx.center-tabs.v1";
+
+/** Read persisted tab sets from sessionStorage. Restored terminal tabs can't reconnect to
+ *  their old PTY, so force `autostart:false` — they render a lazy "start" placeholder instead
+ *  of spawning a fresh shell on mount. Corrupt data or malformed session entries are dropped
+ *  (bad entry skipped, good entries kept) so one broken record can't blank the whole view. */
+function hydrate(): Record<string, SessionTabs> {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: Record<string, SessionTabs> = {};
+    for (const [key, val] of Object.entries(parsed as Record<string, unknown>)) {
+      const v = val as { tabs?: unknown; activeId?: unknown };
+      if (!Array.isArray(v.tabs) || typeof v.activeId !== "string") continue;
+      const tabs = (v.tabs as CenterTab[]).map((t) =>
+        t && t.kind === "terminal" ? { ...t, autostart: false } : t,
+      );
+      out[key] = { tabs, activeId: v.activeId };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function persist(v: Record<string, SessionTabs>): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(v));
+  } catch {
+    /* storage full / disabled — persistence is best-effort */
+  }
+}
+```
+
+**(d)** 在 `useCenterTabsStore` 工厂里,把 `bySession` 初值改成 hydrate,并加 deep watch(紧跟 `bySession` 声明之后):
+
+```ts
+  const bySession = ref<Record<string, SessionTabs>>(hydrate());
+  watch(bySession, (v) => persist(v), { deep: true });
+```
+
+**(e)** `openTerminal` 置 `autostart:true`:
+
+```ts
+  function openTerminal(key: string): void {
+    upsertAndActivate(key, { kind: "terminal", id: "terminal", autostart: true });
+  }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/center-tabs.test.ts`
+Expected: PASS(既有 + 新增全绿)。
+
+- [ ] **Step 5: 全量 store 相关回归 + 类型 + 提交**
+
+跑受影响的相邻测试确认没回归:
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/centertabstrip.test.ts src/__tests__/dashboard-center-tabs.test.ts && npx vue-tsc --noEmit`
+Expected: PASS,vue-tsc 0 报错。
+
+```bash
+cd /Users/maijiazhen/Projects/workspace-a
+git add packages/relay-web/src/stores/center-tabs.ts packages/relay-web/src/__tests__/center-tabs.test.ts
+git commit -m "feat(relay-web): persist center tabs to sessionStorage; terminal autostart flag"
+```
+
+---
+
+### Task 3: 终端懒启动(TerminalTab 占位 + DashboardView 传 autostart + i18n)
+
+`autostart=false` 时不 spawn,渲染"启动新终端"占位;点按钮才 `start()`。`autostart=true`(默认)维持现状。
+
+**Files:**
+- Modify: `packages/relay-web/src/components/TerminalTab.vue`
+- Modify: `packages/relay-web/src/views/DashboardView.vue`(terminal tab 传 `:autostart`)
+- Modify: `packages/relay-web/src/i18n/messages/en.ts`、`packages/relay-web/src/i18n/messages/zh-CN.ts`
+- Test: `packages/relay-web/src/__tests__/terminal-tab.test.ts`(扩充,已存在)
+
+**Interfaces:**
+- Consumes:`CenterTab` 终端变体的 `autostart`(Task 2);`terminals.create`(既有)。
+- Produces:`TerminalTab` 新增 prop `autostart?: boolean`(默认 `true`,保持既有直接挂载行为)。
+
+- [ ] **Step 1: 写失败的测试**
+
+在 `packages/relay-web/src/__tests__/terminal-tab.test.ts` 的 `beforeEach` 补 sessionStorage 清理(改为):
+
+```ts
+  beforeEach(() => { setActivePinia(createPinia()); vi.clearAllMocks(); localStorage.clear(); sessionStorage.clear(); });
+```
+
+在 `describe("TerminalTab", ...)` 内追加(注意顶部 `globalOpts` 的 `$t` mock 把 key 原样返回,故断言占位用 data-test 而非文案):
+
+```ts
+  it("autostart=false does NOT spawn and shows the restore placeholder", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+    await tick();
+    expect(createTerminalAdapter).not.toHaveBeenCalled();
+    expect(w.find('[data-test="term-restore"]').exists()).toBe(true);
+    expect(w.find('[data-test="term-start"]').exists()).toBe(true);
+  });
+
+  it("clicking the placeholder start button spawns the terminal", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+    await tick();
+    await w.find('[data-test="term-start"]').trigger("click");
+    await tick();
+    expect(createTerminalAdapter).toHaveBeenCalledTimes(1);
+    expect(w.find('[data-test="term-restore"]').exists()).toBe(false);
+  });
+
+  it("autostart=true (default) spawns on mount as before", async () => {
+    mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    expect(createTerminalAdapter).toHaveBeenCalledTimes(1);
+  });
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/terminal-tab.test.ts`
+Expected: FAIL — autostart=false 仍 spawn、无 `term-restore`/`term-start`。
+
+- [ ] **Step 3a: 改 TerminalTab.vue —— props + 懒启动逻辑**
+
+`import` 行加 `computed`(第 2 行):
+
+```ts
+import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+```
+
+props 改为带默认(第 8 行):
+
+```ts
+const props = withDefaults(defineProps<{ instanceId: string; sessionAlias: string; autostart?: boolean }>(), {
+  autostart: true,
+});
+```
+
+在 `let adapter ...` 附近(第 52 行区域,`status` 声明之后)加懒启动状态:
+
+```ts
+// Lazy start: a tab restored from sessionStorage arrives autostart=false — it can't reconnect
+// to its old PTY, so it waits on a "start new terminal" placeholder instead of spawning on
+// mount. `started` gates the prop-watch so a dormant tab never auto-spawns on a prop change.
+let started = false;
+const showPlaceholder = computed(() => !!props.sessionAlias && status.value === "idle" && !props.autostart);
+```
+
+`start()` 里,在通过 session/host 守卫、设 `status.value = "connecting";` 之后,加 `started = true;`(第 232 行附近):
+
+```ts
+  if (!props.sessionAlias || !host.value) { status.value = "idle"; return; }
+  status.value = "connecting";
+  started = true;
+```
+
+`onMounted` 把无条件 `void start()` 改成看 autostart(第 293-294 行):
+
+```ts
+onMounted(() => {
+  if (props.autostart) void start();
+  attachTouch();
+  window.visualViewport?.addEventListener("resize", updateKeyboardInset);
+  window.visualViewport?.addEventListener("scroll", updateKeyboardInset);
+});
+```
+
+prop-watch 改成仅已启动才重启(第 299 行):
+
+```ts
+watch(() => [props.instanceId, props.sessionAlias], () => { if (started) void start(); });
+```
+
+- [ ] **Step 3b: 改 TerminalTab.vue —— 模板占位**
+
+在 body 区(第 331-335 行),`error`/`exited` 之后、host div 之前插入占位;host div 加 `v-show="!showPlaceholder"` 使其 dormant 时仍在 DOM(`start()` 需 `host.value`):
+
+```html
+    <!-- body -->
+    <div v-if="!props.sessionAlias" class="p-4 text-sm text-fg-muted">{{ $t("terminal.noSession") }}</div>
+    <div v-else-if="status === 'error'" class="p-4 text-sm text-fg-muted">{{ $t(errorKey) }}</div>
+    <div v-else-if="status === 'exited'" class="p-4 text-sm text-fg-muted">{{ $t("terminal.exited", { code: errorKey }) }}</div>
+    <div v-if="showPlaceholder" data-test="term-restore"
+         class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+      <p class="text-sm text-fg-muted">{{ $t("terminal.restoredHint") }}</p>
+      <button data-test="term-start"
+              class="rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-fg transition-colors hover:bg-raised"
+              @click="void start()">{{ $t("terminal.startNew") }}</button>
+    </div>
+    <div v-show="!showPlaceholder" ref="host" class="term-host flex min-h-0 flex-1 touch-none items-center justify-center overflow-hidden bg-bg" data-test="terminal-host"></div>
+```
+
+- [ ] **Step 3c: 改 DashboardView.vue —— 传 autostart**
+
+找到 TerminalTab 挂载处(约第 400-402 行 `<TerminalTab ... :session-alias="keyAlias(key)" ...>`),加 `:autostart`:
+
+```html
+            <TerminalTab v-else-if="tab.kind === 'terminal'" class="absolute inset-0 z-20"
+                         v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
+                         :instance-id="keyInstance(key)" :session-alias="keyAlias(key)"
+                         :autostart="tab.autostart ?? false"
+```
+
+保留该标签原有的其余属性/事件(如 `@close`)不变。
+
+- [ ] **Step 3d: 改 i18n —— 两个占位文案键**
+
+`packages/relay-web/src/i18n/messages/en.ts` 的 `terminal:` 块内(`noSession` 之后)加:
+
+```ts
+    restoredHint: "This terminal disconnected on reload.",
+    startNew: "Start new terminal",
+```
+
+`packages/relay-web/src/i18n/messages/zh-CN.ts` 的 `terminal:` 块内对应位置加:
+
+```ts
+    restoredHint: "终端会话已随刷新断开。",
+    startNew: "启动新终端",
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/terminal-tab.test.ts src/__tests__/i18n-parity.test.ts`
+Expected: PASS(新增 3 用例 + 既有终端用例 + i18n parity 全绿)。
+
+- [ ] **Step 5: 相邻回归 + 类型 + 提交**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/dashboard-center-tabs.test.ts src/__tests__/terminal-store.test.ts && npx vue-tsc --noEmit`
+Expected: PASS,vue-tsc 0 报错。
+
+```bash
+cd /Users/maijiazhen/Projects/workspace-a
+git add packages/relay-web/src/components/TerminalTab.vue packages/relay-web/src/views/DashboardView.vue packages/relay-web/src/i18n/messages/en.ts packages/relay-web/src/i18n/messages/zh-CN.ts packages/relay-web/src/__tests__/terminal-tab.test.ts
+git commit -m "feat(relay-web): lazy-start restored terminal tabs with a start placeholder"
+```
+
+---
+
+### Task 4: FileViewer 草稿接线(恢复进编辑态 + 写/清草稿)
+
+`FileViewer.vue` 新增 `sessionKey` prop;`load()` 后若有草稿则灌入并进编辑态;编辑时写草稿、保存/取消时清草稿。`DashboardView.vue` 传 `:session-key="key"`。
+
+**Files:**
+- Modify: `packages/relay-web/src/components/FileViewer.vue`
+- Modify: `packages/relay-web/src/views/DashboardView.vue`(FileViewer 传 `:session-key`)
+- Test: `packages/relay-web/src/__tests__/fileviewer.test.ts`(扩充,已存在)
+
+**Interfaces:**
+- Consumes:`lib/file-drafts` 的 `draftKey/loadFileDraft/saveFileDraft/clearFileDraft`(Task 1);`sessionKey` prop。
+- Produces:无(叶子组件);行为契约:有草稿且异于磁盘且可编辑 → 恢复进编辑态;编辑改动写草稿;save/cancel 清草稿。
+
+- [ ] **Step 1: 写失败的测试**
+
+该文件已有 helper:`mountViewer(props)`(注入 pinia、固定 `instanceId:"i1", workspace:"ws"`)、`settle()`(await 加载)、fixture `TEXT`、`useFilesStore()` + `vi.spyOn(files,"readFile").mockResolvedValue(...)`。**先把 `beforeEach` 补上 `sessionStorage.clear()`**(现有 beforeEach 未清):
+
+```ts
+beforeEach(() => {
+  pinia = createPinia();
+  setActivePinia(pinia);
+  sessionStorage.clear();
+  Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+});
+```
+
+在 `describe("FileViewer", ...)` 内追加以下用例(复用 `mountViewer`/`settle`/`TEXT`):
+
+```ts
+  it("restores an edit draft into edit mode on load", async () => {
+    const files = useFilesStore();
+    vi.spyOn(files, "readFile").mockResolvedValue({ ...TEXT, path: "src/a.ts", content: "DISK BODY" });
+    sessionStorage.setItem("xacpx.file-drafts.v1", JSON.stringify({ "i1::s1::src/a.ts": "DRAFT BODY" }));
+    const w = mountViewer({ path: "src/a.ts", sessionKey: "i1::s1" });
+    await settle();
+    // Draft differs from disk + file is editable ⇒ enter edit mode with the draft buffer.
+    expect(w.find('[data-test="fv-dirty-dot"]').exists()).toBe(true);
+    expect(w.find('[data-test="fv-save"]').exists()).toBe(true);
+    expect(w.emitted("dirty-change")?.some((e) => e[0] === true)).toBe(true);
+  });
+
+  it("does NOT enter edit mode when the draft equals disk content", async () => {
+    const files = useFilesStore();
+    vi.spyOn(files, "readFile").mockResolvedValue({ ...TEXT, path: "src/a.ts", content: "DISK BODY" });
+    sessionStorage.setItem("xacpx.file-drafts.v1", JSON.stringify({ "i1::s1::src/a.ts": "DISK BODY" }));
+    const w = mountViewer({ path: "src/a.ts", sessionKey: "i1::s1" });
+    await settle();
+    expect(w.find('[data-test="fv-dirty-dot"]').exists()).toBe(false);
+    expect(w.find('[data-test="fv-edit"]').exists()).toBe(true); // read mode: pencil visible
+  });
+
+  it("clears the draft on cancel", async () => {
+    const files = useFilesStore();
+    vi.spyOn(files, "readFile").mockResolvedValue({ ...TEXT, path: "src/a.ts", content: "DISK BODY" });
+    sessionStorage.setItem("xacpx.file-drafts.v1", JSON.stringify({ "i1::s1::src/a.ts": "DRAFT BODY" }));
+    const w = mountViewer({ path: "src/a.ts", sessionKey: "i1::s1" });
+    await settle();
+    await w.get('[data-test="fv-cancel"]').trigger("click");
+    expect(JSON.parse(sessionStorage.getItem("xacpx.file-drafts.v1")!)["i1::s1::src/a.ts"]).toBeUndefined();
+  });
+
+  it("clears the draft after a successful save", async () => {
+    const files = useFilesStore();
+    vi.spyOn(files, "readFile").mockResolvedValue({ ...TEXT, path: "src/a.ts", content: "DISK BODY" });
+    vi.spyOn(files, "saveFile").mockResolvedValue({ path: "src/a.ts", mtimeMs: 2000, size: 5 });
+    sessionStorage.setItem("xacpx.file-drafts.v1", JSON.stringify({ "i1::s1::src/a.ts": "DRAFT BODY" }));
+    const w = mountViewer({ path: "src/a.ts", sessionKey: "i1::s1" });
+    await settle();
+    await w.get('[data-test="fv-save"]').trigger("click");
+    await settle();
+    expect(JSON.parse(sessionStorage.getItem("xacpx.file-drafts.v1")!)["i1::s1::src/a.ts"]).toBeUndefined();
+  });
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/fileviewer.test.ts`
+Expected: FAIL — 无草稿恢复逻辑,dirty dot 不出现、cancel 不清 sessionStorage。
+
+- [ ] **Step 3a: 改 FileViewer.vue —— import + prop**
+
+顶部 import 区加(第 8 行附近,`unified-diff` import 一带):
+
+```ts
+import { draftKey, loadFileDraft, saveFileDraft, clearFileDraft } from "../lib/file-drafts";
+```
+
+props 加 `sessionKey`(第 15-22 行 `defineProps` 块,加一行;可选默认空串以免既有直接挂载测试因缺 prop 告警):
+
+```ts
+const props = defineProps<{
+  instanceId: string;
+  workspace: string;
+  path?: string;
+  diffPath?: string;
+  line?: number;
+  lineRev?: number;
+  sessionKey?: string;
+}>();
+```
+
+- [ ] **Step 3b: 改 FileViewer.vue —— load() 恢复草稿**
+
+在 `load()` 的 `if (path)` 分支,`emit("dirty-change", false);`(第 52 行)之后追加草稿恢复:
+
+```ts
+      file.value = result;
+      diff.value = null;
+      content.value = result.binary ? "" : result.content;
+      editing.value = false;
+      emit("dirty-change", false);
+      // Restore a persisted edit draft: enter edit mode with the saved buffer. Only when the
+      // draft differs from disk (equal ⇒ nothing to restore) and the file is actually editable
+      // (a truncated / mtime-less file can't be saved). Staleness isn't checked here — the
+      // existing save-time mtime guard (baseRev) catches a disk that changed while away.
+      if (!result.binary && !result.truncated && typeof result.mtimeMs === "number") {
+        const draft = loadFileDraft(draftKey(props.sessionKey ?? "", path));
+        if (draft !== null && draft !== result.content) {
+          baseRev.value = { mtimeMs: result.mtimeMs, size: result.size };
+          content.value = draft;
+          editing.value = true;
+        }
+      }
+```
+
+- [ ] **Step 3c: 改 FileViewer.vue —— 编辑时持久化草稿**
+
+在 `watch(editDirty, ...)`(第 93 行)之后加一个 watch,把编辑中的 buffer 落盘:
+
+```ts
+// Persist the edit buffer while editing so a reload can restore it. Clearing the edits back to
+// disk content removes the key (empty store). Only writes in edit mode with a real path.
+watch(content, (val) => {
+  if (!editing.value || !props.path) return;
+  const key = draftKey(props.sessionKey ?? "", props.path);
+  if (file.value && val !== file.value.content) saveFileDraft(key, val);
+  else clearFileDraft(key);
+});
+```
+
+- [ ] **Step 3d: 改 FileViewer.vue —— save/cancel 清草稿**
+
+`save()` 成功分支,`emit("dirty-change", false);`(第 132 行)之后加:
+
+```ts
+    editing.value = false;
+    baseRev.value = null;
+    emit("dirty-change", false);
+    if (props.path) clearFileDraft(draftKey(props.sessionKey ?? "", props.path));
+```
+
+`cancelEdit()`(第 114-120 行)结尾 `emit("dirty-change", false);` 之后加:
+
+```ts
+function cancelEdit() {
+  if (file.value) content.value = file.value.content; // revert the buffer
+  editing.value = false;
+  baseRev.value = null;
+  saveError.value = null;
+  emit("dirty-change", false);
+  if (props.path) clearFileDraft(draftKey(props.sessionKey ?? "", props.path));
+}
+```
+
+- [ ] **Step 3e: 改 DashboardView.vue —— 传 session-key**
+
+FileViewer 挂载处(约第 391-393 行 `:instance-id="keyInstance(key)" :workspace="keyWorkspace(key)"` 一带)加 `:session-key="key"`:
+
+```html
+            <FileViewer v-if="tab.kind === 'file' || tab.kind === 'diff'" class="absolute inset-0 z-10"
+                        v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
+                        :instance-id="keyInstance(key)" :workspace="keyWorkspace(key)"
+                        :session-key="key"
+```
+
+保留该标签其余属性/事件(`:path` `:diff-path` `:line` `:line-rev` `@dirty-change` 等)不变。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/fileviewer.test.ts`
+Expected: PASS(新增草稿用例 + 既有用例全绿)。
+
+- [ ] **Step 5: 相邻回归 + 类型 + 提交**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/file-tree-writes.test.ts src/__tests__/dashboard-center-tabs.test.ts && npx vue-tsc --noEmit`
+Expected: PASS,vue-tsc 0 报错。
+
+```bash
+cd /Users/maijiazhen/Projects/workspace-a
+git add packages/relay-web/src/components/FileViewer.vue packages/relay-web/src/views/DashboardView.vue packages/relay-web/src/__tests__/fileviewer.test.ts
+git commit -m "feat(relay-web): restore & persist file edit drafts across reload"
+```
+
+---
+
+## 收尾(全部任务完成后)
+
+- 全量测试:`cd packages/relay-web && npx vitest run`(~155s,预期全绿)+ `npx vue-tsc --noEmit` 0 报错。
+- 这是 UI-only,发布时只 bump hub(`@ganglion/xacpx-relay`)一个 beta(发布流程见既有 runbook,不在本计划内)。
+- 实机验收:开若干文件 tab + 一个 diff + 一个终端,编辑某文件不保存 → 硬刷新 → tab 集/激活 tab 还原、草稿在且处编辑态、终端 tab 在但显"启动新终端"占位;点占位 → 正常新 shell;关标签页重开 → 不恢复(sessionStorage 语义)。

--- a/docs/superpowers/specs/2026-07-04-relay-web-refresh-restore-design.md
+++ b/docs/superpowers/specs/2026-07-04-relay-web-refresh-restore-design.md
@@ -1,0 +1,185 @@
+# relay-web 刷新恢复(第 1+2 层)设计
+
+> 状态:待实现。范围严格限定纯前端(仅 `packages/relay-web`),一个 hub beta 验收。
+
+## 目标
+
+浏览器刷新 / 崩溃重载(F5、页面重载)后,还原刷新前的**中置 tab 集**(文件 / diff / 终端)、**当前激活 tab**、以及**未保存的编辑草稿**,让用户回到刷新前的工作视图。
+
+**明确不做(第 3 层,单独立项):** 终端输出内容 / scrollback 的补发与接回原 PTY。终端接不回是既有事实(后端 emit 即丢、无 ring buffer),本次只恢复"终端 tab 位置",不恢复其内容。
+
+## 非目标 / 边界
+
+- 不存文件内容:恢复 tab 后各自 `FileViewer` 走既有 `control.fs.read` 重新拉最新磁盘内容。存内容只会引入陈旧问题且无收益。
+- 不改后端、不改协议、不动 `packages/relay` / `packages/channel-relay` / `src/control`。
+- 不引入 pinia 持久化插件;沿用仓库既有"手写 sessionStorage/localStorage + try/catch 容错"模式。
+- 寿命 = sessionStorage(只到关标签页),与既有输入框草稿(`lib/composer-drafts.ts`)语义一致。纯 F5/崩溃重载能恢复;关标签页/浏览器则清空。
+
+## 架构总览
+
+四个改动单元,互相解耦:
+
+1. **center-tabs 持久化** — `stores/center-tabs.ts` 内加 hydrate(初始化读回)+ persist(deep watch 写回)。终端 tab 引入 `autostart` 语义,hydrate 回来的终端 tab 一律 `autostart=false`。
+2. **终端懒启动** — `components/TerminalTab.vue` 按 `autostart` prop 决定挂载即 spawn 还是显示"启动新终端"占位。`DashboardView.vue` 传 `:autostart`。
+3. **文件草稿库** — 新建 `lib/file-drafts.ts`,结构照抄 `lib/composer-drafts.ts`(flat `Record<string,string>` + sessionStorage + try/catch)。
+4. **FileViewer 草稿接线** — `components/FileViewer.vue` 新增 `sessionKey` prop;`load()` 后若有草稿则灌入并进编辑态;编辑时写草稿、保存/取消时清草稿。`DashboardView.vue` 传 `:session-key="key"`。
+
+数据流(恢复路径):
+```
+页面重载
+  → center-tabs store 创建 → hydrate 从 sessionStorage 读回 bySession(终端 tab autostart=false)
+  → DashboardView onMounted → reconcileCenterTabs 剪掉已不存在的 session(既有逻辑)
+  → allOpenTabs() 重新渲染每个 tab 的 FileViewer / TerminalTab
+      · FileViewer.load() 重拉磁盘内容;若 fileDrafts 有本 (sessionKey,path) 草稿 → 灌入 content + editing=true
+      · TerminalTab autostart=false → 显示占位,不 spawn;用户点"启动"才 start()
+```
+
+## 现有事实(锚定实现)
+
+- `stores/center-tabs.ts`:setup store `"center-tabs"`,`bySession = ref<Record<string, SessionTabs>>({})`。`CenterTab` 是 file/diff/terminal 判别联合;终端 tab 现为 `{ kind:"terminal"; id:"terminal" }`。`sessionKey(instanceId, alias)` 已导出。mutator:`openFile/openDiff/openTerminal/setActive/closeTab/reorder/clearSession/setDirty/closeTabGuarded`。
+- `lib/composer-drafts.ts`:`loadDraft(draftKey): string` / `saveDraft(draftKey, text)`;KEY=`"xacpx.composer-drafts.v1"`;flat `Record<string,string>`;空文本删键;read/write 均 try/catch 吞异常。
+- `FileViewer.vue`:props `{ instanceId, workspace, path?, diffPath?, line?, lineRev? }`;`load()`(FileViewer.vue:39)读文件后设 `content.value = result.content; editing.value=false`;`watch([instanceId,workspace,path,diffPath], load, {immediate:true})`;`editDirty = editing && content !== file.content`(FileViewer.vue:92)并 `watch(editDirty, v => emit("dirty-change", v))`。已有 `startEdit()/save()/cancelEdit()` 写路径 + `baseRev` mtime 陈旧写保护。
+- `DashboardView.vue`:`allOpenTabs()` v-for 里 `key` 即 sessionKey;已有 `keyInstance/keyAlias/keyWorkspace(key)` 派生器;FileViewer 传 `:instance-id="keyInstance(key)" :workspace="keyWorkspace(key)"`,TerminalTab 传 `:session-alias="keyAlias(key)"`。`reconcileCenterTabs`(onMounted)剪掉不存在 session 的 tab 集。
+- `TerminalTab.vue`:`onMounted(() => void start())` 无条件 spawn;`watch([instanceId,sessionAlias], () => void start())`;`start()` 调 `terminals.create(...)` 新开 PTY;props 现为 `{ instanceId, sessionAlias }`。
+
+## 单元设计
+
+### 单元 1 — center-tabs 持久化(`stores/center-tabs.ts`)
+
+**类型变更:** 终端 tab 变体加可选 `autostart`:
+```ts
+| { kind: "terminal"; id: string; autostart?: boolean };
+```
+
+**mutator 变更:** `openTerminal` 建终端 tab 时置 `autostart: true`(用户主动开 → 挂载即 spawn,维持现状 UX):
+```ts
+function openTerminal(key: string): void {
+  upsertAndActivate(key, { kind: "terminal", id: "terminal", autostart: true });
+}
+```
+
+**持久化(store 内新增,不引插件):**
+- 常量 `const STORAGE_KEY = "xacpx.center-tabs.v1";`
+- `hydrate()`:`sessionStorage.getItem(STORAGE_KEY)` → `JSON.parse`,结构为 `Record<string, SessionTabs>`。try/catch 失败或非对象 → 返回 `{}`。**读回后把每个终端 tab 的 `autostart` 强制改成 `false`**(刷新后接不回,一律懒启动)。在 store 工厂里 `bySession.value = hydrate();`(初值)。
+- persist:`watch(bySession, (v) => persist(v), { deep: true })`;`persist(v)` = try/catch 包 `sessionStorage.setItem(STORAGE_KEY, JSON.stringify(v))`,失败静默(存储满/禁用)。
+- hydrate 的健壮性:只接受 `tabs` 为数组、`activeId` 为字符串的 session 条目;不符则丢弃该条目(不是整个丢)。防止损坏数据让 store 崩。
+
+**Interfaces**
+- Produces:`CenterTab` 终端变体新增 `autostart?: boolean`;store 行为不变(现有 mutator 签名不动)。
+- Consumes:浏览器 `sessionStorage`、`vue` 的 `watch`。
+
+### 单元 2 — 终端懒启动(`components/TerminalTab.vue` + `DashboardView.vue`)
+
+**TerminalTab.vue:**
+- props 新增 `autostart: boolean`(必填,DashboardView 显式传)。
+- 新增本地 `const started = ref(false);`。
+- `onMounted`:`if (props.autostart) void start();`——否则不 spawn。
+- `start()` 内部成功进入后置 `started.value = true`(已 spawn 过就不再回占位)。
+- prop-watch `watch([instanceId, sessionAlias], ...)`:改为仅当 `started.value`(已经在跑)时才 `void start()` 重启,避免懒态下因 prop 变化误 spawn。
+- 模板:当 `!started` 时渲染占位层(替代终端 canvas),内容 = 一句说明(i18n `terminal.restoredHint`,如"终端会话已随刷新断开")+ 一个按钮(i18n `terminal.startNew`,如"启动新终端"),按钮 `@click="void start()"`。header(标题 / 关闭)照常显示。`started` 后渲染既有终端视图。
+
+**DashboardView.vue:** TerminalTab 传 `:autostart="tab.autostart ?? false"`(v-for 内 `tab` 在该分支已是终端变体)。
+
+**Interfaces**
+- Consumes:`autostart` prop、`terminals.create`(既有)。
+- 行为契约:`autostart=true` 挂载 = 现状(立即 spawn);`autostart=false` 挂载 = 不 spawn、显占位、点按钮才 spawn。
+
+### 单元 3 — 文件草稿库(`lib/file-drafts.ts`,新建)
+
+照抄 `composer-drafts.ts` 结构,独立 KEY:
+```ts
+const KEY = "xacpx.file-drafts.v1";
+type Drafts = Record<string, string>;
+// read()/write() 同 composer-drafts:try/catch 吞异常,write 失败静默(配额兜底)
+
+export function draftKey(sessionKey: string, path: string): string {
+  return `${sessionKey}::${path}`;
+}
+export function loadFileDraft(key: string): string | null {
+  if (!key) return null;
+  const v = read()[key];
+  return v ?? null;   // 用 null 区分"无草稿",空串是合法草稿(全删空的编辑)
+}
+export function saveFileDraft(key: string, text: string): void { /* 有 text 写、无则删键;write try/catch */ }
+export function clearFileDraft(key: string): void { /* 删键 */ }
+```
+说明:草稿键 = `${sessionKey}::${path}`,与 center-tabs 的 per-session 身份对齐(两个 session 编辑同一文件 = 两份独立草稿,匹配两个独立 tab / dirty)。write 的 try/catch 即配额兜底:`QuotaExceeded`(大文件草稿撑爆 ~5MB)时静默跳过,tab 仍会恢复(重拉磁盘),只是那份草稿不保。
+
+**Interfaces**
+- Produces:`draftKey / loadFileDraft / saveFileDraft / clearFileDraft`。
+- Consumes:`sessionStorage`。
+
+### 单元 4 — FileViewer 草稿接线(`components/FileViewer.vue` + `DashboardView.vue`)
+
+**FileViewer.vue:**
+- props 新增 `sessionKey: string`(DashboardView 传 v-for 的 `key`)。
+- `load()` 成功读到文件后(FileViewer.vue:50 一带),在 `content.value = result.binary ? "" : result.content; editing.value = false;` 之后:
+  ```ts
+  if (path && !result.binary) {
+    const dk = draftKey(props.sessionKey, path);
+    const draft = loadFileDraft(dk);
+    if (draft !== null && draft !== result.content) {
+      content.value = draft;
+      editing.value = true;
+      baseRev.value = typeof result.mtimeMs === "number" ? { mtimeMs: result.mtimeMs, size: result.size } : null;
+    }
+  }
+  ```
+  说明:`draft !== result.content` 时才进编辑态(草稿与磁盘已一致就不当 dirty,顺带覆盖"别处存了相同改动"边界)。恢复不比对 mtime——真去保存时既有 `baseRev` 陈旧写保护兜底。`baseRev` 需设成本次读回的 mtime/size(等价于 `startEdit()` 里的快照),让保存路径有陈旧令牌。
+- 编辑时持久化:新增 `watch(content, ...)`——`editing.value` 为真时,`editDirty` 为真则 `saveFileDraft(draftKey(sessionKey, path), content.value)`,否则(改回原样)`clearFileDraft(...)`。仅在 `editing` 且有 `path` 时写,避免只读态误写。
+- 清理:`save()` 成功后、`cancelEdit()` 里各 `clearFileDraft(draftKey(sessionKey, props.path))`。
+- 注意 `editDirty`(FileViewer.vue:92)已存在并驱动 `dirty-change` emit → `setDirty`;恢复进编辑态后它自然为真 → tab dirty 点亮,无需额外接线。
+
+**DashboardView.vue:** FileViewer 传 `:session-key="key"`。
+
+**Interfaces**
+- Consumes:`sessionKey` prop、`lib/file-drafts` 的四个函数。
+- 行为契约:有草稿 → 恢复进编辑态 + dirty;无草稿 → 现状(只读);save/cancel 后草稿清除。
+
+## 错误处理
+
+- sessionStorage 读:任何解析异常 → 视作空(回到"无恢复"),绝不抛。
+- sessionStorage 写:任何异常(配额满 / 隐私模式禁用)→ 静默跳过,功能降级为"不持久化",不阻塞交互、不报错。
+- hydrate 结构校验:逐 session 条目校验,坏条目丢弃,不因单条坏数据丢掉整份或崩溃。
+- 终端懒态:占位只在"从未 start 过"显示;一旦 start 过就不回退(PTY 之后断开是既有行为,不在本范围)。
+
+## 测试策略
+
+跑法:`cd packages/relay-web && npx vitest run`(jsdom,**绝不用 bun test**);类型 `npx vue-tsc --noEmit`。新增/删除 i18n 键必须过 `i18n-parity.test.ts`(en.ts / zh-CN.ts 同步)。CodeMirror 在 jsdom 报 `getClientRects is not a function`,已在 `src/__tests__/setup.ts` stub;终端测试复用既有 `ghostty-web` 动态 import 的 mock 先例。
+
+**单元测试(纯函数,最扎实):**
+- `lib/file-drafts.test.ts`:
+  - `draftKey` 组合正确。
+  - save→load round-trip 返回原文;空串合法(load 返 `""` 而非 `null`)。
+  - 无草稿 `loadFileDraft` 返 `null`。
+  - `saveFileDraft(key, "")` 删键;`clearFileDraft` 删键。
+  - 损坏 JSON(`sessionStorage` 塞非法值)→ load 返 `null`、不抛。
+  - `setItem` 抛(mock 抛 QuotaExceeded)→ `saveFileDraft` 吞掉不抛。
+- center-tabs 持久化(扩充 `stores/center-tabs.test.ts` 或新增):
+  - mutator(openFile / openTerminal / setActive / closeTab)后 sessionStorage `xacpx.center-tabs.v1` 被写、内容含该 tab。
+  - hydrate:预置 sessionStorage → 新建 store → `tabsFor/activeFor` 还原。
+  - hydrate 把终端 tab 的 `autostart` 强制为 `false`(预置 `autostart:true` 也读成 false)。
+  - `openTerminal()` 新建的终端 tab `autostart === true`。
+  - 损坏值(非 JSON / 非对象 / 坏 session 条目)→ 不崩,坏条目丢弃、好条目保留。
+
+**组件测试(jsdom mount):**
+- FileViewer:
+  - `load()` 时存在草稿(mock `files.readFile` 返回内容 + 预置草稿)→ `content` = 草稿、进编辑态、`dirty-change` emit true。
+  - 草稿 == 磁盘内容 → 不进编辑态(只读)。
+  - 无草稿 → 只读态、`content` = 磁盘内容。
+  - 编辑改动 → sessionStorage 写入草稿;`cancelEdit()` / `save()` 成功 → 草稿清除。
+- TerminalTab:
+  - `autostart=false` 挂载 → 不调 `terminals.create`、渲染占位(按 data-test 断言)。
+  - 点占位"启动"按钮 → 调一次 `terminals.create`、占位消失。
+  - `autostart=true` 挂载 → 直接调 `terminals.create`(维持现状,回归)。
+
+## i18n
+
+新增两个终端占位文案键(en.ts + zh-CN.ts 同步,过 parity 测试):
+- `terminal.restoredHint` — en: "This terminal disconnected on reload." / zh: "终端会话已随刷新断开。"
+- `terminal.startNew` — en: "Start new terminal" / zh: "启动新终端"。
+
+## 交付与验收
+
+- 纯前端,只动 `packages/relay-web`;UI-only → 只 bump hub(`@ganglion/xacpx-relay`)一个 beta。
+- 验收(实机):打开若干文件 tab + 一个 diff + 一个终端,编辑某文件不保存 → 硬刷新 → tab 集/激活 tab 还原、草稿仍在且处编辑态、终端 tab 在但显"启动新终端"占位;点占位启动 → 正常新 shell;关标签页重开 → 不恢复(sessionStorage 语义)。

--- a/packages/relay-web/src/__tests__/center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/center-tabs.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useCenterTabsStore, sessionKey, TAB_DROP_END } from "../stores/center-tabs";
+import { draftKey, loadFileDraft, saveFileDraft } from "../lib/file-drafts";
 
 beforeEach(() => { setActivePinia(createPinia()); sessionStorage.clear(); });
 const K = sessionKey("i1", "s1");
@@ -88,6 +89,57 @@ describe("center-tabs store", () => {
     s.clearSession(K);
     expect(s.tabsFor(K)).toEqual([]);
     expect(s.allOpenTabs().length).toBe(1);
+  });
+
+  it("closeTab clears the closed file tab's draft (abandoned edit does not come back)", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts");
+    saveFileDraft(draftKey(K, "a.ts"), "draft content");
+    expect(loadFileDraft(draftKey(K, "a.ts"))).toBe("draft content");
+    s.closeTab(K, "file:a.ts");
+    expect(loadFileDraft(draftKey(K, "a.ts"))).toBeNull();
+  });
+
+  it("closeTab on a file tab with no draft is a no-op for drafts (doesn't throw / doesn't create one)", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts");
+    s.closeTab(K, "file:a.ts");
+    expect(loadFileDraft(draftKey(K, "a.ts"))).toBeNull();
+  });
+
+  it("closeTab on a diff or terminal tab does not touch any file draft", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts");
+    saveFileDraft(draftKey(K, "a.ts"), "draft content");
+    s.openDiff(K, "b.ts");
+    s.openTerminal(K);
+    s.closeTab(K, "diff:b.ts");
+    s.closeTab(K, "terminal");
+    expect(loadFileDraft(draftKey(K, "a.ts"))).toBe("draft content");
+  });
+
+  it("closing one file's tab does not clear a different file's draft", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts");
+    saveFileDraft(draftKey(K, "a.ts"), "draft a");
+    saveFileDraft(draftKey(K, "b.ts"), "draft b");
+    s.closeTab(K, "file:b.ts");
+    expect(loadFileDraft(draftKey(K, "a.ts"))).toBe("draft a");
+    expect(loadFileDraft(draftKey(K, "b.ts"))).toBeNull();
+  });
+
+  it("clearSession clears drafts for every file tab in that session, but not other sessions'", () => {
+    const s = useCenterTabsStore();
+    const K2 = sessionKey("i1", "s2");
+    s.openFile(K, "a.ts"); s.openFile(K, "b.ts"); s.openTerminal(K);
+    s.openFile(K2, "c.ts");
+    saveFileDraft(draftKey(K, "a.ts"), "draft a");
+    saveFileDraft(draftKey(K, "b.ts"), "draft b");
+    saveFileDraft(draftKey(K2, "c.ts"), "draft c");
+    s.clearSession(K);
+    expect(loadFileDraft(draftKey(K, "a.ts"))).toBeNull();
+    expect(loadFileDraft(draftKey(K, "b.ts"))).toBeNull();
+    expect(loadFileDraft(draftKey(K2, "c.ts"))).toBe("draft c");
   });
 
   it("activeFor defaults to chat for an unknown session", () => {

--- a/packages/relay-web/src/__tests__/center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/center-tabs.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useCenterTabsStore, sessionKey, TAB_DROP_END } from "../stores/center-tabs";
 
-beforeEach(() => setActivePinia(createPinia()));
+beforeEach(() => { setActivePinia(createPinia()); sessionStorage.clear(); });
 const K = sessionKey("i1", "s1");
 
 describe("center-tabs store", () => {
@@ -94,6 +94,60 @@ describe("center-tabs store", () => {
     const s = useCenterTabsStore();
     expect(s.activeFor(sessionKey("x", "y"))).toBe("chat");
     expect(s.tabsFor(sessionKey("x", "y"))).toEqual([]);
+  });
+
+  it("openTerminal marks the tab autostart:true (fresh user action spawns)", () => {
+    const s = useCenterTabsStore();
+    s.openTerminal(K);
+    const term = s.tabsFor(K).find((t) => t.kind === "terminal");
+    expect(term && term.kind === "terminal" ? term.autostart : undefined).toBe(true);
+  });
+
+  it("persists tab state to sessionStorage on mutation", () => {
+    const s = useCenterTabsStore();
+    s.openFile(K, "a.ts");
+    const raw = sessionStorage.getItem("xacpx.center-tabs.v1");
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)[K].tabs.map((t: { id: string }) => t.id)).toEqual(["file:a.ts"]);
+    expect(JSON.parse(raw!)[K].activeId).toBe("file:a.ts");
+  });
+
+  it("hydrates tab state from sessionStorage on a fresh store", () => {
+    sessionStorage.setItem(
+      "xacpx.center-tabs.v1",
+      JSON.stringify({ [K]: { tabs: [{ kind: "file", id: "file:a.ts", path: "a.ts" }], activeId: "file:a.ts" } }),
+    );
+    const s = useCenterTabsStore(); // fresh pinia from beforeEach ran BEFORE we set storage? see note
+    expect(s.tabsFor(K).map((t) => t.id)).toEqual(["file:a.ts"]);
+    expect(s.activeFor(K)).toBe("file:a.ts");
+  });
+
+  it("forces restored terminal tabs to autostart:false", () => {
+    sessionStorage.setItem(
+      "xacpx.center-tabs.v1",
+      JSON.stringify({ [K]: { tabs: [{ kind: "terminal", id: "terminal", autostart: true }], activeId: "terminal" } }),
+    );
+    const s = useCenterTabsStore();
+    const term = s.tabsFor(K).find((t) => t.kind === "terminal");
+    expect(term && term.kind === "terminal" ? term.autostart : undefined).toBe(false);
+  });
+
+  it("discards corrupt storage and bad session entries without throwing", () => {
+    sessionStorage.setItem("xacpx.center-tabs.v1", "{not json");
+    expect(() => useCenterTabsStore()).not.toThrow();
+    expect(useCenterTabsStore().tabsFor(K)).toEqual([]);
+
+    // Pinia memoizes the store per active pinia instance — calling useCenterTabsStore() again
+    // here would just return the already-hydrated store above, not re-read storage. Activate a
+    // fresh pinia so the next call re-triggers the factory's hydrate() against the new data.
+    setActivePinia(createPinia());
+    sessionStorage.setItem(
+      "xacpx.center-tabs.v1",
+      JSON.stringify({ [K]: { tabs: "nope", activeId: 5 }, "i1::s2": { tabs: [{ kind: "file", id: "file:b.ts", path: "b.ts" }], activeId: "file:b.ts" } }),
+    );
+    const s2 = useCenterTabsStore();
+    expect(s2.tabsFor(K)).toEqual([]); // bad entry dropped
+    expect(s2.tabsFor(sessionKey("i1", "s2")).map((t) => t.id)).toEqual(["file:b.ts"]); // good entry kept
   });
 });
 

--- a/packages/relay-web/src/__tests__/centertabstrip.test.ts
+++ b/packages/relay-web/src/__tests__/centertabstrip.test.ts
@@ -6,7 +6,9 @@ import { useCenterTabsStore, sessionKey, TAB_DROP_END } from "../stores/center-t
 
 const g = { global: { mocks: { $t: (k: string) => k } } };
 
-beforeEach(() => setActivePinia(createPinia()));
+// center-tabs now persists to sessionStorage (task 2); clear it alongside the pinia reset so
+// tabs opened in one test don't leak into the next test's store via hydrate().
+beforeEach(() => { setActivePinia(createPinia()); sessionStorage.clear(); });
 
 describe("CenterTabStrip", () => {
   it("renders the pinned chat tab plus one tab per open file/terminal", () => {

--- a/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
@@ -28,6 +28,9 @@ const stubs = {
 
 beforeEach(() => {
   setActivePinia(createPinia());
+  // center-tabs now persists to sessionStorage (task 2); clear it too so tabs opened in one
+  // test don't leak into the next test's store via hydrate().
+  sessionStorage.clear();
   vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ instances: [] }), { status: 200 })));
 });
 

--- a/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
@@ -19,6 +19,9 @@ const stubs = { ChatPane: true, FileViewer: true, TaskPanel: true, TerminalTab: 
 
 beforeEach(() => {
   setActivePinia(createPinia());
+  // center-tabs now persists to sessionStorage (task 2); clear it too so tabs opened in one
+  // test don't leak into the next test's store via hydrate().
+  sessionStorage.clear();
   vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ instances: [] }), { status: 200 })));
 });
 

--- a/packages/relay-web/src/__tests__/file-drafts.test.ts
+++ b/packages/relay-web/src/__tests__/file-drafts.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { draftKey, loadFileDraft, saveFileDraft, clearFileDraft } from "../lib/file-drafts";
+
+beforeEach(() => sessionStorage.clear());
+afterEach(() => vi.restoreAllMocks());
+
+describe("file-drafts", () => {
+  it("draftKey composes sessionKey and path", () => {
+    expect(draftKey("i1::s1", "a/b.ts")).toBe("i1::s1::a/b.ts");
+  });
+
+  it("save then load round-trips the text", () => {
+    const k = draftKey("i1::s1", "a.ts");
+    saveFileDraft(k, "hello");
+    expect(loadFileDraft(k)).toBe("hello");
+  });
+
+  it("empty string is a valid draft (distinct from absent)", () => {
+    const k = draftKey("i1::s1", "a.ts");
+    saveFileDraft(k, "x");
+    saveFileDraft(k, ""); // deleting all content is a real draft-clear, so key is removed
+    expect(loadFileDraft(k)).toBeNull();
+  });
+
+  it("returns null when no draft exists", () => {
+    expect(loadFileDraft(draftKey("i1::s1", "none.ts"))).toBeNull();
+  });
+
+  it("clearFileDraft removes the key", () => {
+    const k = draftKey("i1::s1", "a.ts");
+    saveFileDraft(k, "hi");
+    clearFileDraft(k);
+    expect(loadFileDraft(k)).toBeNull();
+  });
+
+  it("tolerates corrupt storage without throwing", () => {
+    sessionStorage.setItem("xacpx.file-drafts.v1", "{not json");
+    expect(loadFileDraft(draftKey("i1::s1", "a.ts"))).toBeNull();
+  });
+
+  it("swallows setItem quota errors", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+    expect(() => saveFileDraft(draftKey("i1::s1", "a.ts"), "big")).not.toThrow();
+    spy.mockRestore();
+  });
+});

--- a/packages/relay-web/src/__tests__/fileviewer.test.ts
+++ b/packages/relay-web/src/__tests__/fileviewer.test.ts
@@ -11,6 +11,7 @@ let pinia: ReturnType<typeof createPinia>;
 beforeEach(() => {
   pinia = createPinia();
   setActivePinia(pinia);
+  sessionStorage.clear();
   Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
 });
 
@@ -142,5 +143,49 @@ describe("FileViewer", () => {
 
     expect(w.find('[data-test="code-editor"]').exists()).toBe(true);
     expect(view.state.doc.toString()).toBe("edited-draft");
+  });
+
+  it("restores an edit draft into edit mode on load", async () => {
+    const files = useFilesStore();
+    vi.spyOn(files, "readFile").mockResolvedValue({ ...TEXT, path: "src/a.ts", content: "DISK BODY" });
+    sessionStorage.setItem("xacpx.file-drafts.v1", JSON.stringify({ "i1::s1::src/a.ts": "DRAFT BODY" }));
+    const w = mountViewer({ path: "src/a.ts", sessionKey: "i1::s1" });
+    await settle();
+    // Draft differs from disk + file is editable ⇒ enter edit mode with the draft buffer.
+    expect(w.find('[data-test="fv-dirty-dot"]').exists()).toBe(true);
+    expect(w.find('[data-test="fv-save"]').exists()).toBe(true);
+    expect(w.emitted("dirty-change")?.some((e) => e[0] === true)).toBe(true);
+  });
+
+  it("does NOT enter edit mode when the draft equals disk content", async () => {
+    const files = useFilesStore();
+    vi.spyOn(files, "readFile").mockResolvedValue({ ...TEXT, path: "src/a.ts", content: "DISK BODY" });
+    sessionStorage.setItem("xacpx.file-drafts.v1", JSON.stringify({ "i1::s1::src/a.ts": "DISK BODY" }));
+    const w = mountViewer({ path: "src/a.ts", sessionKey: "i1::s1" });
+    await settle();
+    expect(w.find('[data-test="fv-dirty-dot"]').exists()).toBe(false);
+    expect(w.find('[data-test="fv-edit"]').exists()).toBe(true); // read mode: pencil visible
+  });
+
+  it("clears the draft on cancel", async () => {
+    const files = useFilesStore();
+    vi.spyOn(files, "readFile").mockResolvedValue({ ...TEXT, path: "src/a.ts", content: "DISK BODY" });
+    sessionStorage.setItem("xacpx.file-drafts.v1", JSON.stringify({ "i1::s1::src/a.ts": "DRAFT BODY" }));
+    const w = mountViewer({ path: "src/a.ts", sessionKey: "i1::s1" });
+    await settle();
+    await w.get('[data-test="fv-cancel"]').trigger("click");
+    expect(JSON.parse(sessionStorage.getItem("xacpx.file-drafts.v1")!)["i1::s1::src/a.ts"]).toBeUndefined();
+  });
+
+  it("clears the draft after a successful save", async () => {
+    const files = useFilesStore();
+    vi.spyOn(files, "readFile").mockResolvedValue({ ...TEXT, path: "src/a.ts", content: "DISK BODY" });
+    vi.spyOn(files, "saveFile").mockResolvedValue({ path: "src/a.ts", mtimeMs: 2000, size: 5 });
+    sessionStorage.setItem("xacpx.file-drafts.v1", JSON.stringify({ "i1::s1::src/a.ts": "DRAFT BODY" }));
+    const w = mountViewer({ path: "src/a.ts", sessionKey: "i1::s1" });
+    await settle();
+    await w.get('[data-test="fv-save"]').trigger("click");
+    await settle();
+    expect(JSON.parse(sessionStorage.getItem("xacpx.file-drafts.v1")!)["i1::s1::src/a.ts"]).toBeUndefined();
   });
 });

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -27,7 +27,7 @@ function onDataOf() {
 }
 
 describe("TerminalTab", () => {
-  beforeEach(() => { setActivePinia(createPinia()); vi.clearAllMocks(); localStorage.clear(); });
+  beforeEach(() => { setActivePinia(createPinia()); vi.clearAllMocks(); localStorage.clear(); sessionStorage.clear(); });
 
   it("creates a terminal and mounts the adapter when a session is selected", async () => {
     mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
@@ -343,5 +343,28 @@ describe("TerminalTab", () => {
     await tick();
     expect(rafSpy).not.toHaveBeenCalled();
     rafSpy.mockRestore();
+  });
+
+  it("autostart=false does NOT spawn and shows the restore placeholder", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+    await tick();
+    expect(createTerminalAdapter).not.toHaveBeenCalled();
+    expect(w.find('[data-test="term-restore"]').exists()).toBe(true);
+    expect(w.find('[data-test="term-start"]').exists()).toBe(true);
+  });
+
+  it("clicking the placeholder start button spawns the terminal", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+    await tick();
+    await w.find('[data-test="term-start"]').trigger("click");
+    await tick();
+    expect(createTerminalAdapter).toHaveBeenCalledTimes(1);
+    expect(w.find('[data-test="term-restore"]').exists()).toBe(false);
+  });
+
+  it("autostart=true (default) spawns on mount as before", async () => {
+    mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await tick();
+    expect(createTerminalAdapter).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/relay-web/src/components/FileViewer.vue
+++ b/packages/relay-web/src/components/FileViewer.vue
@@ -7,6 +7,7 @@ import type { FsDiffResult, FsReadResult } from "@ganglion/xacpx-relay-protocol"
 import CodeEditor from "./CodeEditor.vue";
 import { parseUnifiedDiff } from "../lib/unified-diff";
 import CopyButton from "./CopyButton.vue";
+import { draftKey, loadFileDraft, saveFileDraft, clearFileDraft } from "../lib/file-drafts";
 
 // Roomy file/diff viewer that takes over the center column. A single CodeMirror instance
 // (CodeEditor) renders file content for BOTH read and edit — read is editable:false, the
@@ -19,6 +20,7 @@ const props = defineProps<{
   diffPath?: string;
   line?: number;
   lineRev?: number;
+  sessionKey?: string;
 }>();
 const emit = defineEmits<{ back: []; close: []; "dirty-change": [boolean] }>();
 const { t } = useI18n();
@@ -50,6 +52,18 @@ async function load(): Promise<void> {
       content.value = result.binary ? "" : result.content;
       editing.value = false;
       emit("dirty-change", false);
+      // Restore a persisted edit draft: enter edit mode with the saved buffer. Only when the
+      // draft differs from disk (equal ⇒ nothing to restore) and the file is actually editable
+      // (a truncated / mtime-less file can't be saved). Staleness isn't checked here — the
+      // existing save-time mtime guard (baseRev) catches a disk that changed while away.
+      if (!result.binary && !result.truncated && typeof result.mtimeMs === "number") {
+        const draft = loadFileDraft(draftKey(props.sessionKey ?? "", path));
+        if (draft !== null && draft !== result.content) {
+          baseRev.value = { mtimeMs: result.mtimeMs, size: result.size };
+          content.value = draft;
+          editing.value = true;
+        }
+      }
     } else if (diffPath) {
       const result = await files.readDiff(instanceId, workspace, diffPath);
       if (token !== loadToken) return;
@@ -92,6 +106,15 @@ const canEdit = computed(
 const editDirty = computed(() => editing.value && !!file.value && content.value !== file.value.content);
 watch(editDirty, (v) => emit("dirty-change", v));
 
+// Persist the edit buffer while editing so a reload can restore it. Clearing the edits back to
+// disk content removes the key (empty store). Only writes in edit mode with a real path.
+watch(content, (val) => {
+  if (!editing.value || !props.path) return;
+  const key = draftKey(props.sessionKey ?? "", props.path);
+  if (file.value && val !== file.value.content) saveFileDraft(key, val);
+  else clearFileDraft(key);
+});
+
 const saveErrorLabel = computed(() => {
   const code = saveError.value;
   if (!code) return "";
@@ -117,6 +140,7 @@ function cancelEdit() {
   baseRev.value = null;
   saveError.value = null;
   emit("dirty-change", false);
+  if (props.path) clearFileDraft(draftKey(props.sessionKey ?? "", props.path));
 }
 async function save() {
   if (!editing.value) return;
@@ -130,6 +154,7 @@ async function save() {
     editing.value = false;
     baseRev.value = null;
     emit("dirty-change", false);
+    if (props.path) clearFileDraft(draftKey(props.sessionKey ?? "", props.path));
   } catch (e) {
     saveError.value = e instanceof Error ? e.message : "write-failed";
   } finally {

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import { ArrowLeft, Keyboard, ClipboardPaste, Copy, ChevronUp, ChevronDown, ChevronLeft, ChevronRight } from "lucide-vue-next";
 import { createTerminalAdapter, type TerminalAdapter, type TerminalTheme } from "../lib/terminal-adapter";
 import { useTerminalStore } from "../stores/terminal";
 import { useThemeStore } from "../stores/theme";
 
-const props = defineProps<{ instanceId: string; sessionAlias: string }>();
+const props = withDefaults(defineProps<{ instanceId: string; sessionAlias: string; autostart?: boolean }>(), {
+  autostart: true,
+});
 const emit = defineEmits<{ close: [] }>();
 const terminals = useTerminalStore();
 const theme = useThemeStore();
@@ -48,6 +50,12 @@ function toggleKeybar() {
   keybarVisible.value = !keybarVisible.value;
   try { localStorage.setItem("xacpx.terminalKeybar", keybarVisible.value ? "1" : "0"); } catch { /* ignore */ }
 }
+
+// Lazy start: a tab restored from sessionStorage arrives autostart=false — it can't reconnect
+// to its old PTY, so it waits on a "start new terminal" placeholder instead of spawning on
+// mount. `started` gates the prop-watch so a dormant tab never auto-spawns on a prop change.
+let started = false;
+const showPlaceholder = computed(() => !!props.sessionAlias && status.value === "idle" && !props.autostart);
 
 let adapter: TerminalAdapter | null = null;
 let terminalId = "";
@@ -230,6 +238,7 @@ async function start() {
   const myEpoch = epoch;
   if (!props.sessionAlias || !host.value) { status.value = "idle"; return; }
   status.value = "connecting";
+  started = true;
   const currentAdapter = createTerminalAdapter(host.value, {
     cols: 80, rows: 24,
     onData: handleData,
@@ -291,12 +300,12 @@ function detachTouch() {
 }
 
 onMounted(() => {
-  void start();
+  if (props.autostart) void start();
   attachTouch();
   window.visualViewport?.addEventListener("resize", updateKeyboardInset);
   window.visualViewport?.addEventListener("scroll", updateKeyboardInset);
 });
-watch(() => [props.instanceId, props.sessionAlias], () => void start());
+watch(() => [props.instanceId, props.sessionAlias], () => { if (started) void start(); });
 // Recolor the live terminal when the app toggles light/dark so it never leaves a
 // mismatched background band around the grid.
 watch(() => theme.mode, () => adapter?.setTheme(currentTheme()));
@@ -332,7 +341,14 @@ onBeforeUnmount(() => {
     <div v-if="!props.sessionAlias" class="p-4 text-sm text-fg-muted">{{ $t("terminal.noSession") }}</div>
     <div v-else-if="status === 'error'" class="p-4 text-sm text-fg-muted">{{ $t(errorKey) }}</div>
     <div v-else-if="status === 'exited'" class="p-4 text-sm text-fg-muted">{{ $t("terminal.exited", { code: errorKey }) }}</div>
-    <div ref="host" class="term-host flex min-h-0 flex-1 touch-none items-center justify-center overflow-hidden bg-bg" data-test="terminal-host"></div>
+    <div v-if="showPlaceholder" data-test="term-restore"
+         class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+      <p class="text-sm text-fg-muted">{{ $t("terminal.restoredHint") }}</p>
+      <button data-test="term-start"
+              class="rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-fg transition-colors hover:bg-raised"
+              @click="void start()">{{ $t("terminal.startNew") }}</button>
+    </div>
+    <div v-show="!showPlaceholder" ref="host" class="term-host flex min-h-0 flex-1 touch-none items-center justify-center overflow-hidden bg-bg" data-test="terminal-host"></div>
 
     <!-- shortcut bar — the root's padding-bottom (= keyboard height) lifts the whole pane,
          so both this bar and the terminal's prompt row stay above the on-screen keyboard.

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -347,6 +347,8 @@ export default {
     unsupported: "Terminal is unsupported on this instance platform (v1: macOS/Linux only).",
     offline: "Instance is offline.",
     noSession: "Select a session to open a terminal.",
+    restoredHint: "This terminal disconnected on reload.",
+    startNew: "Start new terminal",
     exited: "Terminal exited (code {code}).",
     error: "Could not open the terminal.",
     close: "Close terminal",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -345,6 +345,8 @@ export default {
     unsupported: "该实例平台不支持终端(v1 仅 macOS/Linux)。",
     offline: "实例已离线。",
     noSession: "选择一个会话以打开终端。",
+    restoredHint: "终端会话已随刷新断开。",
+    startNew: "启动新终端",
     exited: "终端已退出(退出码 {code})。",
     error: "无法打开终端。",
     close: "关闭终端",

--- a/packages/relay-web/src/lib/file-drafts.ts
+++ b/packages/relay-web/src/lib/file-drafts.ts
@@ -1,0 +1,48 @@
+/** Per-session file edit-draft persistence (mirrors composer-drafts). An unsaved edit buffer
+ *  survives a browser reload. Stored in sessionStorage (tab-scoped — dies with the tab) keyed
+ *  by `${sessionKey}::${path}`, matching the center-tab's per-session identity. */
+const KEY = "xacpx.file-drafts.v1";
+
+type Drafts = Record<string, string>;
+
+function read(): Drafts {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as Drafts) : {};
+  } catch {
+    return {};
+  }
+}
+
+function write(drafts: Drafts): void {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify(drafts));
+  } catch {
+    /* storage full / disabled — drafts are best-effort */
+  }
+}
+
+export function draftKey(sessionKey: string, path: string): string {
+  return `${sessionKey}::${path}`;
+}
+
+export function loadFileDraft(key: string): string | null {
+  if (!key) return null;
+  const v = read()[key];
+  return v ?? null; // null = absent; "" = a real (emptied) draft
+}
+
+export function saveFileDraft(key: string, text: string): void {
+  if (!key) return;
+  const drafts = read();
+  if (text) drafts[key] = text;
+  else delete drafts[key];
+  write(drafts);
+}
+
+export function clearFileDraft(key: string): void {
+  if (!key) return;
+  const drafts = read();
+  delete drafts[key];
+  write(drafts);
+}

--- a/packages/relay-web/src/stores/center-tabs.ts
+++ b/packages/relay-web/src/stores/center-tabs.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { ref, watch } from "vue";
+import { draftKey, clearFileDraft } from "../lib/file-drafts";
 
 export type CenterTab =
   // targetLine/targetRev: a scroll-to-line request (e.g. from a content-search hit). rev is
@@ -114,6 +115,8 @@ export const useCenterTabsStore = defineStore("center-tabs", () => {
     if (!current) return;
     const index = current.tabs.findIndex((t) => t.id === id);
     if (index === -1) return;
+    const closed = current.tabs[index];
+    if (closed.kind === "file") clearFileDraft(draftKey(key, closed.path));
     const tabs = current.tabs.filter((t) => t.id !== id);
     const wasActive = current.activeId === id;
     const activeId = wasActive ? (current.tabs[index - 1]?.id ?? tabs[index]?.id ?? "chat") : current.activeId;
@@ -145,6 +148,9 @@ export const useCenterTabsStore = defineStore("center-tabs", () => {
 
   function clearSession(key: string): void {
     if (!(key in bySession.value)) return;
+    for (const t of bySession.value[key].tabs) {
+      if (t.kind === "file") clearFileDraft(draftKey(key, t.path));
+    }
     const next = { ...bySession.value };
     delete next[key];
     bySession.value = next;

--- a/packages/relay-web/src/stores/center-tabs.ts
+++ b/packages/relay-web/src/stores/center-tabs.ts
@@ -1,12 +1,12 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { ref, watch } from "vue";
 
 export type CenterTab =
   // targetLine/targetRev: a scroll-to-line request (e.g. from a content-search hit). rev is
   // bumped on every openFile so re-opening the SAME file at the same line still re-scrolls.
   | { kind: "file"; id: string; path: string; targetLine?: number; targetRev?: number; dirty?: boolean }
   | { kind: "diff"; id: string; path: string }
-  | { kind: "terminal"; id: string };
+  | { kind: "terminal"; id: string; autostart?: boolean };
 
 interface SessionTabs {
   tabs: CenterTab[];
@@ -22,8 +22,46 @@ export function sessionKey(instanceId: string, alias: string): string {
  *  dragged tab to the end of the list instead of before a real tab. */
 export const TAB_DROP_END = "__end__";
 
+const STORAGE_KEY = "xacpx.center-tabs.v1";
+
+/** Read persisted tab sets from sessionStorage. Restored terminal tabs can't reconnect to
+ *  their old PTY, so force `autostart:false` — they render a lazy "start" placeholder instead
+ *  of spawning a fresh shell on mount. Corrupt data or malformed session entries are dropped
+ *  (bad entry skipped, good entries kept) so one broken record can't blank the whole view. */
+function hydrate(): Record<string, SessionTabs> {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: Record<string, SessionTabs> = {};
+    for (const [key, val] of Object.entries(parsed as Record<string, unknown>)) {
+      const v = val as { tabs?: unknown; activeId?: unknown };
+      if (!Array.isArray(v.tabs) || typeof v.activeId !== "string") continue;
+      const tabs = (v.tabs as CenterTab[]).map((t) =>
+        t && t.kind === "terminal" ? { ...t, autostart: false } : t,
+      );
+      out[key] = { tabs, activeId: v.activeId };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function persist(v: Record<string, SessionTabs>): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(v));
+  } catch {
+    /* storage full / disabled — persistence is best-effort */
+  }
+}
+
 export const useCenterTabsStore = defineStore("center-tabs", () => {
-  const bySession = ref<Record<string, SessionTabs>>({});
+  const bySession = ref<Record<string, SessionTabs>>(hydrate());
+  // flush: "sync" — persistence must happen synchronously with the mutation (not on the next
+  // microtask/pre-render flush) so a page unload right after a mutation still sees it saved.
+  watch(bySession, (v) => persist(v), { deep: true, flush: "sync" });
 
   function tabsFor(key: string): CenterTab[] {
     return bySession.value[key]?.tabs ?? [];
@@ -63,7 +101,7 @@ export const useCenterTabsStore = defineStore("center-tabs", () => {
   }
 
   function openTerminal(key: string): void {
-    upsertAndActivate(key, { kind: "terminal", id: "terminal" });
+    upsertAndActivate(key, { kind: "terminal", id: "terminal", autostart: true });
   }
 
   function setActive(key: string, id: string): void {

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -400,6 +400,7 @@ onUnmounted(() => {
             <TerminalTab v-else-if="tab.kind === 'terminal'" class="absolute inset-0 z-20"
                          v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
                          :instance-id="keyInstance(key)" :session-alias="keyAlias(key)"
+                         :autostart="tab.autostart ?? false"
                          @close="requestCloseTab(key, tab.id)" />
           </template>
         </div>

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -391,6 +391,7 @@ onUnmounted(() => {
             <FileViewer v-if="tab.kind === 'file' || tab.kind === 'diff'" class="absolute inset-0 z-10"
                         v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
                         :instance-id="keyInstance(key)" :workspace="keyWorkspace(key)"
+                        :session-key="key"
                         :path="tab.kind === 'file' ? tab.path : undefined"
                         :diff-path="tab.kind === 'diff' ? tab.path : undefined"
                         :line="tab.kind === 'file' ? tab.targetLine : undefined"


### PR DESCRIPTION
## What

浏览器刷新后还原刷新前的工作视图,纯前端 sessionStorage,只动 `packages/relay-web`。

- **中置 tab 集持久化** — center-tabs store hydrate/deep-watch 到 `xacpx.center-tabs.v1`;刷新后还原打开的文件/diff/终端 tab + 激活 tab。文件内容不存(恢复后各自重新走 `control.fs.read` 拉最新)。
- **终端懒启动** — 恢复的终端 tab 接不回旧 PTY,不自动 spawn;显示"启动新终端"占位,点按钮才调组件自身 `start()`。`autostart` 标志:用户主动开=true,hydrate 恢复=强制 false。host 用 `v-show` 常驻 DOM。
- **文件编辑草稿** — 新增 `lib/file-drafts.ts`(镜像 composer-drafts,sessionStorage `xacpx.file-drafts.v1`)。`FileViewer` 编辑时写草稿、刷新后恢复进编辑态(仅当草稿≠磁盘且可编辑,靠既有 save-time mtime 陈旧写保护兑底)、save/cancel/关 tab/剪枝 session 都清草稿。

寿命 = sessionStorage(与既有输入框草稿一致):纯 F5/崩溃重载能恢复,关标签页则清空。终端**内容** replay 是第 3 层,单独立项、不在本次范围。

## Tasks (subagent-driven, TDD)

1. `lib/file-drafts.ts` sessionStorage 草稿库
2. center-tabs 持久化(hydrate/persist)+ 终端 `autostart` 标志
3. TerminalTab 懒启动占位 + DashboardView `:autostart` + i18n
4. FileViewer 草稿接线(恢复/持久化/清除)+ DashboardView `:session-key`
5. fix:关 tab / 剪枝 session 时清草稿(最终评审发现的"已放弃编辑复活")

## Review

- 逐任务门禁 ×4:全 spec ✅ + Approved
- 最终全分支(opus):Ready=YES,1 Important(草稿复活)→ 已修 d2ba242
- 独立 fresh-eyes(opus):**Ship,0 Critical / 0 Important**

## Test

全套 648 测试绿(`npx vitest run`)+ `npx vue-tsc --noEmit` 0 报错。UI-only → 合并后 bump hub 发 beta。

spec: `docs/superpowers/specs/2026-07-04-relay-web-refresh-restore-design.md`
plan: `docs/superpowers/plans/2026-07-04-relay-web-refresh-restore.md`