### PR TITLE
feat(terminal): Windows support — open win32 gate, pwsh/powershell/cmd shell resolution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,26 +49,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'
 
-      # Installs node-pty, resolving its Windows prebuilt binary (ConPTY). A failure here
-      # means the prebuild didn't resolve for this Node ABI on Windows.
+      # Installs node-pty and resolves its Windows prebuilt binary (ConPTY).
       - name: Install dependencies
         run: npm ci
 
-      # Focused terminal coverage only — NOT the full unit suite (never run on Windows).
-      - name: Terminal unit tests
-        run: bun test tests/unit/control/terminal-service.test.ts
-
-      # Real ConPTY: spawns a live shell and asserts the byte stream round-trips.
-      - name: Terminal PTY smoke (ConPTY)
-        run: bun test tests/smoke/terminal-pty-smoke.test.ts
+      # Real ConPTY under the PRODUCTION runtime (Node) — spawns a live shell with a
+      # forward-slash cwd and asserts the byte stream round-trips.
+      - name: Terminal ConPTY smoke (Node)
+        run: node scripts/smoke-terminal-conpty.mjs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,34 @@ jobs:
       # them, so package-level type/build errors used to surface only at publish.
       - name: Build (all packages)
         run: bun run build:packages
+
+  terminal-windows:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      # Installs node-pty, resolving its Windows prebuilt binary (ConPTY). A failure here
+      # means the prebuild didn't resolve for this Node ABI on Windows.
+      - name: Install dependencies
+        run: npm ci
+
+      # Focused terminal coverage only — NOT the full unit suite (never run on Windows).
+      - name: Terminal unit tests
+        run: bun test tests/unit/control/terminal-service.test.ts
+
+      # Real ConPTY: spawns a live shell and asserts the byte stream round-trips.
+      - name: Terminal PTY smoke (ConPTY)
+        run: bun test tests/smoke/terminal-pty-smoke.test.ts

