### PR TITLE
perf(core): coalesce mutex-held state writes; drop per-message config reload

### DIFF
--- a/src/commands/command-router.ts
+++ b/src/commands/command-router.ts
@@ -168,10 +168,14 @@ export class CommandRouter {
       kind: command.kind,
     });
 
-    // Refresh config BEFORE authorization so an ownerIds edit takes effect on
-    // the very next message.
-    await this.refreshConfigFromStore();
-    perfSpan?.mark("router.config_refreshed");
+    // No per-message config reload here. Out-of-band config edits (CLI
+    // `xacpx workspace add`, manual config.json edits — including ownerIds)
+    // are picked up by the config watcher in main.ts, which refreshes this
+    // router's shared AppConfig object in place within ~100ms of the file
+    // change. In-process edits (`/config set`, control-API agent/workspace
+    // writes) update the same object synchronously. Reloading from disk on
+    // every inbound message was a full read + parse + config rebuild on the
+    // hot path for no additional freshness.
 
     // Single seam for channel-turn ownership: the effective metadata (with
     // ownerIds applied) is what gets authorized AND what flows down to the
@@ -862,17 +866,6 @@ export class CommandRouter {
     };
     this.config.language = updated.language;
   }
-
-  private async refreshConfigFromStore(): Promise<void> {
-    if (!this.config || !this.configStore) {
-      return;
-    }
-
-    const updated = await this.configStore.load();
-    this.replaceConfig(updated);
-  }
-
-
 
   private async executeCommand(
     chatKey: string,

--- a/src/config/config-watcher.ts
+++ b/src/config/config-watcher.ts
@@ -8,7 +8,14 @@ export interface ConfigWatcherOptions {
   configPath: string;
   /** Fired (debounced) when the config file is created, replaced, or modified. */
   onChange: () => void;
-  /** Debounce window to coalesce one logical save's burst of fs events. Default 250ms. */
+  /**
+   * Debounce window to coalesce one logical save's burst of fs events.
+   * Default 100ms: since the command router no longer reloads config per
+   * message, this watcher is the only path for out-of-band edits (ownerIds!)
+   * to reach a running daemon — the window must stay well under a human
+   * message round-trip so an edit is live by the next message. 100ms is
+   * still ample to coalesce write-file-atomic's temp-create/rename burst.
+   */
   debounceMs?: number;
   logger?: AppLogger;
   /** Injection seam for tests; defaults to node:fs `watch`. */
@@ -38,7 +45,7 @@ export interface ConfigWatcher {
  * pre-existing "restart to pick up CLI edits" behavior.
  */
 export function startConfigWatcher(options: ConfigWatcherOptions): ConfigWatcher {
-  const { configPath, onChange, debounceMs = 250, logger } = options;
+  const { configPath, onChange, debounceMs = 100, logger } = options;
   const watchFactory = options.watchFactory ?? watch;
   const dir = dirname(configPath);
   const target = basename(configPath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -623,7 +623,13 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
     config,
     loadState: async () => JSON.parse(JSON.stringify(state)) as typeof state,
     saveState: async (nextState) => {
-      await debouncedStateStore.save(nextState);
+      // Orchestration is durability-gated: a task transition becomes visible
+      // in memory only AFTER it is persisted (see the "keeps the previous
+      // orchestration snapshot visible until task completion is persisted"
+      // test). saveNow() writes immediately — it does not wait out the
+      // debounce window and does not resolve at commit time like save() —
+      // and rejects on write failure so the mutation fails loudly.
+      await debouncedStateStore.saveNow(nextState);
       replaceRuntimeState(state, nextState);
     },
     stateMutex,

--- a/src/scheduled/scheduled-service.ts
+++ b/src/scheduled/scheduled-service.ts
@@ -219,6 +219,9 @@ export class ScheduledTaskService {
     return await this.stateMutex.run(critical);
   }
 
+  // Commits the state snapshot to the store; with the production
+  // DebouncedStateStore this resolves at commit time (the disk write happens
+  // debounced, off the mutex), so saving inside mutate() is cheap.
   private async save(): Promise<void> {
     await this.stateStore.save(this.state);
   }

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -768,6 +768,9 @@ export class SessionService {
     return await this.stateMutex.run(critical);
   }
 
+  // Commits the state snapshot to the store; with the production
+  // DebouncedStateStore this resolves at commit time (the disk write happens
+  // debounced, off the mutex), so persisting inside mutate() is cheap.
   private async persist(): Promise<void> {
     await this.stateStore.save(this.state);
   }

--- a/src/state/debounced-state-store.ts
+++ b/src/state/debounced-state-store.ts
@@ -1,11 +1,6 @@
 import type { AppState } from "./types";
 import type { StateStore } from "./state-store";
 
-interface PendingResolver {
-  resolve: () => void;
-  reject: (error: unknown) => void;
-}
-
 export interface DebouncedStateStoreDeps {
   delegate: Pick<StateStore, "save">;
   intervalMs: number;
@@ -14,22 +9,71 @@ export interface DebouncedStateStoreDeps {
 
 export class DebouncedStateStore {
   private pending: AppState | null = null;
-  private resolvers: PendingResolver[] = [];
   private timer: NodeJS.Timeout | null = null;
   private flushing: Promise<void> | null = null;
   private disposed = false;
 
   constructor(private readonly deps: DebouncedStateStoreDeps) {}
 
+  /**
+   * Commit `state` as the next snapshot to write and schedule the debounced
+   * flush. Resolves as soon as the snapshot is accepted — NOT when it reaches
+   * disk. Callers (SessionService / ScheduledTaskService / OrchestrationService)
+   * persist while holding the shared state mutex; if save() only resolved after
+   * the flush, every mutation would pay the full debounce interval and writes
+   * would never coalesce (N mutations ~= N x intervalMs, serialized). Durability
+   * is a shutdown concern: flush()/dispose() await the real disk write. Write
+   * failures are reported through `onError` (main.ts wires it to the app log).
+   */
   save(state: AppState): Promise<void> {
     if (this.disposed) {
       return Promise.reject(new Error("DebouncedStateStore is disposed"));
     }
-    return new Promise<void>((resolve, reject) => {
-      this.pending = state;
-      this.resolvers.push({ resolve, reject });
-      this.scheduleFlush();
+    this.pending = state;
+    this.scheduleFlush();
+    return Promise.resolve();
+  }
+
+  /**
+   * Immediate, durable write of `state` — no debounce. Awaits any in-flight
+   * write first (keeping writes ordered), supersedes a pending debounced
+   * snapshot (callers are mutex-serialized, so `state` is strictly newer),
+   * and REJECTS on write failure. This is the path for durability-gated
+   * callers: orchestration only exposes a task transition in memory after it
+   * has been persisted, so its saves must not resolve at commit time.
+   */
+  async saveNow(state: AppState): Promise<void> {
+    if (this.disposed) {
+      throw new Error("DebouncedStateStore is disposed");
+    }
+    this.pending = null;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    while (this.flushing) {
+      await this.flushing;
+    }
+    let failure: unknown;
+    let failed = false;
+    this.flushing = (async () => {
+      try {
+        await this.deps.delegate.save(state);
+      } catch (error) {
+        failed = true;
+        failure = error;
+        this.deps.onError?.(error);
+      }
+    })().finally(() => {
+      this.flushing = null;
     });
+    await this.flushing;
+    if (this.pending && !this.disposed) {
+      this.scheduleFlush();
+    }
+    if (failed) {
+      throw failure;
+    }
   }
 
   async flush(): Promise<void> {
@@ -39,7 +83,7 @@ export class DebouncedStateStore {
         this.timer = null;
       }
       if (this.flushing) {
-        await this.flushing.catch(() => {});
+        await this.flushing;
       } else if (this.pending) {
         await this.runOneFlushCycle();
       }
@@ -71,16 +115,15 @@ export class DebouncedStateStore {
     }
 
     const state = this.pending;
-    const resolvers = this.resolvers;
     this.pending = null;
-    this.resolvers = [];
 
     this.flushing = (async () => {
       try {
         await this.deps.delegate.save(state);
-        for (const r of resolvers) r.resolve();
       } catch (error) {
-        for (const r of resolvers) r.reject(error);
+        // save() already resolved at commit time, so this is the only place a
+        // write failure can surface. Never rethrow: flush()/dispose() must not
+        // fail shutdown over a logged write error.
         this.deps.onError?.(error);
       }
     })().finally(() => {

--- a/tests/unit/commands/command-router-interaction.test.ts
+++ b/tests/unit/commands/command-router-interaction.test.ts
@@ -62,7 +62,9 @@ test("emits perf marks for prompt transport lifecycle", async () => {
   await router.handle("wx:user", "hello", async () => {}, undefined, undefined, undefined, undefined, undefined, undefined, undefined, perfSpan);
 
   expect(marks.map((m) => m.event)).toContain("router.authorized");
-  expect(marks.map((m) => m.event)).toContain("router.config_refreshed");
+  // No per-message config reload: out-of-band edits arrive via the config
+  // watcher (main.ts), so the router must not read the store on this path.
+  expect(marks.map((m) => m.event)).not.toContain("router.config_refreshed");
   expect(marks.map((m) => m.event)).toContain("session.ready");
   expect(marks.map((m) => m.event)).toContain("transport.prompt_dispatched");
   expect(marks.filter((m) => m.event === "transport.first_chunk")).toHaveLength(1);

--- a/tests/unit/commands/command-router-session.test.ts
+++ b/tests/unit/commands/command-router-session.test.ts
@@ -496,18 +496,36 @@ test("reuses an existing workspace and session from the workspace shortcut comma
   });
 });
 
-test("workspace shortcut refreshes config saved by another process", async () => {
+test("handle() never reloads config from the store; watcher-style in-place refresh is honored", async () => {
+  // Out-of-band config edits (CLI `xacpx workspace add`, manual file edits) are
+  // picked up by the config watcher in main.ts, which refreshes the SAME shared
+  // AppConfig object in place. The router must not read the config store on the
+  // per-message hot path — that was a full disk read + parse + config rebuild
+  // on EVERY inbound message.
   const runtimeConfig = createConfig();
   const persistedConfig = createConfig();
   persistedConfig.workspaces.agent = { cwd: "E:/agent" };
   const configStore = new MemoryConfigStore(persistedConfig);
+  const loadSpy = mock(configStore.load.bind(configStore));
+  configStore.load = loadSpy as never;
   const sessions = new SessionService(runtimeConfig, new MemoryStateStore(), createEmptyState());
   const transport = createTransport();
   const router = new CommandRouter(sessions, transport, runtimeConfig, configStore);
 
-  const reply = await router.handle("wx:user", "/ss codex --ws agent");
+  // The store knows workspace "agent" but the runtime config does not yet:
+  // the router must NOT consult the store mid-message, so the shortcut fails.
+  const before = await router.handle("wx:user", "/ss codex --ws agent");
+  expect(loadSpy).not.toHaveBeenCalled();
+  expect(before.text).toContain(
+    t().shortcut.workspaceNotRegistered("agent", t().shortcut.workspaceAvailable("backend")),
+  );
 
+  // Simulate the watcher's reloadRuntimeConfig: refresh the shared object in place.
+  Object.assign(runtimeConfig, { workspaces: { ...persistedConfig.workspaces } });
+
+  const reply = await router.handle("wx:user", "/ss codex --ws agent");
   expect(reply.text).toContain(t().shortcut.createdHeader("agent:codex"));
+  expect(loadSpy).not.toHaveBeenCalled();
   expect(await sessions.getCurrentSession("wx:user")).toMatchObject({
     alias: "agent:codex",
     workspace: "agent",

--- a/tests/unit/config/config-watcher.test.ts
+++ b/tests/unit/config/config-watcher.test.ts
@@ -64,6 +64,21 @@ test("close() clears a pending callback and closes the underlying watcher", asyn
   expect(fake.state.closed).toBe(1);
 });
 
+test("default debounce is short enough for next-message pickup (fires within 200ms)", async () => {
+  // The router no longer reloads config per message; the watcher is the ONLY
+  // path for out-of-band edits (ownerIds!) to reach a running daemon. The
+  // default debounce must stay well under a human message round-trip so an
+  // edit is live by the next message. 200ms would catch a regression back to
+  // the old 250ms default while giving the 100ms timer real margin.
+  const fake = fakeWatch();
+  let fired = 0;
+  const w = startConfigWatcher({ configPath: "/x/config.json", onChange: () => { fired += 1; }, watchFactory: fake.factory });
+  fake.emit("config.json");
+  await delay(200);
+  expect(fired).toBe(1);
+  w.close();
+});
+
 test("a throwing onChange is swallowed and does not crash the watcher", async () => {
   const fake = fakeWatch();
   const w = startConfigWatcher({ configPath: "/x/config.json", onChange: () => { throw new Error("boom"); }, debounceMs: 10, watchFactory: fake.factory });

--- a/tests/unit/sessions/session-service.test.ts
+++ b/tests/unit/sessions/session-service.test.ts
@@ -4,6 +4,7 @@ import type { AppConfig } from "../../../src/config/types";
 import { createEmptyState } from "../../../src/state/types";
 import type { AppState } from "../../../src/state/types";
 import type { StateStore } from "../../../src/state/state-store";
+import { DebouncedStateStore } from "../../../src/state/debounced-state-store";
 import { SessionService } from "../../../src/sessions/session-service";
 import { registerKnownChannelId } from "../../../src/channels/channel-scope";
 import { setLocale, t } from "../../../src/i18n";
@@ -898,4 +899,33 @@ test("relay ignores a reply_mode override and always streams; the raw override i
   const weixin = service.getResolvedSessionByInternalAlias("weixin:bar");
   expect(weixin!.replyMode).toBe("verbose");
   expect(weixin!.effectiveReplyMode).toBeUndefined();
+});
+
+test("mutations under the shared mutex commit immediately and coalesce into one debounced write", async () => {
+  // Regression for the debounce-defeating pattern: SessionService.mutate() holds the
+  // shared state mutex while it awaits persist(). When the debounced store's save()
+  // only resolved after the flush, every mutation serialized on the full debounce
+  // interval (N writes ~= N x 50ms) and coalescing never happened. save() must
+  // resolve at commit time so back-to-back mutations batch into a single write.
+  const inner = new MemoryStateStore();
+  const debounced = new DebouncedStateStore({ delegate: inner, intervalMs: 200 });
+  const service = new SessionService(createConfig(), debounced, createEmptyState());
+
+  const startedAt = Date.now();
+  await service.createSession("api-fix", "codex", "backend");
+  await service.setSessionModel("api-fix", "gpt-5.5");
+  await service.setArchived("api-fix", true);
+  await service.setArchived("api-fix", false);
+
+  // Four awaited mutations must not pay four debounce intervals (>=800ms before).
+  expect(Date.now() - startedAt).toBeLessThan(200);
+  // Nothing has hit the delegate yet: the debounce window is still open.
+  expect(inner.savedStates.length).toBe(0);
+
+  await debounced.flush();
+  expect(inner.savedStates.length).toBe(1);
+  // The single write carries the LAST committed state (all four mutations).
+  expect(inner.savedStates[0]!.sessions["api-fix"]).toMatchObject({ model: "gpt-5.5" });
+  expect(inner.savedStates[0]!.sessions["api-fix"]!.archived).toBeUndefined();
+  await debounced.dispose();
 });

--- a/tests/unit/state/debounced-state-store.test.ts
+++ b/tests/unit/state/debounced-state-store.test.ts
@@ -60,6 +60,115 @@ test("DebouncedStateStore flushes pending saves immediately", async () => {
   await store.dispose();
 });
 
+test("DebouncedStateStore save resolves before the debounced write reaches the delegate", async () => {
+  let writes = 0;
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async () => {
+        writes += 1;
+      },
+    },
+    // Long interval on purpose: a save() that waited for the flush would stall
+    // here and the write counter would already be 1 by the time we assert.
+    intervalMs: 1000,
+  });
+
+  await store.save({ sessions: {}, chat_contexts: {} });
+
+  expect(writes).toBe(0);
+  await store.flush();
+  expect(writes).toBe(1);
+  await store.dispose();
+});
+
+test("DebouncedStateStore coalesces sequential awaited saves within one interval", async () => {
+  // Mirrors the production pattern: services persist under a shared mutex, so
+  // every save is awaited before the next mutation starts. Under the old
+  // contract (save resolves only after the flush) each save paid the full
+  // debounce interval and NOTHING ever coalesced — N writes, N x interval.
+  const savedStates: any[] = [];
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async (state) => {
+        savedStates.push(state);
+      },
+    },
+    intervalMs: 50,
+  });
+
+  await store.save({ sessions: { a: 1 }, chat_contexts: {} });
+  await store.save({ sessions: { b: 2 }, chat_contexts: {} });
+  await store.save({ sessions: { c: 3 }, chat_contexts: {} });
+  await store.flush();
+
+  expect(savedStates.length).toBe(1);
+  expect(savedStates[0].sessions).toEqual({ c: 3 });
+  await store.dispose();
+});
+
+test("DebouncedStateStore saveNow writes immediately and supersedes a pending debounced snapshot", async () => {
+  const savedStates: any[] = [];
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async (state) => {
+        savedStates.push(state);
+      },
+    },
+    intervalMs: 1000,
+  });
+
+  await store.save({ sessions: { debounced: 1 }, chat_contexts: {} });
+  // saveNow must not wait for the 1000ms debounce window, and its (strictly
+  // newer, mutex-ordered) snapshot supersedes the pending debounced one.
+  await store.saveNow({ sessions: { durable: 2 }, chat_contexts: {} });
+
+  expect(savedStates.length).toBe(1);
+  expect(savedStates[0].sessions).toEqual({ durable: 2 });
+  await store.flush();
+  expect(savedStates.length).toBe(1);
+  await store.dispose();
+});
+
+test("DebouncedStateStore saveNow rejects on write failure (durability-gated callers must see it)", async () => {
+  const errors: unknown[] = [];
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async () => {
+        throw new Error("disk full");
+      },
+    },
+    intervalMs: 10,
+    onError: (error) => {
+      errors.push(error);
+    },
+  });
+
+  await expect(store.saveNow({ sessions: {}, chat_contexts: {} })).rejects.toThrow("disk full");
+  expect(errors.length).toBe(1);
+  await store.dispose();
+});
+
+test("DebouncedStateStore saveNow waits out an in-flight debounced write before writing", async () => {
+  const order: string[] = [];
+  const store = new DebouncedStateStore({
+    delegate: {
+      save: async (state: any) => {
+        order.push(`start:${Object.keys(state.sessions)[0]}`);
+        await new Promise((r) => setTimeout(r, 20));
+        order.push(`end:${Object.keys(state.sessions)[0]}`);
+      },
+    },
+    intervalMs: 5,
+  });
+
+  await store.save({ sessions: { a: 1 }, chat_contexts: {} });
+  await new Promise((r) => setTimeout(r, 10)); // first write now in flight
+  await store.saveNow({ sessions: { b: 2 }, chat_contexts: {} });
+
+  expect(order).toEqual(["start:a", "end:a", "start:b", "end:b"]);
+  await store.dispose();
+});
+
 test("DebouncedStateStore rejects save after dispose", async () => {
   const store = new DebouncedStateStore({
     delegate: { save: async () => {} },
@@ -91,7 +200,9 @@ test("DebouncedStateStore handles concurrent saves with flush", async () => {
   await store.dispose();
 });
 
-test("DebouncedStateStore calls onError when save fails", async () => {
+test("DebouncedStateStore reports write failures via onError, not via the save promise", async () => {
+  // save() resolves at commit time (before the flush), so a later disk failure
+  // can only surface through onError — the logging path main.ts wires up.
   const errors: unknown[] = [];
   const store = new DebouncedStateStore({
     delegate: {
@@ -105,32 +216,32 @@ test("DebouncedStateStore calls onError when save fails", async () => {
     },
   });
 
-  await expect(store.save({ sessions: {}, chat_contexts: {} })).rejects.toThrow("save failed");
-  await new Promise((r) => setTimeout(r, 50));
+  await store.save({ sessions: {}, chat_contexts: {} });
+  await store.flush();
 
   expect(errors.length).toBe(1);
+  expect(errors[0]).toBeInstanceOf(Error);
   await store.dispose();
 });
 
 test("DebouncedStateStore schedules another flush after current flush completes", async () => {
   let saveCount = 0;
-  let inSave = false;
   const store = new DebouncedStateStore({
     delegate: {
       save: async () => {
-        inSave = true;
         saveCount++;
         await new Promise((r) => setTimeout(r, 20));
-        inSave = false;
       },
     },
     intervalMs: 10,
   });
 
   await store.save({ sessions: { a: 1 }, chat_contexts: {} });
-  await new Promise((r) => setTimeout(r, 5));
+  // Let the debounce timer fire so the first write is in flight...
+  await new Promise((r) => setTimeout(r, 15));
+  // ...then commit a new snapshot during that write; it must get its own flush.
   await store.save({ sessions: { b: 2 }, chat_contexts: {} });
-  await new Promise((r) => setTimeout(r, 50));
+  await new Promise((r) => setTimeout(r, 60));
 
   expect(saveCount).toBe(2);
   await store.dispose();


### PR DESCRIPTION
## Summary
Two hot-path fixes from the architecture audit.

**1. State debounce was cancelled by the mutex.** `SessionService.mutate()` awaited `persist()` inside the shared `stateMutex`, but `DebouncedStateStore.save()` only resolved after the 50ms debounce timer flushed to disk — so N mutations serialized to ~N×50ms and never coalesced. `save()` now resolves at commit time (write errors go to `onError`, wired to the app log); `flush()`/`dispose()` still await the real disk write. **Orchestration is exempt**: its contract is "persist before the transition is visible in memory," so it uses a new `saveNow()` (immediate durable write, ordered after any in-flight write, rejects on failure).

**2. Per-message config reload removed.** `CommandRouter.handle()` did a full read+parse+rebuild of config on every inbound message. The config watcher (now 100ms debounce) already refreshes the shared `AppConfig` in place for out-of-band edits; in-process edits update it synchronously. ownerIds edits still take effect on the next message.

## Review (independent, inline)
Spec ✅ / Approved. Verified: orchestration durability gate preserved (loadState clones under mutex, saveNow persists before replaceRuntimeState); no "stale-clone-overwrites-new" race (whole load→save→replace holds the shared mutex, single shared `state` object); CommandRouter shares the exact config object the watcher mutates; watcher is unconditional. Known tradeoffs (all Minor): ~50ms crash-durability window for session/scheduled writes (intended — "durability is a shutdown concern"); scheduled-write failures now log via onError instead of propagating to the user; the watcher is now the sole path for out-of-band edits (load-bearing on fs.watch).

## Testing
- `debounced-state-store` 12, `session-service` 52 (incl. 4-serial-mutation coalescing regression), `main` 36, `config-watcher` 8, orchestration/scheduled/run-console suites — all green (TZ=UTC)
- `npx tsc --noEmit` → 0