### PR TITLE
fix(relay-web): restore visible focus cue on form fields + drop orphaned i18n keys

### DIFF
--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -139,8 +139,6 @@ export default {
   },
   files: {
     title: "Files",
-    back: "Back",
-    backToList: "Back to file list",
     closeFile: "Close file",
     selectToBrowse: "Select a session to browse its workspace",
     searchPlaceholder: "Search files by name…",
@@ -351,7 +349,6 @@ export default {
     startNew: "Start new terminal",
     exited: "Terminal exited (code {code}).",
     error: "Could not open the terminal.",
-    close: "Close terminal",
     keybar: {
       show: "Show shortcut bar",
       hide: "Hide shortcut bar",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -137,8 +137,6 @@ export default {
   },
   files: {
     title: "文件",
-    back: "返回",
-    backToList: "返回文件列表",
     closeFile: "关闭文件",
     selectToBrowse: "选择一个会话以浏览其工作区",
     searchPlaceholder: "按名称搜索文件…",
@@ -349,7 +347,6 @@ export default {
     startNew: "启动新终端",
     exited: "终端已退出(退出码 {code})。",
     error: "无法打开终端。",
-    close: "关闭终端",
     keybar: {
       show: "显示快捷键条",
       hide: "隐藏快捷键条",

--- a/packages/relay-web/src/style.css
+++ b/packages/relay-web/src/style.css
@@ -89,12 +89,15 @@ a:focus-visible, button:focus-visible,
 }
 
 /* No focus box-shadow on form fields. Authoritative override so per-component Tailwind
-   `focus-visible:ring-*` utilities (which compile to box-shadow) are neutralized too. */
+   `focus-visible:ring-*` utilities (which compile to box-shadow) are neutralized too.
+   The accent border replaces the removed halo as the visible focus cue (WCAG 2.4.7) —
+   fields otherwise carry only a static `border-border` that doesn't change on focus. */
 input:focus, input:focus-visible,
 textarea:focus, textarea:focus-visible,
 select:focus, select:focus-visible {
   box-shadow: none !important;
   outline: none;
+  border-color: rgb(var(--c-accent));
 }
 
 /* Live run-dot: expanding bright-green ring (matches mockup softpulse). */


### PR DESCRIPTION
Follow-up to #142.

## Why
#142 removed the focus `box-shadow` on `input`/`textarea`/`select` per request. But those fields carry only a **static** `border-border` with no `focus:border-*`, so after that change keyboard focus became **invisible** across every dialog/settings form — a WCAG 2.4.7 (Focus Visible) regression flagged in the independent review.

## Changes
1. **Restore a focus cue** (`style.css`): add `border-color: rgb(var(--c-accent))` on `input/textarea/select` focus. This is a border change, **not** a box-shadow, so the original "no box-shadow on focus" intent is preserved while keyboard users get a visible cue again. The `box-shadow: none !important` (which also neutralizes the per-component Tailwind `focus-visible:ring-*`) stays.
2. **Prune orphaned i18n keys** left by the back-button removal in #142: `files.back`, `files.backToList`, `terminal.close` — removed from both `en.ts` and `zh-CN.ts` (zero usages; en/zh parity preserved).

## Verification
- `vue-tsc --noEmit`: clean
- relay-web vitest: **93 files / 694 tests green** (incl. i18n key-parity smoke test)