### PR TITLE
feat(terminal): content replay — restore scrollback & reconnect the live shell on reload

### DIFF
--- a/docs/superpowers/plans/2026-07-05-terminal-content-replay.md
+++ b/docs/superpowers/plans/2026-07-05-terminal-content-replay.md
@@ -1,0 +1,785 @@
+# 终端内容 replay(第 3 层)Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** web 刷新后恢复终端 scrollback 并接回同一 live shell(不再新开空 shell)。
+
+**Architecture:** 后端给每个 PTY 加 256KB 输出 ring buffer;新增点对点 RPC `control.terminal.attach` 返回 `{buffer,lastSeq}`;前端持久化 terminalId,刷新挂载时先 attach(灌 buffer + 订阅 live + 按 lastSeq 去重),attach 不到才回落"启动新终端"占位;杀 PTY 从"刷新卸载"移到"显式关闭"。四包:relay-protocol / core / channel-relay / relay-web。
+
+**Tech Stack:** TypeScript;bun:test(core/connector 单测)、Vitest(relay-web,jsdom)、node-pty、ghostty-web。
+
+## Global Constraints
+
+- 四包改动:relay-protocol(RPC 名+类型)、core `src/control`(ring buffer + attach + 门面)、channel-relay(转发 case)、relay-web(持久化 + attach 流 + 生命周期)。**hub 预期零改动**(attach 走 create 同款 RPC 转发路径)。
+- ring buffer 上限 **256KB/终端**,超限从**最旧 `\n` 行边界**裁剪(避免切断 ANSI 转义序列);单行超限退化按字节硬裁。
+- `attach` 返回 `TerminalAttachResult = { ok: false } | { ok: true; buffer: string; lastSeq: number }`;`lastSeq = seq - 1`(seq 是"下一个要发"计数;从未 emit 时为 -1)。
+- `seq` 做去重:attach 快照返回 lastSeq,客户端丢弃 `seq ≤ lastSeq` 的 live 事件;attach handoff 顺序=订阅→排队→attach 返回后灌 buffer→冲 pending(seq>lastSeq)→转直写。
+- PTY 死亡时机:**仅显式关闭(close 按钮 / center-tabs 关终端 tab / 剪枝 dead session)+ idle 超时**;刷新卸载**不杀**。
+- terminalId 持久化:sessionStorage `xacpx.terminal-ids.v1`,按 `sessionKey`(`instanceId::alias`)。read/write try/catch,写失败静默。
+- core 单测:`bun test tests/unit/control/<file>.test.ts`(**单文件,勿整目录**);`npx tsc --noEmit` 0 报错。
+- relay-web 测试:`cd packages/relay-web && npx vitest run <file>`(**绝不 bun test**);`npx vue-tsc --noEmit` 0 报错。shell cwd 在 `cd 仓库根 && git…` 后漂回根,跑前先重新 `cd packages/relay-web`。
+- relay-protocol 用 **tsc** 构建 dist(`export *` 桶被 bun tree-shake 成空);改协议后重建 dist + `assert:relay-protocol` 验运行时导出非空。
+- 连接器(channel-relay)改动上真机要重打包 + 重装插件目录 + 重启 console(沙箱旧 tarball 坑)——本计划只保证单测;端到端在发布阶段验。
+- 不改 output 广播路由、不改 input/resize/close 通道、不改 idle 策略。
+
+---
+
+### Task 1: 协议 — `terminalAttach` RPC + 类型
+
+**Files:**
+- Modify: `packages/relay-protocol/src/messages.ts:48-51`(加 `terminalAttach`)
+- Modify: `packages/relay-protocol/src/dtos.ts`(加 `TerminalAttachRequest` / `TerminalAttachResult` + 导出)
+- Test: `packages/relay-protocol` 的既有断言脚本 `assert:relay-protocol`(验运行时导出)
+
+**Interfaces:**
+- Produces:
+  - `MSG.terminalAttach = "control.terminal.attach"`
+  - `TerminalAttachRequest = { terminalId: string }`
+  - `TerminalAttachResult = { ok: false } | { ok: true; buffer: string; lastSeq: number }`
+
+- [ ] **Step 1: 加 MSG 名**
+
+`packages/relay-protocol/src/messages.ts`,在 `terminalClose` 后加:
+
+```ts
+  terminalCreate: "control.terminal.create",
+  terminalAttach: "control.terminal.attach",
+  terminalInput: "instance.terminal.input",
+  terminalResize: "instance.terminal.resize",
+  terminalClose: "instance.terminal.close",
+```
+
+- [ ] **Step 2: 加类型 + 导出**
+
+`packages/relay-protocol/src/dtos.ts`,在终端相关 DTO(`terminal-output`/`terminal-exit` 联合,约 :216-217)附近加导出类型:
+
+```ts
+export interface TerminalAttachRequest {
+  terminalId: string;
+}
+export type TerminalAttachResult =
+  | { ok: false }
+  | { ok: true; buffer: string; lastSeq: number };
+```
+
+确认这些类型经桶文件 `packages/relay-protocol/src/index.ts` 导出(dtos 若已 `export *` 则自动;否则补 `export type`)。
+
+- [ ] **Step 3: 重建 dist + 断言运行时导出**
+
+Run:
+```bash
+cd /Users/maijiazhen/Projects/workspace-a
+bun run build:relay-protocol 2>/dev/null || npx tsc -p packages/relay-protocol/tsconfig.json
+node -e "const m=require('./packages/relay-protocol/dist/index.js'); if(!m.MSG||m.MSG.terminalAttach!=='control.terminal.attach'){console.error('FATAL: terminalAttach missing from dist');process.exit(1)} console.log('MSG.terminalAttach OK:', m.MSG.terminalAttach)"
+```
+Expected: `MSG.terminalAttach OK: control.terminal.attach`(证明桶未被 tree-shake 成空、新 MSG 在 dist)。类型是 erased 的(编译期),运行时只验 MSG 值。
+
+- [ ] **Step 4: 类型检查 + 提交**
+
+```bash
+cd /Users/maijiazhen/Projects/workspace-a
+npx tsc --noEmit
+git add packages/relay-protocol/src/messages.ts packages/relay-protocol/src/dtos.ts packages/relay-protocol/dist
+git commit -m "feat(protocol): terminalAttach RPC name + TerminalAttachRequest/Result types"
+```
+
+> 注:若 dist 是 gitignored(检查 `git check-ignore packages/relay-protocol/dist`),则不 add dist,只 add src;发布阶段会重建。以 `git status` 实际可见为准。
+
+---
+
+### Task 2: core — ring buffer + `attach` + control 门面
+
+**Files:**
+- Modify: `src/control/terminal-service.ts`(Session 加 buffer、onData 累积+裁剪、`attach`、interface)
+- Modify: `src/control/control-service.ts:879-897`(加 `attachTerminal`)
+- Test: `tests/unit/control/terminal-service.test.ts`
+
+**Interfaces:**
+- Consumes:无(core 结构上独立于 relay-protocol;结构匹配 Task 1 的 `TerminalAttachResult`)。
+- Produces:
+  - `TerminalService.attach(terminalId: string): TerminalAttachResult`,`TerminalAttachResult = { ok: false } | { ok: true; buffer: string; lastSeq: number }`(在 terminal-service.ts 导出)
+  - `ControlService.attachTerminal(terminalId: string): TerminalAttachResult`
+
+- [ ] **Step 1: 写失败的测试**
+
+`tests/unit/control/terminal-service.test.ts`,先在 setup 后加一个能读 buffer 的辅助(用既有 `fakePty()` 的 `emitData`),然后追加:
+
+```ts
+test("attach returns ok:false for an unknown terminal", () => {
+  const { svc } = setup();
+  expect(svc.attach("nope")).toEqual({ ok: false });
+});
+
+test("attach returns buffered output + lastSeq for a live terminal", () => {
+  const { svc, pty } = setup();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("hello\n");
+  pty.emitData("world\n");
+  const res = svc.attach(terminalId);
+  expect(res).toEqual({ ok: true, buffer: "hello\nworld\n", lastSeq: 1 }); // seq 0,1 emitted → lastSeq 1
+});
+
+test("attach on a terminal with no output yet returns lastSeq -1", () => {
+  const { svc } = setup();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  expect(svc.attach(terminalId)).toEqual({ ok: true, buffer: "", lastSeq: -1 });
+});
+
+test("attach returns ok:false after close", () => {
+  const { svc, pty } = setup();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("x");
+  pty.emitExit(0); // exit deletes the session
+  expect(svc.attach(terminalId)).toEqual({ ok: false });
+});
+
+test("ring buffer trims oldest whole lines past 256KB (keeps tail, cuts at newline)", () => {
+  const { svc, pty } = setup();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  // 300 lines of ~1KB each ≈ 300KB > 256KB cap
+  for (let i = 0; i < 300; i++) pty.emitData("L" + i + ":" + "x".repeat(1000) + "\n");
+  const res = svc.attach(terminalId);
+  if (!res.ok) throw new Error("expected ok");
+  expect(Buffer.byteLength(res.buffer, "utf8")).toBeLessThanOrEqual(256 * 1024);
+  // oldest lines dropped, newest retained; buffer starts at a line boundary (no partial leading line)
+  expect(res.buffer.startsWith("L")).toBe(true);
+  expect(res.buffer.endsWith("\n")).toBe(true);
+  expect(res.buffer).toContain("L299:");
+  expect(res.buffer).not.toContain("L0:");
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts`
+Expected: FAIL — `svc.attach` 未定义。
+
+- [ ] **Step 3: 改 terminal-service.ts — 类型 + Session + buffer helper**
+
+`TerminalService` interface(:38-44)加 `attach`,并在文件内导出结果类型:
+
+```ts
+export type TerminalAttachResult =
+  | { ok: false }
+  | { ok: true; buffer: string; lastSeq: number };
+
+export interface TerminalService {
+  create(input: TerminalCreateInput): { terminalId: string };
+  attach(terminalId: string): TerminalAttachResult;
+  write(terminalId: string, data: string): void;
+  resize(terminalId: string, cols: number, rows: number): void;
+  close(terminalId: string): void;
+  disposeAll(): void;
+}
+```
+
+`Session` 接口(现 `{ handle, seq, idleTimer }`)加 buffer 字段:
+
+```ts
+interface Session { handle: PtyHandle; seq: number; idleTimer: unknown; buffer: string; bufBytes: number }
+```
+
+在文件内(`createTerminalService` 外或内均可)加 buffer 常量 + 追加 helper:
+
+```ts
+const MAX_BUFFER_BYTES = 256 * 1024;
+
+function appendToBuffer(session: Session, data: string): void {
+  session.buffer += data;
+  session.bufBytes += Buffer.byteLength(data, "utf8");
+  if (session.bufBytes <= MAX_BUFFER_BYTES) return;
+  // Drop oldest WHOLE lines (cut at "\n") to avoid slicing mid-escape-sequence.
+  while (session.bufBytes > MAX_BUFFER_BYTES) {
+    const nl = session.buffer.indexOf("\n");
+    if (nl === -1) break; // single line longer than the cap → hard-cut below
+    const removed = session.buffer.slice(0, nl + 1);
+    session.buffer = session.buffer.slice(nl + 1);
+    session.bufBytes -= Buffer.byteLength(removed, "utf8");
+  }
+  // Degenerate single huge line: hard-cut leading chars until within cap.
+  while (session.bufBytes > MAX_BUFFER_BYTES && session.buffer.length > 0) {
+    const ch = session.buffer[0]!;
+    session.buffer = session.buffer.slice(1);
+    session.bufBytes -= Buffer.byteLength(ch, "utf8");
+  }
+}
+```
+
+- [ ] **Step 4: 改 create()、加 attach()**
+
+`create()` 内:Session 初值加 `buffer: "", bufBytes: 0`;`onData` 回调在 emit **之外**累积:
+
+```ts
+      const session: Session = { handle, seq: 0, idleTimer: null, buffer: "", bufBytes: 0 };
+      sessions.set(terminalId, session);
+      handle.onData((data) => {
+        // NOTE: resetIdle is intentionally NOT called here (output ≠ user interaction).
+        appendToBuffer(session, data);
+        deps.events.emit({ type: "terminal-output", terminalId, seq: session.seq++, data });
+      });
+```
+
+在 `create` 方法后加 `attach`(在返回的对象里,create 之后、write 之前):
+
+```ts
+    attach(terminalId) {
+      const s = sessions.get(terminalId);
+      if (!s) return { ok: false };
+      resetIdle(terminalId); // reattaching counts as activity
+      return { ok: true, buffer: s.buffer, lastSeq: s.seq - 1 };
+    },
+```
+
+- [ ] **Step 5: 跑测试确认通过**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts`
+Expected: PASS(新增 5 用例 + 既有全绿)。
+
+- [ ] **Step 6: control-service `attachTerminal`**
+
+`src/control/control-service.ts`,在 `closeTerminal`(:895)附近加(仿纯转发 + gate),并 import 类型:
+
+```ts
+  attachTerminal(terminalId: string): import("./terminal-service").TerminalAttachResult {
+    if (!this.deps.terminalEnabled()) throw new Error("terminal-disabled");
+    return this.deps.terminal.attach(terminalId);
+  }
+```
+
+（`ControlServiceDeps.terminal` 已是 `TerminalService`,新增的 `attach` 自动可用,无需改 deps 声明。）
+
+- [ ] **Step 7: 类型 + 提交**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts && npx tsc --noEmit`
+Expected: PASS + tsc 0。
+
+```bash
+git add src/control/terminal-service.ts src/control/control-service.ts tests/unit/control/terminal-service.test.ts
+git commit -m "feat(terminal): per-PTY 256KB ring buffer + attach() replay; control.attachTerminal"
+```
+
+---
+
+### Task 3: connector — attach RPC 转发 case
+
+**Files:**
+- Modify: `packages/channel-relay/src/control-bridge.ts`(`dispatchControlRequest` switch,`MSG.terminalCreate` case 后加 `MSG.terminalAttach`)
+- Test: `tests/unit/packages/channel-relay/control-bridge.test.ts`(RPC 测试家所在;用既有 `makeFakeControl`/`dispatch`/`req` 助手)
+
+**Interfaces:**
+- Consumes:`MSG.terminalAttach`(Task 1);`control.attachTerminal(terminalId)`(Task 2)。
+
+> 连接器 RPC 入口是 `createControlBridge(control): ControlBridge`(control-bridge.ts:78);内部 `dispatchControlRequest`(:88)switch 分发。测试用根目录 `tests/unit/packages/channel-relay/control-bridge.test.ts`(bun:test),助手:`req(type,payload)` 造 envelope、`dispatch(bridge, env)` = `new Promise(r => bridge(env, r))` 取响应、`makeFakeControl(overrides)` 造 mock control。`errorPayload` 形如 `{ error: { code, message } }`。
+
+- [ ] **Step 1: 写失败的测试**
+
+在 `tests/unit/packages/channel-relay/control-bridge.test.ts` 末尾追加(复用文件顶部的 `req`/`dispatch`/`makeFakeControl`,`mock` 来自 `bun:test`):
+
+```ts
+test("terminal.attach RPC forwards to attachTerminal and returns its result", async () => {
+  const { control } = makeFakeControl({ attachTerminal: mock((id: string) => ({ ok: true, buffer: "SCROLL", lastSeq: 3 })) });
+  const bridge = createControlBridge(control as never);
+  expect(await dispatch(bridge, req(MSG.terminalAttach, { terminalId: "t1" }))).toEqual({ ok: true, buffer: "SCROLL", lastSeq: 3 });
+  expect((control.attachTerminal as ReturnType<typeof mock>).mock.calls[0]).toEqual(["t1"]);
+});
+
+test("terminal.attach RPC without terminalId returns bad-request", async () => {
+  const { control } = makeFakeControl({ attachTerminal: mock(() => ({ ok: false })) });
+  const bridge = createControlBridge(control as never);
+  expect(await dispatch(bridge, req(MSG.terminalAttach, {}))).toEqual({ error: { code: "bad-request", message: "terminalId is required" } });
+});
+```
+（`mock` 需在顶部 import 里:`import { expect, test, mock } from "bun:test";`——若文件顶部只 import 了 `expect, test`,补上 `mock`。）
+
+- [ ] **Step 2: 跑到失败**
+
+Run: `bun test tests/unit/packages/channel-relay/control-bridge.test.ts`
+Expected: FAIL — `terminalAttach` case 不存在(落到 unknown-type),或 `control.attachTerminal` 未被调。
+
+- [ ] **Step 3: 加 case**
+
+`packages/channel-relay/src/control-bridge.ts` 的 `dispatchControlRequest` switch,在 `case MSG.terminalCreate:` 块后加:
+
+```ts
+    case MSG.terminalAttach: {
+      const input = payload as { terminalId?: string };
+      if (!input.terminalId) return errorPayload("bad-request", "terminalId is required");
+      return control.attachTerminal(input.terminalId);
+    }
+```
+
+- [ ] **Step 4: 跑到通过 + 类型 + 提交**
+
+Run: `bun test tests/unit/packages/channel-relay/control-bridge.test.ts && npx tsc --noEmit`
+Expected: PASS(2 新用例 + 既有全绿)+ tsc 0。
+
+```bash
+git add packages/channel-relay/src/control-bridge.ts tests/unit/packages/channel-relay/control-bridge.test.ts
+git commit -m "feat(connector): forward control.terminal.attach RPC to attachTerminal"
+```
+
+---
+
+### Task 4: relay-web — terminal-sessions lib + store attach + seq 透传
+
+**Files:**
+- Create: `packages/relay-web/src/lib/terminal-sessions.ts`
+- Modify: `packages/relay-web/src/stores/terminal.ts`(加 `attach`;`applyEvent`/`OutputCb` 带 seq)
+- Test: `packages/relay-web/src/__tests__/terminal-sessions.test.ts`(新建)、`terminal-store.test.ts`(扩充)
+
+**Interfaces:**
+- Consumes:`TerminalAttachResult`(Task 1,from `@ganglion/xacpx-relay-protocol`)。
+- Produces:
+  - `terminal-sessions.ts`:`saveTerminalId(sessionKey, id)` / `loadTerminalId(sessionKey): string | null` / `clearTerminalId(sessionKey)`
+  - store:`attach(instanceId, terminalId): Promise<TerminalAttachResult>`;`OutputCb = (terminalId: string, data: string, seq: number) => void`
+
+- [ ] **Step 1: 写失败的测试(terminal-sessions)**
+
+Create `packages/relay-web/src/__tests__/terminal-sessions.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { saveTerminalId, loadTerminalId, clearTerminalId } from "../lib/terminal-sessions";
+
+beforeEach(() => sessionStorage.clear());
+
+describe("terminal-sessions", () => {
+  it("save then load round-trips the id", () => {
+    saveTerminalId("i1::s1", "term-abc");
+    expect(loadTerminalId("i1::s1")).toBe("term-abc");
+  });
+  it("returns null when absent", () => {
+    expect(loadTerminalId("i1::none")).toBeNull();
+  });
+  it("clear removes the id", () => {
+    saveTerminalId("i1::s1", "t");
+    clearTerminalId("i1::s1");
+    expect(loadTerminalId("i1::s1")).toBeNull();
+  });
+  it("tolerates corrupt storage", () => {
+    sessionStorage.setItem("xacpx.terminal-ids.v1", "{bad");
+    expect(loadTerminalId("i1::s1")).toBeNull();
+  });
+  it("swallows setItem quota errors", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => { throw new DOMException("q", "QuotaExceededError"); });
+    expect(() => saveTerminalId("i1::s1", "t")).not.toThrow();
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: 跑到失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/terminal-sessions.test.ts`
+Expected: FAIL — 模块不存在。
+
+- [ ] **Step 3: 实现 terminal-sessions.ts**
+
+Create `packages/relay-web/src/lib/terminal-sessions.ts`(仿 file-drafts):
+
+```ts
+/** Per-session terminal-id persistence. A live PTY survives a browser reload (the backend keeps
+ *  it until idle-timeout); persisting its terminalId lets the reloaded tab re-attach (replay
+ *  scrollback + reconnect) instead of spawning a fresh shell. sessionStorage (tab-scoped) keyed
+ *  by `${instanceId}::${alias}`. */
+const KEY = "xacpx.terminal-ids.v1";
+type Ids = Record<string, string>;
+
+function read(): Ids {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as Ids) : {};
+  } catch {
+    return {};
+  }
+}
+function write(ids: Ids): void {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify(ids));
+  } catch {
+    /* storage full / disabled — best-effort */
+  }
+}
+
+export function saveTerminalId(sessionKey: string, id: string): void {
+  if (!sessionKey || !id) return;
+  const ids = read();
+  ids[sessionKey] = id;
+  write(ids);
+}
+export function loadTerminalId(sessionKey: string): string | null {
+  if (!sessionKey) return null;
+  return read()[sessionKey] ?? null;
+}
+export function clearTerminalId(sessionKey: string): void {
+  if (!sessionKey) return;
+  const ids = read();
+  delete ids[sessionKey];
+  write(ids);
+}
+```
+
+- [ ] **Step 4: 跑到通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/terminal-sessions.test.ts`
+Expected: PASS(5 用例)。
+
+- [ ] **Step 5: 写失败的测试(store attach + seq)**
+
+在 `packages/relay-web/src/__tests__/terminal-store.test.ts` 加(用既有 mock 方式;`api.rpc` 已被 mock):
+
+```ts
+it("attach() calls control.terminal.attach and unwraps the result", async () => {
+  vi.mocked(api.rpc).mockResolvedValueOnce({ ok: true, buffer: "scroll", lastSeq: 7 } as never);
+  const store = useTerminalStore();
+  const res = await store.attach("i1", "term-x");
+  expect(api.rpc).toHaveBeenCalledWith("i1", "control.terminal.attach", { terminalId: "term-x" });
+  expect(res).toEqual({ ok: true, buffer: "scroll", lastSeq: 7 });
+});
+
+it("applyEvent forwards seq to output callbacks", () => {
+  const store = useTerminalStore();
+  const seen: Array<[string, string, number]> = [];
+  store.onOutput((id, data, seq) => seen.push([id, data, seq]));
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-output", terminalId: "t1", seq: 42, data: "hi" } } as never);
+  expect(seen).toEqual([["t1", "hi", 42]]);
+});
+```
+（对齐该文件既有的 import：`api`、`useTerminalStore` 等。）
+
+- [ ] **Step 6: 跑到失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/terminal-store.test.ts`
+Expected: FAIL — `attach` 未定义;`onOutput` 回调没收到 seq。
+
+- [ ] **Step 7: 改 store**
+
+`packages/relay-web/src/stores/terminal.ts`:import 加 `TerminalAttachResult`;`OutputCb` 带 seq;加 `attach`;`applyEvent` 传 seq:
+
+```ts
+import { isErrorPayload, type WebServerEvent, type TerminalAttachResult } from "@ganglion/xacpx-relay-protocol";
+```
+```ts
+type OutputCb = (terminalId: string, data: string, seq: number) => void;
+```
+```ts
+  async function attach(instanceId: string, terminalId: string): Promise<TerminalAttachResult> {
+    const result = await api.rpc<TerminalAttachResult>(instanceId, "control.terminal.attach", { terminalId });
+    return unwrap(result);
+  }
+```
+`applyEvent` 的 terminal-output 分支:
+```ts
+    if (e.type === "terminal-output") {
+      for (const cb of outputCbs) cb(e.terminalId, e.data, e.seq);
+    }
+```
+`return` 里加 `attach`:`return { create, attach, input, resize, close, onOutput, onExit, applyEvent };`
+
+- [ ] **Step 8: 跑到通过 + 类型 + 提交**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/terminal-sessions.test.ts src/__tests__/terminal-store.test.ts && npx vue-tsc --noEmit`
+Expected: PASS + vue-tsc 0。
+（`OutputCb` 从 2 参变 3 参**不会**破坏 TerminalTab 现有的 `onOutput((id, data) => ...)` 回调——TS 允许把少参数函数赋给多参数回调类型。本任务**不**动 TerminalTab.vue,vue-tsc 应直接 0。）
+
+```bash
+cd /Users/maijiazhen/Projects/workspace-a
+git add packages/relay-web/src/lib/terminal-sessions.ts packages/relay-web/src/stores/terminal.ts packages/relay-web/src/__tests__/terminal-sessions.test.ts packages/relay-web/src/__tests__/terminal-store.test.ts
+git commit -m "feat(relay-web): terminal-sessions persistence + store attach() + seq passthrough"
+```
+
+---
+
+### Task 5: relay-web — TerminalTab attach-on-mount + seq 去重 + 生命周期
+
+**Files:**
+- Modify: `packages/relay-web/src/components/TerminalTab.vue`
+- Test: `packages/relay-web/src/__tests__/terminal-tab.test.ts`
+
+**Interfaces:**
+- Consumes:store `attach`/`onOutput(…,seq)`(Task 4);`loadTerminalId`/`saveTerminalId`/`clearTerminalId`(Task 4);`sessionKey` helper from `../stores/center-tabs`。
+
+- [ ] **Step 1: 写失败的测试**
+
+在 `packages/relay-web/src/__tests__/terminal-tab.test.ts`(`beforeEach` 已有 `sessionStorage.clear()`)加。既有 mock:`api.rpc` 返回 `{terminalId:"t1"}`、adapter mock 有 `write`。追加对 attach 的 mock 能力(按需在用例内 `vi.mocked(api.rpc).mockImplementation` 区分 create vs attach):
+
+```ts
+import { saveTerminalId, loadTerminalId } from "../lib/terminal-sessions";
+
+it("on mount with a persisted terminalId, attaches and replays the buffer (no fresh create)", async () => {
+  saveTerminalId("i1::demo", "term-persisted");
+  vi.mocked(api.rpc).mockImplementation(async (_i, method) => {
+    if (method === "control.terminal.attach") return { ok: true, buffer: "PRIOR SCROLLBACK", lastSeq: 5 } as never;
+    return { terminalId: "should-not-create" } as never;
+  });
+  const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+  await tick();
+  expect(api.rpc).toHaveBeenCalledWith("i1", "control.terminal.attach", { terminalId: "term-persisted" });
+  expect(adapter.write).toHaveBeenCalledWith("PRIOR SCROLLBACK"); // scrollback replayed
+  // did NOT create a fresh terminal
+  expect(api.rpc).not.toHaveBeenCalledWith("i1", "control.terminal.create", expect.anything());
+});
+
+it("drops live output with seq <= lastSeq after attach (dedup)", async () => {
+  saveTerminalId("i1::demo", "term-persisted");
+  vi.mocked(api.rpc).mockImplementation(async (_i, method) =>
+    method === "control.terminal.attach" ? ({ ok: true, buffer: "BUF", lastSeq: 5 } as never) : ({} as never));
+  const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+  await tick();
+  adapter.write.mockClear();
+  // deliver live output via the store event path (reuse this file's helper if present, else applyEvent)
+  const store = useTerminalStore();
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-output", terminalId: "term-persisted", seq: 5, data: "DUP" } } as never); // <= lastSeq → dropped
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-output", terminalId: "term-persisted", seq: 6, data: "NEW" } } as never); // > lastSeq → written
+  await tick();
+  expect(adapter.write).not.toHaveBeenCalledWith("DUP");
+  expect(adapter.write).toHaveBeenCalledWith("NEW");
+});
+
+it("attach ok:false clears the id and falls back to the start placeholder", async () => {
+  saveTerminalId("i1::demo", "gone");
+  vi.mocked(api.rpc).mockImplementation(async (_i, method) =>
+    method === "control.terminal.attach" ? ({ ok: false } as never) : ({} as never));
+  const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+  await tick();
+  expect(w.find('[data-test="term-restore"]').exists()).toBe(true); // placeholder
+  expect(loadTerminalId("i1::demo")).toBeNull(); // stale id cleared
+});
+
+it("fresh create persists the terminalId", async () => {
+  vi.mocked(api.rpc).mockResolvedValue({ terminalId: "t-new" } as never);
+  mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: true }, global: globalOpts });
+  await tick();
+  expect(loadTerminalId("i1::demo")).toBe("t-new");
+});
+
+it("unmount (refresh) does NOT close the PTY", async () => {
+  vi.mocked(api.rpc).mockResolvedValue({ terminalId: "t-new" } as never);
+  const sent: unknown[] = [];
+  vi.mocked(sendWebClientMessage).mockImplementation((m) => { sent.push(m); });
+  const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: true }, global: globalOpts });
+  await tick();
+  w.unmount();
+  expect(sent.some((m: any) => m.kind === "terminal-close")).toBe(false); // no close on unmount
+});
+```
+（`globalOpts`/`tick`/`adapter`/`api`/`sendWebClientMessage` 用该文件既有定义;`useTerminalStore` 从 stores 导入。若该文件没有直接 `applyEvent` 的入口,用它既有把 output 送进组件的 helper。)
+
+- [ ] **Step 2: 跑到失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/terminal-tab.test.ts`
+Expected: FAIL — attach 路径不存在、卸载仍发 close。
+
+- [ ] **Step 3: 改 TerminalTab.vue — import + sessionKey + releaseFrontend**
+
+import 区加:
+```ts
+import { sessionKey as makeSessionKey } from "../stores/center-tabs";
+import { loadTerminalId, saveTerminalId, clearTerminalId } from "../lib/terminal-sessions";
+import { computed } from "vue"; // 若已 import computed 则忽略
+```
+加 sessionKey computed(props 之后):
+```ts
+const sessionKey = computed(() => makeSessionKey(props.instanceId, props.sessionAlias));
+```
+把现有 `teardown()` **改名为 `releaseFrontend()` 并移除 PTY close**(关键):
+```ts
+function releaseFrontend() {
+  epoch++;
+  offOutput?.(); offOutput = null;
+  offExit?.(); offExit = null;
+  resizeObs?.disconnect(); resizeObs = null;
+  adapter?.dispose(); adapter = null; terminalId = "";
+  disarmMods();
+}
+```
+把 `start()` 开头的 `teardown()` 调用改成 `releaseFrontend()`;把 `onBeforeUnmount` 里的 `teardown()` 改成 `releaseFrontend()`。（原 teardown 里的 `if (terminalId) terminals.close(...)` 一行**删除**——PTY 不再在卸载时被杀。）
+
+- [ ] **Step 4: 改 TerminalTab.vue — create 持久化 id**
+
+`start()` 成功分支,`terminalId = newId; status.value = "open";` 之后加:
+```ts
+      terminalId = newId;
+      saveTerminalId(sessionKey.value, newId);
+      status.value = "open";
+```
+
+- [ ] **Step 5: 改 TerminalTab.vue — attach-on-mount + handoff 去重**
+
+加 `tryAttach`(放在 `start()` 附近):
+```ts
+async function tryAttach(id: string): Promise<boolean> {
+  if (!host.value) return false;
+  releaseFrontend();
+  const myEpoch = epoch;
+  status.value = "connecting";
+  started = true;
+  terminalId = id;
+  const currentAdapter = createTerminalAdapter(host.value, { cols: 80, rows: 24, onData: handleData, theme: currentTheme() });
+  adapter = currentAdapter;
+  const pending: Array<{ data: string; seq: number }> = [];
+  let queueing = true;
+  let ignoreThroughSeq = -1;
+  offOutput = terminals.onOutput((oid, data, seq) => {
+    if (oid !== terminalId) return;
+    if (queueing) { pending.push({ data, seq }); return; }
+    if (seq <= ignoreThroughSeq) return;
+    adapter?.write(data);
+  });
+  offExit = terminals.onExit((oid, code) => { if (oid === terminalId) { status.value = "exited"; errorKey.value = String(code); } });
+  try {
+    const res = await terminals.attach(props.instanceId, id);
+    if (myEpoch !== epoch) { currentAdapter.dispose(); return true; } // superseded
+    if (!res.ok) { releaseFrontend(); status.value = "idle"; return false; }
+    ignoreThroughSeq = res.lastSeq;
+    currentAdapter.write(res.buffer);            // replay scrollback
+    queueing = false;
+    for (const p of pending) if (p.seq > ignoreThroughSeq) currentAdapter.write(p.data); // flush queued live
+    pending.length = 0;
+    status.value = "open";
+    resizeObs = new ResizeObserver(() => applyFit());
+    if (host.value) resizeObs.observe(host.value);
+    applyFit(myEpoch);
+    return true;
+  } catch {
+    if (myEpoch !== epoch) return true;
+    releaseFrontend(); status.value = "idle";
+    return false;
+  }
+}
+```
+改挂载入口:把 `onMounted` 里的 `if (props.autostart) void start();` 换成 `void mount();`,并加 `mount()`:
+```ts
+async function mount() {
+  const id = loadTerminalId(sessionKey.value);
+  if (id) {
+    const ok = await tryAttach(id);
+    if (ok) return;
+    clearTerminalId(sessionKey.value); // stale PTY → forget, fall through
+  }
+  if (props.autostart) void start();
+  // else: showPlaceholder stays (status idle)
+}
+```
+（prop-watch `watch([instanceId, sessionAlias], () => { if (started) void start(); })` 保持;它只在已 start 的活动终端上因 prop 变化重启,不影响 attach 首挂载。）
+
+- [ ] **Step 6: 跑到通过**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/terminal-tab.test.ts`
+Expected: PASS(5 新用例 + 既有终端用例;既有 autostart/占位用例应仍绿——autostart=true 无持久化 id 时 mount() 走 start())。
+
+- [ ] **Step 7: 相邻回归 + 类型 + 提交**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/terminal-store.test.ts src/__tests__/dashboard-center-tabs.test.ts && npx vue-tsc --noEmit`
+Expected: PASS + vue-tsc 0。
+
+```bash
+cd /Users/maijiazhen/Projects/workspace-a
+git add packages/relay-web/src/components/TerminalTab.vue packages/relay-web/src/__tests__/terminal-tab.test.ts
+git commit -m "feat(relay-web): TerminalTab attaches to a live PTY on reload (replay + seq dedup); no PTY kill on unmount"
+```
+
+---
+
+### Task 6: relay-web — 显式关闭杀 PTY + 清 id(DashboardView)
+
+**Files:**
+- Modify: `packages/relay-web/src/views/DashboardView.vue`(`requestCloseTab` + reconcile prune 的终端处理)
+- Test: `packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts`(或相应 dashboard 测试)
+
+**Interfaces:**
+- Consumes:`terminals.close`(既有 store)、`loadTerminalId`/`clearTerminalId`(Task 4)、`centerTabs.tabsFor`/`clearSession`(既有)。
+
+- [ ] **Step 1: 写失败的测试**
+
+`dashboard-center-tabs.test.ts` 里 TerminalTab 是 stub(`stub-term`),所以 close 要从**中置 tab 条**(未 stub)的关闭控件触发,而非终端 pane 内部。用该文件既有的 `mountDash()`/`selectSession()`/`useCenterTabsStore()`/`flushPromises()`,并对 terminal store 的 `close` 做 spy。追加:
+
+```ts
+// 顶部按需 import:import { saveTerminalId, loadTerminalId } from "../lib/terminal-sessions";
+// import { useTerminalStore } from "../stores/terminal";
+
+test("closing a terminal tab kills its PTY and clears the persisted id", async () => {
+  const wrapper = mountDash();
+  await flushPromises();
+  const key = selectSession();
+  await flushPromises();
+  const centerTabs = useCenterTabsStore();
+  centerTabs.openTerminal(key);
+  saveTerminalId(key, "tid-1");
+  await flushPromises();
+  const terminals = useTerminalStore();
+  const closeSpy = vi.spyOn(terminals, "close");
+
+  // 触发该终端 tab 的关闭:用中置 tab 条上该 tab 的关闭按钮(data-test 见 CenterTabStrip;
+  // 对齐本文件既有触发方式;若文件已有关闭 helper 则复用)。
+  await closeTerminalTabViaStrip(wrapper, key); // 用文件既有/tab 条的关闭控件
+
+  expect(closeSpy).toHaveBeenCalledWith(expect.any(String), "tid-1"); // (instanceId, terminalId)
+  expect(loadTerminalId(key)).toBeNull();
+});
+
+test("closing a FILE tab does not kill any terminal PTY", async () => {
+  // open a file tab, spy terminals.close, close the file tab → close NOT called
+  // (用 centerTabs.openFile + 文件 tab 的关闭控件;断言 closeSpy 未被调)
+});
+```
+
+> `closeTerminalTabViaStrip` 是占位名——实现时用 `CenterTabStrip` 上该 tab 的关闭按钮的真实 `data-test`(读组件确认),或本测试文件既有的 tab 关闭助手,触发 `requestCloseTab(key, "terminal")`。核心断言不变:关终端 tab → `terminals.close(instanceId, "tid-1")` + `loadTerminalId(key)===null`;关文件 tab → `terminals.close` 不被调。
+
+- [ ] **Step 2: 跑到失败**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/dashboard-center-tabs.test.ts`
+Expected: FAIL — 关终端 tab 没杀 PTY / 没清 id。
+
+- [ ] **Step 3: 改 requestCloseTab**
+
+`packages/relay-web/src/views/DashboardView.vue`。确保已有 `const terminals = useTerminalStore()`(没有则 import + 实例化)、import `loadTerminalId, clearTerminalId` from `../lib/terminal-sessions`。改 `requestCloseTab`(:154):
+
+```ts
+function requestCloseTab(key: string, id: string) {
+  // Explicit close of a terminal tab kills its PTY and forgets the id (a refresh does NOT reach here).
+  const tab = centerTabs.tabsFor(key).find((t) => t.id === id);
+  if (tab?.kind === "terminal") {
+    const tid = loadTerminalId(key);
+    if (tid) terminals.close(keyInstance(key), tid);
+    clearTerminalId(key);
+  }
+  centerTabs.closeTabGuarded(key, id, () => window.confirm(t("files.unsavedConfirm")));
+}
+```
+
+- [ ] **Step 4: 改 reconcile 剪枝(dead session 也杀终端 + 清 id)**
+
+在 `reconcileCenterTabs`(约 :170-182,`if (inst?.sessionsLoaded && !valid.has(key)) centerTabs.clearSession(key)` 处),剪枝前对该 session 的终端 tab 杀 PTY + 清 id:
+
+```ts
+    if (inst?.sessionsLoaded && !valid.has(key)) {
+      const hasTerminal = centerTabs.tabsFor(key).some((t) => t.kind === "terminal");
+      if (hasTerminal) {
+        const tid = loadTerminalId(key);
+        if (tid) terminals.close(keyInstance(key), tid);
+        clearTerminalId(key);
+      }
+      centerTabs.clearSession(key);
+    }
+```
+
+- [ ] **Step 5: 跑到通过 + 类型 + 提交**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/dashboard-center-tabs.test.ts && npx vue-tsc --noEmit`
+Expected: PASS + vue-tsc 0。
+
+```bash
+cd /Users/maijiazhen/Projects/workspace-a
+git add packages/relay-web/src/views/DashboardView.vue packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+git commit -m "feat(relay-web): kill terminal PTY + clear id on explicit tab close / session prune"
+```
+
+---
+
+## 收尾(全部任务完成后)
+
+- 全量:core `bun test tests/unit/control/terminal-service.test.ts` + `npx tsc --noEmit` 0;relay-web `cd packages/relay-web && npx vitest run`(全绿)+ `npx vue-tsc --noEmit` 0;connector 测试绿;protocol dist 重建 + assert。
+- **端到端(发布/真机阶段)**:连接器重打包 + 重装插件目录 + 重启 console(沙箱旧 tarball 坑);hub 若有 RPC 白名单补 `terminalAttach`(预期无需)。
+- **发布(四包,按 runbook)**:relay-protocol(锁 0.1.x 保 ^0.1.0)→ core → channel-relay → relay(hub)。core 版本耦合:`tests/unit/packages/package-metadata.test.ts` 硬编码版本 + `weacpx-compat` shim 镜像 root.version。`npm install --package-lock-only` 同步 lock。可与已在 main 的 Windows 支持批发 core beta。
+- 实机验收:开终端跑输出 → 硬刷新 → scrollback 恢复且接回同一 shell(跑到一半的进程还在);关 tab → PTY 真被杀(不泄漏);>15min idle 回收后刷新 → attach 不到 → 回落"启动新终端"占位;seq 去重无重复/丢行。

