### PR TITLE
refactor(control): split executeTurn into TurnQueue + SessionTurnRunner

### DIFF
--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -3,15 +3,29 @@
 `ControlService` 是面向结构化消费者（首个是 relay 连接器，见
 [docs/superpowers/specs/2026-06-13-relay-hub-design.md](superpowers/specs/2026-06-13-relay-hub-design.md)）的核心控制门面。
 它聚合了 `SessionService` / `ActiveTurnRegistry` / `ScheduledTaskService` /
-`OrchestrationService` / `ConsoleAgent`（ChatAgent），自身无持久状态——仅在内存里
-跟踪 in-flight turn（通过私有 `Map<string, AbortController>`）。
+`OrchestrationService` / `ConsoleAgent`（ChatAgent），自身无持久状态。每轮对话的
+并发闸门与执行体已从门面里拆出：并发生命周期（in-flight / 队列 / drain 三态）由
+`TurnQueue` 持有，单轮执行体由 `SessionTurnRunner` 承担，`ControlService.prompt` 只是把
+调用转交给 `TurnQueue.submit`。
 
 ## 文件
 
 - **`src/control/control-service.ts`** — 门面主体：sessions / scheduler /
   orchestration / prompt / executeCommand。导出类型：`ControlServiceDeps`、
   `ControlSessionInfo`、`ControlPromptInput`、`ControlPromptResult`、
-  `ControlExecuteCommandInput`。
+  `ControlExecuteCommandInput`。`prompt` / `runScheduledTurn` / `cancelTurn` /
+  `cancelQueuedItem` 都转发给 `TurnQueue`。
+- **`src/control/turn-queue.ts`** — `TurnQueue`：三态并发闸门
+  （`inFlight` / `queues` / `draining`）。构造时注入 `{ runTurn, emitQueueUpdated,
+  detectSessionsChanged }`。**无会话依赖**——回合结束后的 `sessions-changed` 检测经
+  `detectSessionsChanged` 回调穿入，而非让 `TurnQueue` 自持 `SessionService`。
+- **`src/control/session-turn-runner.ts`** — `SessionTurnRunner`：单轮执行体（会话绑定、
+  turn-started、媒体沙箱、stream/batched 段落重建、`agent.chat` 驱动与全部事件发射、
+  turn-finished）。契约是**永不 reject**——失败以 `{ ok: false, errorMessage }` resolve，
+  使 `TurnQueue` 能在纯 `finally` 里结算/推进队列而无需 catch。不持任何并发状态。
+- **`src/control/turn-support.ts`** — 中立值模块：`turnKey` / `toErrorMessage` /
+  `buildControlMetadata` / `raceWithTimeout` 与相关常量、`QueuedPrompt` 接口。被
+  `control-service` / `turn-queue` / `session-turn-runner` 以值导入，避免运行时环依赖。
 - **`src/control/control-event-bus.ts`** — `ControlEventBus` 接口与
   `createControlEventBus` 工厂：支持 `turn-output` / `turn-finished` /
   `sessions-changed` / `scheduled-changed` / `orchestration-changed` 五类事件；
@@ -49,13 +63,26 @@
 
 ## 语义要点
 
-### prompt 并发保护
+### prompt 并发保护（`TurnQueue`）
 
-`prompt` 在注册 in-flight 条目之后才调用 `useSession(chatKey, alias)` 绑定当前会话。
-同一 `(chatKey, sessionAlias)` 组合同时只允许一个 in-flight turn——若 key 已存在则立即返回
-`{ ok: false, errorMessage: "turn-already-running" }`，不走 agent。
-这一顺序（先写注册，再调 useSession）刻意闭合了并发竞态窗口。
-`cancelTurn` 通过已保存的 `AbortController.abort()` 中止 turn。
+`prompt` 把调用转交给 `TurnQueue.submit`。闸门按 `(chatKey, sessionAlias)` 组合隔离，
+围绕三个状态运转：
+
+- **`inFlight`** — 每个 key 至多一个进行中的 turn。`submit` 的「忙判定 + `inFlight.set`」
+  是一段**零 await 的同步前缀**，`SessionTurnRunner.run` 是正常路径上唯一的 turn-body
+  await；这样同一 tick 内的第二个 `submit` 一定能读到已注册的忙态。绑定当前会话的
+  `useSession` 由 runner 在这之后调用，闭合了「先注册、后绑定」的竞态窗口。
+- **`queues`** — 交互式 `prompt`（`queueable: true`）遇忙时把提示词追加进 per-session FIFO
+  队列并回 `{ ok: true, queued: true, queueItemId }`；定时轮次（非 `queueable`）遇忙则直接回
+  `{ ok: false, errorMessage: "turn-already-running" }`，不入队。turn 结束时按 FIFO 依次
+  drain，每个队列头作为下一轮 turn 运行。
+- **`draining`** — 一轮结束到下一轮（drained head）重新注册 `inFlight` 之间的短暂交接窗口
+  里，`submit` 把 `draining.has(key)` 也视为忙态，防止有提示词在这个缝隙里起并行 turn。
+
+`cancelTurn` 经保存的 `AbortController.abort()` 中止进行中的 turn；`cancelQueuedItem`
+按 id 移除尚未 drain 的排队项（已 drain 进 turn 的则 no-op）。这些同步时序不变量由
+`tests/unit/control/turn-queue.test.ts`（白盒）与
+`tests/unit/control/golden/turn-oracle.test.ts`（黑盒事件-日志 oracle）共同钉住。
 
 ### turn-output 与 turn-finished 事件
 
@@ -89,9 +116,13 @@ control 通道是 GUI-first 的：relay-web 通过看板按钮驱动会话操作
 只会静默 no-op；而 reset 对 xacpx 会话模型是有副作用的（重建 transport 会话，并保持
 native 标记），不能当作文本发给 agent。见 `src/commands/command-router.ts` 的透传分支。
 
-reset 在回合内重建了 transport 会话，但 reset handler 不发事件，所以 `control.prompt`
-会在回合结束后比较 `transportSession` 前后值，若变化则补发 `sessions-changed`（与 archived
-徽标的兜底刷新同理），否则看板会一直显示旧的 transport id / native 绑定直到下次无关刷新。
+reset 在回合内重建了 transport 会话，但 reset handler 不发事件，所以需要在回合结束后比较
+`transportSession` 前后值，若变化则补发 `sessions-changed`（与 archived 徽标的兜底刷新同理），
+否则看板会一直显示旧的 transport id / native 绑定直到下次无关刷新。`SessionTurnRunner` 只
+捕获回合前的会话状态并作为 `postTurnDetection` 返回，真正的 `getSession` 比较由 `TurnQueue`
+在 `draining.add` **之后**、`resolveSettled` 之前经 `detectSessionsChanged` 回调执行——那个
+await 必须留在 draining 守护窗口内，否则一个被中止且带排队项的回合会让新提示词插进来抢跑
+（由 golden fixture `aborted-queue-sessions-window` 钉住）。
 
 ### 事件总线覆盖范围
 

