### PR TITLE
feat(relay): runtime payload validation + type-level message↔payload binding

### DIFF
--- a/docs/superpowers/plans/2026-07-06-protocol-hardening.md
+++ b/docs/superpowers/plans/2026-07-06-protocol-hardening.md
@@ -1,0 +1,914 @@
+# Protocol Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add hand-written runtime payload validation + a type-level message↔payload binding to the relay control-RPC protocol, so malformed frames crossing a trust boundary are rejected instead of blindly `as`-cast and executed.
+
+**Architecture:** One source of truth in `relay-protocol`: a registry keyed by control-RPC message type whose values are hand-written validators (`unknown → Payload | null`). The registry doubles as the type-level binding (`PayloadFor<T>` + `parseControlPayload<T>`). Three trust boundaries adopt it: (A) the connector's `control-bridge` dispatch (where fs/prompt actually execute), (B) the hub's `onEvent` instance-event path (reusing the existing `validControlEvent`), (C) the hub's HTTP `/rpc` route for the three RPCs it persists before forwarding.
+
+**Tech Stack:** TypeScript (strict), Bun test runner, `@ganglion/xacpx-relay-protocol` (zero-dependency published package), Hono (hub HTTP), `ws`.
+
+## Global Constraints
+
+- **No new dependencies.** The whole repo has zero schema/validation libraries; `relay-protocol` is a zero-dependency published package pinned `^0.1.0` by hub/connector/web. Keep it dependency-free. Hand-write validators in the existing `web-dtos.ts` style.
+- **Privacy red line** (inherited from Track 1 observability): rejection logs and error messages MUST NOT contain payload values — no fs paths, prompt text, upload content, or credentials. Only `type`, `instanceId`, and a structural `reason` (which field is missing / wrong type).
+- **Protocol compatibility unbroken.** Pure additive validation (what it rejects was already malformed); do not change any payload structure or the envelope shallow-check. Protocol stays `0.1.x` / `^0.1.0`. Adding the two `Terminal*Payload` interfaces is additive.
+- **git hygiene:** only `git add` the files you changed, never `git add -A`; do not touch any lockfile; English conventional commits.
+- **Tests:** run per-file with `bun test <path>` (CI runs them under Node too). Type-level bindings are verified by `npx tsc --noEmit` at repo root. Do NOT run whole-directory `bun test` (state-leak false failures). Running tests/tsc may regenerate `packages/relay-protocol/dist/index.js` as a false diff — `git checkout -- packages/relay-protocol/dist` before committing if so.
+
+---
+
+### Task 1: Extract shared field predicates into `validate-primitives.ts`
+
+**Files:**
+- Create: `packages/relay-protocol/src/validate-primitives.ts`
+- Modify: `packages/relay-protocol/src/web-dtos.ts:115-117` (delete the three local predicates, import them instead)
+- Test: `tests/unit/packages/relay-protocol/validate-primitives.test.ts`
+
+**Interfaces:**
+- Produces: `isObj(v: unknown): v is Record<string, unknown>`, `isStr(v: unknown): boolean`, `optStr(v: unknown): boolean`, `optNum(v: unknown): boolean`, `optBool(v: unknown): boolean` — exported from `validate-primitives.ts`. Task 2 consumes all of them.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/packages/relay-protocol/validate-primitives.test.ts`:
+
+```ts
+// tests/unit/packages/relay-protocol/validate-primitives.test.ts
+import { expect, test } from "bun:test";
+import { isObj, isStr, optStr, optNum, optBool } from "../../../../packages/relay-protocol/src/validate-primitives";
+
+test("isObj accepts plain objects, rejects null and non-objects", () => {
+  expect(isObj({})).toBe(true);
+  expect(isObj({ a: 1 })).toBe(true);
+  expect(isObj(null)).toBe(false);
+  expect(isObj(undefined)).toBe(false);
+  expect(isObj("x")).toBe(false);
+  expect(isObj(3)).toBe(false);
+});
+
+test("isStr is true only for strings", () => {
+  expect(isStr("")).toBe(true);
+  expect(isStr("a")).toBe(true);
+  expect(isStr(1)).toBe(false);
+  expect(isStr(undefined)).toBe(false);
+});
+
+test("optStr allows undefined or string, rejects other types", () => {
+  expect(optStr(undefined)).toBe(true);
+  expect(optStr("a")).toBe(true);
+  expect(optStr(null)).toBe(false);
+  expect(optStr(1)).toBe(false);
+});
+
+test("optNum allows undefined or number", () => {
+  expect(optNum(undefined)).toBe(true);
+  expect(optNum(2)).toBe(true);
+  expect(optNum("2")).toBe(false);
+});
+
+test("optBool allows undefined or boolean", () => {
+  expect(optBool(undefined)).toBe(true);
+  expect(optBool(true)).toBe(true);
+  expect(optBool(0)).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/unit/packages/relay-protocol/validate-primitives.test.ts`
+Expected: FAIL — `Cannot find module '.../validate-primitives'`.
+
+- [ ] **Step 3: Create `validate-primitives.ts`**
+
+```ts
+// packages/relay-protocol/src/validate-primitives.ts
+// Shared runtime field predicates for wire-payload validation. Kept dependency-free
+// and framework-free so both web-dtos.ts (relay→web push) and payload-validators.ts
+// (hub↔connector control RPCs) draw from one implementation instead of drifting copies.
+
+/** True for a non-null object; narrows to an indexable record for field access. */
+export const isObj = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null;
+
+/** Required string. */
+export const isStr = (v: unknown): boolean => typeof v === "string";
+
+/** Optional string: absent or a string. */
+export const optStr = (v: unknown): boolean => v === undefined || typeof v === "string";
+
+/** Optional number: absent or a number. */
+export const optNum = (v: unknown): boolean => v === undefined || typeof v === "number";
+
+/** Optional boolean: absent or a boolean. */
+export const optBool = (v: unknown): boolean => v === undefined || typeof v === "boolean";
+```
+
+- [ ] **Step 4: Rewire `web-dtos.ts` to import the three it uses**
+
+In `packages/relay-protocol/src/web-dtos.ts`, delete the three local definitions at lines 115-117:
+
+```ts
+const isStr = (v: unknown): boolean => typeof v === "string";
+const optStr = (v: unknown): boolean => v === undefined || typeof v === "string";
+const optNum = (v: unknown): boolean => v === undefined || typeof v === "number";
+```
+
+Add an import near the top of the file (with the other imports; `web-dtos.ts` currently imports from `./dtos.js` and `./envelope.js` — add this line):
+
+```ts
+import { isStr, optStr, optNum } from "./validate-primitives.js";
+```
+
+Leave everything else in `web-dtos.ts` untouched — do NOT refactor its validator internals.
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run: `bun test tests/unit/packages/relay-protocol/validate-primitives.test.ts`
+Expected: PASS (5 tests).
+
+Run the existing web-dtos suite to prove the extraction is behavior-preserving:
+Run: `bun test tests/unit/packages/relay-protocol/web-dtos.test.ts`
+Expected: PASS (unchanged count).
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git checkout -- packages/relay-protocol/dist 2>/dev/null || true
+git add packages/relay-protocol/src/validate-primitives.ts packages/relay-protocol/src/web-dtos.ts tests/unit/packages/relay-protocol/validate-primitives.test.ts
+git commit -m "refactor(relay-protocol): extract shared field predicates into validate-primitives"
+```
+
+---
+
+### Task 2: Build the control-payload validator registry + type-level binding
+
+**Files:**
+- Create: `packages/relay-protocol/src/payload-validators.ts`
+- Modify: `packages/relay-protocol/src/messages.ts` (append two payload interfaces after line 443)
+- Modify: `packages/relay-protocol/src/index.ts` (export the new module)
+- Modify: `packages/relay-protocol/src/web-dtos.ts` (export `validControlEvent` for Task 4's reuse)
+- Test: `tests/unit/packages/relay-protocol/payload-validators.test.ts`
+
+**Interfaces:**
+- Consumes: `isObj, isStr, optStr, optNum, optBool` from Task 1; all `*Payload` types from `messages.ts`.
+- Produces:
+  - `type Validator<T> = (payload: unknown) => T | null`
+  - `type ControlRpcType` — union of the 35 control-RPC `MSG` literal types listed below.
+  - `const CONTROL_PAYLOAD_VALIDATORS` — `satisfies Record<ControlRpcType, Validator<unknown>>`.
+  - `type PayloadFor<T extends ControlRpcType>` = `NonNullable<ReturnType<(typeof CONTROL_PAYLOAD_VALIDATORS)[T]>>`.
+  - `function parseControlPayload<T extends ControlRpcType>(type: T, payload: unknown): PayloadFor<T> | null` — Task 3 and Task 5 consume this.
+  - `interface TerminalCreatePayload { chatKey: string; sessionAlias: string; cols?: number; rows?: number }` and `interface TerminalAttachPayload { terminalId: string }` in `messages.ts`.
+  - `validControlEvent(e: unknown): boolean` becomes exported from `web-dtos.ts` — Task 4 consumes it.
+
+- [ ] **Step 1: Add the two terminal payload interfaces to `messages.ts`**
+
+`control-bridge.ts` currently types the `terminalCreate`/`terminalAttach` arms with anonymous inline shapes. Give them named interfaces so the validator registry can bind them. Append to the end of `packages/relay-protocol/src/messages.ts` (after `SessionModelResult`, line 450):
+
+```ts
+export interface TerminalCreatePayload {
+  chatKey: string;
+  sessionAlias: string;
+  cols?: number;
+  rows?: number;
+}
+
+export interface TerminalAttachPayload {
+  terminalId: string;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/packages/relay-protocol/payload-validators.test.ts`. This covers a representative slice of validators (happy path + missing-required + wrong-type), the registry's exhaustiveness, and the type-level binding.
+
+```ts
+// tests/unit/packages/relay-protocol/payload-validators.test.ts
+import { expect, test } from "bun:test";
+import {
+  MSG,
+  parseControlPayload,
+  CONTROL_PAYLOAD_VALIDATORS,
+  type PayloadFor,
+  type FsWritePayload,
+  type PromptPayload,
+} from "../../../../packages/relay-protocol/src/index";
+
+test("parseControlPayload accepts a well-formed fsWrite payload", () => {
+  const ok = parseControlPayload(MSG.fsWrite, {
+    workspace: "home", path: "a.txt", content: "hi",
+    expected: { mtimeMs: 1, size: 2 },
+  });
+  expect(ok).not.toBeNull();
+  expect(ok?.workspace).toBe("home");
+});
+
+test("parseControlPayload rejects fsWrite missing required fields", () => {
+  expect(parseControlPayload(MSG.fsWrite, { workspace: "home", path: "a.txt" })).toBeNull(); // no content/expected
+  expect(parseControlPayload(MSG.fsWrite, { workspace: "home", path: "a.txt", content: "x", expected: { mtimeMs: 1 } })).toBeNull(); // expected.size missing
+  expect(parseControlPayload(MSG.fsWrite, null)).toBeNull();
+  expect(parseControlPayload(MSG.fsWrite, "nope")).toBeNull();
+});
+
+test("parseControlPayload rejects fsWrite with wrong field types", () => {
+  expect(parseControlPayload(MSG.fsWrite, { workspace: 1, path: "a", content: "x", expected: { mtimeMs: 1, size: 2 } })).toBeNull();
+  expect(parseControlPayload(MSG.fsWrite, { workspace: "w", path: "a", content: 5, expected: { mtimeMs: 1, size: 2 } })).toBeNull();
+});
+
+test("parseControlPayload validates prompt: required strings, optional media array", () => {
+  expect(parseControlPayload(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", text: "hi", senderId: "u" })).not.toBeNull();
+  expect(parseControlPayload(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", text: "hi", senderId: "u", media: [] })).not.toBeNull();
+  expect(parseControlPayload(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", senderId: "u" })).toBeNull(); // no text
+  expect(parseControlPayload(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", text: "hi", senderId: "u", media: "x" })).toBeNull(); // media not array
+});
+
+test("fsCreate enforces the kind literal union", () => {
+  expect(parseControlPayload(MSG.fsCreate, { workspace: "w", path: "p", kind: "file" })).not.toBeNull();
+  expect(parseControlPayload(MSG.fsCreate, { workspace: "w", path: "p", kind: "dir" })).not.toBeNull();
+  expect(parseControlPayload(MSG.fsCreate, { workspace: "w", path: "p", kind: "socket" })).toBeNull();
+});
+
+test("chatKey-only and chatKey+alias families validate their shape", () => {
+  expect(parseControlPayload(MSG.sessionsList, { chatKey: "relay:a1" })).not.toBeNull();
+  expect(parseControlPayload(MSG.sessionsList, {})).toBeNull();
+  expect(parseControlPayload(MSG.sessionsRemove, { chatKey: "relay:a1", alias: "s" })).not.toBeNull();
+  expect(parseControlPayload(MSG.sessionsRemove, { chatKey: "relay:a1" })).toBeNull();
+});
+
+test("upload requires filename, content, mimeType strings", () => {
+  expect(parseControlPayload(MSG.upload, { filename: "a", content: "b64", mimeType: "text/plain" })).not.toBeNull();
+  expect(parseControlPayload(MSG.upload, { filename: "a", content: "b64" })).toBeNull();
+});
+
+test("every registered validator returns null for a non-object payload", () => {
+  for (const type of Object.keys(CONTROL_PAYLOAD_VALIDATORS) as (keyof typeof CONTROL_PAYLOAD_VALIDATORS)[]) {
+    expect(CONTROL_PAYLOAD_VALIDATORS[type](null)).toBeNull();
+    expect(CONTROL_PAYLOAD_VALIDATORS[type](42)).toBeNull();
+  }
+});
+
+// --- Type-level binding (checked by `npx tsc --noEmit`, not at runtime) ---
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+// PayloadFor<MSG.fsWrite> is exactly FsWritePayload (not `unknown`, not a widened shape).
+type _fsWriteBound = Expect<Equal<PayloadFor<typeof MSG.fsWrite>, FsWritePayload>>;
+type _promptBound = Expect<Equal<PayloadFor<typeof MSG.prompt>, PromptPayload>>;
+
+test("type-level bindings compile", () => {
+  // The `_fsWriteBound`/`_promptBound` aliases above fail `tsc` if PayloadFor drifts
+  // from the hand-written payload type. This runtime assertion just anchors the test.
+  const _use: [_fsWriteBound, _promptBound] = [true, true];
+  expect(_use).toEqual([true, true]);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bun test tests/unit/packages/relay-protocol/payload-validators.test.ts`
+Expected: FAIL — `parseControlPayload` / `CONTROL_PAYLOAD_VALIDATORS` not exported.
+
+- [ ] **Step 4: Create `payload-validators.ts`**
+
+```ts
+// packages/relay-protocol/src/payload-validators.ts
+// Runtime validators for hub→connector control RPCs. Each validator checks a payload's
+// SHAPE (field presence + type, including literal unions and nested objects) and returns
+// the narrowed payload, or null when malformed. Semantic checks (non-empty, valid ISO date,
+// existence) stay in the connector's dispatch — these only guard the wire shape.
+//
+// The registry keys are the control-RPC MessageTypes; `satisfies Record<ControlRpcType, …>`
+// makes tsc fail if a control RPC is added to the union without a validator (or vice versa),
+// and `parseControlPayload` forces every connector dispatch arm to register its message type.
+import {
+  MSG,
+  type AgentsCreatePayload,
+  type AgentsRemovePayload,
+  type CommandExecutePayload,
+  type FsCopyPayload,
+  type FsCreatePayload,
+  type FsDeletePayload,
+  type FsDiffPayload,
+  type FsDownloadPayload,
+  type FsListPayload,
+  type FsReadPayload,
+  type FsRenamePayload,
+  type FsSearchPayload,
+  type FsWritePayload,
+  type OrchestrationCancelPayload,
+  type OrchestrationGetPayload,
+  type PromptCancelPayload,
+  type PromptPayload,
+  type QueueCancelPayload,
+  type ScheduledCancelPayload,
+  type ScheduledCreatePayload,
+  type ScheduledListPayload,
+  type SessionModelGetPayload,
+  type SessionModelSetPayload,
+  type SessionsArchivePayload,
+  type SessionsCreatePayload,
+  type SessionsListPayload,
+  type SessionsNativeListPayload,
+  type SessionsRemovePayload,
+  type SessionsRenamePayload,
+  type SessionsUnarchivePayload,
+  type TerminalAttachPayload,
+  type TerminalCreatePayload,
+  type UploadPayload,
+  type WorkspacesCreatePayload,
+  type WorkspacesRemovePayload,
+} from "./messages.js";
+import { isObj, isStr, optStr, optNum, optBool } from "./validate-primitives.js";
+
+export type Validator<T> = (payload: unknown) => T | null;
+
+/** Non-null-object view for field access, or null. */
+const fields = (p: unknown): Record<string, unknown> | null => (isObj(p) ? p : null);
+
+const isArr = (v: unknown): boolean => Array.isArray(v);
+const optArr = (v: unknown): boolean => v === undefined || Array.isArray(v);
+
+// --- session / agent / workspace ---
+const validateSessionsList: Validator<SessionsListPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) ? (o as SessionsListPayload) : null;
+};
+const validateSessionsCreate: Validator<SessionsCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) && isStr(o.agent) && isStr(o.workspace)
+    && optStr(o.agentSessionId) && optStr(o.model) ? (o as SessionsCreatePayload) : null;
+};
+const validateSessionsNativeList: Validator<SessionsNativeListPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.agent) && isStr(o.workspace) ? (o as SessionsNativeListPayload) : null;
+};
+const validateSessionsRemove: Validator<SessionsRemovePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as SessionsRemovePayload) : null;
+};
+const validateSessionsArchive: Validator<SessionsArchivePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as SessionsArchivePayload) : null;
+};
+const validateSessionsUnarchive: Validator<SessionsUnarchivePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as SessionsUnarchivePayload) : null;
+};
+const validateSessionsRename: Validator<SessionsRenamePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) && isStr(o.displayName) ? (o as SessionsRenamePayload) : null;
+};
+const validateWorkspacesCreate: Validator<WorkspacesCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) && isStr(o.cwd) && optStr(o.description) ? (o as WorkspacesCreatePayload) : null;
+};
+const validateAgentsCreate: Validator<AgentsCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) && isStr(o.driver) ? (o as AgentsCreatePayload) : null;
+};
+const validateAgentsRemove: Validator<AgentsRemovePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) ? (o as AgentsRemovePayload) : null;
+};
+const validateWorkspacesRemove: Validator<WorkspacesRemovePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) ? (o as WorkspacesRemovePayload) : null;
+};
+
+// --- prompt / command / queue ---
+const validatePrompt: Validator<PromptPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.text) && isStr(o.senderId)
+    && optBool(o.isOwner) && optArr(o.media) ? (o as PromptPayload) : null;
+};
+const validatePromptCancel: Validator<PromptCancelPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? (o as PromptCancelPayload) : null;
+};
+const validateQueueCancel: Validator<QueueCancelPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.itemId) ? (o as QueueCancelPayload) : null;
+};
+const validateCommandExecute: Validator<CommandExecutePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.text) && isStr(o.senderId) && optBool(o.isOwner)
+    ? (o as CommandExecutePayload) : null;
+};
+
+// --- scheduled ---
+const validateScheduledList: Validator<ScheduledListPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) ? (o as ScheduledListPayload) : null;
+};
+const validateScheduledCreate: Validator<ScheduledCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.executeAt) && isStr(o.message)
+    ? (o as ScheduledCreatePayload) : null;
+};
+const validateScheduledCancel: Validator<ScheduledCancelPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.id) && isStr(o.chatKey) ? (o as ScheduledCancelPayload) : null;
+};
+
+// --- orchestration ---
+const validateOrchestrationGet: Validator<OrchestrationGetPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.taskId) ? (o as OrchestrationGetPayload) : null;
+};
+const validateOrchestrationCancel: Validator<OrchestrationCancelPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.taskId) ? (o as OrchestrationCancelPayload) : null;
+};
+
+// --- fs (read family: workspace + optional path) ---
+const validateFsList: Validator<FsListPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && optStr(o.path) ? (o as FsListPayload) : null;
+};
+const validateFsRead: Validator<FsReadPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsReadPayload) : null;
+};
+const validateFsDiff: Validator<FsDiffPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && optStr(o.path) ? (o as FsDiffPayload) : null;
+};
+const validateFsSearch: Validator<FsSearchPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.query)
+    && (o.mode === undefined || o.mode === "name" || o.mode === "content")
+    && optBool(o.matchCase) && optBool(o.wholeWord) && optBool(o.regex)
+    && optStr(o.include) && optStr(o.exclude) && optStr(o.path)
+    ? (o as FsSearchPayload) : null;
+};
+
+// --- fs (mutating family) ---
+const validateFsCreate: Validator<FsCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) && (o.kind === "file" || o.kind === "dir")
+    ? (o as FsCreatePayload) : null;
+};
+const validateFsRename: Validator<FsRenamePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) && isStr(o.newName) ? (o as FsRenamePayload) : null;
+};
+const validateFsDelete: Validator<FsDeletePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsDeletePayload) : null;
+};
+const validateFsCopy: Validator<FsCopyPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsCopyPayload) : null;
+};
+const validateFsDownload: Validator<FsDownloadPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsDownloadPayload) : null;
+};
+const validateFsWrite: Validator<FsWritePayload> = (p) => {
+  const o = fields(p);
+  if (!o || !isStr(o.workspace) || !isStr(o.path) || !isStr(o.content)) return null;
+  const exp = fields(o.expected);
+  if (!exp || typeof exp.mtimeMs !== "number" || typeof exp.size !== "number") return null;
+  return o as FsWritePayload;
+};
+
+// --- model / terminal / upload ---
+const validateSessionModelGet: Validator<SessionModelGetPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? (o as SessionModelGetPayload) : null;
+};
+const validateSessionModelSet: Validator<SessionModelSetPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.modelId) ? (o as SessionModelSetPayload) : null;
+};
+const validateTerminalCreate: Validator<TerminalCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && optNum(o.cols) && optNum(o.rows)
+    ? (o as TerminalCreatePayload) : null;
+};
+const validateTerminalAttach: Validator<TerminalAttachPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.terminalId) ? (o as TerminalAttachPayload) : null;
+};
+const validateUpload: Validator<UploadPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.filename) && isStr(o.content) && isStr(o.mimeType) ? (o as UploadPayload) : null;
+};
+
+/** The control-RPC message types that carry a client-supplied payload to validate.
+ *  Excludes: handshake (instanceRegister/instanceAuth — validated in instance-gateway),
+ *  event-direction (instanceEvent/instanceNotice — boundary B via validControlEvent),
+ *  terminal I/O events (terminalInput/Resize/Close — validated by parseWebClientMessage),
+ *  and the four no-payload list RPCs (agentsList/workspacesList/agentsCatalog/orchestrationList). */
+export type ControlRpcType =
+  | typeof MSG.sessionsList | typeof MSG.sessionsCreate | typeof MSG.sessionsNativeList
+  | typeof MSG.sessionsRemove | typeof MSG.sessionsArchive | typeof MSG.sessionsUnarchive
+  | typeof MSG.sessionsRename | typeof MSG.workspacesCreate | typeof MSG.agentsCreate
+  | typeof MSG.agentsRemove | typeof MSG.workspacesRemove | typeof MSG.prompt
+  | typeof MSG.promptCancel | typeof MSG.queueCancel | typeof MSG.commandExecute
+  | typeof MSG.scheduledList | typeof MSG.scheduledCreate | typeof MSG.scheduledCancel
+  | typeof MSG.orchestrationGet | typeof MSG.orchestrationCancel | typeof MSG.fsList
+  | typeof MSG.fsRead | typeof MSG.fsDiff | typeof MSG.fsSearch | typeof MSG.fsCreate
+  | typeof MSG.fsRename | typeof MSG.fsDelete | typeof MSG.fsCopy | typeof MSG.fsDownload
+  | typeof MSG.fsWrite | typeof MSG.sessionModelGet | typeof MSG.sessionModelSet
+  | typeof MSG.terminalCreate | typeof MSG.terminalAttach | typeof MSG.upload;
+
+/** Registry: control-RPC type → shape validator. `satisfies` locks both directions —
+ *  a ControlRpcType with no validator, or a validator whose key isn't a ControlRpcType,
+ *  is a compile error. */
+export const CONTROL_PAYLOAD_VALIDATORS = {
+  [MSG.sessionsList]: validateSessionsList,
+  [MSG.sessionsCreate]: validateSessionsCreate,
+  [MSG.sessionsNativeList]: validateSessionsNativeList,
+  [MSG.sessionsRemove]: validateSessionsRemove,
+  [MSG.sessionsArchive]: validateSessionsArchive,
+  [MSG.sessionsUnarchive]: validateSessionsUnarchive,
+  [MSG.sessionsRename]: validateSessionsRename,
+  [MSG.workspacesCreate]: validateWorkspacesCreate,
+  [MSG.agentsCreate]: validateAgentsCreate,
+  [MSG.agentsRemove]: validateAgentsRemove,
+  [MSG.workspacesRemove]: validateWorkspacesRemove,
+  [MSG.prompt]: validatePrompt,
+  [MSG.promptCancel]: validatePromptCancel,
+  [MSG.queueCancel]: validateQueueCancel,
+  [MSG.commandExecute]: validateCommandExecute,
+  [MSG.scheduledList]: validateScheduledList,
+  [MSG.scheduledCreate]: validateScheduledCreate,
+  [MSG.scheduledCancel]: validateScheduledCancel,
+  [MSG.orchestrationGet]: validateOrchestrationGet,
+  [MSG.orchestrationCancel]: validateOrchestrationCancel,
+  [MSG.fsList]: validateFsList,
+  [MSG.fsRead]: validateFsRead,
+  [MSG.fsDiff]: validateFsDiff,
+  [MSG.fsSearch]: validateFsSearch,
+  [MSG.fsCreate]: validateFsCreate,
+  [MSG.fsRename]: validateFsRename,
+  [MSG.fsDelete]: validateFsDelete,
+  [MSG.fsCopy]: validateFsCopy,
+  [MSG.fsDownload]: validateFsDownload,
+  [MSG.fsWrite]: validateFsWrite,
+  [MSG.sessionModelGet]: validateSessionModelGet,
+  [MSG.sessionModelSet]: validateSessionModelSet,
+  [MSG.terminalCreate]: validateTerminalCreate,
+  [MSG.terminalAttach]: validateTerminalAttach,
+  [MSG.upload]: validateUpload,
+} satisfies Record<ControlRpcType, Validator<unknown>>;
+
+/** The payload type bound to a control-RPC message, derived from its validator's return. */
+export type PayloadFor<T extends ControlRpcType> =
+  NonNullable<ReturnType<(typeof CONTROL_PAYLOAD_VALIDATORS)[T]>>;
+
+/** Type-safe replacement for `payload as XxxPayload`: validates shape, returns the bound
+ *  payload type or null. */
+export function parseControlPayload<T extends ControlRpcType>(type: T, payload: unknown): PayloadFor<T> | null {
+  const validate = CONTROL_PAYLOAD_VALIDATORS[type] as Validator<PayloadFor<T>>;
+  return validate(payload);
+}
+```
+
+- [ ] **Step 5: Export the new module + `validControlEvent`**
+
+In `packages/relay-protocol/src/index.ts`, add:
+
+```ts
+export * from "./validate-primitives.js";
+export * from "./payload-validators.js";
+```
+
+In `packages/relay-protocol/src/web-dtos.ts`, change the `validControlEvent` declaration (currently `function validControlEvent(e: unknown): boolean {` at line 162) to be exported:
+
+```ts
+export function validControlEvent(e: unknown): boolean {
+```
+
+- [ ] **Step 6: Run tests to verify green**
+
+Run: `bun test tests/unit/packages/relay-protocol/payload-validators.test.ts`
+Expected: PASS.
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors. (If a validator's returned shape drifts from its payload type, the `_fsWriteBound`/`_promptBound` aliases in the test fail here.)
+
+Re-run the existing protocol suites to confirm no regression:
+Run: `bun test tests/unit/packages/relay-protocol/web-dtos.test.ts tests/unit/packages/relay-protocol/messages.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git checkout -- packages/relay-protocol/dist 2>/dev/null || true
+git add packages/relay-protocol/src/payload-validators.ts packages/relay-protocol/src/messages.ts packages/relay-protocol/src/index.ts packages/relay-protocol/src/web-dtos.ts tests/unit/packages/relay-protocol/payload-validators.test.ts
+git commit -m "feat(relay-protocol): control-payload validator registry with type-level binding"
+```
+
+---
+
+### Task 3: Boundary A — validate control RPCs in the connector dispatch
+
+**Files:**
+- Modify: `packages/channel-relay/src/control-bridge.ts:151-359` (the `dispatchControlRequest` switch)
+- Test: `tests/unit/packages/channel-relay/control-bridge.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `parseControlPayload`, `TerminalCreatePayload`, `TerminalAttachPayload` from Task 2.
+- Produces: no new exports; every casting arm now rejects malformed payloads with `errorPayload("invalid-payload", …)`.
+
+**Method:** For each arm that currently does `const input = payload as XxxPayload` (or `const i = payload as XxxPayload`), replace the cast with a `parseControlPayload` call and an early `invalid-payload` return. **Keep every existing semantic check** below the cast (non-empty checks, `Date.parse` validity, etc.) — the validator only guarantees wire shape. The four no-payload arms (`agentsList`, `workspacesList`, `agentsCatalog`, `orchestrationList`) are unchanged. The rejection message carries only the message type, never payload contents (privacy).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/packages/channel-relay/control-bridge.test.ts`. These use the existing `req` / `makeFakeControl` / `createControlBridge` helpers already in that file (see its top). Add near the other tests:
+
+```ts
+test("boundary A: malformed fsWrite is rejected and never touches the filesystem", async () => {
+  const control = makeFakeControl();
+  const bridge = createControlBridge(control.control as never);
+  const responses: unknown[] = [];
+  // missing `content` and `expected` → invalid shape
+  bridge(req(MSG.fsWrite, { workspace: "home", path: "a.txt" }), (p) => responses.push(p));
+  await new Promise((r) => setTimeout(r, 0));
+  expect(responses[0]).toEqual({ error: { code: "invalid-payload", message: expect.stringContaining(MSG.fsWrite) } });
+  expect(control.calls.fsWrite).toBeUndefined();
+});
+
+test("boundary A: malformed prompt is rejected and control.prompt is never called", async () => {
+  const control = makeFakeControl();
+  const bridge = createControlBridge(control.control as never);
+  const responses: unknown[] = [];
+  bridge(req(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s" /* no text/senderId */ }), (p) => responses.push(p));
+  await new Promise((r) => setTimeout(r, 0));
+  expect(responses[0]).toEqual({ error: { code: "invalid-payload", message: expect.stringContaining(MSG.prompt) } });
+  expect(control.calls.prompt).toBeUndefined();
+});
+
+test("boundary A: a well-formed prompt still dispatches to control.prompt", async () => {
+  const control = makeFakeControl();
+  const bridge = createControlBridge(control.control as never);
+  const responses: unknown[] = [];
+  bridge(req(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", text: "hi", senderId: "u" }), (p) => responses.push(p));
+  await new Promise((r) => setTimeout(r, 0));
+  expect(responses[0]).toEqual({ ok: true, text: "done" });
+  expect(control.calls.prompt?.length).toBe(1);
+});
+```
+
+Note: `makeFakeControl` in the file returns `{ control, calls }` (it records calls into a `calls` record and exposes `control`). Confirm the exact return shape at the top of the file and adjust the destructuring (`control.control` / `control.calls`) to match how other tests in the file consume it — mirror an existing test's usage exactly. `control.fsWrite` may not exist on the fake; add an `fsWrite` recorder to `makeFakeControl` if the happy-path/rejection test needs it (record into `calls.fsWrite`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/unit/packages/channel-relay/control-bridge.test.ts`
+Expected: FAIL — malformed payloads currently dispatch (or throw) instead of returning `invalid-payload`.
+
+- [ ] **Step 3: Update the import + every casting arm**
+
+In `control-bridge.ts`, add `parseControlPayload` to the `@ganglion/xacpx-relay-protocol` import block, and add `type TerminalCreatePayload`, `type TerminalAttachPayload`. Then rewrite each casting arm. Two representative examples (apply the same transform to ALL 35 casting arms enumerated in Task 2's `ControlRpcType`):
+
+`sessionsList` (was lines 154-157):
+```ts
+    case MSG.sessionsList: {
+      const input = parseControlPayload(MSG.sessionsList, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionsList}: malformed payload`);
+      return { sessions: control.listSessions(input.chatKey) };
+    }
+```
+
+`fsWrite` (was lines 320-328) — keep the existing semantic checks below the parse:
+```ts
+    case MSG.fsWrite: {
+      const i = parseControlPayload(MSG.fsWrite, payload);
+      if (!i) return errorPayload("invalid-payload", `${MSG.fsWrite}: malformed payload`);
+      if (!i.workspace || !i.path) return errorPayload("bad-request", "workspace and path are required");
+      return await control.fsWrite(i.workspace, i.path, i.content, i.expected);
+    }
+```
+
+For `terminalCreate` / `terminalAttach`, the parse now returns the named `TerminalCreatePayload` / `TerminalAttachPayload`:
+```ts
+    case MSG.terminalCreate: {
+      const input = parseControlPayload(MSG.terminalCreate, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.terminalCreate}: malformed payload`);
+      if (!input.sessionAlias) return errorPayload("bad-request", "sessionAlias is required");
+      return await control.createTerminal(input.chatKey, input.sessionAlias, input.cols ?? 80, input.rows ?? 24);
+    }
+    case MSG.terminalAttach: {
+      const input = parseControlPayload(MSG.terminalAttach, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.terminalAttach}: malformed payload`);
+      if (!input.terminalId) return errorPayload("bad-request", "terminalId is required");
+      return control.attachTerminal(input.terminalId);
+    }
+```
+
+Apply the identical pattern to the remaining arms: `sessionsCreate`, `sessionsNativeList`, `sessionsRemove`, `sessionsArchive`, `sessionsUnarchive`, `sessionsRename`, `workspacesCreate`, `agentsCreate`, `agentsRemove`, `workspacesRemove`, `prompt`, `promptCancel`, `queueCancel`, `commandExecute`, `scheduledList`, `scheduledCreate`, `scheduledCancel`, `orchestrationGet`, `orchestrationCancel`, `fsList`, `fsRead`, `fsDiff`, `fsSearch`, `fsCreate`, `fsRename`, `fsDelete`, `fsCopy`, `fsDownload`, `sessionModelGet`, `sessionModelSet`, `upload`. In each: replace `payload as XxxPayload` with `parseControlPayload(MSG.xxx, payload)` + the `if (!input/!i) return errorPayload("invalid-payload", …)` guard; keep the existing semantic checks and the `control.*` call verbatim. `prompt` becomes:
+```ts
+    case MSG.prompt: {
+      const input = parseControlPayload(MSG.prompt, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.prompt}: malformed payload`);
+      return await control.prompt(input);
+    }
+```
+
+After the edits, remove any now-unused single `type XxxPayload` imports that are no longer referenced (tsc under `noUnusedLocals`, if enabled, will flag them; otherwise leave them — do not remove imports still used elsewhere). Do NOT touch `dispatchControlEvent` (lines 393-409, the downward terminal-event path — out of scope).
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run: `bun test tests/unit/packages/channel-relay/control-bridge.test.ts`
+Expected: PASS (existing tests + 3 new).
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git checkout -- packages/relay-protocol/dist 2>/dev/null || true
+git add packages/channel-relay/src/control-bridge.ts tests/unit/packages/channel-relay/control-bridge.test.ts
+git commit -m "feat(channel-relay): validate control-RPC payloads at the connector boundary"
+```
+
+---
+
+### Task 4: Boundary B — validate instance events in the hub's onEvent
+
+**Files:**
+- Modify: `packages/relay/src/server.ts:145-217` (the `onEvent` handler)
+- Test: `tests/unit/packages/relay/runtime-fanout.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `validControlEvent` (now exported from `relay-protocol`, Task 2) and the existing `logger` in scope (a `RelayLogger` from Track 1, already used at `server.ts:216`).
+- Produces: malformed instance events are dropped (not broadcast, not persisted) and logged as `relay.event.invalid`.
+
+- [ ] **Step 1: Write the failing test**
+
+The suite already has a `fire(event)` helper that invokes `onEvent` directly (see `runtime-fanout.test.ts` top). Add a test that a malformed event is dropped and does not reach the web socket or the DB:
+
+```ts
+test("boundary B: a malformed control event is dropped, not broadcast or persisted", async () => {
+  const runtime = await seeded();
+  const web = new FakeSocket();
+  runtime.webGateway.register("a1", web as never);
+  const fire = (event: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceEvent, payload: { event },
+  });
+
+  // turn-finished missing the required `sessionAlias` (and `ok`) → invalid shape.
+  fire({ type: "turn-finished", chatKey: "relay:a1" });
+
+  expect(web.sent.length).toBe(0); // not broadcast
+  const history = runtime.messages.listBySession("a1", "i1", "backend", { limit: 10 });
+  expect(history.messages.length).toBe(0); // not persisted
+});
+```
+
+If `listBySession`'s exact signature differs, mirror the call already used elsewhere in the relay suite (`server.ts:205` calls `messages.listBySession(accountId, instanceId, event.sessionAlias, { limit: 1 })`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/unit/packages/relay/runtime-fanout.test.ts`
+Expected: FAIL — the malformed event is currently broadcast (`web.sent.length` is 1), because `onEvent` casts `as ControlEventDto` with no validation.
+
+- [ ] **Step 3: Add the validation guard in `onEvent`**
+
+In `packages/relay/src/server.ts`, add `validControlEvent` to the `@ganglion/xacpx-relay-protocol` import. Then in the `onEvent` handler, replace the unchecked cast at line 151:
+
+```ts
+        if (envelope.type === MSG.instanceEvent) {
+          const event = (envelope.payload as InstanceEventPayload).event as ControlEventDto;
+```
+
+with a validation gate that drops + logs malformed events before any broadcast/persist:
+
+```ts
+        if (envelope.type === MSG.instanceEvent) {
+          const raw = (envelope.payload as InstanceEventPayload | undefined)?.event;
+          if (!validControlEvent(raw)) {
+            // A malformed event from a buggy/hostile connector must not broadcast to
+            // browsers or seed history. Drop it; log type + instanceId only (no payload).
+            logger.debug("relay.event.invalid", "dropped malformed instance event", {
+              instanceId,
+              eventType: typeof raw === "object" && raw !== null ? String((raw as { type?: unknown }).type) : "(none)",
+            });
+            return;
+          }
+          const event = raw as ControlEventDto;
+```
+
+Leave the rest of the `onEvent` body (the `event.type === "turn-started"` chain) unchanged — it now runs only on validated events. The outer `try/catch` (persist_failed) stays.
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run: `bun test tests/unit/packages/relay/runtime-fanout.test.ts`
+Expected: PASS (existing broadcast test + the new drop test). The existing "control events broadcast…" test still passes because its events are well-formed.
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git checkout -- packages/relay-protocol/dist 2>/dev/null || true
+git add packages/relay/src/server.ts tests/unit/packages/relay/runtime-fanout.test.ts
+git commit -m "feat(relay): validate inbound instance events, drop malformed frames"
+```
+
+---
+
+### Task 5: Boundary C — validate the three persisted RPCs in the hub HTTP route
+
+**Files:**
+- Modify: `packages/relay/src/http/app.ts:298-366` (the `/api/instances/:id/rpc` handler)
+- Test: `tests/unit/packages/relay/http-app.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `parseControlPayload` (Task 2).
+- Produces: a malformed `prompt` / `commandExecute` / `upload` returns HTTP 400 `{ error: { code: "invalid-payload", ... } }` before any `messages.append`, so a bad frame cannot poison history.
+
+**Note on ordering:** `prompt` and `commandExecute` are chat-scoped — the handler stamps `chatKey`/`senderId`/`isOwner` at lines 315-322 BEFORE this validation runs, so the full payload (including the server-stamped fields the validators require) is present. `upload` is not chat-scoped; its validator needs no stamped fields. Validate AFTER the stamp block, at the top of the existing `try`.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `tests/unit/packages/relay/http-app.test.ts`. Mirror the harness the file already uses to build the Hono app + an authenticated session (copy an existing `/rpc` test's setup). Add:
+
+```ts
+test("boundary C: malformed prompt returns 400 and persists nothing", async () => {
+  // ...reuse the file's existing app + authed-cookie setup + a registered instance...
+  const res = await app.request(`/api/instances/${instanceId}/rpc`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie: authCookie },
+    body: JSON.stringify({ type: "control.prompt", payload: { sessionAlias: 123 /* wrong type */ } }),
+  });
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("invalid-payload");
+  // history for the session is still empty
+  const history = runtime.messages.listBySession(account.id, instanceId, "s", { limit: 10 });
+  expect(history.messages.length).toBe(0);
+});
+```
+
+Adjust variable names (`app`, `instanceId`, `authCookie`, `account`, `runtime`) to match the existing test setup in the file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/unit/packages/relay/http-app.test.ts`
+Expected: FAIL — currently a malformed prompt is forwarded (or 500s), not a clean 400.
+
+- [ ] **Step 3: Add validation at the top of the `try`**
+
+In `packages/relay/src/http/app.ts`, add `parseControlPayload` to the `@ganglion/xacpx-relay-protocol` import. Then, immediately after the stamp block (after line 322, before the existing `try {` at line 323 — or as the first statements inside the `try`), add a shape gate for the three persisted types:
+
+```ts
+      // Shape-validate the RPCs the hub persists BEFORE forwarding, so a malformed frame
+      // can't poison history ahead of the connector's own boundary check. Error body carries
+      // no payload contents (privacy). Other control.* types are validated at the connector.
+      if (body.type === MSG.prompt && !parseControlPayload(MSG.prompt, payload)) {
+        return c.json({ error: "invalid-payload" }, 400);
+      }
+      if (body.type === MSG.commandExecute && !parseControlPayload(MSG.commandExecute, payload)) {
+        return c.json({ error: "invalid-payload" }, 400);
+      }
+      if (body.type === MSG.upload && !parseControlPayload(MSG.upload, payload)) {
+        return c.json({ error: "invalid-payload" }, 400);
+      }
+```
+
+Place these lines so they run before the `MSG.upload` size check (line 324) and before the `messages.append` at line 350. Keep the existing upload size check and prompt-persist logic as-is (they now run only on shape-valid payloads).
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run: `bun test tests/unit/packages/relay/http-app.test.ts`
+Expected: PASS (existing `/rpc` tests + the new 400 test). Existing happy-path `/rpc` tests still pass because their payloads are well-formed.
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git checkout -- packages/relay-protocol/dist 2>/dev/null || true
+git add packages/relay/src/http/app.ts tests/unit/packages/relay/http-app.test.ts
+git commit -m "feat(relay): shape-validate persisted RPCs in the hub HTTP route"
+```
+
+---
+
+## Final Verification (after all tasks)
+
+- [ ] Root typecheck: `npx tsc --noEmit` → 0 errors.
+- [ ] Per-file test sweep (CI-equivalent, per-file to avoid state-leak false failures):
+  - `bun test tests/unit/packages/relay-protocol/validate-primitives.test.ts`
+  - `bun test tests/unit/packages/relay-protocol/payload-validators.test.ts`
+  - `bun test tests/unit/packages/relay-protocol/web-dtos.test.ts`
+  - `bun test tests/unit/packages/channel-relay/control-bridge.test.ts`
+  - `bun test tests/unit/packages/relay/runtime-fanout.test.ts`
+  - `bun test tests/unit/packages/relay/http-app.test.ts`
+- [ ] Revert any false dist diff: `git checkout -- packages/relay-protocol/dist`.
+- [ ] Confirm no payload values appear in any log/error added (grep the diff for the rejection sites; they carry only `type`/`instanceId`/`reason`).
+- [ ] Protocol version unchanged (`packages/relay-protocol/package.json` still `0.1.11`); no payload structure changed.
+
+## Notes for the executor
+
+- **Publishing is deferred** (user decision): this branch merges code only; real-world effect needs a core+relay+channel-relay beta, batched with later tracks. Do not bump versions or publish.
+- **Do not** introduce any dependency, change payload structures, or touch the envelope shallow-check.
+- **Privacy is a hard gate** — a reviewer will reject any rejection log/error that embeds a payload value.

--- a/docs/superpowers/specs/2026-07-06-protocol-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-06-protocol-hardening-design.md
@@ -1,0 +1,164 @@
+# 协议加固批次:relay 消息运行时校验 + 类型级绑定 设计文档
+
+**日期:** 2026-07-06
+**来源:** 2026-07 全库架构审读「轨道 2 协议加固」(见 memory `project-arch-audit-2026-07-backlog`)。
+
+## 目标
+
+治两条同源缺陷:
+
+1. **无运行时校验**:relay 46 个消息只有 TS 类型,跨信任边界的 payload 过线即 `as XxxPayload` 强转即信。最危险的是**连接器 `control-bridge.ts`** 的大 switch——~40 处裸 cast 后直接执行 `fs.write/delete/copy/rename`、`prompt` 注入、`commandExecute`;以及 **hub `server.ts:151`** 的 `(payload as InstanceEventPayload).event as ControlEventDto` 双 cast,驱动所有历史 DB 写。唯一已深校验的方向是 web-push(`web-dtos.ts`)。
+2. **无类型级绑定**:`MSG` 是纯字符串常量表(`messages.ts:6`),40+ 个 `XxxPayload` 仅靠**命名约定**关联消息类型;`case MSG.fsWrite: payload as FsWritePayload` 里标签与 cast 各写各的,可静默漂移,tsc 不报。
+
+**一个统一产物同时解决两者**:在 `relay-protocol` 建一个按 `MessageType` 键控的手写校验器注册表,它既是运行时校验的来源,也用 `satisfies Record<...>` 反推出类型级绑定。这是 PR #137 用 `satisfies Record<ControlEventDto["type"], true>` 根治 control-event 白名单漂移那招的推广。
+
+## 全局约束
+
+- **无新依赖**。全仓无任何 schema/校验库,`relay-protocol` 是**零依赖发布包**、被 hub/connector/web 三包 `^0.1.0` 钉死引用;必须保持零运行时依赖。手写校验器,沿用 `web-dtos.ts` 既有风格。
+- **隐私红线**(继承 Track 1):任何 rejection 日志或 error message **绝不**记 payload 值——不记 fs 路径、prompt 文本、upload 内容、凭证;只记 `type` 与结构化 reason(哪个字段缺失/类型错)。
+- **协议兼容不破**:纯新增校验(拒的本就是非法帧),不改任何 payload 结构、不改 envelope 浅校验 → protocol 保持 `0.1.x`、`^0.1.0` 兼容。
+- **git 卫生**:只 add 改动文件,禁 `git add -A`;不改 lockfile;英文 conventional commits。
+- **测试**:relay-protocol / relay / channel-relay 逐文件 `bun test`(CI 在 node 下跑);类型级绑定靠 `npx tsc --noEmit`。
+
+---
+
+## 现状(证据)
+
+### 消息表
+
+- `packages/relay-protocol/src/messages.ts:6-53`:`export const MSG = { … } as const`,46 个消息,camelCase 键 → 命名空间 wire 字符串(如 `prompt: "control.prompt"` @`:25`,`fsWrite: "control.fs.write"` @`:44`)。`MessageType = (typeof MSG)[keyof typeof MSG]` @`:55`。
+- payload 各自独立 `interface XxxPayload`(`messages.ts:73-450`),**与 MSG 键无任何类型级联系**。
+- 信封 `packages/relay-protocol/src/envelope.ts:5-13`:`{ protocolVersion, kind, id?, type, payload?: unknown }`。`decodeEnvelope`/`isEnvelopeShape`(`:23-58`)只校验信封壳,`payload` 保持 `unknown`。
+
+### 两道未校验的信任边界
+
+- **连接器收 hub 控制 RPC** — `packages/channel-relay/src/control-bridge.ts:151-359` 的 `dispatchControlRequest` 大 `switch(envelope.type)`:每 arm `payload as XxxPayload`(~40 处:`:155,159,163,167,171,176,181,191,200,207,214,221,223,227,231,235,239,251,257,262,266,271,276,281,295,301,306,311,316,321,330,335,341,346,351`)。副作用真正落地处:fs 变更(`fsCreate:294`/`fsRename:300`/`fsDelete:305`/`fsCopy:310`/`fsWrite:320`/`fsDownload:315`)、prompt 注入(`:220-221`)、commandExecute(`:230-233`)、upload(`:350-355`,唯一有内联字段检查的 arm)、scheduledCreate(`:238-249`)。默认 arm 返回 `errorPayload("unknown-type", …)`(`:357-358`)。
+- **hub 收连接器事件** — `packages/relay/src/server.ts:151`:`const event = (envelope.payload as InstanceEventPayload).event as ControlEventDto` 双 cast。下游 `onEvent`(`:153-211`)据此做 `messages.append` DB 写:`turn-started`(`:153-158`)、`turn-finished`(`:175-190`)、`session-history` 循环 append 每行(`:201-210`,连接器可塞任意行)。
+
+### hub HTTP 透传(先落库风险)
+
+- `packages/relay/src/http/app.ts` 的 `/api/instances/:id/rpc`:`app.ts:312` 读 body `as { type?, payload? }`,唯一门是 `body.type.startsWith("control.")`(`:313`),payload 原样转发给连接器(`:353`)。但 `MSG.prompt`/`MSG.commandExecute` 在转发**前**先 `messages.append` 落库(`:333-357`),`MSG.upload` 做 size 检查(`:325`)。malformed 会先污染 DB 再被连接器拒。
+
+### 已有深校验样板(web-push 方向,复用之)
+
+- `packages/relay-protocol/src/web-dtos.ts`:`validControlEvent(e)`(`:162-212`)——对 `ControlEventDto` 16 变体逐一校验必填字段的**编译期穷尽** switch,`default` 里 `const _exhaustive: never = type`(`:206-209`)。`parseWebServerEvent`(`:224-235`)、`validNotice`(`:217-221`)、`validToolStep`(`:145-157`)、内联谓词 `isStr/optStr/optNum`(`:115-117`)。
+- `satisfies` 样板:`CONTROL_EVENT_TYPE_MAP = { … } satisfies Record<ControlEventDto["type"], true>`(`web-dtos.ts:91-108`),`CONTROL_EVENT_TYPES` 从其键派生(`:110`)。
+
+### 依赖 / 消费者
+
+- 全仓零校验库(grep zod/valibot/ajv/yup/superstruct/io-ts/typebox/runtypes/arktype 无命中)。`relay-protocol/package.json` 无 dependencies 块。
+- 协议消费者:hub `packages/relay`、连接器 `packages/channel-relay`、前端 `packages/relay-web`,均 `^0.1.0`;core `src/` 仅 `control-service.ts:28` 一处 `import type PromptAttachmentRef`(几乎绝缘)。
+
+---
+
+## 设计
+
+### 构件 1 — `packages/relay-protocol/src/payload-validators.ts`(新建)
+
+按 `MessageType` 键控的手写校验器注册表:
+
+```ts
+// 校验器:unknown → 正确 payload 类型 | null(null = 非法,拒)
+type Validator<T> = (payload: unknown) => T | null;
+
+// 被校验的控制 RPC 请求类型子集(约 40 个:MSG 里 kind=req 的控制 RPC)。
+// 排除:instanceRegister/instanceAuth(握手,已在 instance-gateway 单独校验)、
+// instanceEvent/instanceNotice(事件方向,走边界 B)、terminalInput/Resize/Close(instance.* 事件,
+// 已由 parseWebClientMessage 校验)。terminalCreate/terminalAttach 是 req/res 控制 RPC,纳入。
+// 精确清单由实现计划枚举。
+export type ControlRpcType = /* MSG.sessionsList | MSG.prompt | MSG.fsWrite | … 约 40 个 */;
+
+// 全量注册表,satisfies 强制穷尽:漏一个 ControlRpcType → tsc 红
+export const CONTROL_PAYLOAD_VALIDATORS = {
+  [MSG.sessionsList]: validateChatKeyOnly,
+  [MSG.prompt]: validatePrompt,
+  [MSG.fsWrite]: validateFsWrite,
+  // …全部 40 个
+} satisfies Record<ControlRpcType, Validator<unknown>>;
+```
+
+- **校验器风格**:沿用 `web-dtos.ts` 的 `isStr/optStr/optNum` 谓词逐字段检查;必填缺失或类型错 → 返回 `null`;通过 → 返回**结构收窄后的 payload**(不做深拷贝,原样返回被 narrow 的对象)。
+- **不校验语义**:只校验形状(字段存在 + 类型),不校验业务合法性(如 workspace 是否存在、path 是否越界——那些各 handler 已有自己的检查,不搬到这里)。
+
+### 构件 2 — 类型级绑定 `PayloadFor` + `parseControlPayload`
+
+```ts
+// 每个校验器的返回类型「就是」该消息 payload 类型,由注册表反推
+export type PayloadFor<T extends ControlRpcType> =
+  NonNullable<ReturnType<(typeof CONTROL_PAYLOAD_VALIDATORS)[T]>>;
+
+// 类型安全的统一解析入口,取代裸 `payload as XxxPayload`
+export function parseControlPayload<T extends ControlRpcType>(
+  type: T,
+  payload: unknown,
+): PayloadFor<T> | null {
+  return (CONTROL_PAYLOAD_VALIDATORS[type] as Validator<PayloadFor<T>>)(payload);
+}
+```
+
+`PayloadFor<T>` 应与手写 `XxxPayload` 结构等价——每个校验器写完用一条 type-level 断言(`expectTypeOf` 或等价)锁定「校验器返回类型 = 对应 XxxPayload」,防止校验器漏字段导致 narrow 类型与协议类型漂移。
+
+### 构件 3 — 共享谓词抽取
+
+`web-dtos.ts:115-117` 的 `isStr/optStr/optNum`(及需要的 `isObj` 等)抽到 `packages/relay-protocol/src/validate-primitives.ts`(新建),`web-dtos.ts` 与 `payload-validators.ts` 都从此 import。避免两份实现漂移。
+
+### 三道边界落地
+
+| 边界 | 位置 | 做法 | rejection 行为 |
+|---|---|---|---|
+| **A 连接器控制 RPC** | `control-bridge.ts:151-359` 每 arm | `const input = parseControlPayload(MSG.xxx, payload); if (!input) return errorPayload("invalid-payload", \`${type}: malformed payload\`);` 取代 `payload as XxxPayload` | 回 `errorPayload("invalid-payload", …)`,走现成 res 信封回 hub→web。**不断连、不重试**(malformed 多半版本偏移) |
+| **B hub 收 instanceEvent** | `server.ts:151` | 复用现成 `validControlEvent`(web-dtos.ts)**直接校验内层 event**:`const event = validControlEvent((envelope.payload as InstanceEventPayload)?.event); if (!event) { log invalid; return; }`。**注意**:不要用 `parseWebServerEvent`——那校验的是 hub→浏览器广播信封(`{instanceId,event,kind}` 外壳),与 instance→hub 的 `{event}` 形状不同;这里只需内层 `validControlEvent` | **丢弃**该事件:不 broadcast、不 append;记 `relay.event.invalid`(RelayLogger,只带 instanceId + reason,无 payload) |
+| **C hub 先落库 RPC** | `app.ts` prompt/commandExecute/upload 分支 | `messages.append` **之前** 用对应校验器校验;失败 → HTTP 400 | 返回 400 + `{ error: { code: "invalid-payload", … } }`,**不 append**、不污染 DB。不含 payload 值 |
+
+### 可观测性 + 隐私
+
+- **hub 侧** 用 Track 1 的 `RelayLogger`。事件名:边界 B `relay.event.invalid`(context:`instanceId` + `reason`);边界 C 由 HTTP 400 响应体承载,可选记 `relay.rpc.invalid_payload`(context:`instanceId` + `type` + `reason`)。
+- **连接器侧**:channel-relay 无独立日志层,**不新建**(超范围)。边界 A 的 rejection 靠 `errorPayload` 回传——hub 侧会看到 error res。实现时核实 channel-relay 是否已有可复用 logger;若无则仅回传,不记日志。
+- **隐私**:所有日志/error message **只含** `type`、`instanceId`、结构化 `reason`(如 `"missing field: chatKey"` / `"field text must be string"`);**绝不含** payload 值(fs 路径、prompt 文本、upload 内容、任何凭证)。
+
+---
+
+## 测试策略
+
+### relay-protocol(核心)
+
+- 新单测 `tests/unit/packages/relay-protocol/payload-validators.test.ts`(路径随现有 relay-protocol 测试布局):每个校验器 ≥3 例——合法通过并返回收窄对象、缺必填字段返回 null、字段类型错返回 null。
+- satisfies 穷尽:靠 tsc(注册表漏一个 `ControlRpcType` 即编译红);加注释说明这是穷尽守卫,勿用 `Partial`。
+- 类型级绑定:一条 type-level 断言测 `parseControlPayload(MSG.fsWrite, x)` 的返回类型 = `FsWritePayload | null`,及至少一处 `// @ts-expect-error` 证明接错消息类型的 payload 会编译失败。
+
+### 连接器 control-bridge
+
+- 选代表 arm(`fsWrite`、`prompt`)测:malformed payload → 返回 `errorPayload("invalid-payload", …)` 且**不调用** `control.writeFile`/`control.prompt`(mock control,断言未被调用);合法 payload → 正常执行。
+
+### hub
+
+- 边界 B:畸形 `ControlEventDto`(如 `turn-finished` 缺 `sessionAlias`)→ `messages.append` 未被调用 + `relay.event.invalid` 记录(spy RelayLogger)。
+- 边界 C:畸形 prompt(缺 `text`)→ HTTP 400 且 `messages.append` 未被调用。
+
+---
+
+## 文件清单
+
+| 文件 | 动作 | 责任 |
+|---|---|---|
+| `packages/relay-protocol/src/validate-primitives.ts` | 新建 | `isStr/optStr/optNum/isObj` 等共享谓词 |
+| `packages/relay-protocol/src/payload-validators.ts` | 新建 | 约 40 校验器 + `CONTROL_PAYLOAD_VALIDATORS` + `ControlRpcType` + `PayloadFor` + `parseControlPayload` |
+| `packages/relay-protocol/src/web-dtos.ts` | 改 | 谓词改从 `validate-primitives` import(去重) |
+| `packages/relay-protocol/src/index.ts` | 改 | 导出新符号 |
+| `packages/channel-relay/src/control-bridge.ts` | 改 | 约 40 arm 换 `parseControlPayload` + rejection |
+| `packages/relay/src/server.ts` | 改 | 边界 B 复用 `validControlEvent` + 记 invalid |
+| `packages/relay/src/http/app.ts` | 改 | 边界 C 校验 prompt/commandExecute/upload |
+
+## 发布
+
+纯代码合并,不改 payload 结构 → protocol `0.1.x` 兼容不破。实机生效需 core+relay+channel-relay beta;按用户决定**攒着跟后续轨道一起发**,本批次合并时不发。
+
+## 明确不做(YAGNI / 越界)
+
+- 不校验 res 方向(只读 list 的返回结果由本端产生,可信)。
+- 不给连接器新建日志层。
+- 不做限流 / 断连惩罚 / 重试。
+- 不碰 web-push 方向(`web-dtos.ts` 已深校验)。
+- 不改 envelope 浅校验、不改任何 payload 结构。
+- 不引入任何第三方库。
+- 不校验握手 `instanceRegister/instanceAuth`(已在 instance-gateway 单独处理)与 terminal input/resize/close(已由 `parseWebClientMessage` 校验)。

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -1,43 +1,11 @@
 import {
   MSG,
   errorPayload,
-  type CommandExecutePayload,
-  type FsDiffPayload,
-  type FsListPayload,
-  type FsReadPayload,
-  type FsSearchPayload,
-  type FsCreatePayload,
-  type FsRenamePayload,
-  type FsDeletePayload,
-  type FsCopyPayload,
-  type FsWritePayload,
-  type FsDownloadPayload,
-  type SessionModelGetPayload,
-  type SessionModelSetPayload,
-  type OrchestrationCancelPayload,
-  type OrchestrationGetPayload,
+  parseControlPayload,
   type OrchestrationTaskDto,
-  type PromptCancelPayload,
-  type PromptPayload,
-  type QueueCancelPayload,
   type RelayEnvelope,
-  type ScheduledCancelPayload,
-  type ScheduledCreatePayload,
-  type ScheduledListPayload,
   type ScheduledTaskDto,
   type SessionHistoryRowDto,
-  type AgentsCreatePayload,
-  type AgentsRemovePayload,
-  type SessionsCreatePayload,
-  type SessionsListPayload,
-  type SessionsNativeListPayload,
-  type SessionsRemovePayload,
-  type SessionsArchivePayload,
-  type SessionsUnarchivePayload,
-  type SessionsRenamePayload,
-  type UploadPayload,
-  type WorkspacesCreatePayload,
-  type WorkspacesRemovePayload,
 } from "@ganglion/xacpx-relay-protocol";
 import type { ControlService } from "xacpx/plugin-api";
 import { toolUseEventToStepDto } from "./tool-presentation";
@@ -152,33 +120,40 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
   const payload = envelope.payload;
   switch (envelope.type) {
     case MSG.sessionsList: {
-      const input = payload as SessionsListPayload;
+      const input = parseControlPayload(MSG.sessionsList, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionsList}: malformed payload`);
       return { sessions: control.listSessions(input.chatKey) }; // ControlSessionInfo is field-identical to SessionDto
     }
     case MSG.sessionsCreate: {
-      const input = payload as SessionsCreatePayload;
+      const input = parseControlPayload(MSG.sessionsCreate, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionsCreate}: malformed payload`);
       return await control.createSession(input.chatKey, input.alias, input.agent, input.workspace, input.agentSessionId, input.model);
     }
     case MSG.sessionsNativeList: {
-      const input = payload as SessionsNativeListPayload;
+      const input = parseControlPayload(MSG.sessionsNativeList, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionsNativeList}: malformed payload`);
       return { sessions: await control.listNativeSessions(input.chatKey, input.agent, input.workspace) };
     }
     case MSG.sessionsRemove: {
-      const input = payload as SessionsRemovePayload;
+      const input = parseControlPayload(MSG.sessionsRemove, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionsRemove}: malformed payload`);
       return await control.removeSession(input.chatKey, input.alias);
     }
     case MSG.sessionsArchive: {
-      const input = payload as SessionsArchivePayload;
+      const input = parseControlPayload(MSG.sessionsArchive, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionsArchive}: malformed payload`);
       await control.archiveSession(input.chatKey, input.alias);
       return {};
     }
     case MSG.sessionsUnarchive: {
-      const input = payload as SessionsUnarchivePayload;
+      const input = parseControlPayload(MSG.sessionsUnarchive, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionsUnarchive}: malformed payload`);
       await control.unarchiveSession(input.chatKey, input.alias);
       return {};
     }
     case MSG.sessionsRename: {
-      const input = payload as SessionsRenamePayload;
+      const input = parseControlPayload(MSG.sessionsRename, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionsRename}: malformed payload`);
       if (!input.alias) return errorPayload("bad-request", "alias is required");
       await control.setSessionDisplayName(input.chatKey, input.alias, input.displayName ?? "");
       return { ok: true };
@@ -188,7 +163,8 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
     case MSG.workspacesList:
       return { workspaces: control.listWorkspaces() };
     case MSG.workspacesCreate: {
-      const input = payload as WorkspacesCreatePayload;
+      const input = parseControlPayload(MSG.workspacesCreate, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.workspacesCreate}: malformed payload`);
       const name = typeof input.name === "string" ? input.name.trim() : "";
       const cwd = typeof input.cwd === "string" ? input.cwd.trim() : "";
       if (!name || !cwd) return errorPayload("bad-request", "workspace name and cwd are required");
@@ -197,46 +173,57 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
     case MSG.agentsCatalog:
       return { agents: control.listAgentCatalog() };
     case MSG.agentsCreate: {
-      const input = payload as AgentsCreatePayload;
+      const input = parseControlPayload(MSG.agentsCreate, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.agentsCreate}: malformed payload`);
       const name = typeof input.name === "string" ? input.name.trim() : "";
       const driver = typeof input.driver === "string" ? input.driver.trim() : "";
       if (!name || !driver) return errorPayload("bad-request", "agent name and driver are required");
       return { agent: await control.createAgent(name, driver) };
     }
     case MSG.agentsRemove: {
-      const input = payload as AgentsRemovePayload;
+      const input = parseControlPayload(MSG.agentsRemove, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.agentsRemove}: malformed payload`);
       const name = typeof input.name === "string" ? input.name.trim() : "";
       if (!name) return errorPayload("bad-request", "agent name is required");
       await control.removeAgent(name);
       return { ok: true };
     }
     case MSG.workspacesRemove: {
-      const input = payload as WorkspacesRemovePayload;
+      const input = parseControlPayload(MSG.workspacesRemove, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.workspacesRemove}: malformed payload`);
       const name = typeof input.name === "string" ? input.name.trim() : "";
       if (!name) return errorPayload("bad-request", "workspace name is required");
       await control.removeWorkspace(name);
       return { ok: true };
     }
-    case MSG.prompt:
-      return await control.prompt(payload as PromptPayload);
+    case MSG.prompt: {
+      const input = parseControlPayload(MSG.prompt, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.prompt}: malformed payload`);
+      return await control.prompt(input);
+    }
     case MSG.promptCancel: {
-      const input = payload as PromptCancelPayload;
+      const input = parseControlPayload(MSG.promptCancel, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.promptCancel}: malformed payload`);
       return { cancelled: control.cancelTurn(input.chatKey, input.sessionAlias) };
     }
     case MSG.queueCancel: {
-      const input = payload as QueueCancelPayload;
+      const input = parseControlPayload(MSG.queueCancel, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.queueCancel}: malformed payload`);
       return control.cancelQueuedItem(input.chatKey, input.sessionAlias, input.itemId);
     }
     case MSG.commandExecute: {
-      const input = payload as CommandExecutePayload;
+      const input = parseControlPayload(MSG.commandExecute, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.commandExecute}: malformed payload`);
       return { output: await control.executeCommand(input) };
     }
     case MSG.scheduledList: {
-      const input = payload as ScheduledListPayload;
+      const input = parseControlPayload(MSG.scheduledList, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.scheduledList}: malformed payload`);
       return { tasks: control.listScheduledTasks(input.chatKey).map(scheduledTaskToDto) };
     }
     case MSG.scheduledCreate: {
-      const input = payload as ScheduledCreatePayload;
+      const input = parseControlPayload(MSG.scheduledCreate, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.scheduledCreate}: malformed payload`);
       const ms = Date.parse(input.executeAt);
       if (Number.isNaN(ms)) return errorPayload("bad-request", "executeAt is not a valid ISO timestamp");
       const task = await control.createScheduledTask({
@@ -248,37 +235,44 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
       return scheduledTaskToDto(task);
     }
     case MSG.scheduledCancel: {
-      const input = payload as ScheduledCancelPayload;
+      const input = parseControlPayload(MSG.scheduledCancel, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.scheduledCancel}: malformed payload`);
       return { cancelled: await control.cancelScheduledTask(input.id, input.chatKey) };
     }
     case MSG.orchestrationList:
       return { tasks: (await control.listOrchestrationTasks()).map(orchestrationTaskToDto) };
     case MSG.orchestrationGet: {
-      const input = payload as OrchestrationGetPayload;
+      const input = parseControlPayload(MSG.orchestrationGet, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.orchestrationGet}: malformed payload`);
       const task = await control.getOrchestrationTask(input.taskId);
       return { task: task ? orchestrationTaskToDto(task) : null };
     }
     case MSG.orchestrationCancel: {
-      const input = payload as OrchestrationCancelPayload;
+      const input = parseControlPayload(MSG.orchestrationCancel, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.orchestrationCancel}: malformed payload`);
       return orchestrationTaskToDto(await control.cancelOrchestrationTask({ taskId: input.taskId }));
     }
     case MSG.fsList: {
-      const input = payload as FsListPayload;
+      const input = parseControlPayload(MSG.fsList, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.fsList}: malformed payload`);
       if (!input.workspace) return errorPayload("bad-request", "workspace is required");
       return await control.listDirectory(input.workspace, input.path); // DirListing ≅ FsListResult
     }
     case MSG.fsRead: {
-      const input = payload as FsReadPayload;
+      const input = parseControlPayload(MSG.fsRead, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.fsRead}: malformed payload`);
       if (!input.workspace || !input.path) return errorPayload("bad-request", "workspace and path are required");
       return await control.readWorkspaceFile(input.workspace, input.path); // FileContent ≅ FsReadResult
     }
     case MSG.fsDiff: {
-      const input = payload as FsDiffPayload;
+      const input = parseControlPayload(MSG.fsDiff, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.fsDiff}: malformed payload`);
       if (!input.workspace) return errorPayload("bad-request", "workspace is required");
       return await control.workspaceGitDiff(input.workspace, input.path); // WorkspaceDiff ≅ FsDiffResult
     }
     case MSG.fsSearch: {
-      const input = payload as FsSearchPayload;
+      const input = parseControlPayload(MSG.fsSearch, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.fsSearch}: malformed payload`);
       if (!input.workspace) return errorPayload("bad-request", "workspace is required");
       return await control.searchWorkspace(input.workspace, {
         query: input.query ?? "",
@@ -292,33 +286,39 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
       }); // SearchResult ≅ FsSearchResult
     }
     case MSG.fsCreate: {
-      const i = payload as FsCreatePayload;
+      const i = parseControlPayload(MSG.fsCreate, payload);
+      if (!i) return errorPayload("invalid-payload", `${MSG.fsCreate}: malformed payload`);
       if (!i.workspace || !i.path) return errorPayload("bad-request", "workspace and path are required");
       if (i.kind !== "file" && i.kind !== "dir") return errorPayload("bad-request", "kind must be file or dir");
       return await control.fsCreate(i.workspace, i.path, i.kind);
     }
     case MSG.fsRename: {
-      const i = payload as FsRenamePayload;
+      const i = parseControlPayload(MSG.fsRename, payload);
+      if (!i) return errorPayload("invalid-payload", `${MSG.fsRename}: malformed payload`);
       if (!i.workspace || !i.path || !i.newName) return errorPayload("bad-request", "workspace, path and newName are required");
       return await control.fsRename(i.workspace, i.path, i.newName);
     }
     case MSG.fsDelete: {
-      const i = payload as FsDeletePayload;
+      const i = parseControlPayload(MSG.fsDelete, payload);
+      if (!i) return errorPayload("invalid-payload", `${MSG.fsDelete}: malformed payload`);
       if (!i.workspace || !i.path) return errorPayload("bad-request", "workspace and path are required");
       return await control.fsDelete(i.workspace, i.path);
     }
     case MSG.fsCopy: {
-      const i = payload as FsCopyPayload;
+      const i = parseControlPayload(MSG.fsCopy, payload);
+      if (!i) return errorPayload("invalid-payload", `${MSG.fsCopy}: malformed payload`);
       if (!i.workspace || !i.path) return errorPayload("bad-request", "workspace and path are required");
       return await control.fsCopy(i.workspace, i.path);
     }
     case MSG.fsDownload: {
-      const i = payload as FsDownloadPayload;
+      const i = parseControlPayload(MSG.fsDownload, payload);
+      if (!i) return errorPayload("invalid-payload", `${MSG.fsDownload}: malformed payload`);
       if (!i.workspace || !i.path) return errorPayload("bad-request", "workspace and path are required");
       return await control.fsDownload(i.workspace, i.path);
     }
     case MSG.fsWrite: {
-      const i = payload as FsWritePayload;
+      const i = parseControlPayload(MSG.fsWrite, payload);
+      if (!i) return errorPayload("invalid-payload", `${MSG.fsWrite}: malformed payload`);
       if (!i.workspace || !i.path) return errorPayload("bad-request", "workspace and path are required");
       if (typeof i.content !== "string") return errorPayload("bad-request", "content must be a string");
       if (!i.expected || typeof i.expected.mtimeMs !== "number" || typeof i.expected.size !== "number") {
@@ -327,28 +327,33 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
       return await control.fsWrite(i.workspace, i.path, i.content, i.expected);
     }
     case MSG.sessionModelGet: {
-      const input = payload as SessionModelGetPayload;
+      const input = parseControlPayload(MSG.sessionModelGet, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionModelGet}: malformed payload`);
       if (!input.sessionAlias) return errorPayload("bad-request", "sessionAlias is required");
       return await control.getSessionModel(input.chatKey, input.sessionAlias); // ≅ SessionModelResult
     }
     case MSG.sessionModelSet: {
-      const input = payload as SessionModelSetPayload;
+      const input = parseControlPayload(MSG.sessionModelSet, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionModelSet}: malformed payload`);
       if (!input.sessionAlias || !input.modelId) return errorPayload("bad-request", "sessionAlias and modelId are required");
       await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId);
       return { ok: true };
     }
     case MSG.terminalCreate: {
-      const input = payload as { chatKey: string; sessionAlias: string; cols?: number; rows?: number };
+      const input = parseControlPayload(MSG.terminalCreate, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.terminalCreate}: malformed payload`);
       if (!input.sessionAlias) return errorPayload("bad-request", "sessionAlias is required");
       return await control.createTerminal(input.chatKey, input.sessionAlias, input.cols ?? 80, input.rows ?? 24);
     }
     case MSG.terminalAttach: {
-      const input = payload as { terminalId?: string };
+      const input = parseControlPayload(MSG.terminalAttach, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.terminalAttach}: malformed payload`);
       if (!input.terminalId) return errorPayload("bad-request", "terminalId is required");
       return control.attachTerminal(input.terminalId);
     }
     case MSG.upload: {
-      const input = payload as UploadPayload;
+      const input = parseControlPayload(MSG.upload, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.upload}: malformed payload`);
       if (!input.filename || !input.content || !input.mimeType) {
         return errorPayload("bad-request", "filename, content and mimeType are required");
       }

--- a/packages/relay-protocol/dist/index.d.ts
+++ b/packages/relay-protocol/dist/index.d.ts
@@ -2,3 +2,5 @@ export * from "./envelope.js";
 export * from "./dtos.js";
 export * from "./messages.js";
 export * from "./web-dtos.js";
+export * from "./validate-primitives.js";
+export * from "./payload-validators.js";

--- a/packages/relay-protocol/dist/index.js
+++ b/packages/relay-protocol/dist/index.js
@@ -100,34 +100,40 @@ function isErrorPayload(payload) {
   const error = candidate;
   return typeof error.code === "string" && typeof error.message === "string";
 }
+// packages/relay-protocol/src/validate-primitives.ts
+var isObj = (v) => typeof v === "object" && v !== null;
+var isStr = (v) => typeof v === "string";
+var optStr = (v) => v === undefined || typeof v === "string";
+var optNum = (v) => v === undefined || typeof v === "number";
+var optBool = (v) => v === undefined || typeof v === "boolean";
+
 // packages/relay-protocol/src/web-dtos.ts
 var WEB_EVENT_TYPE = "web.event";
 function webEventEnvelope(event) {
   return { protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: WEB_EVENT_TYPE, payload: event };
 }
 var WEB_EVENT_KINDS = new Set(["instance-status", "control-event", "notice"]);
-var CONTROL_EVENT_TYPES = new Set([
-  "turn-output",
-  "turn-started",
-  "tool-event",
-  "turn-thought",
-  "plan",
-  "turn-usage",
-  "agent-commands",
-  "turn-finished",
-  "queue-updated",
-  "sessions-changed",
-  "workspaces-changed",
-  "scheduled-changed",
-  "orchestration-changed",
-  "terminal-output",
-  "terminal-exit"
-]);
+var CONTROL_EVENT_TYPE_MAP = {
+  "turn-output": true,
+  "turn-started": true,
+  "tool-event": true,
+  "turn-thought": true,
+  plan: true,
+  "turn-usage": true,
+  "agent-commands": true,
+  "turn-finished": true,
+  "queue-updated": true,
+  "sessions-changed": true,
+  "workspaces-changed": true,
+  "scheduled-changed": true,
+  "session-history": true,
+  "orchestration-changed": true,
+  "terminal-output": true,
+  "terminal-exit": true
+};
+var CONTROL_EVENT_TYPES = new Set(Object.keys(CONTROL_EVENT_TYPE_MAP));
 var TOOL_STEP_KINDS = new Set(["read", "search", "execute", "edit", "think", "other"]);
 var TOOL_STEP_STATUSES = new Set(["running", "success", "error"]);
-var isStr = (v) => typeof v === "string";
-var optStr = (v) => v === undefined || typeof v === "string";
-var optNum = (v) => v === undefined || typeof v === "number";
 function validToolDetail(d) {
   switch (d.type) {
     case "diff":
@@ -172,31 +178,43 @@ function validControlEvent(e) {
   const c = e;
   if (typeof c.type !== "string" || !CONTROL_EVENT_TYPES.has(c.type))
     return false;
-  if (c.type === "turn-output")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
-  if (c.type === "turn-finished")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.ok === "boolean";
-  if (c.type === "scheduled-changed")
-    return typeof c.chatKey === "string";
-  if (c.type === "turn-started")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string";
-  if (c.type === "turn-thought")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
-  if (c.type === "plan")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.entries);
-  if (c.type === "turn-usage")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.used === "number" && typeof c.size === "number";
-  if (c.type === "agent-commands")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.commands) && c.commands.every((x) => x !== null && typeof x === "object" && typeof x.name === "string");
-  if (c.type === "queue-updated")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.items);
-  if (c.type === "tool-event")
-    return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && validToolStep(c.step);
-  if (c.type === "terminal-output")
-    return typeof c.terminalId === "string" && typeof c.seq === "number" && typeof c.data === "string";
-  if (c.type === "terminal-exit")
-    return typeof c.terminalId === "string" && typeof c.code === "number";
-  return true;
+  const type = c.type;
+  switch (type) {
+    case "turn-output":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
+    case "turn-finished":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.ok === "boolean";
+    case "scheduled-changed":
+      return typeof c.chatKey === "string";
+    case "turn-started":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string";
+    case "turn-thought":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
+    case "plan":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.entries);
+    case "turn-usage":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.used === "number" && typeof c.size === "number";
+    case "agent-commands":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.commands) && c.commands.every((x) => x !== null && typeof x === "object" && typeof x.name === "string");
+    case "queue-updated":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.items);
+    case "session-history":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && Array.isArray(c.messages) && c.messages.every((m) => m !== null && typeof m === "object" && (m.direction === "in" || m.direction === "out") && typeof m.text === "string");
+    case "tool-event":
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && validToolStep(c.step);
+    case "terminal-output":
+      return typeof c.terminalId === "string" && typeof c.seq === "number" && typeof c.data === "string";
+    case "terminal-exit":
+      return typeof c.terminalId === "string" && typeof c.code === "number";
+    case "sessions-changed":
+    case "workspaces-changed":
+    case "orchestration-changed":
+      return true;
+    default: {
+      const _exhaustive = type;
+      return _exhaustive;
+    }
+  }
 }
 var NOTICE_KINDS = new Set(["task-completion", "task-progress", "coordinator-message"]);
 function validNotice(n) {
@@ -245,11 +263,207 @@ function parseWebClientMessage(envelope) {
     return p;
   return null;
 }
+// packages/relay-protocol/src/payload-validators.ts
+var fields = (p) => isObj(p) ? p : null;
+var optArr = (v) => v === undefined || Array.isArray(v);
+var validateSessionsList = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) ? o : null;
+};
+var validateSessionsCreate = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) && isStr(o.agent) && isStr(o.workspace) && optStr(o.agentSessionId) && optStr(o.model) ? o : null;
+};
+var validateSessionsNativeList = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.agent) && isStr(o.workspace) ? o : null;
+};
+var validateSessionsRemove = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) ? o : null;
+};
+var validateSessionsArchive = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) ? o : null;
+};
+var validateSessionsUnarchive = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) ? o : null;
+};
+var validateSessionsRename = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) && isStr(o.displayName) ? o : null;
+};
+var validateWorkspacesCreate = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) && isStr(o.cwd) && optStr(o.description) ? o : null;
+};
+var validateAgentsCreate = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) && isStr(o.driver) ? o : null;
+};
+var validateAgentsRemove = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) ? o : null;
+};
+var validateWorkspacesRemove = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) ? o : null;
+};
+var validatePrompt = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.text) && isStr(o.senderId) && optBool(o.isOwner) && optArr(o.media) ? o : null;
+};
+var validatePromptCancel = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? o : null;
+};
+var validateQueueCancel = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.itemId) ? o : null;
+};
+var validateCommandExecute = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.text) && isStr(o.senderId) && optBool(o.isOwner) ? o : null;
+};
+var validateScheduledList = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) ? o : null;
+};
+var validateScheduledCreate = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.executeAt) && isStr(o.message) ? o : null;
+};
+var validateScheduledCancel = (p) => {
+  const o = fields(p);
+  return o && isStr(o.id) && isStr(o.chatKey) ? o : null;
+};
+var validateOrchestrationGet = (p) => {
+  const o = fields(p);
+  return o && isStr(o.taskId) ? o : null;
+};
+var validateOrchestrationCancel = (p) => {
+  const o = fields(p);
+  return o && isStr(o.taskId) ? o : null;
+};
+var validateFsList = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && optStr(o.path) ? o : null;
+};
+var validateFsRead = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? o : null;
+};
+var validateFsDiff = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && optStr(o.path) ? o : null;
+};
+var validateFsSearch = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.query) && (o.mode === undefined || o.mode === "name" || o.mode === "content") && optBool(o.matchCase) && optBool(o.wholeWord) && optBool(o.regex) && optStr(o.include) && optStr(o.exclude) && optStr(o.path) ? o : null;
+};
+var validateFsCreate = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) && (o.kind === "file" || o.kind === "dir") ? o : null;
+};
+var validateFsRename = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) && isStr(o.newName) ? o : null;
+};
+var validateFsDelete = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? o : null;
+};
+var validateFsCopy = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? o : null;
+};
+var validateFsDownload = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? o : null;
+};
+var validateFsWrite = (p) => {
+  const o = fields(p);
+  if (!o || !isStr(o.workspace) || !isStr(o.path) || !isStr(o.content))
+    return null;
+  const exp = fields(o.expected);
+  if (!exp || typeof exp.mtimeMs !== "number" || typeof exp.size !== "number")
+    return null;
+  return o;
+};
+var validateSessionModelGet = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? o : null;
+};
+var validateSessionModelSet = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.modelId) ? o : null;
+};
+var validateTerminalCreate = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && optNum(o.cols) && optNum(o.rows) ? o : null;
+};
+var validateTerminalAttach = (p) => {
+  const o = fields(p);
+  return o && isStr(o.terminalId) ? o : null;
+};
+var validateUpload = (p) => {
+  const o = fields(p);
+  return o && isStr(o.filename) && isStr(o.content) && isStr(o.mimeType) ? o : null;
+};
+var CONTROL_PAYLOAD_VALIDATORS = {
+  [MSG.sessionsList]: validateSessionsList,
+  [MSG.sessionsCreate]: validateSessionsCreate,
+  [MSG.sessionsNativeList]: validateSessionsNativeList,
+  [MSG.sessionsRemove]: validateSessionsRemove,
+  [MSG.sessionsArchive]: validateSessionsArchive,
+  [MSG.sessionsUnarchive]: validateSessionsUnarchive,
+  [MSG.sessionsRename]: validateSessionsRename,
+  [MSG.workspacesCreate]: validateWorkspacesCreate,
+  [MSG.agentsCreate]: validateAgentsCreate,
+  [MSG.agentsRemove]: validateAgentsRemove,
+  [MSG.workspacesRemove]: validateWorkspacesRemove,
+  [MSG.prompt]: validatePrompt,
+  [MSG.promptCancel]: validatePromptCancel,
+  [MSG.queueCancel]: validateQueueCancel,
+  [MSG.commandExecute]: validateCommandExecute,
+  [MSG.scheduledList]: validateScheduledList,
+  [MSG.scheduledCreate]: validateScheduledCreate,
+  [MSG.scheduledCancel]: validateScheduledCancel,
+  [MSG.orchestrationGet]: validateOrchestrationGet,
+  [MSG.orchestrationCancel]: validateOrchestrationCancel,
+  [MSG.fsList]: validateFsList,
+  [MSG.fsRead]: validateFsRead,
+  [MSG.fsDiff]: validateFsDiff,
+  [MSG.fsSearch]: validateFsSearch,
+  [MSG.fsCreate]: validateFsCreate,
+  [MSG.fsRename]: validateFsRename,
+  [MSG.fsDelete]: validateFsDelete,
+  [MSG.fsCopy]: validateFsCopy,
+  [MSG.fsDownload]: validateFsDownload,
+  [MSG.fsWrite]: validateFsWrite,
+  [MSG.sessionModelGet]: validateSessionModelGet,
+  [MSG.sessionModelSet]: validateSessionModelSet,
+  [MSG.terminalCreate]: validateTerminalCreate,
+  [MSG.terminalAttach]: validateTerminalAttach,
+  [MSG.upload]: validateUpload
+};
+function parseControlPayload(type, payload) {
+  const validate = CONTROL_PAYLOAD_VALIDATORS[type];
+  return validate(payload);
+}
 export {
   webEventEnvelope,
   webClientEnvelope,
+  validControlEvent,
   parseWebServerEvent,
   parseWebClientMessage,
+  parseControlPayload,
+  optStr,
+  optNum,
+  optBool,
+  isStr,
+  isObj,
   isErrorPayload,
   errorPayload,
   encodeEnvelope,
@@ -257,5 +471,6 @@ export {
   WEB_EVENT_TYPE,
   WEB_CLIENT_TYPE,
   RELAY_PROTOCOL_VERSION,
-  MSG
+  MSG,
+  CONTROL_PAYLOAD_VALIDATORS
 };

--- a/packages/relay-protocol/dist/messages.d.ts
+++ b/packages/relay-protocol/dist/messages.d.ts
@@ -424,3 +424,12 @@ export interface SessionModelResult {
     /** Agent-advertised model ids the session can switch to (may be empty). */
     available: string[];
 }
+export interface TerminalCreatePayload {
+    chatKey: string;
+    sessionAlias: string;
+    cols?: number;
+    rows?: number;
+}
+export interface TerminalAttachPayload {
+    terminalId: string;
+}

--- a/packages/relay-protocol/dist/web-dtos.d.ts
+++ b/packages/relay-protocol/dist/web-dtos.d.ts
@@ -83,6 +83,10 @@ export type WebServerEvent = {
 };
 /** Wrap a server→web push event in a relay envelope. */
 export declare function webEventEnvelope(event: WebServerEvent): RelayEnvelope;
+/** Deep-validate an inner ControlEventDto: discriminant + per-variant required fields.
+ *  The switch is compile-time exhaustive over ControlEventDto["type"] (see the `never`
+ *  check in `default`), mirroring CONTROL_EVENT_TYPE_MAP above. */
+export declare function validControlEvent(e: unknown): boolean;
 /** Parse + validate a relay→web push payload; returns null for any malformed envelope. */
 export declare function parseWebServerEvent(envelope: RelayEnvelope): WebServerEvent | null;
 export declare const WEB_CLIENT_TYPE = "web.client";

--- a/packages/relay-protocol/src/index.ts
+++ b/packages/relay-protocol/src/index.ts
@@ -2,3 +2,5 @@ export * from "./envelope.js";
 export * from "./dtos.js";
 export * from "./messages.js";
 export * from "./web-dtos.js";
+export * from "./validate-primitives.js";
+export * from "./payload-validators.js";

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -448,3 +448,14 @@ export interface SessionModelResult {
   /** Agent-advertised model ids the session can switch to (may be empty). */
   available: string[];
 }
+
+export interface TerminalCreatePayload {
+  chatKey: string;
+  sessionAlias: string;
+  cols?: number;
+  rows?: number;
+}
+
+export interface TerminalAttachPayload {
+  terminalId: string;
+}

--- a/packages/relay-protocol/src/payload-validators.ts
+++ b/packages/relay-protocol/src/payload-validators.ts
@@ -291,3 +291,21 @@ export function parseControlPayload<T extends ControlRpcType>(type: T, payload: 
   const validate = CONTROL_PAYLOAD_VALIDATORS[type] as unknown as Validator<PayloadFor<T>>;
   return validate(payload);
 }
+
+// --- Type-level binding assertions -------------------------------------------------
+// These live here, not in the test file: `tests/` is outside every tsconfig's `include`,
+// so a type-level assertion written there is never checked by tsc. Compiled by
+// `tsc -p packages/relay-protocol/tsconfig.json` (run by `bun run build:relay-protocol`).
+//
+// What they catch: a registry entry wired to the wrong validator, e.g.
+// `[MSG.fsWrite]: validateFsRead` — `satisfies Record<ControlRpcType, Validator<unknown>>`
+// accepts that, these do not. They cannot catch a validator that skips a field check
+// (each is annotated `Validator<XxxPayload>` and returns through `as unknown`, so its
+// return type is fixed by the annotation); the runtime suite covers that.
+type Expect<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+type _fsWriteBound = Expect<Equal<PayloadFor<typeof MSG.fsWrite>, FsWritePayload>>;
+type _promptBound = Expect<Equal<PayloadFor<typeof MSG.prompt>, PromptPayload>>;
+type _fsReadBound = Expect<Equal<PayloadFor<typeof MSG.fsRead>, FsReadPayload>>;
+type _uploadBound = Expect<Equal<PayloadFor<typeof MSG.upload>, UploadPayload>>;

--- a/packages/relay-protocol/src/payload-validators.ts
+++ b/packages/relay-protocol/src/payload-validators.ts
@@ -58,107 +58,107 @@ const optArr = (v: unknown): boolean => v === undefined || Array.isArray(v);
 // --- session / agent / workspace ---
 const validateSessionsList: Validator<SessionsListPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) ? (o as SessionsListPayload) : null;
+  return o && isStr(o.chatKey) ? (o as unknown as SessionsListPayload) : null;
 };
 const validateSessionsCreate: Validator<SessionsCreatePayload> = (p) => {
   const o = fields(p);
   return o && isStr(o.chatKey) && isStr(o.alias) && isStr(o.agent) && isStr(o.workspace)
-    && optStr(o.agentSessionId) && optStr(o.model) ? (o as SessionsCreatePayload) : null;
+    && optStr(o.agentSessionId) && optStr(o.model) ? (o as unknown as SessionsCreatePayload) : null;
 };
 const validateSessionsNativeList: Validator<SessionsNativeListPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && isStr(o.agent) && isStr(o.workspace) ? (o as SessionsNativeListPayload) : null;
+  return o && isStr(o.chatKey) && isStr(o.agent) && isStr(o.workspace) ? (o as unknown as SessionsNativeListPayload) : null;
 };
 const validateSessionsRemove: Validator<SessionsRemovePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as SessionsRemovePayload) : null;
+  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as unknown as SessionsRemovePayload) : null;
 };
 const validateSessionsArchive: Validator<SessionsArchivePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as SessionsArchivePayload) : null;
+  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as unknown as SessionsArchivePayload) : null;
 };
 const validateSessionsUnarchive: Validator<SessionsUnarchivePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as SessionsUnarchivePayload) : null;
+  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as unknown as SessionsUnarchivePayload) : null;
 };
 const validateSessionsRename: Validator<SessionsRenamePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && isStr(o.alias) && isStr(o.displayName) ? (o as SessionsRenamePayload) : null;
+  return o && isStr(o.chatKey) && isStr(o.alias) && isStr(o.displayName) ? (o as unknown as SessionsRenamePayload) : null;
 };
 const validateWorkspacesCreate: Validator<WorkspacesCreatePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.name) && isStr(o.cwd) && optStr(o.description) ? (o as WorkspacesCreatePayload) : null;
+  return o && isStr(o.name) && isStr(o.cwd) && optStr(o.description) ? (o as unknown as WorkspacesCreatePayload) : null;
 };
 const validateAgentsCreate: Validator<AgentsCreatePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.name) && isStr(o.driver) ? (o as AgentsCreatePayload) : null;
+  return o && isStr(o.name) && isStr(o.driver) ? (o as unknown as AgentsCreatePayload) : null;
 };
 const validateAgentsRemove: Validator<AgentsRemovePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.name) ? (o as AgentsRemovePayload) : null;
+  return o && isStr(o.name) ? (o as unknown as AgentsRemovePayload) : null;
 };
 const validateWorkspacesRemove: Validator<WorkspacesRemovePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.name) ? (o as WorkspacesRemovePayload) : null;
+  return o && isStr(o.name) ? (o as unknown as WorkspacesRemovePayload) : null;
 };
 
 // --- prompt / command / queue ---
 const validatePrompt: Validator<PromptPayload> = (p) => {
   const o = fields(p);
   return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.text) && isStr(o.senderId)
-    && optBool(o.isOwner) && optArr(o.media) ? (o as PromptPayload) : null;
+    && optBool(o.isOwner) && optArr(o.media) ? (o as unknown as PromptPayload) : null;
 };
 const validatePromptCancel: Validator<PromptCancelPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? (o as PromptCancelPayload) : null;
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? (o as unknown as PromptCancelPayload) : null;
 };
 const validateQueueCancel: Validator<QueueCancelPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.itemId) ? (o as QueueCancelPayload) : null;
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.itemId) ? (o as unknown as QueueCancelPayload) : null;
 };
 const validateCommandExecute: Validator<CommandExecutePayload> = (p) => {
   const o = fields(p);
   return o && isStr(o.chatKey) && isStr(o.text) && isStr(o.senderId) && optBool(o.isOwner)
-    ? (o as CommandExecutePayload) : null;
+    ? (o as unknown as CommandExecutePayload) : null;
 };
 
 // --- scheduled ---
 const validateScheduledList: Validator<ScheduledListPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) ? (o as ScheduledListPayload) : null;
+  return o && isStr(o.chatKey) ? (o as unknown as ScheduledListPayload) : null;
 };
 const validateScheduledCreate: Validator<ScheduledCreatePayload> = (p) => {
   const o = fields(p);
   return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.executeAt) && isStr(o.message)
-    ? (o as ScheduledCreatePayload) : null;
+    ? (o as unknown as ScheduledCreatePayload) : null;
 };
 const validateScheduledCancel: Validator<ScheduledCancelPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.id) && isStr(o.chatKey) ? (o as ScheduledCancelPayload) : null;
+  return o && isStr(o.id) && isStr(o.chatKey) ? (o as unknown as ScheduledCancelPayload) : null;
 };
 
 // --- orchestration ---
 const validateOrchestrationGet: Validator<OrchestrationGetPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.taskId) ? (o as OrchestrationGetPayload) : null;
+  return o && isStr(o.taskId) ? (o as unknown as OrchestrationGetPayload) : null;
 };
 const validateOrchestrationCancel: Validator<OrchestrationCancelPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.taskId) ? (o as OrchestrationCancelPayload) : null;
+  return o && isStr(o.taskId) ? (o as unknown as OrchestrationCancelPayload) : null;
 };
 
 // --- fs (read family: workspace + optional path) ---
 const validateFsList: Validator<FsListPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.workspace) && optStr(o.path) ? (o as FsListPayload) : null;
+  return o && isStr(o.workspace) && optStr(o.path) ? (o as unknown as FsListPayload) : null;
 };
 const validateFsRead: Validator<FsReadPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsReadPayload) : null;
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as unknown as FsReadPayload) : null;
 };
 const validateFsDiff: Validator<FsDiffPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.workspace) && optStr(o.path) ? (o as FsDiffPayload) : null;
+  return o && isStr(o.workspace) && optStr(o.path) ? (o as unknown as FsDiffPayload) : null;
 };
 const validateFsSearch: Validator<FsSearchPayload> = (p) => {
   const o = fields(p);
@@ -166,60 +166,60 @@ const validateFsSearch: Validator<FsSearchPayload> = (p) => {
     && (o.mode === undefined || o.mode === "name" || o.mode === "content")
     && optBool(o.matchCase) && optBool(o.wholeWord) && optBool(o.regex)
     && optStr(o.include) && optStr(o.exclude) && optStr(o.path)
-    ? (o as FsSearchPayload) : null;
+    ? (o as unknown as FsSearchPayload) : null;
 };
 
 // --- fs (mutating family) ---
 const validateFsCreate: Validator<FsCreatePayload> = (p) => {
   const o = fields(p);
   return o && isStr(o.workspace) && isStr(o.path) && (o.kind === "file" || o.kind === "dir")
-    ? (o as FsCreatePayload) : null;
+    ? (o as unknown as FsCreatePayload) : null;
 };
 const validateFsRename: Validator<FsRenamePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.workspace) && isStr(o.path) && isStr(o.newName) ? (o as FsRenamePayload) : null;
+  return o && isStr(o.workspace) && isStr(o.path) && isStr(o.newName) ? (o as unknown as FsRenamePayload) : null;
 };
 const validateFsDelete: Validator<FsDeletePayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsDeletePayload) : null;
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as unknown as FsDeletePayload) : null;
 };
 const validateFsCopy: Validator<FsCopyPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsCopyPayload) : null;
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as unknown as FsCopyPayload) : null;
 };
 const validateFsDownload: Validator<FsDownloadPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsDownloadPayload) : null;
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as unknown as FsDownloadPayload) : null;
 };
 const validateFsWrite: Validator<FsWritePayload> = (p) => {
   const o = fields(p);
   if (!o || !isStr(o.workspace) || !isStr(o.path) || !isStr(o.content)) return null;
   const exp = fields(o.expected);
   if (!exp || typeof exp.mtimeMs !== "number" || typeof exp.size !== "number") return null;
-  return o as FsWritePayload;
+  return o as unknown as FsWritePayload;
 };
 
 // --- model / terminal / upload ---
 const validateSessionModelGet: Validator<SessionModelGetPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? (o as SessionModelGetPayload) : null;
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? (o as unknown as SessionModelGetPayload) : null;
 };
 const validateSessionModelSet: Validator<SessionModelSetPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.modelId) ? (o as SessionModelSetPayload) : null;
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.modelId) ? (o as unknown as SessionModelSetPayload) : null;
 };
 const validateTerminalCreate: Validator<TerminalCreatePayload> = (p) => {
   const o = fields(p);
   return o && isStr(o.chatKey) && isStr(o.sessionAlias) && optNum(o.cols) && optNum(o.rows)
-    ? (o as TerminalCreatePayload) : null;
+    ? (o as unknown as TerminalCreatePayload) : null;
 };
 const validateTerminalAttach: Validator<TerminalAttachPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.terminalId) ? (o as TerminalAttachPayload) : null;
+  return o && isStr(o.terminalId) ? (o as unknown as TerminalAttachPayload) : null;
 };
 const validateUpload: Validator<UploadPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.filename) && isStr(o.content) && isStr(o.mimeType) ? (o as UploadPayload) : null;
+  return o && isStr(o.filename) && isStr(o.content) && isStr(o.mimeType) ? (o as unknown as UploadPayload) : null;
 };
 
 /** The control-RPC message types that carry a client-supplied payload to validate.
@@ -288,6 +288,6 @@ export type PayloadFor<T extends ControlRpcType> =
 /** Type-safe replacement for `payload as XxxPayload`: validates shape, returns the bound
  *  payload type or null. */
 export function parseControlPayload<T extends ControlRpcType>(type: T, payload: unknown): PayloadFor<T> | null {
-  const validate = CONTROL_PAYLOAD_VALIDATORS[type] as Validator<PayloadFor<T>>;
+  const validate = CONTROL_PAYLOAD_VALIDATORS[type] as unknown as Validator<PayloadFor<T>>;
   return validate(payload);
 }

--- a/packages/relay-protocol/src/payload-validators.ts
+++ b/packages/relay-protocol/src/payload-validators.ts
@@ -1,0 +1,293 @@
+// packages/relay-protocol/src/payload-validators.ts
+// Runtime validators for hub→connector control RPCs. Each validator checks a payload's
+// SHAPE (field presence + type, including literal unions and nested objects) and returns
+// the narrowed payload, or null when malformed. Semantic checks (non-empty, valid ISO date,
+// existence) stay in the connector's dispatch — these only guard the wire shape.
+//
+// The registry keys are the control-RPC MessageTypes; `satisfies Record<ControlRpcType, …>`
+// makes tsc fail if a control RPC is added to the union without a validator (or vice versa),
+// and `parseControlPayload` forces every connector dispatch arm to register its message type.
+import {
+  MSG,
+  type AgentsCreatePayload,
+  type AgentsRemovePayload,
+  type CommandExecutePayload,
+  type FsCopyPayload,
+  type FsCreatePayload,
+  type FsDeletePayload,
+  type FsDiffPayload,
+  type FsDownloadPayload,
+  type FsListPayload,
+  type FsReadPayload,
+  type FsRenamePayload,
+  type FsSearchPayload,
+  type FsWritePayload,
+  type OrchestrationCancelPayload,
+  type OrchestrationGetPayload,
+  type PromptCancelPayload,
+  type PromptPayload,
+  type QueueCancelPayload,
+  type ScheduledCancelPayload,
+  type ScheduledCreatePayload,
+  type ScheduledListPayload,
+  type SessionModelGetPayload,
+  type SessionModelSetPayload,
+  type SessionsArchivePayload,
+  type SessionsCreatePayload,
+  type SessionsListPayload,
+  type SessionsNativeListPayload,
+  type SessionsRemovePayload,
+  type SessionsRenamePayload,
+  type SessionsUnarchivePayload,
+  type TerminalAttachPayload,
+  type TerminalCreatePayload,
+  type UploadPayload,
+  type WorkspacesCreatePayload,
+  type WorkspacesRemovePayload,
+} from "./messages.js";
+import { isObj, isStr, optStr, optNum, optBool } from "./validate-primitives.js";
+
+export type Validator<T> = (payload: unknown) => T | null;
+
+/** Non-null-object view for field access, or null. */
+const fields = (p: unknown): Record<string, unknown> | null => (isObj(p) ? p : null);
+
+const isArr = (v: unknown): boolean => Array.isArray(v);
+const optArr = (v: unknown): boolean => v === undefined || Array.isArray(v);
+
+// --- session / agent / workspace ---
+const validateSessionsList: Validator<SessionsListPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) ? (o as SessionsListPayload) : null;
+};
+const validateSessionsCreate: Validator<SessionsCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) && isStr(o.agent) && isStr(o.workspace)
+    && optStr(o.agentSessionId) && optStr(o.model) ? (o as SessionsCreatePayload) : null;
+};
+const validateSessionsNativeList: Validator<SessionsNativeListPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.agent) && isStr(o.workspace) ? (o as SessionsNativeListPayload) : null;
+};
+const validateSessionsRemove: Validator<SessionsRemovePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as SessionsRemovePayload) : null;
+};
+const validateSessionsArchive: Validator<SessionsArchivePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as SessionsArchivePayload) : null;
+};
+const validateSessionsUnarchive: Validator<SessionsUnarchivePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) ? (o as SessionsUnarchivePayload) : null;
+};
+const validateSessionsRename: Validator<SessionsRenamePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.alias) && isStr(o.displayName) ? (o as SessionsRenamePayload) : null;
+};
+const validateWorkspacesCreate: Validator<WorkspacesCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) && isStr(o.cwd) && optStr(o.description) ? (o as WorkspacesCreatePayload) : null;
+};
+const validateAgentsCreate: Validator<AgentsCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) && isStr(o.driver) ? (o as AgentsCreatePayload) : null;
+};
+const validateAgentsRemove: Validator<AgentsRemovePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) ? (o as AgentsRemovePayload) : null;
+};
+const validateWorkspacesRemove: Validator<WorkspacesRemovePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.name) ? (o as WorkspacesRemovePayload) : null;
+};
+
+// --- prompt / command / queue ---
+const validatePrompt: Validator<PromptPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.text) && isStr(o.senderId)
+    && optBool(o.isOwner) && optArr(o.media) ? (o as PromptPayload) : null;
+};
+const validatePromptCancel: Validator<PromptCancelPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? (o as PromptCancelPayload) : null;
+};
+const validateQueueCancel: Validator<QueueCancelPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.itemId) ? (o as QueueCancelPayload) : null;
+};
+const validateCommandExecute: Validator<CommandExecutePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.text) && isStr(o.senderId) && optBool(o.isOwner)
+    ? (o as CommandExecutePayload) : null;
+};
+
+// --- scheduled ---
+const validateScheduledList: Validator<ScheduledListPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) ? (o as ScheduledListPayload) : null;
+};
+const validateScheduledCreate: Validator<ScheduledCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.executeAt) && isStr(o.message)
+    ? (o as ScheduledCreatePayload) : null;
+};
+const validateScheduledCancel: Validator<ScheduledCancelPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.id) && isStr(o.chatKey) ? (o as ScheduledCancelPayload) : null;
+};
+
+// --- orchestration ---
+const validateOrchestrationGet: Validator<OrchestrationGetPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.taskId) ? (o as OrchestrationGetPayload) : null;
+};
+const validateOrchestrationCancel: Validator<OrchestrationCancelPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.taskId) ? (o as OrchestrationCancelPayload) : null;
+};
+
+// --- fs (read family: workspace + optional path) ---
+const validateFsList: Validator<FsListPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && optStr(o.path) ? (o as FsListPayload) : null;
+};
+const validateFsRead: Validator<FsReadPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsReadPayload) : null;
+};
+const validateFsDiff: Validator<FsDiffPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && optStr(o.path) ? (o as FsDiffPayload) : null;
+};
+const validateFsSearch: Validator<FsSearchPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.query)
+    && (o.mode === undefined || o.mode === "name" || o.mode === "content")
+    && optBool(o.matchCase) && optBool(o.wholeWord) && optBool(o.regex)
+    && optStr(o.include) && optStr(o.exclude) && optStr(o.path)
+    ? (o as FsSearchPayload) : null;
+};
+
+// --- fs (mutating family) ---
+const validateFsCreate: Validator<FsCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) && (o.kind === "file" || o.kind === "dir")
+    ? (o as FsCreatePayload) : null;
+};
+const validateFsRename: Validator<FsRenamePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) && isStr(o.newName) ? (o as FsRenamePayload) : null;
+};
+const validateFsDelete: Validator<FsDeletePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsDeletePayload) : null;
+};
+const validateFsCopy: Validator<FsCopyPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsCopyPayload) : null;
+};
+const validateFsDownload: Validator<FsDownloadPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.workspace) && isStr(o.path) ? (o as FsDownloadPayload) : null;
+};
+const validateFsWrite: Validator<FsWritePayload> = (p) => {
+  const o = fields(p);
+  if (!o || !isStr(o.workspace) || !isStr(o.path) || !isStr(o.content)) return null;
+  const exp = fields(o.expected);
+  if (!exp || typeof exp.mtimeMs !== "number" || typeof exp.size !== "number") return null;
+  return o as FsWritePayload;
+};
+
+// --- model / terminal / upload ---
+const validateSessionModelGet: Validator<SessionModelGetPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? (o as SessionModelGetPayload) : null;
+};
+const validateSessionModelSet: Validator<SessionModelSetPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.modelId) ? (o as SessionModelSetPayload) : null;
+};
+const validateTerminalCreate: Validator<TerminalCreatePayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && optNum(o.cols) && optNum(o.rows)
+    ? (o as TerminalCreatePayload) : null;
+};
+const validateTerminalAttach: Validator<TerminalAttachPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.terminalId) ? (o as TerminalAttachPayload) : null;
+};
+const validateUpload: Validator<UploadPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.filename) && isStr(o.content) && isStr(o.mimeType) ? (o as UploadPayload) : null;
+};
+
+/** The control-RPC message types that carry a client-supplied payload to validate.
+ *  Excludes: handshake (instanceRegister/instanceAuth — validated in instance-gateway),
+ *  event-direction (instanceEvent/instanceNotice — boundary B via validControlEvent),
+ *  terminal I/O events (terminalInput/Resize/Close — validated by parseWebClientMessage),
+ *  and the four no-payload list RPCs (agentsList/workspacesList/agentsCatalog/orchestrationList). */
+export type ControlRpcType =
+  | typeof MSG.sessionsList | typeof MSG.sessionsCreate | typeof MSG.sessionsNativeList
+  | typeof MSG.sessionsRemove | typeof MSG.sessionsArchive | typeof MSG.sessionsUnarchive
+  | typeof MSG.sessionsRename | typeof MSG.workspacesCreate | typeof MSG.agentsCreate
+  | typeof MSG.agentsRemove | typeof MSG.workspacesRemove | typeof MSG.prompt
+  | typeof MSG.promptCancel | typeof MSG.queueCancel | typeof MSG.commandExecute
+  | typeof MSG.scheduledList | typeof MSG.scheduledCreate | typeof MSG.scheduledCancel
+  | typeof MSG.orchestrationGet | typeof MSG.orchestrationCancel | typeof MSG.fsList
+  | typeof MSG.fsRead | typeof MSG.fsDiff | typeof MSG.fsSearch | typeof MSG.fsCreate
+  | typeof MSG.fsRename | typeof MSG.fsDelete | typeof MSG.fsCopy | typeof MSG.fsDownload
+  | typeof MSG.fsWrite | typeof MSG.sessionModelGet | typeof MSG.sessionModelSet
+  | typeof MSG.terminalCreate | typeof MSG.terminalAttach | typeof MSG.upload;
+
+/** Registry: control-RPC type → shape validator. `satisfies` locks both directions —
+ *  a ControlRpcType with no validator, or a validator whose key isn't a ControlRpcType,
+ *  is a compile error. */
+export const CONTROL_PAYLOAD_VALIDATORS = {
+  [MSG.sessionsList]: validateSessionsList,
+  [MSG.sessionsCreate]: validateSessionsCreate,
+  [MSG.sessionsNativeList]: validateSessionsNativeList,
+  [MSG.sessionsRemove]: validateSessionsRemove,
+  [MSG.sessionsArchive]: validateSessionsArchive,
+  [MSG.sessionsUnarchive]: validateSessionsUnarchive,
+  [MSG.sessionsRename]: validateSessionsRename,
+  [MSG.workspacesCreate]: validateWorkspacesCreate,
+  [MSG.agentsCreate]: validateAgentsCreate,
+  [MSG.agentsRemove]: validateAgentsRemove,
+  [MSG.workspacesRemove]: validateWorkspacesRemove,
+  [MSG.prompt]: validatePrompt,
+  [MSG.promptCancel]: validatePromptCancel,
+  [MSG.queueCancel]: validateQueueCancel,
+  [MSG.commandExecute]: validateCommandExecute,
+  [MSG.scheduledList]: validateScheduledList,
+  [MSG.scheduledCreate]: validateScheduledCreate,
+  [MSG.scheduledCancel]: validateScheduledCancel,
+  [MSG.orchestrationGet]: validateOrchestrationGet,
+  [MSG.orchestrationCancel]: validateOrchestrationCancel,
+  [MSG.fsList]: validateFsList,
+  [MSG.fsRead]: validateFsRead,
+  [MSG.fsDiff]: validateFsDiff,
+  [MSG.fsSearch]: validateFsSearch,
+  [MSG.fsCreate]: validateFsCreate,
+  [MSG.fsRename]: validateFsRename,
+  [MSG.fsDelete]: validateFsDelete,
+  [MSG.fsCopy]: validateFsCopy,
+  [MSG.fsDownload]: validateFsDownload,
+  [MSG.fsWrite]: validateFsWrite,
+  [MSG.sessionModelGet]: validateSessionModelGet,
+  [MSG.sessionModelSet]: validateSessionModelSet,
+  [MSG.terminalCreate]: validateTerminalCreate,
+  [MSG.terminalAttach]: validateTerminalAttach,
+  [MSG.upload]: validateUpload,
+} satisfies Record<ControlRpcType, Validator<unknown>>;
+
+/** The payload type bound to a control-RPC message, derived from its validator's return. */
+export type PayloadFor<T extends ControlRpcType> =
+  NonNullable<ReturnType<(typeof CONTROL_PAYLOAD_VALIDATORS)[T]>>;
+
+/** Type-safe replacement for `payload as XxxPayload`: validates shape, returns the bound
+ *  payload type or null. */
+export function parseControlPayload<T extends ControlRpcType>(type: T, payload: unknown): PayloadFor<T> | null {
+  const validate = CONTROL_PAYLOAD_VALIDATORS[type] as Validator<PayloadFor<T>>;
+  return validate(payload);
+}

--- a/packages/relay-protocol/src/validate-primitives.ts
+++ b/packages/relay-protocol/src/validate-primitives.ts
@@ -1,0 +1,20 @@
+// packages/relay-protocol/src/validate-primitives.ts
+// Shared runtime field predicates for wire-payload validation. Kept dependency-free
+// and framework-free so both web-dtos.ts (relay→web push) and payload-validators.ts
+// (hub↔connector control RPCs) draw from one implementation instead of drifting copies.
+
+/** True for a non-null object; narrows to an indexable record for field access. */
+export const isObj = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null;
+
+/** Required string. */
+export const isStr = (v: unknown): boolean => typeof v === "string";
+
+/** Optional string: absent or a string. */
+export const optStr = (v: unknown): boolean => v === undefined || typeof v === "string";
+
+/** Optional number: absent or a number. */
+export const optNum = (v: unknown): boolean => v === undefined || typeof v === "number";
+
+/** Optional boolean: absent or a boolean. */
+export const optBool = (v: unknown): boolean => v === undefined || typeof v === "boolean";

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -1,6 +1,7 @@
 import { RELAY_PROTOCOL_VERSION, type RelayEnvelope } from "./envelope.js";
 import type { AgentCommandDto, ControlEventDto, ScheduledOriginDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto } from "./dtos.js";
 import type { InstanceNoticePayload } from "./messages.js";
+import { isStr, optStr, optNum } from "./validate-primitives.js";
 
 /** Envelope `type` for every relay→web push. */
 export const WEB_EVENT_TYPE = "web.event";
@@ -111,10 +112,6 @@ const CONTROL_EVENT_TYPES: ReadonlySet<string> = new Set(Object.keys(CONTROL_EVE
 
 const TOOL_STEP_KINDS = new Set(["read", "search", "execute", "edit", "think", "other"]);
 const TOOL_STEP_STATUSES = new Set(["running", "success", "error"]);
-
-const isStr = (v: unknown): boolean => typeof v === "string";
-const optStr = (v: unknown): boolean => v === undefined || typeof v === "string";
-const optNum = (v: unknown): boolean => v === undefined || typeof v === "number";
 
 /** Validate the inner fields of a ToolDetailDto per its discriminant — a known
  *  tag is not enough; junk/missing fields must be rejected so a buggy connector

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -156,7 +156,7 @@ function validToolStep(s: unknown): boolean {
 /** Deep-validate an inner ControlEventDto: discriminant + per-variant required fields.
  *  The switch is compile-time exhaustive over ControlEventDto["type"] (see the `never`
  *  check in `default`), mirroring CONTROL_EVENT_TYPE_MAP above. */
-function validControlEvent(e: unknown): boolean {
+export function validControlEvent(e: unknown): boolean {
   if (typeof e !== "object" || e === null) return false;
   const c = e as Record<string, unknown>;
   if (typeof c.type !== "string" || !CONTROL_EVENT_TYPES.has(c.type)) return false;

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { serveStatic } from "@hono/node-server/serve-static";
 
-import { MSG, type LiveTurnSnapshotDto, type SessionCommandsSnapshotDto, type SessionUsageSnapshotDto } from "@ganglion/xacpx-relay-protocol";
+import { MSG, parseControlPayload, type LiveTurnSnapshotDto, type SessionCommandsSnapshotDto, type SessionUsageSnapshotDto } from "@ganglion/xacpx-relay-protocol";
 
 import type { AccountRow, AccountStore } from "../stores/accounts.js";
 import type { InstanceStore } from "../stores/instances.js";
@@ -321,6 +321,18 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       };
     }
     try {
+      // Shape-validate the RPCs the hub persists BEFORE forwarding, so a malformed frame
+      // can't poison history ahead of the connector's own boundary check. Error body carries
+      // no payload contents (privacy). Other control.* types are validated at the connector.
+      if (body.type === MSG.prompt && !parseControlPayload(MSG.prompt, payload)) {
+        return c.json({ error: "invalid-payload" }, 400);
+      }
+      if (body.type === MSG.commandExecute && !parseControlPayload(MSG.commandExecute, payload)) {
+        return c.json({ error: "invalid-payload" }, 400);
+      }
+      if (body.type === MSG.upload && !parseControlPayload(MSG.upload, payload)) {
+        return c.json({ error: "invalid-payload" }, 400);
+      }
       if (body.type === MSG.upload) {
         const up = payload as { content?: string };
         const approxBytes = up.content ? Math.floor((up.content.length * 3) / 4) : 0;

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -6,6 +6,7 @@ import { WebSocketServer } from "ws";
 import {
   MSG, type AgentCommandDto, type ControlEventDto, type InstanceEventPayload, type InstanceNoticePayload, type LiveTurnSnapshotDto, type RelayEnvelope,
   type SessionCommandsSnapshotDto, type SessionUsageSnapshotDto, type ToolStepDto, type TurnPartDto, type UsageBreakdownDto, type UsageCostDto,
+  validControlEvent,
 } from "@ganglion/xacpx-relay-protocol";
 
 import { createSqlDriver, initSchema, type SqlDriver } from "./db.js";
@@ -148,7 +149,17 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
       // generic relay.instance.message_failed (see instance-gateway's outer message guard).
       try {
         if (envelope.type === MSG.instanceEvent) {
-          const event = (envelope.payload as InstanceEventPayload).event as ControlEventDto;
+          const raw = (envelope.payload as InstanceEventPayload | undefined)?.event;
+          if (!validControlEvent(raw)) {
+            // A malformed event from a buggy/hostile connector must not broadcast to
+            // browsers or seed history. Drop it; log type + instanceId only (no payload).
+            logger.debug("relay.event.invalid", "dropped malformed instance event", {
+              instanceId,
+              eventType: typeof raw === "object" && raw !== null ? String((raw as { type?: unknown }).type) : "(none)",
+            });
+            return;
+          }
+          const event = raw as ControlEventDto;
           webGateway.broadcast(accountId, { kind: "control-event", instanceId, event });
           if (event.type === "turn-started") {
             turnBuffers.set(key(instanceId, event.sessionAlias), { text: "", steps: new Map(), reasoning: "", parts: [], startedAt: Date.now() });

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -29,6 +29,10 @@ function makeFakeControl(overrides: Record<string, unknown> = {}) {
       return { name, cwd, ...(description ? { description } : {}) };
     },
     prompt: async (input: unknown) => { record("prompt", input); return { ok: true, text: "done" }; },
+    fsWrite: async (workspace: string, path: string, content: string, expected: unknown) => {
+      record("fsWrite", { workspace, path, content, expected });
+      return { path, mtimeMs: 2, size: content.length };
+    },
     cancelTurn: (chatKey: string, alias: string) => { record("cancelTurn", { chatKey, alias }); return true; },
     cancelQueuedItem: (chatKey: string, alias: string, itemId: string) => {
       record("cancelQueuedItem", { chatKey, alias, itemId });
@@ -71,7 +75,7 @@ async function dispatch(bridge: ReturnType<typeof createControlBridge>, envelope
 test("sessions.list / prompt / command.execute dispatch and shape results", async () => {
   const { control, calls } = makeFakeControl();
   const bridge = createControlBridge(control as never);
-  expect(await dispatch(bridge, req(MSG.sessionsList, {}))).toEqual({
+  expect(await dispatch(bridge, req(MSG.sessionsList, { chatKey: "relay:acct" }))).toEqual({
     sessions: [{ alias: "a", agent: "claude", workspace: "/ws", transportSession: "t", running: false }],
   });
   const promptResult = await dispatch(bridge, req(MSG.prompt, {
@@ -204,9 +208,9 @@ test("control.upload dispatches to uploadFile and returns UploadResult", async (
   // happy path: all fields present → returns UploadResult
   expect(await dispatch(bridge, req(MSG.upload, { filename: "photo.png", content: "abc123", mimeType: "image/png" }))).toEqual(uploadResult);
 
-  // bad-request: missing mimeType
+  // missing mimeType fails wire-shape validation (mimeType is a required field) → invalid-payload
   expect(await dispatch(bridge, req(MSG.upload, { filename: "photo.png", content: "abc123" }))).toEqual({
-    error: { code: "bad-request", message: "filename, content and mimeType are required" },
+    error: { code: "invalid-payload", message: expect.stringContaining(MSG.upload) },
   });
 });
 
@@ -243,7 +247,7 @@ test("fs.search passes advanced search options through to control.searchWorkspac
   }]]);
 });
 
-test("fs.search returns bad-request when workspace is missing", async () => {
+test("fs.search rejects a missing workspace (required wire field) as invalid-payload", async () => {
   const { control, calls } = makeFakeControl({
     searchWorkspace: async (workspace: string, opts: unknown) => {
       calls.searchWorkspace ??= [];
@@ -253,7 +257,7 @@ test("fs.search returns bad-request when workspace is missing", async () => {
   });
   const bridge = createControlBridge(control as never);
   expect(await dispatch(bridge, req(MSG.fsSearch, { query: "x" }))).toEqual({
-    error: { code: "bad-request", message: "workspace is required" },
+    error: { code: "invalid-payload", message: expect.stringContaining(MSG.fsSearch) },
   });
   expect(calls.searchWorkspace).toBeUndefined();
 });
@@ -273,7 +277,7 @@ test("unknown type and thrown errors become error payloads", async () => {
   const broken = { ...control, listSessions: () => { throw new Error("boom"); } };
   const bridge = createControlBridge(broken as never);
   expect(await dispatch(bridge, req("control.nope", {}))).toEqual({ error: { code: "unknown-type", message: "unsupported rpc type: control.nope" } });
-  expect(await dispatch(bridge, req(MSG.sessionsList, {}))).toEqual({ error: { code: "internal", message: "boom" } });
+  expect(await dispatch(bridge, req(MSG.sessionsList, { chatKey: "relay:acct" }))).toEqual({ error: { code: "internal", message: "boom" } });
 });
 
 test("subscribeControlEvents forwards events and unsubscribes", () => {
@@ -364,10 +368,38 @@ test("terminal.attach RPC forwards to attachTerminal and returns its result", as
   expect((control.attachTerminal as ReturnType<typeof mock>).mock.calls[0]).toEqual(["t1"]);
 });
 
-test("terminal.attach RPC without terminalId returns bad-request", async () => {
+test("terminal.attach RPC without terminalId is rejected as invalid-payload (terminalId is a required wire field)", async () => {
   const { control } = makeFakeControl({ attachTerminal: mock(() => ({ ok: false })) });
   const bridge = createControlBridge(control as never);
-  expect(await dispatch(bridge, req(MSG.terminalAttach, {}))).toEqual({ error: { code: "bad-request", message: "terminalId is required" } });
+  expect(await dispatch(bridge, req(MSG.terminalAttach, {}))).toEqual({
+    error: { code: "invalid-payload", message: expect.stringContaining(MSG.terminalAttach) },
+  });
+  expect((control.attachTerminal as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+});
+
+test("boundary A: malformed fsWrite is rejected and never touches the filesystem", async () => {
+  const { control, calls } = makeFakeControl();
+  const bridge = createControlBridge(control as never);
+  // missing `content` and `expected` → invalid shape
+  const result = await dispatch(bridge, req(MSG.fsWrite, { workspace: "home", path: "a.txt" }));
+  expect(result).toEqual({ error: { code: "invalid-payload", message: expect.stringContaining(MSG.fsWrite) } });
+  expect(calls.fsWrite).toBeUndefined();
+});
+
+test("boundary A: malformed prompt is rejected and control.prompt is never called", async () => {
+  const { control, calls } = makeFakeControl();
+  const bridge = createControlBridge(control as never);
+  const result = await dispatch(bridge, req(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s" /* no text/senderId */ }));
+  expect(result).toEqual({ error: { code: "invalid-payload", message: expect.stringContaining(MSG.prompt) } });
+  expect(calls.prompt).toBeUndefined();
+});
+
+test("boundary A: a well-formed prompt still dispatches to control.prompt", async () => {
+  const { control, calls } = makeFakeControl();
+  const bridge = createControlBridge(control as never);
+  const result = await dispatch(bridge, req(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", text: "hi", senderId: "u" }));
+  expect(result).toEqual({ ok: true, text: "done" });
+  expect(calls.prompt?.length).toBe(1);
 });
 
 // ── connector-side RPC dispatch timeout ──────────────────────────────────────

--- a/tests/unit/packages/relay-protocol/payload-validators.test.ts
+++ b/tests/unit/packages/relay-protocol/payload-validators.test.ts
@@ -1,0 +1,79 @@
+// tests/unit/packages/relay-protocol/payload-validators.test.ts
+import { expect, test } from "bun:test";
+import {
+  MSG,
+  parseControlPayload,
+  CONTROL_PAYLOAD_VALIDATORS,
+  type PayloadFor,
+  type FsWritePayload,
+  type PromptPayload,
+} from "../../../../packages/relay-protocol/src/index";
+
+test("parseControlPayload accepts a well-formed fsWrite payload", () => {
+  const ok = parseControlPayload(MSG.fsWrite, {
+    workspace: "home", path: "a.txt", content: "hi",
+    expected: { mtimeMs: 1, size: 2 },
+  });
+  expect(ok).not.toBeNull();
+  expect(ok?.workspace).toBe("home");
+});
+
+test("parseControlPayload rejects fsWrite missing required fields", () => {
+  expect(parseControlPayload(MSG.fsWrite, { workspace: "home", path: "a.txt" })).toBeNull(); // no content/expected
+  expect(parseControlPayload(MSG.fsWrite, { workspace: "home", path: "a.txt", content: "x", expected: { mtimeMs: 1 } })).toBeNull(); // expected.size missing
+  expect(parseControlPayload(MSG.fsWrite, null)).toBeNull();
+  expect(parseControlPayload(MSG.fsWrite, "nope")).toBeNull();
+});
+
+test("parseControlPayload rejects fsWrite with wrong field types", () => {
+  expect(parseControlPayload(MSG.fsWrite, { workspace: 1, path: "a", content: "x", expected: { mtimeMs: 1, size: 2 } })).toBeNull();
+  expect(parseControlPayload(MSG.fsWrite, { workspace: "w", path: "a", content: 5, expected: { mtimeMs: 1, size: 2 } })).toBeNull();
+});
+
+test("parseControlPayload validates prompt: required strings, optional media array", () => {
+  expect(parseControlPayload(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", text: "hi", senderId: "u" })).not.toBeNull();
+  expect(parseControlPayload(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", text: "hi", senderId: "u", media: [] })).not.toBeNull();
+  expect(parseControlPayload(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", senderId: "u" })).toBeNull(); // no text
+  expect(parseControlPayload(MSG.prompt, { chatKey: "relay:a1", sessionAlias: "s", text: "hi", senderId: "u", media: "x" })).toBeNull(); // media not array
+});
+
+test("fsCreate enforces the kind literal union", () => {
+  expect(parseControlPayload(MSG.fsCreate, { workspace: "w", path: "p", kind: "file" })).not.toBeNull();
+  expect(parseControlPayload(MSG.fsCreate, { workspace: "w", path: "p", kind: "dir" })).not.toBeNull();
+  expect(parseControlPayload(MSG.fsCreate, { workspace: "w", path: "p", kind: "socket" })).toBeNull();
+});
+
+test("chatKey-only and chatKey+alias families validate their shape", () => {
+  expect(parseControlPayload(MSG.sessionsList, { chatKey: "relay:a1" })).not.toBeNull();
+  expect(parseControlPayload(MSG.sessionsList, {})).toBeNull();
+  expect(parseControlPayload(MSG.sessionsRemove, { chatKey: "relay:a1", alias: "s" })).not.toBeNull();
+  expect(parseControlPayload(MSG.sessionsRemove, { chatKey: "relay:a1" })).toBeNull();
+});
+
+test("upload requires filename, content, mimeType strings", () => {
+  expect(parseControlPayload(MSG.upload, { filename: "a", content: "b64", mimeType: "text/plain" })).not.toBeNull();
+  expect(parseControlPayload(MSG.upload, { filename: "a", content: "b64" })).toBeNull();
+});
+
+test("every registered validator returns null for a non-object payload", () => {
+  for (const type of Object.keys(CONTROL_PAYLOAD_VALIDATORS) as (keyof typeof CONTROL_PAYLOAD_VALIDATORS)[]) {
+    expect(CONTROL_PAYLOAD_VALIDATORS[type](null)).toBeNull();
+    expect(CONTROL_PAYLOAD_VALIDATORS[type](42)).toBeNull();
+  }
+});
+
+// --- Type-level binding (checked by `npx tsc --noEmit`, not at runtime) ---
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+// PayloadFor<MSG.fsWrite> is exactly FsWritePayload (not `unknown`, not a widened shape).
+type _fsWriteBound = Expect<Equal<PayloadFor<typeof MSG.fsWrite>, FsWritePayload>>;
+type _promptBound = Expect<Equal<PayloadFor<typeof MSG.prompt>, PromptPayload>>;
+
+test("type-level bindings compile", () => {
+  // The `_fsWriteBound`/`_promptBound` aliases above fail `tsc` if PayloadFor drifts
+  // from the hand-written payload type. This runtime assertion just anchors the test.
+  const _use: [_fsWriteBound, _promptBound] = [true, true];
+  expect(_use).toEqual([true, true]);
+});

--- a/tests/unit/packages/relay-protocol/payload-validators.test.ts
+++ b/tests/unit/packages/relay-protocol/payload-validators.test.ts
@@ -1,13 +1,6 @@
 // tests/unit/packages/relay-protocol/payload-validators.test.ts
 import { expect, test } from "bun:test";
-import {
-  MSG,
-  parseControlPayload,
-  CONTROL_PAYLOAD_VALIDATORS,
-  type PayloadFor,
-  type FsWritePayload,
-  type PromptPayload,
-} from "../../../../packages/relay-protocol/src/index";
+import { MSG, parseControlPayload, CONTROL_PAYLOAD_VALIDATORS } from "../../../../packages/relay-protocol/src/index";
 
 test("parseControlPayload accepts a well-formed fsWrite payload", () => {
   const ok = parseControlPayload(MSG.fsWrite, {
@@ -62,18 +55,5 @@ test("every registered validator returns null for a non-object payload", () => {
   }
 });
 
-// --- Type-level binding (checked by `npx tsc --noEmit`, not at runtime) ---
-type Expect<T extends true> = T;
-type Equal<A, B> =
-  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
-
-// PayloadFor<MSG.fsWrite> is exactly FsWritePayload (not `unknown`, not a widened shape).
-type _fsWriteBound = Expect<Equal<PayloadFor<typeof MSG.fsWrite>, FsWritePayload>>;
-type _promptBound = Expect<Equal<PayloadFor<typeof MSG.prompt>, PromptPayload>>;
-
-test("type-level bindings compile", () => {
-  // The `_fsWriteBound`/`_promptBound` aliases above fail `tsc` if PayloadFor drifts
-  // from the hand-written payload type. This runtime assertion just anchors the test.
-  const _use: [_fsWriteBound, _promptBound] = [true, true];
-  expect(_use).toEqual([true, true]);
-});
+// The type-level `PayloadFor<T>` bindings are asserted in payload-validators.ts itself,
+// where tsc actually sees them — `tests/` is outside every tsconfig's `include`.

--- a/tests/unit/packages/relay-protocol/validate-primitives.test.ts
+++ b/tests/unit/packages/relay-protocol/validate-primitives.test.ts
@@ -1,0 +1,38 @@
+// tests/unit/packages/relay-protocol/validate-primitives.test.ts
+import { expect, test } from "bun:test";
+import { isObj, isStr, optStr, optNum, optBool } from "../../../../packages/relay-protocol/src/validate-primitives";
+
+test("isObj accepts plain objects, rejects null and non-objects", () => {
+  expect(isObj({})).toBe(true);
+  expect(isObj({ a: 1 })).toBe(true);
+  expect(isObj(null)).toBe(false);
+  expect(isObj(undefined)).toBe(false);
+  expect(isObj("x")).toBe(false);
+  expect(isObj(3)).toBe(false);
+});
+
+test("isStr is true only for strings", () => {
+  expect(isStr("")).toBe(true);
+  expect(isStr("a")).toBe(true);
+  expect(isStr(1)).toBe(false);
+  expect(isStr(undefined)).toBe(false);
+});
+
+test("optStr allows undefined or string, rejects other types", () => {
+  expect(optStr(undefined)).toBe(true);
+  expect(optStr("a")).toBe(true);
+  expect(optStr(null)).toBe(false);
+  expect(optStr(1)).toBe(false);
+});
+
+test("optNum allows undefined or number", () => {
+  expect(optNum(undefined)).toBe(true);
+  expect(optNum(2)).toBe(true);
+  expect(optNum("2")).toBe(false);
+});
+
+test("optBool allows undefined or boolean", () => {
+  expect(optBool(undefined)).toBe(true);
+  expect(optBool(true)).toBe(true);
+  expect(optBool(0)).toBe(false);
+});

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -423,6 +423,28 @@ test("rpc prompt persists the inbound message before the turn's out message (his
   expect(cached.messages.map((m) => [m.direction, m.text])).toEqual([["in", "hi"], ["out", "agent reply"]]);
 });
 
+test("rpc boundary C: malformed prompt returns 400 and persists nothing", async () => {
+  const { app, instances, messages, loginToken, login, rpcCalls } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const { instanceId, accountId } = instances.redeemPairingToken(token)!;
+
+  const res = await app.request(`/api/instances/${instanceId}/rpc`, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: 123 /* wrong type */ } }),
+  });
+  expect(res.status).toBe(400);
+  expect(((await res.json()) as { error: string }).error).toBe("invalid-payload");
+  expect(rpcCalls.length).toBe(0);
+
+  // history for the session is still empty — nothing persisted ahead of the shape check
+  const history = messages.listBySession(accountId, instanceId, "s");
+  expect(history.messages.length).toBe(0);
+});
+
 test("rpc prompt persists a valid small image previewUrl on the attachment", async () => {
   const { app, instances, loginToken, login } = await makeApp();
   const { cookie } = await login(loginToken);

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -185,6 +185,23 @@ test("a throwing DB write during onEvent logs relay.event.persist_failed with in
   runtime.close();
 });
 
+test("boundary B: a malformed control event is dropped, not broadcast or persisted", async () => {
+  const runtime = await seeded();
+  const web = new FakeSocket();
+  runtime.webGateway.register("a1", web as never);
+  const fire = (event: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceEvent, payload: { event },
+  });
+
+  // turn-finished missing the required `sessionAlias` (and `ok`) → invalid shape.
+  fire({ type: "turn-finished", chatKey: "relay:a1" });
+
+  expect(web.sent.length).toBe(0); // not broadcast
+  const history = runtime.messages.listBySession("a1", "i1", "backend", { limit: 10 });
+  expect(history.messages.length).toBe(0); // not persisted
+  runtime.close();
+});
+
 test("a finish with no text but with tool steps still persists a structured turn", async () => {
   const runtime = await seeded();
   const fire = (event: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-06-protocol-hardening-design.md` (Track 2 of the 2026-07 architecture audit).

## What

Relay control RPCs crossed two trust boundaries with nothing but `as XxxPayload` casts — ~40 of them in the connector's dispatch, right above `fs.write/delete/copy/rename`, `prompt` injection and `commandExecute`; plus a double cast in the hub that drove every history DB write.

One artifact fixes both the missing runtime validation and the missing type-level binding: a hand-written validator registry in `relay-protocol`, keyed by `MessageType`. It is the runtime source of truth, and `satisfies Record<ControlRpcType, Validator<unknown>>` makes it the compile-time one too.

Three boundaries adopt it:

- **A — connector dispatch** (`control-bridge.ts`): all 35 casting arms now go through `parseControlPayload`; a malformed frame returns `errorPayload("invalid-payload", …)` and never reaches `control.*`. Existing semantic checks (non-empty, ISO date) are preserved below the parse.
- **B — hub `onEvent`** (`server.ts`): inbound instance events are checked with the existing `validControlEvent`; malformed ones are dropped — not broadcast, not persisted — and logged as `relay.event.invalid`.
- **C — hub HTTP `/rpc`** (`http/app.ts`): the three RPCs the hub persists *before* forwarding (`prompt`, `commandExecute`, `upload`) are shape-checked first, so a bad frame can't poison history. Returns 400.

## Constraints held

- **Zero new dependencies** — `relay-protocol` stays a zero-dependency published package. Validators are hand-written in the existing `web-dtos.ts` style; shared predicates extracted to `validate-primitives.ts`.
- **Privacy** — no rejection log or error message contains a payload value. Only the message `type`, `instanceId`, and a structural reason.
- **Protocol compatibility** — purely additive validation (what it rejects was already malformed). No payload structure changed, envelope shallow-check untouched. Stays `0.1.11` / `^0.1.0`.

## Verification

- 112 tests across the six affected suites, run per-file (whole-directory `bun test` gives state-leak false failures).
- Root `tsc --noEmit` and the `relay-protocol` package tsc: 0 errors.
- All 35 connector arms mechanically verified to pair `case MSG.X` with `parseControlPayload(MSG.X, …)`; zero residual `payload as` casts. The 7 unvalidated arms are exactly the spec's documented exclusions (4 no-payload list RPCs, 3 terminal I/O events already validated by `parseWebClientMessage`).
- Both hub guards mutation-tested: replacing each with `if (false)` turns its new test red, so the tests are load-bearing rather than vacuous.
- The `PayloadFor<T>` bindings live in `payload-validators.ts`, not the test file — `tests/` is outside every tsconfig's `include`, so an assertion written there is never checked. Mutation-tested: mismapping `[MSG.fsWrite]` to `validateFsRead` now fails the package tsc that `build:relay-protocol` runs.

## Not shipping

Code merge only. Real-world effect needs a core + relay + channel-relay beta, batched with later tracks — no version bump, no publish.