### PR TITLE
feat(relay-web): dashboard UX tweaks (focus ring, panel/search defaults, back buttons)

### DIFF
--- a/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
@@ -217,7 +217,7 @@ test("closing a terminal tab kills its PTY and clears the persisted id", async (
 });
 
 test("closing a FILE tab does not kill any terminal PTY", async () => {
-  const fileStub = { name: "FileViewer", template: '<div data-test="stub-file" />', emits: ["close", "back", "dirty-change"] };
+  const fileStub = { name: "FileViewer", template: '<div data-test="stub-file" />', emits: ["close", "dirty-change"] };
   const wrapper = mount(DashboardView, { global: { stubs: { ...stubs, FileViewer: fileStub } } });
   await flushPromises();
   const key = selectSession();

--- a/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
@@ -78,35 +78,25 @@ test("the mobile bar exposes a discoverable Files button that opens the Files dr
   expect(filesTab.classes()).toContain("font-semibold");
 });
 
-test("file viewer Back opens the file list drawer (the tab stays open); Close removes the tab and returns to chat", async () => {
+test("file viewer Close removes the tab and returns to chat", async () => {
   const chat = useChatStore();
   chat.instanceId = "i1";
   chat.sessionAlias = "demo";
   const centerTabs = useCenterTabsStore();
   const key = sessionKey("i1", "demo");
-  // Replace the FileViewer stub with a minimal one that re-emits back/close so we can
-  // exercise DashboardView's nav handlers (rightTab/rightOpen are internal refs, so we
-  // assert via observable drawer DOM).
-  const fvStub = { name: "FileViewer", template: "<div data-test=\"fv-stub\" />", emits: ["back", "close"] };
+  // Replace the FileViewer stub with a minimal one that re-emits close so we can
+  // exercise DashboardView's close wiring.
+  const fvStub = { name: "FileViewer", template: "<div data-test=\"fv-stub\" />", emits: ["close"] };
   const wrapper = mount(DashboardView, {
     global: { stubs: { ChatPane: true, TaskPanel: true, "router-link": true, FileViewer: fvStub } },
   });
   await flushPromises();
-  const right = wrapper.find('[data-drawer="right"]');
 
   // Open a file tab so the (stubbed) FileViewer renders.
   centerTabs.openFile(key, "a.ts");
   await flushPromises();
   expect(wrapper.findComponent(FileViewer).exists()).toBe(true);
   expect(centerTabs.activeFor(key)).toBe("file:a.ts");
-
-  // Back -> file list: right drawer opens on files, but the tab is untouched (still
-  // open/active) — the drawer just overlays it on mobile.
-  wrapper.findComponent(FileViewer).vm.$emit("back");
-  await flushPromises();
-  expect(centerTabs.activeFor(key)).toBe("file:a.ts");
-  expect(right.classes()).toContain("translate-x-0");
-  expect(right.classes()).not.toContain("translate-x-full");
 
   // Close -> the tab is actually removed and active falls back to chat.
   wrapper.findComponent(FileViewer).vm.$emit("close");

--- a/packages/relay-web/src/__tests__/files-i18n.test.ts
+++ b/packages/relay-web/src/__tests__/files-i18n.test.ts
@@ -22,9 +22,6 @@ describe("files browser i18n", () => {
     const w = mount(FileViewer, { props: { instanceId: "i1", workspace: "ws", path: "src/a.ts" }, global: { plugins: [pinia] } });
     await flushPromises();
     await w.vm.$nextTick();
-    // Back-to-list affordance shows "文件" (Files); desktop Back shows "返回".
-    expect(w.find('[data-test="fv-back-list"]').text()).toContain("文件");
-    expect(w.find('[data-test="fv-back"]').text()).toContain("返回");
     expect(w.find('[data-test="fv-close"]').attributes("aria-label")).toBe("关闭文件");
   });
 

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -55,6 +55,7 @@ describe("files store", () => {
     rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [] });
     const s = useFilesStore();
     await s.selectWorkspace("i1", "ws");
+    s.searchOpts.mode = "name"; // this case exercises name-mode search explicitly
     rpc.mockResolvedValueOnce({ workspace: "ws", query: "a.ts", matches: ["src/a.ts"], truncated: false });
     await s.search("a.ts");
     expect(rpc).toHaveBeenLastCalledWith("i1", "control.fs.search", { workspace: "ws", query: "a.ts", mode: "name", matchCase: false, wholeWord: false, regex: false, include: "", exclude: "" });

--- a/packages/relay-web/src/__tests__/filespanel.test.ts
+++ b/packages/relay-web/src/__tests__/filespanel.test.ts
@@ -92,6 +92,8 @@ describe("FilesPanel navigation rail", () => {
 
   it("search placeholder tracks the active mode (name vs content)", async () => {
     const w = mount(FilesPanel, { props: { instanceId: "i1" }, global: { plugins: [pinia] } });
+    const files = useFilesStore();
+    files.searchOpts.mode = "name"; // start from name mode; default is now content
     await w.vm.$nextTick();
     const namePh = w.find('[data-test="fs-search"]').attributes("placeholder");
     await w.find('[data-test="search-mode-content"]').trigger("click");
@@ -285,6 +287,7 @@ describe("FilesPanel center-tab routing", () => {
     const centerTabs = useCenterTabsStore();
     vi.spyOn(files, "search").mockResolvedValue();
     const openFile = vi.spyOn(centerTabs, "openFile");
+    files.searchOpts.mode = "name"; // this case exercises the name-mode flat result list
     files.query = "foo";
     files.results = ["src/foo.ts"] as never;
     await w.vm.$nextTick();

--- a/packages/relay-web/src/components/FileViewer.vue
+++ b/packages/relay-web/src/components/FileViewer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch, onMounted, onBeforeUnmount } from "vue";
-import { ArrowLeft, FileText, FileDiff, X, Search, Pencil, Save as SaveIcon } from "lucide-vue-next";
+import { FileText, FileDiff, X, Search, Pencil, Save as SaveIcon } from "lucide-vue-next";
 import { useI18n } from "vue-i18n";
 import { useFilesStore } from "../stores/files";
 import type { FsDiffResult, FsReadResult } from "@ganglion/xacpx-relay-protocol";
@@ -22,7 +22,7 @@ const props = defineProps<{
   lineRev?: number;
   sessionKey?: string;
 }>();
-const emit = defineEmits<{ back: []; close: []; "dirty-change": [boolean] }>();
+const emit = defineEmits<{ close: []; "dirty-change": [boolean] }>();
 const { t } = useI18n();
 const files = useFilesStore();
 
@@ -206,15 +206,8 @@ onBeforeUnmount(() => document.removeEventListener("keydown", onKeydown));
 
 <template>
   <div ref="rootEl" class="flex h-full flex-1 flex-col bg-bg" data-test="file-viewer-center">
-    <!-- header: back + path + meta -->
+    <!-- header: path + meta -->
     <div class="flex h-11 shrink-0 items-center gap-2 border-b border-border bg-surface/60 px-3 backdrop-blur-md">
-      <button data-test="fv-back-list" :aria-label="$t('files.backToList')"
-              class="flex lg:hidden shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2 py-1 text-[12px] font-medium text-fg-muted transition-colors hover:bg-raised hover:text-fg"
-              @click="emit('back')"><ArrowLeft :size="14" class="shrink-0" />{{ $t("files.title") }}</button>
-      <button data-test="fv-back" :aria-label="$t('files.back')"
-              class="hidden lg:flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2 py-1 text-[12px] font-medium text-fg-muted transition-colors hover:bg-raised hover:text-fg"
-              @click="emit('close')"><ArrowLeft :size="14" class="shrink-0" />{{ $t("files.back") }}</button>
-      <span class="h-4 w-px bg-border" aria-hidden="true" />
       <template v-if="file">
         <FileText :size="14" class="shrink-0 text-accent" />
         <span class="truncate font-mono text-[12.5px] text-fg">{{ file.path }}</span>

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
-import { ArrowLeft, Keyboard, ClipboardPaste, Copy, ChevronUp, ChevronDown, ChevronLeft, ChevronRight } from "lucide-vue-next";
+import { Keyboard, ClipboardPaste, Copy, ChevronUp, ChevronDown, ChevronLeft, ChevronRight } from "lucide-vue-next";
 import { createTerminalAdapter, type TerminalAdapter, type TerminalTheme } from "../lib/terminal-adapter";
 import { useTerminalStore } from "../stores/terminal";
 import { useThemeStore } from "../stores/theme";
@@ -10,7 +10,9 @@ import { loadTerminalId, saveTerminalId, clearTerminalId } from "../lib/terminal
 const props = withDefaults(defineProps<{ instanceId: string; sessionAlias: string; autostart?: boolean }>(), {
   autostart: true,
 });
-const emit = defineEmits<{ close: [] }>();
+// A terminal tab is closed from the center tab strip; the parent routes @close to
+// requestCloseTab (which kills the PTY). Declared here, never emitted internally.
+defineEmits<{ close: [] }>();
 const terminals = useTerminalStore();
 const theme = useThemeStore();
 const sessionKey = computed(() => makeSessionKey(props.instanceId, props.sessionAlias));
@@ -396,10 +398,6 @@ onBeforeUnmount(() => {
        :style="keyboardInset ? { paddingBottom: `${keyboardInset}px` } : undefined">
     <!-- header -->
     <div class="flex h-11 shrink-0 items-center gap-2 border-b border-border bg-surface/60 px-3 backdrop-blur-md">
-      <button data-test="term-close" :aria-label="$t('terminal.close')"
-              class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2 py-1 text-[12px] font-medium text-fg-muted transition-colors hover:bg-raised hover:text-fg"
-              @click="emit('close')"><ArrowLeft :size="14" class="shrink-0" />{{ $t("terminal.title") }}</button>
-      <span class="h-4 w-px bg-border" aria-hidden="true" />
       <span class="min-w-0 truncate font-mono text-[12.5px] text-fg">{{ props.sessionAlias }}</span>
       <div class="ml-auto flex shrink-0 items-center gap-1">
         <button data-test="toggle-keybar"

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -53,7 +53,7 @@ export const useFilesStore = defineStore("files", () => {
   const loadingDirs = ref<Set<string>>(new Set());
   const hits = ref<FsSearchHitDto[]>([]);
   const searchOpts = ref<{ mode: "name" | "content"; matchCase: boolean; wholeWord: boolean; regex: boolean; include: string; exclude: string }>({
-    mode: "name", matchCase: false, wholeWord: false, regex: false, include: "", exclude: "",
+    mode: "content", matchCase: false, wholeWord: false, regex: false, include: "", exclude: "",
   });
 
   function reset(): void {

--- a/packages/relay-web/src/style.css
+++ b/packages/relay-web/src/style.css
@@ -79,12 +79,22 @@ html, body, #app { height: 100%; }
 html, body { overflow-x: hidden; }
 body { @apply bg-bg text-fg font-sans antialiased; }
 
-/* Branded focus ring on interactive elements (gap + accent halo). */
-a:focus-visible, button:focus-visible, input:focus-visible, textarea:focus-visible,
-select:focus-visible, [tabindex]:focus-visible, [role="button"]:focus-visible {
+/* Branded focus ring on interactive elements (gap + accent halo).
+   Text fields (input/textarea/select) are intentionally excluded — see the rule below. */
+a:focus-visible, button:focus-visible,
+[tabindex]:focus-visible, [role="button"]:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px rgb(var(--c-bg)), 0 0 0 4px rgb(var(--c-accent));
   border-radius: 6px;
+}
+
+/* No focus box-shadow on form fields. Authoritative override so per-component Tailwind
+   `focus-visible:ring-*` utilities (which compile to box-shadow) are neutralized too. */
+input:focus, input:focus-visible,
+textarea:focus, textarea:focus-visible,
+select:focus, select:focus-visible {
+  box-shadow: none !important;
+  outline: none;
 }
 
 /* Live run-dot: expanding bright-green ring (matches mockup softpulse). */

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -43,7 +43,7 @@ let disconnect: (() => void) | null = null;
 // these flags are visually irrelevant because the lg: classes override the transform.
 const leftOpen = ref(false);
 const rightOpen = ref(false);
-const rightTab = ref<"tasks" | "files">("tasks");
+const rightTab = ref<"tasks" | "files">("files");
 function closeDrawers() {
   leftOpen.value = false;
   rightOpen.value = false;
@@ -68,13 +68,6 @@ const swipe = createEdgeSwipe({
   closeLeft: () => { leftOpen.value = false; },
   closeRight: () => { rightOpen.value = false; },
 });
-// Mobile: "Back" from the file viewer returns to the FILE LIST (reopen the Files drawer)
-// so the user can pick another file. It does NOT close the underlying file/diff tab — the
-// tab stays open (and active) in the per-session tab strip; the drawer just overlays it.
-function backToFileList() {
-  openRight("files");
-}
-
 // Desktop-only: collapse the instances sidebar to reclaim width. Persisted so the
 // choice survives reloads. (Mobile uses the leftOpen off-canvas drawer instead.)
 const leftCollapsed = ref(localStorage.getItem("xacpx.leftCollapsed") === "1");
@@ -408,7 +401,7 @@ onUnmounted(() => {
                         :line="tab.kind === 'file' ? tab.targetLine : undefined"
                         :line-rev="tab.kind === 'file' ? tab.targetRev : undefined"
                         @dirty-change="(v) => centerTabs.setDirty(key, tab.id, v)"
-                        @close="requestCloseTab(key, tab.id)" @back="backToFileList" />
+                        @close="requestCloseTab(key, tab.id)" />
             <TerminalTab v-else-if="tab.kind === 'terminal'" class="absolute inset-0 z-20"
                          v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
                          :instance-id="keyInstance(key)" :session-alias="keyAlias(key)"


### PR DESCRIPTION
Four small relay-web dashboard UX tweaks (no protocol/core changes).

## Changes
1. **No focus box-shadow on form fields.** `input`/`textarea`/`select` lose the focus halo; the branded focus ring stays on links/buttons for keyboard a11y. An authoritative `style.css` rule (`box-shadow: none !important` on their focus) also neutralizes the per-component Tailwind `focus-visible:ring-*` utilities, which compile to box-shadow.
2. **Right panel defaults to Files** (was Tasks).
3. **File search defaults to content mode** (was name mode). `searchOpts.mode` is still treated as a user preference in `reset()`, so returning users keep their last choice — the new default only affects first load.
4. **Remove redundant back buttons** from the terminal and file panes — tabs are now closed from the center tab strip (present on both desktop and mobile). `TerminalTab` still declares `close` (routed by the parent to `requestCloseTab`, which kills the PTY); the mobile file-close **X** is kept.

## Notes
- Unused i18n keys (`terminal.close`, `files.back`, `files.backToList`) left in place to avoid en/zh key-parity churn.
- `bun install --frozen-lockfile` was needed locally to pull `@codemirror/*` (added upstream) — no lockfile change.

## Verification
- `vue-tsc --noEmit`: clean
- relay-web vitest: **89 files / 668 tests green**
- Tests updated for the new defaults and removed affordances (files/filespanel/files-i18n/dashboard-responsive/dashboard-center-tabs).