--- a/docs/superpowers/plans/2026-07-10-control-turn-queue-split.md
+++ b/docs/superpowers/plans/2026-07-10-control-turn-queue-split.md
@@ -420,15 +420,18 @@ constructor(private readonly deps: ControlServiceDeps) {
 
 - [ ] **Step 6: 白盒补测 —— 三处 wedge + FIFO drain + Stop-followup + stranded tail**
 
-在 `turn-queue.test.ts` 追加白盒用例（喂假 `runTurn`，逐个 resolve）：busy→enqueue、FIFO drain 各自成 turn、drain 窗口入队、drained 头 runTurn reject 仍 drain 后续（stranded tail）、cancel 清空队列清 draining（wedge #3，断言后续 submit 不 enqueue）、Stop 后 followup 等 drain（wedge #2，`cancelTurn` 后 submit 走 `raceWithTimeout` 分支）。每条用可控 `runTurn` 驱动。
+在 `turn-queue.test.ts` 追加白盒用例（喂假 `runTurn`，逐个 resolve）：busy→enqueue、FIFO drain 各自成 turn、drain 窗口入队、drained 头执行失败仍 drain 后续（stranded tail）、cancel 清空队列清 draining（wedge #3，断言后续 submit 不 enqueue）、Stop 后 followup 等 drain（wedge #2，`cancelTurn` 后 submit 走 `raceWithTimeout` 分支）。每条用可控 `runTurn` 驱动。**契约说明**：`SessionTurnRunner.run` 永不 reject——session-bind / agent-drive 失败在内部 catch 后以 `{ ok:false, errorMessage }` resolve（见 runner 类注释）。所以假 `runTurn` 只 resolve、无 reject 路径；stranded-tail 用例用 `{ ok:false }` 模拟失败头，正是这个契约的忠实建模，而非绕过真实 reject。
 
 - [ ] **Step 7: 变异验证三处不变量真承重**
 
 对每个变异：`cp` 备份 `turn-queue.ts` → 施加 → `grep` 确认应用 → 跑白盒+oracle → 还原。
-  - 变异 A：删 `advanceQueue` 里的 `draining.add` → wedge #3 相关白盒用例或 oracle 场景 6 必红。
+  - 变异 A（drain 守护窗口顺序）：把 `submit` finally 里的 `draining.add` 挪到 `detectSessionsChanged` await **之后** → golden fixture `aborted-queue-sessions-window`（第 9 个）必红。
   - 变异 B：`submit` 里把 `inFlight.set` 挪到首个 await 后 → 同 tick 同步断言（Step 1）必红。
   - 变异 C：busy 判定跨一个 `await Promise.resolve()` → 同 tick 同步断言必红。
+  - 变异 D（wedge #3 泄漏守护）：删 `advanceQueue` 空 `else` 分支里的 `draining.delete(key)` → cancel-empties-queue-clears-draining 白盒用例（+ oracle 场景 6）必红。
 记录每个变异命中的具体用例；任一变异全绿 = 该处无测试守护，补测。
+
+> **修订（2026-07-11，评审反馈）：原变异 A「删 `advanceQueue` 里的 `draining.add`」是错的验收标准。** 实测该 `draining.add` 相对 `submit` finally 里的写入是**冗余**的（同一 finally 同步调用 advanceQueue，`draining` 已被 finally 设好），单独删它三套件全绿——不满足「必红」。据此已**删除**这个被证明冗余的写入（YAGNI），`draining` 的守护改由 `submit` finally 作为单一写入点承担。真正承重的守护是上面修订后的变异 A（顺序）与变异 D（泄漏），二者均经变异验证必红。
 
 - [ ] **Step 8: oracle + 现有测试 + 白盒全绿**
 

--- a/docs/superpowers/plans/2026-07-10-control-turn-queue-split.md
+++ b/docs/superpowers/plans/2026-07-10-control-turn-queue-split.md
@@ -1,0 +1,493 @@
+# control-service executeTurn 拆分 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 `src/control/control-service.ts` 的 `executeTurn`（约 290 行三态并发闸门）拆成 `TurnQueue`（并发原语）+ `SessionTurnRunner`（单次执行），零行为变更。
+
+**Architecture:** `ControlService.executeTurn` 退化为组装 req → `TurnQueue.submit`。`TurnQueue` 持有 `inFlight`/`queues`/`draining` 三态与所有 microtask 同步时序不变量，唯一 await 点是 `runTurn` 回调；`SessionTurnRunner` 是那个回调，负责 session 解析/media/段落/`agent.chat`/事件发射。等价性靠两层测试：黑盒事件-日志 oracle（重构前 commit 独立 worktree 录基线）+ 白盒 TurnQueue 单测（零 await 同 tick 同步断言）。
+
+**Tech Stack:** TypeScript (strict, `verbatimModuleSyntax`)，Bun test，DI 注入。
+
+## Global Constraints
+
+- **零行为变更**。三处 wedge 隐患本身不修，只是变可测。
+- **现有测试一字不改**：`tests/unit/control/control-service-queue.test.ts`、`control-service-prompt.test.ts`、`control-service-prompt-status.test.ts` 等全程绿。这是回归判据的一半。
+- **基线 fixture 必须在重构前 commit（`54be207`）、独立 git worktree 里录**。`GOLDEN_UPDATE=1` 只在基线 worktree 出现，绝不对重构后的代码录基线。
+- **逐文件 `bun test`**，never 整目录（模块状态泄漏 → 假失败）。
+- **每个并发不变量靠变异验证**：删 `draining.add`、把 `inFlight.set` 挪到 await 后、把 busy 判定跨一个 await —— 各自必须让对应 oracle 场景或白盒断言变红。变异先 `grep` 确认应用成功再下结论。
+- **值导入是真运行时循环**：子模块 `import type` 门面安全，但自由函数/常量（`turnKey`/`toErrorMessage`/`buildControlMetadata`/`raceWithTimeout`/`CANCEL_DRAIN_TIMEOUT_MS`/`QUEUE_PREVIEW_MAX`）从门面 import 回来会成环 —— 迁到中立模块 `src/control/turn-support.ts`，门面 `export { … } from "./turn-support"` 保住既有 import 路径。
+- **子代理 git 卫生**：实现子代理不跑任何 git 命令；controller 自己 `git log`/`git status` 核实真实提交；会改文件的评审子代理必须 `isolation: "worktree"`。
+- **TZ=UTC**：`npm test` 需要 `TZ=UTC`（`src/commands` 一个测试硬编码 UTC）。
+
+---
+
+## File Structure
+
+| 文件 | 责任 | 阶段 |
+|---|---|---|
+| `src/control/turn-support.ts`（新） | 中立模块：`turnKey`/`toErrorMessage`/`buildControlMetadata`/`raceWithTimeout`/`CANCEL_DRAIN_TIMEOUT_MS`/`QUEUE_PREVIEW_MAX`/`QueuedPrompt` 类型 + `TurnRequest`/`TurnResult` 类型 | 1 |
+| `src/control/session-turn-runner.ts`（新） | 单次 turn 执行：session 解析、archived/clear→sessions-changed、media sandbox、stream/batched 段落、`agent.chat`、8 种事件 + turn-started/finished | 1 |
+| `src/control/turn-queue.ts`（新） | 并发原语：`inFlight`/`queues`/`draining`、`submit`/`cancelTurn`/`cancelQueuedItem`/`queueLength`/`isBusy`、`advanceQueue` drain 交接 | 2 |
+| `src/control/control-service.ts`（改） | `executeTurn`/`advanceQueue`/三态字段迁出；`prompt`/`runScheduledTurn` 组装 req → `turnQueue.submit`；re-export turn-support | 1-3 |
+| `tests/unit/control/golden/turn-oracle-harness.ts`（新） | 黑盒 harness：可控 deferred agent + 记录事件发射有序日志 + 入口返回；`expectMatchesFixture` | 0 |
+| `tests/unit/control/golden/turn-oracle.test.ts`（新） | 8 个并发场景，驱动 ControlService 公开面，比对 fixture | 0 |
+| `tests/unit/control/golden/fixtures/*.json`（新） | 8 个基线 fixture，在 `54be207` 录 | 0 |
+| `tests/unit/control/turn-queue.test.ts`（新） | 白盒单测：喂假 `runTurn`，含零 await 同 tick 同步断言 + 三处 wedge 变异验证用例 | 2 |
+
+---
+
+## Task 0：黑盒事件-日志 oracle harness + 基线 fixture
+
+**Files:**
+- Create: `tests/unit/control/golden/turn-oracle-harness.ts`
+- Create: `tests/unit/control/golden/turn-oracle.test.ts`
+- Create: `tests/unit/control/golden/fixtures/*.json`（8 个，在基线 worktree 录）
+
+**Interfaces:**
+- Consumes: `ControlService`（公开面 `prompt`/`runScheduledTurn`/`cancelTurn`/`cancelQueuedItem`），`createControlEventBus`/`ControlEvent`（`src/control/control-event-bus`）。
+- Produces: `makeTurnOracle()` 返回 `{ service, log, controls }`：
+  - `log: OracleEntry[]` —— 有序日志，条目形如 `{ kind: "event", event: {type, …fields} }` 或 `{ kind: "return", label, value }`。
+  - `controls.resolveChat(index?)` / `controls.rejectChat(index?, msg)` / `controls.abortChat(index?)` —— 逐个控制挂起的 `agent.chat`（FIFO）。
+  - `expectMatchesFixture(name, log)` —— 深比较 parsed JSON，`GOLDEN_UPDATE=1` 时写 fixture。
+
+- [ ] **Step 1: 建 harness，可控 deferred agent + 有序事件日志**
+
+`tests/unit/control/golden/turn-oracle-harness.ts`：
+
+```ts
+// tests/unit/control/golden/turn-oracle-harness.ts
+// Black-box characterization oracle for ControlService's turn machinery. Records, in
+// order, every event ControlService emits AND every entry-call return value across a
+// scenario. `deps.events.emit` is synchronous, so the log order IS the execution order
+// (across microtasks) — that is how this catches a same-tick timing regression that a
+// plain result assertion cannot see. Drives ControlService's PUBLIC surface only; never
+// inspects the private inFlight/queues/draining maps.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { expect } from "bun:test";
+import { createControlEventBus, type ControlEvent } from "../../../../src/control/control-event-bus";
+import { ControlService } from "../../../../src/control/control-service";
+import type { ChatRequest, ChatResponse } from "../../../../src/weixin/agent/interface";
+
+export type OracleEntry =
+  | { kind: "event"; event: ControlEvent }
+  | { kind: "return"; label: string; value: unknown };
+
+interface PendingChat {
+  request: ChatRequest;
+  resolve: (r: ChatResponse) => void;
+  reject: (e: unknown) => void;
+}
+
+export function makeTurnOracle(opts?: {
+  useSession?: (chatKey: string, alias: string) => Promise<unknown>;
+  getSession?: (alias: string) => Promise<unknown>;
+}) {
+  const log: OracleEntry[] = [];
+  const events = createControlEventBus();
+  events.subscribe((event) => log.push({ kind: "event", event: clone(event) }));
+
+  const pending: PendingChat[] = [];
+  const chat = async (request: ChatRequest): Promise<ChatResponse> => {
+    // Drive the reply/onThought/etc callbacks the real transport would, so the event log
+    // is representative. A scenario resolves each chat explicitly via controls.
+    return await new Promise<ChatResponse>((resolve, reject) => {
+      pending.push({ request, resolve, reject });
+    });
+  };
+
+  const service = new ControlService({
+    agent: { chat },
+    sessions: {
+      listAllResolvedSessions: () => [],
+      useSession:
+        opts?.useSession ??
+        (async (_c: string, alias: string) => ({ alias, agent: "claude", workspace: "/ws" })),
+      resolveAliasForChat: async (_c: string, alias: string) => alias,
+      getSession: opts?.getSession ?? (async () => null),
+    },
+    activeTurns: { isActiveAnywhere: () => false },
+    scheduled: {} as never,
+    orchestration: {} as never,
+    events,
+    uploadStore: { root: "/tmp/uploads" },
+  } as never);
+
+  const record = async <T>(label: string, p: Promise<T>): Promise<T> => {
+    const value = await p;
+    log.push({ kind: "return", label, value: clone(value) });
+    return value;
+  };
+
+  return {
+    service,
+    log,
+    record,
+    controls: {
+      resolveChat: (index = 0, text = "done") => pending.splice(index, 1)[0]?.resolve({ text }),
+      rejectChat: (index = 0, message = "boom") =>
+        pending.splice(index, 1)[0]?.reject(new Error(message)),
+      pendingCount: () => pending.length,
+    },
+  };
+}
+
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v ?? null)) as T;
+}
+
+const FIXTURE_DIR = new URL("./fixtures/", import.meta.url).pathname;
+
+export function expectMatchesFixture(name: string, actual: unknown): void {
+  const path = `${FIXTURE_DIR}${name}.json`;
+  const serialized = `${JSON.stringify(actual, null, 2)}\n`;
+  if (process.env.GOLDEN_UPDATE === "1") {
+    mkdirSync(FIXTURE_DIR, { recursive: true });
+    writeFileSync(path, serialized);
+    return;
+  }
+  if (!existsSync(path)) {
+    throw new Error(`turn oracle fixture missing: ${name}.json — record with GOLDEN_UPDATE=1 on the baseline`);
+  }
+  expect(JSON.parse(serialized) as unknown).toEqual(JSON.parse(readFileSync(path, "utf8")) as unknown);
+}
+```
+
+- [ ] **Step 2: 核对假 deps 面足够驱动 executeTurn**
+
+Run: `env -u GOLDEN_UPDATE bun test tests/unit/control/control-service-queue.test.ts`
+Expected: PASS（确认 harness 的假 deps 形态与现有 queue 测试一致——两者共享同一最小 deps 集）。harness 若缺某个 executeTurn 用到的 dep（如 `resolveControlSession` 依赖的字段），补进 `makeTurnOracle` 的 stub，与 `control-service-prompt-status.test.ts` 的 `makeControl` 对齐。
+
+- [ ] **Step 3: 写 8 个场景（尚无 fixture，先让它们 GOLDEN_UPDATE 录）**
+
+`tests/unit/control/golden/turn-oracle.test.ts`。每个场景 driver 复用 `control-service-queue.test.ts` 已验证的时序手法（`await tick()` 让 turn 注册、`resolveChat` 逐个放行）。8 个场景名与 spec 一致：
+
+```ts
+// tests/unit/control/golden/turn-oracle.test.ts
+import { test } from "bun:test";
+import { makeTurnOracle, expectMatchesFixture } from "./turn-oracle-harness";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const C = { chatKey: "c", sessionAlias: "s", senderId: "u" };
+
+test("oracle: busy second prompt enqueues", async () => {
+  const o = makeTurnOracle();
+  const p1 = o.service.prompt({ ...C, text: "first" });
+  await tick();
+  await o.record("prompt#2", o.service.prompt({ ...C, text: "second" }));
+  o.controls.resolveChat();
+  await p1;
+  await tick();
+  expectMatchesFixture("busy-second-enqueues", o.log);
+});
+
+test("oracle: same-tick two prompts — exactly one wins", async () => {
+  const o = makeTurnOracle();
+  // Both submitted in ONE synchronous tick — never await the first before sending the
+  // second. The event log's relative order (queue-updated vs turn-started) is the signal.
+  const pA = o.service.prompt({ ...C, text: "A" });
+  const pB = o.service.prompt({ ...C, text: "B" });
+  await Promise.all([pA.then(() => {}), pB.then(() => {})].map(() => tick()));
+  await tick();
+  o.controls.resolveChat();
+  o.controls.resolveChat();
+  await Promise.all([pA, pB]);
+  await tick();
+  expectMatchesFixture("same-tick-one-wins", o.log);
+});
+```
+
+其余 6 个场景（scheduled 不入队 / FIFO drain / drain 窗口入队 / stranded tail / cancel 清空清 draining / Stop-followup）按 `control-service-queue.test.ts` 与 `control-service-prompt-status.test.ts` 里对应用例的 driver 逐一翻写为记录 `o.log` 的形式。**每个 driver 只驱动、只记录，断言只有一行 `expectMatchesFixture`。**
+
+- [ ] **Step 4: 在基线 worktree 录 fixture（关键纪律步）**
+
+```bash
+BASE=/private/tmp/claude-501/.../scratchpad/control-baseline
+git worktree add --detach "$BASE" 54be207
+ln -s "$PWD/node_modules" "$BASE/node_modules"
+mkdir -p "$BASE/tests/unit/control/golden/fixtures"
+cp tests/unit/control/golden/turn-oracle-harness.ts tests/unit/control/golden/turn-oracle.test.ts \
+   "$BASE/tests/unit/control/golden/"
+(cd "$BASE" && GOLDEN_UPDATE=1 bun test tests/unit/control/golden/turn-oracle.test.ts)
+# 基线自我复现（GOLDEN_UPDATE 未设）
+(cd "$BASE" && env -u GOLDEN_UPDATE bun test tests/unit/control/golden/turn-oracle.test.ts)
+```
+Expected: 8 pass；`GOLDEN_UPDATE` 未设时仍 8 pass。把 `$BASE/tests/unit/control/golden/fixtures/*.json` 拷回工作树。
+
+- [ ] **Step 5: 工作树上复现（重构前的 executeTurn 必须复现基线）**
+
+Run: `env -u GOLDEN_UPDATE bun test tests/unit/control/golden/turn-oracle.test.ts`
+Expected: 8 pass, 0 fail。此刻工作树代码 == 基线代码，必然绿；这确认 harness 确定性（无 setTimeout race）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/unit/control/golden/
+git commit -m "test(control): black-box event-log oracle for the turn machinery (baseline)"
+```
+
+---
+
+## Task 1：抽 SessionTurnRunner（turn 执行体）+ 中立 turn-support 模块
+
+**Files:**
+- Create: `src/control/turn-support.ts`
+- Create: `src/control/session-turn-runner.ts`
+- Modify: `src/control/control-service.ts`（`executeTurn` 中段调 runner；迁出自由函数并 re-export）
+- Test: `tests/unit/control/golden/turn-oracle.test.ts`（不改，作判据）
+
+**Interfaces:**
+- Consumes: `ControlServiceDeps`（`agent`/`sessions`/`events`/`uploadStore`），`ControlEventBus`，`ScheduledOrigin`，`PromptAttachmentRef`。
+- Produces:
+  - `turn-support.ts`：`export function turnKey(chatKey, sessionAlias): string`；`export function toErrorMessage(error: unknown): string`；`export function buildControlMetadata(senderId, isOwner): ChatRequestMetadata`；`export const CANCEL_DRAIN_TIMEOUT_MS = 5000`；`export const QUEUE_PREVIEW_MAX = 120`；`export async function raceWithTimeout(promise, ms): Promise<void>`；`export interface QueuedPrompt {...}`。
+  - `session-turn-runner.ts`：`export interface TurnRequest { chatKey; sessionAlias; text; senderId; isOwner?; accountId?; abortSignal?; turnStarted?; media? }`（**不含** `queueable`/`drained` —— 那是 TurnQueue 的闸门参数）；`export interface TurnResult { ok: boolean; text?: string; errorMessage?: string }`；`export class SessionTurnRunner { constructor(deps: Pick<ControlServiceDeps, "agent"|"sessions"|"events"|"uploadStore">); run(req: TurnRequest, signal: AbortSignal): Promise<TurnResult> }`。
+
+- [ ] **Step 1: 建 `turn-support.ts`，迁入 4 个自由函数 + 2 常量 + QueuedPrompt 类型**
+
+从 `control-service.ts` **逐字剪切** `turnKey`/`toErrorMessage`/`buildControlMetadata`/`raceWithTimeout`/`CANCEL_DRAIN_TIMEOUT_MS`/`QUEUE_PREVIEW_MAX` 及 `QueuedPrompt` 接口到新文件，加 `import type { ChatRequestMetadata } from "../weixin/agent/interface";`。**陷阱**：这些是**值**，`control-service.ts` 必须 `import { … } from "./turn-support"`（值导入），不能 `import type`——否则运行时缺失。为保住外部可能的 import 路径，`control-service.ts` 顶部加 `export { turnKey, toErrorMessage, CANCEL_DRAIN_TIMEOUT_MS } from "./turn-support";`（仅 re-export 原本可能被外部引用的；实测 `grep -rn "from.*control-service" src tests` 确认哪些符号被外部 import，只 re-export 那些）。
+
+- [ ] **Step 2: 运行现有测试确认 turn-support 迁移无回归**
+
+Run: `env -u GOLDEN_UPDATE bun test tests/unit/control/control-service-queue.test.ts && npx tsc --noEmit`
+Expected: PASS, tsc 0 errors。
+
+- [ ] **Step 3: 建 `session-turn-runner.ts`，把执行体逐字搬入 `run()`**
+
+`run(req, signal)` 的体 = 当前 `control-service.ts` 中 `executeTurn` 的 **585→761 行**（`internalAlias`/`wasArchived`/`priorTransportSession` 捕获 → `useSession` → `turn-started` → 段落/media/`agent.chat` → `turn-finished` → `return { ok, text }`），**以及 finally 里的 sessions-changed 检测（779-788）**。逐字搬移规则：
+  - `params.X` → `req.X`；`controller.signal` → `signal`；`this.deps` → `this.deps`（runner 也叫 deps）。
+  - `useSession` 失败分支（604-614）里的 `resolveSettled()` / `advanceQueue(...)` **不搬**（那是并发状态，Task 2 之前留在 executeTurn）。改法：runner 的 `useSession` 失败**只**返回 `{ ok:false, errorMessage: toErrorMessage(error) }`；executeTurn 侧保留 settled/advanceQueue 收尾（见 Step 5）。
+  - sessions-changed 的两段（turn 前捕获 + turn 后比对）**整体搬进 runner** —— 它是"一次执行的可观测效果"，与并发无关。runner 内部自己 try/catch，best-effort。
+  - **陷阱（microtask hop）**：runner 的 `turn-started`/`turn-finished` emit 顺序、以及 sessions-changed 相对 turn-finished 的位置，必须与基线逐字一致。搬移后靠 oracle 场景 1（busy-second-enqueues）+ 现有 prompt-status 测试验证顺序未漂移。
+
+- [ ] **Step 4: `SessionTurnRunner` 构造与 deps 收窄**
+
+```ts
+// src/control/session-turn-runner.ts（骨架）
+import path from "node:path";
+import type { ControlServiceDeps } from "./control-service";
+import type { ScheduledOrigin } from "./control-event-bus";
+import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
+import { toErrorMessage, buildControlMetadata } from "./turn-support";
+
+export interface TurnRequest {
+  chatKey: string; sessionAlias: string; text: string; senderId: string;
+  isOwner?: boolean; accountId?: string; abortSignal?: AbortSignal;
+  turnStarted?: { prompt?: string; scheduled?: ScheduledOrigin; queueItemId?: string };
+  media?: PromptAttachmentRef[];
+}
+export interface TurnResult { ok: boolean; text?: string; errorMessage?: string }
+
+export class SessionTurnRunner {
+  constructor(private readonly deps: Pick<ControlServiceDeps, "agent" | "sessions" | "events" | "uploadStore">) {}
+  async run(req: TurnRequest, signal: AbortSignal): Promise<TurnResult> {
+    // ← 搬入 executeTurn 585-761 + 779-788（sessions-changed），见 Step 3
+  }
+  private async resolveStreamMode(chatKey: string, sessionAlias: string): Promise<boolean> { /* 搬 632-638 */ return false; }
+}
+```
+`resolveControlSession`（当前 private，用于 streamMode）：若 runner 需要它，把 `resolveControlSession` 也搬进 runner 或迁 turn-support（它只读 `sessions`）。实测其依赖后决定归属，**不留跨文件私有方法调用**。
+
+- [ ] **Step 5: `executeTurn` 中段改调 runner**
+
+`executeTurn` 保留闸门（502-584）+ controller/settled/inFlight 生命周期 + finally 的并发收尾（`draining.add`/`resolveSettled`/`advanceQueue`），中段替换为：
+
+```ts
+    const result = await this.runner.run(
+      { chatKey: params.chatKey, sessionAlias: params.sessionAlias, text: params.text,
+        senderId: params.senderId,
+        ...(params.isOwner !== undefined ? { isOwner: params.isOwner } : {}),
+        ...(params.accountId !== undefined ? { accountId: params.accountId } : {}),
+        ...(params.turnStarted ? { turnStarted: params.turnStarted } : {}),
+        ...(params.media !== undefined ? { media: params.media } : {}) },
+      controller.signal,
+    );
+```
+`this.runner` 在构造函数里 `= new SessionTurnRunner(deps)`。useSession 失败路径：runner 返回 `{ok:false}`，executeTurn 在拿到该结果后走原 finally（`resolveSettled` + `advanceQueue`）—— **注意**当前代码 useSession 失败是 early return 不进 finally；搬移后要保证失败仍触发一次 settled+advanceQueue（等价于原 604-614）。用 `try { result = await runner.run(...) } finally { …收尾… }` 结构统一收尾路径。
+
+- [ ] **Step 6: oracle + 现有测试全绿**
+
+Run（逐文件）:
+```
+env -u GOLDEN_UPDATE bun test tests/unit/control/golden/turn-oracle.test.ts
+env -u GOLDEN_UPDATE bun test tests/unit/control/control-service-queue.test.ts
+env -u GOLDEN_UPDATE bun test tests/unit/control/control-service-prompt.test.ts
+env -u GOLDEN_UPDATE bun test tests/unit/control/control-service-prompt-status.test.ts
+npx tsc --noEmit
+```
+Expected: 全 pass，tsc 0 errors，**8 个 fixture 一字不改**（`git status tests/unit/control/golden/fixtures/` 为空）。若某 fixture 变红 → 事件顺序漂移，回 Step 3 对齐 emit 顺序，不得重录 fixture。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/control/turn-support.ts src/control/session-turn-runner.ts src/control/control-service.ts
+git commit -m "refactor(control): extract SessionTurnRunner for the per-turn execution body"
+```
+
+---
+
+## Task 2：抽 TurnQueue（三态闸门）+ 白盒单测
+
+**Files:**
+- Create: `src/control/turn-queue.ts`
+- Create: `tests/unit/control/turn-queue.test.ts`
+- Modify: `src/control/control-service.ts`（`executeTurn`/`advanceQueue`/`cancelTurn`/`cancelQueuedItem`/三态字段迁出，退化为 `submit`）
+
+**Interfaces:**
+- Consumes: `turn-support`（`turnKey`/`QueuedPrompt`/`CANCEL_DRAIN_TIMEOUT_MS`/`QUEUE_PREVIEW_MAX`/`raceWithTimeout`），`SessionTurnRunner`（`TurnRequest`/`TurnResult`）。
+- Produces:
+```ts
+// src/control/turn-queue.ts
+export interface TurnQueueDeps {
+  runTurn(req: TurnRequest, signal: AbortSignal): Promise<TurnResult>;
+  emitQueueUpdated(chatKey: string, sessionAlias: string, items: QueuedItemSnapshot[]): void;
+}
+export interface SubmitParams {  // req 字段 + 闸门旗标
+  chatKey: string; sessionAlias: string; text: string; senderId: string;
+  isOwner?: boolean; accountId?: string; abortSignal?: AbortSignal;
+  turnStarted?: TurnRequest["turnStarted"]; media?: PromptAttachmentRef[];
+  queueable?: boolean;
+}
+export type SubmitResult = TurnResult | { ok: true; queued: true; queueItemId: string };
+export class TurnQueue {
+  constructor(deps: TurnQueueDeps);
+  submit(params: SubmitParams): Promise<SubmitResult>;
+  cancelTurn(chatKey: string, sessionAlias: string): boolean;
+  cancelQueuedItem(chatKey: string, sessionAlias: string, itemId: string): { cancelled: boolean };
+  queueLength(chatKey: string, sessionAlias: string): number;  // 同步查询
+  isBusy(chatKey: string, sessionAlias: string): boolean;      // 同步查询
+}
+```
+
+- [ ] **Step 1: 白盒 failing test —— 零 await 同 tick 同步断言（先写，先红）**
+
+`tests/unit/control/turn-queue.test.ts`：
+
+```ts
+import { expect, test } from "bun:test";
+import { TurnQueue } from "../../../src/control/turn-queue";
+import type { TurnRequest, TurnResult } from "../../../src/control/session-turn-runner";
+
+function deferredRunTurn() {
+  const pending: Array<{ resolve: (r: TurnResult) => void }> = [];
+  const runTurn = (_req: TurnRequest, _s: AbortSignal) =>
+    new Promise<TurnResult>((resolve) => pending.push({ resolve }));
+  return { runTurn, resolveNext: (r: TurnResult = { ok: true }) => pending.shift()?.resolve(r), pendingCount: () => pending.length };
+}
+
+test("submit's busy-decision + enqueue is a synchronous prefix (same tick, zero await)", () => {
+  const d = deferredRunTurn();
+  const tq = new TurnQueue({ runTurn: d.runTurn, emitQueueUpdated: () => {} });
+  const req = { chatKey: "c", sessionAlias: "s", text: "A", senderId: "u", queueable: true };
+  void tq.submit(req);                 // sync inFlight.set
+  void tq.submit({ ...req, text: "B" }); // sync enqueue
+  // ZERO await between submit and this assertion — pins the synchronous prefix.
+  expect(tq.queueLength("c", "s")).toBe(1);
+  expect(tq.isBusy("c", "s")).toBe(true);
+});
+```
+
+- [ ] **Step 2: 运行确认它红（TurnQueue 尚不存在）**
+
+Run: `env -u GOLDEN_UPDATE bun test tests/unit/control/turn-queue.test.ts`
+Expected: FAIL（`Cannot find module turn-queue`）。
+
+- [ ] **Step 3: 建 `turn-queue.ts`，把三态闸门逐字搬入**
+
+从 `control-service.ts` 搬移：`inFlight`/`queues`/`draining` 三字段、`executeTurn` 的闸门+生命周期部分（502-584 + finally 并发收尾 762-793 除 sessions-changed 外）、`advanceQueue`（802-835）、`cancelTurn`（837-844）、`cancelQueuedItem`（850-860）、`emitQueueUpdated`（463-470）。搬移规则：
+  - `executeTurn` → `submit`：中段 `await this.runner.run(...)` → `await this.deps.runTurn(req, controller.signal)`；`this.emitQueueUpdated(...)` → `this.deps.emitQueueUpdated(chatKey, sessionAlias, items)`（items 快照在 TurnQueue 内算，`QUEUE_PREVIEW_MAX` 从 turn-support）。
+  - `advanceQueue` 里的 fire-and-forget `void this.executeTurn({...drained:true})` → `void this.submit({...drained:true})`。**陷阱（核心不变量）**：`draining.add` 必须在 `void this.submit(...)` **之前**（同步），`submit` 的 `inFlight.set` 必须在其首个 await（`runTurn`）**之前**（同步）。搬移后**不得**在两者间插入任何 await。
+  - `drained` 旗标：`submit` 内部保留（drained 头 bypass 闸门、re-register inFlight、清 draining，全同步）。
+  - `queueLength`/`isBusy`：新增同步查询——`queueLength = this.queues.get(key)?.length ?? 0`；`isBusy = this.draining.has(key) || (existing !== undefined && !existing.controller.signal.aborted)`。
+
+- [ ] **Step 4: 白盒同 tick 断言转绿**
+
+Run: `env -u GOLDEN_UPDATE bun test tests/unit/control/turn-queue.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: `ControlService` 退化 —— `executeTurn` 删除，`prompt`/`runScheduledTurn` 直接 `submit`**
+
+`control-service.ts`：删掉 `executeTurn`/`advanceQueue`/`cancelTurn`/`cancelQueuedItem`/`emitQueueUpdated`/三态字段。构造函数装配：
+```ts
+constructor(private readonly deps: ControlServiceDeps) {
+  this.runner = new SessionTurnRunner(deps);
+  this.turnQueue = new TurnQueue({
+    runTurn: (req, signal) => this.runner.run(req, signal),
+    emitQueueUpdated: (chatKey, sessionAlias, items) =>
+      this.deps.events.emit({ type: "queue-updated", chatKey, sessionAlias, items }),
+  });
+}
+```
+`prompt` → `return this.turnQueue.submit({ …, queueable: true })`；`runScheduledTurn` → `return this.turnQueue.submit({ …, senderId:"scheduler", isOwner:true, turnStarted:{...} })`（无 queueable）；`cancelTurn`/`cancelQueuedItem` → 转发 `this.turnQueue.*`。**陷阱**：`cancelTurn`/`cancelQueuedItem` 是 `ControlService` 的公开方法（被 relay/web 调），签名保持不变，只改实现为转发。
+
+- [ ] **Step 6: 白盒补测 —— 三处 wedge + FIFO drain + Stop-followup + stranded tail**
+
+在 `turn-queue.test.ts` 追加白盒用例（喂假 `runTurn`，逐个 resolve）：busy→enqueue、FIFO drain 各自成 turn、drain 窗口入队、drained 头 runTurn reject 仍 drain 后续（stranded tail）、cancel 清空队列清 draining（wedge #3，断言后续 submit 不 enqueue）、Stop 后 followup 等 drain（wedge #2，`cancelTurn` 后 submit 走 `raceWithTimeout` 分支）。每条用可控 `runTurn` 驱动。
+
+- [ ] **Step 7: 变异验证三处不变量真承重**
+
+对每个变异：`cp` 备份 `turn-queue.ts` → 施加 → `grep` 确认应用 → 跑白盒+oracle → 还原。
+  - 变异 A：删 `advanceQueue` 里的 `draining.add` → wedge #3 相关白盒用例或 oracle 场景 6 必红。
+  - 变异 B：`submit` 里把 `inFlight.set` 挪到首个 await 后 → 同 tick 同步断言（Step 1）必红。
+  - 变异 C：busy 判定跨一个 `await Promise.resolve()` → 同 tick 同步断言必红。
+记录每个变异命中的具体用例；任一变异全绿 = 该处无测试守护，补测。
+
+- [ ] **Step 8: oracle + 现有测试 + 白盒全绿**
+
+Run（逐文件）: oracle、`control-service-queue`、`control-service-prompt`、`control-service-prompt-status`、`turn-queue`、`npx tsc --noEmit`。
+Expected: 全 pass；**8 个 fixture 一字不改**（`git status .../fixtures/` 空）。fixture 变红 → 时序漂移，回 Step 3 对齐，不重录。
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/control/turn-queue.ts tests/unit/control/turn-queue.test.ts src/control/control-service.ts
+git commit -m "refactor(control): extract TurnQueue; executeTurn collapses to submit"
+```
+
+---
+
+## Task 3：收尾 —— 死代码、注释迁移、行数核对
+
+**Files:**
+- Modify: `src/control/control-service.ts`
+
+- [ ] **Step 1: 核对 control-service.ts 无遗留三态引用 / 孤儿 import**
+
+Run:
+```bash
+grep -n "inFlight\|draining\|advanceQueue\|raceWithTimeout" src/control/control-service.ts
+grep -c "QueuedPrompt\|QUEUE_PREVIEW_MAX\|CANCEL_DRAIN_TIMEOUT_MS" src/control/control-service.ts
+```
+Expected: 三态字段/闸门无残留；被搬走的符号在 control-service.ts 里出现 0 次（除必要 re-export 行）。孤儿 `import type` 手动删（tsc 抓不到——`import type` 擦除 + `noUnusedLocals` 关）。
+
+- [ ] **Step 2: wedge 注释迁移到 TurnQueue**
+
+三处"永久 wedge"注释（原 control-service.ts 约 562/570/831）搬到 `turn-queue.ts` 对应位置，且**在依赖同步时序的调用点写明"变异 X 会让白盒断言 Y 变红"**（照 orchestration group-service 的做法），避免下一个人误判 flaky 重录 fixture。
+
+- [ ] **Step 3: 全量核对**
+
+Run:
+```bash
+for f in $(git ls-files 'tests/unit/control/*.test.ts' 'tests/unit/control/golden/*.test.ts'); do env -u GOLDEN_UPDATE bun test "$f"; done
+npx tsc --noEmit
+wc -l src/control/control-service.ts src/control/turn-queue.ts src/control/session-turn-runner.ts src/control/turn-support.ts
+git diff --stat origin/main -- tests/unit/control/golden/fixtures/
+```
+Expected: 全 pass；tsc 0；control-service.ts 显著变短；fixtures 相对 origin/main 无改动（它们是 Task 0 新增，相对 base 是 A；关键是相对 Task 0 commit 无 M）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/control/control-service.ts src/control/turn-queue.ts
+git commit -m "refactor(control): migrate wedge comments to TurnQueue; drop dead code"
+```
+
+---
+
+## 全套验证（每 Task 后 controller 核对）
+
+```bash
+env -u GOLDEN_UPDATE bun test tests/unit/control/golden/turn-oracle.test.ts   # 8 pass, fixtures unchanged
+env -u GOLDEN_UPDATE bun test tests/unit/control/turn-queue.test.ts           # 白盒全绿
+for f in $(git ls-files 'tests/unit/control/*.test.ts'); do env -u GOLDEN_UPDATE bun test "$f"; done
+npx tsc --noEmit
+git status tests/unit/control/golden/fixtures/   # 相对 Task 0 commit 无 M
+```

--- a/docs/superpowers/specs/2026-07-10-control-turn-queue-split-design.md
+++ b/docs/superpowers/specs/2026-07-10-control-turn-queue-split-design.md
@@ -1,0 +1,134 @@
+# control-service executeTurn 拆分 — 设计 spec
+
+**归属**：2026-07 架构审读轨道 3(核心可维护性重构）第二块。第一块 `orchestration-service` 拆分已合入 main（PR #146/#147，squash `648a8e4`/`07874c0`），靠一层黄金特征化 oracle 保证行为等价。本 spec 沿用同一方法论。
+
+**状态**：已批准（brainstorming 三节全部确认，2026-07-10）。分支 `refactor/control-turn-queue-split`，base `origin/main`(`54be207`)。
+
+---
+
+## 目标（一句话）
+
+把 `src/control/control-service.ts` 的 `executeTurn`（约 290 行，`inFlight`/`queues`/`draining` 三态并发闸门）拆成两个可独立测试的单元 —— `TurnQueue`（并发原语）与 `SessionTurnRunner`（单次 turn 执行）—— **零行为变更**。
+
+## 为什么
+
+`executeTurn` 一个方法混了五类职责：并发闸门、会话解析 + `sessions-changed` 检测、media sandbox 过滤、stream/batched 段落重建、`agent.chat` 驱动 + 8 种事件发射。核心并发不变量**全靠同步执行顺序**维持（`inFlight.set` 在首个 `await` 前、`draining.add` 在 fire-and-forget 前）——这是 microtask 时序敏感的，重排一个 `await` 就可能破坏它。代码里三处注释自陈"永久 wedge"风险（`control-service.ts` 约 562/570/831 行，行号以本 spec 落地时的实际为准）。
+
+拆分后，那三处 wedge 的同步时序从"散落在 942 行大类里"变成"内聚在一个喂假 `runTurn` 就能穷举时序的单元"。
+
+## 非目标
+
+- **不碰** `control-service.ts` 里 `executeTurn` 之外的约 650 行（fs / session CRUD / scheduled / orchestration 转发）。聚焦并发闸门。
+- **不修** 三处 wedge 的隐患本身。行为等价重构：现有行为（包括脆弱处）原样保留，只是变得可测。wedge 的根治属于未来行为变更 spec。
+- **不改** 任何现有测试文件。它们是回归判据。
+
+---
+
+## 架构：三个单元的边界
+
+### `TurnQueue`（新，`src/control/turn-queue.ts`）
+
+并发原语。**零 `import` agent / session / uploadStore**。
+
+- 持有 `inFlight` / `queues` / `draining` 三态。
+- **所有 microtask 同步时序不变量内聚在这**：`inFlight.set` 在首个 `await` 前、`advanceQueue` 里 `draining.add` 在 fire-and-forget 的 drained turn 之前。
+- 构造接收 `{ runTurn(req, signal): Promise<Result>, emitQueueUpdated(key) }`。`runTurn` 是 `submit` 内**唯一的 await 点**（除 Stop-followup 分支的 `raceWithTimeout`，见下）。
+- API：
+  - `submit(key, req, { queueable }): Promise<Result | { queued: true, queueItemId }>` —— 含 busy 判定、排队、drain 交接、`CANCEL_DRAIN_TIMEOUT` 等待。
+  - `cancelTurn(key): boolean`
+  - `cancelQueuedItem(key, itemId): { cancelled: boolean }`
+  - 同步查询：`queueLength(key): number`、`isBusy(key): boolean` —— 供白盒同 tick 断言。
+- `submit` 的 busy 判定 + inFlight 登记 + 入队是**纯同步前缀**（常规路径）。唯一带 `await` 的决策分支是 Stop-followup 的 `raceWithTimeout(existing.settled, CANCEL_DRAIN_TIMEOUT_MS)`（wedge #2），与当前 executeTurn 等价。
+
+### `SessionTurnRunner`（新，`src/control/session-turn-runner.ts`）
+
+一次 turn 的完整执行，就是 `TurnQueue` 的 `runTurn` 回调实现。**不碰任何并发状态**。
+
+- session 解析、archived / `/clear` 检测 → `sessions-changed`。
+- media sandbox 过滤（逃逸上传根就丢弃）、stream vs batched 段落重建（复用已成型的纯函数）。
+- `agent.chat` 驱动 + 8 种事件发射、`turn-started` / `turn-finished`。
+- 给定 req，跑一次，发事件，返回 `Result`。
+
+### `ControlService.executeTurn`
+
+退化为：组装 req → `this.turnQueue.submit(...)`。`prompt()`(queueable) 与 `runScheduledTurn()`(不 queueable) 几乎不变。
+
+### 事件归属
+
+- `queue-updated` 由 **TurnQueue** 发（它是排队状态变化的唯一来源）。
+- `turn-started` / `turn-finished` / `turn-output` / `turn-thought` / `plan` / `turn-usage` / `agent-commands` / `tool-event` / `sessions-changed` 由 **SessionTurnRunner** 发（一次执行的生命周期）。
+- **数据流，非归属冲突**：`turn-started` 事件始终由 runner 发；当它是一个 drained 队列头时，其 `queueItemId` 字段的值由 TurnQueue 通过 `req` 传入（TurnQueue 知道哪个队列项正在 drain，runner 只是把它盖进事件）。同理 drained 头**不**重发 `prompt` 字段（hub 已在入队时持久化，重发会双持久化）——这条约束随 `req` 从 TurnQueue 流向 runner。
+
+---
+
+## 等价性判据：两层测试
+
+### 黑盒 oracle（跨重构，等价性判据）
+
+一个 characterization harness，面向 `ControlService` 公开面（`prompt` / `runScheduledTurn` / `cancelTurn` / `cancelQueuedItem`）驱动。**不窥探 private 三态**——只记两样跨整个场景的东西：
+
+1. **事件发射有序日志** —— 每次 `deps.events.emit(evt)` 记 `{ type + 关键字段 }`。`emit` 是同步的，harness 按调用顺序 append，**所以日志顺序 = 真实执行顺序（含跨 microtask）**。
+2. **每个入口调用的返回** —— `{ ok }` / `{ queued, queueItemId }` / `{ ok:false, "turn-already-running" }`。
+
+**驱动方式**：假 `agent.chat` 用**可控 deferred**（手动决定何时 resolve / reject / abort）；假 `events` 记有序日志；session / uploadStore 用最小 stub。
+
+**场景集**（8 个，覆盖三处 wedge）：
+
+1. busy 时第二个 prompt 入队（不 reject），发 `queue-updated`。
+2. scheduled turn 不入队仍 reject（`queueable` 缺省）。
+3. 队列 FIFO drain，每个各自成 turn。
+4. drain 交接窗口到达的 prompt 被入队（无并行 turn）。
+5. drained 头 `useSession` 失败仍 drain 后续队列项（无 stranded tail）。
+6. **cancel 清空队列时清 `draining`（wedge #3，无永久 wedge）**。
+7. **同 tick 两个 prompt 并发发起：恰一个赢，另一个入队**（见下"同 tick 时序"）。
+8. **Stop 后 follow-up 等被 cancel 的 turn drain 完再跑（wedge #2，`raceWithTimeout`）**。
+
+**同 tick 时序（场景 7 的强化）**：两个 `prompt` 在同一同步 tick 内并发发起（`const pA = svc.prompt(A); const pB = svc.prompt(B); await Promise.all([pA, pB])` —— 绝不 `await` 第一个再发第二个）。当前实现下 B 的 `queue-updated` 同步发、A 的 `turn-started` 在 await 链之后，基线日志形如 `[queue-updated([B]), turn-started(A), ...]`。任何改变这个相对顺序的时序回归（busy 判定从同步变跨 await → 两个都 `turn-started`、无 `queue-updated`）都让序列变、oracle 红。
+
+**盲区（诚实记录）**：纯粹多一个 `await Promise.resolve()`、却不改变任何事件相对顺序的 hop 增加——黑盒看不见。由白盒层覆盖。
+
+### 白盒 TurnQueue 单测（重构后新增，兑现"新单元可测"）
+
+直接喂假 `runTurn`（可控 resolve 时点），穷举 busy / 排队 / drain / cancel / wedge 时序。
+
+**同 tick 同步断言（覆盖黑盒盲区）**：`submit` 的同步前缀契约使得——
+
+```
+tq.submit(A);                        // 同步 inFlight.set
+tq.submit(B);                        // 同步入队
+expect(tq.queueLength(key)).toBe(1); // 同步断言,不 await
+```
+
+如果重构让 busy 判定跨了一个 `await`，这行同步断言时 `queueLength` 还是 0，直接失败——连"不改变事件顺序的纯 hop"也抓得住。
+
+### 现有测试
+
+`tests/unit/control/control-service-queue.test.ts`、`control-service-prompt.test.ts`、`control-service-prompt-status.test.ts` 等**一字不改**，全程绿。
+
+---
+
+## 阶段划分（交给 writing-plans）
+
+| 阶段 | 做什么 | 判据 |
+|---|---|---|
+| **0** | 建黑盒事件-日志 harness，**在重构前 commit（`54be207`）、独立 git worktree** 对当前 `executeTurn` 录基线 fixture（8 个并发场景）。若发现现有测试未覆盖的边角，**新增**测试补上（不改现有文件） | fixture 在基线上自我复现绿，`GOLDEN_UPDATE` 仅在基线 worktree 出现 |
+| **1** | 抽 `SessionTurnRunner`：把 turn 执行体搬进去，`executeTurn` 调它 | oracle + 现有测试全绿 |
+| **2** | 抽 `TurnQueue`：三态闸门搬进去，`executeTurn` 退化为 `submit`；新增 TurnQueue 白盒单测（含同 tick 同步断言 + 三处 wedge 变异验证） | oracle + 现有测试 + 白盒全绿 |
+| **3** | `ControlService` 收尾，删死代码，注释迁移 | 全绿 + `npx tsc --noEmit` |
+
+## 纪律（照搬 orchestration 的血泪教训）
+
+- **基线 fixture 必须在重构前 commit（`54be207`）、独立 worktree 里录**，再让重构后的实现复现——绝不拿重构后行为当基线，否则把回归洗进新基线。`GOLDEN_UPDATE=1` 只在基线 worktree 出现。
+- **每个关键不变量靠变异验证**：删掉 `draining.add`、把 `inFlight.set` 挪到 await 后、把 busy 判定跨一个 await —— 各自必须让对应的 oracle 场景或白盒断言变红。变异先 `grep` 确认应用成功再下结论。
+- **逐文件 `bun test`**，never 整目录（模块状态泄漏→假失败）。
+- **子代理 git 卫生**：实现子代理不跑任何 git 命令，controller 自己 `git log` 核实真实提交；会改文件的评审子代理必须 `isolation: "worktree"`。
+- **值导入是真运行时循环**：子服务 `import type` 门面安全，但自由函数/常量从门面 import 回来会成环——自由函数迁中立模块。
+- **microtask hop 敏感**：`turn-finished` finally 里的 `draining.add`、`advanceQueue` 的 fire-and-forget `void executeTurn(...)` 是同步时序不变量的载体，搬运时保持同步执行顺序；hop 深度靠变异验证，不靠猜。
+
+## 落点
+
+- `src/control/turn-queue.ts`（新）
+- `src/control/session-turn-runner.ts`（新）
+- `src/control/control-service.ts`（`executeTurn`/`advanceQueue`/`cancelTurn`/`cancelQueuedItem` 迁出，退化为 `submit` 组装）
+- `tests/unit/control/golden/`（新，黑盒事件-日志 harness + fixture）
+- `tests/unit/control/turn-queue.test.ts`（新，白盒单测）

--- a/docs/superpowers/specs/2026-07-10-control-turn-queue-split-design.md
+++ b/docs/superpowers/specs/2026-07-10-control-turn-queue-split-design.md
@@ -32,7 +32,7 @@
 
 - 持有 `inFlight` / `queues` / `draining` 三态。
 - **所有 microtask 同步时序不变量内聚在这**：`inFlight.set` 在首个 `await` 前、`advanceQueue` 里 `draining.add` 在 fire-and-forget 的 drained turn 之前。
-- 构造接收 `{ runTurn(req, signal): Promise<Result>, emitQueueUpdated(key) }`。`runTurn` 是 `submit` 内**唯一的 await 点**（除 Stop-followup 分支的 `raceWithTimeout`，见下）。
+- 构造接收 `{ runTurn(req, signal): Promise<Result>, emitQueueUpdated(key), detectSessionsChanged(detection) }`（`detectSessionsChanged` 见下方 2026-07-11 修订）。`runTurn` 是 `submit` 内正常路径的主 await 点（另有 Stop-followup 分支的 `raceWithTimeout`，以及回合结束后 `draining` 守护窗口内的 `detectSessionsChanged`，均见下）。
 - API：
   - `submit(key, req, { queueable }): Promise<Result | { queued: true, queueItemId }>` —— 含 busy 判定、排队、drain 交接、`CANCEL_DRAIN_TIMEOUT` 等待。
   - `cancelTurn(key): boolean`
@@ -58,6 +58,22 @@
 - `queue-updated` 由 **TurnQueue** 发（它是排队状态变化的唯一来源）。
 - `turn-started` / `turn-finished` / `turn-output` / `turn-thought` / `plan` / `turn-usage` / `agent-commands` / `tool-event` / `sessions-changed` 由 **SessionTurnRunner** 发（一次执行的生命周期）。
 - **数据流，非归属冲突**：`turn-started` 事件始终由 runner 发；当它是一个 drained 队列头时，其 `queueItemId` 字段的值由 TurnQueue 通过 `req` 传入（TurnQueue 知道哪个队列项正在 drain，runner 只是把它盖进事件）。同理 drained 头**不**重发 `prompt` 字段（hub 已在入队时持久化，重发会双持久化）——这条约束随 `req` 从 TurnQueue 流向 runner。
+
+> **修订（2026-07-11，实现落地）：`sessions-changed` 归属拆成两半。**
+> 上面的原始边界把整个 `sessions-changed` 检测划给 runner。实现时发现回合结束后的
+> **transport-session-moved 检测**（`/clear` reset 重建了 transport 会话）必须在
+> `TurnQueue` 设置 `draining.add` **之后**、`resolveSettled` 之前执行——那个 `getSession`
+> await 必须留在 draining 守护窗口内，否则一个被中止且带排队项的回合会让新提示词插进来抢跑。
+> 若把它整个留在 runner 里（runTurn 之内），`draining.add` 必然排在 `getSession` await 之后，
+> 重开这个竞态（Task 1 用探针实测：朴素版把窗口内新 prompt 从「立即入队」变成 5000ms 阻塞）。
+>
+> 因此最终边界是：
+> - **archived-restore** 的 `sessions-changed` 仍由 runner 在回合开始（`useSession` 之后）发。
+> - **transport-moved** 的检测由 runner 只**捕获回合前状态并作为 `TurnResult.postTurnDetection` 返回**，
+>   真正的 `getSession` 比较 + emit 由 `TurnQueue` 经注入的 `detectSessionsChanged(detection)` 回调
+>   在 draining 守护窗口内执行。`TurnQueue` 因此仍**零 session 依赖**（检测经回调穿入，不自持 `SessionService`）。
+> - 这个额外 await 由第 9 个 golden fixture `aborted-queue-sessions-window` 钉住（基线录、变异验证：
+>   把 `draining.add` 移到该 await 之后 → 仅该 fixture 变红）。原始 8 场景不覆盖这个窗口，所以朴素抽取才溜过。
 
 ---
 

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-
 import type { Agent as ChatAgent } from "../weixin/agent/interface";
 import type { SessionService } from "../sessions/session-service";
 import type { AgentSession, ResolvedSession, SessionTransport } from "../transport/types";
@@ -20,22 +18,15 @@ import {
   isSessionAliasVisibleInChannel,
   toDisplaySessionAlias,
 } from "../channels/channel-scope";
-import type { ControlEventBus, ScheduledOrigin } from "./control-event-bus";
+import type { ControlEventBus } from "./control-event-bus";
 import { readNativeSessionHistory, type NativeHistoryMessage } from "../transport/native-session-history";
 import type { AgentCatalogEntry } from "../config/agent-catalog";
 import { WorkspaceFs, type DirListing, type FileContent, type SearchOptions, type SearchResult, type WorkspaceDiff } from "./workspace-fs";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import type { UploadStore } from "./upload-store.js";
-import { SessionTurnRunner, type TurnResult } from "./session-turn-runner";
-import {
-  turnKey,
-  toErrorMessage,
-  buildControlMetadata,
-  raceWithTimeout,
-  CANCEL_DRAIN_TIMEOUT_MS,
-  QUEUE_PREVIEW_MAX,
-  type QueuedPrompt,
-} from "./turn-support";
+import { SessionTurnRunner } from "./session-turn-runner";
+import { TurnQueue } from "./turn-queue";
+import { buildControlMetadata } from "./turn-support";
 
 export interface ControlSessionInfo {
   alias: string;
@@ -178,9 +169,25 @@ export interface ControlExecuteCommandInput {
 // connector first). Holds no state of its own beyond in-flight turn tracking.
 export class ControlService {
   private readonly runner: SessionTurnRunner;
+  private readonly turnQueue: TurnQueue;
 
   constructor(private readonly deps: ControlServiceDeps) {
     this.runner = new SessionTurnRunner(deps);
+    this.turnQueue = new TurnQueue({
+      runTurn: (req, signal) => this.runner.run(req, signal),
+      emitQueueUpdated: (chatKey, sessionAlias, items) =>
+        this.deps.events.emit({ type: "queue-updated", chatKey, sessionAlias, items }),
+      detectSessionsChanged: async (detection) => {
+        try {
+          const after = await this.deps.sessions.getSession(detection.internalAlias);
+          if (after && after.transportSession !== detection.priorTransportSession) {
+            this.deps.events.emit({ type: "sessions-changed" });
+          }
+        } catch {
+          /* best-effort: no refresh on detection failure */
+        }
+      },
+    });
   }
 
   // Read-only workspace file browser, scoped to configured workspace roots. Lazily
@@ -446,32 +453,8 @@ export class ControlService {
     return task;
   }
 
-  // Each in-flight turn carries its AbortController plus a `settled` promise that
-  // resolves once the turn has fully unwound (transport cancelled, inFlight cleared).
-  private readonly inFlight = new Map<string, { controller: AbortController; settled: Promise<void> }>();
-
-  // Per-session FIFO queue of prompts that arrived while a turn was already running.
-  // Only interactive prompt() enqueues (see `queueable` on executeTurn); scheduled
-  // turns keep rejecting immediately. Drained by Task 2's turn-finish hand-off.
-  private readonly queues = new Map<string, QueuedPrompt[]>();
-
-  // Set synchronously during a turn-finish drain hand-off: the finished turn has cleared
-  // its inFlight entry but the drained head has not yet re-registered its own. The enqueue
-  // gate treats `draining.has(key)` as busy so nothing starts a parallel turn in that
-  // window. The drained turn clears it right after it re-registers inFlight.
-  private readonly draining = new Set<string>();
-
-  private emitQueueUpdated(chatKey: string, sessionAlias: string): void {
-    const items = (this.queues.get(turnKey(chatKey, sessionAlias)) ?? []).map((q) => ({
-      id: q.id,
-      textPreview: q.text.length > QUEUE_PREVIEW_MAX ? q.text.slice(0, QUEUE_PREVIEW_MAX) : q.text,
-      enqueuedAt: q.enqueuedAt,
-    }));
-    this.deps.events.emit({ type: "queue-updated", chatKey, sessionAlias, items });
-  }
-
   async prompt(input: ControlPromptInput): Promise<ControlPromptResult> {
-    return this.executeTurn({
+    return this.turnQueue.submit({
       chatKey: input.chatKey,
       sessionAlias: input.sessionAlias,
       text: input.text,
@@ -488,7 +471,7 @@ export class ControlService {
    *  with the prompt text + schedule origin so the hub records the inbound message and
    *  the web can badge it. Owner-authorized: the task was owner-gated at creation. */
   async runScheduledTurn(input: ControlScheduledTurnInput): Promise<ControlPromptResult> {
-    return this.executeTurn({
+    return this.turnQueue.submit({
       chatKey: input.chatKey,
       sessionAlias: input.sessionAlias,
       text: input.promptText,
@@ -500,199 +483,8 @@ export class ControlService {
     });
   }
 
-  private async executeTurn(params: {
-    chatKey: string;
-    sessionAlias: string;
-    text: string;
-    senderId: string;
-    isOwner?: boolean;
-    accountId?: string;
-    // External abort (e.g. the scheduler's per-dispatch timeout) linked to this turn.
-    abortSignal?: AbortSignal;
-    // Extra fields stamped onto turn-started for scheduled-origin turns. `queueItemId`
-    // is set only for a drained queue head (Task 2) so the web can reconcile the badge.
-    turnStarted?: { prompt?: string; scheduled?: ScheduledOrigin; queueItemId?: string };
-    media?: PromptAttachmentRef[];
-    // Only interactive prompt() sets this. When true and a turn is already running,
-    // the prompt is appended to the per-session queue instead of being rejected.
-    // runScheduledTurn omits it, so scheduled turns keep the immediate-or-reject
-    // behavior.
-    queueable?: boolean;
-    // Set only by the turn-finish drain hand-off. A drained head turn bypasses the busy
-    // gate (it is what the finished turn intentionally started next), re-registers its own
-    // inFlight, and clears the `draining` guard — all synchronously at its top.
-    drained?: boolean;
-  }): Promise<ControlPromptResult> {
-    const key = turnKey(params.chatKey, params.sessionAlias);
-    // A drained head turn (params.drained) is the turn the just-finished turn intentionally
-    // started next; it must bypass this gate (it re-registers its own inFlight and clears
-    // the `draining` guard synchronously at its top). Every other caller treats a live turn
-    // OR an in-progress drain hand-off as busy.
-    if (!params.drained) {
-      const existing = this.inFlight.get(key);
-      // Busy when a live un-cancelled turn holds the slot, OR a drain hand-off is mid-flight
-      // (inFlight momentarily cleared but the drained head not yet re-registered).
-      const busy =
-        this.draining.has(key) || (existing !== undefined && !existing.controller.signal.aborted);
-      if (busy) {
-        if (params.queueable) {
-          const id = randomUUID();
-          const item: QueuedPrompt = {
-            id,
-            text: params.text,
-            enqueuedAt: new Date().toISOString(),
-            senderId: params.senderId,
-            ...(params.isOwner !== undefined ? { isOwner: params.isOwner } : {}),
-            ...(params.accountId !== undefined ? { accountId: params.accountId } : {}),
-            ...(params.media !== undefined ? { media: params.media } : {}),
-          };
-          const q = this.queues.get(key) ?? [];
-          q.push(item);
-          this.queues.set(key, q);
-          this.emitQueueUpdated(params.chatKey, params.sessionAlias);
-          return { ok: true, queued: true, queueItemId: id };
-        }
-        // Not queueable (e.g. a scheduled turn) — reject right away.
-        return { ok: false, errorMessage: "turn-already-running" };
-      }
-      if (existing) {
-        // existing is present but its controller is aborted (a Stop is unwinding it) and no
-        // drain is in progress. Cancelling the transport and draining the agent takes time,
-        // during which the turn stays registered. Wait (bounded) for it to clear so the
-        // user's immediate follow-up starts a fresh turn instead of hitting
-        // "turn-already-running"; a wedged turn still falls through to the rejection below.
-        await raceWithTimeout(existing.settled, CANCEL_DRAIN_TIMEOUT_MS);
-        if (this.inFlight.has(key)) {
-          return { ok: false, errorMessage: "turn-already-running" };
-        }
-      }
-    }
-    const controller = new AbortController();
-    // Link an external abort (scheduler dispatch timeout) to this turn so a wedged
-    // scheduled prompt is cancelled cooperatively, just like a user Stop.
-    if (params.abortSignal) {
-      if (params.abortSignal.aborted) controller.abort();
-      else params.abortSignal.addEventListener("abort", () => controller.abort(), { once: true });
-    }
-    let resolveSettled!: () => void;
-    const settled = new Promise<void>((resolve) => { resolveSettled = resolve; });
-    this.inFlight.set(key, { controller, settled });
-    // A drained head turn has now re-registered its own inFlight synchronously (no await
-    // since the finished turn's finally). Clear the hand-off guard: the slot is genuinely
-    // held again, so the temporary `draining` busy marker is no longer needed.
-    if (params.drained) {
-      this.draining.delete(key);
-    }
-    // The per-turn execution body (session bind, turn-started, media sandboxing,
-    // stream/batched reconstruction, the agent.chat drive, turn-finished, and the
-    // sessions-changed detection for a transport session that moved mid-turn) lives in
-    // SessionTurnRunner — this method keeps only the concurrency gate + inFlight/settled
-    // lifecycle around it.
-    let result: TurnResult | undefined;
-    try {
-      result = await this.runner.run(
-        {
-          chatKey: params.chatKey,
-          sessionAlias: params.sessionAlias,
-          text: params.text,
-          senderId: params.senderId,
-          ...(params.isOwner !== undefined ? { isOwner: params.isOwner } : {}),
-          ...(params.accountId !== undefined ? { accountId: params.accountId } : {}),
-          ...(params.turnStarted ? { turnStarted: params.turnStarted } : {}),
-          ...(params.media !== undefined ? { media: params.media } : {}),
-        },
-        controller.signal,
-      );
-    } finally {
-      // If a queued head is waiting, mark `draining` synchronously NOW — before the slot is
-      // handed off, and before the awaited post-turn detection below — so nothing starts a
-      // parallel turn during the release→drain window, even for an *aborted* turn whose
-      // lingering inFlight entry no longer reads as busy. advanceQueue re-adds it harmlessly;
-      // the drained turn clears it once it re-registers its own inFlight. When the queue is
-      // empty, this turn's still-present inFlight entry is itself the busy marker (a
-      // normally-finished turn's controller is not aborted), so no drain is possible.
-      if ((this.queues.get(key)?.length ?? 0) > 0) {
-        this.draining.add(key);
-      }
-      // Post-turn `sessions-changed` detection runs HERE, after `draining` is set — not inside
-      // the runner. A transport session that moved during the turn (archived-restore or
-      // `/clear`) needs a dashboard refresh, but the getSession await it takes must stay inside
-      // the draining-guarded window, or an aborted turn with a queued item lets a fresh prompt
-      // race in. The runner returns the captured inputs via postTurnDetection.
-      const detection = result?.postTurnDetection;
-      if (detection) {
-        try {
-          const after = await this.deps.sessions.getSession(detection.internalAlias);
-          if (after && after.transportSession !== detection.priorTransportSession) {
-            this.deps.events.emit({ type: "sessions-changed" });
-          }
-        } catch {
-          /* best-effort: no refresh on detection failure */
-        }
-      }
-      resolveSettled();
-      // Single decision point (shared whether the runner failed at useSession or at the chat
-      // drive): start the next queued head as the drained turn while holding the slot, or
-      // release inFlight if empty.
-      this.advanceQueue(key, params.chatKey, params.sessionAlias);
-    }
-    // Strip the internal postTurnDetection so ControlPromptResult stays exactly
-    // {ok, text?, errorMessage?} — the golden fixtures record this return value.
-    return {
-      ok: result!.ok,
-      ...(result!.text !== undefined ? { text: result!.text } : {}),
-      ...(result!.errorMessage !== undefined ? { errorMessage: result!.errorMessage } : {}),
-    };
-  }
-
-  // Advances the per-session FIFO queue after a turn ends. If a head exists, starts it as the
-  // next (drained) turn while holding the busy slot via `draining`; otherwise releases the
-  // inFlight slot. Must be called exactly once per ended turn. Fully synchronous: `draining` is
-  // added BEFORE the fire-and-forget drained `executeTurn`, whose `inFlight.set` runs
-  // synchronously before its first await — so there is no window in which an incoming prompt
-  // could observe a not-busy session between the ended turn and the drained turn.
-  private advanceQueue(key: string, chatKey: string, sessionAlias: string): void {
-    const q = this.queues.get(key);
-    const next = q?.shift();
-    if (q && q.length === 0) this.queues.delete(key);
-    if (next) {
-      this.draining.add(key);
-      // The head was already popped above; emit the shorter snapshot.
-      this.emitQueueUpdated(chatKey, sessionAlias);
-      // Fire-and-forget: the drained turn drives its own settled lifecycle. It bypasses the
-      // busy gate (drained: true), re-registers inFlight and clears `draining` at its top — all
-      // synchronously before the first await — so there is no parallel-turn window. Pass
-      // queueItemId ONLY, never prompt: the hub already persisted the inbound at enqueue, so
-      // re-emitting prompt would double-persist and duplicate the bubble.
-      void this.executeTurn({
-        chatKey,
-        sessionAlias,
-        text: next.text,
-        senderId: next.senderId,
-        queueable: true,
-        drained: true,
-        ...(next.isOwner !== undefined ? { isOwner: next.isOwner } : {}),
-        ...(next.accountId !== undefined ? { accountId: next.accountId } : {}),
-        ...(next.media !== undefined ? { media: next.media } : {}),
-        turnStarted: { queueItemId: next.id },
-      });
-    } else {
-      // The queue emptied during the drain hand-off (e.g. a cancel removed the only queued
-      // item while the finally's post-turn `await getSession` was in flight, after the finally
-      // set `draining`). No drained turn is coming to clear the guard, so clear it here too —
-      // otherwise `draining` leaks and every future prompt enqueues forever (permanent wedge).
-      this.draining.delete(key);
-      this.inFlight.delete(key);
-    }
-  }
-
   cancelTurn(chatKey: string, sessionAlias: string): boolean {
-    const entry = this.inFlight.get(turnKey(chatKey, sessionAlias));
-    if (!entry) {
-      return false;
-    }
-    entry.controller.abort();
-    return true;
+    return this.turnQueue.cancelTurn(chatKey, sessionAlias);
   }
 
   /** Remove a pending queued prompt (by id) before it drains. No-ops (returns
@@ -700,15 +492,7 @@ export class ControlService {
    *  e.g. a race where the item drained into a running turn just before the cancel
    *  arrived. Does NOT touch a turn that is already running (use `cancelTurn`). */
   cancelQueuedItem(chatKey: string, sessionAlias: string, itemId: string): { cancelled: boolean } {
-    const key = turnKey(chatKey, sessionAlias);
-    const q = this.queues.get(key);
-    if (!q) return { cancelled: false };
-    const i = q.findIndex((x) => x.id === itemId);
-    if (i < 0) return { cancelled: false };
-    q.splice(i, 1);
-    if (q.length === 0) this.queues.delete(key);
-    this.emitQueueUpdated(chatKey, sessionAlias);
-    return { cancelled: true };
+    return this.turnQueue.cancelQueuedItem(chatKey, sessionAlias, itemId);
   }
 
   async executeCommand(input: ControlExecuteCommandInput): Promise<string> {

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -1,7 +1,6 @@
-import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-import type { Agent as ChatAgent, ChatRequestMetadata } from "../weixin/agent/interface";
+import type { Agent as ChatAgent } from "../weixin/agent/interface";
 import type { SessionService } from "../sessions/session-service";
 import type { AgentSession, ResolvedSession, SessionTransport } from "../transport/types";
 import type { ActiveTurnRegistry } from "../sessions/active-turn-registry";
@@ -27,6 +26,16 @@ import type { AgentCatalogEntry } from "../config/agent-catalog";
 import { WorkspaceFs, type DirListing, type FileContent, type SearchOptions, type SearchResult, type WorkspaceDiff } from "./workspace-fs";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import type { UploadStore } from "./upload-store.js";
+import { SessionTurnRunner, type TurnResult } from "./session-turn-runner";
+import {
+  turnKey,
+  toErrorMessage,
+  buildControlMetadata,
+  raceWithTimeout,
+  CANCEL_DRAIN_TIMEOUT_MS,
+  QUEUE_PREVIEW_MAX,
+  type QueuedPrompt,
+} from "./turn-support";
 
 export interface ControlSessionInfo {
   alias: string;
@@ -143,18 +152,6 @@ export interface ControlPromptResult {
   queueItemId?: string;
 }
 
-/** A prompt held in the per-session server-side queue while a turn is in flight.
- *  Runs through the same `executeTurn` machinery as a manual prompt once drained. */
-export interface QueuedPrompt {
-  id: string;
-  text: string;
-  enqueuedAt: string;
-  senderId: string;
-  isOwner?: boolean;
-  accountId?: string;
-  media?: PromptAttachmentRef[];
-}
-
 /** A turn started by a fired scheduled task. Runs through the same agent + turn-event
  *  machinery as a normal prompt, so it streams live and persists to history — but it
  *  also carries the prompt text + schedule origin in turn-started, so the hub can
@@ -180,7 +177,11 @@ export interface ControlExecuteCommandInput {
 // Thin structured facade over core services for non-text consumers (the relay
 // connector first). Holds no state of its own beyond in-flight turn tracking.
 export class ControlService {
-  constructor(private readonly deps: ControlServiceDeps) {}
+  private readonly runner: SessionTurnRunner;
+
+  constructor(private readonly deps: ControlServiceDeps) {
+    this.runner = new SessionTurnRunner(deps);
+  }
 
   // Read-only workspace file browser, scoped to configured workspace roots. Lazily
   // reads the live workspace list so newly-created workspaces are immediately browsable.
@@ -582,204 +583,47 @@ export class ControlService {
     if (params.drained) {
       this.draining.delete(key);
     }
-    // Sending to an archived session restores it (useSession clears `archived`), and
-    // `/clear` (session.reset) recreates the transport session under the same alias — both
-    // mutate the session row, but neither useSession nor the reset handler emits an event.
-    // Capture the pre-turn state here so we can detect the transition afterwards and emit
-    // `sessions-changed`, otherwise the dashboard keeps showing a stale archived badge /
-    // transport+native binding on the row until the next unrelated refresh.
-    let internalAlias: string | undefined;
-    let wasArchived = false;
-    let priorTransportSession: string | undefined;
+    // The per-turn execution body (session bind, turn-started, media sandboxing,
+    // stream/batched reconstruction, the agent.chat drive, turn-finished, and the
+    // sessions-changed detection for a transport session that moved mid-turn) lives in
+    // SessionTurnRunner — this method keeps only the concurrency gate + inFlight/settled
+    // lifecycle around it.
+    let result: TurnResult | undefined;
     try {
-      internalAlias = await this.deps.sessions.resolveAliasForChat(params.chatKey, params.sessionAlias);
-      const prior = await this.deps.sessions.getSession(internalAlias);
-      wasArchived = prior?.archived === true;
-      priorTransportSession = prior?.transportSession;
-    } catch {
-      /* best-effort: a detection failure just means no badge refresh */
-    }
-    try {
-      await this.deps.sessions.useSession(params.chatKey, params.sessionAlias);
-    } catch (error) {
-      // This turn never really started, but it still holds the slot. Settle it and advance the
-      // queue so a transient bind failure on a *drained* head does not strand the items behind
-      // it (which would otherwise only run when a future unrelated prompt arrives, reordering
-      // FIFO). advanceQueue releases inFlight itself when the queue is empty and hands the slot
-      // to the next drained turn otherwise — so we must NOT delete inFlight here (no
-      // double-release, no double-drain).
-      resolveSettled();
-      this.advanceQueue(key, params.chatKey, params.sessionAlias);
-      return { ok: false, errorMessage: toErrorMessage(error) };
-    }
-    if (wasArchived) {
-      this.deps.events.emit({ type: "sessions-changed" });
-    }
-    this.deps.events.emit({
-      type: "turn-started",
-      chatKey: params.chatKey,
-      sessionAlias: params.sessionAlias,
-      ...(params.turnStarted?.prompt ? { prompt: params.turnStarted.prompt } : {}),
-      ...(params.turnStarted?.scheduled ? { scheduled: params.turnStarted.scheduled } : {}),
-      ...(params.turnStarted?.queueItemId ? { queueItemId: params.turnStarted.queueItemId } : {}),
-    });
-    // Stream-mode sessions (replyMode "stream") get raw token streaming: the transport
-    // forwards chunks verbatim (paragraph breaks intact), so we concatenate as-is.
-    // Batched sessions get pre-split, trimmed paragraph segments instead — there the
-    // original "\n\n" is gone, and both turn-output consumers (web live view + hub
-    // history buffer) simply concatenate, running paragraphs together on one line. For
-    // those we re-insert the break between segments so live and history stay identical.
-    let streamMode = false;
-    try {
-      const resolved = await this.resolveControlSession(params.chatKey, params.sessionAlias);
-      streamMode = (resolved?.effectiveReplyMode ?? resolved?.replyMode) === "stream";
-    } catch {
-      // Best-effort: fall back to batched paragraph reconstruction.
-    }
-    let emittedChunk = false;
-    const emitChunk = (chunk: string) => {
-      if (!chunk) return;
-      this.deps.events.emit({
-        type: "turn-output",
-        chatKey: params.chatKey,
-        sessionAlias: params.sessionAlias,
-        chunk: !streamMode && emittedChunk ? `\n\n${chunk}` : chunk,
-      });
-      emittedChunk = true;
-    };
-    // Defense-in-depth: the two-phase upload sandbox is meant to be the only source of
-    // attachment bytes (the web flow echoes back the path control.upload returned, which
-    // lives under the sandbox root). Drop any media ref whose resolved filePath escapes
-    // that root so a caller cannot point the agent at an arbitrary absolute path. Only
-    // touch the upload store when a turn actually carries media — a plain prompt turn
-    // has no attachments and must not depend on the store being present.
-    const incomingMedia = params.media ?? [];
-    const sandboxedMedia = incomingMedia.length
-      ? (() => {
-          const uploadRoot = path.resolve(this.deps.uploadStore.root);
-          const kept = incomingMedia.filter((ref) => {
-            const resolved = path.resolve(ref.filePath);
-            return resolved === uploadRoot || resolved.startsWith(uploadRoot + path.sep);
-          });
-          const dropped = incomingMedia.length - kept.length;
-          if (dropped > 0) {
-            console.warn(
-              `[control] dropped ${dropped} media ref(s) with filePath outside the upload sandbox`,
-            );
-          }
-          return kept;
-        })()
-      : incomingMedia;
-    const chatMedia = sandboxedMedia.map((ref) => ({
-      kind: ref.kind,
-      filePath: ref.filePath,
-      mimeType: ref.mimeType,
-      ...(ref.fileName ? { fileName: ref.fileName } : {}),
-      sizeBytes: ref.size,
-      source: {
-        channelId: "relay",
-        accountId: params.accountId ?? "control",
-        chatKey: params.chatKey,
-        messageId: ref.id,
-      },
-    }));
-    try {
-      const response = await this.deps.agent.chat({
-        accountId: params.accountId ?? "control",
-        conversationId: params.chatKey,
-        text: params.text,
-        metadata: buildControlMetadata(params.senderId, params.isOwner),
-        abortSignal: controller.signal,
-        ...(chatMedia.length > 0 ? { media: chatMedia } : {}),
-        reply: async (chunk) => {
-          emitChunk(chunk);
+      result = await this.runner.run(
+        {
+          chatKey: params.chatKey,
+          sessionAlias: params.sessionAlias,
+          text: params.text,
+          senderId: params.senderId,
+          ...(params.isOwner !== undefined ? { isOwner: params.isOwner } : {}),
+          ...(params.accountId !== undefined ? { accountId: params.accountId } : {}),
+          ...(params.turnStarted ? { turnStarted: params.turnStarted } : {}),
+          ...(params.media !== undefined ? { media: params.media } : {}),
         },
-        onToolEvent: (event) => {
-          this.deps.events.emit({
-            type: "tool-event",
-            chatKey: params.chatKey,
-            sessionAlias: params.sessionAlias,
-            event,
-          });
-        },
-        onThought: (chunk) => {
-          this.deps.events.emit({
-            type: "turn-thought",
-            chatKey: params.chatKey,
-            sessionAlias: params.sessionAlias,
-            chunk,
-          });
-        },
-        onPlan: (entries) => {
-          this.deps.events.emit({
-            type: "plan",
-            chatKey: params.chatKey,
-            sessionAlias: params.sessionAlias,
-            entries,
-          });
-        },
-        onUsage: (usage) => {
-          this.deps.events.emit({
-            type: "turn-usage",
-            chatKey: params.chatKey,
-            sessionAlias: params.sessionAlias,
-            used: usage.used,
-            size: usage.size,
-            ...(usage.cost ? { cost: usage.cost } : {}),
-            ...(usage.breakdown ? { breakdown: usage.breakdown } : {}),
-          });
-        },
-        onCommands: (commands) => {
-          this.deps.events.emit({
-            type: "agent-commands",
-            chatKey: params.chatKey,
-            sessionAlias: params.sessionAlias,
-            commands,
-          });
-        },
-      });
-      if (response.text) {
-        emitChunk(response.text);
-      }
-      this.deps.events.emit({
-        type: "turn-finished",
-        chatKey: params.chatKey,
-        sessionAlias: params.sessionAlias,
-        ok: true,
-      });
-      return { ok: true, text: response.text };
-    } catch (error) {
-      const errorMessage = toErrorMessage(error);
-      this.deps.events.emit({
-        type: "turn-finished",
-        chatKey: params.chatKey,
-        sessionAlias: params.sessionAlias,
-        ok: false,
-        errorMessage,
-        ...(controller.signal.aborted ? { cancelled: true } : {}),
-      });
-      return { ok: false, errorMessage };
+        controller.signal,
+      );
     } finally {
-      // If a queued head is waiting, mark `draining` synchronously NOW — before the awaited
-      // sessions-changed detection below and before the slot is handed off — so nothing starts
-      // a parallel turn during the release→drain window, even for an *aborted* turn whose
+      // If a queued head is waiting, mark `draining` synchronously NOW — before the slot is
+      // handed off, and before the awaited post-turn detection below — so nothing starts a
+      // parallel turn during the release→drain window, even for an *aborted* turn whose
       // lingering inFlight entry no longer reads as busy. advanceQueue re-adds it harmlessly;
       // the drained turn clears it once it re-registers its own inFlight. When the queue is
-      // empty, this turn's still-present inFlight entry is itself the busy marker across the
-      // await (a normally-finished turn's controller is not aborted), so no drain is possible
-      // and none is needed.
+      // empty, this turn's still-present inFlight entry is itself the busy marker (a
+      // normally-finished turn's controller is not aborted), so no drain is possible.
       if ((this.queues.get(key)?.length ?? 0) > 0) {
         this.draining.add(key);
       }
-      // `/clear` (session.reset) recreated the transport session during the turn (and may
-      // have re-bound a fresh native agentSessionId). Emit `sessions-changed` so the
-      // dashboard refreshes the row; best-effort, and only when the binding actually moved.
-      // Kept inline (NOT inside advanceQueue): it is async/awaited and specific to THIS
-      // just-completed turn. inFlight is still held here, so it stays busy across the await.
-      if (internalAlias && priorTransportSession) {
+      // Post-turn `sessions-changed` detection runs HERE, after `draining` is set — not inside
+      // the runner. A transport session that moved during the turn (archived-restore or
+      // `/clear`) needs a dashboard refresh, but the getSession await it takes must stay inside
+      // the draining-guarded window, or an aborted turn with a queued item lets a fresh prompt
+      // race in. The runner returns the captured inputs via postTurnDetection.
+      const detection = result?.postTurnDetection;
+      if (detection) {
         try {
-          const after = await this.deps.sessions.getSession(internalAlias);
-          if (after && after.transportSession !== priorTransportSession) {
+          const after = await this.deps.sessions.getSession(detection.internalAlias);
+          if (after && after.transportSession !== detection.priorTransportSession) {
             this.deps.events.emit({ type: "sessions-changed" });
           }
         } catch {
@@ -787,10 +631,18 @@ export class ControlService {
         }
       }
       resolveSettled();
-      // Single decision point (shared with the useSession-failure path): start the next queued
-      // head as the drained turn while holding the slot, or release inFlight if empty.
+      // Single decision point (shared whether the runner failed at useSession or at the chat
+      // drive): start the next queued head as the drained turn while holding the slot, or
+      // release inFlight if empty.
       this.advanceQueue(key, params.chatKey, params.sessionAlias);
     }
+    // Strip the internal postTurnDetection so ControlPromptResult stays exactly
+    // {ok, text?, errorMessage?} — the golden fixtures record this return value.
+    return {
+      ok: result!.ok,
+      ...(result!.text !== undefined ? { text: result!.text } : {}),
+      ...(result!.errorMessage !== undefined ? { errorMessage: result!.errorMessage } : {}),
+    };
   }
 
   // Advances the per-session FIFO queue after a turn ends. If a head exists, starts it as the
@@ -900,43 +752,4 @@ export class ControlService {
   closeTerminal(terminalId: string): void {
     this.deps.terminal.close(terminalId);
   }
-}
-
-// Upper bound on how long a follow-up prompt waits for a just-cancelled turn to
-// finish tearing down before giving up and reporting the session still busy.
-const CANCEL_DRAIN_TIMEOUT_MS = 5000;
-
-// Server-side truncation for a queued item's textPreview on the queue-updated wire
-// event, so a very long queued prompt doesn't bloat the snapshot payload.
-const QUEUE_PREVIEW_MAX = 120;
-
-// Resolve when `promise` settles or `ms` elapses, whichever comes first. The timer
-// is cleared on the winning path so a fast drain doesn't keep the event loop alive.
-async function raceWithTimeout(promise: Promise<void>, ms: number): Promise<void> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<void>((resolve) => {
-    timer = setTimeout(resolve, ms);
-  });
-  try {
-    await Promise.race([promise, timeout]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
-function turnKey(chatKey: string, sessionAlias: string): string {
-  return `${chatKey} ${sessionAlias}`;
-}
-
-function toErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function buildControlMetadata(senderId: string, isOwner: boolean | undefined): ChatRequestMetadata {
-  return {
-    channel: "control",
-    chatType: "direct",
-    senderId,
-    ...(isOwner === undefined ? {} : { isOwner }),
-  };
 }

--- a/src/control/session-turn-runner.ts
+++ b/src/control/session-turn-runner.ts
@@ -1,0 +1,246 @@
+import path from "node:path";
+import type { ControlServiceDeps } from "./control-service";
+import type { ScheduledOrigin } from "./control-event-bus";
+import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
+import { toErrorMessage, buildControlMetadata } from "./turn-support";
+
+export interface TurnRequest {
+  chatKey: string;
+  sessionAlias: string;
+  text: string;
+  senderId: string;
+  isOwner?: boolean;
+  accountId?: string;
+  // External abort (e.g. the scheduler's per-dispatch timeout) linked to this turn.
+  // Unused by run() itself — the caller links it into the AbortController whose
+  // .signal is passed as run()'s second argument — kept here only for call-shape
+  // symmetry with executeTurn's params.
+  abortSignal?: AbortSignal;
+  // Extra fields stamped onto turn-started for scheduled-origin turns. `queueItemId`
+  // is set only for a drained queue head so the web can reconcile the badge.
+  turnStarted?: { prompt?: string; scheduled?: ScheduledOrigin; queueItemId?: string };
+  media?: PromptAttachmentRef[];
+}
+
+export interface TurnResult {
+  ok: boolean;
+  text?: string;
+  errorMessage?: string;
+  // Inputs for the post-turn `sessions-changed` detection (a transport session that moved
+  // during the turn — archived-restore or `/clear`). The CALLER performs the getSession
+  // compare, not run(), because it must happen AFTER the caller sets `draining`: that await
+  // window has to stay guarded so an aborted turn with a queued item cannot let a fresh
+  // prompt race in. Set only when the turn ran past useSession with a prior session captured.
+  postTurnDetection?: { internalAlias: string; priorTransportSession: string };
+}
+
+// Runs the per-turn execution body: session bind, turn-started, media sandboxing,
+// stream/batched paragraph reconstruction, the agent.chat drive with all event
+// emissions, turn-finished, and the sessions-changed detection for a transport
+// session that moved (archived-session restore or `/clear`) during the turn.
+// Holds no concurrency state of its own — the queue/inFlight/draining lifecycle
+// stays in ControlService, which decides whether to call run() at all.
+export class SessionTurnRunner {
+  constructor(
+    private readonly deps: Pick<ControlServiceDeps, "agent" | "sessions" | "events" | "uploadStore">,
+  ) {}
+
+  async run(req: TurnRequest, signal: AbortSignal): Promise<TurnResult> {
+    // Sending to an archived session restores it (useSession clears `archived`), and
+    // `/clear` (session.reset) recreates the transport session under the same alias — both
+    // mutate the session row, but neither useSession nor the reset handler emits an event.
+    // Capture the pre-turn state here so we can detect the transition afterwards and emit
+    // `sessions-changed`, otherwise the dashboard keeps showing a stale archived badge /
+    // transport+native binding on the row until the next unrelated refresh.
+    let internalAlias: string | undefined;
+    let wasArchived = false;
+    let priorTransportSession: string | undefined;
+    try {
+      internalAlias = await this.deps.sessions.resolveAliasForChat(req.chatKey, req.sessionAlias);
+      const prior = await this.deps.sessions.getSession(internalAlias);
+      wasArchived = prior?.archived === true;
+      priorTransportSession = prior?.transportSession;
+    } catch {
+      /* best-effort: a detection failure just means no badge refresh */
+    }
+    try {
+      await this.deps.sessions.useSession(req.chatKey, req.sessionAlias);
+    } catch (error) {
+      // This turn never really started, but it still holds the concurrency slot in
+      // ControlService. Just report the failure — the caller settles/advances the
+      // queue around this call so a transient bind failure on a *drained* head does
+      // not strand the items behind it.
+      return { ok: false, errorMessage: toErrorMessage(error) };
+    }
+    if (wasArchived) {
+      this.deps.events.emit({ type: "sessions-changed" });
+    }
+    this.deps.events.emit({
+      type: "turn-started",
+      chatKey: req.chatKey,
+      sessionAlias: req.sessionAlias,
+      ...(req.turnStarted?.prompt ? { prompt: req.turnStarted.prompt } : {}),
+      ...(req.turnStarted?.scheduled ? { scheduled: req.turnStarted.scheduled } : {}),
+      ...(req.turnStarted?.queueItemId ? { queueItemId: req.turnStarted.queueItemId } : {}),
+    });
+    // Stream-mode sessions (replyMode "stream") get raw token streaming: the transport
+    // forwards chunks verbatim (paragraph breaks intact), so we concatenate as-is.
+    // Batched sessions get pre-split, trimmed paragraph segments instead — there the
+    // original "\n\n" is gone, and both turn-output consumers (web live view + hub
+    // history buffer) simply concatenate, running paragraphs together on one line. For
+    // those we re-insert the break between segments so live and history stay identical.
+    const streamMode = await this.resolveStreamMode(req.chatKey, req.sessionAlias);
+    let emittedChunk = false;
+    const emitChunk = (chunk: string) => {
+      if (!chunk) return;
+      this.deps.events.emit({
+        type: "turn-output",
+        chatKey: req.chatKey,
+        sessionAlias: req.sessionAlias,
+        chunk: !streamMode && emittedChunk ? `\n\n${chunk}` : chunk,
+      });
+      emittedChunk = true;
+    };
+    // Defense-in-depth: the two-phase upload sandbox is meant to be the only source of
+    // attachment bytes (the web flow echoes back the path control.upload returned, which
+    // lives under the sandbox root). Drop any media ref whose resolved filePath escapes
+    // that root so a caller cannot point the agent at an arbitrary absolute path. Only
+    // touch the upload store when a turn actually carries media — a plain prompt turn
+    // has no attachments and must not depend on the store being present.
+    const incomingMedia = req.media ?? [];
+    const sandboxedMedia = incomingMedia.length
+      ? (() => {
+          const uploadRoot = path.resolve(this.deps.uploadStore.root);
+          const kept = incomingMedia.filter((ref) => {
+            const resolved = path.resolve(ref.filePath);
+            return resolved === uploadRoot || resolved.startsWith(uploadRoot + path.sep);
+          });
+          const dropped = incomingMedia.length - kept.length;
+          if (dropped > 0) {
+            console.warn(
+              `[control] dropped ${dropped} media ref(s) with filePath outside the upload sandbox`,
+            );
+          }
+          return kept;
+        })()
+      : incomingMedia;
+    const chatMedia = sandboxedMedia.map((ref) => ({
+      kind: ref.kind,
+      filePath: ref.filePath,
+      mimeType: ref.mimeType,
+      ...(ref.fileName ? { fileName: ref.fileName } : {}),
+      sizeBytes: ref.size,
+      source: {
+        channelId: "relay",
+        accountId: req.accountId ?? "control",
+        chatKey: req.chatKey,
+        messageId: ref.id,
+      },
+    }));
+    try {
+      const response = await this.deps.agent.chat({
+        accountId: req.accountId ?? "control",
+        conversationId: req.chatKey,
+        text: req.text,
+        metadata: buildControlMetadata(req.senderId, req.isOwner),
+        abortSignal: signal,
+        ...(chatMedia.length > 0 ? { media: chatMedia } : {}),
+        reply: async (chunk) => {
+          emitChunk(chunk);
+        },
+        onToolEvent: (event) => {
+          this.deps.events.emit({
+            type: "tool-event",
+            chatKey: req.chatKey,
+            sessionAlias: req.sessionAlias,
+            event,
+          });
+        },
+        onThought: (chunk) => {
+          this.deps.events.emit({
+            type: "turn-thought",
+            chatKey: req.chatKey,
+            sessionAlias: req.sessionAlias,
+            chunk,
+          });
+        },
+        onPlan: (entries) => {
+          this.deps.events.emit({
+            type: "plan",
+            chatKey: req.chatKey,
+            sessionAlias: req.sessionAlias,
+            entries,
+          });
+        },
+        onUsage: (usage) => {
+          this.deps.events.emit({
+            type: "turn-usage",
+            chatKey: req.chatKey,
+            sessionAlias: req.sessionAlias,
+            used: usage.used,
+            size: usage.size,
+            ...(usage.cost ? { cost: usage.cost } : {}),
+            ...(usage.breakdown ? { breakdown: usage.breakdown } : {}),
+          });
+        },
+        onCommands: (commands) => {
+          this.deps.events.emit({
+            type: "agent-commands",
+            chatKey: req.chatKey,
+            sessionAlias: req.sessionAlias,
+            commands,
+          });
+        },
+      });
+      if (response.text) {
+        emitChunk(response.text);
+      }
+      this.deps.events.emit({
+        type: "turn-finished",
+        chatKey: req.chatKey,
+        sessionAlias: req.sessionAlias,
+        ok: true,
+      });
+      return {
+        ok: true,
+        text: response.text,
+        ...(internalAlias && priorTransportSession
+          ? { postTurnDetection: { internalAlias, priorTransportSession } }
+          : {}),
+      };
+    } catch (error) {
+      const errorMessage = toErrorMessage(error);
+      this.deps.events.emit({
+        type: "turn-finished",
+        chatKey: req.chatKey,
+        sessionAlias: req.sessionAlias,
+        ok: false,
+        errorMessage,
+        ...(signal.aborted ? { cancelled: true } : {}),
+      });
+      return {
+        ok: false,
+        errorMessage,
+        ...(internalAlias && priorTransportSession
+          ? { postTurnDetection: { internalAlias, priorTransportSession } }
+          : {}),
+      };
+    }
+    // NB: no `finally` doing the post-turn `sessions-changed` getSession here — that compare
+    // is deliberately the caller's job (see TurnResult.postTurnDetection), so it runs after
+    // `draining` is set and the await window stays guarded.
+  }
+
+  /** Resolve a chat-scoped display alias to its ResolvedSession and read whether it is
+   *  in stream reply mode. Best-effort: any resolution failure falls back to batched
+   *  paragraph reconstruction (the pre-existing default). */
+  private async resolveStreamMode(chatKey: string, sessionAlias: string): Promise<boolean> {
+    try {
+      const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, sessionAlias);
+      const resolved = await this.deps.sessions.getSession(internalAlias);
+      return (resolved?.effectiveReplyMode ?? resolved?.replyMode) === "stream";
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/control/session-turn-runner.ts
+++ b/src/control/session-turn-runner.ts
@@ -11,11 +11,6 @@ export interface TurnRequest {
   senderId: string;
   isOwner?: boolean;
   accountId?: string;
-  // External abort (e.g. the scheduler's per-dispatch timeout) linked to this turn.
-  // Unused by run() itself — the caller links it into the AbortController whose
-  // .signal is passed as run()'s second argument — kept here only for call-shape
-  // symmetry with executeTurn's params.
-  abortSignal?: AbortSignal;
   // Extra fields stamped onto turn-started for scheduled-origin turns. `queueItemId`
   // is set only for a drained queue head so the web can reconcile the badge.
   turnStarted?: { prompt?: string; scheduled?: ScheduledOrigin; queueItemId?: string };
@@ -36,10 +31,17 @@ export interface TurnResult {
 
 // Runs the per-turn execution body: session bind, turn-started, media sandboxing,
 // stream/batched paragraph reconstruction, the agent.chat drive with all event
-// emissions, turn-finished, and the sessions-changed detection for a transport
-// session that moved (archived-session restore or `/clear`) during the turn.
-// Holds no concurrency state of its own — the queue/inFlight/draining lifecycle
-// stays in ControlService, which decides whether to call run() at all.
+// emissions, and turn-finished. It also captures the pre-turn session state and
+// returns it (postTurnDetection) so the CALLER can detect a transport session that
+// moved (archived-session restore or `/clear`) during the turn — run() does not do
+// that compare itself, see TurnResult.postTurnDetection.
+//
+// Contract: run() signals turn failure by RESOLVING with { ok: false, errorMessage }
+// (session-bind and agent-drive failures are caught internally), never by rejecting —
+// so TurnQueue can settle/advance the queue in a plain finally without a catch.
+//
+// Holds no concurrency state of its own — the inFlight/queues/draining lifecycle
+// lives in TurnQueue, which decides whether to call run() at all.
 export class SessionTurnRunner {
   constructor(
     private readonly deps: Pick<ControlServiceDeps, "agent" | "sessions" | "events" | "uploadStore">,

--- a/src/control/turn-queue.ts
+++ b/src/control/turn-queue.ts
@@ -180,10 +180,11 @@ export class TurnQueue {
       // If a queued head is waiting, mark `draining` synchronously NOW — before the slot is
       // handed off, and before the awaited post-turn detection below — so nothing starts a
       // parallel turn during the release→drain window, even for an *aborted* turn whose
-      // lingering inFlight entry no longer reads as busy. advanceQueue re-adds it harmlessly;
-      // the drained turn clears it once it re-registers its own inFlight. When the queue is
-      // empty, this turn's still-present inFlight entry is itself the busy marker (a normally-
-      // finished turn's controller is not aborted), so no drain is possible.
+      // lingering inFlight entry no longer reads as busy. This is the single writer of the
+      // hand-off guard; advanceQueue (called synchronously below) relies on it already being
+      // set and the drained turn clears it once it re-registers its own inFlight. When the
+      // queue is empty, this turn's still-present inFlight entry is itself the busy marker (a
+      // normally-finished turn's controller is not aborted), so no drain is possible.
       if ((this.queues.get(key)?.length ?? 0) > 0) {
         this.draining.add(key);
       }
@@ -224,15 +225,12 @@ export class TurnQueue {
     const next = q?.shift();
     if (q && q.length === 0) this.queues.delete(key);
     if (next) {
-      // Mark `draining` BEFORE the fire-and-forget drained submit below, so a submit landing
-      // between this frame and the drained turn's own inFlight.set sees a busy gate rather than
-      // starting a parallel turn. NOTE this is belt-and-suspenders: on the normal drain path
-      // submit's finally already set `draining` (line ~181) before calling advanceQueue
-      // synchronously, so removing THIS add alone reddens nothing (verified: oracle/turn-queue/
-      // queue all stay green). It is kept as a local invariant for the direct call site — the
-      // hand-off enqueue behavior itself is pinned by turn-queue.test.ts "a submit arriving
-      // during the drain hand-off enqueues (no parallel turn)".
-      this.draining.add(key);
+      // `draining` is already set here: this runs synchronously inside submit's finally, which
+      // set `draining` (when the queue was non-empty) before calling advanceQueue. That guard
+      // stays up across the fire-and-forget drained submit below until the drained turn
+      // re-registers its own inFlight, so a submit landing in that gap sees a busy gate rather
+      // than starting a parallel turn — pinned by turn-queue.test.ts "a submit arriving during
+      // the drain hand-off enqueues (no parallel turn)".
       // The head was already popped above; emit the shorter snapshot.
       this.emitQueueUpdated(chatKey, sessionAlias);
       // Fire-and-forget: the drained turn drives its own settled lifecycle. It bypasses the

--- a/src/control/turn-queue.ts
+++ b/src/control/turn-queue.ts
@@ -1,0 +1,272 @@
+import { randomUUID } from "node:crypto";
+
+import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
+import type { TurnRequest, TurnResult } from "./session-turn-runner";
+import {
+  turnKey,
+  raceWithTimeout,
+  CANCEL_DRAIN_TIMEOUT_MS,
+  QUEUE_PREVIEW_MAX,
+  type QueuedPrompt,
+} from "./turn-support";
+
+export interface QueuedItemSnapshot {
+  id: string;
+  textPreview: string;
+  enqueuedAt: string;
+}
+
+export interface TurnQueueDeps {
+  // Runs the per-turn execution body (SessionTurnRunner.run in production). TurnQueue
+  // owns only the concurrency gate + inFlight/settled lifecycle around this call.
+  runTurn(req: TurnRequest, signal: AbortSignal): Promise<TurnResult>;
+  emitQueueUpdated(chatKey: string, sessionAlias: string, items: QueuedItemSnapshot[]): void;
+  // Post-turn `sessions-changed` detection (a transport session that moved during the turn —
+  // archived-restore or `/clear`). Called AFTER `draining.add` and BEFORE `resolveSettled`, so
+  // the await it takes stays inside the draining-guarded window (see submit's finally). Must be
+  // best-effort itself — TurnQueue does not catch on its behalf.
+  detectSessionsChanged(detection: NonNullable<TurnResult["postTurnDetection"]>): Promise<void>;
+}
+
+export interface SubmitParams {
+  chatKey: string;
+  sessionAlias: string;
+  text: string;
+  senderId: string;
+  isOwner?: boolean;
+  accountId?: string;
+  // External abort (e.g. the scheduler's per-dispatch timeout) linked to this turn.
+  abortSignal?: AbortSignal;
+  // Extra fields stamped onto turn-started for scheduled-origin turns. `queueItemId`
+  // is set only for a drained queue head so the web can reconcile the badge.
+  turnStarted?: TurnRequest["turnStarted"];
+  media?: PromptAttachmentRef[];
+  // Only interactive prompt() sets this. When true and a turn is already running, the
+  // submission is appended to the per-session queue instead of being rejected. Scheduled
+  // turns omit it, so they keep the immediate-or-reject behavior.
+  queueable?: boolean;
+  // Set only by the turn-finish drain hand-off. A drained head turn bypasses the busy gate
+  // (it is what the finished turn intentionally started next), re-registers its own inFlight,
+  // and clears the `draining` guard — all synchronously at its top.
+  drained?: boolean;
+}
+
+export type SubmitResult = TurnResult | { ok: true; queued: true; queueItemId: string };
+
+// The three-state concurrency gate (inFlight/queues/draining) that used to live inline in
+// ControlService.executeTurn. Session-free by design: post-turn sessions-changed detection is
+// threaded in via TurnQueueDeps.detectSessionsChanged rather than TurnQueue reaching for a
+// sessions dependency itself.
+export class TurnQueue {
+  constructor(private readonly deps: TurnQueueDeps) {}
+
+  // Each in-flight turn carries its AbortController plus a `settled` promise that resolves
+  // once the turn has fully unwound (transport cancelled, inFlight cleared).
+  private readonly inFlight = new Map<string, { controller: AbortController; settled: Promise<void> }>();
+
+  // Per-session FIFO queue of prompts that arrived while a turn was already running. Only
+  // interactive submissions with `queueable: true` enqueue; non-queueable (scheduled) turns
+  // keep rejecting immediately. Drained by the turn-finish hand-off in advanceQueue.
+  private readonly queues = new Map<string, QueuedPrompt[]>();
+
+  // Set synchronously during a turn-finish drain hand-off: the finished turn has cleared its
+  // inFlight entry but the drained head has not yet re-registered its own. The enqueue gate
+  // treats `draining.has(key)` as busy so nothing starts a parallel turn in that window. The
+  // drained turn clears it right after it re-registers inFlight.
+  private readonly draining = new Set<string>();
+
+  queueLength(chatKey: string, sessionAlias: string): number {
+    return this.queues.get(turnKey(chatKey, sessionAlias))?.length ?? 0;
+  }
+
+  isBusy(chatKey: string, sessionAlias: string): boolean {
+    const key = turnKey(chatKey, sessionAlias);
+    const existing = this.inFlight.get(key);
+    return this.draining.has(key) || (existing !== undefined && !existing.controller.signal.aborted);
+  }
+
+  private emitQueueUpdated(chatKey: string, sessionAlias: string): void {
+    const items = (this.queues.get(turnKey(chatKey, sessionAlias)) ?? []).map((q) => ({
+      id: q.id,
+      textPreview: q.text.length > QUEUE_PREVIEW_MAX ? q.text.slice(0, QUEUE_PREVIEW_MAX) : q.text,
+      enqueuedAt: q.enqueuedAt,
+    }));
+    this.deps.emitQueueUpdated(chatKey, sessionAlias, items);
+  }
+
+  async submit(params: SubmitParams): Promise<SubmitResult> {
+    const key = turnKey(params.chatKey, params.sessionAlias);
+    // A drained head turn (params.drained) is the turn the just-finished turn intentionally
+    // started next; it must bypass this gate (it re-registers its own inFlight and clears the
+    // `draining` guard synchronously at its top). Every other caller treats a live turn OR an
+    // in-progress drain hand-off as busy.
+    if (!params.drained) {
+      const existing = this.inFlight.get(key);
+      // Busy when a live un-cancelled turn holds the slot, OR a drain hand-off is mid-flight
+      // (inFlight momentarily cleared but the drained head not yet re-registered).
+      const busy = this.draining.has(key) || (existing !== undefined && !existing.controller.signal.aborted);
+      if (busy) {
+        if (params.queueable) {
+          const id = randomUUID();
+          const item: QueuedPrompt = {
+            id,
+            text: params.text,
+            enqueuedAt: new Date().toISOString(),
+            senderId: params.senderId,
+            ...(params.isOwner !== undefined ? { isOwner: params.isOwner } : {}),
+            ...(params.accountId !== undefined ? { accountId: params.accountId } : {}),
+            ...(params.media !== undefined ? { media: params.media } : {}),
+          };
+          const q = this.queues.get(key) ?? [];
+          q.push(item);
+          this.queues.set(key, q);
+          this.emitQueueUpdated(params.chatKey, params.sessionAlias);
+          return { ok: true, queued: true, queueItemId: id };
+        }
+        // Not queueable (e.g. a scheduled turn) — reject right away.
+        return { ok: false, errorMessage: "turn-already-running" };
+      }
+      if (existing) {
+        // existing is present but its controller is aborted (a Stop is unwinding it) and no
+        // drain is in progress. Cancelling the transport and draining the agent takes time,
+        // during which the turn stays registered. Wait (bounded) for it to clear so the user's
+        // immediate follow-up starts a fresh turn instead of hitting "turn-already-running"; a
+        // wedged turn still falls through to the rejection below.
+        await raceWithTimeout(existing.settled, CANCEL_DRAIN_TIMEOUT_MS);
+        if (this.inFlight.has(key)) {
+          return { ok: false, errorMessage: "turn-already-running" };
+        }
+      }
+    }
+    const controller = new AbortController();
+    // Link an external abort (scheduler dispatch timeout) to this turn so a wedged scheduled
+    // prompt is cancelled cooperatively, just like a user Stop.
+    if (params.abortSignal) {
+      if (params.abortSignal.aborted) controller.abort();
+      else params.abortSignal.addEventListener("abort", () => controller.abort(), { once: true });
+    }
+    let resolveSettled!: () => void;
+    const settled = new Promise<void>((resolve) => { resolveSettled = resolve; });
+    this.inFlight.set(key, { controller, settled });
+    // A drained head turn has now re-registered its own inFlight synchronously (no await since
+    // the finished turn's finally). Clear the hand-off guard: the slot is genuinely held again,
+    // so the temporary `draining` busy marker is no longer needed.
+    if (params.drained) {
+      this.draining.delete(key);
+    }
+    let result: TurnResult | undefined;
+    try {
+      result = await this.deps.runTurn(
+        {
+          chatKey: params.chatKey,
+          sessionAlias: params.sessionAlias,
+          text: params.text,
+          senderId: params.senderId,
+          ...(params.isOwner !== undefined ? { isOwner: params.isOwner } : {}),
+          ...(params.accountId !== undefined ? { accountId: params.accountId } : {}),
+          ...(params.turnStarted ? { turnStarted: params.turnStarted } : {}),
+          ...(params.media !== undefined ? { media: params.media } : {}),
+        },
+        controller.signal,
+      );
+    } finally {
+      // If a queued head is waiting, mark `draining` synchronously NOW — before the slot is
+      // handed off, and before the awaited post-turn detection below — so nothing starts a
+      // parallel turn during the release→drain window, even for an *aborted* turn whose
+      // lingering inFlight entry no longer reads as busy. advanceQueue re-adds it harmlessly;
+      // the drained turn clears it once it re-registers its own inFlight. When the queue is
+      // empty, this turn's still-present inFlight entry is itself the busy marker (a normally-
+      // finished turn's controller is not aborted), so no drain is possible.
+      if ((this.queues.get(key)?.length ?? 0) > 0) {
+        this.draining.add(key);
+      }
+      // Post-turn `sessions-changed` detection runs HERE, after `draining` is set. A transport
+      // session that moved during the turn (archived-restore or `/clear`) needs a dashboard
+      // refresh, but the await it takes must stay inside the draining-guarded window, or an
+      // aborted turn with a queued item lets a fresh prompt race in.
+      const detection = result?.postTurnDetection;
+      if (detection) {
+        await this.deps.detectSessionsChanged(detection);
+      }
+      resolveSettled();
+      // Single decision point (shared whether the run failed at useSession or at the chat
+      // drive): start the next queued head as the drained turn while holding the slot, or
+      // release inFlight if empty.
+      this.advanceQueue(key, params.chatKey, params.sessionAlias);
+    }
+    // Strip the internal postTurnDetection so the return value stays exactly
+    // {ok, text?, errorMessage?} — the golden fixtures record this return value.
+    return {
+      ok: result!.ok,
+      ...(result!.text !== undefined ? { text: result!.text } : {}),
+      ...(result!.errorMessage !== undefined ? { errorMessage: result!.errorMessage } : {}),
+    };
+  }
+
+  // Advances the per-session FIFO queue after a turn ends. If a head exists, starts it as the
+  // next (drained) turn while holding the busy slot via `draining`; otherwise releases the
+  // inFlight slot. Must be called exactly once per ended turn. Fully synchronous: `draining` is
+  // added BEFORE the fire-and-forget drained `submit`, whose `inFlight.set` runs synchronously
+  // before its first await — so there is no window in which an incoming submission could
+  // observe a not-busy session between the ended turn and the drained turn.
+  private advanceQueue(key: string, chatKey: string, sessionAlias: string): void {
+    const q = this.queues.get(key);
+    const next = q?.shift();
+    if (q && q.length === 0) this.queues.delete(key);
+    if (next) {
+      this.draining.add(key);
+      // The head was already popped above; emit the shorter snapshot.
+      this.emitQueueUpdated(chatKey, sessionAlias);
+      // Fire-and-forget: the drained turn drives its own settled lifecycle. It bypasses the
+      // busy gate (drained: true), re-registers inFlight and clears `draining` at its top — all
+      // synchronously before the first await — so there is no parallel-turn window. Pass
+      // queueItemId ONLY, never prompt: the hub already persisted the inbound at enqueue, so
+      // re-emitting prompt would double-persist and duplicate the bubble.
+      void this.submit({
+        chatKey,
+        sessionAlias,
+        text: next.text,
+        senderId: next.senderId,
+        queueable: true,
+        drained: true,
+        ...(next.isOwner !== undefined ? { isOwner: next.isOwner } : {}),
+        ...(next.accountId !== undefined ? { accountId: next.accountId } : {}),
+        ...(next.media !== undefined ? { media: next.media } : {}),
+        turnStarted: { queueItemId: next.id },
+      });
+    } else {
+      // The queue emptied during the drain hand-off (e.g. a cancel removed the only queued
+      // item while the finally's post-turn detection was in flight, after the finally set
+      // `draining`). No drained turn is coming to clear the guard, so clear it here too —
+      // otherwise `draining` leaks and every future submission enqueues forever (permanent
+      // wedge).
+      this.draining.delete(key);
+      this.inFlight.delete(key);
+    }
+  }
+
+  cancelTurn(chatKey: string, sessionAlias: string): boolean {
+    const entry = this.inFlight.get(turnKey(chatKey, sessionAlias));
+    if (!entry) {
+      return false;
+    }
+    entry.controller.abort();
+    return true;
+  }
+
+  /** Remove a pending queued prompt (by id) before it drains. No-ops (returns
+   *  `{ cancelled: false }`) when the queue or the id is absent/already drained — e.g. a race
+   *  where the item drained into a running turn just before the cancel arrived. Does NOT touch
+   *  a turn that is already running (use `cancelTurn`). */
+  cancelQueuedItem(chatKey: string, sessionAlias: string, itemId: string): { cancelled: boolean } {
+    const key = turnKey(chatKey, sessionAlias);
+    const q = this.queues.get(key);
+    if (!q) return { cancelled: false };
+    const i = q.findIndex((x) => x.id === itemId);
+    if (i < 0) return { cancelled: false };
+    q.splice(i, 1);
+    if (q.length === 0) this.queues.delete(key);
+    this.emitQueueUpdated(chatKey, sessionAlias);
+    return { cancelled: true };
+  }
+}

--- a/src/control/turn-queue.ts
+++ b/src/control/turn-queue.ts
@@ -147,6 +147,13 @@ export class TurnQueue {
     }
     let resolveSettled!: () => void;
     const settled = new Promise<void>((resolve) => { resolveSettled = resolve; });
+    // SYNCHRONOUS PREFIX: everything from the busy-decision above through this inFlight.set runs
+    // with no await, so two submits in the same tick see a consistent gate — the first registers
+    // inFlight, the second reads it as busy and enqueues. Moving this set (or the busy-check
+    // above) behind the runTurn await opens a same-tick window where the second submit starts a
+    // parallel turn. Pinned by turn-queue.test.ts "submit's busy-decision + enqueue is a
+    // synchronous prefix (same tick, zero await)": that mutation reddens its zero-await
+    // queueLength===1 / isBusy===true assertions.
     this.inFlight.set(key, { controller, settled });
     // A drained head turn has now re-registered its own inFlight synchronously (no await since
     // the finished turn's finally). Clear the hand-off guard: the slot is genuinely held again,
@@ -183,7 +190,10 @@ export class TurnQueue {
       // Post-turn `sessions-changed` detection runs HERE, after `draining` is set. A transport
       // session that moved during the turn (archived-restore or `/clear`) needs a dashboard
       // refresh, but the await it takes must stay inside the draining-guarded window, or an
-      // aborted turn with a queued item lets a fresh prompt race in.
+      // aborted turn with a queued item lets a fresh prompt race in. Moving the draining.add
+      // above to AFTER this await reddens the golden fixture `aborted-queue-sessions-window`
+      // (turn-oracle.test.ts): during that window an aborted turn's lingering inFlight no longer
+      // reads as busy, so a fresh prompt would start a parallel turn instead of queueing.
       const detection = result?.postTurnDetection;
       if (detection) {
         await this.deps.detectSessionsChanged(detection);
@@ -214,6 +224,14 @@ export class TurnQueue {
     const next = q?.shift();
     if (q && q.length === 0) this.queues.delete(key);
     if (next) {
+      // Mark `draining` BEFORE the fire-and-forget drained submit below, so a submit landing
+      // between this frame and the drained turn's own inFlight.set sees a busy gate rather than
+      // starting a parallel turn. NOTE this is belt-and-suspenders: on the normal drain path
+      // submit's finally already set `draining` (line ~181) before calling advanceQueue
+      // synchronously, so removing THIS add alone reddens nothing (verified: oracle/turn-queue/
+      // queue all stay green). It is kept as a local invariant for the direct call site — the
+      // hand-off enqueue behavior itself is pinned by turn-queue.test.ts "a submit arriving
+      // during the drain hand-off enqueues (no parallel turn)".
       this.draining.add(key);
       // The head was already popped above; emit the shorter snapshot.
       this.emitQueueUpdated(chatKey, sessionAlias);

--- a/src/control/turn-support.ts
+++ b/src/control/turn-support.ts
@@ -1,0 +1,53 @@
+import type { ChatRequestMetadata } from "../weixin/agent/interface";
+import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
+
+/** A prompt held in the per-session server-side queue while a turn is in flight.
+ *  Runs through the same `executeTurn` machinery as a manual prompt once drained. */
+export interface QueuedPrompt {
+  id: string;
+  text: string;
+  enqueuedAt: string;
+  senderId: string;
+  isOwner?: boolean;
+  accountId?: string;
+  media?: PromptAttachmentRef[];
+}
+
+// Upper bound on how long a follow-up prompt waits for a just-cancelled turn to
+// finish tearing down before giving up and reporting the session still busy.
+export const CANCEL_DRAIN_TIMEOUT_MS = 5000;
+
+// Server-side truncation for a queued item's textPreview on the queue-updated wire
+// event, so a very long queued prompt doesn't bloat the snapshot payload.
+export const QUEUE_PREVIEW_MAX = 120;
+
+// Resolve when `promise` settles or `ms` elapses, whichever comes first. The timer
+// is cleared on the winning path so a fast drain doesn't keep the event loop alive.
+export async function raceWithTimeout(promise: Promise<void>, ms: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, ms);
+  });
+  try {
+    await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export function turnKey(chatKey: string, sessionAlias: string): string {
+  return `${chatKey} ${sessionAlias}`;
+}
+
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function buildControlMetadata(senderId: string, isOwner: boolean | undefined): ChatRequestMetadata {
+  return {
+    channel: "control",
+    chatType: "direct",
+    senderId,
+    ...(isOwner === undefined ? {} : { isOwner }),
+  };
+}

--- a/tests/unit/control/golden/fixtures/aborted-queue-sessions-window.json
+++ b/tests/unit/control/golden/fixtures/aborted-queue-sessions-window.json
@@ -1,0 +1,160 @@
+[
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "second",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": false,
+      "errorMessage": "boom",
+      "cancelled": true
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        },
+        {
+          "id": "<id-2>",
+          "textPreview": "third",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "third",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-2>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-2>",
+          "textPreview": "third",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "first",
+    "value": {
+      "ok": false,
+      "errorMessage": "boom"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": []
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "queueItemId": "<id-2>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  }
+]

--- a/tests/unit/control/golden/fixtures/busy-second-enqueues.json
+++ b/tests/unit/control/golden/fixtures/busy-second-enqueues.json
@@ -1,0 +1,70 @@
+[
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "second",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": []
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "queueItemId": "<id-1>"
+    }
+  }
+]

--- a/tests/unit/control/golden/fixtures/cancel-empties-queue-clears-draining.json
+++ b/tests/unit/control/golden/fixtures/cancel-empties-queue-clears-draining.json
@@ -1,0 +1,95 @@
+[
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "second",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": []
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "return",
+    "label": "after",
+    "value": {
+      "ok": true,
+      "text": "done"
+    }
+  }
+]

--- a/tests/unit/control/golden/fixtures/drain-window-enqueue.json
+++ b/tests/unit/control/golden/fixtures/drain-window-enqueue.json
@@ -1,0 +1,105 @@
+[
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "q2",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        },
+        {
+          "id": "<id-2>",
+          "textPreview": "third",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-2>",
+          "textPreview": "third",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "q3",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-2>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "queueItemId": "<id-1>"
+    }
+  }
+]

--- a/tests/unit/control/golden/fixtures/fifo-drain.json
+++ b/tests/unit/control/golden/fixtures/fifo-drain.json
@@ -1,0 +1,159 @@
+[
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "q2",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        },
+        {
+          "id": "<id-2>",
+          "textPreview": "third",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "q3",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-2>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-2>",
+          "textPreview": "third",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": []
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "queueItemId": "<id-2>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  }
+]

--- a/tests/unit/control/golden/fixtures/same-tick-one-wins.json
+++ b/tests/unit/control/golden/fixtures/same-tick-one-wins.json
@@ -1,0 +1,96 @@
+[
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "B",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "return",
+    "label": "promptB",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": []
+    }
+  },
+  {
+    "kind": "return",
+    "label": "promptA",
+    "value": {
+      "ok": true,
+      "text": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  }
+]

--- a/tests/unit/control/golden/fixtures/scheduled-not-queued.json
+++ b/tests/unit/control/golden/fixtures/scheduled-not-queued.json
@@ -1,0 +1,36 @@
+[
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "return",
+    "label": "scheduled",
+    "value": {
+      "ok": false,
+      "errorMessage": "turn-already-running"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  }
+]

--- a/tests/unit/control/golden/fixtures/stop-then-followup.json
+++ b/tests/unit/control/golden/fixtures/stop-then-followup.json
@@ -1,0 +1,63 @@
+[
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": false,
+      "errorMessage": "boom",
+      "cancelled": true
+    }
+  },
+  {
+    "kind": "return",
+    "label": "first",
+    "value": {
+      "ok": false,
+      "errorMessage": "boom"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "return",
+    "label": "second",
+    "value": {
+      "ok": true,
+      "text": "done"
+    }
+  }
+]

--- a/tests/unit/control/golden/fixtures/stranded-tail.json
+++ b/tests/unit/control/golden/fixtures/stranded-tail.json
@@ -1,0 +1,132 @@
+[
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "q2",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-1>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-1>",
+          "textPreview": "second",
+          "enqueuedAt": "<ts>"
+        },
+        {
+          "id": "<id-2>",
+          "textPreview": "third",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "return",
+    "label": "q3",
+    "value": {
+      "ok": true,
+      "queued": true,
+      "queueItemId": "<id-2>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": [
+        {
+          "id": "<id-2>",
+          "textPreview": "third",
+          "enqueuedAt": "<ts>"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "queue-updated",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "items": []
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-started",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "queueItemId": "<id-2>"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-output",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "chunk": "done"
+    }
+  },
+  {
+    "kind": "event",
+    "event": {
+      "type": "turn-finished",
+      "chatKey": "c",
+      "sessionAlias": "s",
+      "ok": true
+    }
+  }
+]

--- a/tests/unit/control/golden/turn-oracle-harness.ts
+++ b/tests/unit/control/golden/turn-oracle-harness.ts
@@ -1,0 +1,132 @@
+// tests/unit/control/golden/turn-oracle-harness.ts
+// Black-box characterization oracle for ControlService's turn machinery. Records, in
+// order, every event ControlService emits AND every entry-call return value across a
+// scenario. `deps.events.emit` is synchronous, so the log order IS the execution order
+// (across microtasks) — that is how this catches a same-tick timing regression that a
+// plain result assertion cannot see. Drives ControlService's PUBLIC surface only; never
+// inspects the private inFlight/queues/draining maps.
+//
+// Recorded values are STABILIZED before they enter the log: a queued item's id is a
+// randomUUID and its enqueuedAt is wall-clock time, so without this the fixtures would be
+// flaky (a fresh id/timestamp every run). `stabilize` maps each distinct UUID to `<id-N>`
+// in first-seen order and every ISO timestamp to `<ts>`, which keeps the fixtures
+// deterministic while preserving order, structure, and — crucially — which prompt won
+// (the winner's return is {ok}, the loser's is {queued}; those are not ids or timestamps).
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { expect } from "bun:test";
+import { createControlEventBus, type ControlEvent } from "../../../../src/control/control-event-bus";
+import { ControlService } from "../../../../src/control/control-service";
+import type { ChatRequest, ChatResponse } from "../../../../src/weixin/agent/interface";
+
+export type OracleEntry =
+  | { kind: "event"; event: unknown }
+  | { kind: "return"; label: string; value: unknown };
+
+interface PendingChat {
+  request: ChatRequest;
+  resolve: (r: ChatResponse) => void;
+  reject: (e: unknown) => void;
+}
+
+export function makeTurnOracle(opts?: {
+  useSession?: (chatKey: string, alias: string) => Promise<unknown>;
+  getSession?: (alias: string) => Promise<unknown>;
+}) {
+  const log: OracleEntry[] = [];
+  const stabilizer = makeStabilizer();
+  const events = createControlEventBus();
+  events.subscribe((event: ControlEvent) => log.push({ kind: "event", event: stabilizer(event) }));
+
+  const pending: PendingChat[] = [];
+  const chat = async (request: ChatRequest): Promise<ChatResponse> => {
+    // A scenario resolves each chat explicitly via controls (FIFO), so the recording is
+    // deterministic — no setTimeout races, no wall-clock ordering.
+    return await new Promise<ChatResponse>((resolve, reject) => {
+      pending.push({ request, resolve, reject });
+    });
+  };
+
+  const service = new ControlService({
+    agent: { chat },
+    sessions: {
+      listAllResolvedSessions: () => [],
+      useSession:
+        opts?.useSession ??
+        (async (_c: string, alias: string) => ({ alias, agent: "claude", workspace: "/ws" })),
+      resolveAliasForChat: async (_c: string, alias: string) => alias,
+      getSession: opts?.getSession ?? (async () => null),
+    },
+    activeTurns: { isActiveAnywhere: () => false },
+    scheduled: {} as never,
+    orchestration: {} as never,
+    events,
+    uploadStore: { root: "/tmp/uploads" },
+  } as never);
+
+  const record = async <T>(label: string, p: Promise<T>): Promise<T> => {
+    const value = await p;
+    log.push({ kind: "return", label, value: stabilizer(value) });
+    return value;
+  };
+
+  return {
+    service,
+    log,
+    record,
+    controls: {
+      resolveChat: (index = 0, text = "done") => pending.splice(index, 1)[0]?.resolve({ text }),
+      rejectChat: (index = 0, message = "boom") =>
+        pending.splice(index, 1)[0]?.reject(new Error(message)),
+      pendingCount: () => pending.length,
+    },
+  };
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+/** Returns a stabilizer that deep-clones a value and replaces non-deterministic scalars.
+ *  UUIDs → `<id-N>` (stable in first-seen order); ISO timestamps → `<ts>`. Note the JSON
+ *  round-trip drops `undefined`-valued fields — fine here: the real StateStore/wire also
+ *  JSON-serializes, so a fixture never carries `undefined` keys. */
+function makeStabilizer() {
+  const ids = new Map<string, string>();
+  const walk = (v: unknown): unknown => {
+    if (typeof v === "string") {
+      if (UUID_RE.test(v)) {
+        let mapped = ids.get(v);
+        if (mapped === undefined) {
+          mapped = `<id-${ids.size + 1}>`;
+          ids.set(v, mapped);
+        }
+        return mapped;
+      }
+      if (ISO_RE.test(v)) return "<ts>";
+      return v;
+    }
+    if (Array.isArray(v)) return v.map(walk);
+    if (v !== null && typeof v === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [k, val] of Object.entries(v)) out[k] = walk(val);
+      return out;
+    }
+    return v;
+  };
+  return (v: unknown): unknown => walk(JSON.parse(JSON.stringify(v ?? null)));
+}
+
+const FIXTURE_DIR = new URL("./fixtures/", import.meta.url).pathname;
+
+export function expectMatchesFixture(name: string, actual: unknown): void {
+  const path = `${FIXTURE_DIR}${name}.json`;
+  const serialized = `${JSON.stringify(actual, null, 2)}\n`;
+  if (process.env.GOLDEN_UPDATE === "1") {
+    mkdirSync(FIXTURE_DIR, { recursive: true });
+    writeFileSync(path, serialized);
+    return;
+  }
+  if (!existsSync(path)) {
+    throw new Error(`turn oracle fixture missing: ${name}.json — record with GOLDEN_UPDATE=1 on the baseline`);
+  }
+  expect(JSON.parse(serialized) as unknown).toEqual(JSON.parse(readFileSync(path, "utf8")) as unknown);
+}

--- a/tests/unit/control/golden/turn-oracle.test.ts
+++ b/tests/unit/control/golden/turn-oracle.test.ts
@@ -166,3 +166,46 @@ test("oracle: a follow-up after Stop waits for the cancelled turn to drain, then
   await tick();
   expectMatchesFixture("stop-then-followup", o.log);
 });
+
+test("oracle: an aborted turn's queued item — draining guards the post-turn sessions-changed window", async () => {
+  // The post-turn sessions-changed detection takes a getSession await, and it must run with
+  // `draining` already set. Otherwise an aborted turn (its inFlight entry no longer reads
+  // busy) with a queued item leaves the session looking free during that await, and a fresh
+  // prompt races in — enqueue turns into a block/reject. This fixture pins the guarded
+  // ordering: the fresh "third" prompt arriving mid-window must ENQUEUE. The getSession
+  // override holds ONLY the post-turn call open (armed right before the abort settles),
+  // mirroring the cancel-empties scenario's arming technique.
+  let armGate = false;
+  let releaseGate!: () => void;
+  const gate = new Promise<void>((r) => {
+    releaseGate = r;
+  });
+  const o = makeTurnOracle({
+    getSession: async (a: string) => {
+      if (armGate) {
+        armGate = false;
+        await gate;
+      }
+      return { alias: a, transportSession: "t1" };
+    },
+  });
+  const p1 = o.record("first", o.service.prompt({ ...C, text: "first" }));
+  await tick();
+  await o.record("second", o.service.prompt({ ...C, text: "second" })); // queued behind turn 1
+  o.service.cancelTurn("c", "s"); // abort turn 1
+  armGate = true; // the next getSession (turn 1's post-turn detection) holds open
+  o.controls.rejectChat(); // turn 1 unwinds → finally sets draining, then awaits the gated getSession
+  await tick();
+  await tick();
+  const third = o.record("third", o.service.prompt({ ...C, text: "third" })); // mid-window → must enqueue
+  await tick();
+  releaseGate(); // close the window
+  await tick();
+  o.controls.resolveChat(); // drain "second"
+  await tick();
+  o.controls.resolveChat(); // drain "third"
+  await tick();
+  await Promise.all([p1, third]);
+  await tick();
+  expectMatchesFixture("aborted-queue-sessions-window", o.log);
+});

--- a/tests/unit/control/golden/turn-oracle.test.ts
+++ b/tests/unit/control/golden/turn-oracle.test.ts
@@ -1,0 +1,168 @@
+// tests/unit/control/golden/turn-oracle.test.ts
+// Eight concurrency scenarios for ControlService's turn machinery, each driving the public
+// surface and asserting the whole recorded log against a baseline fixture. Fixtures were
+// recorded on the pre-refactor executeTurn (54be207); a behaviour-equivalent refactor must
+// reproduce them byte-for-byte (structurally). Each scenario mirrors an existing test in
+// control-service-{queue,prompt}.test.ts — the oracle version records the ORDERED event +
+// return log instead of asserting individual facts, so it also catches microtask-timing
+// regressions those tests cannot see.
+import { test } from "bun:test";
+import { makeTurnOracle, expectMatchesFixture } from "./turn-oracle-harness";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const C = { chatKey: "c", sessionAlias: "s", senderId: "u" };
+
+test("oracle: a busy second prompt enqueues", async () => {
+  const o = makeTurnOracle();
+  const p1 = o.service.prompt({ ...C, text: "first" });
+  await tick();
+  await o.record("second", o.service.prompt({ ...C, text: "second" }));
+  o.controls.resolveChat();
+  await p1;
+  await tick();
+  expectMatchesFixture("busy-second-enqueues", o.log);
+});
+
+test("oracle: same-tick two prompts — exactly one wins, the other queues", async () => {
+  const o = makeTurnOracle();
+  // Both submitted in ONE synchronous tick — never await the first before the second.
+  // Recording each return under a stable label makes the fixture ENCODE the winner: the
+  // first-submitted takes the slot synchronously (inFlight.set before its first await), the
+  // second sees busy and enqueues. Reversing submit order flips the fixture — a plain
+  // "exactly one wins" result assertion would not, which is why this scenario records order.
+  const pA = o.record("promptA", o.service.prompt({ ...C, text: "A" }));
+  const pB = o.record("promptB", o.service.prompt({ ...C, text: "B" }));
+  await tick();
+  o.controls.resolveChat(); // the winner's turn finishes → drains the loser
+  await tick(); // let the loser's drained turn register + park on its own chat
+  o.controls.resolveChat(); // the drained loser's turn finishes
+  await Promise.all([pA, pB]);
+  await tick();
+  expectMatchesFixture("same-tick-one-wins", o.log);
+});
+
+test("oracle: a scheduled turn is not queued (still rejects)", async () => {
+  const o = makeTurnOracle();
+  const p1 = o.service.prompt({ ...C, text: "first" });
+  await tick();
+  await o.record(
+    "scheduled",
+    o.service.runScheduledTurn({
+      chatKey: "c",
+      sessionAlias: "s",
+      promptText: "sched",
+      taskId: "t1",
+      executeAt: "2026-07-01T00:00:00Z",
+    }),
+  );
+  o.controls.resolveChat();
+  await p1;
+  await tick();
+  expectMatchesFixture("scheduled-not-queued", o.log);
+});
+
+test("oracle: queued prompts drain FIFO, each its own turn", async () => {
+  const o = makeTurnOracle();
+  const p1 = o.service.prompt({ ...C, text: "first" });
+  await tick();
+  await o.record("q2", o.service.prompt({ ...C, text: "second" }));
+  await o.record("q3", o.service.prompt({ ...C, text: "third" }));
+  o.controls.resolveChat();
+  await tick(); // finish "first" → drain "second"
+  o.controls.resolveChat();
+  await tick(); // finish "second" → drain "third"
+  o.controls.resolveChat();
+  await tick(); // finish "third" → queue empty
+  await p1;
+  expectMatchesFixture("fifo-drain", o.log);
+});
+
+test("oracle: a prompt during the drain hand-off enqueues (no parallel turn)", async () => {
+  const o = makeTurnOracle();
+  const p1 = o.service.prompt({ ...C, text: "first" });
+  await tick();
+  await o.record("q2", o.service.prompt({ ...C, text: "second" }));
+  o.controls.resolveChat(); // finish "first"; drain starts "second"
+  await o.record("q3", o.service.prompt({ ...C, text: "third" })); // saw busy → queued
+  o.controls.resolveChat();
+  o.controls.resolveChat();
+  await p1;
+  await tick();
+  expectMatchesFixture("drain-window-enqueue", o.log);
+});
+
+test("oracle: a drained head whose useSession fails still drains the following item", async () => {
+  // Turn 1 binds on call 1. The drained "second" fails its bind (call 2). "third" (call 3)
+  // must still drain — not be stranded behind the failed head. Mirrors the queue test's
+  // useCount===2 override exactly.
+  let useCount = 0;
+  const o = makeTurnOracle({
+    useSession: async (_c: string, alias: string) => {
+      useCount += 1;
+      if (useCount === 2) throw new Error("transient bind failure");
+      return { alias, agent: "claude", workspace: "/ws" };
+    },
+  });
+  const p1 = o.service.prompt({ ...C, text: "first" });
+  await tick();
+  await o.record("q2", o.service.prompt({ ...C, text: "second" }));
+  await o.record("q3", o.service.prompt({ ...C, text: "third" }));
+  o.controls.resolveChat(); // finish "first" → drain "second" (bind throws) → must reach "third"
+  await tick();
+  o.controls.resolveChat(); // finish "third"
+  await tick();
+  await p1;
+  expectMatchesFixture("stranded-tail", o.log);
+});
+
+test("oracle: a cancel emptying the queue during hand-off clears draining (no wedge)", async () => {
+  // The finally sets `draining`, then awaits a post-turn getSession. Cancelling the only
+  // queued item during that await makes advanceQueue take its empty `else` branch, which
+  // must clear `draining` too — else it leaks and every future prompt enqueues forever. The
+  // getSession override arms the cancel ONLY for the post-turn window (mirrors the queue test).
+  const ref: { itemId?: string } = {};
+  let armCancel = false;
+  const o = makeTurnOracle({
+    getSession: async (a: string) => {
+      if (armCancel && ref.itemId) {
+        armCancel = false;
+        o.service.cancelQueuedItem("c", "s", ref.itemId);
+      }
+      return { alias: a, transportSession: "t1" };
+    },
+  });
+  const p1 = o.service.prompt({ ...C, text: "first" });
+  await tick();
+  const r2 = await o.record("second", o.service.prompt({ ...C, text: "second" }));
+  ref.itemId = (r2 as { queueItemId?: string }).queueItemId;
+  armCancel = true;
+  o.controls.resolveChat(); // finish "first" → draining set → post-turn getSession cancels "second"
+  await tick();
+  await p1;
+  // A fresh prompt must START a real turn (park on the chat), not enqueue — proving draining cleared.
+  const after = o.record("after", o.service.prompt({ ...C, text: "after" }));
+  await tick();
+  o.controls.resolveChat(); // release "after"
+  await after;
+  await tick();
+  expectMatchesFixture("cancel-empties-queue-clears-draining", o.log);
+});
+
+test("oracle: a follow-up after Stop waits for the cancelled turn to drain, then runs", async () => {
+  // Stop aborts the turn, but teardown is async so it lingers in inFlight. A follow-up in
+  // that window must wait (raceWithTimeout on settled) and then start fresh, not bounce with
+  // "turn-already-running". Mirrors the prompt test: abort, then reject the chat to simulate
+  // teardown completing, then the follow-up proceeds.
+  const o = makeTurnOracle();
+  const first = o.record("first", o.service.prompt({ ...C, text: "long" }));
+  await tick();
+  o.service.cancelTurn("c", "s"); // abort turn 1's controller
+  const second = o.record("second", o.service.prompt({ ...C, text: "next" })); // waits on settled
+  await tick();
+  o.controls.rejectChat(); // teardown done: turn 1's chat rejects → turn-finished cancelled → settled
+  await tick();
+  o.controls.resolveChat(); // the follow-up's chat completes
+  await Promise.all([first, second]);
+  await tick();
+  expectMatchesFixture("stop-then-followup", o.log);
+});

--- a/tests/unit/control/turn-queue.test.ts
+++ b/tests/unit/control/turn-queue.test.ts
@@ -1,0 +1,207 @@
+// tests/unit/control/turn-queue.test.ts
+// White-box tests for TurnQueue: the three-state concurrency gate (inFlight/queues/draining)
+// extracted out of ControlService.executeTurn. Drives TurnQueue directly with a controllable
+// fake runTurn — no ControlService, no SessionTurnRunner, no sessions dependency (TurnQueue is
+// session-free by design; the sessions-changed compare is threaded in via
+// deps.detectSessionsChanged).
+import { expect, test } from "bun:test";
+import { TurnQueue } from "../../../src/control/turn-queue";
+import type { TurnRequest, TurnResult } from "../../../src/control/session-turn-runner";
+
+// Models SessionTurnRunner.run's real contract: it never rejects, even on an aborted or
+// failed turn — it always resolves with a TurnResult (ok:false + errorMessage on failure).
+// So the fake here only ever resolves; there is no reject path to fake.
+function deferredRunTurn() {
+  const pending: Array<{ req: TurnRequest; resolve: (r: TurnResult) => void }> = [];
+  const runTurn = (req: TurnRequest, _s: AbortSignal) =>
+    new Promise<TurnResult>((resolve) => pending.push({ req, resolve }));
+  return {
+    runTurn,
+    resolveNext: (r: TurnResult = { ok: true }) => pending.shift()?.resolve(r),
+    pendingCount: () => pending.length,
+    pendingReqs: () => pending.map((p) => p.req),
+  };
+}
+
+const C = { chatKey: "c", sessionAlias: "s", senderId: "u" };
+
+test("submit's busy-decision + enqueue is a synchronous prefix (same tick, zero await)", () => {
+  const d = deferredRunTurn();
+  const tq = new TurnQueue({ runTurn: d.runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
+  const req = { ...C, text: "A", queueable: true };
+  void tq.submit(req); // sync inFlight.set
+  void tq.submit({ ...req, text: "B" }); // sync enqueue
+  // ZERO await between submit and this assertion — pins the synchronous prefix.
+  expect(tq.queueLength("c", "s")).toBe(1);
+  expect(tq.isBusy("c", "s")).toBe(true);
+});
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+test("a busy second submit enqueues and reports queued:true with an id", async () => {
+  const d = deferredRunTurn();
+  const tq = new TurnQueue({ runTurn: d.runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
+  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  await tick();
+  const r2 = await tq.submit({ ...C, text: "second", queueable: true });
+  expect(r2).toMatchObject({ ok: true, queued: true });
+  expect(typeof (r2 as { queueItemId: string }).queueItemId).toBe("string");
+  expect(tq.queueLength("c", "s")).toBe(1);
+  d.resolveNext();
+  await p1;
+});
+
+test("a non-queueable submit while busy rejects immediately with turn-already-running", async () => {
+  const d = deferredRunTurn();
+  const tq = new TurnQueue({ runTurn: d.runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
+  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  await tick();
+  const r2 = await tq.submit({ ...C, text: "sched" }); // no queueable flag
+  expect(r2).toEqual({ ok: false, errorMessage: "turn-already-running" });
+  expect(tq.queueLength("c", "s")).toBe(0);
+  d.resolveNext();
+  await p1;
+});
+
+test("FIFO drain: queued items each run their own turn in order", async () => {
+  const d = deferredRunTurn();
+  const started: string[] = [];
+  const runTurn = (req: TurnRequest, s: AbortSignal) => {
+    started.push(req.text);
+    return d.runTurn(req, s);
+  };
+  const tq = new TurnQueue({ runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
+  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  await tick();
+  const p2 = tq.submit({ ...C, text: "second", queueable: true });
+  const p3 = tq.submit({ ...C, text: "third", queueable: true });
+
+  d.resolveNext(); // finish "first" -> drain "second"
+  await tick();
+  d.resolveNext(); // finish "second" -> drain "third"
+  await tick();
+  d.resolveNext(); // finish "third" -> empty
+  await tick();
+
+  await Promise.all([p1, p2, p3]);
+  expect(started).toEqual(["first", "second", "third"]);
+  expect(tq.queueLength("c", "s")).toBe(0);
+  expect(tq.isBusy("c", "s")).toBe(false);
+});
+
+test("a submit arriving during the drain hand-off enqueues (no parallel turn)", async () => {
+  const d = deferredRunTurn();
+  const started: string[] = [];
+  const runTurn = (req: TurnRequest, s: AbortSignal) => {
+    started.push(req.text);
+    return d.runTurn(req, s);
+  };
+  const tq = new TurnQueue({ runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
+  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  await tick();
+  const p2 = tq.submit({ ...C, text: "second", queueable: true });
+  d.resolveNext(); // finish "first"; drain hands off to "second" (still async before it registers)
+  const r3 = await tq.submit({ ...C, text: "third", queueable: true }); // saw busy -> queued
+  expect(r3).toMatchObject({ ok: true, queued: true });
+  d.resolveNext();
+  await tick();
+  d.resolveNext();
+  await Promise.all([p1, p2]);
+  expect(started).toEqual(["first", "second", "third"]);
+});
+
+test("stranded-tail: a drained head whose turn fails still drains the following item", async () => {
+  const d = deferredRunTurn();
+  const started: string[] = [];
+  const runTurn = (req: TurnRequest, s: AbortSignal) => {
+    started.push(req.text);
+    return d.runTurn(req, s);
+  };
+  const tq = new TurnQueue({ runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
+  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  await tick();
+  // "second"/"third" submit while busy -> both return the enqueue ack immediately, NOT the
+  // eventual drained-turn outcome (mirrors the oracle harness's q2/q3 recording).
+  const r2 = await tq.submit({ ...C, text: "second", queueable: true });
+  const r3 = await tq.submit({ ...C, text: "third", queueable: true });
+  expect(r2).toMatchObject({ ok: true, queued: true });
+  expect(r3).toMatchObject({ ok: true, queued: true });
+
+  d.resolveNext(); // finish "first" -> drain "second"
+  await tick();
+  // "second"'s turn fails (e.g. a transient bind failure inside SessionTurnRunner.run, which
+  // never rejects — it always resolves ok:false) -> must still reach "third", not strand it.
+  d.resolveNext({ ok: false, errorMessage: "transient bind failure" });
+  await tick();
+  expect(started).toEqual(["first", "second", "third"]);
+  d.resolveNext(); // finish "third"
+  await tick();
+
+  await p1;
+  expect(tq.queueLength("c", "s")).toBe(0);
+  expect(tq.isBusy("c", "s")).toBe(false);
+});
+
+test("cancel-empties-queue (wedge #3): a cancel emptying the queue during hand-off clears draining", async () => {
+  // Mirrors the golden fixture "cancel-empties-queue-clears-draining": the finally sets
+  // `draining`, then awaits detectSessionsChanged. If that await cancels the only queued item,
+  // advanceQueue's empty `else` branch must clear `draining` too, or the guard leaks and every
+  // future submit enqueues forever.
+  const d = deferredRunTurn();
+  const ref: { queueItemId?: string; tq?: TurnQueue } = {};
+  let armCancel = false;
+  const tq = new TurnQueue({
+    runTurn: d.runTurn,
+    emitQueueUpdated: () => {},
+    detectSessionsChanged: async () => {
+      if (armCancel && ref.queueItemId) {
+        armCancel = false;
+        ref.tq!.cancelQueuedItem("c", "s", ref.queueItemId);
+      }
+    },
+  });
+  ref.tq = tq;
+
+  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  await tick();
+  const r2 = await tq.submit({ ...C, text: "second", queueable: true });
+  ref.queueItemId = (r2 as { queueItemId: string }).queueItemId;
+
+  armCancel = true;
+  // "first"'s result carries no postTurnDetection by default, so detectSessionsChanged would
+  // never be called — force a detection by giving the resolved result a postTurnDetection.
+  d.resolveNext({ ok: true, postTurnDetection: { internalAlias: "a", priorTransportSession: "t0" } });
+  await tick();
+  await p1;
+
+  // A fresh submit must START a real turn (park on runTurn), not enqueue — proving draining
+  // cleared and the cancelled "second" never ran.
+  expect(tq.queueLength("c", "s")).toBe(0);
+  expect(tq.isBusy("c", "s")).toBe(false);
+  const after = tq.submit({ ...C, text: "after", queueable: true });
+  await tick();
+  expect(d.pendingCount()).toBe(1); // parked on runTurn, not resolved via queue
+  expect(d.pendingReqs().at(-1)?.text).toBe("after");
+  d.resolveNext();
+  await after;
+});
+
+test("Stop-then-followup: a submit after cancelTurn waits (raceWithTimeout) then runs fresh", async () => {
+  const d = deferredRunTurn();
+  const tq = new TurnQueue({ runTurn: d.runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
+  const first = tq.submit({ ...C, text: "long", queueable: true });
+  await tick();
+  expect(tq.cancelTurn("c", "s")).toBe(true); // aborts turn 1's controller; it stays in inFlight until settled
+  const second = tq.submit({ ...C, text: "next", queueable: true }); // waits on settled via raceWithTimeout
+  await tick();
+  expect(d.pendingCount()).toBe(1); // "second" has NOT started a turn yet — it's parked on raceWithTimeout
+  // Simulate teardown completing: turn 1's runTurn resolves ok:false (SessionTurnRunner.run
+  // never rejects, even on abort) -> its finally resolves `settled`.
+  d.resolveNext({ ok: false, errorMessage: "aborted" });
+  await tick();
+  expect(d.pendingCount()).toBe(1); // now "second" has started its own turn
+  d.resolveNext();
+  const [r1, r2] = await Promise.all([first, second]);
+  expect(r1).toEqual({ ok: false, errorMessage: "aborted" });
+  expect((r2 as TurnResult).ok).toBe(true);
+});

--- a/tests/unit/control/turn-queue.test.ts
+++ b/tests/unit/control/turn-queue.test.ts
@@ -5,141 +5,131 @@
 // session-free by design; the sessions-changed compare is threaded in via
 // deps.detectSessionsChanged).
 import { expect, test } from "bun:test";
-import { TurnQueue } from "../../../src/control/turn-queue";
+import { TurnQueue, type TurnQueueDeps } from "../../../src/control/turn-queue";
 import type { TurnRequest, TurnResult } from "../../../src/control/session-turn-runner";
 
-// Models SessionTurnRunner.run's real contract: it never rejects, even on an aborted or
-// failed turn — it always resolves with a TurnResult (ok:false + errorMessage on failure).
-// So the fake here only ever resolves; there is no reject path to fake.
-function deferredRunTurn() {
+// Wires a TurnQueue to a controllable deferred runTurn. `runTurn` records each turn's text into
+// `started` (so drain-order tests can assert it) and parks on a pending promise the test resolves
+// by hand via `resolveNext`. Deps default to no-ops; pass `overrides` to inject behavior (e.g. a
+// detectSessionsChanged that cancels a queued item). Models SessionTurnRunner.run's real
+// contract: it never rejects — it always resolves with a TurnResult (ok:false + errorMessage on
+// failure), so there is no reject path to fake.
+function makeQueue(overrides?: Partial<TurnQueueDeps>) {
+  const started: string[] = [];
   const pending: Array<{ req: TurnRequest; resolve: (r: TurnResult) => void }> = [];
-  const runTurn = (req: TurnRequest, _s: AbortSignal) =>
-    new Promise<TurnResult>((resolve) => pending.push({ req, resolve }));
+  const queue = new TurnQueue({
+    runTurn: (req: TurnRequest, _s: AbortSignal) => {
+      started.push(req.text);
+      return new Promise<TurnResult>((resolve) => pending.push({ req, resolve }));
+    },
+    emitQueueUpdated: () => {},
+    detectSessionsChanged: async () => {},
+    ...overrides,
+  });
   return {
-    runTurn,
+    queue,
+    started,
     resolveNext: (r: TurnResult = { ok: true }) => pending.shift()?.resolve(r),
     pendingCount: () => pending.length,
     pendingReqs: () => pending.map((p) => p.req),
   };
 }
 
-const C = { chatKey: "c", sessionAlias: "s", senderId: "u" };
-
-test("submit's busy-decision + enqueue is a synchronous prefix (same tick, zero await)", () => {
-  const d = deferredRunTurn();
-  const tq = new TurnQueue({ runTurn: d.runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
-  const req = { ...C, text: "A", queueable: true };
-  void tq.submit(req); // sync inFlight.set
-  void tq.submit({ ...req, text: "B" }); // sync enqueue
-  // ZERO await between submit and this assertion — pins the synchronous prefix.
-  expect(tq.queueLength("c", "s")).toBe(1);
-  expect(tq.isBusy("c", "s")).toBe(true);
-});
-
+const BASE = { chatKey: "c", sessionAlias: "s", senderId: "u" };
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
+test("submit's busy-decision + enqueue is a synchronous prefix (same tick, zero await)", () => {
+  const { queue } = makeQueue();
+  const req = { ...BASE, text: "A", queueable: true };
+  void queue.submit(req); // sync inFlight.set
+  void queue.submit({ ...req, text: "B" }); // sync enqueue
+  // ZERO await between submit and this assertion — pins the synchronous prefix.
+  expect(queue.queueLength("c", "s")).toBe(1);
+  expect(queue.isBusy("c", "s")).toBe(true);
+});
+
 test("a busy second submit enqueues and reports queued:true with an id", async () => {
-  const d = deferredRunTurn();
-  const tq = new TurnQueue({ runTurn: d.runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
-  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  const { queue, resolveNext } = makeQueue();
+  const p1 = queue.submit({ ...BASE, text: "first", queueable: true });
   await tick();
-  const r2 = await tq.submit({ ...C, text: "second", queueable: true });
+  const r2 = await queue.submit({ ...BASE, text: "second", queueable: true });
   expect(r2).toMatchObject({ ok: true, queued: true });
   expect(typeof (r2 as { queueItemId: string }).queueItemId).toBe("string");
-  expect(tq.queueLength("c", "s")).toBe(1);
-  d.resolveNext();
+  expect(queue.queueLength("c", "s")).toBe(1);
+  resolveNext();
   await p1;
 });
 
 test("a non-queueable submit while busy rejects immediately with turn-already-running", async () => {
-  const d = deferredRunTurn();
-  const tq = new TurnQueue({ runTurn: d.runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
-  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  const { queue, resolveNext } = makeQueue();
+  const p1 = queue.submit({ ...BASE, text: "first", queueable: true });
   await tick();
-  const r2 = await tq.submit({ ...C, text: "sched" }); // no queueable flag
+  const r2 = await queue.submit({ ...BASE, text: "sched" }); // no queueable flag
   expect(r2).toEqual({ ok: false, errorMessage: "turn-already-running" });
-  expect(tq.queueLength("c", "s")).toBe(0);
-  d.resolveNext();
+  expect(queue.queueLength("c", "s")).toBe(0);
+  resolveNext();
   await p1;
 });
 
 test("FIFO drain: queued items each run their own turn in order", async () => {
-  const d = deferredRunTurn();
-  const started: string[] = [];
-  const runTurn = (req: TurnRequest, s: AbortSignal) => {
-    started.push(req.text);
-    return d.runTurn(req, s);
-  };
-  const tq = new TurnQueue({ runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
-  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  const { queue, started, resolveNext } = makeQueue();
+  const p1 = queue.submit({ ...BASE, text: "first", queueable: true });
   await tick();
-  const p2 = tq.submit({ ...C, text: "second", queueable: true });
-  const p3 = tq.submit({ ...C, text: "third", queueable: true });
+  const p2 = queue.submit({ ...BASE, text: "second", queueable: true });
+  const p3 = queue.submit({ ...BASE, text: "third", queueable: true });
 
-  d.resolveNext(); // finish "first" -> drain "second"
+  resolveNext(); // finish "first" -> drain "second"
   await tick();
-  d.resolveNext(); // finish "second" -> drain "third"
+  resolveNext(); // finish "second" -> drain "third"
   await tick();
-  d.resolveNext(); // finish "third" -> empty
+  resolveNext(); // finish "third" -> empty
   await tick();
 
   await Promise.all([p1, p2, p3]);
   expect(started).toEqual(["first", "second", "third"]);
-  expect(tq.queueLength("c", "s")).toBe(0);
-  expect(tq.isBusy("c", "s")).toBe(false);
+  expect(queue.queueLength("c", "s")).toBe(0);
+  expect(queue.isBusy("c", "s")).toBe(false);
 });
 
 test("a submit arriving during the drain hand-off enqueues (no parallel turn)", async () => {
-  const d = deferredRunTurn();
-  const started: string[] = [];
-  const runTurn = (req: TurnRequest, s: AbortSignal) => {
-    started.push(req.text);
-    return d.runTurn(req, s);
-  };
-  const tq = new TurnQueue({ runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
-  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  const { queue, started, resolveNext } = makeQueue();
+  const p1 = queue.submit({ ...BASE, text: "first", queueable: true });
   await tick();
-  const p2 = tq.submit({ ...C, text: "second", queueable: true });
-  d.resolveNext(); // finish "first"; drain hands off to "second" (still async before it registers)
-  const r3 = await tq.submit({ ...C, text: "third", queueable: true }); // saw busy -> queued
+  const p2 = queue.submit({ ...BASE, text: "second", queueable: true });
+  resolveNext(); // finish "first"; drain hands off to "second" (still async before it registers)
+  const r3 = await queue.submit({ ...BASE, text: "third", queueable: true }); // saw busy -> queued
   expect(r3).toMatchObject({ ok: true, queued: true });
-  d.resolveNext();
+  resolveNext();
   await tick();
-  d.resolveNext();
+  resolveNext();
   await Promise.all([p1, p2]);
   expect(started).toEqual(["first", "second", "third"]);
 });
 
 test("stranded-tail: a drained head whose turn fails still drains the following item", async () => {
-  const d = deferredRunTurn();
-  const started: string[] = [];
-  const runTurn = (req: TurnRequest, s: AbortSignal) => {
-    started.push(req.text);
-    return d.runTurn(req, s);
-  };
-  const tq = new TurnQueue({ runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
-  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  const { queue, started, resolveNext } = makeQueue();
+  const p1 = queue.submit({ ...BASE, text: "first", queueable: true });
   await tick();
   // "second"/"third" submit while busy -> both return the enqueue ack immediately, NOT the
   // eventual drained-turn outcome (mirrors the oracle harness's q2/q3 recording).
-  const r2 = await tq.submit({ ...C, text: "second", queueable: true });
-  const r3 = await tq.submit({ ...C, text: "third", queueable: true });
+  const r2 = await queue.submit({ ...BASE, text: "second", queueable: true });
+  const r3 = await queue.submit({ ...BASE, text: "third", queueable: true });
   expect(r2).toMatchObject({ ok: true, queued: true });
   expect(r3).toMatchObject({ ok: true, queued: true });
 
-  d.resolveNext(); // finish "first" -> drain "second"
+  resolveNext(); // finish "first" -> drain "second"
   await tick();
   // "second"'s turn fails (e.g. a transient bind failure inside SessionTurnRunner.run, which
   // never rejects — it always resolves ok:false) -> must still reach "third", not strand it.
-  d.resolveNext({ ok: false, errorMessage: "transient bind failure" });
+  resolveNext({ ok: false, errorMessage: "transient bind failure" });
   await tick();
   expect(started).toEqual(["first", "second", "third"]);
-  d.resolveNext(); // finish "third"
+  resolveNext(); // finish "third"
   await tick();
 
   await p1;
-  expect(tq.queueLength("c", "s")).toBe(0);
-  expect(tq.isBusy("c", "s")).toBe(false);
+  expect(queue.queueLength("c", "s")).toBe(0);
+  expect(queue.isBusy("c", "s")).toBe(false);
 });
 
 test("cancel-empties-queue (wedge #3): a cancel emptying the queue during hand-off clears draining", async () => {
@@ -147,60 +137,55 @@ test("cancel-empties-queue (wedge #3): a cancel emptying the queue during hand-o
   // `draining`, then awaits detectSessionsChanged. If that await cancels the only queued item,
   // advanceQueue's empty `else` branch must clear `draining` too, or the guard leaks and every
   // future submit enqueues forever.
-  const d = deferredRunTurn();
-  const ref: { queueItemId?: string; tq?: TurnQueue } = {};
+  let queueItemId: string | undefined;
   let armCancel = false;
-  const tq = new TurnQueue({
-    runTurn: d.runTurn,
-    emitQueueUpdated: () => {},
+  const h = makeQueue({
     detectSessionsChanged: async () => {
-      if (armCancel && ref.queueItemId) {
+      if (armCancel && queueItemId) {
         armCancel = false;
-        ref.tq!.cancelQueuedItem("c", "s", ref.queueItemId);
+        h.queue.cancelQueuedItem("c", "s", queueItemId);
       }
     },
   });
-  ref.tq = tq;
 
-  const p1 = tq.submit({ ...C, text: "first", queueable: true });
+  const p1 = h.queue.submit({ ...BASE, text: "first", queueable: true });
   await tick();
-  const r2 = await tq.submit({ ...C, text: "second", queueable: true });
-  ref.queueItemId = (r2 as { queueItemId: string }).queueItemId;
+  const r2 = await h.queue.submit({ ...BASE, text: "second", queueable: true });
+  queueItemId = (r2 as { queueItemId: string }).queueItemId;
 
   armCancel = true;
   // "first"'s result carries no postTurnDetection by default, so detectSessionsChanged would
   // never be called — force a detection by giving the resolved result a postTurnDetection.
-  d.resolveNext({ ok: true, postTurnDetection: { internalAlias: "a", priorTransportSession: "t0" } });
+  h.resolveNext({ ok: true, postTurnDetection: { internalAlias: "a", priorTransportSession: "t0" } });
   await tick();
   await p1;
 
   // A fresh submit must START a real turn (park on runTurn), not enqueue — proving draining
   // cleared and the cancelled "second" never ran.
-  expect(tq.queueLength("c", "s")).toBe(0);
-  expect(tq.isBusy("c", "s")).toBe(false);
-  const after = tq.submit({ ...C, text: "after", queueable: true });
+  expect(h.queue.queueLength("c", "s")).toBe(0);
+  expect(h.queue.isBusy("c", "s")).toBe(false);
+  const after = h.queue.submit({ ...BASE, text: "after", queueable: true });
   await tick();
-  expect(d.pendingCount()).toBe(1); // parked on runTurn, not resolved via queue
-  expect(d.pendingReqs().at(-1)?.text).toBe("after");
-  d.resolveNext();
+  expect(h.pendingCount()).toBe(1); // parked on runTurn, not resolved via queue
+  expect(h.pendingReqs().at(-1)?.text).toBe("after");
+  h.resolveNext();
   await after;
 });
 
 test("Stop-then-followup: a submit after cancelTurn waits (raceWithTimeout) then runs fresh", async () => {
-  const d = deferredRunTurn();
-  const tq = new TurnQueue({ runTurn: d.runTurn, emitQueueUpdated: () => {}, detectSessionsChanged: async () => {} });
-  const first = tq.submit({ ...C, text: "long", queueable: true });
+  const { queue, pendingCount, resolveNext } = makeQueue();
+  const first = queue.submit({ ...BASE, text: "long", queueable: true });
   await tick();
-  expect(tq.cancelTurn("c", "s")).toBe(true); // aborts turn 1's controller; it stays in inFlight until settled
-  const second = tq.submit({ ...C, text: "next", queueable: true }); // waits on settled via raceWithTimeout
+  expect(queue.cancelTurn("c", "s")).toBe(true); // aborts turn 1's controller; it stays in inFlight until settled
+  const second = queue.submit({ ...BASE, text: "next", queueable: true }); // waits on settled via raceWithTimeout
   await tick();
-  expect(d.pendingCount()).toBe(1); // "second" has NOT started a turn yet — it's parked on raceWithTimeout
+  expect(pendingCount()).toBe(1); // "second" has NOT started a turn yet — it's parked on raceWithTimeout
   // Simulate teardown completing: turn 1's runTurn resolves ok:false (SessionTurnRunner.run
   // never rejects, even on abort) -> its finally resolves `settled`.
-  d.resolveNext({ ok: false, errorMessage: "aborted" });
+  resolveNext({ ok: false, errorMessage: "aborted" });
   await tick();
-  expect(d.pendingCount()).toBe(1); // now "second" has started its own turn
-  d.resolveNext();
+  expect(pendingCount()).toBe(1); // now "second" has started its own turn
+  resolveNext();
   const [r1, r2] = await Promise.all([first, second]);
   expect(r1).toEqual({ ok: false, errorMessage: "aborted" });
   expect((r2 as TurnResult).ok).toBe(true);


### PR DESCRIPTION
## Summary

Behaviour-equivalent refactor of `ControlService.executeTurn` — the ~290-line, three-state concurrency gate (`inFlight` / `queues` / `draining`) that carried three self-flagged "permanent wedge" risks — into three focused, independently testable units. `control-service.ts` shrinks from **942 → 539 lines**.

This is the second block of the 2026-07 architecture-audit Track 3 (the orchestration-service split was the first, already merged).

## What changed

- **`src/control/turn-queue.ts`** — new `TurnQueue`, the concurrency primitive owning `inFlight`/`queues`/`draining`. **Session-free by design**: post-turn `sessions-changed` detection is threaded in via a `detectSessionsChanged` callback rather than a session dependency.
- **`src/control/session-turn-runner.ts`** — new `SessionTurnRunner`, the per-turn execution body (session resolve, archived/`clear` pre-capture, media sandbox, stream/batched paragraph reconstruction, `agent.chat` drive, turn lifecycle events).
- **`src/control/turn-support.ts`** — new neutral value module (`turnKey`, `toErrorMessage`, `buildControlMetadata`, `raceWithTimeout`, constants, `QueuedPrompt`), value-imported to avoid a runtime cycle.
- **`src/control/control-service.ts`** — `executeTurn` deleted; constructor wires the two new units; `prompt`/`runScheduledTurn`/`cancelTurn`/`cancelQueuedItem` forward to `TurnQueue`. Public signatures unchanged.

## Equivalence guarantee

A **black-box golden oracle** (`tests/unit/control/golden/turn-oracle.test.ts`) records the event-emission order — `deps.events.emit` is synchronous, so log order equals execution order across microtasks — plus entry-call returns, recorded on the pre-refactor baseline (`54be207`) and replayed unchanged. **9 fixtures, byte-identical across the refactor.**

The one real timing subtlety — `draining.add` must precede the post-turn `getSession` await, or an aborted turn with a queued item lets a fresh prompt race in — is pinned by a dedicated fixture (`aborted-queue-sessions-window`) and mutation-verified. A white-box suite (`turn-queue.test.ts`) additionally pins the synchronous prefix (busy-decision + `inFlight.set` before the first await) with a zero-await same-tick assertion.

## Verification

- 9-fixture oracle: 9/9 · white-box `turn-queue.test.ts`: 8/8 · all 21 `tests/unit/control/*` suites green · `tsc --noEmit` clean.
- No existing control test file modified (`--name-status`: only `control-service.ts` is Modified; everything else is Added).
- Final whole-branch review (isolated worktree, mutation-verified): **APPROVE**, no Critical/Important/Minor fixes outstanding. All three "mutation X reddens test Y" code comments were independently mutation-confirmed accurate.

### Note

The ok-path return now omits a `text: undefined` key that the baseline always included. Boundary-invisible: the value crosses the JSON/wire boundary to every real consumer (which drops `undefined`), and the oracle harness stabilizer round-trips JSON — documented in the harness.
