### PR TITLE
feat(track4·A): terminal stream hardening — output coalescing + WS backpressure

### DIFF
--- a/docs/superpowers/plans/2026-07-12-track4-terminal-stream-hardening.md
+++ b/docs/superpowers/plans/2026-07-12-track4-terminal-stream-hardening.md
@@ -4,7 +4,7 @@
 
 **Goal:** Bound the two unbounded paths in terminal streaming — coalesce PTY output bursts into ~one-frame windows, and evict a slow web socket by `bufferedAmount` — with **zero wire-format change**.
 
-**Architecture:** Two independent changes. (1) Core `terminal-service.ts` debounces its per-chunk `terminal-output` emit into a 16ms / 64KB coalescing window, flushing on window/size-cap/attach/exit/dispose; every byte still lands in the replay buffer, and `attach` flushes-then-snapshots so the client's `seq > lastSeq` reconciliation stays correct. (2) Hub `WebGateway.broadcast` terminates any socket whose `bufferedAmount` exceeds 4MB (self-healing via the existing re-attach path) instead of growing its send buffer without bound.
+**Architecture:** Two independent changes. (1) Core `terminal-service.ts` debounces its per-chunk `terminal-output` emit into a 16ms / 64KB coalescing window, flushing on window/size-cap/attach/exit (`disposeAll` is a hard teardown: it clears the timers and drops any unflushed pending — not a flush); every byte still lands in the replay buffer, and `attach` flushes-then-snapshots so the client's `seq > lastSeq` reconciliation stays correct. (2) Hub `WebGateway.broadcast` terminates any socket whose `bufferedAmount` exceeds 4MB (self-healing via the existing re-attach path) instead of growing its send buffer without bound.
 
 **Tech Stack:** TypeScript, Bun test runner, `node-pty` (PTY), `ws` (hub sockets). Core tests under `tests/unit/control/`, hub tests under `tests/unit/packages/relay/`, both run per-file by `scripts/run-tests.mjs` (never whole-dir — state-leak rule).
 
@@ -339,7 +339,7 @@ Expected: no errors.
 feat(control): coalesce terminal output into ~one-frame windows
 
 Debounce terminal-service's per-chunk terminal-output emit into a 16ms /
-64KB coalescing window (flush on window/size-cap/attach/exit/dispose).
+64KB coalescing window (flush on window/size-cap/attach/exit; dispose is teardown, clears timers).
 attach flushes pending before snapshotting so the client's seq>lastSeq
 reconciliation stays correct (no double-render). Every byte still lands in
 the replay buffer; seq stays monotonic. Track 4 · A (1/2).
@@ -496,7 +496,7 @@ dashboard no longer starves the others or OOMs the hub. Track 4 · A (2/2).
 ## Self-Review
 
 **Spec coverage:**
