### PR TITLE
fix(transport): bound acpx management commands / bridge / connector RPC with timeouts

### DIFF
--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -75,12 +75,79 @@ export function orchestrationTaskToDto(
 
 export type ControlBridge = (envelope: RelayEnvelope, respond: (payload: unknown) => void) => void;
 
-export function createControlBridge(control: ControlService): ControlBridge {
+/**
+ * Default time bound for one control RPC dispatch. A hung `await control.*`
+ * would otherwise leave the hub-side pending entry waiting out its full
+ * request timeout (120s default) with no signal from the connector. The
+ * timeout only bounds the RPC *response* — the underlying control operation
+ * is not cancelled and keeps running.
+ */
+export const CONTROL_RPC_TIMEOUT_MS = 60_000;
+
+/**
+ * Time bound for RPC types that legitimately run long — anything that may
+ * spawn/initialize an agent session (sessionInitTimeoutMs defaults to 120s)
+ * or replay native history. Kept just under the hub's 120s request timeout so
+ * the connector still answers with a descriptive error first.
+ */
+export const CONTROL_RPC_SLOW_TIMEOUT_MS = 110_000;
+
+// May trigger session ensure/resume (agent cold start), command execution
+// (e.g. `/session new`), or native-session listing/import.
+const SLOW_RPC_TYPES: ReadonlySet<string> = new Set([
+  MSG.sessionsCreate,
+  MSG.sessionsNativeList,
+  MSG.sessionsArchive,
+  MSG.sessionsUnarchive,
+  MSG.commandExecute,
+]);
+
+// `prompt` awaits the whole interactive turn; bounding it here would be a
+// turn watchdog (policy-sensitive, out of scope). The hub's own request
+// timeout still caps how long its pending entry waits.
+const UNBOUNDED_RPC_TYPES: ReadonlySet<string> = new Set([MSG.prompt]);
+
+export interface ControlBridgeOptions {
+  timeoutMs?: number;
+  slowTimeoutMs?: number;
+  /** Test seams for the dispatch timeout timer. */
+  setTimeoutFn?: (fn: () => void, ms: number) => unknown;
+  clearTimeoutFn?: (timer: unknown) => void;
+}
+
+function controlRpcTimeoutMs(type: string, options: ControlBridgeOptions): number | undefined {
+  if (UNBOUNDED_RPC_TYPES.has(type)) return undefined;
+  if (SLOW_RPC_TYPES.has(type)) return options.slowTimeoutMs ?? CONTROL_RPC_SLOW_TIMEOUT_MS;
+  return options.timeoutMs ?? CONTROL_RPC_TIMEOUT_MS;
+}
+
+export function createControlBridge(control: ControlService, options: ControlBridgeOptions = {}): ControlBridge {
+  const setTimeoutFn = options.setTimeoutFn ?? ((fn: () => void, ms: number) => setTimeout(fn, ms));
+  const clearTimeoutFn = options.clearTimeoutFn ?? ((timer: unknown) => clearTimeout(timer as ReturnType<typeof setTimeout>));
   return (envelope, respond) => {
+    let settled = false;
+    let timer: unknown;
+    const respondOnce = (payload: unknown) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) {
+        clearTimeoutFn(timer);
+        timer = undefined;
+      }
+      respond(payload);
+    };
+
+    const timeoutMs = controlRpcTimeoutMs(envelope.type, options);
+    if (timeoutMs !== undefined) {
+      timer = setTimeoutFn(() => {
+        respondOnce(errorPayload("timeout", `rpc ${envelope.type} timed out after ${timeoutMs}ms in the connector`));
+      }, timeoutMs);
+    }
+
     void dispatchControlRequest(control, envelope)
-      .then(respond)
+      .then(respondOnce)
       .catch((error: unknown) => {
-        respond(errorPayload("internal", error instanceof Error ? error.message : String(error)));
+        respondOnce(errorPayload("internal", error instanceof Error ? error.message : String(error)));
       });
   };
 }

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -84,40 +84,36 @@ export type ControlBridge = (envelope: RelayEnvelope, respond: (payload: unknown
  */
 export const CONTROL_RPC_TIMEOUT_MS = 60_000;
 
-/**
- * Time bound for RPC types that legitimately run long — anything that may
- * spawn/initialize an agent session (sessionInitTimeoutMs defaults to 120s)
- * or replay native history. Kept just under the hub's 120s request timeout so
- * the connector still answers with a descriptive error first.
- */
-export const CONTROL_RPC_SLOW_TIMEOUT_MS = 110_000;
-
-// May trigger session ensure/resume (agent cold start), command execution
-// (e.g. `/session new`), or native-session listing/import.
-const SLOW_RPC_TYPES: ReadonlySet<string> = new Set([
+// RPC types the connector must NOT bound, because a dispatch timeout here does
+// not cancel the underlying control operation — it only stops waiting and
+// returns a spurious error while the op keeps running. Bounding these below
+// their real ceiling only preempts legitimate slow work:
+//   - prompt: awaits the whole interactive turn (bounding = a turn watchdog,
+//     policy-sensitive, out of scope).
+//   - sessionsCreate / sessionsNativeList: wrap a core operation that already
+//     carries its own timeout at the hub's 120s ceiling (agent cold start /
+//     session-init defaults to 120s, native-history listing is core-bounded).
+//     A 110s connector bound would fire ~10s early on a slow first-run cold
+//     start, reporting failure while the session still gets created.
+//   - commandExecute: runs a slash command / agent command that is prompt-like
+//     in duration.
+// For all of these the hub's own 120s request timeout is the real backstop.
+const CONNECTOR_TIMEOUT_EXEMPT_TYPES: ReadonlySet<string> = new Set([
+  MSG.prompt,
   MSG.sessionsCreate,
   MSG.sessionsNativeList,
-  MSG.sessionsArchive,
-  MSG.sessionsUnarchive,
   MSG.commandExecute,
 ]);
 
-// `prompt` awaits the whole interactive turn; bounding it here would be a
-// turn watchdog (policy-sensitive, out of scope). The hub's own request
-// timeout still caps how long its pending entry waits.
-const UNBOUNDED_RPC_TYPES: ReadonlySet<string> = new Set([MSG.prompt]);
-
 export interface ControlBridgeOptions {
   timeoutMs?: number;
-  slowTimeoutMs?: number;
   /** Test seams for the dispatch timeout timer. */
   setTimeoutFn?: (fn: () => void, ms: number) => unknown;
   clearTimeoutFn?: (timer: unknown) => void;
 }
 
 function controlRpcTimeoutMs(type: string, options: ControlBridgeOptions): number | undefined {
-  if (UNBOUNDED_RPC_TYPES.has(type)) return undefined;
-  if (SLOW_RPC_TYPES.has(type)) return options.slowTimeoutMs ?? CONTROL_RPC_SLOW_TIMEOUT_MS;
+  if (CONNECTOR_TIMEOUT_EXEMPT_TYPES.has(type)) return undefined;
   return options.timeoutMs ?? CONTROL_RPC_TIMEOUT_MS;
 }
 

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -18,6 +18,10 @@ import { permissionModeToFlag } from "../transport/permission-mode-flag";
 import { runAgentSessionList } from "../transport/agent-session-list";
 import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../transport/codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../transport/acpx-session-files";
+import {
+  DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
+  DEFAULT_SESSION_INIT_TIMEOUT_MS,
+} from "../transport/command-timeouts";
 import type {
   EnsureSessionProgress,
   MissingOptionalDepErrorData,
@@ -54,9 +58,6 @@ interface CommandResult {
   stdout: string;
   stderr: string;
 }
-
-/** Mirrors the acpx-cli transport's `sessionInitTimeoutMs ?? 120_000` default. */
-const DEFAULT_SESSION_INIT_TIMEOUT_MS = 120_000;
 
 export class CommandTimeoutError extends Error {
   constructor(readonly timeoutMs: number, command: string) {
@@ -129,6 +130,12 @@ interface BridgeRuntimeOptions {
   queueOwnerTtlSeconds?: number;
   /** Time bound for session-creation spawns (ensure/new/resume); defaults to 120s like acpx-cli. */
   sessionInitTimeoutMs?: number;
+  /**
+   * Time bound for one-shot management commands (sessions show/close, cancel,
+   * set-mode, set model, status, history, list). A hung acpx here would
+   * otherwise wedge the session's serial bridge lane forever. Defaults to 30s.
+   */
+  managementCommandTimeoutMs?: number;
   /** Test seam: clock used for the shared session-init deadline. */
   now?: () => number;
 }
@@ -186,7 +193,8 @@ export class BridgeRuntime {
           ...(includeFilterCwd && input.filterCwd ? ["--filter-cwd", input.filterCwd] : []),
           ...(input.cursor ? ["--cursor", input.cursor] : []),
         ], { format: "json" }));
-        return await this.run(spec.command, spec.args);
+        // Mirrors acpx-cli, which bounds sessions list by sessionInitTimeoutMs.
+        return await this.run(spec.command, spec.args, { timeoutMs: this.sessionInitTimeoutMs() });
       },
       formatError: (result) => result.stderr || result.stdout || `sessions list failed with exit code ${result.code}`,
       // Codex's session list leaks native subagent threads; hide them (fail-open).
@@ -233,6 +241,13 @@ export class BridgeRuntime {
       : DEFAULT_SESSION_INIT_TIMEOUT_MS;
   }
 
+  private managementCommandTimeoutMs(): number {
+    const value = this.options.managementCommandTimeoutMs;
+    return typeof value === "number" && Number.isFinite(value) && value > 0
+      ? value
+      : DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS;
+  }
+
   async hasSession(input: {
     agent: string;
     agentCommand?: string;
@@ -244,7 +259,9 @@ export class BridgeRuntime {
       "show",
       input.name,
     ]));
-    const result = await this.run(spawnSpec.command, spawnSpec.args);
+    const result = await this.run(spawnSpec.command, spawnSpec.args, {
+      timeoutMs: this.managementCommandTimeoutMs(),
+    });
 
     return { exists: result.code === 0 };
   }
@@ -264,10 +281,15 @@ export class BridgeRuntime {
       ["sessions", "history", "--name", input.name, "--tail", String(input.lines)],
     ];
 
+    // One shared deadline across all candidate invocations so a hung acpx
+    // bounds the whole method at managementCommandTimeoutMs, not per candidate.
+    const deadline = Date.now() + this.managementCommandTimeoutMs();
     let lastResult: CommandResult | undefined;
     for (const tailArgs of candidates) {
       const spawnSpec = resolveSpawnCommand(this.command, this.buildSessionArgs(input, tailArgs));
-      const result = await this.run(spawnSpec.command, spawnSpec.args);
+      const result = await this.run(spawnSpec.command, spawnSpec.args, {
+        timeoutMs: Math.max(deadline - Date.now(), 1),
+      });
       if (result.code === 0) {
         return { text: result.stdout.trimEnd() };
       }
@@ -470,6 +492,8 @@ export class BridgeRuntime {
     const toolEventMode: ToolEventMode =
       input.toolEventMode ?? (input.toolEvents === true ? "structured" : "text");
     try {
+      // Prompts are deliberately NOT bounded by a total-duration timeout:
+      // long agent turns are legitimate (see command-timeouts.ts).
       const result = onEvent
         ? await this.runPromptCommand(spawnSpec.command, spawnSpec.args, onEvent, {
             formatToolCalls,
@@ -507,7 +531,9 @@ export class BridgeRuntime {
       "show",
       input.name,
     ]));
-    const result = await this.run(spawnSpec.command, spawnSpec.args);
+    const result = await this.run(spawnSpec.command, spawnSpec.args, {
+      timeoutMs: this.managementCommandTimeoutMs(),
+    });
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "sessions show failed");
     }
@@ -557,7 +583,9 @@ export class BridgeRuntime {
       input.name,
       input.modeId,
     ]));
-    const result = await this.run(spawnSpec.command, spawnSpec.args);
+    const result = await this.run(spawnSpec.command, spawnSpec.args, {
+      timeoutMs: this.managementCommandTimeoutMs(),
+    });
 
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "set-mode failed");
@@ -581,7 +609,9 @@ export class BridgeRuntime {
       "model",
       input.modelId,
     ]));
