### PR TITLE
orchestration: record loadState in the golden oracle, then fix approveTask's parallel-slot TOCTOU (#152, #148)

### DIFF
--- a/src/orchestration/service/task-approval-service.ts
+++ b/src/orchestration/service/task-approval-service.ts
@@ -75,11 +75,18 @@ export class TaskApprovalService {
     // slot stays claimed until the task is persisted as `running` (where
     // countActiveParallelSlots starts counting it), or until any path between here and
     // there fails. Releasing is idempotent so the failure paths can call it unconditionally.
-    let parallelStartClaimed = false;
+    //
+    // It holds the agent it CLAIMED, not `currentTask.targetAgent`. `currentTask` was read
+    // before the gate's own `loadState`, and the gate claims against the agent it read
+    // inside its critical section. Those are the same string today — nothing assigns
+    // `task.targetAgent` after creation — but a release that re-derives the key can only
+    // ever be wrong, never more right, so it does not re-derive it.
+    let claimedParallelAgent: string | undefined;
     const releaseParallelStartOnce = (): void => {
-      if (!parallelStartClaimed) return;
-      parallelStartClaimed = false;
-      this.workerSessions.releaseParallelStart(currentTask.targetAgent);
+      if (claimedParallelAgent === undefined) return;
+      const agent = claimedParallelAgent;
+      claimedParallelAgent = undefined;
+      this.workerSessions.releaseParallelStart(agent);
     };
 
     if (currentTask.ephemeralWorkerSession === true) {
@@ -97,7 +104,7 @@ export class TaskApprovalService {
           // claim a second concurrent approve reads the same free slot and both dispatch —
           // the agent runs one task over its cap. Mirrors the two delegation gates.
           this.workerSessions.claimParallelStart(task.targetAgent);
-          parallelStartClaimed = true;
+          claimedParallelAgent = task.targetAgent;
           return null; // capacity available — fall through to normal start
         }
         const now = this.deps.now().toISOString();

--- a/src/orchestration/service/task-approval-service.ts
+++ b/src/orchestration/service/task-approval-service.ts
@@ -71,6 +71,17 @@ export class TaskApprovalService {
     // (those tasks never enter `needs_confirmation`). We check here, before
     // ensureReservedWorkerSession and dispatch, so those expensive operations are
     // skipped for queued tasks.
+    // Set inside the gate's critical section when this approve takes a parallel slot; the
+    // slot stays claimed until the task is persisted as `running` (where
+    // countActiveParallelSlots starts counting it), or until any path between here and
+    // there fails. Releasing is idempotent so the failure paths can call it unconditionally.
+    let parallelStartClaimed = false;
+    const releaseParallelStartOnce = (): void => {
+      if (!parallelStartClaimed) return;
+      parallelStartClaimed = false;
+      this.workerSessions.releaseParallelStart(currentTask.targetAgent);
+    };
+
     if (currentTask.ephemeralWorkerSession === true) {
       const queuedResult = await this.kernel.mutate(async () => {
         const state = await this.deps.loadState();
@@ -81,6 +92,12 @@ export class TaskApprovalService {
         this.questionFlow.assertCoordinatorOwnership(task, input.coordinatorSession);
         this.assertNeedsConfirmation(task);
         if (this.workerSessions.canStartParallelTask(state, task.targetAgent)) {
+          // Take the slot inside this critical section. Between here and the persist mutate
+          // below, the task is neither persisted as `running` nor pending, so without this
+          // claim a second concurrent approve reads the same free slot and both dispatch —
+          // the agent runs one task over its cap. Mirrors the two delegation gates.
+          this.workerSessions.claimParallelStart(task.targetAgent);
+          parallelStartClaimed = true;
           return null; // capacity available — fall through to normal start
         }
         const now = this.deps.now().toISOString();
@@ -103,7 +120,16 @@ export class TaskApprovalService {
       }
     }
 
-    const releaseWorkerReservation = await this.workerSessions.reserveProposedWorkerSession(workerSession, input.taskId);
+    // reserveProposedWorkerSession sits outside the try below and can throw (the worker
+    // session is already reserved or bound). Without this guard a claimed slot leaks and the
+    // agent's capacity shrinks permanently.
+    let releaseWorkerReservation: () => Promise<void>;
+    try {
+      releaseWorkerReservation = await this.workerSessions.reserveProposedWorkerSession(workerSession, input.taskId);
+    } catch (error) {
+      releaseParallelStartOnce();
+      throw error;
+    }
     let ensuredWorkerSession = workerSession;
     let prepared: {
       task: OrchestrationTaskRecord;
@@ -166,9 +192,14 @@ export class TaskApprovalService {
       });
     } catch (error) {
       await releaseWorkerReservation();
+      releaseParallelStartOnce();
       throw error;
     }
     await releaseWorkerReservation();
+    // The task is persisted as `running` now, so countActiveParallelSlots counts it and the
+    // pending claim is redundant. Released here rather than after dispatch: the
+    // dispatch-failure path below rolls the status back, which frees the slot on its own.
+    releaseParallelStartOnce();
 
     try {
       await this.deps.dispatchWorkerTask({

--- a/tests/unit/orchestration/golden/fixtures/approvetask-starts-a-needs-confirmation-task.json
+++ b/tests/unit/orchestration/golden/fixtures/approvetask-starts-a-needs-confirmation-task.json
@@ -64,6 +64,10 @@
   },
   "calls": [
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "findReusableWorkerSession",
       "request": {
         "sourceHandle": "backend:claude:backend:main",
@@ -75,8 +79,21 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -118,12 +135,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -141,6 +153,14 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:codex:reviewer:backend:main",
@@ -153,8 +173,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -213,12 +242,7 @@
               "role": "reviewer"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {

--- a/tests/unit/orchestration/golden/fixtures/cleantasks-removes-terminal-tasks-clean-state.json
+++ b/tests/unit/orchestration/golden/fixtures/cleantasks-removes-terminal-tasks-clean-state.json
@@ -26,6 +26,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -37,8 +41,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -79,12 +92,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -113,8 +121,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -164,12 +181,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -187,15 +199,19 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
-        "tasks": [],
-        "workerBindings": [],
-        "groups": [],
-        "humanQuestionPackages": [],
         "coordinatorQuestionState": [],
         "coordinatorRoutes": [],
-        "externalCoordinators": []
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
+        "tasks": [],
+        "workerBindings": []
       }
     }
   ],

--- a/tests/unit/orchestration/golden/fixtures/completetaskcancellation-on-a-cancel-requested-task.json
+++ b/tests/unit/orchestration/golden/fixtures/completetaskcancellation-on-a-cancel-requested-task.json
@@ -58,8 +58,17 @@
   },
   "calls": [
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -106,12 +115,7 @@
             }
           }
         ],
-        "workerBindings": [],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        "workerBindings": []
       }
     },
     {
@@ -127,6 +131,14 @@
           "worker_session": "backend:claude:backend:main"
         }
       }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
     }
   ],
   "taskEvents": {

--- a/tests/unit/orchestration/golden/fixtures/coordinatorrequesthumaninput-builds-and-delivers-a-question.json
+++ b/tests/unit/orchestration/golden/fixtures/coordinatorrequesthumaninput-builds-and-delivers-a-question.json
@@ -116,12 +116,12 @@
   },
   "calls": [
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
-        "tasks": [],
-        "workerBindings": [],
-        "groups": [],
-        "humanQuestionPackages": [],
         "coordinatorQuestionState": [],
         "coordinatorRoutes": [
           {
@@ -133,7 +133,11 @@
             }
           }
         ],