-- Coalescing (window/size-cap/exit/dispose flush, byte-complete buffer, monotonic seq) → Task 1 Steps 4-15. ✔
+- Coalescing (window/size-cap/attach/exit flush; dispose clears timers, drops pending; byte-complete buffer, monotonic seq) → Task 1 Steps 4-15. ✔
 - `attach` flush-before-snapshot (the seq-reconciliation correctness fix) → Task 1 Steps 5, 13. ✔
 - Hub-side `bufferedAmount` backpressure (terminate + skip, one-slow-doesn't-starve, undefined = under) → Task 2. ✔
 - Constants `COALESCE_MS=16`, `COALESCE_MAX_BYTES=64*1024`, `BACKPRESSURE_MAX=4*1024*1024`, module-level, no config keys → Task 1 Step 7, Task 2 Step 4. ✔

--- a/docs/superpowers/plans/2026-07-12-track4-terminal-stream-hardening.md
+++ b/docs/superpowers/plans/2026-07-12-track4-terminal-stream-hardening.md
@@ -1,0 +1,508 @@
+# Terminal Stream Hardening (Track 4 · A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound the two unbounded paths in terminal streaming — coalesce PTY output bursts into ~one-frame windows, and evict a slow web socket by `bufferedAmount` — with **zero wire-format change**.
+
+**Architecture:** Two independent changes. (1) Core `terminal-service.ts` debounces its per-chunk `terminal-output` emit into a 16ms / 64KB coalescing window, flushing on window/size-cap/attach/exit/dispose; every byte still lands in the replay buffer, and `attach` flushes-then-snapshots so the client's `seq > lastSeq` reconciliation stays correct. (2) Hub `WebGateway.broadcast` terminates any socket whose `bufferedAmount` exceeds 4MB (self-healing via the existing re-attach path) instead of growing its send buffer without bound.
+
+**Tech Stack:** TypeScript, Bun test runner, `node-pty` (PTY), `ws` (hub sockets). Core tests under `tests/unit/control/`, hub tests under `tests/unit/packages/relay/`, both run per-file by `scripts/run-tests.mjs` (never whole-dir — state-leak rule).
+
+## Global Constraints
+
+- **No wire-format / DTO / envelope change.** `terminal-output` keeps exactly `{ type, terminalId, seq, data }`.
+- **No new `terminal.*` config keys.** The three tuning values are module-level constants: `COALESCE_MS = 16`, `COALESCE_MAX_BYTES = 64 * 1024`, `BACKPRESSURE_MAX = 4 * 1024 * 1024`.
+- **Behaviour-changing work** → characterization tests assert the *new* behaviour; regression guards pin the surviving contracts (byte-complete replay buffer, strictly monotonic `seq`, `buffer` = output through `lastSeq`).
+- Timers must be injectable (`deps.setTimer` / `deps.clearTimer`) and `unref`'d in production.
+- Public interfaces unchanged: `TerminalService`, `WebGateway`, `WebSocketLike` (additive optional field only).
+- Run tests per-file: `bun test <path>`. Typecheck: core `npx tsc --noEmit`; relay `npx tsc -p packages/relay/tsconfig.json --noEmit`.
+- The implementer runs **no git**; the controller commits. (Steps show the intended commit message for the controller.)
+
+---
+
+### Task 1: Output coalescing in `terminal-service`
+
+**Files:**
+- Modify: `src/control/terminal-service.ts`
+- Test: `tests/unit/control/terminal-service.test.ts`
+
+**Interfaces:**
+- Consumes: existing `ControlEventBus.emit`, injected `deps.setTimer`/`deps.clearTimer`.
+- Produces: no signature change. `terminal-output` events are now **coalesced** (one per ≤16ms window or per 64KB burst) instead of one-per-chunk; `attach` emits a pending flush before returning; `seq` counts coalesced events.
+
+This task both **adds** coalescing tests and **updates** existing tests that pinned the old per-chunk behaviour. Do the harness upgrade first (behaviour-preserving, keeps existing tests green), then write the new/updated tests as failing, then implement.
+
+- [ ] **Step 1: Upgrade the fake-timer harness to a multi-timer model**
+
+The existing `setupWithFakeTimer` (terminal-service.test.ts:151-178) has a single `pendingFn` slot and counts all `setTimer` calls. Coalescing arms a *second* timer per session (the 16ms flush) alongside the ~900000ms idle timer, so the harness must track multiple timers and distinguish them by `ms`. It also needs to capture emitted events for the coalescing assertions. Replace the whole `setupWithFakeTimer` function (lines 151-178) with:
+
+```ts
+function setupWithFakeTimer(opts?: { idle?: number; platform?: NodeJS.Platform }) {
+  // Multiple timers can be live at once: the idle timer (idleTimeoutSeconds*1000,
+  // i.e. >=1000ms) and the coalesce flush timer (COALESCE_MS = 16ms). Track them by
+  // id and split on ms so a test can fire/inspect each kind independently.
+  const timers = new Map<number, { fn: () => void; ms: number }>();
+  let timerId = 0;
+  let idleSetCount = 0;
+  const setTimer = (fn: () => void, ms: number): unknown => {
+    const id = ++timerId;
+    timers.set(id, { fn, ms });
+    if (ms >= 1000) idleSetCount++; // idle timer only; the 16ms flush timer is excluded
+    return id;
+  };
+  const clearTimer = (id: unknown) => { timers.delete(id as number); };
+  const fireWhere = (pred: (ms: number) => boolean) => {
+    for (const [id, t] of [...timers]) if (pred(t.ms)) { timers.delete(id); t.fn(); }
+  };
+  /** Fire the pending idle timer(s) (>=1000ms). */
+  const tick = () => fireWhere((ms) => ms >= 1000);
+  /** Fire the pending coalesce flush timer(s) (<1000ms). */
+  const fireFlush = () => fireWhere((ms) => ms < 1000);
+  /** True when an idle timer is pending. */
+  const hasPending = () => [...timers.values()].some((t) => t.ms >= 1000);
+  /** True when a coalesce flush timer is pending. */
+  const hasFlushPending = () => [...timers.values()].some((t) => t.ms < 1000);
+
+  const events = createControlEventBus();
+  const captured: ControlEvent[] = [];
+  events.subscribe((e) => captured.push(e));
+  const pty = fakePty();
+  const spawn = mock(() => pty);
+  const svc = createTerminalService({
+    events,
+    idleTimeoutSeconds: () => opts?.idle ?? 900,
+    spawn: spawn as never,
+    platform: opts?.platform ?? "darwin",
+    setTimer,
+    clearTimer,
+  });
+  return { svc, pty, spawn, captured, tick, fireFlush, hasPending, hasFlushPending, getIdleSetCount: () => idleSetCount };
+}
+```
+
+- [ ] **Step 2: Adapt the existing idle tests to the renamed helper**
+
+The only breaking rename is `getSetTimerCount` → `getIdleSetCount` in the "output does NOT reset the idle timer" test. In terminal-service.test.ts:180-197 replace the two `getSetTimerCount` references and update the destructure:
+
+```ts
+test("idle: PTY output (onData) does NOT reset the idle timer", () => {
+  const { svc, pty, tick, getIdleSetCount } = setupWithFakeTimer();
+  svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+
+  pty.emitData("line1\r\n");
+  pty.emitData("line2\r\n");
+  pty.emitData("line3\r\n");
+
+  // The IDLE timer is armed exactly once (at create); output must not re-arm it.
+  // (Output DOES arm a separate coalesce flush timer — excluded from this count.)
+  expect(getIdleSetCount()).toBe(1);
+
+  tick();
+  expect((pty.kill as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+});
+```
+
+The other idle tests ("write() DOES reset", "resize() DOES reset", "output does not block kill") already use only `tick` / `hasPending` and stay as-is — `hasPending` now means "idle timer pending", which is exactly what they assert.
+
+- [ ] **Step 3: Run the existing test file — still green (harness refactor is behaviour-preserving)**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts`
+Expected: PASS (no production code changed yet; only the harness + one rename).
+
+- [ ] **Step 4: Replace the per-chunk "monotonic seq" test with a coalesced version**
+
+The old test at terminal-service.test.ts:53-63 uses real timers and expects one event per chunk — invalid under coalescing. Replace that whole `test(...)` block with:
+
+```ts
+test("coalesces multiple output chunks within a window into one terminal-output", () => {
+  const { svc, pty, captured, fireFlush } = setupWithFakeTimer();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("foo"); pty.emitData("bar"); pty.emitData("baz");
+  // Still inside the coalesce window — nothing emitted yet.
+  expect(captured.filter((e) => e.type === "terminal-output").length).toBe(0);
+  fireFlush();
+  const outs = captured.filter((e) => e.type === "terminal-output") as Extract<ControlEvent, { type: "terminal-output" }>[];
+  expect(outs.length).toBe(1);
+  expect(outs[0]).toEqual({ type: "terminal-output", terminalId, seq: 0, data: "foobarbaz" });
+});
+
+test("seq is monotonic across coalesced windows", () => {
+  const { svc, pty, captured, fireFlush } = setupWithFakeTimer();
+  svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("a"); fireFlush();
+  pty.emitData("b"); fireFlush();
+  const outs = captured.filter((e) => e.type === "terminal-output") as Extract<ControlEvent, { type: "terminal-output" }>[];
+  expect(outs.map((o) => [o.seq, o.data])).toEqual([[0, "a"], [1, "b"]]);
+});
+
+test("a burst >= COALESCE_MAX_BYTES flushes immediately (no window wait)", () => {
+  const { svc, pty, captured } = setupWithFakeTimer();
+  svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  const big = "x".repeat(64 * 1024); // 64KB of ascii == COALESCE_MAX_BYTES
+  pty.emitData(big);
+  const outs = captured.filter((e) => e.type === "terminal-output") as Extract<ControlEvent, { type: "terminal-output" }>[];
+  expect(outs.length).toBe(1); // emitted synchronously, before any fireFlush()
+  expect(outs[0]!.seq).toBe(0);
+  expect(outs[0]!.data).toBe(big);
+});
+
+test("exit flushes pending output before emitting terminal-exit", () => {
+  const { svc, pty, captured } = setupWithFakeTimer();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("tail-end"); // armed in the window, not yet flushed
+  pty.emitExit(0);
+  const types = captured.map((e) => e.type);
+  const outIdx = types.indexOf("terminal-output");
+  const exitIdx = types.indexOf("terminal-exit");
+  expect(outIdx).toBeGreaterThanOrEqual(0);
+  expect(exitIdx).toBeGreaterThan(outIdx); // output strictly BEFORE exit
+  expect(captured[outIdx]).toEqual({ type: "terminal-output", terminalId, seq: 0, data: "tail-end" });
+});
+
+test("disposeAll clears a pending flush timer (no stale flush after dispose)", () => {
+  const { svc, pty, hasFlushPending } = setupWithFakeTimer();
+  svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("pending"); // arms a flush timer
+  expect(hasFlushPending()).toBe(true);
+  svc.disposeAll();
+  expect(hasFlushPending()).toBe(false);
+});
+```
+
+- [ ] **Step 5: Update the two attach tests that assumed per-chunk seq**
+
+At terminal-service.test.ts:93-100, `attach` now flushes pending first, so the two synchronously-emitted chunks coalesce into **one** event (seq 0) and `lastSeq` is 0. Replace that test, and add the flush-before-snapshot assertion:
+
+```ts
+test("attach returns buffered output + lastSeq for a live terminal (coalesced)", () => {
+  const { svc, pty } = setupWithFakeTimer();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("hello\n");
+  pty.emitData("world\n"); // both pending; attach flushes them as ONE event (seq 0)
+  const res = svc.attach(terminalId);
+  expect(res).toEqual({ ok: true, buffer: "hello\nworld\n", lastSeq: 0 });
+});
+
+test("attach flushes pending first so lastSeq covers the buffer (no double-render)", () => {
+  const { svc, pty, captured } = setupWithFakeTimer();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("live-"); pty.emitData("bytes"); // pending, window not fired
+  const res = svc.attach(terminalId);
+  // attach emitted exactly one coalesced event at seq 0...
+  const outs = captured.filter((e) => e.type === "terminal-output") as Extract<ControlEvent, { type: "terminal-output" }>[];
+  expect(outs.length).toBe(1);
+  expect(outs[0]).toEqual({ type: "terminal-output", terminalId, seq: 0, data: "live-bytes" });
+  // ...and lastSeq === that seq, so the client's `seq > lastSeq` filter drops the flush
+  // event it queued during the attach RPC — the bytes render once (from the buffer), not twice.
+  expect(res).toEqual({ ok: true, buffer: "live-bytes", lastSeq: 0 });
+});
+```
+
+The remaining attach tests ("no output yet returns lastSeq -1" at :102, "ok:false after close" at :108, "ring buffer trims" at :116) stay unchanged — with no pending, `attach`'s flush is a no-op; the ring-buffer test only inspects `buffer`. Convert the "no output yet" and "ok:false after close" and "ring buffer trims" tests' `setup()` call to `setupWithFakeTimer()` **only if** they currently use `setup()` and you need deterministic timing — but they don't depend on flush timing, so leave them on `setup()` (real timers). No change required there.
+
+- [ ] **Step 6: Run the test file to verify the new/updated tests FAIL**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts`
+Expected: FAIL — the coalescing tests fail (e.g. "expected 0 terminal-output before fireFlush" but the current code emits one per chunk immediately; `attach` returns `lastSeq: 1` not `0`).
+
+- [ ] **Step 7: Add the coalescing constants**
+
+In `src/control/terminal-service.ts`, immediately after the existing `const MAX_BUFFER_BYTES = 256 * 1024;` (line 125), add:
+
+```ts
+// Output coalescing: accumulate PTY output into ~one-frame windows and emit a single
+// terminal-output per window instead of one per chunk. A noisy process (yes, tail -f,
+// a build log) otherwise produces a firehose of tiny events across every downstream hop.
+const COALESCE_MS = 16;
+// Flush a large burst immediately rather than sit on it and add latency. Well under the
+// 256KB replay cap so a single window never dominates the buffer.
+const COALESCE_MAX_BYTES = 64 * 1024;
+```
+
+- [ ] **Step 8: Add the coalescing fields to the Session interface**
+
+Replace the `interface Session` line (terminal-service.ts:123) with:
+
+```ts
+interface Session { handle: PtyHandle; seq: number; idleTimer: unknown; buffer: string; bufBytes: number; pending: string; flushTimer: unknown }
+```
+
+- [ ] **Step 9: Add the `flushOutput` helper inside `createTerminalService`**
+
+Immediately after the `resetIdle` closure (ends at terminal-service.ts:167), add:
+
+```ts
+  // Emit the coalesced output window as a single terminal-output event. Disarms the
+  // window timer FIRST so a throwing consumer cannot strand it (state stays clean:
+  // pending cleared, timer null). No-op when nothing is pending. Callers: the window
+  // timer, the size-cap in onData, attach (flush-before-snapshot), and onExit.
+  const flushOutput = (terminalId: string) => {
+    const s = sessions.get(terminalId);
+    if (!s) return;
+    if (s.flushTimer) { clearTimer(s.flushTimer); s.flushTimer = null; }
+    if (s.pending.length === 0) return;
+    const data = s.pending;
+    s.pending = "";
+    deps.events.emit({ type: "terminal-output", terminalId, seq: s.seq++, data });
+  };
+```
+
+- [ ] **Step 10: Initialise the new Session fields in `create`**
+
+Replace the session-construction line (terminal-service.ts:174) with:
+
+```ts
+      const session: Session = { handle, seq: 0, idleTimer: null, buffer: "", bufBytes: 0, pending: "", flushTimer: null };
+```
+
+- [ ] **Step 11: Rewrite the `onData` handler to coalesce**
+
+Replace the `handle.onData(...)` block (terminal-service.ts:176-180) with:
+
+```ts
+      handle.onData((data) => {
+        // NOTE: resetIdle is intentionally NOT called here (output ≠ user interaction).
+        appendToBuffer(session, data); // every byte still lands in the replay buffer
+        // Coalesce: accumulate and emit one event per window instead of per chunk.
+        session.pending += data;
+        if (Buffer.byteLength(session.pending, "utf8") >= COALESCE_MAX_BYTES) {
+          flushOutput(terminalId); // large burst: flush now, don't add window latency
+          return;
+        }
+        if (!session.flushTimer) {
+          session.flushTimer = setTimer(() => flushOutput(terminalId), COALESCE_MS);
+          const t = session.flushTimer as { unref?: () => void };
+          if (typeof t.unref === "function") t.unref();
+        }
+      });
+```
+
+- [ ] **Step 12: Flush pending before `terminal-exit` in `onExit`**
+
+Replace the `handle.onExit(...)` block (terminal-service.ts:181-185) with:
+
+```ts
+      handle.onExit(({ exitCode }) => {
+        flushOutput(terminalId); // emit any coalesced-but-unflushed output BEFORE the exit event
+        if (session.idleTimer) clearTimer(session.idleTimer);
+        sessions.delete(terminalId);
+        deps.events.emit({ type: "terminal-exit", terminalId, code: exitCode });
+      });
+```
+
+- [ ] **Step 13: Flush pending before snapshotting in `attach`**
+
+Replace the `attach(terminalId)` method body (terminal-service.ts:189-194) with:
+
+```ts
+    attach(terminalId) {
+      const s = sessions.get(terminalId);
+      if (!s) return { ok: false };
+      // Assign the pending bytes a seq BEFORE snapshotting buffer/lastSeq, so the
+      // returned lastSeq covers the whole buffer. The client queues live events during
+      // the attach RPC and applies only those with seq > lastSeq, so this flush event
+      // (seq === returned lastSeq) is correctly dropped — the bytes render once.
+      flushOutput(terminalId);
+      resetIdle(terminalId); // reattaching counts as activity
+      return { ok: true, buffer: s.buffer, lastSeq: s.seq - 1 };
+    },
+```
+
+- [ ] **Step 14: Clear the flush timer in `disposeAll`**
+
+Replace the `disposeAll()` method body (terminal-service.ts:212-218) with:
+
+```ts
+    disposeAll() {
+      for (const s of sessions.values()) {
+        if (s.idleTimer) clearTimer(s.idleTimer);
+        if (s.flushTimer) clearTimer(s.flushTimer);
+        try { s.handle.kill(); } catch { /* ignore */ }
+      }
+      sessions.clear();
+    },
+```
+
+- [ ] **Step 15: Run the test file to verify all tests pass**
+
+Run: `bun test tests/unit/control/terminal-service.test.ts`
+Expected: PASS (all coalescing + regression + idle tests green).
+
+- [ ] **Step 16: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 17: Commit** (controller performs git)
+
+```
+feat(control): coalesce terminal output into ~one-frame windows
+
+Debounce terminal-service's per-chunk terminal-output emit into a 16ms /
+64KB coalescing window (flush on window/size-cap/attach/exit/dispose).
+attach flushes pending before snapshotting so the client's seq>lastSeq
+reconciliation stays correct (no double-render). Every byte still lands in
+the replay buffer; seq stays monotonic. Track 4 · A (1/2).
+```
+
+---
+
+### Task 2: Hub-side backpressure in `WebGateway`
+
+**Files:**
+- Modify: `packages/relay/src/gateway/web-gateway.ts`
+- Test: `tests/unit/packages/relay/gateway/web-gateway.test.ts`
+
+**Interfaces:**
+- Consumes: existing `WebGateway.broadcast`, `WebSocketLike`, `RelayLogger` (`debug`/`info`/`error` only — no `warn`).
+- Produces: `WebSocketLike` gains an optional `bufferedAmount?: number`; `broadcast` now terminates + skips any socket over `BACKPRESSURE_MAX`.
+
+- [ ] **Step 1: Add the backpressure tests (extend the FakeSocket)**
+
+At the top of `tests/unit/packages/relay/gateway/web-gateway.test.ts`, extend `FakeSocket` (lines 6-12) to carry `bufferedAmount` and a `terminate` that fires the close listeners (real `ws.terminate()` triggers a `close`, which the gateway's close handler uses to drop the socket). **Do NOT add a default `readyState`** — the existing "sockets without readyState still receive" test relies on `FakeSocket` having none, and the backpressure guard is skipped when `readyState` is undefined (the `typeof === "number"` check), so the backpressure tests work without it:
+
+```ts
+class FakeSocket {
+  sent: string[] = [];
+  closeListeners: (() => void)[] = [];
+  bufferedAmount = 0;
+  terminated = false;
+  send(data: string) { this.sent.push(data); }
+  terminate() { this.terminated = true; this.close(); } // real ws: terminate -> close -> drop
+  on(event: string, listener: () => void) { if (event === "close") this.closeListeners.push(listener); return this; }
+  close() { this.closeListeners.forEach((l) => l()); }
+}
+```
+
+Note: tests that need an explicit `readyState` (the existing L69-83 test) already cast to `FakeSocket & { readyState: number }` and assign it — that pattern is unaffected.
+
+Then append these tests at the end of the file:
+
+```ts
+const BACKPRESSURE_MAX = 4 * 1024 * 1024;
+
+test("a socket over the bufferedAmount threshold is terminated and skipped, not sent", () => {
+  const logs: Array<[string, string, Record<string, unknown> | undefined]> = [];
+  const gw = new WebGateway({ logger: { debug: () => {}, info: (e, m, c) => logs.push([e, m, c]), error: () => {} } });
+  const slow = new FakeSocket();
+  slow.bufferedAmount = BACKPRESSURE_MAX + 1;
+  gw.register("a1", slow as never);
+  gw.broadcast("a1", evt(true));
+  expect(slow.sent.length).toBe(0);
+  expect(slow.terminated).toBe(true);
+  // the terminate-triggered close dropped it from the account set: a second broadcast is a no-op
+  slow.bufferedAmount = 0;
+  gw.broadcast("a1", evt(false));
+  expect(slow.sent.length).toBe(0);
+  expect(logs.some(([e]) => e === "relay.web.backpressure_evict")).toBe(true);
+});
+
+test("a socket at/under the threshold receives normally", () => {
+  const gw = new WebGateway();
+  const ok = new FakeSocket();
+  ok.bufferedAmount = BACKPRESSURE_MAX; // exactly at the cap is NOT over it
+  gw.register("a1", ok as never);
+  gw.broadcast("a1", evt(true));
+  expect(ok.sent.length).toBe(1);
+  expect(ok.terminated).toBe(false);
+});
+
+test("one slow socket does not starve the healthy sockets in the same account", () => {
+  const gw = new WebGateway();
+  const slow = new FakeSocket(); slow.bufferedAmount = BACKPRESSURE_MAX + 1;
+  const good = new FakeSocket();
+  gw.register("a1", slow as never); // slow first, so its eviction must not skip `good`
+  gw.register("a1", good as never);
+  gw.broadcast("a1", evt(true));
+  expect(slow.sent.length).toBe(0);
+  expect(slow.terminated).toBe(true);
+  expect(good.sent.length).toBe(1);
+});
+```
+
+The existing "sockets without readyState still receive" test (lines 69-83) already covers the `bufferedAmount === undefined` path implicitly via `FakeSocket`'s default `bufferedAmount = 0`; no separate undefined-case test is needed since 0 is under threshold and behaves identically.
+
+- [ ] **Step 2: Run the gateway test file to verify the new tests FAIL**
+
+Run: `bun test tests/unit/packages/relay/gateway/web-gateway.test.ts`
+Expected: FAIL — `slow.terminated` is `false` and `slow.sent.length` is `1` (no backpressure yet).
+
+- [ ] **Step 3: Add `bufferedAmount` to `WebSocketLike`**
+
+In `packages/relay/src/gateway/web-gateway.ts`, add to the `WebSocketLike` interface (after the `readyState?: number;` line, ~line 15):
+
+```ts
+  /** Optional (real `ws` sockets have it): bytes queued but not yet flushed to the OS. */
+  bufferedAmount?: number;
+```
+
+- [ ] **Step 4: Add the `BACKPRESSURE_MAX` constant**
+
+In the same file, next to the existing `const WS_OPEN = 1;` (line 7), add:
+
+```ts
+/** Terminate a web socket whose send buffer exceeds this — a genuinely stalled client.
+ *  A healthy client drains to ~0, so this never false-positives on transient bursts. The
+ *  evicted client reconnects and re-attaches, replaying the bounded terminal scrollback. */
+const BACKPRESSURE_MAX = 4 * 1024 * 1024;
+```
+
+- [ ] **Step 5: Add the backpressure guard in `broadcast`**
+
+In `broadcast` (web-gateway.ts:45-58), insert the guard **after** the `readyState` check and **before** `socket.send(data)`:
+
+```ts
+    for (const socket of set) {
+      // One dead/throwing socket must not starve the remaining dashboards.
+      if (typeof socket.readyState === "number" && socket.readyState !== WS_OPEN) continue;
+      // Backpressure: a stalled client's send buffer grows without bound. Evict it (it
+      // reconnects and re-attaches, replaying the bounded scrollback) rather than OOM the hub.
+      if (typeof socket.bufferedAmount === "number" && socket.bufferedAmount > BACKPRESSURE_MAX) {
+        this.options.logger?.info("relay.web.backpressure_evict", "evicting slow web client", { accountId, bufferedAmount: socket.bufferedAmount });
+        try { socket.terminate?.(); } catch { /* already gone */ }
+        continue;
+      }
+      try {
+        socket.send(data);
+      } catch (err) {
+        this.options.logger?.error("relay.web.broadcast_failed", "broadcast send failed", { error: String(err) });
+      }
+    }
+```
+
+- [ ] **Step 6: Run the gateway test file to verify all tests pass**
+
+Run: `bun test tests/unit/packages/relay/gateway/web-gateway.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Typecheck the relay package**
+
+Run: `npx tsc -p packages/relay/tsconfig.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 8: Commit** (controller performs git)
+
+```
+feat(relay): evict slow web sockets by bufferedAmount (backpressure)
+
+WebGateway.broadcast terminates any socket whose bufferedAmount exceeds
+4MB instead of growing its send buffer without bound; the evicted client
+reconnects and re-attaches, replaying the bounded scrollback. One slow
+dashboard no longer starves the others or OOMs the hub. Track 4 · A (2/2).
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Coalescing (window/size-cap/exit/dispose flush, byte-complete buffer, monotonic seq) → Task 1 Steps 4-15. ✔
+- `attach` flush-before-snapshot (the seq-reconciliation correctness fix) → Task 1 Steps 5, 13. ✔
+- Hub-side `bufferedAmount` backpressure (terminate + skip, one-slow-doesn't-starve, undefined = under) → Task 2. ✔
+- Constants `COALESCE_MS=16`, `COALESCE_MAX_BYTES=64*1024`, `BACKPRESSURE_MAX=4*1024*1024`, module-level, no config keys → Task 1 Step 7, Task 2 Step 4. ✔
+- No wire-format change → both tasks are additive to internal emit/broadcast; `terminal-output` DTO untouched. ✔
+- Non-goals (PTY pause / back-channel / per-session routing / client resync) → not present in any task. ✔
+
+**Placeholder scan:** none — every code step carries complete code; every run step names the command and expected outcome.
+
+**Type consistency:** `flushOutput` defined (Step 9) before use (Steps 11-13); `Session` fields `pending`/`flushTimer` added (Step 8) before use; harness helpers `fireFlush`/`hasFlushPending`/`getIdleSetCount`/`captured` defined (Step 1) before use (Steps 2, 4, 5); `bufferedAmount` added to `WebSocketLike` (Task 2 Step 3) before use (Step 5); `BACKPRESSURE_MAX` value identical in test (Task 2 Step 1) and source (Step 4).

--- a/docs/superpowers/plans/2026-07-12-track4-terminal-stream-hardening.md
+++ b/docs/superpowers/plans/2026-07-12-track4-terminal-stream-hardening.md
@@ -420,7 +420,7 @@ test("one slow socket does not starve the healthy sockets in the same account", 
 });
 ```
 
-The existing "sockets without readyState still receive" test (lines 69-83) already covers the `bufferedAmount === undefined` path implicitly via `FakeSocket`'s default `bufferedAmount = 0`; no separate undefined-case test is needed since 0 is under threshold and behaves identically.
+Note: `bufferedAmount = 0` (the FakeSocket default) exercises the `typeof===number` TRUE branch under threshold; a separate test with `bufferedAmount` genuinely absent covers the FALSE short-circuit branch (added below).
 
 - [ ] **Step 2: Run the gateway test file to verify the new tests FAIL**
 

--- a/docs/superpowers/specs/2026-07-12-track4-terminal-stream-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-12-track4-terminal-stream-hardening-design.md
@@ -98,8 +98,11 @@ On `onData(data)`:
 
 Flush triggers: (a) timer fires; (b) `pending` ≥ `COALESCE_MAX_BYTES`;
 (c) **`onExit` flushes pending *before* emitting `terminal-exit`** (ordering
-contract — the final output must not arrive after / be lost to the exit event);
-(d) `disposeAll` (best-effort flush is optional but the timer MUST be cleared).
+contract — the final output must not arrive after / be lost to the exit event).
+`disposeAll` is **NOT** a flush trigger: it is a hard teardown (daemon shutdown)
+that clears both timers and kills every PTY — any coalesced-but-unflushed `pending`
+is intentionally dropped rather than emitted into a bus that is closing at the same
+moment. It only guarantees no armed timer survives.
 
 Preserved contracts:
 - Every byte still lands in `buffer` → `attach` replay stays byte-complete.
@@ -146,7 +149,8 @@ scoped to the one slow client.
 ```
 PTY chunk
   → appendToBuffer (per byte)  +  pending (accumulate)
-  → flush on [16ms window | 64KB cap | exit | dispose]  →  ONE terminal-output{seq++}
+  → flush on [16ms window | 64KB cap | attach | exit]  →  ONE terminal-output{seq++}
+    (disposeAll is teardown: clears timers, drops pending — not a flush)
   → connector → hub → broadcast(bufferedAmount > 4MB ? terminate+skip : send)
   → web
 ```

--- a/docs/superpowers/specs/2026-07-12-track4-terminal-stream-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-12-track4-terminal-stream-hardening-design.md
@@ -102,11 +102,24 @@ contract — the final output must not arrive after / be lost to the exit event)
 (d) `disposeAll` (best-effort flush is optional but the timer MUST be cleared).
 
 Preserved contracts:
-- Every byte still lands in `buffer` → `attach` replay unchanged.
+- Every byte still lands in `buffer` → `attach` replay stays byte-complete.
 - `seq` stays strictly monotonic; it now counts coalesced events, not chunks.
-  `attach` returns `{ buffer, lastSeq: seq - 1 }` exactly as before.
+- **`attach` must flush pending before snapshotting `buffer`/`lastSeq`.** The
+  client (`TerminalTab.vue:258-281`) reconciles by seq: it queues live events
+  during the attach RPC, replays `res.buffer`, then applies only queued events
+  with `seq > res.lastSeq` (and the live handler drops `seq <= lastSeq`). The
+  invariant it relies on is **`buffer` = output through `lastSeq`; any live event
+  with `seq > lastSeq` is genuinely new**. Without a flush, `attach` would return
+  a `buffer` containing un-emitted `pending` bytes while `lastSeq = seq-1` has not
+  covered them, so the later pending-flush event (`seq > lastSeq`) would
+  double-render. Flushing first assigns the pending bytes `seq = N`, sets
+  `lastSeq = N`, and the client's `seq > lastSeq` filter then correctly drops that
+  same flush event (which it queued during the RPC). Verified correct for other
+  already-attached clients too: the flush event is the first time they see those
+  bytes, so they render them exactly once.
 - Idle timer semantics unchanged (still reset only by input, never by output —
-  coalescing does not touch `resetIdle`).
+  coalescing does not touch `resetIdle`). `attach` still counts as activity
+  (`resetIdle`), unchanged.
 
 ### Component 2 — Hub-side backpressure (`packages/relay/src/gateway/web-gateway.ts`)
 