-    const result = await this.run(spawnSpec.command, spawnSpec.args);
+    const result = await this.run(spawnSpec.command, spawnSpec.args, {
+      timeoutMs: this.managementCommandTimeoutMs(),
+    });
 
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "set-model failed");
@@ -601,7 +631,9 @@ export class BridgeRuntime {
       "-s",
       input.name,
     ], { format: "json" }));
-    const result = await this.run(spawnSpec.command, spawnSpec.args);
+    const result = await this.run(spawnSpec.command, spawnSpec.args, {
+      timeoutMs: this.managementCommandTimeoutMs(),
+    });
 
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "status failed");
@@ -629,7 +661,9 @@ export class BridgeRuntime {
       "-s",
       input.name,
     ]));
-    const result = await this.run(spawnSpec.command, spawnSpec.args);
+    const result = await this.run(spawnSpec.command, spawnSpec.args, {
+      timeoutMs: this.managementCommandTimeoutMs(),
+    });
 
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "cancel failed");
@@ -652,7 +686,9 @@ export class BridgeRuntime {
       "close",
       input.name,
     ]));
-    const result = await this.run(spawnSpec.command, spawnSpec.args);
+    const result = await this.run(spawnSpec.command, spawnSpec.args, {
+      timeoutMs: this.managementCommandTimeoutMs(),
+    });
 
     if (result.code === 0) {
       return {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -267,6 +267,14 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
                 ...(typeof config.transport.sessionInitTimeoutMs === "number"
                   ? { sessionInitTimeoutMs: config.transport.sessionInitTimeoutMs }
                   : {}),
+                // A dropped (undecodable) bridge stdout line can be a lost
+                // response; the client-side request timeout unblocks the
+                // caller, but the corruption itself must be visible in logs.
+                onMalformedLine: (line) => {
+                  void logger.error("bridge.protocol.malformed_line", "dropped undecodable bridge output line", {
+                    line: line.length > 500 ? `${line.slice(0, 500)}…` : line,
+                  });
+                },
               }),
             ),
           ))

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -16,6 +16,11 @@ import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
 import type { AgentCommand, UsageBreakdown, UsageCost } from "../types";
 import { getLocale } from "../../i18n";
 import { resolveDefaultXacpxCommand } from "../acpx-queue-owner-launcher";