-        "externalCoordinators": []
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
+        "tasks": [],
+        "workerBindings": []
       }
     },
     {
@@ -147,6 +151,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -158,8 +166,26 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [
+          {
+            "key": "backend:main",
+            "value": {
+              "coordinatorSession": "backend:main",
+              "chatKey": "wx:room-1",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -200,21 +226,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [
-          {
-            "key": "backend:main",
-            "value": {
-              "coordinatorSession": "backend:main",
-              "chatKey": "wx:room-1",
-              "updatedAt": "2026-04-13T10:00:00.000Z"
-            }
-          }
-        ],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -243,8 +255,26 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [
+          {
+            "key": "backend:main",
+            "value": {
+              "coordinatorSession": "backend:main",
+              "chatKey": "wx:room-1",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -300,10 +330,31 @@
               "targetAgent": "claude"
             }
           }
+        ]
+      }
+    },
+    {
+      "port": "wakeCoordinatorSession",
+      "request": {
+        "coordinatorSession": "backend:main"
+      }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "saveState",
+      "request": {
+        "coordinatorQuestionState": [
+          {
+            "key": "backend:main",
+            "value": {
+              "queuedQuestions": [],
+              "activePackageId": "pkg-1"
+            }
+          }
         ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
         "coordinatorRoutes": [
           {
             "key": "backend:main",
@@ -314,82 +365,7 @@
             }
           }
         ],
-        "externalCoordinators": []
-      }
-    },
-    {
-      "port": "wakeCoordinatorSession",
-      "request": {
-        "coordinatorSession": "backend:main"
-      }
-    },
-    {
-      "port": "saveState",
-      "request": {
-        "tasks": [
-          {
-            "key": "task-1",
-            "value": {
-              "taskId": "task-1",
-              "sourceHandle": "wx:user-1",
-              "sourceKind": "human",
-              "coordinatorSession": "backend:main",
-              "workerSession": "backend:claude:backend:main",
-              "workspace": "backend",
-              "targetAgent": "claude",
-              "task": "ask me",
-              "status": "waiting_for_human",
-              "summary": "",
-              "resultText": "",
-              "createdAt": "2026-04-13T10:00:00.000Z",
-              "updatedAt": "2026-04-13T10:00:00.000Z",
-              "eventSeq": 3,
-              "events": [
-                {
-                  "seq": 1,
-                  "at": "2026-04-13T10:00:00.000Z",
-                  "type": "created",
-                  "status": "running",
-                  "message": "Task created"
-                },
-                {
-                  "seq": 2,
-                  "at": "2026-04-13T10:00:00.000Z",
-                  "type": "attention_required",
-                  "status": "blocked",
-                  "message": "which database?"
-                },
-                {
-                  "seq": 3,
-                  "at": "2026-04-13T10:00:00.000Z",
-                  "type": "attention_required",
-                  "status": "waiting_for_human",
-                  "message": "which database?"
-                }
-              ],
-              "openQuestion": {
-                "questionId": "q-1",
-                "question": "which database?",
-                "whyBlocked": "schema ambiguous",
-                "whatIsNeeded": "a table name",
-                "askedAt": "2026-04-13T10:00:00.000Z",
-                "status": "open",
-                "packageId": "pkg-1"
-              }
-            }
-          }
-        ],
-        "workerBindings": [
-          {
-            "key": "backend:claude:backend:main",
-            "value": {
-              "sourceHandle": "backend:claude:backend:main",
-              "coordinatorSession": "backend:main",
-              "workspace": "backend",
-              "targetAgent": "claude"
-            }
-          }
-        ],
+        "externalCoordinators": [],
         "groups": [],
         "humanQuestionPackages": [
           {
@@ -425,39 +401,6 @@
             }
           }
         ],
-        "coordinatorQuestionState": [
-          {
-            "key": "backend:main",
-            "value": {
-              "queuedQuestions": [],
-              "activePackageId": "pkg-1"
-            }
-          }
-        ],
-        "coordinatorRoutes": [
-          {
-            "key": "backend:main",
-            "value": {
-              "coordinatorSession": "backend:main",
-              "chatKey": "wx:room-1",
-              "updatedAt": "2026-04-13T10:00:00.000Z"
-            }
-          }
-        ],
-        "externalCoordinators": []
-      }
-    },
-    {
-      "port": "deliverCoordinatorMessage",
-      "request": {
-        "coordinatorSession": "backend:main",
-        "chatKey": "wx:room-1",
-        "text": "need a decision"
-      }
-    },
-    {
-      "port": "saveState",
-      "request": {
         "tasks": [
           {
             "key": "task-1",
@@ -521,7 +464,44 @@
               "targetAgent": "claude"
             }
           }
+        ]
+      }
+    },
+    {
+      "port": "deliverCoordinatorMessage",
+      "request": {
+        "coordinatorSession": "backend:main",
+        "chatKey": "wx:room-1",
+        "text": "need a decision"
+      }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "saveState",
+      "request": {
+        "coordinatorQuestionState": [
+          {
+            "key": "backend:main",
+            "value": {
+              "queuedQuestions": [],
+              "activePackageId": "pkg-1"
+            }
+          }
         ],
+        "coordinatorRoutes": [
+          {
+            "key": "backend:main",
+            "value": {
+              "coordinatorSession": "backend:main",
+              "chatKey": "wx:room-1",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "externalCoordinators": [],
         "groups": [],
         "humanQuestionPackages": [
           {
@@ -560,26 +540,70 @@
             }
           }
         ],
-        "coordinatorQuestionState": [
+        "tasks": [
           {
-            "key": "backend:main",
+            "key": "task-1",
             "value": {
-              "queuedQuestions": [],
-              "activePackageId": "pkg-1"
-            }
-          }
-        ],
-        "coordinatorRoutes": [
-          {
-            "key": "backend:main",
-            "value": {
+              "taskId": "task-1",
+              "sourceHandle": "wx:user-1",
+              "sourceKind": "human",
               "coordinatorSession": "backend:main",
-              "chatKey": "wx:room-1",
-              "updatedAt": "2026-04-13T10:00:00.000Z"
+              "workerSession": "backend:claude:backend:main",
+              "workspace": "backend",
+              "targetAgent": "claude",
+              "task": "ask me",
+              "status": "waiting_for_human",
+              "summary": "",
+              "resultText": "",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z",
+              "eventSeq": 3,
+              "events": [
+                {
+                  "seq": 1,
+                  "at": "2026-04-13T10:00:00.000Z",
+                  "type": "created",
+                  "status": "running",
+                  "message": "Task created"
+                },
+                {
+                  "seq": 2,
+                  "at": "2026-04-13T10:00:00.000Z",
+                  "type": "attention_required",
+                  "status": "blocked",
+                  "message": "which database?"
+                },
+                {
+                  "seq": 3,
+                  "at": "2026-04-13T10:00:00.000Z",
+                  "type": "attention_required",
+                  "status": "waiting_for_human",
+                  "message": "which database?"
+                }
+              ],
+              "openQuestion": {
+                "questionId": "q-1",
+                "question": "which database?",
+                "whyBlocked": "schema ambiguous",
+                "whatIsNeeded": "a table name",
+                "askedAt": "2026-04-13T10:00:00.000Z",
+                "status": "open",
+                "packageId": "pkg-1"
+              }
             }
           }
         ],
-        "externalCoordinators": []
+        "workerBindings": [
+          {
+            "key": "backend:claude:backend:main",
+            "value": {
+              "sourceHandle": "backend:claude:backend:main",
+              "coordinatorSession": "backend:main",
+              "workspace": "backend",
+              "targetAgent": "claude"
+            }
+          }
+        ]
       }
     }
   ],

--- a/tests/unit/orchestration/golden/fixtures/coordinatorretractanswer-on-a-running-task-reopens-the-blocker.json
+++ b/tests/unit/orchestration/golden/fixtures/coordinatorretractanswer-on-a-running-task-reopens-the-blocker.json
@@ -95,6 +95,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -106,8 +110,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -148,12 +161,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -182,8 +190,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -239,12 +256,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -254,8 +266,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -321,12 +342,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -341,8 +357,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -420,12 +445,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -444,6 +464,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "interruptWorkerTask",
       "request": {
         "taskId": "task-1",
@@ -453,8 +477,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -531,12 +564,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {

--- a/tests/unit/orchestration/golden/fixtures/coordinatorreviewcontestedresult-accepts-a-contested-result.json
+++ b/tests/unit/orchestration/golden/fixtures/coordinatorreviewcontestedresult-accepts-a-contested-result.json
@@ -110,6 +110,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -121,8 +125,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -165,12 +178,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -199,8 +207,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -258,12 +275,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -273,8 +285,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -342,12 +363,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -362,8 +378,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -441,12 +466,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -464,8 +484,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -557,12 +586,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -581,8 +605,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -674,13 +707,16 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
     }
   ],
   "taskEvents": {

--- a/tests/unit/orchestration/golden/fixtures/coordinatorreviewcontestedresult-discards-a-contested-result-and-reopens-the-question.json
+++ b/tests/unit/orchestration/golden/fixtures/coordinatorreviewcontestedresult-discards-a-contested-result-and-reopens-the-question.json
@@ -107,6 +107,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -118,8 +122,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -162,12 +175,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -196,8 +204,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -255,12 +272,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -270,8 +282,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -339,12 +360,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -359,8 +375,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -438,12 +463,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -461,8 +481,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -554,12 +583,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -578,8 +602,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -668,12 +701,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {

--- a/tests/unit/orchestration/golden/fixtures/creategroup-then-cancelgroup-cancels-its-tasks-cancel-group-state.json
+++ b/tests/unit/orchestration/golden/fixtures/creategroup-then-cancelgroup-cancels-its-tasks-cancel-group-state.json
@@ -74,10 +74,15 @@
   },
   "calls": [
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
-        "tasks": [],
-        "workerBindings": [],
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
         "groups": [
           {
             "key": "g1",
@@ -91,9 +96,8 @@
           }
         ],
         "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        "tasks": [],
+        "workerBindings": []
       }
     },
     {
@@ -119,6 +123,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -130,8 +138,28 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "review",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -173,23 +201,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [
-          {
-            "key": "g1",
-            "value": {
-              "groupId": "g1",
-              "coordinatorSession": "backend:main",
-              "title": "review",
-              "createdAt": "2026-04-13T10:00:00.000Z",
-              "updatedAt": "2026-04-13T10:00:00.000Z"
-            }
-          }
-        ],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -219,8 +231,32 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "review",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -270,23 +306,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [
-          {
-            "key": "g1",
-            "value": {
-              "groupId": "g1",
-              "coordinatorSession": "backend:main",
-              "title": "review",
-              "createdAt": "2026-04-13T10:00:00.000Z",
-              "updatedAt": "2026-04-13T10:00:00.000Z"
-            }
-          }
-        ],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -305,6 +325,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "cancelWorkerTask",
       "request": {
         "taskId": "task-1",
@@ -312,6 +336,14 @@
         "workspace": "backend",
         "targetAgent": "claude"
       }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
     },
     {
       "port": "logger.info",
@@ -330,6 +362,22 @@
     {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "review",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -387,23 +435,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [
-          {
-            "key": "g1",
-            "value": {
-              "groupId": "g1",
-              "coordinatorSession": "backend:main",
-              "title": "review",
-              "createdAt": "2026-04-13T10:00:00.000Z",
-              "updatedAt": "2026-04-13T10:00:00.000Z"
-            }
-          }
-        ],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -420,6 +452,14 @@
           "worker_session": "backend:claude:backend:main"
         }
       }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
     }
   ],
   "taskEvents": {

--- a/tests/unit/orchestration/golden/fixtures/failtaskcancellation-on-a-cancel-requested-task.json
+++ b/tests/unit/orchestration/golden/fixtures/failtaskcancellation-on-a-cancel-requested-task.json
@@ -58,8 +58,17 @@
   },
   "calls": [
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -106,12 +115,7 @@
             }
           }
         ],
