### PR TITLE
fix(relay-protocol): allow session-history control event through web whitelist

### DIFF
--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -83,23 +83,31 @@ export function webEventEnvelope(event: WebServerEvent): RelayEnvelope {
 
 const WEB_EVENT_KINDS = new Set(["instance-status", "control-event", "notice"]);
 
-const CONTROL_EVENT_TYPES = new Set([
-  "turn-output",
-  "turn-started",
-  "tool-event",
-  "turn-thought",
-  "plan",
-  "turn-usage",
-  "agent-commands",
-  "turn-finished",
-  "queue-updated",
-  "sessions-changed",
-  "workspaces-changed",
-  "scheduled-changed",
-  "orchestration-changed",
-  "terminal-output",
-  "terminal-exit",
-]);
+/** Compile-time-exhaustive whitelist of inner control-event discriminants. The
+ *  `satisfies Record<ControlEventDto["type"], true>` clause makes tsc fail if a new
+ *  member is added to the ControlEventDto union without being listed here — the drift
+ *  that once silently dropped `session-history` pushes. When you add a key here, also
+ *  add its per-variant field check to the switch in `validControlEvent` below. */
+const CONTROL_EVENT_TYPE_MAP = {
+  "turn-output": true,
+  "turn-started": true,
+  "tool-event": true,
+  "turn-thought": true,
+  "plan": true,
+  "turn-usage": true,
+  "agent-commands": true,
+  "turn-finished": true,
+  "queue-updated": true,
+  "sessions-changed": true,
+  "workspaces-changed": true,
+  "scheduled-changed": true,
+  "session-history": true,
+  "orchestration-changed": true,
+  "terminal-output": true,
+  "terminal-exit": true,
+} satisfies Record<ControlEventDto["type"], true>;
+
+const CONTROL_EVENT_TYPES: ReadonlySet<string> = new Set(Object.keys(CONTROL_EVENT_TYPE_MAP));
 
 const TOOL_STEP_KINDS = new Set(["read", "search", "execute", "edit", "think", "other"]);
 const TOOL_STEP_STATUSES = new Set(["running", "success", "error"]);
@@ -148,37 +156,59 @@ function validToolStep(s: unknown): boolean {
   return true;
 }
 
-/** Deep-validate an inner ControlEventDto: discriminant + per-variant required fields. */
+/** Deep-validate an inner ControlEventDto: discriminant + per-variant required fields.
+ *  The switch is compile-time exhaustive over ControlEventDto["type"] (see the `never`
+ *  check in `default`), mirroring CONTROL_EVENT_TYPE_MAP above. */
 function validControlEvent(e: unknown): boolean {
   if (typeof e !== "object" || e === null) return false;
   const c = e as Record<string, unknown>;
   if (typeof c.type !== "string" || !CONTROL_EVENT_TYPES.has(c.type)) return false;
-  if (c.type === "turn-output")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
-  if (c.type === "turn-finished")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.ok === "boolean";
-  if (c.type === "scheduled-changed") return typeof c.chatKey === "string";
-  if (c.type === "turn-started")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string";
-  if (c.type === "turn-thought")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
-  if (c.type === "plan")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.entries);
-  if (c.type === "turn-usage")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.used === "number" && typeof c.size === "number";
-  if (c.type === "agent-commands")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string"
-      && Array.isArray(c.commands)
-      && c.commands.every((x) => x !== null && typeof x === "object" && typeof (x as { name?: unknown }).name === "string");
-  if (c.type === "queue-updated")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.items);
-  if (c.type === "tool-event")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && validToolStep(c.step);
-  if (c.type === "terminal-output")
-    return typeof c.terminalId === "string" && typeof c.seq === "number" && typeof c.data === "string";
-  if (c.type === "terminal-exit")
-    return typeof c.terminalId === "string" && typeof c.code === "number";
-  return true; // sessions-changed / workspaces-changed / orchestration-changed carry no extra fields
+  const type = c.type as ControlEventDto["type"];
+  switch (type) {
+    case "turn-output":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
+    case "turn-finished":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.ok === "boolean";
+    case "scheduled-changed":
+      return typeof c.chatKey === "string";
+    case "turn-started":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string";
+    case "turn-thought":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
+    case "plan":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.entries);
+    case "turn-usage":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.used === "number" && typeof c.size === "number";
+    case "agent-commands":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string"
+        && Array.isArray(c.commands)
+        && c.commands.every((x) => x !== null && typeof x === "object" && typeof (x as { name?: unknown }).name === "string");
+    case "queue-updated":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.items);
+    case "session-history":
+      // Recovered rows are rendered directly; each must carry a direction + text so
+      // the web's history seed can't crash on a junk row from a buggy connector.
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string"
+        && Array.isArray(c.messages)
+        && c.messages.every((m) => m !== null && typeof m === "object"
+          && ((m as { direction?: unknown }).direction === "in" || (m as { direction?: unknown }).direction === "out")
+          && typeof (m as { text?: unknown }).text === "string");
+    case "tool-event":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && validToolStep(c.step);
+    case "terminal-output":
+      return typeof c.terminalId === "string" && typeof c.seq === "number" && typeof c.data === "string";
+    case "terminal-exit":
+      return typeof c.terminalId === "string" && typeof c.code === "number";
+    case "sessions-changed":
+    case "workspaces-changed":
+    case "orchestration-changed":
+      return true; // no extra fields
+    default: {
+      // Exhaustiveness guard: adding a ControlEventDto member without a case above is a tsc error.
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
 }
 
 const NOTICE_KINDS = new Set(["task-completion", "task-progress", "coordinator-message"]);