+import {
+  BRIDGE_REQUEST_TIMEOUT_GRACE_MS,
+  DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
+  DEFAULT_SESSION_INIT_TIMEOUT_MS,
+} from "../command-timeouts";
 
 // `boolean | void` return mirrors Writable.write: `false` only signals
 // backpressure (the line is still queued and delivered), never failure.
@@ -38,12 +43,69 @@ interface PendingRequest {
   onEvent?: (event: BridgeEvent) => void;
 }
 
+export interface AcpxBridgeClientOptions {
+  /**
+   * Session-init budget the bridge subprocess runs with (XACPX_BRIDGE_SESSION_INIT_TIMEOUT_MS);
+   * used to derive the client-side timeout for ensure/resume/list requests.
+   */
+  sessionInitTimeoutMs?: number;
+  /**
+   * Called when the bridge emits a stdout line that is not valid JSON. Such a
+   * line is dropped — if it was a response, its request would hang without the
+   * per-request timeout — so at minimum it must be observable in logs.
+   */
+  onMalformedLine?: (line: string) => void;
+  /** Test seams for the per-request timeout timer. */
+  setTimeoutFn?: (fn: () => void, ms: number) => unknown;
+  clearTimeoutFn?: (timer: unknown) => void;
+}
+
+/**
+ * Client-side backstop timeout per bridge request. Each value sits
+ * BRIDGE_REQUEST_TIMEOUT_GRACE_MS above the subprocess-side bound for that
+ * method, so the subprocess timeout (better error, kills the hung process
+ * tree) fires first and this only catches lost or undecodable responses.
+ * `prompt` is unbounded: long streaming agent turns are legitimate.
+ */
+export function bridgeRequestTimeoutMs(
+  method: BridgeMethod,
+  sessionInitTimeoutMs: number = DEFAULT_SESSION_INIT_TIMEOUT_MS,
+): number | undefined {
+  switch (method) {
+    case "prompt":
+      return undefined;
+    case "ensureSession":
+    case "resumeAgentSession":
+      return sessionInitTimeoutMs + BRIDGE_REQUEST_TIMEOUT_GRACE_MS;
+    case "listAgentSessions":
+      // The subprocess may run the list twice (--filter-cwd capability
+      // fallback), each run bounded by sessionInitTimeoutMs like acpx-cli.
+      return 2 * sessionInitTimeoutMs + BRIDGE_REQUEST_TIMEOUT_GRACE_MS;
+    case "deleteSession":
+    case "freeWarmProcess":
+      // Two sequential management commands (sessions show + close/owner kill).
+      return 2 * DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS + BRIDGE_REQUEST_TIMEOUT_GRACE_MS;
+    default:
+      return DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS + BRIDGE_REQUEST_TIMEOUT_GRACE_MS;
+  }
+}
+
+const defaultSetTimeoutFn = (fn: () => void, ms: number): unknown => {
+  const timer = setTimeout(fn, ms);
+  // Never keep the host process alive just for a request-timeout backstop.
+  (timer as NodeJS.Timeout).unref?.();
+  return timer;
+};
+
 export class AcpxBridgeClient {
   private nextId = 1;
   private readonly pending = new Map<string, PendingRequest>();
   private terminalError: Error | null = null;
 
-  constructor(private readonly writeLine: WriteLine) {}
+  constructor(
+    private readonly writeLine: WriteLine,
+    private readonly options: AcpxBridgeClientOptions = {},
+  ) {}
 
   request<TResult>(
     method: BridgeMethod,
@@ -58,11 +120,38 @@ export class AcpxBridgeClient {
     this.nextId += 1;
 
     return awaitable<TResult>((resolve, reject) => {
+      const setTimeoutFn = this.options.setTimeoutFn ?? defaultSetTimeoutFn;
+      const clearTimeoutFn = this.options.clearTimeoutFn ?? ((timer: unknown) => clearTimeout(timer as NodeJS.Timeout));
+      let timer: unknown;
+      const clearTimer = () => {
+        if (timer !== undefined) {
+          clearTimeoutFn(timer);
+          timer = undefined;
+        }
+      };
       this.pending.set(id, {
-        resolve: (value) => resolve(value as TResult),
-        reject,
+        resolve: (value) => {
+          clearTimer();
+          resolve(value as TResult);
+        },
+        reject: (error) => {
+          clearTimer();
+          reject(error);
+        },
         onEvent,
       });
+
+      // Backstop: a bridge response that never arrives (subprocess wedged in a
+      // way its own timeouts don't cover, or the response line was dropped as
+      // malformed) must not hang this session's serial request lane forever.
+      const timeoutMs = bridgeRequestTimeoutMs(method, this.options.sessionInitTimeoutMs);
+      if (timeoutMs !== undefined) {
+        timer = setTimeoutFn(() => {
+          if (this.pending.delete(id)) {
+            reject(new Error(`bridge request "${method}" timed out after ${timeoutMs}ms`));
+          }
+        }, timeoutMs);
+      }
 
       try {
         // A `false` return only signals backpressure (the line is still
@@ -76,12 +165,14 @@ export class AcpxBridgeClient {
           }),
           (error) => {
             if (error && this.pending.delete(id)) {
+              clearTimer();
               reject(error);
             }
           },
         );
       } catch (error) {
         this.pending.delete(id);
+        clearTimer();
         reject(error);
       }
     });
@@ -92,6 +183,10 @@ export class AcpxBridgeClient {
     try {
       message = JSON.parse(line) as BridgeMessage;
     } catch {
+      // Dropped line: if it carried a response, the per-request timeout is the
+      // safety net that eventually unblocks the caller — but log it so a
+      // protocol corruption is diagnosable instead of silent.
+      this.options.onMalformedLine?.(line);
       return;
     }
 
@@ -214,6 +309,8 @@ interface SpawnedBridgeClientOptions {
   permissionPolicy?: string;
   queueOwnerTtlSeconds?: number;
   sessionInitTimeoutMs?: number;
+  /** Forwarded to AcpxBridgeClient: observability for undecodable bridge output lines. */
+  onMalformedLine?: (line: string) => void;
 }
 
 export function buildBridgeSpawnEnv(
@@ -278,7 +375,14 @@ export async function spawnAcpxBridgeClient(
     stdio: ["pipe", "pipe", "inherit"],
   });
 
-  const client = manageBridgeChild(child);
+  const client = manageBridgeChild(child, {
+    ...(typeof options.sessionInitTimeoutMs === "number"
+      && Number.isFinite(options.sessionInitTimeoutMs)
+      && options.sessionInitTimeoutMs > 0
+      ? { sessionInitTimeoutMs: options.sessionInitTimeoutMs }
+      : {}),
+    ...(options.onMalformedLine ? { onMalformedLine: options.onMalformedLine } : {}),
+  });
   await client.waitUntilReady();
   return client;
 }
@@ -300,9 +404,13 @@ export interface BridgeChildProcess {
 }
 
 /** Wire a spawned bridge child process into a managed bridge client. */
-export function manageBridgeChild(child: BridgeChildProcess): ManagedBridgeClient {
+export function manageBridgeChild(
+  child: BridgeChildProcess,
+  options: AcpxBridgeClientOptions = {},
+): ManagedBridgeClient {
   const client = new AcpxBridgeClient(
     (line, onWriteError) => child.stdin.write(line, onWriteError),
+    options,
   ) as ManagedBridgeClient;
 
   // Per Node stream semantics a failed stdin write is reported through the

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -35,10 +35,17 @@ import { resolveToolEventMode, type ToolEventMode } from "../tool-event-mode.js"
 import { runAgentSessionList } from "../agent-session-list";
 import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../acpx-session-files";
+import { DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS } from "../command-timeouts";
 
 interface AcpxCliTransportOptions {
   command?: string;
   sessionInitTimeoutMs?: number;
+  /**
+   * Time bound for one-shot management commands (sessions show/close, cancel,
+   * set-mode, set model, status, history). A hung acpx here would otherwise
+   * wedge the session's serial request lane forever. Defaults to 30s.
+   */
+  managementCommandTimeoutMs?: number;
   permissionMode?: PermissionMode;
   nonInteractivePermissions?: NonInteractivePermissions;
   permissionPolicy?: string;
@@ -168,6 +175,7 @@ async function defaultPtyRunner(command: string, args: string[], options?: RunOp
 export class AcpxCliTransport implements SessionTransport {
   private readonly command: string;
   private readonly sessionInitTimeoutMs: number;
+  private readonly managementCommandTimeoutMs: number;
   private permissionMode: PermissionMode;
   private nonInteractivePermissions: NonInteractivePermissions;
   private permissionPolicy: string | undefined;
@@ -186,6 +194,7 @@ export class AcpxCliTransport implements SessionTransport {
   ) {
     this.command = options.command ?? "acpx";
     this.sessionInitTimeoutMs = options.sessionInitTimeoutMs ?? 120_000;
+    this.managementCommandTimeoutMs = options.managementCommandTimeoutMs ?? DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS;
     this.permissionMode = options.permissionMode ?? "approve-all";
     this.nonInteractivePermissions = options.nonInteractivePermissions ?? "deny";
     this.permissionPolicy = options.permissionPolicy;
@@ -268,10 +277,15 @@ export class AcpxCliTransport implements SessionTransport {
       ["sessions", "history", "--name", session.transportSession, "--tail", String(lines)],
     ];
 
+    // One shared deadline across all candidate invocations so a hung acpx
+    // bounds the whole method at managementCommandTimeoutMs, not per candidate.
+    const deadline = Date.now() + this.managementCommandTimeoutMs;
     let lastResult: CommandResult | undefined;
     for (const tail of candidates) {
       const args = this.buildArgs(session, tail);
-      const result = await this.runCommandWithTimeout(this.runCommand, args);
+      const result = await this.runCommandWithTimeout(this.runCommand, args, {
+        timeoutMs: Math.max(deadline - Date.now(), 1),
+      });
       if (result.code === 0) {
         return { text: result.stdout.trimEnd() };
       }
@@ -332,6 +346,8 @@ export class AcpxCliTransport implements SessionTransport {
         // may have been partially or fully dropped from the stream.
         return { text: summary ? `${summary}\n\n${baseText}` : "" };
       }
+      // Prompts are deliberately NOT bounded by a total-duration timeout:
+      // long agent turns are legitimate (see command-timeouts.ts).
       const result = await this.runCommand(this.command, args);
       return { text: getPromptText(result) };
     } finally {
@@ -349,7 +365,7 @@ export class AcpxCliTransport implements SessionTransport {
       "-s",
       session.transportSession,
       modeId,
-    ]));
+    ]), { timeoutMs: this.managementCommandTimeoutMs });
   }
 
   // acpx's generic config setter: `<agent> set -s <name> model '<id>'`. Build args
@@ -363,7 +379,7 @@ export class AcpxCliTransport implements SessionTransport {
       session.transportSession,
       "model",
       modelId,
-    ]));
+    ]), { timeoutMs: this.managementCommandTimeoutMs });
   }
 
   // Read the session's current model and the agent-advertised available ids from