-        "workerBindings": [],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        "workerBindings": []
       }
     },
     {

--- a/tests/unit/orchestration/golden/fixtures/listgroupsummaries-reflects-task-status-rollup-snapshot.json
+++ b/tests/unit/orchestration/golden/fixtures/listgroupsummaries-reflects-task-status-rollup-snapshot.json
@@ -13,13 +13,14 @@
           "workerSession": "backend:claude:backend:main",
           "workspace": "backend",
           "targetAgent": "claude",
-          "task": "ask me",
-          "status": "running",
-          "summary": "",
-          "resultText": "",
+          "groupId": "g1",
+          "task": "in group",
+          "status": "completed",
+          "summary": "done",
+          "resultText": "ok",
           "createdAt": "2026-04-13T10:00:00.000Z",
           "updatedAt": "2026-04-13T10:00:00.000Z",
-          "eventSeq": 3,
+          "eventSeq": 2,
           "events": [
             {
               "seq": 1,
@@ -31,29 +32,13 @@
             {
               "seq": 2,
               "at": "2026-04-13T10:00:00.000Z",
-              "type": "attention_required",
-              "status": "blocked",
-              "message": "which database?"
-            },
-            {
-              "seq": 3,
-              "at": "2026-04-13T10:00:00.000Z",
               "type": "status_changed",
-              "status": "running",
-              "message": "Blocker question answered"
+              "status": "completed",
+              "summary": "done",
+              "message": "Task completed"
             }
           ],
-          "openQuestion": {
-            "questionId": "q-1",
-            "question": "which database?",
-            "whyBlocked": "schema ambiguous",
-            "whatIsNeeded": "a table name",
-            "askedAt": "2026-04-13T10:00:00.000Z",
-            "status": "answered",
-            "answeredAt": "2026-04-13T10:00:00.000Z",
-            "answerSource": "coordinator",
-            "answerText": "users"
-          }
+          "injectionPending": true
         }
       },
       "workerBindings": {
@@ -64,7 +49,15 @@
           "targetAgent": "claude"
         }
       },
-      "groups": {},
+      "groups": {
+        "g1": {
+          "groupId": "g1",
+          "coordinatorSession": "backend:main",
+          "title": "review",
+          "createdAt": "2026-04-13T10:00:00.000Z",
+          "updatedAt": "2026-04-13T10:00:00.000Z"
+        }
+      },
       "humanQuestionPackages": {},
       "coordinatorQuestionState": {},
       "coordinatorRoutes": {},
@@ -73,6 +66,45 @@
     "scheduled_tasks": {}
   },
   "calls": [
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "saveState",
+      "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "review",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "humanQuestionPackages": [],
+        "tasks": [],
+        "workerBindings": []
+      }
+    },
+    {
+      "port": "logger.info",
+      "request": {
+        "event": "orchestration.group.created",
+        "message": "group created",
+        "context": {
+          "group_id": "g1",
+          "coordinator_session": "backend:main",
+          "title": "review"
+        }
+      }
+    },
     {
       "port": "findReusableWorkerSession",
       "request": {
@@ -108,7 +140,18 @@
         "coordinatorQuestionState": [],
         "coordinatorRoutes": [],
         "externalCoordinators": [],
-        "groups": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "review",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
         "humanQuestionPackages": [],
         "tasks": [
           {
@@ -121,7 +164,8 @@
               "workerSession": "backend:claude:backend:main",
               "workspace": "backend",
               "targetAgent": "claude",
-              "task": "ask me",
+              "groupId": "g1",
+              "task": "in group",
               "status": "running",
               "summary": "",
               "resultText": "",
@@ -161,7 +205,7 @@
         "coordinatorSession": "backend:main",
         "workspace": "backend",
         "targetAgent": "claude",
-        "task": "ask me"
+        "task": "in group"
       }
     },
     {
@@ -174,6 +218,7 @@
           "coordinator_session": "backend:main",
           "target_agent": "claude",
           "status": "running",
+          "group_id": "g1",
           "worker_session": "backend:claude:backend:main"
         }
       }
@@ -188,7 +233,18 @@
         "coordinatorQuestionState": [],
         "coordinatorRoutes": [],
         "externalCoordinators": [],
-        "groups": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "review",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
         "humanQuestionPackages": [],
         "tasks": [
           {
@@ -201,10 +257,11 @@
               "workerSession": "backend:claude:backend:main",
               "workspace": "backend",
               "targetAgent": "claude",
-              "task": "ask me",
-              "status": "blocked",
-              "summary": "",
-              "resultText": "",
+              "groupId": "g1",
+              "task": "in group",
+              "status": "completed",
+              "summary": "done",
+              "resultText": "ok",
               "createdAt": "2026-04-13T10:00:00.000Z",
               "updatedAt": "2026-04-13T10:00:00.000Z",
               "eventSeq": 2,
@@ -219,19 +276,13 @@
                 {
                   "seq": 2,
                   "at": "2026-04-13T10:00:00.000Z",
-                  "type": "attention_required",
-                  "status": "blocked",
-                  "message": "which database?"
+                  "type": "status_changed",
+                  "status": "completed",
+                  "summary": "done",
+                  "message": "Task completed"
                 }
               ],
-              "openQuestion": {
-                "questionId": "q-1",
-                "question": "which database?",
-                "whyBlocked": "schema ambiguous",
-                "whatIsNeeded": "a table name",
-                "askedAt": "2026-04-13T10:00:00.000Z",
-                "status": "open"
-              }
+              "injectionPending": true
             }
           }
         ],
