### PR TITLE
release: terminal batch beta (Windows support + content replay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [terminal batch beta] - 2026-07-05
+
+A four-package beta shipping two terminal features together: **Windows support** and **content replay across reload**. Versions: `@ganglion/xacpx-relay-protocol` 0.1.11, `@ganglion/xacpx` (core) 0.17.0-beta.4, `@ganglion/xacpx-channel-relay` 0.3.3-beta.4, `@ganglion/xacpx-relay` (hub) 0.9.12-beta.19 — all on the npm `next` dist-tag. Update the core/daemon and the hub, restart both, then hard-reload the dashboard.
+
+### Added
+
+- **The built-in terminal now works on Windows** (#134). The previous macOS/Linux-only gate is lifted. The shell is chosen as `pwsh` → Windows PowerShell → `cmd.exe` (scanning `PATH`), and a new cross-platform `terminal.shell` config overrides it explicitly. `SHELL` is deliberately ignored on Windows (git-bash sets it to an MSYS path that can't be spawned). Validated by a `windows-latest` CI leg that spawns a real ConPTY shell under Node.
+- **Terminals survive a browser reload** (#135). Reloading the dashboard now restores a terminal's scrollback and **reconnects to the same running shell** instead of opening a fresh one — the working directory, environment, and in-progress commands are still there. Each terminal keeps a bounded 256 KB output buffer on the backend; on reload the tab re-attaches and replays it. If the shell was already reaped (after ~15 min idle), the tab falls back to the "start new terminal" placeholder. Closing a terminal tab (or archiving/deleting its session) still kills the shell; only a reload keeps it alive.
+
+### Notes
+
+- Windows terminal real-machine validation is confirmatory (the CI leg already exercises the native ConPTY path); please still try it on a Windows instance.
+- Terminal replay is per-account: as before, a terminal's output is visible to your own account's dashboard sessions only.
+
 ## [relay 0.9.12-beta.18] - 2026-07-05
 
 A `@ganglion/xacpx-relay` (hub) beta that restores your dashboard workspace across a browser refresh (#132). UI-only (bundled `relay-web`), published to the npm `next` dist-tag. Update with `xacpx-relay update`, then restart the hub and hard-reload the dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.3",
+  "version": "0.17.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.3",
+      "version": "0.17.0-beta.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -12040,7 +12040,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.3",
+      "version": "0.3.3-beta.4",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -12082,7 +12082,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.18",
+      "version": "0.9.12-beta.19",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -12099,7 +12099,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT"
     },
     "packages/relay-web": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.3",
+  "version": "0.17.0-beta.4",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/channel-relay/package.json
+++ b/packages/channel-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-relay",
-  "version": "0.3.3-beta.3",
+  "version": "0.3.3-beta.4",
   "description": "Relay hub connector channel plugin for xacpx.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay-protocol/package.json
+++ b/packages/relay-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay-protocol",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Shared wire protocol types and codecs for the xacpx relay hub.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.18",
+  "version": "0.9.12-beta.19",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.3", () => {
+test("root package version is 0.17.0-beta.4", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.3");
+  expect(pkg.version).toBe("0.17.0-beta.4");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.3",
+  "version": "0.17.0-beta.4",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.3"
+    "@ganglion/xacpx": "^0.17.0-beta.4"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Batched 4-package beta shipping both terminal features now on main:
- **Windows terminal support** (#134)
- **Terminal content replay across reload** (#135)

Version bumps:
| package | → |
|---|---|
| `@ganglion/xacpx-relay-protocol` | 0.1.10 → **0.1.11** (adds `control.terminal.attach` RPC; stays ^0.1.0-compatible) |
| `@ganglion/xacpx` (core/root) | 0.17.0-beta.3 → **0.17.0-beta.4** |
| `@ganglion/xacpx-channel-relay` | 0.3.3-beta.3 → **0.3.3-beta.4** |
| `@ganglion/xacpx-relay` (hub) | 0.9.12-beta.18 → **0.9.12-beta.19** |

Coupling synced: `weacpx-compat` version + `^dep` mirror root; `package-metadata.test.ts` root-version assertion updated (4 pass). `npm install --package-lock-only` synced. `verify:publish` ✓ (relay-protocol dist barrel non-empty asserted). English CHANGELOG added.

Publishes to npm `next` on tags, pushed in dependency order: `relay-protocol-v0.1.11` → `v0.17.0-beta.4` → `channel-relay-v0.3.3-beta.4` → `relay-v0.9.12-beta.19`.