@@ -375,7 +391,9 @@ export class AcpxCliTransport implements SessionTransport {
     const args = session.agentCommand
       ? [...prefix, "--agent", session.agentCommand, ...tail]
       : [...prefix, session.agent, ...tail];
-    const result = await this.runCommandWithTimeout(this.runCommand, args);
+    const result = await this.runCommandWithTimeout(this.runCommand, args, {
+      timeoutMs: this.managementCommandTimeoutMs,
+    });
     if (result.code !== 0) {
       const detail = normalizeCommandError(result) ?? `command failed with exit code ${result.code}`;
       throw new Error(detail);
@@ -396,7 +414,7 @@ export class AcpxCliTransport implements SessionTransport {
       "cancel",
       "-s",
       session.transportSession,
-    ]));
+    ]), { timeoutMs: this.managementCommandTimeoutMs });
     return {
       cancelled: true,
       message: output.trim(),
@@ -426,11 +444,11 @@ export class AcpxCliTransport implements SessionTransport {
   }
 
   async removeSession(session: ResolvedSession): Promise<void> {
-    const result = await this.runCommand(this.command, this.buildArgs(session, [
+    const result = await this.runCommandWithTimeout(this.runCommand, this.buildArgs(session, [
       "sessions",
       "close",
       session.transportSession,
-    ]));
+    ]), { timeoutMs: this.managementCommandTimeoutMs });
     if (result.code === 0) {
       return;
     }
@@ -471,11 +489,11 @@ export class AcpxCliTransport implements SessionTransport {
   }
 
   async hasSession(session: ResolvedSession): Promise<boolean> {
-    const result = await this.runCommand(this.command, this.buildArgs(session, [
+    const result = await this.runCommandWithTimeout(this.runCommand, this.buildArgs(session, [
       "sessions",
       "show",
       session.transportSession,
-    ]));
+    ]), { timeoutMs: this.managementCommandTimeoutMs });
 
     return result.code === 0;
   }
@@ -496,11 +514,11 @@ export class AcpxCliTransport implements SessionTransport {
   }
 
   private async readSessionRecord(session: ResolvedSession): Promise<{ acpxRecordId: string; agentSessionId?: string }> {
-    const result = await this.runCommand(this.command, this.buildArgs(session, [
+    const result = await this.runCommandWithTimeout(this.runCommand, this.buildArgs(session, [
       "sessions",
       "show",
       session.transportSession,
-    ]));
+    ]), { timeoutMs: this.managementCommandTimeoutMs });
     if (result.code !== 0) {
       const detail = normalizeCommandError(result) ?? `command failed with exit code ${result.code}`;
       throw new Error(detail);

--- a/src/transport/command-timeouts.ts
+++ b/src/transport/command-timeouts.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared time bounds for one-shot acpx subprocess commands.
+ *
+ * Session-scoped requests run through a serial per-session scheduler (a `tail`
+ * promise chain), so a single command that never settles wedges every later
+ * request for that session forever. These constants bound the non-prompt
+ * ("management") commands so a stuck acpx rejects — and unblocks the lane —
+ * instead of deadlocking it. Streaming prompts are intentionally NOT bounded
+ * by a total-duration timeout: long agent turns are legitimate.
+ */
+
+/**
+ * Default timeout for one-shot management commands (sessions show/close,
+ * cancel, set-mode, set model, status, history). These normally finish in
+ * well under a second; 30s only trips when acpx itself is hung.
+ */
+export const DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS = 30_000;
+
+/**
+ * Default timeout for session initialization (sessions new / ensure / resume).
+ * Mirrors the long-standing `sessionInitTimeoutMs ?? 120_000` default used by
+ * both transports (agent cold start, adapter download, auth handshake).
+ */
+export const DEFAULT_SESSION_INIT_TIMEOUT_MS = 120_000;
+
+/**
+ * Grace added on top of the subprocess-side timeout for the bridge client's
+ * per-request timeout, so the subprocess-side timeout (which carries the
+ * better error message and kills the hung process tree) always fires first
+ * and the client-side timeout is only a backstop for lost/undecodable
+ * responses.
+ */
+export const BRIDGE_REQUEST_TIMEOUT_GRACE_MS = 15_000;

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -495,7 +495,7 @@ test("ensureSession surfaces the configured total when a later step times out", 
   expect((caught as Error).message).toBe("session initialization timed out after 100s");
 });
 
-test("prompt and other session commands are not subject to the session init timeout", async () => {
+test("prompt is unbounded while management commands get the management timeout", async () => {
   const timeouts: Array<number | undefined> = [];
   const runtime = new BridgeRuntime(
     "acpx",
@@ -507,10 +507,64 @@ test("prompt and other session commands are not subject to the session init time
     { sessionInitTimeoutMs: 50 },
   );
 
+  // Long agent turns are legitimate: no total-duration timeout on prompt.
   await runtime.prompt({ agent: "codex", cwd: "/repo", name: "demo", text: "hello" });
+  // One-shot management commands must be bounded so a hung acpx can't wedge
+  // the session's serial bridge lane forever.
   await runtime.hasSession({ agent: "codex", cwd: "/repo", name: "demo" });
 
-  expect(timeouts).toEqual([undefined, undefined]);
+  expect(timeouts).toEqual([undefined, 30_000]);
+});
+
+test("management commands honor a configured managementCommandTimeoutMs", async () => {
+  const timeouts: Array<number | undefined> = [];
+  const runtime = new BridgeRuntime(
+    "acpx",
+    async (_command, _args, options?: CommandRunnerOptions) => {
+      timeouts.push(options?.timeoutMs);
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    undefined,
+    { managementCommandTimeoutMs: 5_000 },
+  );
+
+  await runtime.hasSession({ agent: "codex", cwd: "/repo", name: "demo" });
+  await runtime.cancel({ agent: "codex", cwd: "/repo", name: "demo" });
+  await runtime.setMode({ agent: "codex", cwd: "/repo", name: "demo", modeId: "plan" });
+  await runtime.removeSession({ agent: "codex", cwd: "/repo", name: "demo" });
+
+  expect(timeouts).toEqual([5_000, 5_000, 5_000, 5_000]);
+});
+
+test("a hung management command kills the spawned tree and rejects with CommandTimeoutError", async () => {
+  // The fake child never emits "close" — equivalent to acpx wedging on
+  // `sessions show`. The management timeout must kill it and reject so the
+  // session's serial bridge lane unblocks.
+  const killed: number[] = [];
+  const spawnFn = (() => makeFakeSpawnChild({ pid: 777 })) as never;
+  const runtime = new BridgeRuntime(
+    "acpx",
+    (command, args, options?: CommandRunnerOptions) =>
+      spawnCapture(command, args, {
+        ...options,
+        spawnFn,
+        killProcessTreeFn: async (pid: number) => {
+          killed.push(pid);
+        },
+      }),
+    undefined,
+    { managementCommandTimeoutMs: 50 },
+  );
+
+  let caught: unknown;
+  try {
+    await runtime.hasSession({ agent: "codex", cwd: "/repo", name: "demo" });
+  } catch (error) {
+    caught = error;
+  }
+
+  expect(caught).toBeInstanceOf(CommandTimeoutError);
+  expect(killed).toEqual([777]);
 });
 
 test("prompt starts queue owner with orchestration MCP identity", async () => {

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -369,3 +369,123 @@ test("terminal.attach RPC without terminalId returns bad-request", async () => {
   const bridge = createControlBridge(control as never);
   expect(await dispatch(bridge, req(MSG.terminalAttach, {}))).toEqual({ error: { code: "bad-request", message: "terminalId is required" } });
 });
+
+// ── connector-side RPC dispatch timeout ──────────────────────────────────────
+
+type ArmedTimer = { fn: () => void; ms: number };
+
+function makeTimerSeams() {
+  const armed: ArmedTimer[] = [];
+  const cleared: unknown[] = [];
+  return {
+    armed,
+    cleared,
+    setTimeoutFn: (fn: () => void, ms: number) => {
+      const timer = { fn, ms };
+      armed.push(timer);
+      return timer;
+    },
+    clearTimeoutFn: (timer: unknown) => {
+      cleared.push(timer);
+    },
+  };
+}
+
+test("a hung control call responds with a timeout errorPayload instead of hanging the hub pending entry", async () => {
+  const seams = makeTimerSeams();
+  const { control } = makeFakeControl({
+    // Never settles — equivalent to a wedged transport underneath the control API.
+    removeSession: () => new Promise(() => {}),
+  });
+  const bridge = createControlBridge(control as never, seams);
+
+  const responses: unknown[] = [];
+  bridge(req(MSG.sessionsRemove, { chatKey: "relay:acct", alias: "a" }), (payload) => responses.push(payload));
+
+  expect(seams.armed).toHaveLength(1);
+  expect(seams.armed[0]!.ms).toBe(60_000);
+
+  seams.armed[0]!.fn();
+  expect(responses).toEqual([
+    { error: { code: "timeout", message: `rpc ${MSG.sessionsRemove} timed out after 60000ms in the connector` } },
+  ]);
+});
+
+test("slow rpc types (session create / command execute) get the slow timeout tier", async () => {
+  const seams = makeTimerSeams();
+  const { control } = makeFakeControl({
+    createSession: () => new Promise(() => {}),
+    executeCommand: () => new Promise(() => {}),
+  });
+  const bridge = createControlBridge(control as never, seams);
+
+  bridge(req(MSG.sessionsCreate, { chatKey: "relay:acct", alias: "a", agent: "codex", workspace: "ws" }), () => {});
+  bridge(req(MSG.commandExecute, { chatKey: "relay:acct", command: "/status" }), () => {});
+
+  expect(seams.armed.map((timer) => timer.ms)).toEqual([110_000, 110_000]);
+});
+
+test("prompt dispatch is never bounded by the connector timeout (interactive turn)", async () => {
+  const seams = makeTimerSeams();
+  const { control } = makeFakeControl();
+  const bridge = createControlBridge(control as never, seams);
+
+  const result = await dispatch(bridge, req(MSG.prompt, {
+    chatKey: "relay:acct", sessionAlias: "a", text: "hi", senderId: "acct", isOwner: true,
+  }));
+
+  expect(result).toEqual({ ok: true, text: "done" });
+  expect(seams.armed).toHaveLength(0);
+});
+
+test("a dispatch that resolves in time clears its timer and a late timeout fire is a no-op", async () => {
+  const seams = makeTimerSeams();
+  const { control } = makeFakeControl();
+  const bridge = createControlBridge(control as never, seams);
+
+  const responses: unknown[] = [];
+  await new Promise((resolve) => bridge(req(MSG.sessionsList, {}), (payload) => {
+    responses.push(payload);
+    resolve(undefined);
+  }));
+
+  expect(seams.cleared).toEqual([seams.armed[0]]);
+  // Even if the timer somehow fired afterwards, respond must not run twice.
+  seams.armed[0]!.fn();
+  expect(responses).toHaveLength(1);
+});
+
+test("a late resolution after the timeout fired does not respond a second time", async () => {
+  const seams = makeTimerSeams();
+  let settle: ((value: unknown) => void) | undefined;
+  const { control } = makeFakeControl({
+    removeSession: () => new Promise((resolve) => { settle = resolve; }),
+  });
+  const bridge = createControlBridge(control as never, seams);
+
+  const responses: unknown[] = [];
+  bridge(req(MSG.sessionsRemove, { chatKey: "relay:acct", alias: "a" }), (payload) => responses.push(payload));
+
+  seams.armed[0]!.fn();
+  settle!({ wasActive: false });
+  // Let the .then(respondOnce) microtask run.
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(responses).toHaveLength(1);
+  expect((responses[0] as { error: { code: string } }).error.code).toBe("timeout");
+});
+
+test("custom timeout values override the defaults", async () => {
+  const seams = makeTimerSeams();
+  const { control } = makeFakeControl({
+    removeSession: () => new Promise(() => {}),
+    executeCommand: () => new Promise(() => {}),
+  });
+  const bridge = createControlBridge(control as never, { ...seams, timeoutMs: 1_000, slowTimeoutMs: 2_000 });
+
+  bridge(req(MSG.sessionsRemove, { chatKey: "relay:acct", alias: "a" }), () => {});
+  bridge(req(MSG.commandExecute, { chatKey: "relay:acct", command: "/status" }), () => {});
+
+  expect(seams.armed.map((timer) => timer.ms)).toEqual([1_000, 2_000]);
+});

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -411,18 +411,36 @@ test("a hung control call responds with a timeout errorPayload instead of hangin
   ]);
 });
 
-test("slow rpc types (session create / command execute) get the slow timeout tier", async () => {
+test("core-bounded / long RPC types are exempt from the connector timeout", async () => {
   const seams = makeTimerSeams();
   const { control } = makeFakeControl({
+    // Each of these wraps a core operation with its own ceiling (session-init
+    // 120s) or is prompt-like; a connector timeout would preempt legit slow
+    // work without cancelling it. The hub's 120s request timeout is the backstop.
     createSession: () => new Promise(() => {}),
+    listNativeSessions: () => new Promise(() => {}),
     executeCommand: () => new Promise(() => {}),
   });
   const bridge = createControlBridge(control as never, seams);
 
   bridge(req(MSG.sessionsCreate, { chatKey: "relay:acct", alias: "a", agent: "codex", workspace: "ws" }), () => {});
+  bridge(req(MSG.sessionsNativeList, { chatKey: "relay:acct", agent: "codex", workspace: "ws" }), () => {});
   bridge(req(MSG.commandExecute, { chatKey: "relay:acct", command: "/status" }), () => {});
 
-  expect(seams.armed.map((timer) => timer.ms)).toEqual([110_000, 110_000]);
+  // No timer armed for any exempt type.
+  expect(seams.armed).toHaveLength(0);
+});
+
+test("session archive is bounded by the default connector timeout (core-bounded at 30s)", async () => {
+  const seams = makeTimerSeams();
+  const { control } = makeFakeControl({
+    archiveSession: () => new Promise(() => {}),
+  });
+  const bridge = createControlBridge(control as never, seams);
+
+  bridge(req(MSG.sessionsArchive, { chatKey: "relay:acct", alias: "a" }), () => {});
+
+  expect(seams.armed.map((timer) => timer.ms)).toEqual([60_000]);
 });
 
 test("prompt dispatch is never bounded by the connector timeout (interactive turn)", async () => {
@@ -476,16 +494,16 @@ test("a late resolution after the timeout fired does not respond a second time",
   expect((responses[0] as { error: { code: string } }).error.code).toBe("timeout");
 });
 
-test("custom timeout values override the defaults", async () => {
+test("custom timeout value overrides the default for bounded RPCs", async () => {
   const seams = makeTimerSeams();
   const { control } = makeFakeControl({
     removeSession: () => new Promise(() => {}),
-    executeCommand: () => new Promise(() => {}),
+    archiveSession: () => new Promise(() => {}),
   });
-  const bridge = createControlBridge(control as never, { ...seams, timeoutMs: 1_000, slowTimeoutMs: 2_000 });
+  const bridge = createControlBridge(control as never, { ...seams, timeoutMs: 1_000 });
 
   bridge(req(MSG.sessionsRemove, { chatKey: "relay:acct", alias: "a" }), () => {});
-  bridge(req(MSG.commandExecute, { chatKey: "relay:acct", command: "/status" }), () => {});
+  bridge(req(MSG.sessionsArchive, { chatKey: "relay:acct", alias: "a" }), () => {});
 
-  expect(seams.armed.map((timer) => timer.ms)).toEqual([1_000, 2_000]);
+  expect(seams.armed.map((timer) => timer.ms)).toEqual([1_000, 1_000]);
 });

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
@@ -4,6 +4,7 @@ import { PassThrough } from "node:stream";
 
 import {
   AcpxBridgeClient,
+  bridgeRequestTimeoutMs,
   buildBridgeSpawnEnv,
   buildBridgeSpawnSpec,
   manageBridgeChild,
@@ -331,4 +332,121 @@ describe("AcpxBridgeClient", () => {
     await promise;
     expect(events).toEqual([{ type: "prompt.plan", entries }]);
   });
+});
+
+// ── per-request timeout backstop ─────────────────────────────────────────────
+
+describe("per-request timeout", () => {
+  type ArmedTimer = { fn: () => void; ms: number };
+
+  function makeTimerSeams() {
+    const armed: ArmedTimer[] = [];
+    const cleared: unknown[] = [];
+    return {
+      armed,
+      cleared,
+      setTimeoutFn: (fn: () => void, ms: number) => {
+        const timer = { fn, ms };
+        armed.push(timer);
+        return timer;
+      },
+      clearTimeoutFn: (timer: unknown) => {
+        cleared.push(timer);
+      },
+    };
+  }
+
+  test("a management request whose response never arrives times out and rejects", async () => {
+    const seams = makeTimerSeams();
+    const client = new AcpxBridgeClient(() => {}, seams);
+
+    const pending = client.request("cancel", {});
+    expect(seams.armed).toHaveLength(1);
+    // Management subprocess bound (30s) + client-side grace (15s).
+    expect(seams.armed[0]!.ms).toBe(45_000);
+
+    seams.armed[0]!.fn();
+    await expect(pending).rejects.toThrow('bridge request "cancel" timed out after 45000ms');
+  });
+
+  test("a late response after the timeout fired is ignored (pending entry removed)", async () => {
+    const seams = makeTimerSeams();
+    const client = new AcpxBridgeClient(() => {}, seams);
+
+    const pending = client.request("hasSession", {});
+    seams.armed[0]!.fn();
+    await expect(pending).rejects.toThrow(/timed out/);
+
+    // The pending map entry is gone, so a straggler response must be a no-op.
+    expect(() => client.handleLine('{"id":"1","ok":true,"result":{"exists":true}}')).not.toThrow();
+  });
+
+  test("prompt requests never arm a timeout (long agent turns are legitimate)", async () => {
+    const seams = makeTimerSeams();
+    const client = new AcpxBridgeClient(() => {}, seams);
+
+    const pending = client.request("prompt", {});
+    expect(seams.armed).toHaveLength(0);
+
+    client.handleLine('{"id":"1","ok":true,"result":{"text":"done"}}');
+    await expect(pending).resolves.toEqual({ text: "done" });
+  });
+
+  test("ensureSession timeout derives from sessionInitTimeoutMs plus grace", () => {
+    const seams = makeTimerSeams();
+    const client = new AcpxBridgeClient(() => {}, { ...seams, sessionInitTimeoutMs: 1_000 });
+
+    void client.request("ensureSession", {}).catch(() => {});
+    expect(seams.armed[0]!.ms).toBe(16_000);
+  });
+
+  test("bridgeRequestTimeoutMs tiers match the subprocess-side bounds", () => {
+    expect(bridgeRequestTimeoutMs("prompt")).toBeUndefined();
+    expect(bridgeRequestTimeoutMs("ensureSession")).toBe(135_000);
+    expect(bridgeRequestTimeoutMs("resumeAgentSession")).toBe(135_000);
+    // Two list runs (--filter-cwd capability fallback), each sessionInit-bounded.
+    expect(bridgeRequestTimeoutMs("listAgentSessions")).toBe(255_000);
+    // Two sequential management commands (sessions show + close / owner kill).
+    expect(bridgeRequestTimeoutMs("deleteSession")).toBe(75_000);
+    expect(bridgeRequestTimeoutMs("freeWarmProcess")).toBe(75_000);
+    expect(bridgeRequestTimeoutMs("cancel")).toBe(45_000);
+    expect(bridgeRequestTimeoutMs("hasSession")).toBe(45_000);
+    expect(bridgeRequestTimeoutMs("setMode")).toBe(45_000);
+  });
+
+  test("a response arriving in time clears the armed timer", async () => {
+    const seams = makeTimerSeams();
+    const client = new AcpxBridgeClient(() => {}, seams);
+
+    const pending = client.request("hasSession", {});
+    client.handleLine('{"id":"1","ok":true,"result":{"exists":true}}');
+
+    await expect(pending).resolves.toEqual({ exists: true });
+    expect(seams.cleared).toEqual([seams.armed[0]]);
+  });
+
+  test("a bridge exit rejection clears the armed timer", async () => {
+    const seams = makeTimerSeams();
+    const client = new AcpxBridgeClient(() => {}, seams);
+
+    const pending = client.request("hasSession", {});
+    client.handleExit(new Error("bridge process exited before responding"));
+
+    await expect(pending).rejects.toThrow("bridge process exited before responding");
+    expect(seams.cleared).toEqual([seams.armed[0]]);
+  });
+});
+
+test("reports malformed bridge output lines through onMalformedLine", async () => {
+  const malformed: string[] = [];
+  const client = new AcpxBridgeClient(() => {}, {
+    onMalformedLine: (line) => malformed.push(line),
+  });
+
+  const pending = client.request("ping", {});
+  client.handleLine("garbled-not-json");
+  client.handleLine('{"id":"1","ok":true,"result":{}}');
+
+  await expect(pending).resolves.toEqual({});
+  expect(malformed).toEqual(["garbled-not-json"]);
 });

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -247,7 +247,7 @@ test("uses the normal command runner for setMode", async () => {
     "-s",
     "backend:api-fix",
     "plan",
-  ], undefined);
+  ], expect.objectContaining({ timeoutMs: 30_000 }));
   expect(runPty).not.toHaveBeenCalled();
 });
 
@@ -411,7 +411,8 @@ test("tails session history by invoking sessions history quiet", async () => {
     "-s",
     "backend:api-fix",
     "20",
-  ], undefined);
+    // Shared deadline across history candidates: bounded by the management timeout.
+  ], expect.objectContaining({ timeoutMs: expect.any(Number) }));
 });
 
 test("passes default permission policy flags to prompt", async () => {
@@ -851,7 +852,7 @@ test("invokes cancel for the resolved session", async () => {
     "cancel",
     "-s",
     "backend:api-fix",
-  ], undefined);
+  ], expect.objectContaining({ timeoutMs: 30_000 }));
 });
 
 test("checks whether a named session exists", async () => {
@@ -873,7 +874,7 @@ test("checks whether a named session exists", async () => {
     "sessions",
     "show",
     "backend:api-fix",
-  ]);
+  ], expect.objectContaining({ timeoutMs: 30_000 }));
 });
 
 test("returns false when a named session does not exist", async () => {
@@ -881,6 +882,37 @@ test("returns false when a named session does not exist", async () => {
   const transport = new AcpxCliTransport({ command: "acpx" }, run);
 
   await expect(transport.hasSession(session)).resolves.toBe(false);
+});
+
+test("times out a hung management command, aborts the spawn, and rejects", async () => {
+  // A runner that never settles — equivalent to acpx wedging on a one-shot
+  // command. Without the management timeout this would deadlock the session's
+  // serial request lane forever.
+  let aborted = false;
+  const run = mock((_command: string, _args: string[], options?: { signal?: AbortSignal }) => {
+    return new Promise<never>(() => {
+      options?.signal?.addEventListener("abort", () => {
+        aborted = true;
+      }, { once: true });
+    });
+  });
+  const transport = new AcpxCliTransport(
+    { command: "acpx", managementCommandTimeoutMs: 20 },
+    run as never,
+  );
+
+  await expect(transport.cancel(session)).rejects.toThrow(/timed out after 20ms/);
+  expect(aborted).toBe(true);
+});
+
+test("times out a hung sessions close (removeSession) instead of hanging forever", async () => {
+  const run = mock(() => new Promise<never>(() => {}));
+  const transport = new AcpxCliTransport(
+    { command: "acpx", managementCommandTimeoutMs: 20 },
+    run as never,
+  );
+
+  await expect(transport.removeSession(session)).rejects.toThrow(/timed out after 20ms/);
 });
 
 test("concatenates agent message chunks across thought and tool-call boundaries", async () => {
@@ -2141,7 +2173,11 @@ test("getAgentSessionId returns the agentSessionId from sessions show", async ()
   const id = await transport.getAgentSessionId(session);
 
   expect(id).toBe("agent-xyz");
-  expect(run).toHaveBeenCalledWith("acpx", expect.arrayContaining(["sessions", "show", "backend:api-fix"]));
+  expect(run).toHaveBeenCalledWith(
+    "acpx",
+    expect.arrayContaining(["sessions", "show", "backend:api-fix"]),
+    expect.objectContaining({ timeoutMs: 30_000 }),
+  );
 });
 
 test("getAgentSessionId returns undefined when the record has no agentSessionId", async () => {


### PR DESCRIPTION
## Summary
Closes four "a hung acpx wedges the whole session lane forever" holes from the audit. Session requests run through a serial per-session scheduler (`tail` promise chain); one command that never settles blocks every later request for that session with no self-heal.

1. **acpx-cli management commands** (show/close/cancel/set-mode/set-model/status/history, readSessionRecord) now run under a 30s timeout → `terminateProcessTree` + reject, which unblocks the scheduler lane. Streaming **and non-streaming prompt stay unbounded** (long turns are legitimate).
2. **bridge-runtime** management `spawnCapture` calls bounded the same way (shared 30s constant in new `src/transport/command-timeouts.ts`).
3. **bridge client `request`** gets a per-request timeout (subprocess-side +15s grace, so the subprocess timeout with the better error and process-tree kill fires first) and logs undecodable response lines instead of dropping them silently.
4. **connector control-RPC dispatch** wrapped with a timeout (60s default, 110s for slow types) → `errorPayload("timeout")` instead of letting the hub pending sit for the full 120s.

## Review (independent, inline) — Approved with one Important to decide
Spec ✅. Coverage verified: every acpx-cli/bridge-runtime management call now routes through the bounded runner; both prompt paths are the only intentional exemptions; scheduler unlock confirmed (reject propagates on the tail chain).

**Important (design decision needed):** the connector's slow-RPC timeout is **110s**, but the operations it wraps have their **own** core-side bound at **120s** (session-init) — and the connector timeout does **not** cancel the underlying op. So a cold start that legitimately takes 110–120s (e.g. first-run adapter download on a slow link) now returns a spurious `timeout` at 110s while the session still gets created ~5s later (self-heals via `sessions-changed`). Before this change that 110–120s window succeeded cleanly. The window is narrow and self-healing, but it's a real tail regression.
Recommended fix (fast-follow): for RPCs that already carry a core-side timeout at the hub's 120s ceiling (sessionsCreate, native-list, archive), either exempt them from the connector timeout (like prompt) or raise their budget above the core bound — the connector timeout should be a backstop for *unbounded* hangs, not a preemption of core-bounded work. `commandExecute` is prompt-like and should likely be exempt too.

## Testing
- `acpx-cli-transport` 65, `bridge-runtime` 36, `acpx-bridge-client` 34, `control-bridge` 29, `bridge-request-scheduler` 5 — 169 pass / 0 fail (all with controllable stubs, no real sleeps)
- `npx tsc --noEmit` → 0