@@ -249,101 +300,23 @@
       }
     },
     {
-      "port": "wakeCoordinatorSession",
+      "port": "logger.info",
       "request": {
-        "coordinatorSession": "backend:main"
+        "event": "orchestration.task.completed",
+        "message": "task completed",
+        "context": {
+          "task_id": "task-1",
+          "coordinator_session": "backend:main",
+          "target_agent": "claude",
+          "status": "completed",
+          "group_id": "g1",
+          "worker_session": "backend:claude:backend:main"
+        }
       }
     },
     {
       "port": "loadState",
       "request": null
-    },
-    {
-      "port": "saveState",
-      "request": {
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": [],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "tasks": [
-          {
-            "key": "task-1",
-            "value": {
-              "taskId": "task-1",
-              "sourceHandle": "wx:user-1",
-              "sourceKind": "human",
-              "coordinatorSession": "backend:main",
-              "workerSession": "backend:claude:backend:main",
-              "workspace": "backend",
-              "targetAgent": "claude",
-              "task": "ask me",
-              "status": "running",
-              "summary": "",
-              "resultText": "",
-              "createdAt": "2026-04-13T10:00:00.000Z",
-              "updatedAt": "2026-04-13T10:00:00.000Z",
-              "eventSeq": 3,
-              "events": [
-                {
-                  "seq": 1,
-                  "at": "2026-04-13T10:00:00.000Z",
-                  "type": "created",
-                  "status": "running",
-                  "message": "Task created"
-                },
-                {
-                  "seq": 2,
-                  "at": "2026-04-13T10:00:00.000Z",
-                  "type": "attention_required",
-                  "status": "blocked",
-                  "message": "which database?"
-                },
-                {
-                  "seq": 3,
-                  "at": "2026-04-13T10:00:00.000Z",
-                  "type": "status_changed",
-                  "status": "running",
-                  "message": "Blocker question answered"
-                }
-              ],
-              "openQuestion": {
-                "questionId": "q-1",
-                "question": "which database?",
-                "whyBlocked": "schema ambiguous",
-                "whatIsNeeded": "a table name",
-                "askedAt": "2026-04-13T10:00:00.000Z",
-                "status": "answered",
-                "answeredAt": "2026-04-13T10:00:00.000Z",
-                "answerSource": "coordinator",
-                "answerText": "users"
-              }
-            }
-          }
-        ],
-        "workerBindings": [
-          {
-            "key": "backend:claude:backend:main",
-            "value": {
-              "sourceHandle": "backend:claude:backend:main",
-              "coordinatorSession": "backend:main",
-              "workspace": "backend",
-              "targetAgent": "claude"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "port": "resumeWorkerTask",
-      "request": {
-        "taskId": "task-1",
-        "workerSession": "backend:claude:backend:main",
-        "coordinatorSession": "backend:main",
-        "workspace": "backend",
-        "targetAgent": "claude",
-        "answer": "users"
-      }
     }
   ],
   "taskEvents": {
@@ -358,16 +331,10 @@
       {
         "seq": 2,
         "at": "2026-04-13T10:00:00.000Z",
-        "type": "attention_required",
-        "status": "blocked",
-        "message": "which database?"
-      },
-      {
-        "seq": 3,
-        "at": "2026-04-13T10:00:00.000Z",
         "type": "status_changed",
-        "status": "running",
-        "message": "Blocker question answered"
+        "status": "completed",
+        "summary": "done",
+        "message": "Task completed"
       }
     ]
   }

--- a/tests/unit/orchestration/golden/fixtures/listgroupsummaries-sorts-multiple-groups-for-the-same-coordinator-snapshot.json
+++ b/tests/unit/orchestration/golden/fixtures/listgroupsummaries-sorts-multiple-groups-for-the-same-coordinator-snapshot.json
@@ -1,0 +1,127 @@
+{
+  "state": {
+    "sessions": {},
+    "chat_contexts": {},
+    "native_session_lists": {},
+    "orchestration": {
+      "tasks": {},
+      "workerBindings": {},
+      "groups": {
+        "g1": {
+          "groupId": "g1",
+          "coordinatorSession": "backend:main",
+          "title": "alpha",
+          "createdAt": "2026-04-13T10:00:00.000Z",
+          "updatedAt": "2026-04-13T10:00:00.000Z"
+        },
+        "g2": {
+          "groupId": "g2",
+          "coordinatorSession": "backend:main",
+          "title": "beta",
+          "createdAt": "2026-04-13T10:00:00.000Z",
+          "updatedAt": "2026-04-13T10:00:00.000Z"
+        }
+      },
+      "humanQuestionPackages": {},
+      "coordinatorQuestionState": {},
+      "coordinatorRoutes": {},
+      "externalCoordinators": {}
+    },
+    "scheduled_tasks": {}
+  },
+  "calls": [
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "saveState",
+      "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "alpha",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "humanQuestionPackages": [],
+        "tasks": [],
+        "workerBindings": []
+      }
+    },
+    {
+      "port": "logger.info",
+      "request": {
+        "event": "orchestration.group.created",
+        "message": "group created",
+        "context": {
+          "group_id": "g1",
+          "coordinator_session": "backend:main",
+          "title": "alpha"
+        }
+      }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "saveState",
+      "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "alpha",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          },
+          {
+            "key": "g2",
+            "value": {
+              "groupId": "g2",
+              "coordinatorSession": "backend:main",
+              "title": "beta",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "humanQuestionPackages": [],
+        "tasks": [],
+        "workerBindings": []
+      }
+    },
+    {
+      "port": "logger.info",
+      "request": {
+        "event": "orchestration.group.created",
+        "message": "group created",
+        "context": {
+          "group_id": "g2",
+          "coordinator_session": "backend:main",
+          "title": "beta"
+        }
+      }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    }
+  ],
+  "taskEvents": {}
+}

--- a/tests/unit/orchestration/golden/fixtures/markcoordinatorgroupsinjectionfailed-records-the-failure.json
+++ b/tests/unit/orchestration/golden/fixtures/markcoordinatorgroupsinjectionfailed-records-the-failure.json
@@ -69,10 +69,15 @@
   },
   "calls": [
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
-        "tasks": [],
-        "workerBindings": [],
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
         "groups": [
           {
             "key": "g1",
@@ -86,9 +91,8 @@
           }
         ],
         "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        "tasks": [],
+        "workerBindings": []
       }
     },
     {
@@ -114,6 +118,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -125,8 +133,28 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "review",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -168,23 +196,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [
-          {
-            "key": "g1",
-            "value": {
-              "groupId": "g1",
-              "coordinatorSession": "backend:main",
-              "title": "review",
-              "createdAt": "2026-04-13T10:00:00.000Z",
-              "updatedAt": "2026-04-13T10:00:00.000Z"
-            }
-          }
-        ],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -214,8 +226,28 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "review",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z"
+            }
+          }
+        ],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -266,23 +298,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [
-          {
-            "key": "g1",
-            "value": {
-              "groupId": "g1",
-              "coordinatorSession": "backend:main",
-              "title": "review",
-              "createdAt": "2026-04-13T10:00:00.000Z",
-              "updatedAt": "2026-04-13T10:00:00.000Z"
-            }
-          }
-        ],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -301,8 +317,30 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [
+          {
+            "key": "g1",
+            "value": {
+              "groupId": "g1",
+              "coordinatorSession": "backend:main",
+              "title": "review",
+              "createdAt": "2026-04-13T10:00:00.000Z",
+              "updatedAt": "2026-04-13T10:00:00.000Z",
+              "injectionPending": true,
+              "lastInjectionError": "injection blew up"
+            }
+          }
+        ],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -353,25 +391,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [
-          {
-            "key": "g1",
-            "value": {
-              "groupId": "g1",
-              "coordinatorSession": "backend:main",
-              "title": "review",
-              "createdAt": "2026-04-13T10:00:00.000Z",
-              "updatedAt": "2026-04-13T10:00:00.000Z",
-              "injectionPending": true,
-              "lastInjectionError": "injection blew up"
-            }
-          }
-        ],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     }
   ],

--- a/tests/unit/orchestration/golden/fixtures/marktasknoticepending-marks-a-tasks-notice-pending-state.json
+++ b/tests/unit/orchestration/golden/fixtures/marktasknoticepending-marks-a-tasks-notice-pending-state.json
@@ -60,6 +60,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -71,8 +75,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -113,12 +126,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -147,8 +155,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -190,12 +207,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     }
   ],

