### PR TITLE
fix(relay): WS reconnect/heartbeat/broadcast robustness

### DIFF
--- a/packages/channel-relay/src/relay-client.ts
+++ b/packages/channel-relay/src/relay-client.ts
@@ -23,11 +23,19 @@ export interface RelayClientOptions {
   onEvent?: (envelope: RelayEnvelope) => void;
   onReady?: () => void;
   reconnectDelaysMs?: number[];
+  /**
+   * Kill the socket when no inbound traffic (the hub pings every 30s) arrives
+   * within this window — detects half-open connections the connector would
+   * otherwise never notice. The resulting close runs the normal reconnect path.
+   */
+  livenessTimeoutMs?: number;
   createSocket?: (url: string) => WebSocket;
   logger?: AppLogger;
 }
 
 const DEFAULT_DELAYS = [1_000, 2_000, 5_000, 10_000, 30_000];
+/** 3x the hub's 30s heartbeat interval: tolerate two lost pings before declaring death. */
+const DEFAULT_LIVENESS_TIMEOUT_MS = 90_000;
 const HANDSHAKE_ID = "handshake-1";
 
 export class RelayClient {
@@ -64,12 +72,43 @@ export class RelayClient {
     this.socket = socket;
     this.ready = false;
 
-    socket.on("open", () => this.sendHandshake(socket));
-    socket.on("message", (data) => this.handleMessage(socket, String(data)));
+    // Liveness watchdog: the hub pings on a 30s cadence, so prolonged silence
+    // means the connection is half-open. terminate() forces the close event,
+    // which runs the normal reconnect path below. (`ws` answers pings with
+    // pongs automatically; we only need to notice their absence.)
+    let livenessTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearLiveness = () => {
+      if (livenessTimer) clearTimeout(livenessTimer);
+      livenessTimer = null;
+    };
+    const armLiveness = () => {
+      clearLiveness();
+      livenessTimer = setTimeout(() => {
+        void this.options.logger?.error(
+          "relay.connection_stalled",
+          "no traffic from relay within the liveness window; terminating half-open socket",
+          {},
+        );
+        if (typeof socket.terminate === "function") socket.terminate();
+        else socket.close();
+      }, this.options.livenessTimeoutMs ?? DEFAULT_LIVENESS_TIMEOUT_MS);
+      (livenessTimer as unknown as { unref?: () => void }).unref?.();
+    };
+
+    socket.on("open", () => {
+      armLiveness();
+      this.sendHandshake(socket);
+    });
+    socket.on("ping", armLiveness);
+    socket.on("message", (data) => {
+      armLiveness();
+      this.handleMessage(socket, String(data));
+    });
     socket.on("error", () => {
       // close event follows; reconnect is handled there
     });
     socket.on("close", () => {
+      clearLiveness();
       this.ready = false;
       if (this.stopped) return;
       const delays = this.options.reconnectDelaysMs ?? DEFAULT_DELAYS;

--- a/packages/channel-relay/src/relay-client.ts
+++ b/packages/channel-relay/src/relay-client.ts
@@ -38,6 +38,14 @@ const DEFAULT_DELAYS = [1_000, 2_000, 5_000, 10_000, 30_000];
 const DEFAULT_LIVENESS_TIMEOUT_MS = 90_000;
 const HANDSHAKE_ID = "handshake-1";
 
+/**
+ * +-20% random jitter so a fleet of connectors dropped by the same hub restart
+ * does not reconnect in lockstep (thundering herd).
+ */
+export function applyReconnectJitter(baseMs: number, random: () => number = Math.random): number {
+  return Math.round(baseMs * (0.8 + random() * 0.4));
+}
+
 export class RelayClient {
   private socket: WebSocket | null = null;
   private attempts = 0;
@@ -114,7 +122,7 @@ export class RelayClient {
       const delays = this.options.reconnectDelaysMs ?? DEFAULT_DELAYS;
       const delay = delays[Math.min(this.attempts, delays.length - 1)] ?? 30_000;
       this.attempts += 1;
-      setTimeout(() => this.connect(), delay);
+      setTimeout(() => this.connect(), applyReconnectJitter(delay));
     });
   }
 
@@ -237,15 +245,35 @@ export class RelayClient {
 
     if (envelope.kind === "req") {
       const respond = (payload: unknown) => {
-        socket.send(
-          encodeEnvelope({
-            protocolVersion: RELAY_PROTOCOL_VERSION,
-            kind: "res",
-            id: envelope.id,
-            type: envelope.type,
-            payload,
-          }),
-        );
+        // Handlers may respond long after the request arrived (async control
+        // dispatch); the socket can be gone by then. Sending on a closed socket
+        // throws, which would surface as an unhandledRejection in callers like
+        // control-bridge's catch-path respond — drop the response instead.
+        if (socket.readyState !== WebSocket.OPEN) {
+          void this.options.logger?.debug(
+            "relay.response_dropped",
+            `dropping response for ${envelope.type}: socket is no longer open`,
+            { type: envelope.type, id: envelope.id ?? "" },
+          );
+          return;
+        }
+        try {
+          socket.send(
+            encodeEnvelope({
+              protocolVersion: RELAY_PROTOCOL_VERSION,
+              kind: "res",
+              id: envelope.id,
+              type: envelope.type,
+              payload,
+            }),
+          );
+        } catch (err) {
+          void this.options.logger?.error(
+            "relay.response_send_failed",
+            `sending response for ${envelope.type} failed: ${err instanceof Error ? err.message : String(err)}`,
+            { type: envelope.type },
+          );
+        }
       };
       this.options.onRequest(envelope, respond);
     }

--- a/packages/relay/src/gateway/heartbeat.ts
+++ b/packages/relay/src/gateway/heartbeat.ts
@@ -1,0 +1,54 @@
+/** Ping cadence for hub-side sockets (instance connectors and web dashboards). */
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+/** Consecutive unanswered pings tolerated before the socket is declared dead. */
+export const HEARTBEAT_MAX_MISSED_PONGS = 2;
+
+/**
+ * Structural subset of a `ws` socket the heartbeat needs. `ping`/`terminate` are
+ * optional so unit-test fakes (and any non-ws transport) opt out gracefully.
+ */
+export interface HeartbeatSocket {
+  ping?(): void;
+  terminate?(): void;
+  close?(code?: number, reason?: string): void;
+  on(event: "pong", listener: () => void): unknown;
+  on(event: "close", listener: () => void): unknown;
+}
+
+/**
+ * Application-level keepalive that kills half-open TCP connections: ping every
+ * `intervalMs`; once `maxMissed` pings in a row go unanswered, terminate the
+ * socket so its close handler runs (offline broadcast on the hub, reconnect on
+ * the peer). No-op for sockets without `ping` (unit-test fakes).
+ */
+export function startHeartbeat(
+  socket: HeartbeatSocket,
+  intervalMs = HEARTBEAT_INTERVAL_MS,
+  maxMissed = HEARTBEAT_MAX_MISSED_PONGS,
+): void {
+  if (typeof socket.ping !== "function") return;
+  let missed = 0;
+  socket.on("pong", () => {
+    missed = 0;
+  });
+  const timer = setInterval(() => {
+    if (missed >= maxMissed) {
+      clearInterval(timer);
+      try {
+        if (typeof socket.terminate === "function") socket.terminate();
+        else socket.close?.(4408, "heartbeat-timeout");
+      } catch (err) {
+        console.error("[relay] heartbeat terminate failed:", err);
+      }
+      return;
+    }
+    missed += 1;
+    try {
+      socket.ping!();
+    } catch (err) {
+      console.error("[relay] heartbeat ping failed:", err);
+    }
+  }, intervalMs);
+  (timer as unknown as { unref?: () => void }).unref?.();
+  socket.on("close", () => clearInterval(timer));
+}

--- a/packages/relay/src/gateway/instance-gateway.ts
+++ b/packages/relay/src/gateway/instance-gateway.ts
@@ -11,6 +11,7 @@ import {
 
 import type { AccountStore } from "../stores/accounts.js";
 import type { InstanceStore } from "../stores/instances.js";
+import { startHeartbeat } from "./heartbeat.js";
 
 /** Single authoritative default for the gateway RPC timeout, shared by the server layer. */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
@@ -18,14 +19,20 @@ export const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 export interface GatewaySocket {
   send(data: string): void;
   close(code?: number, reason?: string): void;
+  /** Optional (real `ws` sockets have them): enables the keepalive heartbeat. */
+  ping?(): void;
+  terminate?(): void;
   on(event: "message", listener: (data: unknown) => void): unknown;
   on(event: "close", listener: () => void): unknown;
+  on(event: "pong", listener: () => void): unknown;
 }
 
 export interface InstanceGatewayDeps {
   instances: Pick<InstanceStore, "redeemPairingToken" | "registerInstanceForAccount" | "verifyCredential" | "touch">;
   accounts: Pick<AccountStore, "resolveLoginToken">;
   requestTimeoutMs?: number;
+  /** Keepalive ping cadence; overridable for tests. Defaults to HEARTBEAT_INTERVAL_MS. */
+  heartbeatIntervalMs?: number;
   onEvent?: (instanceId: string, accountId: string, envelope: RelayEnvelope) => void;
   onStatusChange?: (instanceId: string, accountId: string, online: boolean) => void;
 }
@@ -50,6 +57,7 @@ export class InstanceGateway {
 
   handleConnection(socket: GatewaySocket): void {
     let authed: { instanceId: string; accountId: string } | null = null;
+    startHeartbeat(socket, this.deps.heartbeatIntervalMs);
 
     socket.on("message", (data) => {
       const decoded = decodeEnvelope(String(data));

--- a/packages/relay/src/gateway/instance-gateway.ts
+++ b/packages/relay/src/gateway/instance-gateway.ts
@@ -60,57 +60,22 @@ export class InstanceGateway {
     startHeartbeat(socket, this.deps.heartbeatIntervalMs);
 
     socket.on("message", (data) => {
-      const decoded = decodeEnvelope(String(data));
-      if (!decoded.ok) {
-        socket.send(encodeEnvelope({
-          protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: "relay.protocol-error",
-          payload: errorPayload(decoded.error, decoded.detail ?? "invalid envelope"),
-        }));
-        if (!authed) socket.close(4400, decoded.error);
-        return;
-      }
-      const envelope = decoded.envelope;
-
-      if (!authed) {
-        authed = this.handleHandshake(socket, envelope);
-        if (authed) {
-          // A reconnect can race the old (often half-open) socket: replace the map
-          // entry FIRST, then close the old socket, whose close handler no-ops
-          // because the entry no longer points at it.
-          const existing = this.connections.get(authed.instanceId);
-          this.connections.set(authed.instanceId, { socket, accountId: authed.accountId });
-          if (existing && existing.socket !== socket) {
-            try {
-              existing.socket.close(4409, "superseded");
-            } catch (err) {
-              console.error("[relay] closing superseded instance socket failed:", err);
-            }
-          }
-          this.deps.onStatusChange?.(authed.instanceId, authed.accountId, true);
-        }
-        return;
-      }
-
-      if (envelope.kind === "res" && envelope.id) {
-        const waiting = this.pending.get(envelope.id);
-        if (waiting) {
-          clearTimeout(waiting.timer);
-          this.pending.delete(envelope.id);
-          waiting.resolve(envelope.payload);
-        }
-        return;
-      }
-      if (envelope.kind === "event") {
-        this.deps.instances.touch(authed.instanceId);
-        this.deps.onEvent?.(authed.instanceId, authed.accountId, envelope);
+      // A single bad frame (or a throwing onEvent consumer, e.g. a DB write) must
+      // not propagate out of the listener and tear down the whole connection.
+      try {
+        this.handleMessage(socket, data, authed, (identity) => {
+          authed = identity;
+        });
+      } catch (err) {
+        console.error("[relay] instance gateway message handling failed:", err);
       }
     });
 
     socket.on("close", () => {
       if (!authed) return;
       // Only the socket that currently owns the map entry may take the instance
-      // offline. A superseded socket's late close would otherwise evict the NEW
-      // connection and reject its in-flight requests.
+      // offline. A superseded socket's late close (see handleMessage) would
+      // otherwise evict the NEW connection and reject its in-flight requests.
       const current = this.connections.get(authed.instanceId);
       if (current?.socket !== socket) return;
       this.connections.delete(authed.instanceId);
@@ -123,6 +88,59 @@ export class InstanceGateway {
       }
       this.deps.onStatusChange?.(authed.instanceId, authed.accountId, false);
     });
+  }
+
+  private handleMessage(
+    socket: GatewaySocket,
+    data: unknown,
+    authed: { instanceId: string; accountId: string } | null,
+    setAuthed: (identity: { instanceId: string; accountId: string }) => void,
+  ): void {
+    const decoded = decodeEnvelope(String(data));
+    if (!decoded.ok) {
+      socket.send(encodeEnvelope({
+        protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: "relay.protocol-error",
+        payload: errorPayload(decoded.error, decoded.detail ?? "invalid envelope"),
+      }));
+      if (!authed) socket.close(4400, decoded.error);
+      return;
+    }
+    const envelope = decoded.envelope;
+
+    if (!authed) {
+      const identity = this.handleHandshake(socket, envelope);
+      if (identity) {
+        setAuthed(identity);
+        // A reconnect can race the old (often half-open) socket: replace the map
+        // entry FIRST, then close the old socket, whose close handler no-ops
+        // because the entry no longer points at it.
+        const existing = this.connections.get(identity.instanceId);
+        this.connections.set(identity.instanceId, { socket, accountId: identity.accountId });
+        if (existing && existing.socket !== socket) {
+          try {
+            existing.socket.close(4409, "superseded");
+          } catch (err) {
+            console.error("[relay] closing superseded instance socket failed:", err);
+          }
+        }
+        this.deps.onStatusChange?.(identity.instanceId, identity.accountId, true);
+      }
+      return;
+    }
+
+    if (envelope.kind === "res" && envelope.id) {
+      const waiting = this.pending.get(envelope.id);
+      if (waiting) {
+        clearTimeout(waiting.timer);
+        this.pending.delete(envelope.id);
+        waiting.resolve(envelope.payload);
+      }
+      return;
+    }
+    if (envelope.kind === "event") {
+      this.deps.instances.touch(authed.instanceId);
+      this.deps.onEvent?.(authed.instanceId, authed.accountId, envelope);
+    }
   }
 
   /** Returns the authed identity, or null (after replying/closing) when the handshake fails. */

--- a/packages/relay/src/gateway/instance-gateway.ts
+++ b/packages/relay/src/gateway/instance-gateway.ts
@@ -66,7 +66,18 @@ export class InstanceGateway {
       if (!authed) {
         authed = this.handleHandshake(socket, envelope);
         if (authed) {
+          // A reconnect can race the old (often half-open) socket: replace the map
+          // entry FIRST, then close the old socket, whose close handler no-ops
+          // because the entry no longer points at it.
+          const existing = this.connections.get(authed.instanceId);
           this.connections.set(authed.instanceId, { socket, accountId: authed.accountId });
+          if (existing && existing.socket !== socket) {
+            try {
+              existing.socket.close(4409, "superseded");
+            } catch (err) {
+              console.error("[relay] closing superseded instance socket failed:", err);
+            }
+          }
           this.deps.onStatusChange?.(authed.instanceId, authed.accountId, true);
         }
         return;
@@ -88,17 +99,21 @@ export class InstanceGateway {
     });
 
     socket.on("close", () => {
-      if (authed) {
-        this.connections.delete(authed.instanceId);
-        for (const [id, p] of this.pending) {
-          if (p.instanceId === authed.instanceId) {
-            clearTimeout(p.timer);
-            this.pending.delete(id);
-            p.reject(new Error("instance-offline"));
-          }
+      if (!authed) return;
+      // Only the socket that currently owns the map entry may take the instance
+      // offline. A superseded socket's late close would otherwise evict the NEW
+      // connection and reject its in-flight requests.
+      const current = this.connections.get(authed.instanceId);
+      if (current?.socket !== socket) return;
+      this.connections.delete(authed.instanceId);
+      for (const [id, p] of this.pending) {
+        if (p.instanceId === authed.instanceId) {
+          clearTimeout(p.timer);
+          this.pending.delete(id);
+          p.reject(new Error("instance-offline"));
         }
-        this.deps.onStatusChange?.(authed.instanceId, authed.accountId, false);
       }
+      this.deps.onStatusChange?.(authed.instanceId, authed.accountId, false);
     });
   }
 

--- a/packages/relay/src/gateway/web-gateway.ts
+++ b/packages/relay/src/gateway/web-gateway.ts
@@ -1,18 +1,33 @@
 import { encodeEnvelope, webEventEnvelope, type WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 
+import { startHeartbeat } from "./heartbeat.js";
+
 export interface WebSocketLike {
   send(data: string): void;
+  close?(code?: number, reason?: string): void;
+  /** Optional (real `ws` sockets have them): enables the keepalive heartbeat. */
+  ping?(): void;
+  terminate?(): void;
   on(event: "close", listener: () => void): unknown;
+  on(event: "pong", listener: () => void): unknown;
+}
+
+export interface WebGatewayOptions {
+  /** Keepalive ping cadence; overridable for tests. Defaults to HEARTBEAT_INTERVAL_MS. */
+  heartbeatIntervalMs?: number;
 }
 
 /** Tracks authenticated browser sockets per account and fans events out to them. */
 export class WebGateway {
   private readonly byAccount = new Map<string, Set<WebSocketLike>>();
 
+  constructor(private readonly options: WebGatewayOptions = {}) {}
+
   register(accountId: string, socket: WebSocketLike): void {
     const set = this.byAccount.get(accountId) ?? new Set<WebSocketLike>();
     set.add(socket);
     this.byAccount.set(accountId, set);
+    startHeartbeat(socket, this.options.heartbeatIntervalMs);
     socket.on("close", () => {
       set.delete(socket);
       if (set.size === 0) this.byAccount.delete(accountId);

--- a/packages/relay/src/gateway/web-gateway.ts
+++ b/packages/relay/src/gateway/web-gateway.ts
@@ -2,12 +2,16 @@ import { encodeEnvelope, webEventEnvelope, type WebServerEvent } from "@ganglion
 
 import { startHeartbeat } from "./heartbeat.js";
 
+/** ws readyState OPEN (avoid importing the ws package for one constant). */
+const WS_OPEN = 1;
+
 export interface WebSocketLike {
   send(data: string): void;
   close?(code?: number, reason?: string): void;
   /** Optional (real `ws` sockets have them): enables the keepalive heartbeat. */
   ping?(): void;
   terminate?(): void;
+  readyState?: number;
   on(event: "close", listener: () => void): unknown;
   on(event: "pong", listener: () => void): unknown;
 }
@@ -38,6 +42,14 @@ export class WebGateway {
     const set = this.byAccount.get(accountId);
     if (!set) return;
     const data = encodeEnvelope(webEventEnvelope(event));
-    for (const socket of set) socket.send(data);
+    for (const socket of set) {
+      // One dead/throwing socket must not starve the remaining dashboards.
+      if (typeof socket.readyState === "number" && socket.readyState !== WS_OPEN) continue;
+      try {
+        socket.send(data);
+      } catch (err) {
+        console.error("[relay] web broadcast send failed:", err);
+      }
+    }
   }
 }

--- a/tests/unit/packages/channel-relay/relay-client.test.ts
+++ b/tests/unit/packages/channel-relay/relay-client.test.ts
@@ -190,6 +190,68 @@ test("onEvent throwing does not tear down the socket — subsequent events are s
   wss.close();
 });
 
+test("liveness watchdog terminates a silent connection and reconnects", async () => {
+  let connections = 0;
+  const wss = new WebSocketServer({ port: 0 });
+  await new Promise<void>((resolve) => wss.on("listening", () => resolve()));
+  wss.on("connection", (socket) => {
+    connections += 1;
+    // Auth ok, then total silence: no pings, no frames.
+    socket.on("message", (data) => {
+      const decoded = decodeEnvelope(String(data));
+      if (decoded.ok && decoded.envelope.type === MSG.instanceAuth) {
+        socket.send(encodeEnvelope(res(decoded.envelope, { ok: true })));
+      }
+    });
+  });
+  const url = `ws://127.0.0.1:${(wss.address() as { port: number }).port}`;
+  const store = new MemoryCredentialStore({ instanceId: "i-1", credential: "cred-1", relayUrl: url });
+  const { logger, errors } = makeFakeLogger();
+  const controller = new AbortController();
+  const client = new RelayClient({
+    url, credentialStore: store, onRequest: () => {}, reconnectDelaysMs: [0], logger,
+    livenessTimeoutMs: 120,
+  });
+  client.start(controller.signal);
+  await new Promise((resolve) => setTimeout(resolve, 600));
+  expect(connections).toBeGreaterThanOrEqual(2); // watchdog fired -> close -> reconnect
+  expect(errors.some((e) => e.code === "relay.connection_stalled")).toBe(true);
+  controller.abort();
+  wss.close();
+});
+
+test("server pings keep the liveness watchdog from firing", async () => {
+  let connections = 0;
+  const wss = new WebSocketServer({ port: 0 });
+  await new Promise<void>((resolve) => wss.on("listening", () => resolve()));
+  const pingTimers: ReturnType<typeof setInterval>[] = [];
+  wss.on("connection", (socket) => {
+    connections += 1;
+    socket.on("message", (data) => {
+      const decoded = decodeEnvelope(String(data));
+      if (decoded.ok && decoded.envelope.type === MSG.instanceAuth) {
+        socket.send(encodeEnvelope(res(decoded.envelope, { ok: true })));
+      }
+    });
+    const timer = setInterval(() => { if (socket.readyState === socket.OPEN) socket.ping(); }, 40);
+    pingTimers.push(timer);
+    socket.on("close", () => clearInterval(timer));
+  });
+  const url = `ws://127.0.0.1:${(wss.address() as { port: number }).port}`;
+  const store = new MemoryCredentialStore({ instanceId: "i-1", credential: "cred-1", relayUrl: url });
+  const controller = new AbortController();
+  const client = new RelayClient({
+    url, credentialStore: store, onRequest: () => {}, reconnectDelaysMs: [0],
+    livenessTimeoutMs: 150,
+  });
+  client.start(controller.signal);
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  expect(connections).toBe(1); // pings kept it alive
+  controller.abort();
+  pingTimers.forEach((timer) => clearInterval(timer));
+  wss.close();
+});
+
 test("reconnects after a drop; fatal handshake rejection stops retrying", async () => {
   let connections = 0;
   const { wss, url } = await makeFakeRelay((envelope, reply, raw) => {

--- a/tests/unit/packages/channel-relay/relay-client.test.ts
+++ b/tests/unit/packages/channel-relay/relay-client.test.ts
@@ -9,7 +9,7 @@ import {
   errorPayload,
   type RelayEnvelope,
 } from "../../../../packages/relay-protocol/src/index";
-import { RelayClient } from "../../../../packages/channel-relay/src/relay-client";
+import { RelayClient, applyReconnectJitter } from "../../../../packages/channel-relay/src/relay-client";
 import type { RelayCredential } from "../../../../packages/channel-relay/src/credential-store";
 
 class MemoryCredentialStore {
@@ -187,6 +187,48 @@ test("onEvent throwing does not tear down the socket — subsequent events are s
   // The throw was logged as relay.event_dispatch_failed.
   expect(errors.some((e) => e.code === "relay.event_dispatch_failed")).toBe(true);
   controller.abort();
+  wss.close();
+});
+
+test("reconnect delay gets +/-20% jitter around the configured base", () => {
+  expect(applyReconnectJitter(1000, () => 0)).toBe(800);
+  expect(applyReconnectJitter(1000, () => 0.5)).toBe(1000);
+  expect(applyReconnectJitter(1000, () => 1)).toBe(1200);
+  expect(applyReconnectJitter(0, () => 1)).toBe(0); // zero-delay test configs stay zero
+});
+
+test("respond after the socket closed is dropped safely instead of throwing", async () => {
+  let capturedRespond: ((payload: unknown) => void) | undefined;
+  const seen: RelayEnvelope[] = [];
+  const { wss, url } = await makeFakeRelay((envelope, reply) => {
+    seen.push(envelope);
+    if (envelope.type === MSG.instanceAuth) {
+      reply(res(envelope, { ok: true }));
+      // Push a control req; the handler will answer only after the socket is gone.
+      reply({ protocolVersion: RELAY_PROTOCOL_VERSION, kind: "req", id: "late-1", type: MSG.sessionsList, payload: {} });
+    }
+  });
+  const store = new MemoryCredentialStore({ instanceId: "i-1", credential: "cred-1", relayUrl: url });
+  const droppedLogs: string[] = [];
+  const logger = {
+    info: async () => {}, error: async () => {}, cleanup: async () => {}, flush: async () => {},
+    debug: async (code: string) => { droppedLogs.push(code); },
+  } as never;
+  const controller = new AbortController();
+  const client = new RelayClient({
+    url, credentialStore: store, reconnectDelaysMs: [0], logger,
+    onRequest: (_envelope, respond) => { capturedRespond = respond; },
+  });
+  client.start(controller.signal);
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  expect(capturedRespond).toBeDefined();
+
+  controller.abort(); // closes the socket
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(() => capturedRespond!({ sessions: [] })).not.toThrow();
+  expect(droppedLogs).toContain("relay.response_dropped");
+  // No res frame ever reached the relay for the late request.
+  expect(seen.some((e) => e.kind === "res" && e.id === "late-1")).toBe(false);
   wss.close();
 });
 

--- a/tests/unit/packages/relay/gateway/gateway-heartbeat.test.ts
+++ b/tests/unit/packages/relay/gateway/gateway-heartbeat.test.ts
@@ -1,0 +1,98 @@
+// tests/unit/packages/relay/gateway/gateway-heartbeat.test.ts
+import { expect, test } from "bun:test";
+import { MSG, RELAY_PROTOCOL_VERSION, encodeEnvelope, type WebServerEvent } from "../../../../../packages/relay-protocol/src/index";
+import { InstanceGateway } from "../../../../../packages/relay/src/gateway/instance-gateway";
+import { WebGateway } from "../../../../../packages/relay/src/gateway/web-gateway";
+
+/** Fake ws socket with ping/pong/terminate; terminate emits close like the real thing. */
+class FakeWsSocket {
+  sent: string[] = [];
+  pings = 0;
+  terminated = false;
+  answerPongs = false;
+  listeners: Record<string, ((data?: unknown) => void)[]> = {};
+  send(data: string) { this.sent.push(data); }
+  close() { this.emit("close"); }
+  ping() { this.pings += 1; if (this.answerPongs) this.emit("pong"); }
+  terminate() { this.terminated = true; this.emit("close"); }
+  on(event: string, listener: (data?: unknown) => void) { (this.listeners[event] ??= []).push(listener); return this; }
+  emit(event: string, data?: unknown) { (this.listeners[event] ?? []).forEach((l) => l(data)); }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const stubDeps = {
+  instances: {
+    redeemPairingToken: () => null,
+    registerInstanceForAccount: () => ({ instanceId: "i1", credential: "c", accountId: "a1", name: "" }),
+    verifyCredential: () => ({ id: "i1", accountId: "a1" }),
+    touch: () => {},
+  } as never,
+  accounts: { resolveLoginToken: () => null },
+};
+
+const auth = (socket: FakeWsSocket) => socket.emit("message", encodeEnvelope({
+  protocolVersion: RELAY_PROTOCOL_VERSION, kind: "req", id: "h1", type: MSG.instanceAuth,
+  payload: { instanceId: "i1", credential: "c" },
+}));
+
+test("instance socket that never pongs is terminated and the instance goes offline", async () => {
+  const events: Array<[string, boolean]> = [];
+  const gateway = new InstanceGateway({
+    ...stubDeps,
+    heartbeatIntervalMs: 10,
+    onStatusChange: (instanceId, _accountId, online) => events.push([instanceId, online]),
+  });
+  const socket = new FakeWsSocket();
+  gateway.handleConnection(socket as never);
+  auth(socket);
+  expect(gateway.isOnline("i1")).toBe(true);
+
+  await sleep(120); // > 3 intervals: ping, ping, declare dead
+  expect(socket.pings).toBeGreaterThanOrEqual(2);
+  expect(socket.terminated).toBe(true);
+  expect(gateway.isOnline("i1")).toBe(false);
+  expect(events).toEqual([["i1", true], ["i1", false]]);
+});
+
+test("instance socket that answers pongs stays alive", async () => {
+  const gateway = new InstanceGateway({ ...stubDeps, heartbeatIntervalMs: 10 });
+  const socket = new FakeWsSocket();
+  socket.answerPongs = true;
+  gateway.handleConnection(socket as never);
+  auth(socket);
+
+  await sleep(120);
+  expect(socket.pings).toBeGreaterThanOrEqual(3);
+  expect(socket.terminated).toBe(false);
+  expect(gateway.isOnline("i1")).toBe(true);
+  socket.close();
+});
+
+test("web socket that never pongs is terminated and dropped from the broadcast set", async () => {
+  const gw = new WebGateway({ heartbeatIntervalMs: 10 });
+  const dead = new FakeWsSocket();
+  const alive = new FakeWsSocket();
+  alive.answerPongs = true;
+  gw.register("a1", dead as never);
+  gw.register("a1", alive as never);
+
+  await sleep(120);
+  expect(dead.terminated).toBe(true);
+  expect(alive.terminated).toBe(false);
+
+  const evt: WebServerEvent = { kind: "instance-status", instanceId: "i1", online: true };
+  gw.broadcast("a1", evt);
+  expect(dead.sent.length).toBe(0);
+  expect(alive.sent.length).toBe(1);
+  alive.close();
+});
+
+test("sockets without ping support are left alone (no heartbeat, no crash)", async () => {
+  const gw = new WebGateway({ heartbeatIntervalMs: 10 });
+  const plain = { sent: [] as string[], send(data: string) { this.sent.push(data); }, on() { return this; } };
+  gw.register("a1", plain as never);
+  await sleep(50);
+  gw.broadcast("a1", { kind: "instance-status", instanceId: "i1", online: true });
+  expect(plain.sent.length).toBe(1);
+});

--- a/tests/unit/packages/relay/gateway/instance-gateway-robustness.test.ts
+++ b/tests/unit/packages/relay/gateway/instance-gateway-robustness.test.ts
@@ -1,5 +1,5 @@
 // tests/unit/packages/relay/gateway/instance-gateway-robustness.test.ts
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { MSG, RELAY_PROTOCOL_VERSION, decodeEnvelope, encodeEnvelope } from "../../../../../packages/relay-protocol/src/index";
 import { InstanceGateway } from "../../../../../packages/relay/src/gateway/instance-gateway";
 
@@ -69,4 +69,35 @@ test("a reconnect supersedes the old socket; its late close does not evict the n
   newSocket.emit("close");
   expect(gateway.isOnline("i1")).toBe(false);
   expect(events).toEqual([["i1", true], ["i1", true], ["i1", false]]);
+});
+
+test("a throwing onEvent consumer does not kill the connection or later events", () => {
+  const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+  try {
+    let calls = 0;
+    const gateway = new InstanceGateway({
+      instances: stubInstances,
+      accounts: stubAccounts,
+      onEvent: () => {
+        calls += 1;
+        if (calls === 1) throw new Error("db write boom");
+      },
+    });
+    const socket = new FakeSocket();
+    gateway.handleConnection(socket as never);
+    auth(socket);
+
+    const event = encodeEnvelope({
+      protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceEvent,
+      payload: { event: { type: "sessions-changed" } },
+    });
+    expect(() => socket.emit("message", event)).not.toThrow();
+    // Connection survives and subsequent events still reach the consumer.
+    expect(gateway.isOnline("i1")).toBe(true);
+    socket.emit("message", event);
+    expect(calls).toBe(2);
+    expect(errorSpy).toHaveBeenCalled();
+  } finally {
+    errorSpy.mockRestore();
+  }
 });

--- a/tests/unit/packages/relay/gateway/instance-gateway-robustness.test.ts
+++ b/tests/unit/packages/relay/gateway/instance-gateway-robustness.test.ts
@@ -1,0 +1,72 @@
+// tests/unit/packages/relay/gateway/instance-gateway-robustness.test.ts
+import { expect, test } from "bun:test";
+import { MSG, RELAY_PROTOCOL_VERSION, decodeEnvelope, encodeEnvelope } from "../../../../../packages/relay-protocol/src/index";
+import { InstanceGateway } from "../../../../../packages/relay/src/gateway/instance-gateway";
+
+class FakeSocket {
+  sent: string[] = [];
+  closedWith: Array<{ code?: number; reason?: string }> = [];
+  listeners: Record<string, ((data?: unknown) => void)[]> = {};
+  send(data: string) { this.sent.push(data); }
+  close(code?: number, reason?: string) { this.closedWith.push({ code, reason }); this.emit("close"); }
+  on(event: string, listener: (data?: unknown) => void) { (this.listeners[event] ??= []).push(listener); return this; }
+  emit(event: string, data?: unknown) { (this.listeners[event] ?? []).forEach((l) => l(data)); }
+}
+
+const stubAccounts = { resolveLoginToken: () => null };
+const stubInstances = {
+  redeemPairingToken: () => null,
+  registerInstanceForAccount: () => ({ instanceId: "i1", credential: "c", accountId: "a1", name: "" }),
+  verifyCredential: () => ({ id: "i1", accountId: "a1" }),
+  touch: () => {},
+} as never;
+
+const auth = (socket: FakeSocket) => socket.emit("message", encodeEnvelope({
+  protocolVersion: RELAY_PROTOCOL_VERSION, kind: "req", id: "h1", type: MSG.instanceAuth,
+  payload: { instanceId: "i1", credential: "c" },
+}));
+
+test("a reconnect supersedes the old socket; its late close does not evict the new connection", async () => {
+  const events: Array<[string, boolean]> = [];
+  const gateway = new InstanceGateway({
+    instances: stubInstances,
+    accounts: stubAccounts,
+    requestTimeoutMs: 60_000,
+    onStatusChange: (instanceId, _accountId, online) => events.push([instanceId, online]),
+  });
+
+  const oldSocket = new FakeSocket();
+  gateway.handleConnection(oldSocket as never);
+  auth(oldSocket);
+  expect(gateway.isOnline("i1")).toBe(true);
+
+  // Same instance reconnects while the old (half-open) socket is still around.
+  const newSocket = new FakeSocket();
+  gateway.handleConnection(newSocket as never);
+  auth(newSocket);
+
+  // The hub explicitly closed the superseded socket...
+  expect(oldSocket.closedWith).toEqual([{ code: 4409, reason: "superseded" }]);
+  // ...and its (re-entrant) close did NOT take the instance offline.
+  expect(gateway.isOnline("i1")).toBe(true);
+  expect(events).toEqual([["i1", true], ["i1", true]]);
+
+  // In-flight requests on the new connection survive a stray late close of the old socket.
+  const pending = gateway.sendRequest("i1", MSG.sessionsList, {});
+  oldSocket.emit("close"); // duplicate/late close event from the dead socket
+  expect(gateway.isOnline("i1")).toBe(true);
+
+  // Requests route to the NEW socket and resolve through it.
+  const req = decodeEnvelope(newSocket.sent[newSocket.sent.length - 1]!);
+  expect(req.ok && req.envelope.kind === "req" && req.envelope.type === MSG.sessionsList).toBe(true);
+  const reqId = req.ok ? req.envelope.id : undefined;
+  newSocket.emit("message", encodeEnvelope({
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "res", id: reqId, type: MSG.sessionsList, payload: { sessions: [] },
+  }));
+  await expect(pending).resolves.toEqual({ sessions: [] });
+
+  // Closing the CURRENT socket still takes the instance offline.
+  newSocket.emit("close");
+  expect(gateway.isOnline("i1")).toBe(false);
+  expect(events).toEqual([["i1", true], ["i1", true], ["i1", false]]);
+});

--- a/tests/unit/packages/relay/gateway/web-gateway.test.ts
+++ b/tests/unit/packages/relay/gateway/web-gateway.test.ts
@@ -1,5 +1,5 @@
 // tests/unit/packages/relay/gateway/web-gateway.test.ts
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { decodeEnvelope, parseWebServerEvent, type WebServerEvent } from "../../../../../packages/relay-protocol/src/index";
 import { WebGateway } from "../../../../../packages/relay/src/gateway/web-gateway";
 
@@ -32,4 +32,38 @@ test("closed sockets are dropped from the account set", () => {
   a.close();
   gw.broadcast("a1", evt(false));
   expect(a.sent.length).toBe(0);
+});
+
+test("a throwing socket does not prevent delivery to the remaining sockets", () => {
+  const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const gw = new WebGateway();
+    const bad = new FakeSocket();
+    bad.send = () => { throw new Error("send boom"); };
+    const good = new FakeSocket();
+    // Insertion order matters: the throwing socket comes first.
+    gw.register("a1", bad as never);
+    gw.register("a1", good as never);
+    expect(() => gw.broadcast("a1", evt(true))).not.toThrow();
+    expect(good.sent.length).toBe(1);
+    expect(errorSpy).toHaveBeenCalled();
+  } finally {
+    errorSpy.mockRestore();
+  }
+});
+
+test("non-open sockets are skipped; sockets without readyState still receive", () => {
+  const gw = new WebGateway();
+  const closing = new FakeSocket() as FakeSocket & { readyState: number };
+  closing.readyState = 3; // CLOSED, but close event has not fired yet
+  const open = new FakeSocket() as FakeSocket & { readyState: number };
+  open.readyState = 1; // OPEN
+  const bare = new FakeSocket(); // no readyState (test fakes / non-ws transports)
+  gw.register("a1", closing as never);
+  gw.register("a1", open as never);
+  gw.register("a1", bare as never);
+  gw.broadcast("a1", evt(true));
+  expect(closing.sent.length).toBe(0);
+  expect(open.sent.length).toBe(1);
+  expect(bare.sent.length).toBe(1);
 });


### PR DESCRIPTION
## Summary
Five relay WS-link robustness fixes from the audit.

1. **Reconnect no longer evicts the live connection.** A new instance socket replaces the map entry *first*, then closes the old socket; the old socket's late close no-ops because the entry no longer points at it (previously it deleted the fresh entry, rejected its in-flight requests, and broadcast offline).
2. **Application-level heartbeat.** Both hub gateways ping every 30s and `terminate()` after 2 missed pongs; the connector runs a 90s liveness watchdog (re-armed by any inbound frame/ping) so a half-open TCP link is detected and reconnected instead of becoming a silent black hole.
3. **onEvent DB writes guarded.** The instance message listener wraps handling in try/catch so a throwing consumer (e.g. a failed `messages.append`) can't tear down the connection.
4. **Broadcast fanout survives a bad socket.** Per-socket `readyState===OPEN` check + try/catch so one dead dashboard doesn't starve the rest.
5. **Reconnect backoff jitter (±20%)** to avoid a thundering herd after a hub restart, plus a `readyState` guard on the connector's `respond`/`sendEvent` to prevent unhandled rejections on a closed socket.

## Review (independent, inline)
Spec ✅ / Approved. Traced all supersede interleavings (late close, near-simultaneous close, in-flight-on-superseded) — no eviction of the fresh connection, no spurious offline. Heartbeat: dead socket terminated after 3 intervals, ws protocol auto-pong keeps live sockets' missed-count at 0, `clearInterval` on close (no leak), `unref`. Connector watchdog + jitter (line 125) + respond guard verified. Minor tradeoffs: superseded socket's in-flight requests wait out the 120s timeout rather than rejecting immediately (spec chose identity-guard-only); heartbeat runs pre-auth (idle unauth sockets not reaped — pre-existing no-handshake-timeout gap); heartbeat tests use real 10–40ms timers (3 local runs clean, watch on slow CI).

## Testing
- New `instance-gateway-robustness` (2), `gateway-heartbeat` (4); `web-gateway` (+2), `relay-client` (+ jitter/watchdog/respond); ran 3× — 20 pass / 0 fail each, no flake
- Regression: 12 relay gateway files + 7 channel-relay files green; `npx tsc --noEmit` → 0