--- a/docs/superpowers/specs/2026-07-05-terminal-content-replay-design.md
+++ b/docs/superpowers/specs/2026-07-05-terminal-content-replay-design.md
@@ -1,0 +1,135 @@
+# 终端内容 replay(第 3 层)设计
+
+> 状态:待实现。四包改动(relay-protocol / core / channel-relay / relay-web)。目标:web 刷新后恢复终端 scrollback 并接回同一个 live shell。
+
+## 目标
+
+浏览器刷新/崩溃重载后,终端 tab 不再新开空 shell,而是:恢复刷新前的 scrollback,并**接回同一个仍在运行的 PTY**(shell 的 cwd、环境、跑到一半的进程都还在)。
+
+## 非目标 / 边界
+
+- 不做客户端保留态的增量续传(客户端 ghostty scrollback 在刷新时清空,无保留态)——attach 一次性回放整段 ring buffer。
+- 不改 output 的广播路由(仍按账号广播 + 前端按 terminalId 过滤);只有 **replay buffer** 走点对点 RPC 响应。
+- 不改 idle 回收策略(仍 900s、只被 write/resize 重置);不新增"web 断连驱动的回收"(跨层管线,YAGNI)。
+- 不做多客户端并发 attach 的特殊处理(v1 单活动客户端假设)。
+
+## 依赖的既有事实(锚定)
+
+- 终端 RPC:`control.terminal.create` 是**点对点 RPC**(有响应);`terminal-input/resize/close` 是 fire-and-forget 的 `web.client` 上行事件。
+- `terminal-output` 事件:`{ type, terminalId, seq, data }`,**按账号广播**(`web-gateway.ts` broadcast),前端 `if(id===terminalId)` 过滤;`seq` 携带但**当前无人消费**(前端 `terminal.ts` 回调丢弃 seq)。
+- `TerminalService.Session = { handle, seq, idleTimer }`——**无输出缓冲**;`onData` emit 即弃;idle 只被 write/resize 重置。
+- 前端 `terminalId` 是 `TerminalTab.vue` 组件局部 `let terminalId`,**不落盘**;`onBeforeUnmount → teardown → terminals.close()` **杀 PTY**(刷新即杀是这里造成的)。
+- 第 1+2 层已落地:恢复的终端 tab `autostart=false` → 显"启动新终端"占位;center-tabs `closeTab`/`clearSession` 是"显式关闭"信号(已用于清文件草稿)。
+- relay-protocol 用 **tsc**(非 bun)构建 dist(`export *` 桶文件会被 bun tree-shake 成空)。
+
+## 架构总览
+
+新增一条点对点 RPC `control.terminal.attach`,配后端 per-PTY ring buffer。刷新恢复路径:
+
+```
+web 刷新 → TerminalTab 挂载 → 有持久化 terminalId?
+  是 → store.attach(instanceId, id) → RPC control.terminal.attach {terminalId}
+        → connector control-bridge(新 case) → control.attachTerminal(id)
+        → TerminalService.attach(id):
+             PTY 活 → { ok:true, buffer, lastSeq }（并 resetIdle）
+             PTY 无 → { ok:false }
+      ← 点对点 RPC 响应回发起 tab
+      ok  → 灌 buffer 进 ghostty + 订阅 live(丢弃 seq≤lastSeq)+ 进 open
+      !ok → clearTerminalId + 回落第 1+2 层占位
+  否 → 现状(autostart→create / 非 autostart→占位)
+```
+
+`seq` 的用途:解决 attach 快照与 live 订阅之间的边界(重叠/遗漏)——attach 返回快照时的 `lastSeq`,客户端丢弃 seq≤lastSeq 的 live 事件去重。
+
+## 单元设计
+
+### 单元 1 — 后端 ring buffer + attach(`src/control/terminal-service.ts`)
+
+- `Session` 加缓冲:`{ handle, seq, idleTimer, buffer: string, bufBytes: number }`。
+- `onData` 回调:在既有 `events.emit(...)` **之外**,`session.buffer += data; session.bufBytes += byteLen(data)`;若 `bufBytes > 256*1024`,从 buffer **最旧的 `\n` 行边界**起裁剪直到 ≤256KB(按行边界裁,避免从半截 ANSI 转义序列中间切开导致回放渲染错乱;若单行本身超限则退化为按字节硬裁)。`seq` 自增逻辑不变。
+- `TerminalService` interface 加:`attach(terminalId: string): TerminalAttachResult`。
+- `attach` 实现:`const s = sessions.get(terminalId); if (!s) return { ok: false }; resetIdle(terminalId); return { ok: true, buffer: s.buffer, lastSeq: s.seq - 1 }`（`seq` 是"下一个要发的"计数,已发出的最后一个是 `seq-1`;若从未 emit 过则 lastSeq 可为 -1,客户端不丢任何 live 事件——正确)。
+- `close`/`disposeAll`/idle 回收:**不变**(显式关闭 + daemon 关停 + idle 超时仍杀;后端无"刷新即杀")。session 删除时 buffer 随之释放。
+
+**类型**:`TerminalAttachResult = { ok: false } | { ok: true; buffer: string; lastSeq: number }`(在 protocol 定义,core 复用或结构对齐)。
+
+### 单元 2 — control 门面(`src/control/control-service.ts`)
+
+- 加 `attachTerminal(terminalId: string): TerminalAttachResult`:仿 `writeTerminal` 那批纯转发——`if (!this.deps.terminalEnabled()) throw new Error("terminal-disabled"); return this.deps.terminal.attach(terminalId);`。不做 session 解析(attach 只认 terminalId)。
+- `ControlServiceDeps.terminal` 类型加 `attach`。
+
+### 单元 3 — 协议(`packages/relay-protocol/src/`)
+
+- `messages.ts`:`MSG` 加 `terminalAttach: "control.terminal.attach"`。
+- 新类型:`TerminalAttachRequest = { terminalId: string }`;`TerminalAttachResult = { ok: false } | { ok: true; buffer: string; lastSeq: number }`。放在终端相关 DTO 处并从桶文件导出。
+- **构建**:改完 `bun run` 相关 relay-protocol 的 tsc 构建、重生成 dist,`assert:relay-protocol` 验运行时导出非空(桶空导出坑)。
+
+### 单元 4 — 连接器(`packages/channel-relay/src/control-bridge.ts`)
+
+- `handleControlRpc` 的 switch(create case 附近)加 `case MSG.terminalAttach:`——校验 `terminalId` 为字符串 → `await control.attachTerminal(terminalId)` → 返回结果对象(走 create 同款点对点 RPC 响应)。
+- input/resize/close 下行通道、terminal-output 上行广播:**不动**。
+- **沙箱连接器坑**:连接器改动要重打包 + 重装插件目录 + 重启 console 才生效(否则改了 dist 不生效——native tab/定时派发都踩过)。
+
+### 单元 5 — hub(`packages/relay`)
+
+- attach 走既有 create 的 RPC 转发路径,**预期零改动**;若存在按 message 名的显式 RPC 白名单/路由表,补 `terminalAttach` 一条。web→hub 用现成 RPC 通道则 `web-inbound` 无需加 case。实现时对照 create 的端到端路径确认 attach 能发/能收/能回。
+
+### 单元 6 — 前端 store(`packages/relay-web/src/stores/terminal.ts`)
+
+- 加 `attach(instanceId, terminalId): Promise<TerminalAttachResult>` → `api.rpc(instanceId, "control.terminal.attach", { terminalId })`。
+- `applyEvent` 的 `terminal-output` 分支**接住 seq**:`onOutput` 回调签名 `(terminalId, data)` → `(terminalId, data, seq)`;`applyEvent` 传入 `event.seq`。`onExit` 不变。
+
+### 单元 7 — 前端持久化(`packages/relay-web/src/lib/terminal-sessions.ts`,新建)
+
+仿 `lib/file-drafts.ts` 结构,sessionStorage `xacpx.terminal-ids.v1`,按 `sessionKey`(`instanceId::alias`)存 `terminalId`:
+- `saveTerminalId(sessionKey: string, id: string): void`
+- `loadTerminalId(sessionKey: string): string | null`
+- `clearTerminalId(sessionKey: string): void`
+- read/write try/catch 兜底,写失败静默(配额)。
+
+### 单元 8 — 前端组件(`packages/relay-web/src/components/TerminalTab.vue` + `DashboardView.vue`)
+
+**挂载决策**(取代当前简单的 autostart 二分):
+1. `loadTerminalId(sessionKey)` 有值 → `await terminals.attach(instanceId, id)`:
+   - `ok` → adapter.write(buffer) 灌 scrollback;订阅 onOutput(**丢弃 seq ≤ lastSeq**);status 直接 open;`started=true`。无缝接回。
+   - `!ok` → `clearTerminalId(sessionKey)` → 走占位(showPlaceholder)。
+2. 无持久化 id 且 `autostart` → 现有 `start()` 新建;create 成功后 `saveTerminalId(sessionKey, terminalId)`。
+3. 无 id 且非 autostart → 占位(现状)。
+
+**seq 去重 + attach handoff 排序(避免乱序/丢事件)**:必须**先订阅 live、再发 attach**——否则快照与订阅之间的 emit 会漏。但订阅早了 live 会在 buffer 灌入前乱序写。正确顺序:
+1. 订阅 `onOutput`,进入**排队模式**:incoming `(id,data,seq)`(id 匹配)先推入本地 `pending[]`,不直接写 adapter。
+2. 发 `terminals.attach(...)`。
+3. attach `ok` 返回后:先 `adapter.write(buffer)` 灌 scrollback;再把 `pending` 里 `seq > lastSeq` 的按序 `adapter.write`(≤lastSeq 的丢弃,已含在 buffer);清空 pending;切**直写模式**(后续 onOutput 直接 write,仍 `if(id===terminalId)` 过滤)。
+4. attach `!ok`:丢弃 pending、注销回调、回落占位。
+
+新建/placeholder-start 路径无 attach、无排队,onOutput 直写(与现状一致)。组件持有一个 `attaching` 标志与 `pending` 数组表达排队模式。
+
+**生命周期(关键改动):**
+- `start()` create 成功 → `saveTerminalId(sessionKey, terminalId)`。
+- **`onBeforeUnmount` / `teardown` 不再杀 PTY**:只做前端资源释放(dispose adapter、注销回调、清 resizeObserver)。**移除** teardown 里的 `terminals.close(terminalId)`。
+- **显式关闭才杀 + 清 id**:
+  - close 按钮 emit `close` → DashboardView 关闭该终端 tab 的路径里,显式 `terminals.close(instanceId, terminalId)` + `clearTerminalId(sessionKey)`。
+  - center-tabs 关终端 tab / `clearSession`(session 被剪)时,像清文件草稿那样,对终端 tab 一并 `terminals.close` + `clearTerminalId`。因 store 无 instanceId/terminalId 上下文,close 的触发点放在 DashboardView 的关闭处理(它有 key→instanceId + 能读持久化 id),而非 center-tabs store 内部。
+- **sessionKey**:给 TerminalTab 传 `:session-key`(DashboardView v-for 的 `key`,与第 1+2 层 FileViewer 一致),或组件用 `instanceId`+`sessionAlias` 自拼。
+
+## 错误处理
+
+- attach RPC 失败/超时 → 当作 `{ok:false}` 处理:清 id、回落占位,不崩、不卡。
+- ring buffer 裁剪:单行超 256KB 的极端 → 退化按字节硬裁(可能顶部一行有渲染瑕疵,可接受)。
+- sessionStorage 读写:try/catch 吞异常,写失败静默降级(功能退化为"不接回",回落占位)。
+- PTY 在 attach 前刚 exit(竞态)→ `sessions.get` 落空 → `{ok:false}` → 占位。正确。
+
+## 测试策略
+
+- **core**(bun,单文件 `bun test tests/unit/control/terminal-service.test.ts`):onData 累积;超 256KB 从最旧 `\n` 裁剪(断言不切转义序列);`attach` 存在返 `{ok,buffer,lastSeq}`+resetIdle、不存在返 `{ok:false}`、close 后返 `{ok:false}`;lastSeq = seq-1 语义(含从未 emit 时 -1)。`control-service` attachTerminal gate + 转发。
+- **protocol**:`terminalAttach` 名/类型;重建 dist + `assert:relay-protocol` 运行时导出非空。
+- **connector**:control-bridge attach RPC case 转发(需 fresh dist;改后重打包重装插件重启)。
+- **relay-web**(`cd packages/relay-web && npx vitest run`,**非 bun**):`terminal-sessions.ts` round-trip/容错/配额;store `attach` + `applyEvent` 接住 seq;TerminalTab 挂载三分支(attach ok 灌 buffer+去重、!ok 回落占位、无 id autostart 新建);生命周期——刷新卸载**不** close、显式关闭才 close+clear（mock `terminals.close` 断言时机);seq 去重(lastSeq=N → live seq≤N 丢、>N 渲染)。mock `ghostty-web`。
+- 类型:core `npx tsc --noEmit`;relay-web `npx vue-tsc --noEmit`。i18n 若增键过 parity。
+
+## 交付与发布
+
+- 四包:relay-protocol(加 RPC)、core(ring buffer + attach + control 门面)、channel-relay(转发 case)、relay-web(持久化 + attach 流 + 生命周期)。
+- 发布顺序(收尾阶段按 runbook):protocol(锁 0.1.x 保 ^0.1.0)→ core → channel-relay → relay(hub)。core 版本耦合:`tests/unit/packages/package-metadata.test.ts` 硬编码版本 + `weacpx-compat` shim 镜像 root.version。`npm install --package-lock-only` 同步 lock。
+- **可与已在 main 的 Windows 支持批在一起发 core beta**(用户已同意批发)。
+- 实机验收:开终端跑输出 → 硬刷新 → scrollback 恢复且**接回同一 shell**(不是空的)、跑到一半的进程还在;关 tab → PTY 真被杀不泄漏;>15min idle 回收后刷新 → attach 不到 → 回落"启动新终端"占位;seq 去重无重复/丢行。

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -279,6 +279,11 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
       if (!input.sessionAlias) return errorPayload("bad-request", "sessionAlias is required");
       return await control.createTerminal(input.chatKey, input.sessionAlias, input.cols ?? 80, input.rows ?? 24);
     }