--- a/tests/unit/orchestration/golden/fixtures/notice-lifecycle-pending-delivered.json
+++ b/tests/unit/orchestration/golden/fixtures/notice-lifecycle-pending-delivered.json
@@ -73,6 +73,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -84,8 +88,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -128,12 +141,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -162,8 +170,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -216,12 +233,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -239,8 +251,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -295,12 +316,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {

--- a/tests/unit/orchestration/golden/fixtures/purgesessionreferences-drops-bindings-and-metadata-state.json
+++ b/tests/unit/orchestration/golden/fixtures/purgesessionreferences-drops-bindings-and-metadata-state.json
@@ -26,6 +26,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -37,8 +41,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -79,12 +92,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -113,8 +121,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -164,12 +181,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -187,15 +199,19 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
-        "tasks": [],
-        "workerBindings": [],
-        "groups": [],
-        "humanQuestionPackages": [],
         "coordinatorQuestionState": [],
         "coordinatorRoutes": [],
-        "externalCoordinators": []
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
+        "tasks": [],
+        "workerBindings": []
       }
     }
   ],

--- a/tests/unit/orchestration/golden/fixtures/reconcileparallelslots-drains-a-queued-task-when.json
+++ b/tests/unit/orchestration/golden/fixtures/reconcileparallelslots-drains-a-queued-task-when.json
@@ -94,6 +94,14 @@
   },
   "calls": [
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main:p-task-1-slot",
@@ -105,8 +113,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -149,12 +166,7 @@
               "ephemeral": true
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -183,8 +195,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -256,12 +277,7 @@
               "ephemeral": true
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -276,8 +292,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -358,12 +383,7 @@
               "ephemeral": true
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -381,8 +401,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -453,12 +482,7 @@
             }
           }
         ],
-        "workerBindings": [],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        "workerBindings": []
       }
     },
     {
@@ -471,8 +495,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -554,12 +587,7 @@
               "ephemeral": true
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -585,8 +613,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -675,12 +712,7 @@
               "ephemeral": true
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -693,6 +725,10 @@
           "targetAgent": "claude"
         }
       }
+    },
+    {
+      "port": "loadState",
+      "request": null
     }
   ],
   "taskEvents": {

--- a/tests/unit/orchestration/golden/fixtures/recordworkerreply-completes-the-task-and-marks-state.json
+++ b/tests/unit/orchestration/golden/fixtures/recordworkerreply-completes-the-task-and-marks-state.json
@@ -71,6 +71,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -82,8 +86,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -126,12 +139,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -160,8 +168,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -214,12 +231,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {

--- a/tests/unit/orchestration/golden/fixtures/requestdelegate-human-path-at-parallel-capacity.json
+++ b/tests/unit/orchestration/golden/fixtures/requestdelegate-human-path-at-parallel-capacity.json
@@ -77,6 +77,14 @@
   },
   "calls": [
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main:p-task-1-slot",
@@ -88,8 +96,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -132,12 +149,7 @@
               "ephemeral": true
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -166,8 +178,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -239,12 +260,7 @@
               "ephemeral": true
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {

--- a/tests/unit/orchestration/golden/fixtures/requestdelegate-human-path-creates-a-running.json
+++ b/tests/unit/orchestration/golden/fixtures/requestdelegate-human-path-creates-a-running.json
@@ -59,6 +59,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -70,8 +74,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -112,12 +125,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {

--- a/tests/unit/orchestration/golden/fixtures/requestdelegatefromrpc-creates-a-task-and-returns-rpc-state.json
+++ b/tests/unit/orchestration/golden/fixtures/requestdelegatefromrpc-creates-a-task-and-returns-rpc-state.json
@@ -58,6 +58,10 @@
   },
   "calls": [
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "findReusableWorkerSession",
       "request": {
         "sourceHandle": "backend:main",
@@ -68,8 +72,21 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -110,12 +127,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -142,6 +154,14 @@
           "worker_session": "backend:claude:backend:main"
         }
       }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
     },
     {
       "port": "dispatchWorkerTask",

--- a/tests/unit/orchestration/golden/fixtures/requesttaskcancellation-drains-its-detached-chain.json
+++ b/tests/unit/orchestration/golden/fixtures/requesttaskcancellation-drains-its-detached-chain.json
@@ -75,6 +75,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -86,8 +90,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -128,12 +141,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -162,8 +170,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -212,12 +229,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -235,6 +247,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "cancelWorkerTask",
       "request": {
         "taskId": "task-1",
@@ -244,8 +260,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -302,12 +327,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -323,6 +343,14 @@
           "worker_session": "backend:claude:backend:main"
         }
       }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
     }
   ],
   "taskEvents": {

--- a/tests/unit/orchestration/golden/fixtures/reservelogicaltransportsession-reserves-and-releases-snapshot.json
+++ b/tests/unit/orchestration/golden/fixtures/reservelogicaltransportsession-reserves-and-releases-snapshot.json
@@ -1,0 +1,28 @@
+{
+  "state": {
+    "sessions": {},
+    "chat_contexts": {},
+    "native_session_lists": {},
+    "orchestration": {
+      "tasks": {},
+      "workerBindings": {},
+      "groups": {},
+      "humanQuestionPackages": {},
+      "coordinatorQuestionState": {},
+      "coordinatorRoutes": {},
+      "externalCoordinators": {}
+    },
+    "scheduled_tasks": {}
+  },
+  "calls": [
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "loadState",
+      "request": null
+    }
+  ],
+  "taskEvents": {}
+}