--- a/docs/superpowers/plans/2026-07-05-terminal-windows-support.md
+++ b/docs/superpowers/plans/2026-07-05-terminal-windows-support.md
@@ -1,0 +1,485 @@
+# 终端 Windows 支持 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 放开内置终端的 Windows 门禁,使 win32 实例也能开终端,shell 走 pwsh→PowerShell→cmd 并支持跨平台 `terminal.shell` 覆盖。
+
+**Architecture:** 把 shell 选择抽成可注入 `exists` 的纯函数 `resolveShell`(取代 `defaultShell`),ubuntu CI 以注入 `platform="win32"` 全覆盖;删 `terminal-service.ts` 的 win32 throw;`TerminalConfig.shell?` 经 deps 回调串入;前端只改 i18n 文案;新增最小 windows-latest CI leg(装依赖 + 终端单测 + 真 ConPTY smoke)。
+
+**Tech Stack:** TypeScript(core `src/`)、node-pty ^1.1.0(自带 Windows ConPTY 预构建)、bun:test(core 单测)、Vitest(relay-web i18n)、GitHub Actions。
+
+## Global Constraints
+
+- 只改 core `src/` + `.github/workflows/test.yml` + `packages/relay-web` 的 i18n;**不改** connector(`channel-relay`)/ hub(`relay`)/ control-service(纯透传)。
+- shell 优先级(所有平台):`terminal.shell` 配置 → 平台默认。unix 默认:`SHELL` → darwin `/bin/zsh` / 其它 `/bin/bash`(**行为不变**)。win32 默认:**忽略 `SHELL`** → 扫 PATH `pwsh.exe` → `powershell.exe` → 回落 `%ComSpec%` → `cmd.exe`。
+- shell 解析永不抛(始终有值)。
+- core 单测跑法:`bun test tests/unit/control/terminal-service.test.ts`(**单文件,勿整目录**——整目录 bun test 有状态泄漏假失败)。类型检查:`npx tsc --noEmit` 必须 0 报错(`npm test` 会先 typecheck 再跑全 unit)。
+- relay-web i18n:改文案 en.ts + zh-CN.ts 同步,过 `cd packages/relay-web && npx vitest run src/__tests__/i18n-parity.test.ts`;类型 `cd packages/relay-web && npx vue-tsc --noEmit`。
+- smoke(`tests/smoke/**`)默认不入 `npm test`(仅 tests/unit);Windows CI leg 显式调用。
+- 前端保留 `terminal-unsupported-platform` → `terminal.unsupported` 映射作防御兜底,**不删**。
+- **不在 Windows CI 跑全量单测**(从未在 Windows 跑过、会因无关差异红掉);只跑终端单测 + smoke。
+
+---
+
+### Task 1: `resolveShell` 纯函数
+
+在 `terminal-service.ts` 内新增可注入、导出的 shell 解析函数,取代 `defaultShell()`。本任务只加函数 + 单测,**不**改 `create()`(下个任务放开门禁时才切换调用)。
+
+**Files:**
+- Modify: `src/control/terminal-service.ts`(新增 `resolveShell` + `defaultExists`;暂保留 `defaultShell` 不删,Task 2 删)
+- Test: `tests/unit/control/terminal-service.test.ts`(新增 resolveShell 用例)
+
+**Interfaces:**
+- Consumes: `node:fs` 的 `statSync`。
+- Produces:
+  - `export interface ResolveShellArgs { platform: NodeJS.Platform; env: NodeJS.ProcessEnv; shellOverride?: string; exists?: (p: string) => boolean }`
+  - `export function resolveShell(args: ResolveShellArgs): string`
+
+- [ ] **Step 1: 写失败的测试**
+
+在 `tests/unit/control/terminal-service.test.ts` 顶部 import 追加 `resolveShell`(与既有 import 合并):
+
+```ts
+import { createTerminalService, resolveShell, type PtyHandle } from "../../../src/control/terminal-service";
+```
+
+在文件末尾追加(bun:test 风格,与既有用例一致):
+
+```ts
+// ── resolveShell ─────────────────────────────────────────────────────────────
+const noExist = () => false;
+
+test("resolveShell: explicit shellOverride wins on any platform", () => {
+  expect(resolveShell({ platform: "win32", env: {}, shellOverride: "C:/tools/nu.exe", exists: noExist })).toBe("C:/tools/nu.exe");
+  expect(resolveShell({ platform: "darwin", env: { SHELL: "/bin/zsh" }, shellOverride: "/bin/fish" })).toBe("/bin/fish");
+  // blank override is ignored (falls through to platform default)
+  expect(resolveShell({ platform: "linux", env: { SHELL: "/bin/bash" }, shellOverride: "   " })).toBe("/bin/bash");
+});
+
+test("resolveShell: unix honors SHELL then falls to zsh(darwin)/bash(other) — unchanged", () => {
+  expect(resolveShell({ platform: "darwin", env: { SHELL: "/opt/homebrew/bin/fish" } })).toBe("/opt/homebrew/bin/fish");
+  expect(resolveShell({ platform: "darwin", env: {} })).toBe("/bin/zsh");
+  expect(resolveShell({ platform: "linux", env: {} })).toBe("/bin/bash");
+});
+
+test("resolveShell: win32 IGNORES SHELL and scans PATH pwsh -> powershell -> ComSpec -> cmd", () => {
+  const PATH = "C:\\Windows\\System32;C:\\PS7";
+  // SHELL set to an MSYS path (git-bash) must be ignored on win32
+  const env = { SHELL: "/usr/bin/bash", PATH, ComSpec: "C:\\Windows\\System32\\cmd.exe" };
+  // pwsh present anywhere in PATH wins
+  const pwshExists = (p: string) => p === "C:\\PS7\\pwsh.exe";
+  expect(resolveShell({ platform: "win32", env, exists: pwshExists })).toBe("C:\\PS7\\pwsh.exe");
+  // no pwsh, powershell present in System32
+  const psExists = (p: string) => p === "C:\\Windows\\System32\\powershell.exe";
+  expect(resolveShell({ platform: "win32", env, exists: psExists })).toBe("C:\\Windows\\System32\\powershell.exe");
+  // neither present -> ComSpec
+  expect(resolveShell({ platform: "win32", env, exists: noExist })).toBe("C:\\Windows\\System32\\cmd.exe");
+  // neither present and no ComSpec -> literal cmd.exe
+  expect(resolveShell({ platform: "win32", env: { PATH }, exists: noExist })).toBe("cmd.exe");
+});
+
+test("resolveShell: win32 prefers pwsh over powershell when both exist", () => {
+  const env = { PATH: "C:\\A;C:\\B" };
+  const bothExist = (p: string) => p === "C:\\B\\pwsh.exe" || p === "C:\\A\\powershell.exe";
+  expect(resolveShell({ platform: "win32", env, exists: bothExist })).toBe("C:\\B\\pwsh.exe");
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts`
+Expected: FAIL — `resolveShell` 未导出(import 报错 / 用例未定义)。
+
+- [ ] **Step 3: 实现 `resolveShell`**
+
+在 `src/control/terminal-service.ts` 顶部 import 加 `statSync`:
+
+```ts
+import { statSync } from "node:fs";
+```
+
+在 `defaultShell`(:67）**之后**新增(暂不删 `defaultShell`):
+
+```ts
+function defaultExists(p: string): boolean {
+  try {
+    return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export interface ResolveShellArgs {
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  /** Explicit override from config terminal.shell — wins on every platform. */
+  shellOverride?: string;
+  /** Injectable executable-existence predicate (defaults to fs statSync). */
+  exists?: (p: string) => boolean;
+}
+
+/** Pick the shell to spawn. Priority: explicit override -> platform default.
+ *  win32 deliberately ignores SHELL (git-bash sets it to an MSYS path that
+ *  node-pty can't spawn on Windows) and scans PATH for pwsh -> powershell,
+ *  falling back to %ComSpec% (cmd.exe). Never throws — always returns a value. */
+export function resolveShell(args: ResolveShellArgs): string {
+  const { platform, env, shellOverride } = args;
+  const exists = args.exists ?? defaultExists;
+  if (shellOverride && shellOverride.trim()) return shellOverride;
+  if (platform === "win32") {
+    const pathValue = env.PATH ?? env.Path ?? "";
+    const dirs = pathValue.split(";").filter(Boolean);
+    for (const name of ["pwsh.exe", "powershell.exe"]) {
+      for (const dir of dirs) {
+        const full = `${dir}\\${name}`;
+        if (exists(full)) return full;
+      }
+    }
+    return env.ComSpec ?? "cmd.exe";
+  }
+  if (env.SHELL) return env.SHELL;
+  return platform === "darwin" ? "/bin/zsh" : "/bin/bash";
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts`
+Expected: PASS — 新增 4 个 resolveShell 用例全绿;既有用例(含仍在的 "win32 throws" 用例)仍绿。
+
+- [ ] **Step 5: 类型检查 + 提交**
+
+```bash
+npx tsc --noEmit
+git add src/control/terminal-service.ts tests/unit/control/terminal-service.test.ts
+git commit -m "feat(terminal): resolveShell — cross-platform shell selection (pwsh/powershell/cmd on win32)"
+```
+
+---
+
+### Task 2: 放开 win32 门禁 + `terminal.shell` 配置串联
+
+删 `create()` 的 win32 throw、改用 `resolveShell`、删旧 `defaultShell`;新增 `TerminalConfig.shell` + `terminalShell()` 访问器 + `TerminalServiceDeps.shell` 回调 + `main.ts` 布线;更新既有 "win32 throws" 用例。
+
+**Files:**
+- Modify: `src/control/terminal-service.ts:104-107`(create 放开 + 用 resolveShell)、删 `defaultShell`、`TerminalServiceDeps` 加 `shell?`
+- Modify: `src/config/types.ts`(`TerminalConfig.shell?` + `terminalShell()`)
+- Modify: `src/main.ts:17,768-771`(import + 布线 `shell`)
+- Test: `tests/unit/control/terminal-service.test.ts`(改 win32 用例;扩 `setup` 支持 shell)
+
+**Interfaces:**
+- Consumes: `resolveShell`(Task 1)、`terminalShell(config)`。
+- Produces:
+  - `TerminalConfig` 加 `shell?: string`
+  - `export function terminalShell(config: AppConfig): string | undefined`
+  - `TerminalServiceDeps` 加 `shell?: () => string | undefined`
+  - `create()` 在所有平台(含 win32)可用。
+
+- [ ] **Step 1: 写失败的测试**
+
+改 `tests/unit/control/terminal-service.test.ts` 的 `setup` 支持注入 `shell`(改现有 setup):
+
+```ts
+function setup(opts?: { idle?: number; platform?: NodeJS.Platform; shell?: () => string | undefined }) {
+  const events = createControlEventBus();
+  const captured: ControlEvent[] = [];
+  events.subscribe((e) => captured.push(e));
+  const pty = fakePty();
+  const spawn = mock(() => pty);
+  const svc = createTerminalService({
+    events,
+    idleTimeoutSeconds: () => opts?.idle ?? 900,
+    spawn: spawn as never,
+    platform: opts?.platform ?? "darwin",
+    shell: opts?.shell,
+  });
+  return { svc, pty, spawn, captured };
+}
+```
+
+把既有用例 `test("create throws terminal-unsupported-platform on win32", ...)` **替换**为:
+
+```ts
+test("create no longer throws on win32 and spawns the resolved shell", () => {
+  const { svc, spawn } = setup({ platform: "win32", shell: () => "C:/win/pwsh.exe" });
+  expect(() => svc.create({ cwd: "C:/ws", cols: 80, rows: 24 })).not.toThrow();
+  const call = (spawn as ReturnType<typeof mock>).mock.calls[0];
+  expect(call[0]).toBe("C:/win/pwsh.exe"); // shellOverride from config wins
+});
+
+test("create uses resolveShell (darwin default /bin/zsh) when no override", () => {
+  const { svc, spawn } = setup(); // darwin, no shell override, no SHELL guaranteed? force it
+  const prev = process.env.SHELL;
+  delete process.env.SHELL;
+  svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  const call = (spawn as ReturnType<typeof mock>).mock.calls[0];
+  expect(call[0]).toBe("/bin/zsh");
+  if (prev !== undefined) process.env.SHELL = prev;
+});
+```
+
+> 说明:win32 用例用 `shell` 覆盖让 spawn 收到的 file 确定(不依赖测试宿主 PATH);shell 选择的分支逻辑已由 Task 1 的 resolveShell 单测覆盖。darwin 用例临时删 `process.env.SHELL` 以断言默认 `/bin/zsh`。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts`
+Expected: FAIL — win32 仍 throw(旧 create 未改)、`setup` 传的 `shell` 未被消费。
+
+- [ ] **Step 3: 改 config 类型**
+
+`src/config/types.ts` 的 `TerminalConfig`(:50)加字段:
+
+```ts
+export interface TerminalConfig {
+  /** Default false. When false, control.terminal.create is rejected before any PTY spawns. */
+  enabled: boolean;
+  /** Idle seconds before a terminal PTY is auto-killed. Defaults to 900 (15 min). */
+  idleTimeoutSeconds?: number;
+  /** Explicit shell override (absolute path or bare name). Cross-platform: wins over SHELL / platform default. */
+  shell?: string;
+}
+```
+
+在 `terminalIdleTimeoutSeconds` 之后加访问器:
+
+```ts
+export function terminalShell(config: AppConfig): string | undefined {
+  const v = config.terminal?.shell;
+  return typeof v === "string" && v.trim() ? v : undefined;
+}
+```
+
+- [ ] **Step 4: 改 TerminalService — deps + create**
+
+`src/control/terminal-service.ts`:`TerminalServiceDeps`(:45-53)加 `shell` 回调:
+
+```ts
+export interface TerminalServiceDeps {
+  events: ControlEventBus;
+  idleTimeoutSeconds: () => number;
+  /** Optional explicit shell override from config (terminal.shell). */
+  shell?: () => string | undefined;
+  spawn?: PtySpawn;
+  platform?: NodeJS.Platform;
+  /** Injectable timer primitives; defaults to global setTimeout/clearTimeout. */
+  setTimer?: (fn: () => void, ms: number) => unknown;
+  clearTimer?: (id: unknown) => void;
+}
+```
+
+`create()`（:104-107)删 win32 throw、用 resolveShell:
+
+```ts
+    create({ cwd, cols, rows }) {
+      const shell = resolveShell({ platform, env: process.env, shellOverride: deps.shell?.() });
+      const terminalId = randomUUID();
+      const handle = spawn(shell, [], { name: "xterm-256color", cols, rows, cwd, env: scrubEnv() });
+```
+
+删掉现在已无引用的 `defaultShell` 函数(:67-70)。
+
+- [ ] **Step 5: 布线 main.ts**
+
+`src/main.ts:17` import 加 `terminalShell`:
+
+```ts
+import { terminalEnabled, terminalIdleTimeoutSeconds, terminalShell, filesWriteEnabled } from "./config/types";
+```
+
+`src/main.ts:768-771` 构造加 `shell`:
+
+```ts
+  const terminalService = createTerminalService({
+    events: controlEvents,
+    idleTimeoutSeconds: () => terminalIdleTimeoutSeconds(config),
+    shell: () => terminalShell(config),
+  });
+```
+
+- [ ] **Step 6: 跑测试确认通过 + 类型 + 提交**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts && npx tsc --noEmit`
+Expected: PASS(win32 不再 throw、用解析 shell;darwin 默认 zsh)+ tsc 0 报错。
+
+```bash
+git add src/control/terminal-service.ts src/config/types.ts src/main.ts tests/unit/control/terminal-service.test.ts
+git commit -m "feat(terminal): open win32 gate; thread terminal.shell config into shell selection"
+```
+
+---
+
+### Task 3: 前端 i18n 文案(去掉"仅 mac/Linux"暗示)
+
+后端不再抛 unsupported,前端保留映射作兜底,但文案不该再暗示"仅 mac/Linux"。
+
+**Files:**
+- Modify: `packages/relay-web/src/i18n/messages/en.ts:347`
+- Modify: `packages/relay-web/src/i18n/messages/zh-CN.ts:345`
+- Test: `packages/relay-web/src/__tests__/i18n-parity.test.ts`(既有,验同步)
+
+**Interfaces:**
+- Consumes/Produces:无代码接口变化,仅文案键值。
+
+- [ ] **Step 1: 改文案**
+
+`packages/relay-web/src/i18n/messages/en.ts` 的 `terminal.unsupported`:
+
+```ts
+    unsupported: "Terminal is not supported on this instance platform.",
+```
+
+`packages/relay-web/src/i18n/messages/zh-CN.ts` 的 `terminal.unsupported`:
+
+```ts
+    unsupported: "该实例平台不支持终端。",
+```
+
+- [ ] **Step 2: 跑 i18n parity + 类型**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/i18n-parity.test.ts && npx vue-tsc --noEmit`
+Expected: PASS(en/zh 键仍同步)+ vue-tsc 0 报错。
+（注意:持久盘 shell cwd 在 `cd 仓库根 && git…` 后会漂回根,跑 vitest/vue-tsc 前先 `cd /Users/maijiazhen/Projects/workspace-a/packages/relay-web`。)
+
+- [ ] **Step 3: 提交**
+
+```bash
+cd /Users/maijiazhen/Projects/workspace-a
+git add packages/relay-web/src/i18n/messages/en.ts packages/relay-web/src/i18n/messages/zh-CN.ts
+git commit -m "i18n(relay-web): terminal.unsupported no longer implies macOS/Linux-only"
+```
+
+---
+
+### Task 4: 真 ConPTY / PTY smoke 测试
+
+新建一个用**真** node-pty spawn 的 smoke,验证终端在真实平台上能起 shell、字节流往返、退出。放在 `tests/smoke/`(默认不入 `npm test`),Windows CI leg 显式调用;在 macOS/Linux 上跑也应通过(真 PTY)。
+
+**Files:**
+- Create: `tests/smoke/terminal-pty-smoke.test.ts`
+
+**Interfaces:**
+- Consumes:`createTerminalService`(Task 1+2 后 create 跨平台可用)、`createControlEventBus`。
+
+- [ ] **Step 1: 写 smoke(先跑,应在本机 macOS 通过)**
+
+Create `tests/smoke/terminal-pty-smoke.test.ts`:
+
+```ts
+// Real-PTY smoke: spawns an actual shell via node-pty (no injected spawn) and asserts the
+// byte stream round-trips. NOT run by `npm test` (tests/unit only) — invoked explicitly by
+// the windows-latest CI leg to validate ConPTY, and runnable locally on macOS/Linux.
+import { test, expect } from "bun:test";
+import { createTerminalService } from "../../src/control/terminal-service";
+import { createControlEventBus, type ControlEvent } from "../../src/control/control-event-bus";
+
+const MARKER = "__PTY_SMOKE_OK__";
+
+test("spawns a real shell and round-trips output", async () => {
+  const events = createControlEventBus();
+  let buf = "";
+  events.subscribe((e: ControlEvent) => {
+    if (e.type === "terminal-output") buf += e.data;
+  });
+  const svc = createTerminalService({ events, idleTimeoutSeconds: () => 900 });
+  const { terminalId } = svc.create({ cwd: process.cwd(), cols: 80, rows: 24 });
+
+  // `echo <marker>` prints the marker in pwsh / powershell / cmd / bash / zsh alike.
+  // The trailing CR submits the line.
+  svc.write(terminalId, `echo ${MARKER}\r`);
+
+  const deadline = Date.now() + 15000;
+  while (!buf.includes(MARKER) && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  expect(buf).toContain(MARKER);
+
+  expect(() => svc.close(terminalId)).not.toThrow();
+}, 20000);
+```
+
+- [ ] **Step 2: 本机跑通(macOS 真 PTY)**
+
+Run: `bun test tests/smoke/terminal-pty-smoke.test.ts`
+Expected: PASS(本机 zsh 起来、输出含 `__PTY_SMOKE_OK__`)。若本机因沙箱无法起 PTY,记在报告里(不阻塞——真价值在 Windows CI)。
+
+- [ ] **Step 3: 确认 smoke 不污染默认单测**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts`
+Expected: PASS(smoke 在 tests/smoke,不被此命令收录;确认无跨文件泄漏)。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add tests/smoke/terminal-pty-smoke.test.ts
+git commit -m "test(terminal): real-PTY smoke (ConPTY validation for the windows CI leg)"
+```
+
+---
+
+### Task 5: windows-latest CI leg
+
+在 `.github/workflows/test.yml` 新增 `terminal-windows` job(与既有 `test` 并列),只做聚焦验证。
+
+**Files:**
+- Modify: `.github/workflows/test.yml`
+
+**Interfaces:**
+- Consumes:`tests/unit/control/terminal-service.test.ts`(Task 1+2)、`tests/smoke/terminal-pty-smoke.test.ts`(Task 4)。
+
+- [ ] **Step 1: 加 windows job**
+
+在 `.github/workflows/test.yml` 的 `jobs:` 下、`test:` job **之后**追加(与 `test` 同级缩进):
+
+```yaml
+  terminal-windows:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      # Installs node-pty, resolving its Windows prebuilt binary (ConPTY). A failure here
+      # means the prebuild didn't resolve for this Node ABI on Windows.
+      - name: Install dependencies
+        run: npm ci
+
+      # Focused terminal coverage only — NOT the full unit suite (never run on Windows).
+      - name: Terminal unit tests
+        run: bun test tests/unit/control/terminal-service.test.ts
+
+      # Real ConPTY: spawns a live shell and asserts the byte stream round-trips.
+      - name: Terminal PTY smoke (ConPTY)
+        run: bun test tests/smoke/terminal-pty-smoke.test.ts
+```
+
+- [ ] **Step 2: 校验 workflow YAML**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/test.yml')); print('yaml ok')"`
+Expected: `yaml ok`(语法有效;新增 job 缩进正确)。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: add minimal windows-latest terminal leg (install + terminal tests + ConPTY smoke)"
+```
+
+---
+
+## 收尾(全部任务完成后)
+
+- 核心回归:`bun test tests/unit/control/terminal-service.test.ts` 绿 + `npx tsc --noEmit` 0;relay-web `cd packages/relay-web && npx vitest run src/__tests__/i18n-parity.test.ts` 绿 + `npx vue-tsc --noEmit` 0。
+- windows-latest leg 的真机效果在 PR 的 CI 上首次可见(装依赖 + 终端单测 + ConPTY smoke)。
+- **发布(不在本计划的编码范围,收尾时按 runbook 处理)**:改了 core(`src/`)→ 需发 **core beta**(带 terminal Windows 能力);注意 core 版本耦合——`tests/unit/packages/package-metadata.test.ts` 硬编码版本断言 + `weacpx-compat` shim 的 version/dep 需同步(镜像 root.version)。前端只改 i18n 文案,relay-web 打进 hub → 视需要连带 hub beta。版本号/发布顺序在收尾时定。
+- 实机验收(Windows,hub beta):`terminal.enabled=true` 的 Windows 实例开终端 → 起 pwsh/PowerShell → 输入/输出/resize/退出正常;设 `terminal.shell` 覆盖生效;git-bash 机器 `SHELL=/usr/bin/bash` 不影响(仍起 PowerShell)。

--- a/docs/superpowers/specs/2026-07-05-terminal-windows-support-design.md
+++ b/docs/superpowers/specs/2026-07-05-terminal-windows-support-design.md
@@ -1,0 +1,154 @@
+# 终端 Windows 支持设计
+
+> 状态:待实现。范围:放开内置终端的 Windows 门禁,让 Windows 实例也能开终端。验证靠 hub beta 真机 + 一条最小 windows-latest CI leg。
+
+## 目标
+
+删掉终端的 Windows 主动门禁,使 `process.platform === "win32"` 的实例也能创建/使用内置终端;shell 选择走 pwsh→PowerShell→cmd 回落,并新增跨平台 `terminal.shell` 显式覆盖配置。
+
+## 非目标 / 边界
+
+- 不做终端**内容 replay**(第 3 层,单独立项)。本次只让 Windows 能起终端,行为与现有 macOS/Linux 终端一致(create/write/resize/idle 回收/close/exit)。
+- 不动 connector(`channel-relay`)/ hub(`relay`):它们对终端纯透传,无平台逻辑。
+- 不改前端终端渲染(ghostty-web 是原始字节流、平台无关)。
+- 不跑全量单测于 Windows CI——只跑终端相关 + 装依赖冒烟(理由见"CI"节)。
+
+## 已知底子(锚定,无需再查)
+
+- 门禁是**单点主动 gating**:`src/control/terminal-service.ts:105` 一行 `if (platform === "win32") throw new Error("terminal-unsupported-platform")`,在选 shell / spawn 之前。
+- node-pty `^1.1.0` 自带 Windows 预构建(`prebuilds/win32-{x64,arm64}/pty.node`+`conpty.node`+打包的 `conpty.dll`)。打包对 node-pty 是 `--external`(`package.json:45`),运行时从 `node_modules` require;`npm i` 时 node-pty 的 install 脚本取预构建,正常路径不需本地 MSVC。
+- `node-pty-helper.ts:11` 对 win32 返回 null,`ensureNodePtyHelperExecutable(null)` no-op——已就绪,不改。
+- cwd 链路 Windows 安全:`normalizePath`(`src/util/path.ts:8`)保盘符、`\`→`/`(`C:\x`→`C:/x`),ConPTY 接受正斜杠;终端路径上无 `realpath`/`path.posix` 破坏盘符。
+- xacpx 本身早已跑 Windows(daemon/命名管道 IPC/`taskkill /F`/`.exe` 解析等成熟 win32 分支)——终端是唯一被主动 gate 的能力。
+
+## 架构总览
+
+四个改动单元,解耦:
+
+1. **shell 解析纯函数** `resolveShell(...)`(在 `terminal-service.ts` 内或抽小工具)——可注入 `exists` 谓词,便于在 ubuntu CI 上以 `platform="win32"` 单测。取代现有 `defaultShell()`。
+2. **门禁放开 + 配置串联**:删 win32 throw;`TerminalConfig` 加 `shell?: string`;经 deps 回调把配置串到 `resolveShell`。
+3. **前端**:保留 `terminal-unsupported-platform` 映射作防御兜底(正常路径不再触发),更新 i18n 文案去掉"仅 mac/Linux"暗示。
+4. **windows-latest CI leg**:最小、聚焦——装依赖 + 终端单测 + 真 ConPTY smoke。
+
+## 单元设计
+
+### 单元 1 — shell 解析(`src/control/terminal-service.ts`)
+
+新增纯函数(导出以便单测),取代 `defaultShell()`(现 :67-70):
+
+```ts
+export interface ResolveShellArgs {
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  shellOverride?: string;                 // config terminal.shell(跨平台,最高优先)
+  exists?: (p: string) => boolean;        // 可注入;默认 fs 存在性检查
+}
+
+export function resolveShell(args: ResolveShellArgs): string {
+  const { platform, env, shellOverride } = args;
+  const exists = args.exists ?? defaultExists;
+  // 1. 显式配置覆盖(任何平台)
+  if (shellOverride && shellOverride.trim()) return shellOverride;
+  // 2. 平台默认
+  if (platform === "win32") {
+    // 忽略 SHELL(常被 git-bash 污染成 MSYS 路径,node-pty 按 Windows 路径 spawn 会失败)
+    const pathValue = env.PATH ?? env.Path ?? "";
+    const dirs = pathValue.split(";").filter(Boolean);
+    for (const name of ["pwsh.exe", "powershell.exe"]) {
+      for (const dir of dirs) {
+        const full = `${dir}\\${name}`;
+        if (exists(full)) return full;   // 找到即返回绝对路径(确知存在)
+      }
+    }
+    return env.ComSpec ?? "cmd.exe";     // 最终回落
+  }
+  // unix:行为不变
+  if (env.SHELL) return env.SHELL;
+  return platform === "darwin" ? "/bin/zsh" : "/bin/bash";
+}
+```
+
+`defaultExists`:`(p) => { try { return statSync(p).isFile(); } catch { return false; } }`(win32 分支硬编码 `;` 与 `\\`,不依赖测试宿主的 `path.delimiter`/`path.sep`,故 ubuntu 上注入 `exists` 可完整测 win32 分支)。
+
+**Interfaces**
+- Produces:`resolveShell(args) => string`。
+- Consumes:`fs.statSync`(默认 exists)、注入的 `platform`/`env`/`shellOverride`/`exists`。
+
+### 单元 2 — 门禁放开 + 配置串联
+
+**(a) config 类型 + 访问器**(`src/config/types.ts`):
+- `TerminalConfig`(:50)加:`/** Explicit shell override (path or name). Cross-platform: wins over SHELL / platform default. */ shell?: string;`
+- 新增访问器(镜像 `terminalIdleTimeoutSeconds`):
+```ts
+export function terminalShell(config: AppConfig): string | undefined {
+  const v = config.terminal?.shell;
+  return typeof v === "string" && v.trim() ? v : undefined;
+}
+```
+
+**(b) TerminalService deps**(`terminal-service.ts`):`TerminalServiceDeps` 加可选回调 `shell?: () => string | undefined;`(镜像 `idleTimeoutSeconds: () => number`)。
+
+**(c) create() 放开门禁 + 用解析 shell**(:104-107):
+```ts
+    create({ cwd, cols, rows }) {
+      const shell = resolveShell({ platform, env: process.env, shellOverride: deps.shell?.() });
+      const terminalId = randomUUID();
+      const handle = spawn(shell, [], { name: "xterm-256color", cols, rows, cwd, env: scrubEnv() });
+      ...
+```
+即删掉 `if (platform === "win32") throw ...` 那行,`defaultShell(platform)` 换成 `resolveShell(...)`。其余(session 管理/idle/事件)不变。
+
+**(d) 布线**(`src/main.ts:768`):`createTerminalService({ ... })` 加 `shell: () => terminalShell(config),`,并在 :17 import 加 `terminalShell`。
+
+**(e) control-service 不改**:`createTerminal` 仍传 `{cwd,cols,rows}`;shell 是 TerminalService 经 deps 读的配置,不走 control-service。connector/hub 不改。
+
+**Interfaces**
+- Consumes:`terminalShell(config)`、`resolveShell`。
+- Produces:TerminalService 在所有平台(含 win32)可 create。
+
+### 单元 3 — 前端(`packages/relay-web`)
+
+- **保留** `TerminalTab.vue:270` 的 `"terminal-unsupported-platform" → terminal.unsupported` 映射作防御兜底(后端正常路径不再抛,但保留零风险,防未来再 gate)。**不删**。
+- 更新 i18n 文案去掉"仅 mac/Linux"暗示(`en.ts:347` + `zh-CN.ts:345`,过 `i18n-parity.test.ts`):
+  - en:`terminal.unsupported` → `"Terminal is not supported on this instance platform."`
+  - zh:`"该实例平台不支持终端。"`
+
+### 单元 4 — windows-latest CI leg(`.github/workflows/test.yml`)
+
+在现有单 `test`(ubuntu-latest)job 旁**新增** `terminal-windows` job(`runs-on: windows-latest`),**只做聚焦验证,不跑全量**:
+- checkout → setup Bun → setup Node 24 → `npm ci`(**验 node-pty 预构建在 Windows 解析安装**)。
+- 跑终端单测:`bun test tests/unit/control/terminal-service.test.ts`(纯逻辑,注入 platform/spawn,平台无关,确认改动无回归)。
+- 跑真 ConPTY smoke(单元 5 的 smoke 文件):`bun test tests/smoke/terminal-pty-smoke.test.ts`——在真 Windows 上起真实 shell 验证。
+
+**关键取舍:不在 Windows 上跑 `npm test`(全量单测)**——整套单测从未在 Windows 跑过,会因大量无关既有 Windows 差异红掉、淹没本功能信号。只把"Windows 能装 node-pty + 能起终端 + 终端逻辑无回归"这件事验清。全量回归仍由既有 ubuntu leg 保证。
+
+### 单元 5 — 测试
+
+跑法:核心单测 `bun test tests/unit/control/terminal-service.test.ts`(单文件,勿整目录——整目录 bun test 有状态泄漏假失败)。前端 i18n `cd packages/relay-web && npx vitest run src/__tests__/i18n-parity.test.ts`。
+
+**(a) `resolveShell` 单元**(`tests/unit/control/terminal-service.test.ts` 内新增,注入 platform/env/exists):
+- config `shellOverride` 设了 → 任何平台都返回它(win32 + darwin 各一例)。
+- unix 无覆盖:`env.SHELL` 优先;无 SHELL → darwin `/bin/zsh`、linux `/bin/bash`(**回归既有行为**)。
+- win32 无覆盖:**忽略 `env.SHELL`**(即使 `SHELL=/usr/bin/bash` 也不用它);`exists` 让 `pwsh.exe` 命中 → 返回其绝对路径;pwsh 不在但 `powershell.exe` 在 → 返 powershell;都不在 → `env.ComSpec`;`ComSpec` 也无 → `cmd.exe`。
+- win32 pwsh 优先于 powershell(两者都"存在"时选 pwsh)。
+
+**(b) terminal-service 门禁**(改既有 :85-88 用例):
+- 原"win32 抛 terminal-unsupported-platform"→ 改为"win32 不再抛;create 用解析出的 shell spawn"(注入 spawn 断言收到的 file = 解析结果;注入 platform=win32 + exists)。
+
+**(c) 真 ConPTY smoke**(新建 `tests/smoke/terminal-pty-smoke.test.ts`):
+- 用**真 spawn**(不注入)+ 真 platform 构造 TerminalService,`create({cwd: process.cwd(), cols:80, rows:24})`,write 一条打印命令(如 pwsh `echo __PTY_OK__\r`),收集 `terminal-output` 事件,断言输出含标记,然后 close,断言收到 `terminal-exit`。
+- **平台守卫**:仅在能起真实 PTY 时跑(smoke 目录默认不入 `npm test`);Windows CI leg 显式调它验 ConPTY。非 Windows 上跑也应通过(macOS/Linux 真 PTY),故可作跨平台 PTY 冒烟,但主用途是 Windows leg。用合理超时,避免 CI 卡死。
+
+**(d) i18n parity**:改文案后 en/zh-CN 同步,过 `i18n-parity.test.ts`。
+
+## 错误处理
+
+- shell 解析永不抛:PATH 空/无候选 → 回落 `ComSpec` → `cmd.exe`(始终有值)。
+- node-pty 预构建缺失(极端:Windows 上 install 未取到二进制)→ `spawn` 抛,现有 `create` 无 try/catch 会向上冒泡成 rpc 错误,前端映射为 `terminal.error`(既有兜底文案)——可接受,beta 真机会暴露此类环境问题。
+- `terminal.shell` 配置指向不存在的可执行 → spawn 失败同上冒泡;不做预校验(YAGNI,配置是用户显式行为)。
+
+## 交付与验收
+
+- 后端改动(core):`terminal-service.ts` + `config/types.ts` + `main.ts` + 单测;CI:`test.yml`;前端:`TerminalTab` i18n 文案。
+- **发布**:core 改了 → 需发 core beta(带 terminal Windows 能力)+ relay/channel-relay 视版本耦合(前端只改了 i18n 文案,relay-web 打进 hub)。具体发布顺序/版本耦合按既有 runbook,在计划/发布阶段定,不在本 spec。
+- **验收(hub beta 真机,Windows)**:Windows 实例上 `terminal.enabled=true` → 看板开终端 → 起 pwsh/PowerShell(或配 `terminal.shell` 指定)→ 能输入命令、看输出、resize、退出;设 `terminal.shell` 覆盖生效;git-bash 机器上 `SHELL=/usr/bin/bash` 不影响(仍起 PowerShell)。CI:windows-latest leg 绿(装依赖 + 终端单测 + ConPTY smoke)。

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -344,7 +344,7 @@ export default {
   terminal: {
     title: "Terminal",
     disabled: "Terminal is disabled. Enable `terminal.enabled` in the instance config.",
-    unsupported: "Terminal is unsupported on this instance platform (v1: macOS/Linux only).",
+    unsupported: "Terminal is not supported on this instance platform.",
     offline: "Instance is offline.",
     noSession: "Select a session to open a terminal.",
     restoredHint: "This terminal disconnected on reload.",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -342,7 +342,7 @@ export default {
   terminal: {
     title: "终端",
     disabled: "终端未启用。请在实例 config 中开启 `terminal.enabled`。",
-    unsupported: "该实例平台不支持终端(v1 仅 macOS/Linux)。",
+    unsupported: "该实例平台不支持终端。",
     offline: "实例已离线。",
     noSession: "选择一个会话以打开终端。",
     restoredHint: "终端会话已随刷新断开。",

--- a/scripts/smoke-terminal-conpty.mjs
+++ b/scripts/smoke-terminal-conpty.mjs
@@ -1,0 +1,32 @@
+// Node-runtime PTY/ConPTY smoke — matches production (the Windows daemon runs Node, not Bun,
+// and loads node-pty's native addon at runtime). Spawns a real shell with a FORWARD-SLASH cwd
+// (mirroring the normalized session.cwd the app actually hands to spawn), writes an echo marker,
+// asserts it round-trips, then exits non-zero on failure. Run: `node scripts/smoke-terminal-conpty.mjs`.
+import { spawn } from "node-pty";
+
+const MARKER = "__PTY_SMOKE_OK__";
+
+function pickShell() {
+  if (process.platform === "win32") return process.env.ComSpec ?? "cmd.exe";
+  return process.env.SHELL ?? "/bin/bash";
+}
+
+// Forward-slash cwd mirrors production: workspace cwd is stored normalized (C:/x, not C:\x).
+const cwd = process.cwd().replace(/\\/g, "/");
+const pty = spawn(pickShell(), [], { name: "xterm-256color", cols: 80, rows: 24, cwd });
+let buf = "";
+pty.onData((d) => { buf += d; });
+pty.write(`echo ${MARKER}\r`);
+
+const deadline = Date.now() + 15000;
+while (!buf.includes(MARKER) && Date.now() < deadline) {
+  await new Promise((r) => setTimeout(r, 100));
+}
+try { pty.kill(); } catch { /* already gone */ }
+
+if (!buf.includes(MARKER)) {
+  console.error("PTY smoke FAILED: marker not seen. buffer=", JSON.stringify(buf.slice(0, 500)));
+  process.exit(1);
+}
+console.log("PTY smoke OK (shell + node-pty + forward-slash cwd round-trip)");
+process.exit(0);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -52,6 +52,8 @@ export interface TerminalConfig {
   enabled: boolean;
   /** Idle seconds before a terminal PTY is auto-killed. Defaults to 900 (15 min). */
   idleTimeoutSeconds?: number;
+  /** Explicit shell override (absolute path or bare name). Cross-platform: wins over SHELL / platform default. */
+  shell?: string;
 }
 
 export interface FilesConfig {
@@ -142,6 +144,11 @@ export function terminalEnabled(config: AppConfig): boolean {
 export function terminalIdleTimeoutSeconds(config: AppConfig): number {
   const v = config.terminal?.idleTimeoutSeconds;
   return typeof v === "number" && v > 0 ? v : 900;
+}
+
+export function terminalShell(config: AppConfig): string | undefined {
+  const v = config.terminal?.shell;
+  return typeof v === "string" && v.trim() ? v : undefined;
 }
 
 export function filesWriteEnabled(config: AppConfig): boolean {

--- a/src/control/terminal-service.ts
+++ b/src/control/terminal-service.ts
@@ -46,6 +46,8 @@ export interface TerminalService {
 export interface TerminalServiceDeps {
   events: ControlEventBus;
   idleTimeoutSeconds: () => number;
+  /** Optional explicit shell override from config (terminal.shell). */
+  shell?: () => string | undefined;
   spawn?: PtySpawn;
   platform?: NodeJS.Platform;
   /** Injectable timer primitives; defaults to global setTimeout/clearTimeout. */
@@ -63,11 +65,6 @@ function scrubEnv(): Record<string, string> {
   out.TERM = "xterm-256color";
   out.LANG = out.LANG ?? "en_US.UTF-8";
   return out;
-}
-
-function defaultShell(platform: NodeJS.Platform): string {
-  if (process.env.SHELL) return process.env.SHELL;
-  return platform === "darwin" ? "/bin/zsh" : "/bin/bash";
 }
 
 function defaultExists(p: string): boolean {
@@ -143,9 +140,9 @@ export function createTerminalService(deps: TerminalServiceDeps): TerminalServic
 
   return {
     create({ cwd, cols, rows }) {
-      if (platform === "win32") throw new Error("terminal-unsupported-platform");
+      const shell = resolveShell({ platform, env: process.env, shellOverride: deps.shell?.() });
       const terminalId = randomUUID();
-      const handle = spawn(defaultShell(platform), [], { name: "xterm-256color", cols, rows, cwd, env: scrubEnv() });
+      const handle = spawn(shell, [], { name: "xterm-256color", cols, rows, cwd, env: scrubEnv() });
       const session: Session = { handle, seq: 0, idleTimer: null };
       sessions.set(terminalId, session);
       handle.onData((data) => {

--- a/src/control/terminal-service.ts
+++ b/src/control/terminal-service.ts
@@ -97,7 +97,8 @@ export function resolveShell(args: ResolveShellArgs): string {
     const dirs = pathValue.split(";").filter(Boolean);
     for (const name of ["pwsh.exe", "powershell.exe"]) {
       for (const dir of dirs) {
-        const full = `${dir}\\${name}`;
+        const clean = dir.replace(/^"|"$/g, "");
+        const full = `${clean}\\${name}`;
         if (exists(full)) return full;
       }
     }

--- a/src/control/terminal-service.ts
+++ b/src/control/terminal-service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
+import { statSync } from "node:fs";
 import { spawn as spawnPty } from "node-pty";
 import { resolveNodePtyHelperPath, ensureNodePtyHelperExecutable } from "../transport/acpx-cli/node-pty-helper";
 import type { ControlEventBus } from "./control-event-bus";
@@ -66,6 +67,46 @@ function scrubEnv(): Record<string, string> {
 
 function defaultShell(platform: NodeJS.Platform): string {
   if (process.env.SHELL) return process.env.SHELL;
+  return platform === "darwin" ? "/bin/zsh" : "/bin/bash";
+}
+
+function defaultExists(p: string): boolean {
+  try {
+    return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export interface ResolveShellArgs {
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  /** Explicit override from config terminal.shell — wins on every platform. */
+  shellOverride?: string;
+  /** Injectable executable-existence predicate (defaults to fs statSync). */
+  exists?: (p: string) => boolean;
+}
+
+/** Pick the shell to spawn. Priority: explicit override -> platform default.
+ *  win32 deliberately ignores SHELL (git-bash sets it to an MSYS path that
+ *  node-pty can't spawn on Windows) and scans PATH for pwsh -> powershell,
+ *  falling back to %ComSpec% (cmd.exe). Never throws — always returns a value. */
+export function resolveShell(args: ResolveShellArgs): string {
+  const { platform, env, shellOverride } = args;
+  const exists = args.exists ?? defaultExists;
+  if (shellOverride && shellOverride.trim()) return shellOverride;
+  if (platform === "win32") {
+    const pathValue = env.PATH ?? env.Path ?? "";
+    const dirs = pathValue.split(";").filter(Boolean);
+    for (const name of ["pwsh.exe", "powershell.exe"]) {
+      for (const dir of dirs) {
+        const full = `${dir}\\${name}`;
+        if (exists(full)) return full;
+      }
+    }
+    return env.ComSpec ?? "cmd.exe";
+  }
+  if (env.SHELL) return env.SHELL;
   return platform === "darwin" ? "/bin/zsh" : "/bin/bash";
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import { resolveAcpxCommand } from "./config/resolve-acpx-command";
 import { resolveRuntimeAgentCommand } from "./config/resolve-agent-command";
 import { ConsoleAgent } from "./console-agent";
 import type { AppConfig, LoggingLevel } from "./config/types";
-import { terminalEnabled, terminalIdleTimeoutSeconds, filesWriteEnabled } from "./config/types";
+import { terminalEnabled, terminalIdleTimeoutSeconds, terminalShell, filesWriteEnabled } from "./config/types";
 import { createAppLogger, type AppLogger } from "./logging/app-logger";
 import { resolveDaemonOrchestrationSocketPath, resolveRuntimeDirFromConfigPath } from "./daemon/daemon-files";
 import type { OrchestrationTaskRecord } from "./orchestration/orchestration-types";
@@ -768,6 +768,7 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
   const terminalService = createTerminalService({
     events: controlEvents,
     idleTimeoutSeconds: () => terminalIdleTimeoutSeconds(config),
+    shell: () => terminalShell(config),
   });
   const uploadStore = new UploadStore();
   void uploadStore.cleanup(); // best-effort startup sweep of expired uploads

--- a/tests/smoke/terminal-pty-smoke.test.ts
+++ b/tests/smoke/terminal-pty-smoke.test.ts
@@ -14,7 +14,7 @@ test("spawns a real shell and round-trips output", async () => {
     if (e.type === "terminal-output") buf += e.data;
   });
   const svc = createTerminalService({ events, idleTimeoutSeconds: () => 900 });
-  const { terminalId } = svc.create({ cwd: process.cwd(), cols: 80, rows: 24 });
+  const { terminalId } = svc.create({ cwd: process.cwd().replace(/\\/g, "/"), cols: 80, rows: 24 });
 
   // `echo <marker>` prints the marker in pwsh / powershell / cmd / bash / zsh alike.
   // The trailing CR submits the line.

--- a/tests/smoke/terminal-pty-smoke.test.ts
+++ b/tests/smoke/terminal-pty-smoke.test.ts
@@ -1,0 +1,30 @@
+// Real-PTY smoke: spawns an actual shell via node-pty (no injected spawn) and asserts the
+// byte stream round-trips. NOT run by `npm test` (tests/unit only) — invoked explicitly by
+// the windows-latest CI leg to validate ConPTY, and runnable locally on macOS/Linux.
+import { test, expect } from "bun:test";
+import { createTerminalService } from "../../src/control/terminal-service";
+import { createControlEventBus, type ControlEvent } from "../../src/control/control-event-bus";
+
+const MARKER = "__PTY_SMOKE_OK__";
+
+test("spawns a real shell and round-trips output", async () => {
+  const events = createControlEventBus();
+  let buf = "";
+  events.subscribe((e: ControlEvent) => {
+    if (e.type === "terminal-output") buf += e.data;
+  });
+  const svc = createTerminalService({ events, idleTimeoutSeconds: () => 900 });
+  const { terminalId } = svc.create({ cwd: process.cwd(), cols: 80, rows: 24 });
+
+  // `echo <marker>` prints the marker in pwsh / powershell / cmd / bash / zsh alike.
+  // The trailing CR submits the line.
+  svc.write(terminalId, `echo ${MARKER}\r`);
+
+  const deadline = Date.now() + 15000;
+  while (!buf.includes(MARKER) && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  expect(buf).toContain(MARKER);
+
+  expect(() => svc.close(terminalId)).not.toThrow();
+}, 20000);

--- a/tests/unit/control/terminal-service.test.ts
+++ b/tests/unit/control/terminal-service.test.ts
@@ -263,3 +263,9 @@ test("resolveShell: win32 prefers pwsh over powershell when both exist", () => {
   const bothExist = (p: string) => p === "C:\\B\\pwsh.exe" || p === "C:\\A\\powershell.exe";
   expect(resolveShell({ platform: "win32", env, exists: bothExist })).toBe("C:\\B\\pwsh.exe");
 });
+
+test("resolveShell: win32 strips surrounding quotes from PATH entries", () => {
+  const env = { PATH: "\"C:\\PS7\";C:\\Windows\\System32" };
+  const exists = (p: string) => p === "C:\\PS7\\pwsh.exe"; // unquoted form
+  expect(resolveShell({ platform: "win32", env, exists })).toBe("C:\\PS7\\pwsh.exe");
+});

--- a/tests/unit/control/terminal-service.test.ts
+++ b/tests/unit/control/terminal-service.test.ts
@@ -18,7 +18,7 @@ function fakePty() {
   return handle;
 }
 
-function setup(opts?: { idle?: number; platform?: NodeJS.Platform }) {
+function setup(opts?: { idle?: number; platform?: NodeJS.Platform; shell?: () => string | undefined }) {
   const events = createControlEventBus();
   const captured: ControlEvent[] = [];
   events.subscribe((e) => captured.push(e));
@@ -29,6 +29,7 @@ function setup(opts?: { idle?: number; platform?: NodeJS.Platform }) {
     idleTimeoutSeconds: () => opts?.idle ?? 900,
     spawn: spawn as never,
     platform: opts?.platform ?? "darwin",
+    shell: opts?.shell,
   });
   return { svc, pty, spawn, captured };
 }
@@ -82,9 +83,21 @@ test("write/resize/close on an unknown terminalId are no-ops (no throw)", () => 
   expect(() => svc.close("nope")).not.toThrow();
 });
 
-test("create throws terminal-unsupported-platform on win32", () => {
-  const { svc } = setup({ platform: "win32" });
-  expect(() => svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 })).toThrow("terminal-unsupported-platform");
+test("create no longer throws on win32 and spawns the resolved shell", () => {
+  const { svc, spawn } = setup({ platform: "win32", shell: () => "C:/win/pwsh.exe" });
+  expect(() => svc.create({ cwd: "C:/ws", cols: 80, rows: 24 })).not.toThrow();
+  const call = (spawn as ReturnType<typeof mock>).mock.calls[0];
+  expect(call[0]).toBe("C:/win/pwsh.exe"); // shellOverride from config wins
+});
+
+test("create uses resolveShell (darwin default /bin/zsh) when no override", () => {
+  const { svc, spawn } = setup(); // darwin, no shell override, no SHELL guaranteed? force it
+  const prev = process.env.SHELL;
+  delete process.env.SHELL;
+  svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  const call = (spawn as ReturnType<typeof mock>).mock.calls[0];
+  expect(call[0]).toBe("/bin/zsh");
+  if (prev !== undefined) process.env.SHELL = prev;
 });
 
 // ── Idle timer behavior (Fix 1) ──────────────────────────────────────────────

--- a/tests/unit/control/terminal-service.test.ts
+++ b/tests/unit/control/terminal-service.test.ts
@@ -1,6 +1,6 @@
 // tests/unit/control/terminal-service.test.ts
 import { test, expect, mock } from "bun:test";
-import { createTerminalService, type PtyHandle } from "../../../src/control/terminal-service";
+import { createTerminalService, resolveShell, type PtyHandle } from "../../../src/control/terminal-service";
 import { createControlEventBus, type ControlEvent } from "../../../src/control/control-event-bus";
 
 function fakePty() {
@@ -211,4 +211,42 @@ test("disposeAll clears timers and kills all PTYs without throwing", () => {
   // Idle timer must be cleared (no stale fire after dispose).
   expect(hasPending()).toBe(false);
   expect((pty.kill as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+});
+
+// ── resolveShell ─────────────────────────────────────────────────────────────
+const noExist = () => false;
+
+test("resolveShell: explicit shellOverride wins on any platform", () => {
+  expect(resolveShell({ platform: "win32", env: {}, shellOverride: "C:/tools/nu.exe", exists: noExist })).toBe("C:/tools/nu.exe");
+  expect(resolveShell({ platform: "darwin", env: { SHELL: "/bin/zsh" }, shellOverride: "/bin/fish" })).toBe("/bin/fish");
+  // blank override is ignored (falls through to platform default)
+  expect(resolveShell({ platform: "linux", env: { SHELL: "/bin/bash" }, shellOverride: "   " })).toBe("/bin/bash");
+});
+
+test("resolveShell: unix honors SHELL then falls to zsh(darwin)/bash(other) — unchanged", () => {
+  expect(resolveShell({ platform: "darwin", env: { SHELL: "/opt/homebrew/bin/fish" } })).toBe("/opt/homebrew/bin/fish");
+  expect(resolveShell({ platform: "darwin", env: {} })).toBe("/bin/zsh");
+  expect(resolveShell({ platform: "linux", env: {} })).toBe("/bin/bash");
+});
+
+test("resolveShell: win32 IGNORES SHELL and scans PATH pwsh -> powershell -> ComSpec -> cmd", () => {
+  const PATH = "C:\\Windows\\System32;C:\\PS7";
+  // SHELL set to an MSYS path (git-bash) must be ignored on win32
+  const env = { SHELL: "/usr/bin/bash", PATH, ComSpec: "C:\\Windows\\System32\\cmd.exe" };
+  // pwsh present anywhere in PATH wins
+  const pwshExists = (p: string) => p === "C:\\PS7\\pwsh.exe";
+  expect(resolveShell({ platform: "win32", env, exists: pwshExists })).toBe("C:\\PS7\\pwsh.exe");
+  // no pwsh, powershell present in System32
+  const psExists = (p: string) => p === "C:\\Windows\\System32\\powershell.exe";
+  expect(resolveShell({ platform: "win32", env, exists: psExists })).toBe("C:\\Windows\\System32\\powershell.exe");
+  // neither present -> ComSpec
+  expect(resolveShell({ platform: "win32", env, exists: noExist })).toBe("C:\\Windows\\System32\\cmd.exe");
+  // neither present and no ComSpec -> literal cmd.exe
+  expect(resolveShell({ platform: "win32", env: { PATH }, exists: noExist })).toBe("cmd.exe");
+});
+
+test("resolveShell: win32 prefers pwsh over powershell when both exist", () => {
+  const env = { PATH: "C:\\A;C:\\B" };
+  const bothExist = (p: string) => p === "C:\\B\\pwsh.exe" || p === "C:\\A\\powershell.exe";
+  expect(resolveShell({ platform: "win32", env, exists: bothExist })).toBe("C:\\B\\pwsh.exe");
 });


### PR DESCRIPTION
## What

放开内置终端的 Windows 门禁,使 win32 实例也能开终端。终端行为与现有 macOS/Linux 一致(create/write/resize/idle 回收/close/exit)。

- **shell 选择** `resolveShell`(纯函数,可注入 exists):`terminal.shell` 配置(跨平台最高优先)→ unix `SHELL`/zsh/bash(不变)→ **win32 忽略 SHELL**(避 git-bash 污染)、扫 PATH `pwsh.exe`→`powershell.exe`→`%ComSpec%`→`cmd.exe`(去 PATH 项两端引号)。
- **门禁** 删 `terminal-service.ts` 的 win32 throw;新增跨平台 `terminal.shell` 配置 + `terminalShell()` 访问器,经 deps 回调串入。control-service/connector/hub **不改**。
- **前端** 保留 `terminal-unsupported-platform` 映射作兜底,i18n 文案去掉"仅 mac/Linux"暗示。
- **CI** 新增最小 `windows-latest` leg:`npm ci`(验 node-pty Windows 预构建)+ `node scripts/smoke-terminal-conpty.mjs`(在**生产 runtime Node** 下真 ConPTY spawn、正斜杠 cwd、marker 往返)。**不跑全量**(从未在 Windows 跑过)。

node-pty ^1.1.0 自带 Windows 预构建(ConPTY,`--external` 运行时加载);cwd 链路 Windows 安全(normalizePath 保盘符、`\`→`/`)。

## Validation strategy

Windows 真机验证靠 core beta;这条 windows-latest CI leg 给**首个真 Windows/ConPTY 信号**(在 Node 下,匹配生产)。

## Review

- 5 任务逐门禁:全 spec ✅ + Approved
- 最终全分支(opus):Ready=YES,0/0
- 独立 fresh-eyes(opus):Ship-with-fixes → 2 Important(CI leg 测错 runtime、smoke 反斜杠 cwd)已修 106e400,re-review 确认

## Test

core 单测 18 绿、本机 node smoke "PTY smoke OK"、tsc 0、i18n parity、js-yaml。

spec: `docs/superpowers/specs/2026-07-05-terminal-windows-support-design.md`
plan: `docs/superpowers/plans/2026-07-05-terminal-windows-support.md`