--- a/tests/unit/packages/relay-protocol/web-dtos.test.ts
+++ b/tests/unit/packages/relay-protocol/web-dtos.test.ts
@@ -149,6 +149,44 @@ test("parseWebServerEvent accepts an agent-commands control event and rejects ma
   expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "agent-commands", chatKey: "k", sessionAlias: "a", commands: [{ description: "no name" }] } })).toBeNull();
 });
 
+test("parseWebServerEvent accepts a session-history control event and preserves its rows", () => {
+  // The gate (CONTROL_EVENT_TYPES + validControlEvent) must let session-history through,
+  // or recovered native-session conversations are silently dropped and the web
+  // handler for them is dead code.
+  const ev = roundtrip({
+    kind: "control-event", instanceId: "i1",
+    event: {
+      type: "session-history", chatKey: "k", sessionAlias: "a",
+      messages: [
+        { direction: "in", text: "hello" },
+        { direction: "out", text: "hi", structured: { reasoning: "r" } },
+      ],
+    },
+  });
+  expect(ev).not.toBeNull();
+  expect((ev as Extract<WebServerEvent, { kind: "control-event" }>).event).toMatchObject({
+    type: "session-history",
+    chatKey: "k",
+    sessionAlias: "a",
+    messages: [
+      { direction: "in", text: "hello" },
+      { direction: "out", text: "hi", structured: { reasoning: "r" } },
+    ],
+  });
+  // an empty recovery is valid (a native session with no prior rows)…
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", chatKey: "k", sessionAlias: "a", messages: [] } })).not.toBeNull();
+});
+
+test("parseWebServerEvent rejects malformed session-history events", () => {
+  // messages must be an array, or the hub's seed loop has nothing iterable.
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", chatKey: "k", sessionAlias: "a" } })).toBeNull();
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", chatKey: "k", sessionAlias: "a", messages: "x" } })).toBeNull();
+  // chatKey/sessionAlias must be strings (routing keys).
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", sessionAlias: "a", messages: [] } })).toBeNull();
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", chatKey: 1, sessionAlias: "a", messages: [] } })).toBeNull();
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", chatKey: "k", messages: [] } })).toBeNull();
+});
+
 test("parseWebServerEvent rejects a plan event without entries", () => {
   expect(roundtrip({
     kind: "control-event", instanceId: "i1",

--- a/tests/unit/packages/relay-protocol/web-dtos.test.ts
+++ b/tests/unit/packages/relay-protocol/web-dtos.test.ts
@@ -185,6 +185,10 @@ test("parseWebServerEvent rejects malformed session-history events", () => {
   expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", sessionAlias: "a", messages: [] } })).toBeNull();
   expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", chatKey: 1, sessionAlias: "a", messages: [] } })).toBeNull();
   expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", chatKey: "k", messages: [] } })).toBeNull();
+  // per-row guards: direction must be "in"/"out" and text must be a string,
+  // or the web's history seed renders junk rows from a buggy connector.
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", chatKey: "k", sessionAlias: "a", messages: [{ direction: "sideways", text: "x" }] } })).toBeNull();
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "session-history", chatKey: "k", sessionAlias: "a", messages: [{ direction: "in" }] } })).toBeNull();
 });
 
 test("parseWebServerEvent rejects a plan event without entries", () => {


### PR DESCRIPTION
## Summary
- Fix a confirmed bug: `session-history` exists in the `ControlEventDto` union (`dtos.ts:215`) and relay-web has a handler for it (`stores/chat.ts:348`), but `CONTROL_EVENT_TYPES` in `web-dtos.ts` was missing the entry, so `validControlEvent` silently dropped every live session-history push. The handler was dead code; history only appeared after a manual refresh.
- Add `session-history` to the whitelist plus per-field validation (chatKey/sessionAlias strings, messages rows with `direction: "in"|"out"` + `text: string`; optional `structured` passes through), matching the strictness of adjacent branches.
- Drift-proofing: the whitelist is now derived from `CONTROL_EVENT_TYPE_MAP satisfies Record<ControlEventDto["type"], true>`, and the validation if-chain became an exhaustive switch with a `never` guard — adding a union member without updating the gate is now a compile error in `build:relay-protocol`.

## Review
Independent opus review: Spec ✅ / Approved. Verified no over-strict rejection risk (optional fields untouched), switch rewrite behavior-identical for all 15 existing event types, both exhaustiveness guards proven live (removing a MAP key fails tsc). Review Minor (missing per-row reject cases) addressed in the second commit.

## Testing
- `bun test tests/unit/packages/relay-protocol/web-dtos.test.ts` → 24 pass (incl. new accept/reject cases; red-first verified)
- `bun run build:relay-protocol` → dist exports OK (barrel not tree-shaken)
- `npx tsc --noEmit` → 0 errors; `cd packages/relay-web && npx vitest run src/__tests__/chat.test.ts` → 49 pass