--- a/tests/unit/orchestration/golden/fixtures/workerraisequestion-blocks-the-task-and-wakes.json
+++ b/tests/unit/orchestration/golden/fixtures/workerraisequestion-blocks-the-task-and-wakes.json
@@ -74,6 +74,10 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "ensureWorkerSession",
       "request": {
         "workerSession": "backend:claude:backend:main",
@@ -85,8 +89,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -127,12 +140,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {
@@ -161,8 +169,17 @@
       }
     },
     {
+      "port": "loadState",
+      "request": null
+    },
+    {
       "port": "saveState",
       "request": {
+        "coordinatorQuestionState": [],
+        "coordinatorRoutes": [],
+        "externalCoordinators": [],
+        "groups": [],
+        "humanQuestionPackages": [],
         "tasks": [
           {
             "key": "task-1",
@@ -218,12 +235,7 @@
               "targetAgent": "claude"
             }
           }
-        ],
-        "groups": [],
-        "humanQuestionPackages": [],
-        "coordinatorQuestionState": [],
-        "coordinatorRoutes": [],
-        "externalCoordinators": []
+        ]
       }
     },
     {

--- a/tests/unit/orchestration/golden/golden-harness.test.ts
+++ b/tests/unit/orchestration/golden/golden-harness.test.ts
@@ -208,3 +208,32 @@ test("an empty collection and an empty array do not digest alike", async () => {
   expect(objectDigest["externalCoordinators"]).toEqual([]);
   await expect(arrayHarness.deps.saveState(asArray)).rejects.toThrow(/is not a keyed record/);
 });
+
+test("state reads are recorded, interleaved with the writes they order against", async () => {
+  // A check-then-act race lives in exactly one dimension: where the read sits relative to
+  // the write. While `loadState` went unrecorded, a change that dropped a read, added one,
+  // or moved it to the wrong side of a save left every fixture green. Ports were logged;
+  // the reads between them were not.
+  const harness = makeGoldenHarness();
+
+  await harness.deps.loadState();
+  await harness.deps.saveState(createEmptyState());
+  await harness.deps.loadState();
+
+  expect(harness.calls.map((call) => call.port)).toEqual(["loadState", "saveState", "loadState"]);
+  expect(harness.calls[0]!.request).toBeNull();
+});
+
+test("loadState hands out a copy, so a caller cannot mutate the harness's state", async () => {
+  // `loadState` returns `cloneState(state)`. If it ever returned the live object, a service
+  // could mutate persisted state without a `saveState` — invisible to the digest, which only
+  // renders what a save was given.
+  const harness = makeGoldenHarness();
+  const first = await harness.deps.loadState();
+  first.orchestration.tasks["injected"] = { taskId: "injected" } as never;
+
+  const second = await harness.deps.loadState();
+
+  expect(second.orchestration.tasks).toEqual({});
+  expect(harness.getState().orchestration.tasks).toEqual({});
+});

--- a/tests/unit/orchestration/golden/golden-harness.ts
+++ b/tests/unit/orchestration/golden/golden-harness.ts
@@ -9,8 +9,8 @@
 //   * `loadState`, recorded with a `null` argument because it takes none. Its POSITION in the
 //     log is the signal: a read-modify-write that grows or loses a read, or that reads on the
 //     wrong side of a write, moves a `loadState` entry and turns the affected fixtures red.
-//     Until this was recorded, the count and position of state reads were invisible to all 30
-//     fixtures — the exact dimension a check-then-act race lives in.
+//     Until this was recorded, the count and position of state reads were invisible to every
+//     fixture — the exact dimension a check-then-act race lives in.
 //   * `now` and `createId` are NOT recorded, and need not be: `now` is a fixed instant and
 //     `createId` a fixed sequence, so each leaves its trace in the state it stamps.
 //
@@ -30,7 +30,7 @@
 //   (cd /tmp/baseline && bun test tests/unit/orchestration/golden/orchestration-golden.test.ts)
 //
 // 24 pass, GOLDEN_UPDATE unset. The pre-refactor facade and every refactored unit satisfy
-// the same thirty fixtures.
+// the same fixtures.
 //
 // "Satisfy", not "reproduce byte-for-byte". Three different claims get confused here, so
 // be precise about which one you are making:

--- a/tests/unit/orchestration/golden/golden-harness.ts
+++ b/tests/unit/orchestration/golden/golden-harness.ts
@@ -92,8 +92,13 @@ function cloneState(state: AppState): AppState {
  *
  * Reading the keys off the object closes that. A collection that appears, disappears, or is
  * added to the type all change the digest's key set, so every fixture that records an
- * affected save goes red. (Adding an eighth collection to `createEmptyOrchestrationState`
- * turns 21 of the 24 golden tests red; the other three never reach a save.)
+ * affected save goes red. Measured: adding an eighth collection to
+ * `createEmptyOrchestrationState` turns all 24 golden tests red — 21 through a save's digest,
+ * and the three query tests (`listGroupSummaries` ×2, `reserveLogicalTransportSession`)
+ * through the `state` in their snapshot. Those three used to be the exception, back when they
+ * asserted only a return value; `reserveLogicalTransportSession` still records no `saveState`
+ * at all and goes red anyway. Do not restate that exception without re-measuring it — it was
+ * true and then a later commit made it false.
  *
  * Each collection becomes `{ key, value }` entries, sorted by key. `{ key, value }` rather
  * than `{ ...record, key }` on purpose: spreading the record and stamping the map key over

--- a/tests/unit/orchestration/golden/golden-harness.ts
+++ b/tests/unit/orchestration/golden/golden-harness.ts
@@ -3,18 +3,16 @@
 // ORDERED log of its outbound EFFECT calls, and each task's event sequence. Line coverage
 // cannot see a reordered side effect; this can.
 //
-// Three deps are deliberately not in that log, and it is worth knowing which:
-//   * `saveState` and every worker/coordinator port ARE recorded, argument included, plus
-//     `logger.*` — so a dropped, renamed or reordered observability call is caught too.
-//   * `loadState`, `now` and `createId` are NOT recorded. `now` is a fixed instant and
-//     `createId` a fixed sequence, so their effect shows up in the state they stamp. But
-//     `loadState` is a genuine gap: the COUNT and POSITION of state reads is invisible to
-//     every fixture, so a change that adds or drops a read cannot turn one red.
-//     Measured, not assumed — instrumenting `loadState` and replaying all 24 golden tests
-//     against the 4539-line monolith at bf767b0 and against the split gives the identical
-//     per-test sequence (2 4 5 6 9 7 3 1 10 11 4 6 7 9 7 3 4 4 5 4 4 2; 117 reads). So this
-//     is a latent hole, not an escape. Closing it means re-recording every fixture from the
-//     baseline; see the follow-up issue rather than doing it inside a behaviour-preserving PR.
+// Every dep that reads or writes state, and every outbound port, is in that log:
+//   * `saveState` and every worker/coordinator port, argument included, plus `logger.*` — so
+//     a dropped, renamed or reordered observability call is caught too.
+//   * `loadState`, recorded with a `null` argument because it takes none. Its POSITION in the
+//     log is the signal: a read-modify-write that grows or loses a read, or that reads on the
+//     wrong side of a write, moves a `loadState` entry and turns the affected fixtures red.
+//     Until this was recorded, the count and position of state reads were invisible to all 30
+//     fixtures — the exact dimension a check-then-act race lives in.
+//   * `now` and `createId` are NOT recorded, and need not be: `now` is a fixed instant and
+//     `createId` a fixed sequence, so each leaves its trace in the state it stamps.
 //
 // Deliberately independent of orchestration-service.test.ts: that file is the
 // regression oracle and must stay byte-identical, so nothing can be exported from it.
@@ -200,7 +198,13 @@ export function makeGoldenHarness(overrides: GoldenHarnessOverrides = {}): Golde
       }
       return id;
     },