@@ -164,8 +177,12 @@ Test files (all under `tests/unit/`, run per-file by the root bun runner
 - A burst ≥ `COALESCE_MAX_BYTES` flushes **immediately** (before the timer),
   emitting its own event.
 - `onExit` flushes pending **before** `terminal-exit` (assert event order).
-- Regression guard: after a coalesced sequence, `attach` returns a byte-complete
-  buffer (every input byte present) and `lastSeq === seq - 1`.
+- **`attach` flushes pending first**: with un-flushed pending output, `attach`
+  emits exactly one coalesced `terminal-output` (seq = N) *before* returning, and
+  the returned `lastSeq === N` so the emitted flush event is not `> lastSeq`
+  (the client would drop it) — i.e. no double-render. Buffer is byte-complete.
+- Regression guard: after a coalesced sequence with no pending, `attach` returns a
+  byte-complete buffer and `lastSeq === seq - 1`.
 - Regression guard: `disposeAll` clears the flush timer (no dangling handle).
 
 **Backpressure** (fake `WebSocketLike` with settable `bufferedAmount`):

--- a/docs/superpowers/specs/2026-07-12-track4-terminal-stream-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-12-track4-terminal-stream-hardening-design.md
@@ -1,0 +1,194 @@
+# Track 4 · Sub-project A — Terminal Stream Hardening (Design Spec)
+
+Date: 2026-07-12
+Branch: `feat/track4-terminal-stream-hardening`
+Track: 2026-07 architecture audit → Track 4 (runtime robustness), block A of 3.
+
+## Context
+
+Track 4 is the runtime-robustness track from the 2026-07 full-repo audit. Unlike
+Track 3 (equivalence-preserving refactors guaranteed by byte-identical golden
+oracles), Track 4 **changes behaviour on purpose**, so the verification method
+flips: characterization tests that assert the *new* behaviour, plus regression
+guards that pin the old contracts which must survive.
+
+Track 4 decomposes into three independent spec→plan→implement cycles:
+
+- **A — Terminal stream hardening** (this spec): output coalescing + hub-side
+  backpressure. No wire-format change.
+- **B — Per-`(instance,session)` subscription routing**: protocol-layer change
+  (relay-protocol + hub + connector + web). Deferred.
+- **C — Interactive-turn watchdog**: policy-sensitive turn-lifecycle guard.
+  Deferred.
+
+Recommended order A → B → C; this spec covers **A only**.
+
+### The two unbounded paths in the terminal stream today
+
+End-to-end path (post Track-3):
+
+```
+PTY chunk
+  → terminal-service.ts onData: appendToBuffer + events.emit(terminal-output{seq++})   [ONE EVENT PER CHUNK]
+  → ControlEventBus
+  → connector
+  → hub server.ts:163 → WebGateway.broadcast(accountId, {kind:"control-event", ...})
+  → web-gateway.ts:45-58: send to EVERY socket in byAccount   [NO bufferedAmount CHECK]
+  → relay-web terminal store: writes data straight to xterm    [NO seq-gap detection]
+```
+
+1. **No output coalescing** — `src/control/terminal-service.ts:176-180` emits one
+   `terminal-output` event per PTY `onData` chunk (`seq++` each). A noisy process
+   (`yes`, `tail -f`, a build log) produces a firehose of tiny events across every
+   downstream hop.
+2. **No hub-side backpressure** — `packages/relay/src/gateway/web-gateway.ts:45-58`
+   sends to every socket with only a `readyState` guard; a slow/stalled client's
+   `ws` `bufferedAmount` grows unbounded → hub OOM. The web client
+   (`packages/relay-web/src/stores/terminal.ts:54`) writes `data` straight to xterm
+   in arrival order with **no seq-gap detection**, so a silently-skipped event
+   would corrupt that terminal's screen with no recovery.
+
+## Goal & non-goals
+
+**Goal:** bound both unbounded paths with **zero wire-format change**.
+
+In scope:
+- Output coalescing: merge PTY output bursts into time-windowed `terminal-output`
+  events in the core `terminal-service`.
+- Hub-side backpressure: evict a slow socket by `bufferedAmount` in
+  `WebGateway.broadcast`.
+
+**Non-goals (explicitly deferred to B or later):**
+- End-to-end PTY pause requiring a hub→connector→core back-channel signal.
+- Any protocol / DTO / envelope change; `terminal-output` keeps its exact shape
+  `{ type, terminalId, seq, data }`.
+- Per-`(instance,session)` routing / subscription model.
+- New `terminal.*` config keys — the three tuning constants stay module-level
+  (config exposure is deferred YAGNI).
+- Client-side seq-gap detection / resync path (that was the rejected backpressure
+  alternative; the chosen close-and-reattach policy needs none).
+
+## Design
+
+### Component 1 — Output coalescing (core, `src/control/terminal-service.ts`)
+
+Today `handle.onData` does `appendToBuffer(session, data)` + `emit(terminal-output)`
+per chunk. Change: keep `appendToBuffer` **per chunk** (the 256 KB replay buffer
+must still see every byte for `attach`), but **debounce the emit**.
+
+Per-session coalescing state (added to the existing `Session` interface):
+- `pending: string` — output accumulated since the last emit.
+- `flushTimer: unknown` — the armed coalesce timer (or null).
+
+On `onData(data)`:
+1. `appendToBuffer(session, data)` — unchanged; every byte still lands in the
+   replay buffer.
+2. Append `data` to `session.pending`.
+3. If `Buffer.byteLength(session.pending, "utf8") >= COALESCE_MAX_BYTES`, **flush
+   immediately** (don't sit on a large burst / add latency).
+4. Else, if no `flushTimer` is armed, arm `setTimer(flush, COALESCE_MS)`
+   (`unref`'d, via the existing injectable `deps.setTimer` / `deps.clearTimer`).
+
+`flush(session, terminalId)`:
+- If `session.pending` is empty, just disarm and return.
+- Emit exactly one `terminal-output{ terminalId, seq: session.seq++, data: pending }`.
+- Clear `session.pending = ""`, clear + null `flushTimer`.
+- Wrapped so a throwing consumer cannot strand the timer (the timer is disarmed
+  before the emit, so a throw leaves clean state and no double-arm).
+
+Flush triggers: (a) timer fires; (b) `pending` ≥ `COALESCE_MAX_BYTES`;
+(c) **`onExit` flushes pending *before* emitting `terminal-exit`** (ordering
+contract — the final output must not arrive after / be lost to the exit event);
+(d) `disposeAll` (best-effort flush is optional but the timer MUST be cleared).
+
+Preserved contracts:
+- Every byte still lands in `buffer` → `attach` replay unchanged.
+- `seq` stays strictly monotonic; it now counts coalesced events, not chunks.
+  `attach` returns `{ buffer, lastSeq: seq - 1 }` exactly as before.
+- Idle timer semantics unchanged (still reset only by input, never by output —
+  coalescing does not touch `resetIdle`).
+
+### Component 2 — Hub-side backpressure (`packages/relay/src/gateway/web-gateway.ts`)
+
+In `broadcast`, before `socket.send(data)`, guard on `bufferedAmount`:
+- If `typeof socket.bufferedAmount === "number" && socket.bufferedAmount > BACKPRESSURE_MAX`:
+  - `socket.terminate?.()` that one socket (bounded-memory eviction), log
+    `relay.web.backpressure_evict` with `{ accountId, bufferedAmount }`, and skip
+    the send. Do **not** touch the other sockets (one slow dashboard must not
+    starve the rest — mirrors the existing dead-socket guard rationale).
+  - The socket's existing `on("close")` handler removes it from `byAccount`;
+    `terminate()` triggers that close, so no separate bookkeeping is added. (If a
+    given `WebSocketLike` test double has no `terminate`, fall through to skip.)
+- A missing / `undefined` `bufferedAmount` is treated as under-threshold (no-op),
+  so existing behaviour is unchanged wherever the property is absent (test doubles,
+  older mocks).
+
+The evicted client reconnects and re-attaches through the existing
+`control.terminal.attach` path, replaying the ≤256 KB buffer + `lastSeq`. Bounded
+memory, self-healing, zero protocol change. Cost: a brief visible reconnect blip,
+scoped to the one slow client.
+
+### Data flow after A
+
+```
+PTY chunk
+  → appendToBuffer (per byte)  +  pending (accumulate)
+  → flush on [16ms window | 64KB cap | exit | dispose]  →  ONE terminal-output{seq++}
+  → connector → hub → broadcast(bufferedAmount > 4MB ? terminate+skip : send)
+  → web
+```
+
+Fewer/bigger events on every hop; slow sockets self-evict instead of growing the
+hub's send buffer without bound.
+
+### Constants (module-level, not config)
+
+| Constant | Value | Rationale |
+|---|---|---|
+| `COALESCE_MS` | `16` | ~one frame; below human perception for echo/output latency. |
+| `COALESCE_MAX_BYTES` | `64 * 1024` | Flush a large burst early instead of adding latency; well under the 256 KB replay cap. |
+| `BACKPRESSURE_MAX` | `4 * 1024 * 1024` | Catches a genuine stall; a healthy client drains to ~0, so no false-positive on transient bursts. |
+
+## Verification (behaviour-changing → characterization + regression guards)
+
+Test files (all under `tests/unit/`, run per-file by the root bun runner
+`scripts/run-tests.mjs` — never whole-dir, per the state-leak rule):
+- `tests/unit/control/terminal-service.test.ts` (extend; coalescing).
+- `tests/unit/packages/relay/gateway/web-gateway.test.ts` (extend the existing
+  gateway test; backpressure).
+
+**Coalescing** (fake timers via injected `setTimer`/`clearTimer`):
+- N chunks within one window → **exactly one** `terminal-output`, `data` = the
+  concatenation in order, `seq` monotonic.
+- Advancing the timer flushes the pending window.
+- A burst ≥ `COALESCE_MAX_BYTES` flushes **immediately** (before the timer),
+  emitting its own event.
+- `onExit` flushes pending **before** `terminal-exit` (assert event order).
+- Regression guard: after a coalesced sequence, `attach` returns a byte-complete
+  buffer (every input byte present) and `lastSeq === seq - 1`.
+- Regression guard: `disposeAll` clears the flush timer (no dangling handle).
+
+**Backpressure** (fake `WebSocketLike` with settable `bufferedAmount`):
+- `bufferedAmount > BACKPRESSURE_MAX` ⇒ `terminate()` called, `send` NOT called,
+  socket removed from the account set.
+- `bufferedAmount` under threshold ⇒ normal `send`, no `terminate`.
+- One slow socket over threshold does not prevent the healthy sockets in the same
+  account from receiving the event.
+- `bufferedAmount === undefined` ⇒ unchanged (send as before).
+
+## Risk & rollout
+
+- Coalescing adds ≤16ms first-byte latency to terminal output — imperceptible for
+  a terminal; interactive echo still feels instant.
+- Backpressure only fires for a genuinely stalled socket (4 MB queued); the blast
+  radius is that single client, which self-heals via re-attach.
+- No wire-format change ⇒ no connector/hub/web version coupling; core and hub can
+  ship independently.
+
+## Out of scope / follow-ups
+
+- **B**: end-to-end PTY pause (`handle.pause()`) driven by a hub→connector→core
+  backpressure signal; per-`(instance,session)` subscription routing.
+- **C**: interactive-turn watchdog (policy-sensitive).
+- Possible future: expose `COALESCE_MS` / `BACKPRESSURE_MAX` as `terminal.*`
+  config if ops ever need to tune or disable them.

--- a/packages/relay/src/gateway/web-gateway.ts
+++ b/packages/relay/src/gateway/web-gateway.ts
@@ -6,6 +6,11 @@ import { startHeartbeat } from "./heartbeat.js";
 /** ws readyState OPEN (avoid importing the ws package for one constant). */
 const WS_OPEN = 1;
 
+/** Terminate a web socket whose send buffer exceeds this — a genuinely stalled client.
+ *  A healthy client drains to ~0, so this never false-positives on transient bursts. The
+ *  evicted client reconnects and re-attaches, replaying the bounded terminal scrollback. */
+const BACKPRESSURE_MAX = 4 * 1024 * 1024;
+
 export interface WebSocketLike {
   send(data: string): void;
   close?(code?: number, reason?: string): void;
@@ -13,6 +18,8 @@ export interface WebSocketLike {
   ping?(): void;
   terminate?(): void;
   readyState?: number;
+  /** Optional (real `ws` sockets have it): bytes queued but not yet flushed to the OS. */
+  bufferedAmount?: number;
   on(event: "close", listener: () => void): unknown;
   on(event: "pong", listener: () => void): unknown;
 }
@@ -49,6 +56,13 @@ export class WebGateway {
     for (const socket of set) {
       // One dead/throwing socket must not starve the remaining dashboards.
       if (typeof socket.readyState === "number" && socket.readyState !== WS_OPEN) continue;
+      // Backpressure: a stalled client's send buffer grows without bound. Evict it (it
+      // reconnects and re-attaches, replaying the bounded scrollback) rather than OOM the hub.
+      if (typeof socket.bufferedAmount === "number" && socket.bufferedAmount > BACKPRESSURE_MAX) {
+        this.options.logger?.info("relay.web.backpressure_evict", "evicting slow web client", { accountId, bufferedAmount: socket.bufferedAmount });
+        try { socket.terminate?.(); } catch { /* already gone */ }
+        continue;
+      }
       try {
         socket.send(data);
       } catch (err) {

--- a/src/control/terminal-service.ts
+++ b/src/control/terminal-service.ts
@@ -120,9 +120,17 @@ function realPtySpawn(file: string, args: string[], opts: { name: string; cols: 
 }
 
 // idleTimer is typed as unknown so the type is compatible with both Node.js Timeout and Bun Timer.
-interface Session { handle: PtyHandle; seq: number; idleTimer: unknown; buffer: string; bufBytes: number }
+interface Session { handle: PtyHandle; seq: number; idleTimer: unknown; buffer: string; bufBytes: number; pending: string; flushTimer: unknown }
 
 const MAX_BUFFER_BYTES = 256 * 1024;
+
+// Output coalescing: accumulate PTY output into ~one-frame windows and emit a single
+// terminal-output per window instead of one per chunk. A noisy process (yes, tail -f,
+// a build log) otherwise produces a firehose of tiny events across every downstream hop.
+const COALESCE_MS = 16;
+// Flush a large burst immediately rather than sit on it and add latency. Well under the
+// 256KB replay cap so a single window never dominates the buffer.
+const COALESCE_MAX_BYTES = 64 * 1024;
 
 function appendToBuffer(session: Session, data: string): void {
   session.buffer += data;
@@ -166,19 +174,44 @@ export function createTerminalService(deps: TerminalServiceDeps): TerminalServic
     if (typeof t.unref === "function") t.unref();
   };
 
+  // Emit the coalesced output window as a single terminal-output event. Disarms the
+  // window timer FIRST so a throwing consumer cannot strand it (state stays clean:
+  // pending cleared, timer null). No-op when nothing is pending. Callers: the window
+  // timer, the size-cap in onData, attach (flush-before-snapshot), and onExit.
+  const flushOutput = (terminalId: string) => {
+    const s = sessions.get(terminalId);
+    if (!s) return;
+    if (s.flushTimer) { clearTimer(s.flushTimer); s.flushTimer = null; }
+    if (s.pending.length === 0) return;
+    const data = s.pending;
+    s.pending = "";
+    deps.events.emit({ type: "terminal-output", terminalId, seq: s.seq++, data });
+  };
+
   return {
     create({ cwd, cols, rows }) {
       const shell = resolveShell({ platform, env: process.env, shellOverride: deps.shell?.() });
       const terminalId = randomUUID();
       const handle = spawn(shell, [], { name: "xterm-256color", cols, rows, cwd, env: scrubEnv() });
-      const session: Session = { handle, seq: 0, idleTimer: null, buffer: "", bufBytes: 0 };
+      const session: Session = { handle, seq: 0, idleTimer: null, buffer: "", bufBytes: 0, pending: "", flushTimer: null };
       sessions.set(terminalId, session);
       handle.onData((data) => {
         // NOTE: resetIdle is intentionally NOT called here (output ≠ user interaction).
-        appendToBuffer(session, data);
-        deps.events.emit({ type: "terminal-output", terminalId, seq: session.seq++, data });
+        appendToBuffer(session, data); // every byte still lands in the replay buffer
+        // Coalesce: accumulate and emit one event per window instead of per chunk.
+        session.pending += data;
+        if (Buffer.byteLength(session.pending, "utf8") >= COALESCE_MAX_BYTES) {
+          flushOutput(terminalId); // large burst: flush now, don't add window latency
+          return;
+        }
+        if (!session.flushTimer) {
+          session.flushTimer = setTimer(() => flushOutput(terminalId), COALESCE_MS);
+          const t = session.flushTimer as { unref?: () => void };
+          if (typeof t.unref === "function") t.unref();
+        }
       });
       handle.onExit(({ exitCode }) => {
+        flushOutput(terminalId); // emit any coalesced-but-unflushed output BEFORE the exit event
         if (session.idleTimer) clearTimer(session.idleTimer);
         sessions.delete(terminalId);
         deps.events.emit({ type: "terminal-exit", terminalId, code: exitCode });
@@ -189,6 +222,11 @@ export function createTerminalService(deps: TerminalServiceDeps): TerminalServic
     attach(terminalId) {
       const s = sessions.get(terminalId);
       if (!s) return { ok: false };
+      // Assign the pending bytes a seq BEFORE snapshotting buffer/lastSeq, so the
+      // returned lastSeq covers the whole buffer. The client queues live events during
+      // the attach RPC and applies only those with seq > lastSeq, so this flush event
+      // (seq === returned lastSeq) is correctly dropped — the bytes render once.
+      flushOutput(terminalId);
       resetIdle(terminalId); // reattaching counts as activity
       return { ok: true, buffer: s.buffer, lastSeq: s.seq - 1 };
     },
@@ -212,6 +250,7 @@ export function createTerminalService(deps: TerminalServiceDeps): TerminalServic
     disposeAll() {
       for (const s of sessions.values()) {
         if (s.idleTimer) clearTimer(s.idleTimer);
+        if (s.flushTimer) clearTimer(s.flushTimer);
         try { s.handle.kill(); } catch { /* ignore */ }
       }
       sessions.clear();

--- a/src/control/terminal-service.ts
+++ b/src/control/terminal-service.ts
@@ -250,6 +250,11 @@ export function createTerminalService(deps: TerminalServiceDeps): TerminalServic
       try { s.handle.kill(); } catch { /* already gone */ }
     },
     disposeAll() {
+      // Hard teardown (daemon shutdown): clear-only, NOT flush. Unlike onExit/attach — which
+      // flush so no output is lost mid-lifecycle — disposeAll is tearing every PTY and the
+      // event sink down together, so any coalesced-but-unflushed `pending` is intentionally
+      // dropped rather than emitted into a closing bus. Both timers are cleared so no armed
+      // handle survives the process's last moments.
       for (const s of sessions.values()) {
         if (s.idleTimer) clearTimer(s.idleTimer);
         if (s.flushTimer) clearTimer(s.flushTimer);

--- a/src/control/terminal-service.ts
+++ b/src/control/terminal-service.ts
@@ -120,7 +120,7 @@ function realPtySpawn(file: string, args: string[], opts: { name: string; cols: 
 }
 
 // idleTimer is typed as unknown so the type is compatible with both Node.js Timeout and Bun Timer.
-interface Session { handle: PtyHandle; seq: number; idleTimer: unknown; buffer: string; bufBytes: number; pending: string; flushTimer: unknown }
+interface Session { handle: PtyHandle; seq: number; idleTimer: unknown; buffer: string; bufBytes: number; pending: string; pendingBytes: number; flushTimer: unknown }
 
 const MAX_BUFFER_BYTES = 256 * 1024;
 
@@ -185,6 +185,7 @@ export function createTerminalService(deps: TerminalServiceDeps): TerminalServic
     if (s.pending.length === 0) return;
     const data = s.pending;
     s.pending = "";
+    s.pendingBytes = 0;
     deps.events.emit({ type: "terminal-output", terminalId, seq: s.seq++, data });
   };
 
@@ -193,14 +194,15 @@ export function createTerminalService(deps: TerminalServiceDeps): TerminalServic
       const shell = resolveShell({ platform, env: process.env, shellOverride: deps.shell?.() });
       const terminalId = randomUUID();
       const handle = spawn(shell, [], { name: "xterm-256color", cols, rows, cwd, env: scrubEnv() });
-      const session: Session = { handle, seq: 0, idleTimer: null, buffer: "", bufBytes: 0, pending: "", flushTimer: null };
+      const session: Session = { handle, seq: 0, idleTimer: null, buffer: "", bufBytes: 0, pending: "", pendingBytes: 0, flushTimer: null };
       sessions.set(terminalId, session);
       handle.onData((data) => {
         // NOTE: resetIdle is intentionally NOT called here (output ≠ user interaction).
         appendToBuffer(session, data); // every byte still lands in the replay buffer
         // Coalesce: accumulate and emit one event per window instead of per chunk.
         session.pending += data;
-        if (Buffer.byteLength(session.pending, "utf8") >= COALESCE_MAX_BYTES) {
+        session.pendingBytes += Buffer.byteLength(data, "utf8");
+        if (session.pendingBytes >= COALESCE_MAX_BYTES) {
           flushOutput(terminalId); // large burst: flush now, don't add window latency
           return;
         }

--- a/tests/unit/control/terminal-service.test.ts
+++ b/tests/unit/control/terminal-service.test.ts
@@ -50,16 +50,58 @@ test("create spawns a PTY with scrubbed env + cwd and returns a terminalId", () 
   delete process.env.ANTHROPIC_API_KEY;
 });
 
-test("PTY data emits terminal-output with monotonic seq", () => {
-  const { svc, pty, captured } = setup();
+test("coalesces multiple output chunks within a window into one terminal-output", () => {
+  const { svc, pty, captured, fireFlush } = setupWithFakeTimer();
   const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
-  pty.emitData("hello");
-  pty.emitData("world");
+  pty.emitData("foo"); pty.emitData("bar"); pty.emitData("baz");
+  // Still inside the coalesce window — nothing emitted yet.
+  expect(captured.filter((e) => e.type === "terminal-output").length).toBe(0);
+  fireFlush();
   const outs = captured.filter((e) => e.type === "terminal-output") as Extract<ControlEvent, { type: "terminal-output" }>[];
-  expect(outs.map((o) => [o.terminalId, o.seq, o.data])).toEqual([
-    [terminalId, 0, "hello"],
-    [terminalId, 1, "world"],
-  ]);
+  expect(outs.length).toBe(1);
+  expect(outs[0]).toEqual({ type: "terminal-output", terminalId, seq: 0, data: "foobarbaz" });
+});
+
+test("seq is monotonic across coalesced windows", () => {
+  const { svc, pty, captured, fireFlush } = setupWithFakeTimer();
+  svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("a"); fireFlush();
+  pty.emitData("b"); fireFlush();
+  const outs = captured.filter((e) => e.type === "terminal-output") as Extract<ControlEvent, { type: "terminal-output" }>[];
+  expect(outs.map((o) => [o.seq, o.data])).toEqual([[0, "a"], [1, "b"]]);
+});
+
+test("a burst >= COALESCE_MAX_BYTES flushes immediately (no window wait)", () => {
+  const { svc, pty, captured } = setupWithFakeTimer();
+  svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  const big = "x".repeat(64 * 1024); // 64KB of ascii == COALESCE_MAX_BYTES
+  pty.emitData(big);
+  const outs = captured.filter((e) => e.type === "terminal-output") as Extract<ControlEvent, { type: "terminal-output" }>[];
+  expect(outs.length).toBe(1); // emitted synchronously, before any fireFlush()
+  expect(outs[0]!.seq).toBe(0);
+  expect(outs[0]!.data).toBe(big);
+});
+
+test("exit flushes pending output before emitting terminal-exit", () => {
+  const { svc, pty, captured } = setupWithFakeTimer();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("tail-end"); // armed in the window, not yet flushed
+  pty.emitExit(0);
+  const types = captured.map((e) => e.type);
+  const outIdx = types.indexOf("terminal-output");
+  const exitIdx = types.indexOf("terminal-exit");
+  expect(outIdx).toBeGreaterThanOrEqual(0);
+  expect(exitIdx).toBeGreaterThan(outIdx); // output strictly BEFORE exit
+  expect(captured[outIdx]).toEqual({ type: "terminal-output", terminalId, seq: 0, data: "tail-end" });
+});
+
+test("disposeAll clears a pending flush timer (no stale flush after dispose)", () => {
+  const { svc, pty, hasFlushPending } = setupWithFakeTimer();
+  svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("pending"); // arms a flush timer
+  expect(hasFlushPending()).toBe(true);
+  svc.disposeAll();
+  expect(hasFlushPending()).toBe(false);
 });
 
 test("write/resize/close proxy to the PTY; exit emits terminal-exit", () => {
@@ -90,13 +132,27 @@ test("attach returns ok:false for an unknown terminal", () => {
   expect(svc.attach("nope")).toEqual({ ok: false });
 });
 
-test("attach returns buffered output + lastSeq for a live terminal", () => {
-  const { svc, pty } = setup();
+test("attach returns buffered output + lastSeq for a live terminal (coalesced)", () => {
+  const { svc, pty } = setupWithFakeTimer();
   const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
   pty.emitData("hello\n");
-  pty.emitData("world\n");
+  pty.emitData("world\n"); // both pending; attach flushes them as ONE event (seq 0)
   const res = svc.attach(terminalId);
-  expect(res).toEqual({ ok: true, buffer: "hello\nworld\n", lastSeq: 1 }); // seq 0,1 emitted → lastSeq 1
+  expect(res).toEqual({ ok: true, buffer: "hello\nworld\n", lastSeq: 0 });
+});
+
+test("attach flushes pending first so lastSeq covers the buffer (no double-render)", () => {
+  const { svc, pty, captured } = setupWithFakeTimer();
+  const { terminalId } = svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
+  pty.emitData("live-"); pty.emitData("bytes"); // pending, window not fired
+  const res = svc.attach(terminalId);
+  // attach emitted exactly one coalesced event at seq 0...
+  const outs = captured.filter((e) => e.type === "terminal-output") as Extract<ControlEvent, { type: "terminal-output" }>[];
+  expect(outs.length).toBe(1);
+  expect(outs[0]).toEqual({ type: "terminal-output", terminalId, seq: 0, data: "live-bytes" });
+  // ...and lastSeq === that seq, so the client's `seq > lastSeq` filter drops the flush
+  // event it queued during the attach RPC — the bytes render once (from the buffer), not twice.
+  expect(res).toEqual({ ok: true, buffer: "live-bytes", lastSeq: 0 });
 });
 
 test("attach on a terminal with no output yet returns lastSeq -1", () => {
@@ -149,21 +205,34 @@ test("create uses resolveShell (darwin default /bin/zsh) when no override", () =
 // Uses fake timer injection so tests are deterministic, not real-time.
 
 function setupWithFakeTimer(opts?: { idle?: number; platform?: NodeJS.Platform }) {
-  let pendingFn: (() => void) | null = null;
+  // Multiple timers can be live at once: the idle timer (idleTimeoutSeconds*1000,
+  // i.e. >=1000ms) and the coalesce flush timer (COALESCE_MS = 16ms). Track them by
+  // id and split on ms so a test can fire/inspect each kind independently.
+  const timers = new Map<number, { fn: () => void; ms: number }>();
   let timerId = 0;
-  let setTimerCount = 0;
-  const setTimer = (fn: () => void, _ms: number): unknown => {
-    pendingFn = fn;
-    setTimerCount++;
-    return ++timerId;
+  let idleSetCount = 0;
+  const setTimer = (fn: () => void, ms: number): unknown => {
+    const id = ++timerId;
+    timers.set(id, { fn, ms });
+    if (ms >= 1000) idleSetCount++; // idle timer only; the 16ms flush timer is excluded
+    return id;
   };
-  const clearTimer = (_id: unknown) => { pendingFn = null; };
-  /** Fire the currently pending idle timer, if any. */
-  const tick = () => { const fn = pendingFn; pendingFn = null; fn?.(); };
-  /** True when a pending timer exists. */
-  const hasPending = () => pendingFn !== null;
+  const clearTimer = (id: unknown) => { timers.delete(id as number); };
+  const fireWhere = (pred: (ms: number) => boolean) => {
+    for (const [id, t] of [...timers]) if (pred(t.ms)) { timers.delete(id); t.fn(); }
+  };
+  /** Fire the pending idle timer(s) (>=1000ms). */
+  const tick = () => fireWhere((ms) => ms >= 1000);
+  /** Fire the pending coalesce flush timer(s) (<1000ms). */
+  const fireFlush = () => fireWhere((ms) => ms < 1000);
+  /** True when an idle timer is pending. */
+  const hasPending = () => [...timers.values()].some((t) => t.ms >= 1000);
+  /** True when a coalesce flush timer is pending. */
+  const hasFlushPending = () => [...timers.values()].some((t) => t.ms < 1000);
 
   const events = createControlEventBus();
+  const captured: ControlEvent[] = [];
+  events.subscribe((e) => captured.push(e));
   const pty = fakePty();
   const spawn = mock(() => pty);
   const svc = createTerminalService({
@@ -174,24 +243,21 @@ function setupWithFakeTimer(opts?: { idle?: number; platform?: NodeJS.Platform }
     setTimer,
     clearTimer,
   });
-  return { svc, pty, spawn, tick, hasPending, getSetTimerCount: () => setTimerCount };
+  return { svc, pty, spawn, captured, tick, fireFlush, hasPending, hasFlushPending, getIdleSetCount: () => idleSetCount };
 }
 
 test("idle: PTY output (onData) does NOT reset the idle timer", () => {
-  // Create a terminal — this queues the initial idle timer.
-  const { svc, pty, tick, getSetTimerCount } = setupWithFakeTimer();
+  const { svc, pty, tick, getIdleSetCount } = setupWithFakeTimer();
   svc.create({ cwd: "/tmp/ws", cols: 80, rows: 24 });
 
-  // Emit several output frames — must NOT replace the pending idle timer.
   pty.emitData("line1\r\n");
   pty.emitData("line2\r\n");
   pty.emitData("line3\r\n");
 
-  // Verify that setTimer was called exactly once (at create), not again on output.
-  // If output handler incorrectly calls resetIdle, this count would be >1.
-  expect(getSetTimerCount()).toBe(1);
+  // The IDLE timer is armed exactly once (at create); output must not re-arm it.
+  // (Output DOES arm a separate coalesce flush timer — excluded from this count.)
+  expect(getIdleSetCount()).toBe(1);
 
-  // The original idle timer is still pending; firing it kills the PTY.
   tick();
   expect((pty.kill as ReturnType<typeof mock>).mock.calls.length).toBe(1);
 });

--- a/tests/unit/packages/relay/gateway/web-gateway.test.ts
+++ b/tests/unit/packages/relay/gateway/web-gateway.test.ts
@@ -6,7 +6,10 @@ import { WebGateway } from "../../../../../packages/relay/src/gateway/web-gatewa
 class FakeSocket {
   sent: string[] = [];
   closeListeners: (() => void)[] = [];
+  bufferedAmount = 0;
+  terminated = false;
   send(data: string) { this.sent.push(data); }
+  terminate() { this.terminated = true; this.close(); } // real ws: terminate -> close -> drop
   on(event: string, listener: () => void) { if (event === "close") this.closeListeners.push(listener); return this; }
   close() { this.closeListeners.forEach((l) => l()); }
 }
@@ -80,4 +83,44 @@ test("non-open sockets are skipped; sockets without readyState still receive", (
   expect(closing.sent.length).toBe(0);
   expect(open.sent.length).toBe(1);
   expect(bare.sent.length).toBe(1);
+});
+
+const BACKPRESSURE_MAX = 4 * 1024 * 1024;
+
+test("a socket over the bufferedAmount threshold is terminated and skipped, not sent", () => {
+  const logs: Array<[string, string, Record<string, unknown> | undefined]> = [];
+  const gw = new WebGateway({ logger: { debug: () => {}, info: (e, m, c) => logs.push([e, m, c]), error: () => {} } });
+  const slow = new FakeSocket();
+  slow.bufferedAmount = BACKPRESSURE_MAX + 1;
+  gw.register("a1", slow as never);
+  gw.broadcast("a1", evt(true));
+  expect(slow.sent.length).toBe(0);
+  expect(slow.terminated).toBe(true);
+  // the terminate-triggered close dropped it from the account set: a second broadcast is a no-op
+  slow.bufferedAmount = 0;
+  gw.broadcast("a1", evt(false));
+  expect(slow.sent.length).toBe(0);
+  expect(logs.some(([e]) => e === "relay.web.backpressure_evict")).toBe(true);
+});
+
+test("a socket at/under the threshold receives normally", () => {
+  const gw = new WebGateway();
+  const ok = new FakeSocket();
+  ok.bufferedAmount = BACKPRESSURE_MAX; // exactly at the cap is NOT over it
+  gw.register("a1", ok as never);
+  gw.broadcast("a1", evt(true));
+  expect(ok.sent.length).toBe(1);
+  expect(ok.terminated).toBe(false);
+});
+
+test("one slow socket does not starve the healthy sockets in the same account", () => {
+  const gw = new WebGateway();
+  const slow = new FakeSocket(); slow.bufferedAmount = BACKPRESSURE_MAX + 1;
+  const good = new FakeSocket();
+  gw.register("a1", slow as never); // slow first, so its eviction must not skip `good`
+  gw.register("a1", good as never);
+  gw.broadcast("a1", evt(true));
+  expect(slow.sent.length).toBe(0);
+  expect(slow.terminated).toBe(true);
+  expect(good.sent.length).toBe(1);
 });

--- a/tests/unit/packages/relay/gateway/web-gateway.test.ts
+++ b/tests/unit/packages/relay/gateway/web-gateway.test.ts
@@ -113,6 +113,16 @@ test("a socket at/under the threshold receives normally", () => {
   expect(ok.terminated).toBe(false);
 });
 
+test("a socket without bufferedAmount (undefined) is unaffected and receives normally", () => {
+  const gw = new WebGateway();
+  const noProp = new FakeSocket() as FakeSocket & { bufferedAmount?: number };
+  delete noProp.bufferedAmount; // genuinely absent → typeof !== "number" → guard skipped
+  gw.register("a1", noProp as never);
+  gw.broadcast("a1", evt(true));
+  expect(noProp.sent.length).toBe(1);
+  expect(noProp.terminated).toBe(false);
+});
+
 test("one slow socket does not starve the healthy sockets in the same account", () => {
   const gw = new WebGateway();
   const slow = new FakeSocket(); slow.bufferedAmount = BACKPRESSURE_MAX + 1;


### PR DESCRIPTION
## Track 4 · A — Terminal stream hardening

First block of Track 4 (runtime robustness) from the 2026-07 architecture audit. Two independent, **behaviour-changing** fixes that bound the two unbounded paths in the terminal streaming path, with **zero wire-format change**.

### 1. Output coalescing (core `terminal-service.ts`)
`terminal-service` emitted one `terminal-output` event per PTY chunk (`seq++` each). A noisy process (`yes`, `tail -f`, a build log) produced a firehose of tiny events across every downstream hop (core → connector → hub → web).

Now the per-chunk emit is debounced into a **16ms / 64KB coalescing window** (flush on window / size-cap / attach / exit). Every byte still lands in the 256KB replay buffer per-chunk, and `seq` stays strictly monotonic (now counts coalesced events). `disposeAll` is *not* a flush trigger — it is a hard shutdown teardown that clears the timers and drops any unflushed `pending` rather than emitting into a closing bus.

**Correctness detail:** `attach` flushes pending *before* snapshotting `buffer`/`lastSeq`. The web client (`TerminalTab.vue`) reconciles by seq — `buffer` = output through `lastSeq`, and any live event with `seq > lastSeq` is new. Flushing first assigns the pending bytes `seq = N` and returns `lastSeq = N`, so the flush event the client queued during the attach RPC is correctly dropped (no double-render).

### 2. Hub-side backpressure (`WebGateway.broadcast`)
`broadcast` sent to every socket with only a `readyState` guard — a slow/stalled client's `ws` `bufferedAmount` grew without bound → hub OOM.

Now `broadcast` **terminates** any socket whose `bufferedAmount` exceeds **4MB** and skips its send; the evicted client reconnects and re-attaches, replaying the bounded scrollback. Self-healing, bounded memory, zero protocol change. One slow dashboard no longer starves the others. Strict `>`; skipped when `bufferedAmount` is absent; `info`-level `relay.web.backpressure_evict`.

### Constants (module-level, no new config keys)
`COALESCE_MS = 16`, `COALESCE_MAX_BYTES = 64 * 1024`, `BACKPRESSURE_MAX = 4 * 1024 * 1024`.

### Testing
- Characterization tests for the new behaviour + regression guards for the surviving contracts (byte-complete replay buffer, monotonic seq, `buffer` = output through `lastSeq`, no starvation).
- `tests/unit/control/terminal-service.test.ts`: 28/28 (coalescing window/size-cap/exit-ordering/attach-flush/dispose + updated idle/attach tests + a multi-timer fake harness distinguishing idle vs flush).
- `tests/unit/packages/relay/gateway/web-gateway.test.ts`: 9/9 (over/at/under threshold, slow-first no-starvation, undefined-branch, terminate+drop).
- `npx tsc --noEmit` (core) and `npx tsc -p packages/relay/tsconfig.json --noEmit` (relay) both clean.

### Non-goals (deferred to later Track 4 blocks)
- **B** — end-to-end PTY pause (hub→connector→core back-channel) + per-`(instance,session)` subscription routing.
- **C** — interactive-turn watchdog (policy-sensitive).

Spec: `docs/superpowers/specs/2026-07-12-track4-terminal-stream-hardening-design.md`
Plan: `docs/superpowers/plans/2026-07-12-track4-terminal-stream-hardening.md`

Reviews: two per-task reviews (spec ✅ / quality Approved) + a whole-branch review (opus, Ready-to-merge = Yes, 0 Critical / 0 Important) + a focused re-review of the fix commit (CONFIRMED-CLEAN).
