### PR TITLE
perf(relay-web): throttle streaming markdown, debounce drafts/tabs; NewSessionDialog a11y

### DIFF
--- a/packages/relay-web/src/__tests__/center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/center-tabs.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { nextTick } from "vue";
 import { setActivePinia, createPinia } from "pinia";
 import { useCenterTabsStore, sessionKey, TAB_DROP_END } from "../stores/center-tabs";
 import { draftKey, loadFileDraft, saveFileDraft } from "../lib/file-drafts";
@@ -155,13 +156,61 @@ describe("center-tabs store", () => {
     expect(term && term.kind === "terminal" ? term.autostart : undefined).toBe(true);
   });
 
-  it("persists tab state to sessionStorage on mutation", () => {
-    const s = useCenterTabsStore();
-    s.openFile(K, "a.ts");
-    const raw = sessionStorage.getItem("xacpx.center-tabs.v1");
-    expect(raw).toBeTruthy();
-    expect(JSON.parse(raw!)[K].tabs.map((t: { id: string }) => t.id)).toEqual(["file:a.ts"]);
-    expect(JSON.parse(raw!)[K].activeId).toBe("file:a.ts");
+  it("persists tab state to sessionStorage after the debounce window", async () => {
+    vi.useFakeTimers();
+    try {
+      const s = useCenterTabsStore();
+      s.openFile(K, "a.ts");
+      await nextTick(); // the (pre-flush) watcher arms the debounce
+      expect(sessionStorage.getItem("xacpx.center-tabs.v1")).toBeNull(); // not synchronous anymore
+      vi.advanceTimersByTime(200);
+      const raw = sessionStorage.getItem("xacpx.center-tabs.v1");
+      expect(raw).toBeTruthy();
+      expect(JSON.parse(raw!)[K].tabs.map((t: { id: string }) => t.id)).toEqual(["file:a.ts"]);
+      expect(JSON.parse(raw!)[K].activeId).toBe("file:a.ts");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("coalesces a burst of mutations into a single persisted write", async () => {
+    vi.useFakeTimers();
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+    try {
+      const s = useCenterTabsStore();
+      s.openFile(K, "a.ts");
+      await nextTick();
+      s.openFile(K, "b.ts");
+      s.setActive(K, "chat");
+      s.setDirty(K, "file:a.ts", true);
+      await nextTick();
+      vi.advanceTimersByTime(200);
+      const writes = spy.mock.calls.filter(([k]) => k === "xacpx.center-tabs.v1");
+      expect(writes.length).toBe(1); // one trailing write for the whole burst
+      const parsed = JSON.parse(writes[0][1])[K];
+      expect(parsed.tabs.map((t: { id: string }) => t.id)).toEqual(["file:a.ts", "file:b.ts"]);
+      expect(parsed.activeId).toBe("chat");
+      expect(parsed.tabs[0].dirty).toBe(true); // final state, nothing lost
+    } finally {
+      spy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("pagehide flushes a pending write synchronously (reload right after a mutation restores it)", async () => {
+    vi.useFakeTimers();
+    try {
+      const s = useCenterTabsStore();
+      s.openFile(K, "a.ts");
+      await nextTick(); // watcher armed, debounce still pending
+      expect(sessionStorage.getItem("xacpx.center-tabs.v1")).toBeNull();
+      window.dispatchEvent(new Event("pagehide"));
+      const raw = sessionStorage.getItem("xacpx.center-tabs.v1");
+      expect(raw).toBeTruthy();
+      expect(JSON.parse(raw!)[K].activeId).toBe("file:a.ts");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("hydrates tab state from sessionStorage on a fresh store", () => {

--- a/packages/relay-web/src/__tests__/draft-debounce.test.ts
+++ b/packages/relay-web/src/__tests__/draft-debounce.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import PromptInput from "../components/PromptInput.vue";
+import { createDebouncedFlush } from "../lib/debounce-flush";
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  sessionStorage.clear();
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createDebouncedFlush", () => {
+  it("runs the callback once on the trailing edge", () => {
+    const fn = vi.fn();
+    const d = createDebouncedFlush(fn, 100);
+    d.schedule();
+    vi.advanceTimersByTime(50);
+    d.schedule(); // restart the window
+    vi.advanceTimersByTime(99);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(d.pending).toBe(false);
+  });
+
+  it("flush runs a pending callback synchronously, and is a no-op when idle", () => {
+    const fn = vi.fn();
+    const d = createDebouncedFlush(fn, 100);
+    d.flush(); // idle → nothing
+    expect(fn).not.toHaveBeenCalled();
+    d.schedule();
+    d.flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(200); // the timer was consumed — no double fire
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel drops a pending callback without running it", () => {
+    const fn = vi.fn();
+    const d = createDebouncedFlush(fn, 100);
+    d.schedule();
+    d.cancel();
+    vi.advanceTimersByTime(200);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+const DRAFTS_KEY = "xacpx.composer-drafts.v1";
+const readDrafts = (): Record<string, string> => JSON.parse(sessionStorage.getItem(DRAFTS_KEY) ?? "{}");
+
+describe("PromptInput draft debounce", () => {
+  it("does not write per keystroke; one trailing write lands the final text after 300ms", async () => {
+    const w = mount(PromptInput, { props: { draftKey: "k1" } });
+    const ta = w.find("textarea");
+    await ta.setValue("h");
+    await ta.setValue("he");
+    await ta.setValue("hello");
+    expect(readDrafts()["k1"]).toBeUndefined(); // nothing written yet
+    vi.advanceTimersByTime(299);
+    expect(readDrafts()["k1"]).toBeUndefined();
+    vi.advanceTimersByTime(1);
+    expect(readDrafts()["k1"]).toBe("hello");
+  });
+
+  it("pagehide flushes the pending draft synchronously (reload right after typing keeps it)", async () => {
+    const w = mount(PromptInput, { props: { draftKey: "k1" } });
+    await w.find("textarea").setValue("half-typed");
+    expect(readDrafts()["k1"]).toBeUndefined();
+    window.dispatchEvent(new Event("pagehide"));
+    expect(readDrafts()["k1"]).toBe("half-typed"); // no timer advance needed
+  });
+
+  it("unmount flushes the pending draft", async () => {
+    const w = mount(PromptInput, { props: { draftKey: "k1" } });
+    await w.find("textarea").setValue("about to leave");
+    w.unmount();
+    expect(readDrafts()["k1"]).toBe("about to leave");
+  });
+
+  it("switching sessions stashes the old draft synchronously and never leaks text across keys", async () => {
+    const w = mount(PromptInput, { props: { draftKey: "k1" } });
+    await w.find("textarea").setValue("draft-a");
+    await w.setProps({ draftKey: "k2" }); // switch before the debounce fires
+    expect(readDrafts()["k1"]).toBe("draft-a"); // stashed immediately by the key watcher
+    vi.advanceTimersByTime(300); // late timer must not write k1's text under k2
+    expect(readDrafts()["k2"]).toBeUndefined();
+    expect(readDrafts()["k1"]).toBe("draft-a");
+  });
+
+  it("pagehide after unmount does not write (listener removed)", async () => {
+    const w = mount(PromptInput, { props: { draftKey: "k1" } });
+    await w.find("textarea").setValue("gone");
+    w.unmount(); // flushes "gone"
+    sessionStorage.clear();
+    window.dispatchEvent(new Event("pagehide"));
+    expect(readDrafts()["k1"]).toBeUndefined();
+  });
+});

--- a/packages/relay-web/src/__tests__/fileviewer-draft-debounce.test.ts
+++ b/packages/relay-web/src/__tests__/fileviewer-draft-debounce.test.ts
@@ -1,0 +1,97 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import FileViewer from "../components/FileViewer.vue";
+import { useFilesStore } from "../stores/files";
+
+const TEXT = { workspace: "ws", path: "src/a.ts", content: "DISK BODY", size: 9, mtimeMs: 1000, truncated: false, binary: false };
+const STORE_KEY = "xacpx.file-drafts.v1";
+const readDrafts = (): Record<string, string> => JSON.parse(sessionStorage.getItem(STORE_KEY) ?? "{}");
+
+let pinia: ReturnType<typeof createPinia>;
+beforeEach(() => {
+  pinia = createPinia();
+  setActivePinia(pinia);
+  sessionStorage.clear();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** Mount + load + enter edit mode under REAL timers (CodeMirror mounting relies on them),
+ *  then hand back the CM view. Callers switch to fake timers before typing. */
+async function mountEditing() {
+  const files = useFilesStore();
+  vi.spyOn(files, "readFile").mockResolvedValue({ ...TEXT });
+  const w = mount(FileViewer, {
+    props: { instanceId: "i1", workspace: "ws", path: "src/a.ts", sessionKey: "i1::s1" },
+    global: { plugins: [pinia] },
+  });
+  await flushPromises();
+  await new Promise((r) => setTimeout(r, 0));
+  await w.get('[data-test="fv-edit"]').trigger("click");
+  const editor = w.findComponent({ name: "CodeEditor" });
+  const view = (editor.vm as unknown as { view: { state: { doc: { length: number } }; dispatch: (t: unknown) => void } }).view;
+  return { w, view };
+}
+
+function type(view: { state: { doc: { length: number } }; dispatch: (t: unknown) => void }, text: string): void {
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+}
+
+describe("FileViewer edit-draft debounce", () => {
+  it("does not persist per keystroke; one trailing write after 300ms holds the final buffer", async () => {
+    const { view } = await mountEditing();
+    vi.useFakeTimers();
+    type(view, "EDIT 1");
+    await flushPromises();
+    type(view, "EDIT 12");
+    await flushPromises();
+    expect(readDrafts()["i1::s1::src/a.ts"]).toBeUndefined();
+    vi.advanceTimersByTime(300);
+    expect(readDrafts()["i1::s1::src/a.ts"]).toBe("EDIT 12");
+  });
+
+  it("pagehide flushes the pending edit draft synchronously", async () => {
+    const { view } = await mountEditing();
+    vi.useFakeTimers();
+    type(view, "ALMOST LOST");
+    await flushPromises();
+    expect(readDrafts()["i1::s1::src/a.ts"]).toBeUndefined();
+    window.dispatchEvent(new Event("pagehide"));
+    expect(readDrafts()["i1::s1::src/a.ts"]).toBe("ALMOST LOST");
+  });
+
+  it("unmount flushes the pending edit draft", async () => {
+    const { w, view } = await mountEditing();
+    vi.useFakeTimers();
+    type(view, "LEAVING NOW");
+    await flushPromises();
+    w.unmount();
+    expect(readDrafts()["i1::s1::src/a.ts"]).toBe("LEAVING NOW");
+  });
+
+  it("cancel drops the pending write so the cleared draft cannot resurrect", async () => {
+    const { w, view } = await mountEditing();
+    vi.useFakeTimers();
+    type(view, "THROWAWAY");
+    await flushPromises();
+    await w.get('[data-test="fv-cancel"]').trigger("click");
+    vi.advanceTimersByTime(1000); // a late timer must not re-write the draft
+    expect(readDrafts()["i1::s1::src/a.ts"]).toBeUndefined();
+  });
+
+  it("a buffer typed back to disk content removes the draft key on the trailing write", async () => {
+    const { view } = await mountEditing();
+    vi.useFakeTimers();
+    type(view, "EDITED");
+    await flushPromises();
+    vi.advanceTimersByTime(300);
+    expect(readDrafts()["i1::s1::src/a.ts"]).toBe("EDITED");
+    type(view, "DISK BODY"); // back to what's on disk
+    await flushPromises();
+    vi.advanceTimersByTime(300);
+    expect(readDrafts()["i1::s1::src/a.ts"]).toBeUndefined();
+  });
+});

--- a/packages/relay-web/src/__tests__/newsessiondialog-a11y.test.ts
+++ b/packages/relay-web/src/__tests__/newsessiondialog-a11y.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import NewSessionDialog from "../components/NewSessionDialog.vue";
+import { useInstancesStore } from "../stores/instances";
+
+beforeEach(() => setActivePinia(createPinia()));
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+// Mount with the REAL Teleport (content lands on document.body) and attachTo, so focus()
+// actually moves document.activeElement and keydowns bubble to the document listener.
+// (The teleport STUB re-creates the dialog subtree when `loading` flips, dropping focus —
+// a stub artifact the real Teleport doesn't have.) Teleported nodes aren't reachable via
+// wrapper.find, so DOM assertions go through document.querySelector.
+function mountDialog() {
+  const store = useInstancesStore();
+  store.instances = [{
+    id: "i1", name: "pc", online: true, lastSeenAt: null,
+    sessions: [],
+    agents: [{ name: "codex", driver: "codex" }],
+    workspaces: [{ name: "home", cwd: "/Users/me" }],
+    agentCatalog: [{ driver: "codex", configured: true, installed: "builtin" }],
+  }] as never;
+  vi.spyOn(store, "loadFormOptions").mockResolvedValue();
+  vi.spyOn(store, "listNativeSessions").mockResolvedValue([]);
+  vi.spyOn(store, "listModelSuggestions").mockResolvedValue([]);
+  const wrapper = mount(NewSessionDialog, {
+    props: { instanceId: "i1", instanceName: "pc" },
+    attachTo: document.body,
+  });
+  return { wrapper, store };
+}
+
+const dialog = (): HTMLElement => document.querySelector<HTMLElement>('[data-test="new-session-dialog"]')!;
+const q = <T extends HTMLElement>(sel: string): T => document.querySelector<T>(sel)!;
+
+describe("NewSessionDialog accessibility", () => {
+  it("exposes the dialog role contract (role, aria-modal, labelled title)", async () => {
+    const { wrapper } = mountDialog();
+    await flushPromises();
+    const dlg = dialog();
+    expect(dlg.getAttribute("role")).toBe("dialog");
+    expect(dlg.getAttribute("aria-modal")).toBe("true");
+    const labelledBy = dlg.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)?.textContent).toContain("New session");
+    wrapper.unmount();
+  });
+
+  it("Escape closes the dialog", async () => {
+    const { wrapper } = mountDialog();
+    await flushPromises();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(wrapper.emitted("close")).toBeTruthy();
+    wrapper.unmount();
+  });
+
+  it("Escape with the model popup open closes only the popup; a second Escape closes the dialog", async () => {
+    const { wrapper } = mountDialog();
+    await flushPromises();
+    const model = q<HTMLInputElement>('[data-test="ns-model"]');
+    model.focus();
+    await nextTick();
+    expect(document.querySelector('[data-test="ns-model-list"]')).toBeTruthy();
+    model.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await nextTick();
+    expect(document.querySelector('[data-test="ns-model-list"]')).toBeNull(); // popup closed
+    expect(wrapper.emitted("close")).toBeFalsy(); // stopPropagation kept the dialog open
+    model.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(wrapper.emitted("close")).toBeTruthy();
+    wrapper.unmount();
+  });
+
+  it("moves focus into the dialog on open", async () => {
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    outside.focus();
+    const { wrapper } = mountDialog();
+    await flushPromises();
+    expect(dialog().contains(document.activeElement)).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("traps Tab focus: Tab on the last element wraps to the first, Shift+Tab wraps back", async () => {
+    const { wrapper } = mountDialog();
+    await flushPromises();
+    const focusable = dialog().querySelectorAll<HTMLElement>(
+      'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    last.focus();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
+    expect(document.activeElement).toBe(first);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true }));
+    expect(document.activeElement).toBe(last);
+    wrapper.unmount();
+  });
+
+  it("restores focus to the previously focused element on close", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+    const { wrapper } = mountDialog();
+    await flushPromises();
+    expect(document.activeElement).not.toBe(opener);
+    wrapper.unmount();
+    expect(document.activeElement).toBe(opener);
+  });
+});

--- a/packages/relay-web/src/__tests__/streammarkdown.test.ts
+++ b/packages/relay-web/src/__tests__/streammarkdown.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import StreamMarkdown from "../components/StreamMarkdown.vue";
+import { renderMarkdown } from "../lib/render-markdown";
+
+// Count parses without paying for the real pipeline (healing + markdown-it + DOMPurify).
+vi.mock("../lib/render-markdown", () => ({
+  renderMarkdown: vi.fn((text: string) => `<p>${text}</p>`),
+}));
+const renderSpy = vi.mocked(renderMarkdown);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  renderSpy.mockClear();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("StreamMarkdown streaming throttle", () => {
+  it("non-streaming: re-renders synchronously on every text change (no throttle)", async () => {
+    const w = mount(StreamMarkdown, { props: { text: "a", streaming: false } });
+    expect(w.html()).toContain("<p>a</p>");
+    await w.setProps({ text: "ab" });
+    expect(w.html()).toContain("<p>ab</p>");
+    await w.setProps({ text: "abc" });
+    expect(w.html()).toContain("<p>abc</p>");
+    expect(renderSpy).toHaveBeenCalledTimes(3); // mount + 2 updates, zero timers involved
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("streaming: coalesces a burst of chunks into one trailing render with the full text", async () => {
+    const w = mount(StreamMarkdown, { props: { text: "a", streaming: true } });
+    expect(renderSpy).toHaveBeenCalledTimes(1); // initial mount render
+    // Rapid chunks well inside the throttle window: no immediate re-parse.
+    await w.setProps({ text: "ab" });
+    await w.setProps({ text: "abc" });
+    await w.setProps({ text: "abcd" });
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    expect(w.html()).toContain("<p>a</p>"); // still the last painted frame
+    // Trailing edge fires once and picks up the LATEST text.
+    vi.advanceTimersByTime(80);
+    await nextTick();
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+    expect(w.html()).toContain("<p>abcd</p>");
+  });
+
+  it("streaming: a chunk arriving after the throttle window renders immediately", async () => {
+    const w = mount(StreamMarkdown, { props: { text: "a", streaming: true } });
+    vi.advanceTimersByTime(100); // let the window elapse with no pending chunk
+    await w.setProps({ text: "ab" });
+    expect(renderSpy).toHaveBeenCalledTimes(2); // leading edge, no wait
+    expect(w.html()).toContain("<p>ab</p>");
+  });
+
+  it("streaming -> false renders the final full text immediately and drops the pending timer", async () => {
+    const w = mount(StreamMarkdown, { props: { text: "a", streaming: true } });
+    await w.setProps({ text: "ab" }); // schedules a trailing render
+    expect(vi.getTimerCount()).toBe(1);
+    await w.setProps({ text: "ab final", streaming: false });
+    expect(w.html()).toContain("<p>ab final</p>"); // no waiting for the timer
+    expect(vi.getTimerCount()).toBe(0);
+    const calls = renderSpy.mock.calls.length;
+    vi.advanceTimersByTime(200); // nothing left to fire
+    expect(renderSpy).toHaveBeenCalledTimes(calls);
+  });
+
+  it("unmount clears a pending throttled render (no stray timer callback)", async () => {
+    const w = mount(StreamMarkdown, { props: { text: "a", streaming: true } });
+    await w.setProps({ text: "ab" });
+    expect(vi.getTimerCount()).toBe(1);
+    w.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+    const calls = renderSpy.mock.calls.length;
+    vi.advanceTimersByTime(200);
+    expect(renderSpy).toHaveBeenCalledTimes(calls);
+  });
+});

--- a/packages/relay-web/src/components/FileViewer.vue
+++ b/packages/relay-web/src/components/FileViewer.vue
@@ -8,6 +8,7 @@ import CodeEditor from "./CodeEditor.vue";
 import { parseUnifiedDiff } from "../lib/unified-diff";
 import CopyButton from "./CopyButton.vue";
 import { draftKey, loadFileDraft, saveFileDraft, clearFileDraft } from "../lib/file-drafts";
+import { createDebouncedFlush } from "../lib/debounce-flush";
 
 // Roomy file/diff viewer that takes over the center column. A single CodeMirror instance
 // (CodeEditor) renders file content for BOTH read and edit — read is editable:false, the
@@ -108,11 +109,34 @@ watch(editDirty, (v) => emit("dirty-change", v));
 
 // Persist the edit buffer while editing so a reload can restore it. Clearing the edits back to
 // disk content removes the key (empty store). Only writes in edit mode with a real path.
+// Writes are debounced (each one re-parses + re-stringifies the whole draft map), with a
+// synchronous flush on pagehide/unmount so a reload right after typing still restores the
+// very last edits. Key + buffer + disk content are captured at schedule time, so a write
+// firing after a tab switch still lands under the file it was typed into.
+let pendingEditDraft: { key: string; text: string; disk: string } | null = null;
+const editDraftPersist = createDebouncedFlush(() => {
+  const p = pendingEditDraft;
+  pendingEditDraft = null;
+  if (!p) return;
+  if (p.text !== p.disk) saveFileDraft(p.key, p.text);
+  else clearFileDraft(p.key);
+}, 300);
+function cancelPendingEditDraft(): void {
+  pendingEditDraft = null;
+  editDraftPersist.cancel();
+}
 watch(content, (val) => {
-  if (!editing.value || !props.path) return;
-  const key = draftKey(props.sessionKey ?? "", props.path);
-  if (file.value && val !== file.value.content) saveFileDraft(key, val);
-  else clearFileDraft(key);
+  if (!editing.value || !props.path || !file.value) return;
+  pendingEditDraft = { key: draftKey(props.sessionKey ?? "", props.path), text: val, disk: file.value.content };
+  editDraftPersist.schedule();
+});
+function flushEditDraft(): void {
+  editDraftPersist.flush();
+}
+onMounted(() => window.addEventListener("pagehide", flushEditDraft));
+onBeforeUnmount(() => {
+  window.removeEventListener("pagehide", flushEditDraft);
+  flushEditDraft();
 });
 
 const saveErrorLabel = computed(() => {
@@ -140,6 +164,7 @@ function cancelEdit() {
   baseRev.value = null;
   saveError.value = null;
   emit("dirty-change", false);
+  cancelPendingEditDraft(); // a late debounced write must not resurrect the cleared draft
   if (props.path) clearFileDraft(draftKey(props.sessionKey ?? "", props.path));
 }
 async function save() {
@@ -154,6 +179,7 @@ async function save() {
     editing.value = false;
     baseRev.value = null;
     emit("dirty-change", false);
+    cancelPendingEditDraft(); // the buffer just became disk content — drop the stale write
     if (props.path) clearFileDraft(draftKey(props.sessionKey ?? "", props.path));
   } catch (e) {
     saveError.value = e instanceof Error ? e.message : "write-failed";

--- a/packages/relay-web/src/components/ManageInstanceDialog.vue
+++ b/packages/relay-web/src/components/ManageInstanceDialog.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, nextTick, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { X } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
+import { useModalA11y } from "../lib/use-modal-a11y";
 import WorkspacesManager from "./WorkspacesManager.vue";
 import AgentsManager from "./AgentsManager.vue";
 
@@ -55,29 +56,12 @@ async function saveName(): Promise<void> {
   }
 }
 
-// Accessibility: trap focus inside the dialog, close on Esc, and restore focus to
-// whatever was focused before the dialog opened.
+// Accessibility (shared composable): trap focus inside the dialog, close on Esc, and
+// restore focus to whatever was focused before the dialog opened.
 const dialogEl = ref<HTMLElement | null>(null);
-let previouslyFocused: HTMLElement | null = null;
-const FOCUSABLE = 'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
-function focusables(): HTMLElement[] {
-  return dialogEl.value ? Array.from(dialogEl.value.querySelectorAll<HTMLElement>(FOCUSABLE)) : [];
-}
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === "Escape") { e.preventDefault(); emit("close"); return; }
-  if (e.key !== "Tab") return;
-  const els = focusables();
-  if (els.length === 0) return;
-  const first = els[0], last = els[els.length - 1];
-  const active = document.activeElement as HTMLElement | null;
-  if (e.shiftKey && active === first) { e.preventDefault(); last.focus(); }
-  else if (!e.shiftKey && active === last) { e.preventDefault(); first.focus(); }
-}
+useModalA11y(dialogEl, () => emit("close"));
 
 onMounted(async () => {
-  previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-  document.addEventListener("keydown", onKeydown);
-  void nextTick(() => { (focusables()[0] ?? dialogEl.value)?.focus(); });
   try {
     await store.loadFormOptions(props.instanceId);
   } catch {
@@ -85,11 +69,6 @@ onMounted(async () => {
   } finally {
     loading.value = false;
   }
-});
-
-onBeforeUnmount(() => {
-  document.removeEventListener("keydown", onKeydown);
-  previouslyFocused?.focus?.();
 });
 </script>
 

--- a/packages/relay-web/src/components/NewSessionDialog.vue
+++ b/packages/relay-web/src/components/NewSessionDialog.vue
@@ -4,6 +4,7 @@ import { useI18n } from "vue-i18n";
 import { X, Loader2, AlertTriangle, ChevronDown } from "lucide-vue-next";
 import type { NativeSessionDto } from "@ganglion/xacpx-relay-protocol";
 import { useInstancesStore } from "../stores/instances";
+import { useModalA11y } from "../lib/use-modal-a11y";
 import { genAlias, uniqueName, workspaceNameFromPath } from "../lib/session-form";
 import { fmtDateTime } from "../lib/format";
 import SelectMenu, { type SelectGroup } from "./SelectMenu.vue";
@@ -14,6 +15,13 @@ const emit = defineEmits<{ created: [alias: string]; close: [] }>();
 const { t } = useI18n();
 const store = useInstancesStore();
 const inst = computed(() => store.byId(props.instanceId));
+
+// Accessibility (shared composable): trap focus inside the dialog, close on Esc, and
+// restore focus to whatever was focused before the dialog opened. The model combobox
+// swallows Escape itself (stopPropagation) while its popup is open, so Esc there only
+// closes the popup — a second Esc closes the dialog.
+const dialogEl = ref<HTMLElement | null>(null);
+useModalA11y(dialogEl, () => emit("close"));
 
 const alias = ref("");
 const agentValue = ref("");           // chosen agent NAME or un-configured driver
@@ -306,9 +314,10 @@ async function submit(): Promise<void> {
        off-canvas) instead of the viewport. -->
   <Teleport to="body">
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="emit('close')">
-    <div class="w-full max-w-md rounded-xl border border-border bg-raised shadow-xl" data-test="new-session-dialog">
+    <div ref="dialogEl" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="new-session-title"
+         class="w-full max-w-md rounded-xl border border-border bg-raised shadow-xl focus:outline-none" data-test="new-session-dialog">
       <header class="flex items-center justify-between border-b border-border px-5 py-3">
-        <h2 class="text-sm font-semibold text-fg">{{ $t("session.newSession") }} <span class="font-normal text-fg-muted">· {{ instanceName }}</span></h2>
+        <h2 id="new-session-title" class="text-sm font-semibold text-fg">{{ $t("session.newSession") }} <span class="font-normal text-fg-muted">· {{ instanceName }}</span></h2>
         <button class="rounded p-1 text-fg-muted hover:bg-fg/5 hover:text-fg" :aria-label='$t("session.close")' @click="emit('close')"><X :size="16" /></button>
       </header>
 

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { Brain, Check, ChevronDown, Gauge, Paperclip, Send, X } from "lucide-vue-next";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
+import { createDebouncedFlush } from "../lib/debounce-flush";
 import UsagePopover from "./UsagePopover.vue";
 import { useComposerStore } from "../stores/composer";
 import { useSessionControlsStore } from "../stores/session-controls";
@@ -97,14 +98,38 @@ async function onDrop(e: DragEvent) {
 
 // Persist the draft per session and restore on switch: when the key changes, stash the
 // current text under the previous key, then load the incoming session's draft.
-watch(text, (t) => saveDraft(props.draftKey ?? "", t));
+// Writes are debounced (parse+stringify of the whole draft map per keystroke is a hot
+// path), with a synchronous flush on pagehide/unmount so a reload right after typing
+// still restores the very last input. The key+text are captured at schedule time so a
+// late-firing write can never land under the wrong session.
+let pendingDraft: { key: string; text: string } | null = null;
+const draftPersist = createDebouncedFlush(() => {
+  const p = pendingDraft;
+  pendingDraft = null;
+  if (p) saveDraft(p.key, p.text);
+}, 300);
+watch(text, (t) => {
+  pendingDraft = { key: props.draftKey ?? "", text: t };
+  draftPersist.schedule();
+});
 watch(
   () => props.draftKey,
   (next, prev) => {
+    // The old session's text is stashed synchronously below — drop the pending write.
+    pendingDraft = null;
+    draftPersist.cancel();
     if (prev) saveDraft(prev, text.value);
     text.value = loadDraft(next ?? "");
   },
 );
+function flushDraft(): void {
+  draftPersist.flush();
+}
+onMounted(() => window.addEventListener("pagehide", flushDraft));
+onBeforeUnmount(() => {
+  window.removeEventListener("pagehide", flushDraft);
+  flushDraft();
+});
 
 // External insert requests (e.g. command palette) targeted at this session.
 watch(

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -1,9 +1,68 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { onBeforeUnmount, ref, watch } from "vue";
 import { renderMarkdown } from "../lib/render-markdown";
 
 const props = defineProps<{ text: string; streaming?: boolean }>();
-const html = computed(() => renderMarkdown(props.text, { streaming: props.streaming }));
+
+// While streaming, every appended chunk grows `text`, and re-parsing the WHOLE buffer
+// (healing + markdown-it + DOMPurify) per chunk is O(n²) over the turn. Throttle the parse
+// to one render per THROTTLE_MS with a trailing call, so the last chunk always lands. The
+// non-streaming path renders synchronously on every change, exactly like the old computed.
+const THROTTLE_MS = 80;
+
+const html = ref("");
+let timer: ReturnType<typeof setTimeout> | null = null;
+let lastRenderAt = 0;
+
+function cancelTimer(): void {
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+function render(): void {
+  lastRenderAt = Date.now();
+  html.value = renderMarkdown(props.text, { streaming: props.streaming });
+}
+
+render(); // initial synchronous render (also seeds the throttle clock)
+
+watch(
+  () => props.text,
+  () => {
+    if (!props.streaming) {
+      cancelTimer();
+      render();
+      return;
+    }
+    const elapsed = Date.now() - lastRenderAt;
+    if (elapsed >= THROTTLE_MS) {
+      cancelTimer();
+      render();
+      return;
+    }
+    // Trailing edge: one pending render picks up whatever `text` holds when it fires.
+    if (timer === null) {
+      timer = setTimeout(() => {
+        timer = null;
+        render();
+      }, THROTTLE_MS - elapsed);
+    }
+  },
+);
+
+// Streaming ended (or toggled): drop any pending throttled render and paint the
+// final full text immediately — the closing frame must never lag or be skipped.
+watch(
+  () => props.streaming,
+  () => {
+    cancelTimer();
+    render();
+  },
+);
+
+onBeforeUnmount(cancelTimer);
 </script>
 
 <template>

--- a/packages/relay-web/src/lib/debounce-flush.ts
+++ b/packages/relay-web/src/lib/debounce-flush.ts
@@ -1,0 +1,46 @@
+/** Trailing-edge debouncer with a synchronous flush, for hot persistence paths
+ *  (drafts / tab state) that used to write sessionStorage on every keystroke.
+ *
+ *  Semantics contract: callers MUST pair `schedule()` with a `flush()` on
+ *  `pagehide` (and component unmount) so a reload/close never loses the last
+ *  few hundred milliseconds of input — the reload-restore features depend on it.
+ *  `flush()` runs the callback only when a write is actually pending, so idle
+ *  instances never clobber storage with stale state. */
+export interface DebouncedFlush {
+  /** (Re)start the trailing timer; the callback runs once, `delayMs` after the last call. */
+  schedule(): void;
+  /** Run a pending callback NOW (synchronously). No-op when nothing is pending. */
+  flush(): void;
+  /** Drop a pending callback without running it. */
+  cancel(): void;
+  /** Whether a callback is currently scheduled. */
+  readonly pending: boolean;
+}
+
+export function createDebouncedFlush(fn: () => void, delayMs: number): DebouncedFlush {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return {
+    schedule(): void {
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        fn();
+      }, delayMs);
+    },
+    flush(): void {
+      if (timer === null) return;
+      clearTimeout(timer);
+      timer = null;
+      fn();
+    },
+    cancel(): void {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+    get pending(): boolean {
+      return timer !== null;
+    },
+  };
+}

--- a/packages/relay-web/src/lib/use-modal-a11y.ts
+++ b/packages/relay-web/src/lib/use-modal-a11y.ts
@@ -1,0 +1,48 @@
+import { nextTick, onBeforeUnmount, onMounted, type Ref } from "vue";
+
+/** Modal-dialog accessibility trio, shared by the overlay dialogs (ManageInstanceDialog,
+ *  NewSessionDialog): trap Tab focus inside the dialog, close on Escape, and restore focus
+ *  to whatever was focused before the dialog opened. The caller owns the markup contract:
+ *  put `ref` on the dialog panel, plus `tabindex="-1" role="dialog" aria-modal="true"`
+ *  (and an `aria-labelledby` pointing at the title).
+ *
+ *  The keydown listener sits on `document`, so a child that must swallow Escape itself
+ *  (e.g. an open combobox closing its own popup) simply calls `e.stopPropagation()`. */
+export function useModalA11y(dialogEl: Ref<HTMLElement | null>, close: () => void): void {
+  let previouslyFocused: HTMLElement | null = null;
+  const FOCUSABLE =
+    'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
+  function focusables(): HTMLElement[] {
+    return dialogEl.value ? Array.from(dialogEl.value.querySelectorAll<HTMLElement>(FOCUSABLE)) : [];
+  }
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const els = focusables();
+    if (els.length === 0) return;
+    const first = els[0], last = els[els.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+  onMounted(() => {
+    previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    document.addEventListener("keydown", onKeydown);
+    void nextTick(() => {
+      (focusables()[0] ?? dialogEl.value)?.focus();
+    });
+  });
+  onBeforeUnmount(() => {
+    document.removeEventListener("keydown", onKeydown);
+    previouslyFocused?.focus?.();
+  });
+}

--- a/packages/relay-web/src/stores/center-tabs.ts
+++ b/packages/relay-web/src/stores/center-tabs.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { ref, watch } from "vue";
 import { draftKey, clearFileDraft } from "../lib/file-drafts";
+import { createDebouncedFlush } from "../lib/debounce-flush";
 
 export type CenterTab =
   // targetLine/targetRev: a scroll-to-line request (e.g. from a content-search hit). rev is
@@ -60,9 +61,15 @@ function persist(v: Record<string, SessionTabs>): void {
 
 export const useCenterTabsStore = defineStore("center-tabs", () => {
   const bySession = ref<Record<string, SessionTabs>>(hydrate());
-  // flush: "sync" — persistence must happen synchronously with the mutation (not on the next
-  // microtask/pre-render flush) so a page unload right after a mutation still sees it saved.
-  watch(bySession, (v) => persist(v), { deep: true, flush: "sync" });
+  // Persistence is debounced: the old `flush:"sync"` watcher JSON.stringify-ed EVERY
+  // session's tab set on each setDirty/tab-switch/reorder, synchronously in the mutation
+  // path. Now mutations only arm a 200ms trailing write; `pagehide` flushes any pending
+  // write synchronously, so a reload/close right after a mutation still sees it saved —
+  // the reload-restore semantics are preserved. (Microtasks drain before the pagehide
+  // task fires, so the pre-flush watcher below has always armed the timer by then.)
+  const persistDebounced = createDebouncedFlush(() => persist(bySession.value), 200);
+  watch(bySession, () => persistDebounced.schedule(), { deep: true });
+  window.addEventListener("pagehide", () => persistDebounced.flush());
 
   function tabsFor(key: string): CenterTab[] {
     return bySession.value[key]?.tabs ?? [];


### PR DESCRIPTION
## Summary
Frontend hot-path fixes + one accessibility gap from the audit.

1. **Streaming markdown re-parse throttled to 80ms (trailing).** Re-parsing the whole growing buffer (healing + markdown-it + DOMPurify) on every token was O(n²) over a turn. A `watch(() => props.streaming)` repaints the final full text immediately on turn end, so the closing frame is never skipped; non-streaming renders stay synchronous.
2. **Composer + file-edit drafts debounced (300ms) with a synchronous `pagehide`/unmount flush.** Every keystroke used to parse+stringify the whole sessionStorage map. The pagehide flush preserves the reload-restore guarantee (last few hundred ms of input survive a reload).
3. **center-tabs persistence: dropped `flush:"sync"` deep watch → 200ms trailing debounce + pagehide flush.** Same reload-safety, far fewer full stringifies.
4. **NewSessionDialog accessibility.** Extracted a shared `use-modal-a11y` composable (focus-trap + Esc + focus restore + role/aria-modal); NewSessionDialog and ManageInstanceDialog both use it. Previously the dialog had no Esc, no focus trap, no focus restore.

## Review (independent, inline)
Spec ✅ / Approved. Final-frame guarantee verified (streaming-flag watch cancels pending throttle and paints full text). All three persistence consumers correctly pair `schedule()` with a `pagehide` + `onBeforeUnmount` flush + listener cleanup, so reload-restore semantics hold. No blocking findings.

## Testing
- New: `streammarkdown`, `draft-debounce`, `fileviewer-draft-debounce`, `newsessiondialog-a11y` — 24 tests; `center-tabs` 26 (updated) — all green
- `npx vue-tsc --noEmit` → 0