-    loadState: async () => cloneState(state),
+    // `loadState` takes no argument, so `null` is all there is to record. The entry's
+    // POSITION in `calls` is the whole point: it pins where each read sits relative to the
+    // saves and effects around it.
+    loadState: async () => {
+      record("loadState", null);
+      return cloneState(state);
+    },
     saveState: async (nextState) => {
       // Record the WHOLE orchestration subtree on every save, verbatim: every runtime
       // collection, every record complete, nothing projected away.

--- a/tests/unit/orchestration/golden/orchestration-concurrency.test.ts
+++ b/tests/unit/orchestration/golden/orchestration-concurrency.test.ts
@@ -29,6 +29,7 @@ import { expect, test } from "bun:test";
 
 import { createConfig } from "../../commands/command-router-test-support";
 import { OrchestrationService } from "../../../../src/orchestration/orchestration-service";
+import { createEmptyState } from "../../../../src/state/types";
 import { makeGoldenHarness } from "./golden-harness";
 
 function deferred<T>() {
@@ -141,6 +142,198 @@ test("concurrency: two parallel delegations at cap 1 dispatch exactly one and qu
   // queued.
   expect(statuses).toEqual(["queued", "running"]);
   expect(dispatches).toBe(statuses.filter((s) => s === "running").length);
+});
+
+test("concurrency: two parallel needs_confirmation tasks approved at cap 1 dispatch exactly one", async () => {
+  // approveTask's parallel gate reads capacity in one mutate() and persists `running` in a
+  // later one, exactly like the two delegation paths — but unlike them it never called
+  // claimParallelStart. countActiveParallelSlots counts tasks persisted as running/blocked/
+  // waiting_for_human, PLUS pendingParallelStarts. Between the gate mutate's exit and the
+  // persist mutate, an approving task belongs to neither set, so a second concurrent
+  // approve saw a free slot that was already spoken for and both dispatched.
+  //
+  // Worker-sourced parallel tasks are the only ones that reach here: rpc-delegation-service
+  // gates only `input.parallel && autoRun`, and autoRun is false for worker-sourced requests
+  // (hence `needs_confirmation`), so their gate is deferred to approveTask.
+  const harness = makeGoldenHarness({
+    ids: ["task-1", "task-1-slot", "task-2", "task-2-slot"],
+    config: {
+      ...cappedConfig,
+      orchestration: { ...cappedConfig.orchestration, allowWorkerChainedRequests: true },
+    },
+    initialState: {
+      ...createEmptyState(),
+      orchestration: {
+        ...createEmptyState().orchestration,
+        workerBindings: {
+          "backend:claude:backend:main": {
+            sourceHandle: "backend:claude:backend:main",
+            coordinatorSession: "backend:main",
+            workspace: "backend",
+            targetAgent: "claude",
+          },
+        },
+      },
+    },
+  });
+  const service = new OrchestrationService(harness.deps);
+
+  for (const task of ["first", "second"]) {
+    await service.requestDelegateFromRpc({
+      sourceHandle: "backend:claude:backend:main",
+      targetAgent: "codex",
+      role: "reviewer",
+      task,
+      parallel: true,
+    });
+  }
+  expect(
+    Object.values(harness.getState().orchestration.tasks).map((t) => t.status).sort(),
+  ).toEqual(["needs_confirmation", "needs_confirmation"]);
+
+  // Approve both concurrently. Sequentially this already works: the first is persisted
+  // `running` before the second's gate reads capacity.
+  const results = await Promise.allSettled([
+    service.approveTask({ coordinatorSession: "backend:main", taskId: "task-1" }),
+    service.approveTask({ coordinatorSession: "backend:main", taskId: "task-2" }),
+  ]);
+
+  const state = harness.getState();
+  const running = Object.values(state.orchestration.tasks).filter((t) => t.status === "running");
+  const dispatches = harness.calls.filter((call) => call.port === "dispatchWorkerTask").length;
+
+  expect(running.length).toBeLessThanOrEqual(cappedConfig.orchestration.maxParallelTasksPerAgent);
+  expect(dispatches).toBe(running.length);
+  // The loser must be parked, not lost: `queued` (gate saw the slot taken) is the intended
+  // outcome. A rejection would also cap the agent, but it would drop the task, so assert on
+  // the status rather than merely on the dispatch count.
+  expect(Object.values(state.orchestration.tasks).map((t) => t.status).sort()).toEqual([
+    "queued",
+    "running",
+  ]);
+  expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+});
+
+/** Two worker-chained parallel tasks, both `needs_confirmation`, ready to approve. */
+async function makeTwoPendingParallelApprovals(maxParallelTasksPerAgent = 1) {
+  const empty = createEmptyState();
+  const harness = makeGoldenHarness({
+    ids: ["task-1", "task-1-slot", "task-2", "task-2-slot"],
+    config: {
+      ...cappedConfig,
+      orchestration: {
+        ...cappedConfig.orchestration,
+        allowWorkerChainedRequests: true,
+        maxParallelTasksPerAgent,
+      },
+    },
+    initialState: {
+      ...empty,
+      orchestration: {
+        ...empty.orchestration,
+        workerBindings: {
+          "backend:claude:backend:main": {
+            sourceHandle: "backend:claude:backend:main",
+            coordinatorSession: "backend:main",
+            workspace: "backend",
+            targetAgent: "claude",
+          },
+        },
+      },
+    },
+  });
+  const service = new OrchestrationService(harness.deps);
+  for (const task of ["first", "second"]) {
+    await service.requestDelegateFromRpc({
+      sourceHandle: "backend:claude:backend:main",
+      targetAgent: "codex",
+      role: "reviewer",
+      task,
+      parallel: true,
+    });
+  }
+  return { harness, service };
+}
+
+test("approveTask releases its parallel slot when the worker-session reservation fails", async () => {
+  // `reserveProposedWorkerSession` runs after the gate has claimed the slot and outside the
+  // try/catch that guards the rest. A leak here is silent and permanent: the agent's
+  // capacity shrinks by one for the lifetime of the process, and nothing in state shows it.
+  //
+  // Make the reservation throw by parking a running task on task-1's ephemeral worker-session
+  // name. It belongs to a DIFFERENT agent, so it does not consume codex's parallel capacity —
+  // countActiveParallelSlots keys on targetAgent + ephemeralWorkerSession, while
+  // hasActiveTaskWorkerSession keys on the session name alone. Injected after both tasks
+  // exist: requestDelegateFromRpc reserves the proposed session at creation time, so seeding
+  // this into the harness's initial state would make task creation throw instead.
+  const { harness, service } = await makeTwoPendingParallelApprovals();
+  const state = harness.getState();
+  const task1WorkerSession = state.orchestration.tasks["task-1"]!.workerSession!;
+  state.orchestration.tasks["blocker"] = {
+    taskId: "blocker",
+    sourceHandle: "wx:user-1",
+    sourceKind: "human",
+    coordinatorSession: "backend:main",
+    workerSession: task1WorkerSession,
+    workspace: "backend",
+    targetAgent: "claude",
+    task: "holds the session name",
+    status: "running",
+    summary: "",
+    resultText: "",
+    createdAt: "2026-04-13T10:00:00.000Z",
+    updatedAt: "2026-04-13T10:00:00.000Z",
+    eventSeq: 0,
+    events: [],
+  } as never;
+  await harness.deps.saveState(state);
+
+  await expect(
+    service.approveTask({ coordinatorSession: "backend:main", taskId: "task-1" }),
+  ).rejects.toThrow(/already in use/);
+
+  // The slot task-1 claimed must be back. If it leaked, task-2's gate reads capacity as
+  // full and parks it as `queued` instead of running it.
+  const approved = await service.approveTask({ coordinatorSession: "backend:main", taskId: "task-2" });
+  expect(approved.status).toBe("running");
+});
+
+test("approveTask releases its parallel slot after a successful approve", async () => {
+  // The success path must release too, once the task is persisted as `running` and
+  // countActiveParallelSlots counts it for real. Holding the pending claim as well would
+  // double-count the task and shrink the agent's capacity by one, permanently.
+  //
+  // Cap 2, not 1: at cap 1 the leak is invisible, because the first task's `running` status
+  // already fills the cap and the second is correctly queued either way. The bug only shows
+  // where a second slot should still be free.
+  const { harness, service } = await makeTwoPendingParallelApprovals(2);
+
+  const first = await service.approveTask({ coordinatorSession: "backend:main", taskId: "task-1" });
+  expect(first.status).toBe("running");
+
+  const second = await service.approveTask({ coordinatorSession: "backend:main", taskId: "task-2" });
+  expect(second.status).toBe("running");
+
+  const dispatches = harness.calls.filter((call) => call.port === "dispatchWorkerTask").length;
+  expect(dispatches).toBe(2);
+});
+
+test("approveTask releases its parallel slot when ensureWorkerSession fails", async () => {
+  const { harness, service } = await makeTwoPendingParallelApprovals();
+  const baseEnsure = harness.deps.ensureWorkerSession;
+  let ensureCalls = 0;
+  harness.deps.ensureWorkerSession = async (request) => {
+    ensureCalls += 1;
+    if (ensureCalls === 1) throw new Error("acpx refused the session");
+    return await baseEnsure(request);
+  };
+
+  await expect(
+    service.approveTask({ coordinatorSession: "backend:main", taskId: "task-1" }),
+  ).rejects.toThrow(/acpx refused the session/);
+
+  const approved = await service.approveTask({ coordinatorSession: "backend:main", taskId: "task-2" });
+  expect(approved.status).toBe("running");
 });
 
 test("concurrency: reconcileParallelSlots racing a delegation never over-dispatches", async () => {

--- a/tests/unit/orchestration/golden/orchestration-concurrency.test.ts
+++ b/tests/unit/orchestration/golden/orchestration-concurrency.test.ts
@@ -318,6 +318,31 @@ test("approveTask releases its parallel slot after a successful approve", async 
   expect(dispatches).toBe(2);
 });
 
+test("approveTask releases its parallel slot when the dispatch fails and rolls back", async () => {
+  // The last exit path, and the one that pins WHERE the success-path release sits. Moving
+  // that release to after `dispatchWorkerTask` is a legal, type-checking edit that keeps
+  // every other test in this file green and the frozen 185-test oracle green — and leaks a
+  // slot on every failed dispatch, because the rollback restores `needs_confirmation`
+  // (the task stops counting) while the pending claim is never given back.
+  const { harness, service } = await makeTwoPendingParallelApprovals();
+  const baseDispatch = harness.deps.dispatchWorkerTask;
+  let dispatches = 0;
+  harness.deps.dispatchWorkerTask = async (request) => {
+    dispatches += 1;
+    if (dispatches === 1) throw new Error("acpx refused the prompt");
+    await baseDispatch(request);
+  };
+
+  await expect(
+    service.approveTask({ coordinatorSession: "backend:main", taskId: "task-1" }),
+  ).rejects.toThrow(/acpx refused the prompt/);
+  // The rollback put task-1 back where it started, so the cap is free again.
+  expect(harness.getState().orchestration.tasks["task-1"]!.status).toBe("needs_confirmation");
+
+  const approved = await service.approveTask({ coordinatorSession: "backend:main", taskId: "task-2" });
+  expect(approved.status).toBe("running");
+});
+
 test("approveTask releases its parallel slot when ensureWorkerSession fails", async () => {
   const { harness, service } = await makeTwoPendingParallelApprovals();
   const baseEnsure = harness.deps.ensureWorkerSession;

--- a/tests/unit/orchestration/golden/orchestration-golden.test.ts
+++ b/tests/unit/orchestration/golden/orchestration-golden.test.ts
@@ -5,7 +5,7 @@
 //
 // DO NOT set GOLDEN_UPDATE=1 outside Tasks 2-6. A failing fixture after a refactor task
 // means the refactor changed observable behaviour.
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 
 import { createConfig } from "../../commands/command-router-test-support";
 import { OrchestrationService } from "../../../../src/orchestration/orchestration-service";
@@ -442,10 +442,23 @@ test("golden: listGroupSummaries reflects task status rollup", async () => {
   // listGroupSummaries is async (orchestration-service.ts:451) — the brief's snippet
   // omitted the `await`, which would have snapshotted an unresolved Promise instead of
   // the summaries.
+  // Everything above is setup, and it writes. Mark the log here so the next assertion can
+  // speak about listGroupSummaries alone.
+  const callsBeforeQuery = harness.calls.length;
+
   expectMatchesFixture(
     "listgroupsummaries-reflects-task-status-rollup",
     await service.listGroupSummaries({ coordinatorSession: "backend:main" }),
   );
+
+  // listGroupSummaries is a query: it must read and persist nothing. A lazily-materialised
+  // rollup that saved on read would slip past the returned value, which is identical either
+  // way. The snapshot below cannot say this on its own — it covers the setup writes too.
+  expect(harness.calls.slice(callsBeforeQuery).map((call) => call.port)).toEqual(["loadState"]);
+
+  // Snapshot as well as the return value: without it, this test's entire port-call log went
+  // unchecked. Three of the 24 golden tests were in that state.
+  expectMatchesFixture("listgroupsummaries-reflects-task-status-rollup-snapshot", harness.snapshot());
 });
 
 // The scenario above only ever creates ONE group, so `.sort((left, right) => {...})`
@@ -464,9 +477,17 @@ test("golden: listGroupSummaries sorts multiple groups for the same coordinator"
   await service.createGroup({ coordinatorSession: "backend:main", title: "alpha" });
   await service.createGroup({ coordinatorSession: "backend:main", title: "beta" });
 
+  const callsBeforeQuery = harness.calls.length;
+
   expectMatchesFixture(
     "listgroupsummaries-sorts-multiple-groups-for-the-same-coordinator",
     await service.listGroupSummaries({ coordinatorSession: "backend:main" }),
+  );
+
+  expect(harness.calls.slice(callsBeforeQuery).map((call) => call.port)).toEqual(["loadState"]);
+  expectMatchesFixture(
+    "listgroupsummaries-sorts-multiple-groups-for-the-same-coordinator-snapshot",
+    harness.snapshot(),
   );
 });
 
@@ -986,4 +1007,7 @@ test("golden: reserveLogicalTransportSession reserves and releases", async () =>
   await release();
 
   expectMatchesFixture("reservelogicaltransportsession-reserves-and-releases-second-reservation", blocked);
+  // The reservation lives in an in-memory map, not in AppState. Snapshotting pins the one
+  // thing a fixture CAN see about it: that reserving and releasing performs no persistence.
+  expectMatchesFixture("reservelogicaltransportsession-reserves-and-releases-snapshot", harness.snapshot());
 });


### PR DESCRIPTION
两个 commit,顺序是刻意的:先让 bug 可观测,再修 bug。

## 1. `#152` — golden oracle 记录 `loadState`

黄金 harness 记录每一次写入和每一个出站端口,**但不记录它们之间的读取**。而 check-then-act 竞态恰恰只活在这一个维度里:读取相对写入的位置。

不靠论证,靠测量。往 `requestTaskCancellation` 里塞一次多余的 `await this.deps.loadState()`:

| | golden |
|---|---|
| `origin/main`(改动前的 harness) | **24 pass / 0 fail** — 完全看不见 |
| 本分支 | **22 pass / 2 fail** — 抓住了 |

冻结的 185 条 oracle 在该变异下也会红一条,但那是 **5000ms 超时**,不是检测:`startWorkerCancellation reads fresh workerSession from state` 把 `loadState` 挂在一个 blocker promise 上,多读一次就永远等下去。它对读取不做任何断言。

**fixture 从基线重录**,遵守 harness 自己写下的规矩:33 个 fixture 由 `bf767b0` 的 4539 行单体配新 harness 写出,再在拆分后的实现上以 `GOLDEN_UPDATE` 未设的方式复现全绿。**diff 当规格审过**:把新增的 `loadState` 条目从 21 个变化的快照里剔除后,每一个都与旧版本深度相等——唯一的语义变化就是那 106 条读取记录。(21 个既有 fixture 106 条,3 个新增 snapshot fixture 另有 10 条,合计 116。)

顺带补了一个比 `#152` 更宽的洞:**24 条 golden 测试里有 3 条只断言返回值、从不取快照**,它们的整条端口调用日志无人核对。现在都取快照了。两条 `listGroupSummaries` 还额外断言查询本身**只读一次、零写入**——一个会在读取时落盘的懒物化 rollup 能让它们变红,而冻结 oracle 全绿(已变异验证)。

新增 2 条契约测试:读取与写入在日志里交错出现;`loadState` 交出的是副本,调用方无法绕过 `saveState` 改写持久化状态。

## 2. `#148` — `approveTask` 的并行槽 TOCTOU

`approveTask` 在 gate mutate 里查 `canStartParallelTask`,**却从不 `claimParallelStart`**。另外两条 delegation 路径都 claim。

`countActiveParallelSlots` 数的是持久化为 `running`/`blocked`/`waiting_for_human` 的任务,**加上** `pendingParallelStarts`。从 gate mutate 退出到 persist mutate 之间,一个正在被批准的任务**两者皆不属于**。

先复现:`maxParallelTasksPerAgent: 1`,并发批准两个 `needs_confirmation` 并行任务 → **2 个 running,2 次 dispatch**,超发一个。只有 worker-sourced 的并行任务能走到这里(`rpc-delegation-service` 只对 `input.parallel && autoRun` 设闸门,而 worker-sourced 请求 autoRun 为 false —— 这正是它们成为 `needs_confirmation` 的原因)。

修法:在 gate 的临界区里占住 slot,并在**每一条出口**上恰好释放一次。`reserveProposedWorkerSession` 位于既有 `try/catch` **之外**且会抛错,需要单独的守卫——那里泄漏一个 slot 是静默且永久的,agent 容量在进程余生里少一个,而状态里看不出任何痕迹。

成功路径也要释放,在任务持久化为 `running`、持久化计数开始覆盖它之后。不是在 dispatch 之后:dispatch 失败路径会回滚状态,自己就把 slot 放了。

四条测试,每一条都经变异验证——删掉对应的那一行,它就变红:

| 删掉 | 变红的测试 |
|---|---|
| `claimParallelStart` | 并发批准 |
| reservation 失败时的 release | reservation-fail |
| ensure 失败时的 release | ensure-fail |
| 成功路径的 release | success-path |

最后一条**特意用 cap 2**。cap 1 下泄漏不可见:第一个任务的 `running` 已经填满容量,第二个无论如何都会被正确排队。我写的第一版就是 cap 1,对着泄漏全绿,是变异把它揪出来的。

修复不改任何 fixture:claim/release 只动内存 map,不触碰持久化状态。

## 验证

```
357 条编排测试 pass / 0 fail(逐文件跑)
npx tsc --noEmit  → 0 errors
冻结的 185 条 oracle 相对 origin/main 零 diff
GOLDEN_UPDATE 未设
```

## 3. 两轮 opus 独立评审(各自独立 worktree)

**TOCTOU 评审**在被 API 配额掐断前留下一个可检验的假设,我复现了,它是对的——**我漏了一条出口**:

把成功路径的 `releaseParallelStartOnce()` 移到 `dispatchWorkerTask` **之后**,是一条合法、`tsc` 零错的改动,**九条并发测试全绿,185 条冻结 oracle 也全绿**——而每一次 dispatch 失败都会泄漏一个 slot:回滚把任务改回 `needs_confirmation`(不再计数),pending claim 却永远不还。

release 本来就在 dispatch 之前。缺的是一条**说它必须在那儿**的测试。已补,并变异验证它是唯一能杀死该错误实现的测试。

claim 之后的每一条出口现在都**实测**过(直接观测 `pendingParallelStarts`),不是论证:

| 出口 | pending |
|---|---|
| 成功返回 | 0 |
| persist mutate 内抛错 | 0 |
| `saveState` 拒绝 | 0 |
| `dispatchWorkerTask` 抛错(走回滚) | 0 |
| gate 排队(从未 claim) | 0,无负数释放 |

另外让 release 使用**被 claim 的那个 agent**,而不是回头去读 `currentTask.targetAgent`——今天两者必然相同(`task.targetAgent` 创建后无任何赋值),但一个重新推导 key 的 release 只可能出错,不可能更对。

**Oracle 评审**独立复现了 provenance(基线重录可再现,结构零 mismatch)、fixture diff(纯粹是新增 `loadState` 条目)、以及新记录的**双向**承重(多读 → 2 条红;少读 → 18 条红;旧 oracle 对多读全绿)。并抓到我一句**改了代码却没重新测量的注释**:

> "Adding an eighth collection … turns 21 of the 24 golden tests red; the other three never reach a save."

这话在 `origin/main` 上成立(实测 21 fail / 3 pass),在本分支上不成立(**24 fail / 0 pass**)——因为**本 PR 正是给那三条 query 测试加了 snapshot**。`reserveLogicalTransportSession` 一次 `saveState` 都没有,却照样变红:它红在快照的 `state` 上,不在 digest 上。注释已按实测改写。