+    case MSG.terminalAttach: {
+      const input = payload as { terminalId?: string };
+      if (!input.terminalId) return errorPayload("bad-request", "terminalId is required");
+      return control.attachTerminal(input.terminalId);
+    }
     case MSG.upload: {
       const input = payload as UploadPayload;
       if (!input.filename || !input.content || !input.mimeType) {

--- a/packages/relay-protocol/dist/dtos.d.ts
+++ b/packages/relay-protocol/dist/dtos.d.ts
@@ -261,6 +261,16 @@ export type ControlEventDto = {
     sessionAlias: string;
     items: QueueItemDto[];
 };
+export interface TerminalAttachRequest {
+    terminalId: string;
+}
+export type TerminalAttachResult = {
+    ok: false;
+} | {
+    ok: true;
+    buffer: string;
+    lastSeq: number;
+};
 /** One recovered history row (a persisted-shaped message) for a native-session seed. */
 export interface SessionHistoryRowDto {
     direction: "in" | "out";

--- a/packages/relay-protocol/dist/index.js
+++ b/packages/relay-protocol/dist/index.js
@@ -83,6 +83,7 @@ var MSG = {
   sessionModelGet: "control.session.model.get",
   sessionModelSet: "control.session.model.set",
   terminalCreate: "control.terminal.create",
+  terminalAttach: "control.terminal.attach",
   terminalInput: "instance.terminal.input",
   terminalResize: "instance.terminal.resize",
   terminalClose: "instance.terminal.close"

--- a/packages/relay-protocol/dist/messages.d.ts
+++ b/packages/relay-protocol/dist/messages.d.ts
@@ -42,6 +42,7 @@ export declare const MSG: {
     readonly sessionModelGet: "control.session.model.get";
     readonly sessionModelSet: "control.session.model.set";
     readonly terminalCreate: "control.terminal.create";
+    readonly terminalAttach: "control.terminal.attach";
     readonly terminalInput: "instance.terminal.input";
     readonly terminalResize: "instance.terminal.resize";
     readonly terminalClose: "instance.terminal.close";

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -220,6 +220,13 @@ export type ControlEventDto =
   // replace-latest snapshot of the pending items.
   | { type: "queue-updated"; chatKey: string; sessionAlias: string; items: QueueItemDto[] };
 
+export interface TerminalAttachRequest {
+  terminalId: string;
+}
+export type TerminalAttachResult =
+  | { ok: false }
+  | { ok: true; buffer: string; lastSeq: number };
+
 /** One recovered history row (a persisted-shaped message) for a native-session seed. */
 export interface SessionHistoryRowDto {
   direction: "in" | "out";

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -46,6 +46,7 @@ export const MSG = {
   sessionModelGet: "control.session.model.get",
   sessionModelSet: "control.session.model.set",
   terminalCreate: "control.terminal.create",
+  terminalAttach: "control.terminal.attach",
   terminalInput: "instance.terminal.input",
   terminalResize: "instance.terminal.resize",
   terminalClose: "instance.terminal.close",

--- a/packages/relay-web/src/__tests__/centertabstrip.test.ts
+++ b/packages/relay-web/src/__tests__/centertabstrip.test.ts
@@ -67,26 +67,26 @@ describe("CenterTabStrip", () => {
     expect(setActive).toHaveBeenLastCalledWith(K, "chat");
   });
 
-  it("clicking a tab's close button closes it via the store (guarded) without also activating it", async () => {
+  it("clicking a tab's close button emits close with the tab id, without closing it directly or activating it", async () => {
     const store = useCenterTabsStore();
     const K = sessionKey("i1", "s1");
     store.openFile(K, "src/a.ts");
     store.openTerminal(K);
     store.setActive(K, "chat");
     const setActive = vi.spyOn(store, "setActive");
-    // The close button routes through closeTabGuarded (Task 7), which asks for confirmation
-    // only when the tab is dirty. This tab is clean, so the guard closes it without prompting
-    // — asserted both via the guard call and the resulting store state (closeTabGuarded calls
-    // the store's OWN closeTab internally via a closure reference, which a spy on the
-    // store-object's `closeTab` property can't observe).
+    // The strip itself no longer decides how a close is handled — it just emits `close` and
+    // leaves the dirty-aware guard (closeTabGuarded) to the parent (DashboardView.requestCloseTab),
+    // which also owns killing a terminal's PTY. Asserting closeTabGuarded is untouched here
+    // guards against the strip silently reintroducing its own bypass of that parent logic.
     const closeTabGuarded = vi.spyOn(store, "closeTabGuarded");
 
     const w = mount(CenterTabStrip, { props: { sessionKey: K }, ...g });
     const fileTab = w.findAll('[data-test="tab"]').find((t) => t.attributes("data-tab-id") === "file:src/a.ts")!;
     await fileTab.find('[data-test="tab-close"]').trigger("click");
 
-    expect(closeTabGuarded).toHaveBeenCalledWith(K, "file:src/a.ts", expect.any(Function));
-    expect(store.tabsFor(K).some((t) => t.id === "file:src/a.ts")).toBe(false); // actually closed
+    expect(w.emitted("close")).toEqual([["file:src/a.ts"]]);
+    expect(closeTabGuarded).not.toHaveBeenCalled(); // closing is the parent's job now
+    expect(store.tabsFor(K).some((t) => t.id === "file:src/a.ts")).toBe(true); // not closed by the strip itself
     expect(setActive).not.toHaveBeenCalled(); // @click.stop must not also bubble into activation
   });
 

--- a/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
@@ -170,8 +170,12 @@ test("out-of-band session removal prunes that session's center-tabs, but leaves 
   centerTabs.openTerminal(goneKey);
   centerTabs.openFile(keepKey, "b.ts");
   centerTabs.openFile(loadingKey, "c.ts");
+  saveTerminalId(goneKey, "tid-prune"); // the pruned session has a live, persisted terminal
   await flushPromises();
   expect(centerTabs.tabsFor(goneKey).length).toBe(2);
+
+  const terminals = useTerminalStore();
+  const closeSpy = vi.spyOn(terminals, "close");
 
   // Simulate a SERVER-driven removal (deleted from the CLI / WeChat / another browser):
   // the session vanishes from i1's list, but sessionsLoaded stays true — exactly what a
@@ -182,6 +186,10 @@ test("out-of-band session removal prunes that session's center-tabs, but leaves 
   expect(centerTabs.tabsFor(goneKey)).toEqual([]); // reconciled away
   expect(centerTabs.tabsFor(keepKey).length).toBe(1); // untouched — still a valid session
   expect(centerTabs.tabsFor(loadingKey).length).toBe(1); // guarded — instance still loading
+  // The pruned session's live terminal PTY must be killed and its persisted id forgotten —
+  // otherwise the process leaks and a later re-attach would resurrect a dead id.
+  expect(closeSpy).toHaveBeenCalledWith("i1", "tid-prune");
+  expect(loadTerminalId(goneKey)).toBeNull();
 });
 
 // The two tests below drive `requestCloseTab` via the pane's `@close` emit — the same idiom

--- a/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
@@ -184,13 +184,10 @@ test("out-of-band session removal prunes that session's center-tabs, but leaves 
   expect(centerTabs.tabsFor(loadingKey).length).toBe(1); // guarded — instance still loading
 });
 
-// Both tests below drive `requestCloseTab` via the pane's `@close` emit — the same idiom
-// dashboard-responsive.test.ts uses for FileViewer's close test — rather than via
-// CenterTabStrip's own tab-close button. That button (data-test="tab-close") calls
-// `store.closeTabGuarded` directly (see centertabstrip.test.ts) and never routes through
-// DashboardView at all, so it can't exercise the PTY-kill logic added here. TerminalTab
-// is stubbed elsewhere in this file (`stub-term`, no real close control), so a
-// close-emitting stub is substituted for just these two tests.
+// The two tests below drive `requestCloseTab` via the pane's `@close` emit — the same idiom
+// dashboard-responsive.test.ts uses for FileViewer's close test. TerminalTab is stubbed
+// elsewhere in this file (`stub-term`, no real close control), so a close-emitting stub is
+// substituted for just these two tests.
 test("closing a terminal tab kills its PTY and clears the persisted id", async () => {
   const termStub = { name: "TerminalTab", template: '<div data-test="stub-term" />', emits: ["close"] };
   const wrapper = mount(DashboardView, { global: { stubs: { ...stubs, TerminalTab: termStub } } });
@@ -228,4 +225,34 @@ test("closing a FILE tab does not kill any terminal PTY", async () => {
 
   expect(closeSpy).not.toHaveBeenCalled();
   expect(centerTabs.tabsFor(key)).toEqual([]);
+});
+
+// Regression for the tab-strip close bypass: CenterTabStrip's own X button used to call
+// store.closeTabGuarded() directly, skipping requestCloseTab's terminal-PTY-kill logic
+// entirely. This test mounts the REAL CenterTabStrip (excluded from the shared `stubs` map
+// below) so its actual `data-test="tab-close"` button is clickable, unlike the tests above
+// which drive requestCloseTab via a stubbed pane's `@close` emit.
+test("clicking the tab strip's own X button kills the terminal's PTY and clears the persisted id", async () => {
+  const { CenterTabStrip: _stubbedStrip, ...stubsWithoutStrip } = stubs;
+  const wrapper = mount(DashboardView, { global: { stubs: stubsWithoutStrip } });
+  await flushPromises();
+  const key = selectSession();
+  await flushPromises();
+  const centerTabs = useCenterTabsStore();
+  centerTabs.openTerminal(key);
+  saveTerminalId(key, "tid-2");
+  await flushPromises();
+  const terminals = useTerminalStore();
+  const closeSpy = vi.spyOn(terminals, "close");
+
+  // Both the mobile (bare) and desktop standalone strips are mounted in jsdom (media
+  // queries aren't evaluated), so more than one real "tab-close" button may exist for the
+  // same terminal tab — any one of them must route through requestCloseTab.
+  const closeButtons = wrapper.findAll('[data-test="tab-close"]');
+  expect(closeButtons.length).toBeGreaterThan(0);
+  await closeButtons[0].trigger("click");
+  await flushPromises();
+
+  expect(closeSpy).toHaveBeenCalledWith("i1", "tid-2");
+  expect(loadTerminalId(key)).toBeNull();
 });

--- a/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
@@ -3,17 +3,23 @@ import { setActivePinia, createPinia } from "pinia";
 import { beforeEach, expect, test, vi } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 
-// Stub the WS client so jsdom needs no real socket.
+// Stub the WS client so jsdom needs no real socket. sendWebClientMessage is exercised
+// indirectly: terminals.close() (spied on, not mocked away) calls through to it.
 vi.mock("../api/events", () => ({
   connectEvents: () => vi.fn(),
+  sendWebClientMessage: vi.fn(),
 }));
 // DashboardView uses useRouter()/<router-link>; mock to avoid a real router.
 vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 import DashboardView from "../views/DashboardView.vue";
+import TerminalTab from "../components/TerminalTab.vue";
+import FileViewer from "../components/FileViewer.vue";
 import { useChatStore } from "../stores/chat";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { useInstancesStore, type InstanceView } from "../stores/instances";
+import { useTerminalStore } from "../stores/terminal";
+import { saveTerminalId, loadTerminalId } from "../lib/terminal-sessions";
 
 const stubs = {
   ChatPane: { template: '<div data-test="stub-chat"/>' },
@@ -176,4 +182,50 @@ test("out-of-band session removal prunes that session's center-tabs, but leaves 
   expect(centerTabs.tabsFor(goneKey)).toEqual([]); // reconciled away
   expect(centerTabs.tabsFor(keepKey).length).toBe(1); // untouched — still a valid session
   expect(centerTabs.tabsFor(loadingKey).length).toBe(1); // guarded — instance still loading
+});
+
+// Both tests below drive `requestCloseTab` via the pane's `@close` emit — the same idiom
+// dashboard-responsive.test.ts uses for FileViewer's close test — rather than via
+// CenterTabStrip's own tab-close button. That button (data-test="tab-close") calls
+// `store.closeTabGuarded` directly (see centertabstrip.test.ts) and never routes through
+// DashboardView at all, so it can't exercise the PTY-kill logic added here. TerminalTab
+// is stubbed elsewhere in this file (`stub-term`, no real close control), so a
+// close-emitting stub is substituted for just these two tests.
+test("closing a terminal tab kills its PTY and clears the persisted id", async () => {
+  const termStub = { name: "TerminalTab", template: '<div data-test="stub-term" />', emits: ["close"] };
+  const wrapper = mount(DashboardView, { global: { stubs: { ...stubs, TerminalTab: termStub } } });
+  await flushPromises();
+  const key = selectSession();
+  await flushPromises();
+  const centerTabs = useCenterTabsStore();
+  centerTabs.openTerminal(key);
+  saveTerminalId(key, "tid-1");
+  await flushPromises();
+  const terminals = useTerminalStore();
+  const closeSpy = vi.spyOn(terminals, "close");
+
+  wrapper.findComponent(TerminalTab).vm.$emit("close");
+  await flushPromises();
+
+  expect(closeSpy).toHaveBeenCalledWith(expect.any(String), "tid-1");
+  expect(loadTerminalId(key)).toBeNull();
+});
+
+test("closing a FILE tab does not kill any terminal PTY", async () => {
+  const fileStub = { name: "FileViewer", template: '<div data-test="stub-file" />', emits: ["close", "back", "dirty-change"] };
+  const wrapper = mount(DashboardView, { global: { stubs: { ...stubs, FileViewer: fileStub } } });
+  await flushPromises();
+  const key = selectSession();
+  await flushPromises();
+  const centerTabs = useCenterTabsStore();
+  centerTabs.openFile(key, "a.ts");
+  await flushPromises();
+  const terminals = useTerminalStore();
+  const closeSpy = vi.spyOn(terminals, "close");
+
+  wrapper.findComponent(FileViewer).vm.$emit("close");
+  await flushPromises();
+
+  expect(closeSpy).not.toHaveBeenCalled();
+  expect(centerTabs.tabsFor(key)).toEqual([]);
 });

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -5,6 +5,8 @@ import InstanceTree from "../components/InstanceTree.vue";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
+import { useTerminalStore } from "../stores/terminal";
+import { saveTerminalId, loadTerminalId } from "../lib/terminal-sessions";
 import { settleConfirm, useConfirmState } from "../lib/use-confirm";
 
 const instance = (sessions: unknown[] = [], sessionsLoaded = true) => ({
@@ -332,6 +334,31 @@ describe("InstanceTree session management", () => {
     w.unmount();
   });
 
+  // Regression: archiving a session with a LIVE terminal must kill its PTY and forget its
+  // persisted id too — clearSession alone only drops the center-tab entry (UI state); without
+  // this the process leaks server-side and a later re-attach could resurrect a dead id.
+  it("kills the terminal PTY and clears the persisted id when a session with a live terminal is archived", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    vi.spyOn(store, "archiveSession").mockResolvedValue();
+    const centerTabs = useCenterTabsStore();
+    const key = sessionKey("i1", "backend");
+    centerTabs.openTerminal(key);
+    saveTerminalId(key, "tid-archive");
+    const terminals = useTerminalStore();
+    const closeSpy = vi.spyOn(terminals, "close");
+    const w = mount(InstanceTree, { attachTo: document.body, global: { stubs: { NewSessionDialog: true } } });
+    await w.find('[data-test="session-menu"]').trigger("mousedown");
+    await w.find('[data-test="session-menu"]').trigger("click");
+    const item = w.find('[data-test="action-archive"]');
+    await item.trigger("mousedown");
+    await item.trigger("click");
+    await flushPromises();
+    expect(closeSpy).toHaveBeenCalledWith("i1", "tid-archive");
+    expect(loadTerminalId(key)).toBeNull();
+    w.unmount();
+  });
+
   it("clears the session's center tabs when it is deleted", async () => {
     const store = useInstancesStore();
     store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
@@ -348,5 +375,26 @@ describe("InstanceTree session management", () => {
     await flushPromises();
     expect(clearSession).toHaveBeenCalledWith(key);
     expect(centerTabs.tabsFor(key)).toEqual([]);
+  });
+
+  // Regression: deleting a session with a LIVE terminal must kill its PTY and forget its
+  // persisted id too, for the same leak/dead-id reasons as the archive case above.
+  it("kills the terminal PTY and clears the persisted id when a session with a live terminal is deleted", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    vi.spyOn(store, "removeSession").mockResolvedValue();
+    const centerTabs = useCenterTabsStore();
+    const key = sessionKey("i1", "backend");
+    centerTabs.openTerminal(key);
+    saveTerminalId(key, "tid-delete");
+    const terminals = useTerminalStore();
+    const closeSpy = vi.spyOn(terminals, "close");
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    await w.find('[data-test="session-menu"]').trigger("click");
+    await w.find('[data-test="delete-session"]').trigger("click");
+    settleConfirm(true);
+    await flushPromises();
+    expect(closeSpy).toHaveBeenCalledWith("i1", "tid-delete");
+    expect(loadTerminalId(key)).toBeNull();
   });
 });

--- a/packages/relay-web/src/__tests__/session-terminal.test.ts
+++ b/packages/relay-web/src/__tests__/session-terminal.test.ts
@@ -1,0 +1,31 @@
+// packages/relay-web/src/__tests__/session-terminal.test.ts
+import { expect, test, vi } from "vitest";
+import { killSessionTerminal } from "../lib/session-terminal";
+import { saveTerminalId, loadTerminalId, clearTerminalId } from "../lib/terminal-sessions";
+import type { useTerminalStore } from "../stores/terminal";
+
+function mockTerminals(): ReturnType<typeof useTerminalStore> {
+  return { close: vi.fn() } as unknown as ReturnType<typeof useTerminalStore>;
+}
+
+test("killSessionTerminal closes the PTY and clears the persisted id when one exists", () => {
+  const key = "i1::demo";
+  saveTerminalId(key, "tid-1");
+  const terminals = mockTerminals();
+
+  killSessionTerminal(key, "i1", terminals);
+
+  expect(terminals.close).toHaveBeenCalledWith("i1", "tid-1");
+  expect(loadTerminalId(key)).toBeNull();
+});
+
+test("killSessionTerminal is a no-op (does not call close) when the session has no persisted terminal id", () => {
+  const key = "i1::demo";
+  clearTerminalId(key); // ensure no stale id from another test
+  const terminals = mockTerminals();
+
+  killSessionTerminal(key, "i1", terminals);
+
+  expect(terminals.close).not.toHaveBeenCalled();
+  expect(loadTerminalId(key)).toBeNull();
+});

--- a/packages/relay-web/src/__tests__/terminal-sessions.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-sessions.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { saveTerminalId, loadTerminalId, clearTerminalId } from "../lib/terminal-sessions";
+
+beforeEach(() => sessionStorage.clear());
+
+describe("terminal-sessions", () => {
+  it("save then load round-trips the id", () => {
+    saveTerminalId("i1::s1", "term-abc");
+    expect(loadTerminalId("i1::s1")).toBe("term-abc");
+  });
+  it("returns null when absent", () => {
+    expect(loadTerminalId("i1::none")).toBeNull();
+  });
+  it("clear removes the id", () => {
+    saveTerminalId("i1::s1", "t");
+    clearTerminalId("i1::s1");
+    expect(loadTerminalId("i1::s1")).toBeNull();
+  });
+  it("tolerates corrupt storage", () => {
+    sessionStorage.setItem("xacpx.terminal-ids.v1", "{bad");
+    expect(loadTerminalId("i1::s1")).toBeNull();
+  });
+  it("swallows setItem quota errors", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => { throw new DOMException("q", "QuotaExceededError"); });
+    expect(() => saveTerminalId("i1::s1", "t")).not.toThrow();
+    spy.mockRestore();
+  });
+});

--- a/packages/relay-web/src/__tests__/terminal-store.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-store.test.ts
@@ -44,7 +44,23 @@ describe("terminal store", () => {
     s.onExit(exit);
     s.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-output", terminalId: "t1", seq: 0, data: "hi" } } as never);
     s.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-exit", terminalId: "t1", code: 0 } } as never);
-    expect(out).toHaveBeenCalledWith("t1", "hi");
+    expect(out).toHaveBeenCalledWith("t1", "hi", 0);
     expect(exit).toHaveBeenCalledWith("t1", 0);
+  });
+
+  it("attach() calls control.terminal.attach and unwraps the result", async () => {
+    vi.mocked(api.rpc).mockResolvedValueOnce({ ok: true, buffer: "scroll", lastSeq: 7 } as never);
+    const store = useTerminalStore();
+    const res = await store.attach("i1", "term-x");
+    expect(api.rpc).toHaveBeenCalledWith("i1", "control.terminal.attach", { terminalId: "term-x" });
+    expect(res).toEqual({ ok: true, buffer: "scroll", lastSeq: 7 });
+  });
+
+  it("applyEvent forwards seq to output callbacks", () => {
+    const store = useTerminalStore();
+    const seen: Array<[string, string, number]> = [];
+    store.onOutput((id, data, seq) => seen.push([id, data, seq]));
+    store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-output", terminalId: "t1", seq: 42, data: "hi" } } as never);
+    expect(seen).toEqual([["t1", "hi", 42]]);
   });
 });

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -400,6 +400,28 @@ describe("TerminalTab", () => {
     expect(adapter.write).toHaveBeenCalledWith("NEW");
   });
 
+  it("queues live output arriving during attach-in-flight, then flushes seq>lastSeq after the buffer", async () => {
+    saveTerminalId("i1::demo", "term-persisted");
+    let resolveAttach!: (v: unknown) => void;
+    vi.mocked(api.rpc).mockImplementation((_i, method) =>
+      method === "control.terminal.attach"
+        ? new Promise((r) => { resolveAttach = r; })
+        : (Promise.resolve({}) as never));
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+    await tick(); // attach now in flight, subscribed + queueing
+    const store = useTerminalStore();
+    // live events arrive WHILE attach is pending → must be queued (not written yet)
+    store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-output", terminalId: "term-persisted", seq: 5, data: "DUP" } } as never); // <= lastSeq → drop
+    store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-output", terminalId: "term-persisted", seq: 6, data: "MID" } } as never); // > lastSeq → flush
+    expect(adapter.write).not.toHaveBeenCalledWith("MID"); // still queued, buffer not replayed yet
+    resolveAttach({ ok: true, buffer: "BUF", lastSeq: 5 });
+    await tick();
+    // order: buffer first, then queued live (MID), DUP dropped
+    expect(adapter.write).toHaveBeenCalledWith("BUF");
+    expect(adapter.write).toHaveBeenCalledWith("MID");
+    expect(adapter.write).not.toHaveBeenCalledWith("DUP");
+  });
+
   it("attach ok:false clears the id and falls back to the start placeholder", async () => {
     saveTerminalId("i1::demo", "gone");
     vi.mocked(api.rpc).mockImplementation(async (_i, method) =>

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -16,6 +16,8 @@ import TerminalTab from "../components/TerminalTab.vue";
 import { createTerminalAdapter } from "../lib/terminal-adapter";
 import { api } from "../api/client";
 import { sendWebClientMessage } from "../api/events";
+import { useTerminalStore } from "../stores/terminal";
+import { saveTerminalId, loadTerminalId } from "../lib/terminal-sessions";
 
 const globalOpts = { mocks: { $t: (k: string) => k } };
 const tick = () => new Promise((r) => setTimeout(r, 0));
@@ -366,5 +368,62 @@ describe("TerminalTab", () => {
     mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
     await tick();
     expect(createTerminalAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  it("on mount with a persisted terminalId, attaches and replays the buffer (no fresh create)", async () => {
+    saveTerminalId("i1::demo", "term-persisted");
+    vi.mocked(api.rpc).mockImplementation(async (_i, method) => {
+      if (method === "control.terminal.attach") return { ok: true, buffer: "PRIOR SCROLLBACK", lastSeq: 5 } as never;
+      return { terminalId: "should-not-create" } as never;
+    });
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+    await tick();
+    expect(api.rpc).toHaveBeenCalledWith("i1", "control.terminal.attach", { terminalId: "term-persisted" });
+    expect(adapter.write).toHaveBeenCalledWith("PRIOR SCROLLBACK"); // scrollback replayed
+    // did NOT create a fresh terminal
+    expect(api.rpc).not.toHaveBeenCalledWith("i1", "control.terminal.create", expect.anything());
+  });
+
+  it("drops live output with seq <= lastSeq after attach (dedup)", async () => {
+    saveTerminalId("i1::demo", "term-persisted");
+    vi.mocked(api.rpc).mockImplementation(async (_i, method) =>
+      method === "control.terminal.attach" ? ({ ok: true, buffer: "BUF", lastSeq: 5 } as never) : ({} as never));
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+    await tick();
+    adapter.write.mockClear();
+    // deliver live output via the store event path
+    const store = useTerminalStore();
+    store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-output", terminalId: "term-persisted", seq: 5, data: "DUP" } } as never); // <= lastSeq → dropped
+    store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "terminal-output", terminalId: "term-persisted", seq: 6, data: "NEW" } } as never); // > lastSeq → written
+    await tick();
+    expect(adapter.write).not.toHaveBeenCalledWith("DUP");
+    expect(adapter.write).toHaveBeenCalledWith("NEW");
+  });
+
+  it("attach ok:false clears the id and falls back to the start placeholder", async () => {
+    saveTerminalId("i1::demo", "gone");
+    vi.mocked(api.rpc).mockImplementation(async (_i, method) =>
+      method === "control.terminal.attach" ? ({ ok: false } as never) : ({} as never));
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: false }, global: globalOpts });
+    await tick();
+    expect(w.find('[data-test="term-restore"]').exists()).toBe(true); // placeholder
+    expect(loadTerminalId("i1::demo")).toBeNull(); // stale id cleared
+  });
+
+  it("fresh create persists the terminalId", async () => {
+    vi.mocked(api.rpc).mockResolvedValue({ terminalId: "t-new" } as never);
+    mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: true }, global: globalOpts });
+    await tick();
+    expect(loadTerminalId("i1::demo")).toBe("t-new");
+  });
+
+  it("unmount (refresh) does NOT close the PTY", async () => {
+    vi.mocked(api.rpc).mockResolvedValue({ terminalId: "t-new" } as never);
+    const sent: unknown[] = [];
+    vi.mocked(sendWebClientMessage).mockImplementation((m) => { sent.push(m); });
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo", autostart: true }, global: globalOpts });
+    await tick();
+    w.unmount();
+    expect(sent.some((m: any) => m.kind === "terminal-close")).toBe(false); // no close on unmount
   });
 });

--- a/packages/relay-web/src/components/CenterTabStrip.vue
+++ b/packages/relay-web/src/components/CenterTabStrip.vue
@@ -18,6 +18,7 @@ import { iconForFile } from "../lib/file-icons";
 // comment would make the component a fragment root, so tests' `w.element` would resolve
 // to the comment instead of the div.
 const props = defineProps<{ sessionKey: string; bare?: boolean }>();
+const emit = defineEmits<{ close: [id: string] }>();
 const store = useCenterTabsStore();
 const { t } = useI18n();
 
@@ -41,11 +42,11 @@ function labelFor(tab: CenterTab): string {
   return tab.kind === "terminal" ? t("center.terminal") : basename(tab.path);
 }
 
-// Guarded close: a clean tab closes immediately; a dirty file tab asks first via the
-// native confirm dialog (the store itself can't show UI, so the confirm callback is
-// injected — see closeTabGuarded).
+// The strip doesn't close tabs itself — it just reports the intent up to the parent
+// (DashboardView.requestCloseTab), which owns the dirty-aware confirm guard AND the
+// terminal-PTY-kill logic that must run before a terminal tab is actually closed.
 function requestClose(id: string) {
-  store.closeTabGuarded(props.sessionKey, id, () => window.confirm(t("files.unsavedConfirm")));
+  emit("close", id);
 }
 
 // Edge-fade + hidden scrollbar. The scrollbar is suppressed (`no-scrollbar`); to signal

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -5,6 +5,8 @@ import { Archive, ChevronDown, ChevronRight, Link2, Loader2, MoreHorizontal, Pen
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
+import { useTerminalStore } from "../stores/terminal";
+import { killSessionTerminal } from "../lib/session-terminal";
 import { confirm } from "../lib/use-confirm";
 import { showActionToast } from "../lib/use-action-toast";
 import { useSwipeActions } from "../lib/use-swipe-actions";
@@ -21,6 +23,7 @@ const vFocus = {
 const store = useInstancesStore();
 const chat = useChatStore();
 const centerTabs = useCenterTabsStore();
+const terminals = useTerminalStore();
 const { t } = useI18n();
 
 // A session row carries the agent NAME; the brand glyph keys on its driver. Resolve via the
@@ -150,9 +153,12 @@ function onRowTap(id: string, alias: string) {
 async function onArchive(id: string, alias: string) {
   openMenuFor.value = null;
   openSwipeFor.value = null;
-  // Drop this session's center tabs (terminal/file panes) right away — the ephemeral
-  // tabs/PTY are freed on archive; unarchive (via the undo toast) does not restore them.
-  centerTabs.clearSession(sessionKey(id, alias));
+  // Drop this session's center tabs (terminal/file panes) right away — a live terminal's
+  // PTY is killed and its persisted id forgotten via killSessionTerminal (unarchive, via
+  // the undo toast, does not restore either the tabs or the PTY).
+  const key = sessionKey(id, alias);
+  killSessionTerminal(key, id, terminals);
+  centerTabs.clearSession(key);
   await store.archiveSession(id, alias).catch(() => {});
   showUndoToast(id, alias);
 }
@@ -178,8 +184,11 @@ async function askDelete(id: string, alias: string) {
   // Deleting the session you're viewing drops the view back to the empty "no session"
   // state rather than leaving a stale, now-broken selection pointed at it.
   const wasActive = isSelected(id, alias);
-  // Drop this session's center tabs (terminal/file panes) so they unmount along with it.
-  centerTabs.clearSession(sessionKey(id, alias));
+  // Drop this session's center tabs (terminal/file panes) so they unmount along with it,
+  // killing any live terminal PTY and forgetting its persisted id first.
+  const key = sessionKey(id, alias);
+  killSessionTerminal(key, id, terminals);
+  centerTabs.clearSession(key);
   void store.removeSession(id, alias).catch(() => {});
   if (wasActive) chat.clearSelection();
 }

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -4,6 +4,8 @@ import { ArrowLeft, Keyboard, ClipboardPaste, Copy, ChevronUp, ChevronDown, Chev
 import { createTerminalAdapter, type TerminalAdapter, type TerminalTheme } from "../lib/terminal-adapter";
 import { useTerminalStore } from "../stores/terminal";
 import { useThemeStore } from "../stores/theme";
+import { sessionKey as makeSessionKey } from "../stores/center-tabs";
+import { loadTerminalId, saveTerminalId, clearTerminalId } from "../lib/terminal-sessions";
 
 const props = withDefaults(defineProps<{ instanceId: string; sessionAlias: string; autostart?: boolean }>(), {
   autostart: true,
@@ -11,6 +13,7 @@ const props = withDefaults(defineProps<{ instanceId: string; sessionAlias: strin
 const emit = defineEmits<{ close: [] }>();
 const terminals = useTerminalStore();
 const theme = useThemeStore();
+const sessionKey = computed(() => makeSessionKey(props.instanceId, props.sessionAlias));
 const host = ref<HTMLDivElement | null>(null);
 const status = ref<"idle" | "connecting" | "open" | "exited" | "error">("idle");
 const errorKey = ref<string>("");
@@ -223,18 +226,67 @@ function applyFit(myEpoch = epoch) {
   terminals.resize(props.instanceId, terminalId, dim.cols, dim.rows);
 }
 
-function teardown() {
+// Releases front-end resources (adapter, listeners, resize observer) WITHOUT killing the
+// backend PTY — a refresh/tab-close should be able to reattach to the same live terminal
+// later. The PTY is only closed on an explicit user action (the close button), which sends
+// terminal-close itself; this function must never do that.
+function releaseFrontend() {
   epoch++;
   offOutput?.(); offOutput = null;
   offExit?.(); offExit = null;
   resizeObs?.disconnect(); resizeObs = null;
-  if (terminalId) terminals.close(props.instanceId, terminalId);
   adapter?.dispose(); adapter = null; terminalId = "";
   disarmMods();
 }
 
+// Attempt to reattach to a persisted terminalId (e.g. after a page reload). Subscribes to
+// live output BEFORE issuing the attach RPC so no output emitted between the RPC firing and
+// its response is lost — those events are queued and, once the attach resolves, flushed in
+// order after the replayed scrollback buffer (so history never appears out of order relative
+// to live output). Returns true on success (adapter mounted, status "open"), false if the
+// PTY is gone (caller should forget the persisted id and fall back to start()/placeholder).
+async function tryAttach(id: string): Promise<boolean> {
+  if (!host.value) return false;
+  releaseFrontend();
+  const myEpoch = epoch;
+  status.value = "connecting";
+  started = true;
+  terminalId = id;
+  const currentAdapter = createTerminalAdapter(host.value, { cols: 80, rows: 24, onData: handleData, theme: currentTheme() });
+  adapter = currentAdapter;
+  const pending: Array<{ data: string; seq: number }> = [];
+  let queueing = true;
+  let ignoreThroughSeq = -1;
+  offOutput = terminals.onOutput((oid, data, seq) => {
+    if (oid !== terminalId) return;
+    if (queueing) { pending.push({ data, seq }); return; }
+    if (seq <= ignoreThroughSeq) return;
+    adapter?.write(data);
+  });
+  offExit = terminals.onExit((oid, code) => { if (oid === terminalId) { status.value = "exited"; errorKey.value = String(code); } });
+  try {
+    const res = await terminals.attach(props.instanceId, id);
+    if (myEpoch !== epoch) { currentAdapter.dispose(); return true; } // superseded
+    if (!res.ok) { releaseFrontend(); status.value = "idle"; return false; }
+    ignoreThroughSeq = res.lastSeq;
+    currentAdapter.write(res.buffer);            // replay scrollback
+    queueing = false;
+    for (const p of pending) if (p.seq > ignoreThroughSeq) currentAdapter.write(p.data); // flush queued live
+    pending.length = 0;
+    status.value = "open";
+    resizeObs = new ResizeObserver(() => applyFit());
+    if (host.value) resizeObs.observe(host.value);
+    applyFit(myEpoch);
+    return true;
+  } catch {
+    if (myEpoch !== epoch) return true;
+    releaseFrontend(); status.value = "idle";
+    return false;
+  }
+}
+
 async function start() {
-  teardown();
+  releaseFrontend();
   const myEpoch = epoch;
   if (!props.sessionAlias || !host.value) { status.value = "idle"; return; }
   status.value = "connecting";
@@ -250,14 +302,15 @@ async function start() {
   try {
     const newId = await terminals.create(props.instanceId, props.sessionAlias, currentAdapter.cols(), currentAdapter.rows());
     if (myEpoch !== epoch) {
-      // Superseded by a later start()/teardown: close the just-created orphan PTY. The superseding
-      // teardown already disposed this adapter when `adapter` still pointed at it, so only dispose
-      // if it wasn't (guard against double-dispose).
+      // Superseded by a later start()/releaseFrontend: close the just-created orphan PTY. The
+      // superseding releaseFrontend already disposed this adapter when `adapter` still pointed at
+      // it, so only dispose if it wasn't (guard against double-dispose).
       terminals.close(props.instanceId, newId);
       if (adapter === currentAdapter) currentAdapter.dispose();
       return;
     }
     terminalId = newId;
+    saveTerminalId(sessionKey.value, newId);
     status.value = "open";
     resizeObs = new ResizeObserver(() => applyFit());
     if (host.value) resizeObs.observe(host.value);
@@ -299,8 +352,23 @@ function detachTouch() {
   el.removeEventListener("focusout", onHostFocusOut);
 }
 
-onMounted(() => {
+// On mount, prefer reattaching to a persisted terminalId (survives a reload) over spawning a
+// fresh PTY. Only falls through to start()/the placeholder when there's no persisted id, or
+// the persisted PTY is gone (attach failed) — in which case the stale id is forgotten so a
+// later mount doesn't keep retrying a dead terminal.
+async function mount() {
+  const id = loadTerminalId(sessionKey.value);
+  if (id) {
+    const ok = await tryAttach(id);
+    if (ok) return;
+    clearTerminalId(sessionKey.value); // stale PTY → forget, fall through
+  }
   if (props.autostart) void start();
+  // else: showPlaceholder stays (status idle)
+}
+
+onMounted(() => {
+  void mount();
   attachTouch();
   window.visualViewport?.addEventListener("resize", updateKeyboardInset);
   window.visualViewport?.addEventListener("scroll", updateKeyboardInset);
@@ -313,7 +381,7 @@ onBeforeUnmount(() => {
   detachTouch();
   window.visualViewport?.removeEventListener("resize", updateKeyboardInset);
   window.visualViewport?.removeEventListener("scroll", updateKeyboardInset);
-  teardown();
+  releaseFrontend();
 });
 </script>
 

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -250,7 +250,6 @@ async function tryAttach(id: string): Promise<boolean> {
   releaseFrontend();
   const myEpoch = epoch;
   status.value = "connecting";
-  started = true;
   terminalId = id;
   const currentAdapter = createTerminalAdapter(host.value, { cols: 80, rows: 24, onData: handleData, theme: currentTheme() });
   adapter = currentAdapter;
@@ -266,13 +265,20 @@ async function tryAttach(id: string): Promise<boolean> {
   offExit = terminals.onExit((oid, code) => { if (oid === terminalId) { status.value = "exited"; errorKey.value = String(code); } });
   try {
     const res = await terminals.attach(props.instanceId, id);
-    if (myEpoch !== epoch) { currentAdapter.dispose(); return true; } // superseded
+    if (myEpoch !== epoch) {
+      // Superseded while the attach RPC was in flight: the superseding releaseFrontend()
+      // already disposed this adapter when `adapter` still pointed at it, so only dispose
+      // if it wasn't (guard against double-dispose).
+      if (adapter === currentAdapter) currentAdapter.dispose();
+      return true;
+    }
     if (!res.ok) { releaseFrontend(); status.value = "idle"; return false; }
     ignoreThroughSeq = res.lastSeq;
     currentAdapter.write(res.buffer);            // replay scrollback
     queueing = false;
     for (const p of pending) if (p.seq > ignoreThroughSeq) currentAdapter.write(p.data); // flush queued live
     pending.length = 0;
+    started = true; // gate the prop-watch only once attach actually succeeded
     status.value = "open";
     resizeObs = new ResizeObserver(() => applyFit());
     if (host.value) resizeObs.observe(host.value);

--- a/packages/relay-web/src/lib/session-terminal.ts
+++ b/packages/relay-web/src/lib/session-terminal.ts
@@ -1,0 +1,15 @@
+import { loadTerminalId, clearTerminalId } from "./terminal-sessions";
+import type { useTerminalStore } from "../stores/terminal";
+
+/** Kill a session's live terminal PTY (if any) and forget its persisted id. Called from every
+ *  EXPLICIT close/prune path (tab close, dead-session reconcile, session archive/delete) — NOT
+ *  from a refresh unmount, so a reload can still re-attach. No-op when the session has no terminal. */
+export function killSessionTerminal(
+  sessionKey: string,
+  instanceId: string,
+  terminals: ReturnType<typeof useTerminalStore>,
+): void {
+  const id = loadTerminalId(sessionKey);
+  if (id) terminals.close(instanceId, id);
+  clearTerminalId(sessionKey);
+}

--- a/packages/relay-web/src/lib/terminal-sessions.ts
+++ b/packages/relay-web/src/lib/terminal-sessions.ts
@@ -1,0 +1,39 @@
+/** Per-session terminal-id persistence. A live PTY survives a browser reload (the backend keeps
+ *  it until idle-timeout); persisting its terminalId lets the reloaded tab re-attach (replay
+ *  scrollback + reconnect) instead of spawning a fresh shell. sessionStorage (tab-scoped) keyed
+ *  by `${instanceId}::${alias}`. */
+const KEY = "xacpx.terminal-ids.v1";
+type Ids = Record<string, string>;
+
+function read(): Ids {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as Ids) : {};
+  } catch {
+    return {};
+  }
+}
+function write(ids: Ids): void {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify(ids));
+  } catch {
+    /* storage full / disabled — best-effort */
+  }
+}
+
+export function saveTerminalId(sessionKey: string, id: string): void {
+  if (!sessionKey || !id) return;
+  const ids = read();
+  ids[sessionKey] = id;
+  write(ids);
+}
+export function loadTerminalId(sessionKey: string): string | null {
+  if (!sessionKey) return null;
+  return read()[sessionKey] ?? null;
+}
+export function clearTerminalId(sessionKey: string): void {
+  if (!sessionKey) return;
+  const ids = read();
+  delete ids[sessionKey];
+  write(ids);
+}

--- a/packages/relay-web/src/stores/terminal.ts
+++ b/packages/relay-web/src/stores/terminal.ts
@@ -1,9 +1,9 @@
 import { defineStore } from "pinia";
-import { isErrorPayload, type WebServerEvent } from "@ganglion/xacpx-relay-protocol";
+import { isErrorPayload, type WebServerEvent, type TerminalAttachResult } from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
 import { sendWebClientMessage } from "../api/events";
 
-type OutputCb = (terminalId: string, data: string) => void;
+type OutputCb = (terminalId: string, data: string, seq: number) => void;
 type ExitCb = (terminalId: string, code: number) => void;
 
 function unwrap<T>(result: T | { error: { code: string; message: string } }): T {
@@ -19,6 +19,11 @@ export const useTerminalStore = defineStore("terminal", () => {
     const result = await api.rpc<{ terminalId: string }>(instanceId, "control.terminal.create", { sessionAlias, cols, rows });
     const { terminalId } = unwrap(result);
     return terminalId;
+  }
+
+  async function attach(instanceId: string, terminalId: string): Promise<TerminalAttachResult> {
+    const result = await api.rpc<TerminalAttachResult>(instanceId, "control.terminal.attach", { terminalId });
+    return unwrap(result);
   }
 
   function input(instanceId: string, terminalId: string, data: string): void {
@@ -47,11 +52,11 @@ export const useTerminalStore = defineStore("terminal", () => {
     if (event.kind !== "control-event") return;
     const e = event.event;
     if (e.type === "terminal-output") {
-      for (const cb of outputCbs) cb(e.terminalId, e.data);
+      for (const cb of outputCbs) cb(e.terminalId, e.data, e.seq);
     } else if (e.type === "terminal-exit") {
       for (const cb of exitCbs) cb(e.terminalId, e.code);
     }
   }
 
-  return { create, input, resize, close, onOutput, onExit, applyEvent };
+  return { create, attach, input, resize, close, onOutput, onExit, applyEvent };
 });

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -339,7 +339,8 @@ onUnmounted(() => {
     <div class="flex items-center gap-2 border-b border-border bg-surface px-2 py-1.5 lg:hidden">
       <button data-test="open-instances" :aria-label='$t("nav.openInstances")'
               class="rounded p-1 leading-none text-fg-muted hover:bg-fg/5" @click="leftOpen = true"><Menu :size="20" /></button>
-      <CenterTabStrip v-if="currentKey" bare :session-key="currentKey" class="min-w-0 flex-1" />
+      <CenterTabStrip v-if="currentKey" bare :session-key="currentKey" class="min-w-0 flex-1"
+                      @close="(id) => currentKey && requestCloseTab(currentKey, id)" />
       <span v-else class="min-w-0 flex-1 truncate text-center text-sm font-medium">{{ chat.sessionAlias ?? "xacpx relay" }}</span>
       <div class="flex shrink-0 items-center gap-0.5">
         <button data-test="open-files" :aria-label='$t("nav.openFiles")' :title='$t("nav.files")'
@@ -397,7 +398,9 @@ onUnmounted(() => {
         <!-- Desktop-only standalone strip (mobile renders it in the top bar above). The
              wrapper — not a class on the strip — owns the responsive show/hide so the
              strip's own `display:flex` never fights a `hidden`/`lg:flex` on the same node. -->
-        <div v-if="currentKey" class="hidden shrink-0 lg:block"><CenterTabStrip :session-key="currentKey" /></div>
+        <div v-if="currentKey" class="hidden shrink-0 lg:block">
+          <CenterTabStrip :session-key="currentKey" @close="(id) => currentKey && requestCloseTab(currentKey, id)" />
+        </div>
         <div class="relative min-h-0 flex-1">
           <ChatPane class="absolute inset-0"
                     :inert="!!currentKey && centerTabs.activeFor(currentKey) !== 'chat'"

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -9,7 +9,7 @@ import { useNoticesStore } from "../stores/notices";
 import { useConnectionStore } from "../stores/connection";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { useTerminalStore } from "../stores/terminal";
-import { loadTerminalId, clearTerminalId } from "../lib/terminal-sessions";
+import { killSessionTerminal } from "../lib/session-terminal";
 import InstanceTree from "../components/InstanceTree.vue";
 import ChatPane from "../components/ChatPane.vue";
 import FileViewer from "../components/FileViewer.vue";
@@ -155,11 +155,7 @@ function keyWorkspace(key: string): string {
 function requestCloseTab(key: string, id: string) {
   // Explicit close of a terminal tab kills its PTY and forgets the id (a refresh does NOT reach here).
   const tab = centerTabs.tabsFor(key).find((t) => t.id === id);
-  if (tab?.kind === "terminal") {
-    const tid = loadTerminalId(key);
-    if (tid) terminals.close(keyInstance(key), tid);
-    clearTerminalId(key);
-  }
+  if (tab?.kind === "terminal") killSessionTerminal(key, keyInstance(key), terminals);
   centerTabs.closeTabGuarded(key, id, () => window.confirm(t("files.unsavedConfirm")));
 }
 
@@ -186,11 +182,7 @@ function reconcileCenterTabs() {
     const inst = instances.byId(keyInstance(key));
     if (inst?.sessionsLoaded && !valid.has(key)) {
       const hasTerminal = centerTabs.tabsFor(key).some((t) => t.kind === "terminal");
-      if (hasTerminal) {
-        const tid = loadTerminalId(key);
-        if (tid) terminals.close(keyInstance(key), tid);
-        clearTerminalId(key);
-      }
+      if (hasTerminal) killSessionTerminal(key, keyInstance(key), terminals);
       centerTabs.clearSession(key);
     }
   }

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -9,6 +9,7 @@ import { useNoticesStore } from "../stores/notices";
 import { useConnectionStore } from "../stores/connection";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { useTerminalStore } from "../stores/terminal";
+import { loadTerminalId, clearTerminalId } from "../lib/terminal-sessions";
 import InstanceTree from "../components/InstanceTree.vue";
 import ChatPane from "../components/ChatPane.vue";
 import FileViewer from "../components/FileViewer.vue";
@@ -152,6 +153,13 @@ function keyWorkspace(key: string): string {
 // Route every tab close (file/diff/terminal) through the dirty-aware guard: a clean tab
 // closes immediately, a dirty file tab asks first (native confirm — the store can't show UI).
 function requestCloseTab(key: string, id: string) {
+  // Explicit close of a terminal tab kills its PTY and forgets the id (a refresh does NOT reach here).
+  const tab = centerTabs.tabsFor(key).find((t) => t.id === id);
+  if (tab?.kind === "terminal") {
+    const tid = loadTerminalId(key);
+    if (tid) terminals.close(keyInstance(key), tid);
+    clearTerminalId(key);
+  }
   centerTabs.closeTabGuarded(key, id, () => window.confirm(t("files.unsavedConfirm")));
 }
 
@@ -176,7 +184,15 @@ function reconcileCenterTabs() {
   const openKeys = new Set(centerTabs.allOpenTabs().map((t) => t.key));
   for (const key of openKeys) {
     const inst = instances.byId(keyInstance(key));
-    if (inst?.sessionsLoaded && !valid.has(key)) centerTabs.clearSession(key);
+    if (inst?.sessionsLoaded && !valid.has(key)) {
+      const hasTerminal = centerTabs.tabsFor(key).some((t) => t.kind === "terminal");
+      if (hasTerminal) {
+        const tid = loadTerminalId(key);
+        if (tid) terminals.close(keyInstance(key), tid);
+        clearTerminalId(key);
+      }
+      centerTabs.clearSession(key);
+    }
   }
 }
 watch(() => instances.instances, reconcileCenterTabs, { deep: true });

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -884,6 +884,11 @@ export class ControlService {
     return this.deps.terminal.create({ cwd: session.cwd, cols, rows });
   }
 
+  attachTerminal(terminalId: string): import("./terminal-service").TerminalAttachResult {
+    if (!this.deps.terminalEnabled()) throw new Error("terminal-disabled");
+    return this.deps.terminal.attach(terminalId);
+  }
+
   writeTerminal(terminalId: string, data: string): void {
     this.deps.terminal.write(terminalId, data);
   }

--- a/src/control/terminal-service.ts
+++ b/src/control/terminal-service.ts
@@ -35,8 +35,13 @@ export type PtySpawn = (
 
 export interface TerminalCreateInput { cwd: string; cols: number; rows: number }
 
+export type TerminalAttachResult =
+  | { ok: false }
+  | { ok: true; buffer: string; lastSeq: number };
+
 export interface TerminalService {
   create(input: TerminalCreateInput): { terminalId: string };
+  attach(terminalId: string): TerminalAttachResult;
   write(terminalId: string, data: string): void;
   resize(terminalId: string, cols: number, rows: number): void;
   close(terminalId: string): void;
@@ -115,7 +120,29 @@ function realPtySpawn(file: string, args: string[], opts: { name: string; cols: 
 }
 
 // idleTimer is typed as unknown so the type is compatible with both Node.js Timeout and Bun Timer.
-interface Session { handle: PtyHandle; seq: number; idleTimer: unknown }
+interface Session { handle: PtyHandle; seq: number; idleTimer: unknown; buffer: string; bufBytes: number }
+
+const MAX_BUFFER_BYTES = 256 * 1024;
+
+function appendToBuffer(session: Session, data: string): void {
+  session.buffer += data;
+  session.bufBytes += Buffer.byteLength(data, "utf8");
+  if (session.bufBytes <= MAX_BUFFER_BYTES) return;
+  // Drop oldest WHOLE lines (cut at "\n") to avoid slicing mid-escape-sequence.
+  while (session.bufBytes > MAX_BUFFER_BYTES) {
+    const nl = session.buffer.indexOf("\n");
+    if (nl === -1) break; // single line longer than the cap → hard-cut below
+    const removed = session.buffer.slice(0, nl + 1);
+    session.buffer = session.buffer.slice(nl + 1);
+    session.bufBytes -= Buffer.byteLength(removed, "utf8");
+  }
+  // Degenerate single huge line: hard-cut leading chars until within cap.
+  while (session.bufBytes > MAX_BUFFER_BYTES && session.buffer.length > 0) {
+    const ch = session.buffer[0]!;
+    session.buffer = session.buffer.slice(1);
+    session.bufBytes -= Buffer.byteLength(ch, "utf8");
+  }
+}
 
 export function createTerminalService(deps: TerminalServiceDeps): TerminalService {
   const spawn = deps.spawn ?? realPtySpawn;
@@ -144,11 +171,11 @@ export function createTerminalService(deps: TerminalServiceDeps): TerminalServic
       const shell = resolveShell({ platform, env: process.env, shellOverride: deps.shell?.() });
       const terminalId = randomUUID();
       const handle = spawn(shell, [], { name: "xterm-256color", cols, rows, cwd, env: scrubEnv() });
-      const session: Session = { handle, seq: 0, idleTimer: null };
+      const session: Session = { handle, seq: 0, idleTimer: null, buffer: "", bufBytes: 0 };
       sessions.set(terminalId, session);
       handle.onData((data) => {
-        // NOTE: resetIdle is intentionally NOT called here.
-        // Output does not count as user interaction; only write/resize do.
+        // NOTE: resetIdle is intentionally NOT called here (output ≠ user interaction).
+        appendToBuffer(session, data);
         deps.events.emit({ type: "terminal-output", terminalId, seq: session.seq++, data });
       });
       handle.onExit(({ exitCode }) => {
@@ -158,6 +185,12 @@ export function createTerminalService(deps: TerminalServiceDeps): TerminalServic
       });
       resetIdle(terminalId);
       return { terminalId };
+    },
+    attach(terminalId) {
+      const s = sessions.get(terminalId);
+      if (!s) return { ok: false };
+      resetIdle(terminalId); // reattaching counts as activity
+      return { ok: true, buffer: s.buffer, lastSeq: s.seq - 1 };
     },
     write(terminalId, data) {
       const s = sessions.get(terminalId);

--- a/tests/unit/control/terminal-service.test.ts
+++ b/tests/unit/control/terminal-service.test.ts
@@ -83,6 +83,51 @@ test("write/resize/close on an unknown terminalId are no-ops (no throw)", () => 
   expect(() => svc.close("nope")).not.toThrow();
 });
 
+// ── attach() / ring buffer (content replay, layer 3) ────────────────────────
+
+test("attach returns ok:false for an unknown terminal", () => {
+  const { svc } = setup();
+  expect(svc.attach("nope")).toEqual({ ok: false });
+});
+
+test("attach returns buffered output + lastSeq for a live terminal", () => {
+  const { svc, pty } = setup();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("hello\n");
+  pty.emitData("world\n");
+  const res = svc.attach(terminalId);
+  expect(res).toEqual({ ok: true, buffer: "hello\nworld\n", lastSeq: 1 }); // seq 0,1 emitted → lastSeq 1
+});
+
+test("attach on a terminal with no output yet returns lastSeq -1", () => {
+  const { svc } = setup();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  expect(svc.attach(terminalId)).toEqual({ ok: true, buffer: "", lastSeq: -1 });
+});
+
+test("attach returns ok:false after close", () => {
+  const { svc, pty } = setup();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("x");
+  pty.emitExit(0); // exit deletes the session
+  expect(svc.attach(terminalId)).toEqual({ ok: false });
+});
+
+test("ring buffer trims oldest whole lines past 256KB (keeps tail, cuts at newline)", () => {
+  const { svc, pty } = setup();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  // 300 lines of ~1KB each ≈ 300KB > 256KB cap
+  for (let i = 0; i < 300; i++) pty.emitData("L" + i + ":" + "x".repeat(1000) + "\n");
+  const res = svc.attach(terminalId);
+  if (!res.ok) throw new Error("expected ok");
+  expect(Buffer.byteLength(res.buffer, "utf8")).toBeLessThanOrEqual(256 * 1024);
+  // oldest lines dropped, newest retained; buffer starts at a line boundary (no partial leading line)
+  expect(res.buffer.startsWith("L")).toBe(true);
+  expect(res.buffer.endsWith("\n")).toBe(true);
+  expect(res.buffer).toContain("L299:");
+  expect(res.buffer).not.toContain("L0:");
+});
+
 test("create no longer throws on win32 and spawns the resolved shell", () => {
   const { svc, spawn } = setup({ platform: "win32", shell: () => "C:/win/pwsh.exe" });
   expect(() => svc.create({ cwd: "C:/ws", cols: 80, rows: 24 })).not.toThrow();

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, test, mock } from "bun:test";
 
 import { MSG, RELAY_PROTOCOL_VERSION, type RelayEnvelope } from "../../../../packages/relay-protocol/src/index";
 import {
@@ -355,4 +355,17 @@ test("subscribeControlEvents normalizes tool-event into a step DTO", () => {
   expect(tool.type).toBe("tool-event");
   expect(tool.step).toMatchObject({ toolCallId: "t1", kind: "execute", title: "ls", detail: { type: "command", command: "ls" } });
   expect(tool.event).toBeUndefined();
+});
+
+test("terminal.attach RPC forwards to attachTerminal and returns its result", async () => {
+  const { control } = makeFakeControl({ attachTerminal: mock((id: string) => ({ ok: true, buffer: "SCROLL", lastSeq: 3 })) });
+  const bridge = createControlBridge(control as never);
+  expect(await dispatch(bridge, req(MSG.terminalAttach, { terminalId: "t1" }))).toEqual({ ok: true, buffer: "SCROLL", lastSeq: 3 });
+  expect((control.attachTerminal as ReturnType<typeof mock>).mock.calls[0]).toEqual(["t1"]);
+});
+
+test("terminal.attach RPC without terminalId returns bad-request", async () => {
+  const { control } = makeFakeControl({ attachTerminal: mock(() => ({ ok: false })) });
+  const bridge = createControlBridge(control as never);
+  expect(await dispatch(bridge, req(MSG.terminalAttach, {}))).toEqual({ error: { code: "bad-request", message: "terminalId is required" } });
 });


### PR DESCRIPTION
## What

web 刷新后恢复终端 scrollback 并**接回同一个仍在运行的 shell**(不再新开空 shell)。四包:relay-protocol / core / channel-relay / relay-web。

- **core** — `TerminalService` 每 PTY 256KB 输出 ring buffer(行边界裁剪)+ `attach(terminalId)` 返回 `{ok,buffer,lastSeq}`;`control.attachTerminal` 门面。杀 PTY 仅显式关闭/剪枝 + idle,**刷新卸载不杀**。
- **protocol** — `control.terminal.attach` RPC + `TerminalAttachRequest/Result`(tsc 重建 dist)。
- **connector** — control-bridge attach RPC 转发 case。
- **relay-web** — `lib/terminal-sessions.ts` 持久化 terminalId(sessionStorage);store `attach()` + 接住 `seq`;TerminalTab 刷新挂载先 attach(灌 buffer + 订阅 live + 按 lastSeq 去重,订阅→排队→buffer→冲 pending→直写),attach 不到回落"启动新终端"占位;`lib/session-terminal.ts` `killSessionTerminal` 让**所有**显式关闭/剪枝路径(tab 条 X、pane close、reconcile 剪枝、session 归档/删除)统一杀 PTY + 清 id。

`seq` 终于派上用场做 attach 快照/live 去重。

## Review

- 6 任务逐门禁(含 3 波 fix):全 spec ✅ + Approved
- 最终全分支(opus,9 提交):Ready=YES,0/0
- 独立 fresh-eyes(opus):**Ship,0/0**;attach 越权读经论证为可接受 v1 信任模型(output 本就账号级广播、跨账号被 instance 归属挡死、terminalId 不可猜 UUID)

## Test

core terminal-service 23、connector 23、relay-web 全套 668、tsc/vue-tsc 0、protocol dist assert 通过。

spec: `docs/superpowers/specs/2026-07-05-terminal-content-replay-design.md`
plan: `docs/superpowers/plans/2026-07-05-terminal-content-replay.md`