### PR TITLE
feat(track4·B): per-instance subscription routing (scope hub→web control-events)

### DIFF
--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -61,13 +61,19 @@
 - **`messages` 缓存表（§5）+ `MessageStore`**：聊天回显缓存
   （`instance_id, session_alias, direction, text, created_at`）。`append()` 写入，
   `listBySession(accountId, ...)` 按 account 隔离、oldest-first 取最近若干条。
-- **`WebGateway` 按账号扇出**：跟踪每个账号已鉴权的浏览器 socket，把 `WebServerEvent`
-  编码为 `web.event` 信封 `broadcast(accountId, event)` 给该账号所有连接。
+- **`WebGateway` 按账号扇出，并按 socket 的实例订阅过滤 `control-event`**：跟踪每个账号
+  已鉴权的浏览器 socket，把 `WebServerEvent` 编码为 `web.event` 信封
+  `broadcast(accountId, event)`。**订阅路由**（`subscribe` 帧 → `setSubscription`）：
+  - `control-event` 只发给订阅了该 `event.instanceId` 的 socket。**未在订阅表里的 socket
+    （刚注册、或从不发 `subscribe` 的旧客户端）= 订阅“全部”**（向后兼容）；显式 `subscribe []`
+    = 订阅“无”，一条 `control-event` 都收不到。
+  - `instance-status` / `notice` **不受订阅过滤，始终按账号全量广播**（看板需要感知任意实例
+    的上下线与通知，与当前查看的是哪个实例无关）。
 - **实例网关 `onStatusChange`/`onEvent` 接线**（server.ts `createRelayRuntime`）：
-  - `onStatusChange` → web 广播 `instance-status`；离线时清空该实例的 turn 缓冲。
-  - `onEvent`（instance.event）→ web 广播 `control-event`；其中 `turn-output` 分片按
-    (instance, session) 累积进内存缓冲，`turn-finished` 时 flush 为一条 `out` 历史消息
-    写入 `MessageStore`；instance.notice → 广播 `notice`。
+  - `onStatusChange` → web 广播 `instance-status`（账号全量）；离线时清空该实例的 turn 缓冲。
+  - `onEvent`（instance.event）→ web 广播 `control-event`（按上面的实例订阅过滤）；其中
+    `turn-output` 分片按 (instance, session) 累积进内存缓冲，`turn-finished` 时 flush 为一条
+    `out` 历史消息写入 `MessageStore`；instance.notice → 广播 `notice`（账号全量）。
 - **cookie 鉴权的 `/ws` web 扇出端点**：挂在 HTTP server 的 upgrade 上，按路径与实例网关分流
   （默认单端口时实例网关合并在同一 upgrade handler 的根 `/`；传 `--ws-port` 时网关另起专用端口），
   校验 `xrelay_session` cookie → 账号后 `webGateway.register(accountId, ws)`。

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -41,6 +41,12 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   `tasksStore.applyEvent`（`scheduled-changed`/`orchestration-changed` 信号触发重拉）、
   `noticesStore.applyEvent`（`instance.notice` toast）；并把 `connectEvents` 的 `onStatus`
   回调接到 `connectionStore.setOnline`，驱动连接徽标。
+- **实例订阅（`control-event` 扇出收敛）**：`DashboardView` 通过 `sendSubscribe([instanceId])`
+  告诉 hub 本 socket 当前查看的实例，hub 据此只把该实例的 `control-event` 发给它
+  （`instance-status`/`notice` 仍账号全量）。触发点：连接/重连成功（`onStatus(true)` 每次都重发，
+  所以断线重连会自动重新订阅）、切换实例（`watch(chat.instanceId)`）。切换实例后还会
+  `loadActiveTurns()` 重新补种在别处订阅期间漏掉的在飞回合。**未发过 `subscribe` = 收全部**
+  （向后兼容），空数组 `[]` = 收无。
 
 ## 右栏任务面板（阶段四）
 

--- a/docs/superpowers/plans/2026-07-13-track4-per-instance-subscription.md
+++ b/docs/superpowers/plans/2026-07-13-track4-per-instance-subscription.md
@@ -1,0 +1,619 @@
+# Per-instance Subscription Routing (Track 4 · B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scope the hub→web `control-event` firehose to the instance(s) a socket is viewing, via a backward-compatible `subscribe` protocol message + a per-socket subscription registry in `WebGateway`, killing cross-instance amplification.
+
+**Architecture:** Four layers, one task each. (1) Protocol: add `{ kind:"subscribe"; instanceIds:string[] }` to `WebClientMessage`. (2) Hub `WebGateway`: per-socket subscription set (absent = all); `control-event` broadcast scoped to it; `instance-status`/`notice` stay account-wide. (3) Hub inbound: a `subscribe` frame binds to its socket via `gateway.setSubscription`. (4) Web: send `subscribe([activeInstance])` on connect/reconnect/instance-switch. No server-event shape change; connector untouched.
+
+**Tech Stack:** TypeScript. Core/relay/protocol tests: Bun (`bun test <file>`), run per-file. relay-web tests: **vitest** (`npx vitest run <file>` — never bun). Protocol changes require rebuilding its dist for downstream packages.
+
+## Global Constraints
+
+- **No `WebServerEvent` / `ControlEventDto` shape change.** Only `WebClientMessage` gains a variant.
+- **Backward-compatible:** a socket with no subscription (never sent `subscribe`, or a legacy client) defaults to receiving **all** control-events. Absent-from-map = all.
+- **Routing rule (the simple rule):** all `control-event`s are subscription-scoped by `event.instanceId`; `instance-status` and `notice` are always account-wide.
+- **No ownership gate on `subscribe`** — it only narrows a socket's own feed; `broadcast` already iterates one account's sockets, so no cross-account leak is possible.
+- **Composes with A (#157):** the subscription filter sits in front of the existing per-socket `readyState` + `bufferedAmount` guards in the same `broadcast` loop (this branch is stacked on A, so `web-gateway.ts` already has them).
+- `subscribe` is a full-set **replace**, idempotent.
+- Connector (`packages/channel-relay`) is **not** modified.
+- The implementer runs **no git**; the controller commits.
+- After Task 1 edits protocol `src`, rebuild its dist (`bun run build:relay-protocol`) so Tasks 3–4 (which import the package → `dist`) resolve the new message. (The full test runner does this up front; per-file runs need it.)
+
+---
+
+### Task 1: Protocol — the `subscribe` client message
+
+**Files:**
+- Modify: `packages/relay-protocol/src/web-dtos.ts` (the `WebClientMessage` union + `parseWebClientMessage`)
+- Test: `tests/unit/packages/relay-protocol/web-dtos.test.ts`
+
+**Interfaces:**
+- Produces: `WebClientMessage` union member `{ kind:"subscribe"; instanceIds:string[] }`; `parseWebClientMessage` accepts/validates it. Later tasks consume this type (hub `web-inbound`, web `sendSubscribe`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/packages/relay-protocol/web-dtos.test.ts` (imports: add `parseWebClientMessage`, `webClientEnvelope` to the existing `../../../../packages/relay-protocol/src/index` import):
+
+```ts
+test("parseWebClientMessage round-trips a subscribe frame", () => {
+  const wire = encodeEnvelope(webClientEnvelope({ kind: "subscribe", instanceIds: ["a", "b"] }));
+  const decoded = decodeEnvelope(wire);
+  expect(decoded.ok).toBe(true);
+  if (!decoded.ok) return;
+  expect(parseWebClientMessage(decoded.envelope)).toEqual({ kind: "subscribe", instanceIds: ["a", "b"] });
+});
+
+test("parseWebClientMessage accepts an empty subscribe set", () => {
+  const wire = encodeEnvelope(webClientEnvelope({ kind: "subscribe", instanceIds: [] }));
+  const decoded = decodeEnvelope(wire);
+  if (!decoded.ok) throw new Error("decode failed");
+  expect(parseWebClientMessage(decoded.envelope)).toEqual({ kind: "subscribe", instanceIds: [] });
+});
+
+test("parseWebClientMessage rejects subscribe with a non-array / non-string instanceIds", () => {
+  const bad1 = { protocolVersion: 1, kind: "event", type: "web-client", payload: { kind: "subscribe", instanceIds: "nope" } } as never;
+  const bad2 = { protocolVersion: 1, kind: "event", type: "web-client", payload: { kind: "subscribe", instanceIds: [1, 2] } } as never;
+  expect(parseWebClientMessage(bad1)).toBeNull();
+  expect(parseWebClientMessage(bad2)).toBeNull();
+});
+
+test("parseWebClientMessage still round-trips terminal-input (regression)", () => {
+  const wire = encodeEnvelope(webClientEnvelope({ kind: "terminal-input", instanceId: "i1", terminalId: "t1", data: "ls\n" }));
+  const decoded = decodeEnvelope(wire);
+  if (!decoded.ok) throw new Error("decode failed");
+  expect(parseWebClientMessage(decoded.envelope)).toEqual({ kind: "terminal-input", instanceId: "i1", terminalId: "t1", data: "ls\n" });
+});
+```
+
+Note: `bad1`/`bad2` build the envelope literally rather than via `webClientEnvelope` (whose parameter type wouldn't accept the malformed payload). If the literal `type: "web-client"` mismatches the real `WEB_CLIENT_TYPE` constant, import `WEB_CLIENT_TYPE` and use it instead.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test tests/unit/packages/relay-protocol/web-dtos.test.ts`
+Expected: the subscribe tests FAIL — `parseWebClientMessage` currently returns `null` for a `subscribe` frame (the top-level `instanceId`/`terminalId` string guard rejects it).
+
+- [ ] **Step 3: Add the union member**
+
+In `packages/relay-protocol/src/web-dtos.ts`, extend `WebClientMessage`:
+
+```ts
+export type WebClientMessage =
+  | { kind: "terminal-input"; instanceId: string; terminalId: string; data: string }
+  | { kind: "terminal-resize"; instanceId: string; terminalId: string; cols: number; rows: number }
+  | { kind: "terminal-close"; instanceId: string; terminalId: string }
+  | { kind: "subscribe"; instanceIds: string[] };
+```
+
+- [ ] **Step 4: Restructure `parseWebClientMessage` so the terminal string-guard gates only the terminal variants**
+
+Replace the body of `parseWebClientMessage` (from the `const c = ...` line through the final `return null;`) with:
+
+```ts
+  const c = p as Record<string, unknown>;
+  if (c.kind === "subscribe") {
+    return Array.isArray(c.instanceIds) && c.instanceIds.every((x) => typeof x === "string")
+      ? (p as WebClientMessage)
+      : null;
+  }
+  // terminal-* frames all require instanceId + terminalId strings.
+  if (typeof c.instanceId !== "string" || typeof c.terminalId !== "string") return null;
+  if (c.kind === "terminal-input") return typeof c.data === "string" ? (p as WebClientMessage) : null;
+  if (c.kind === "terminal-resize") return typeof c.cols === "number" && typeof c.rows === "number" ? (p as WebClientMessage) : null;
+  if (c.kind === "terminal-close") return p as WebClientMessage;
+  return null;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bun test tests/unit/packages/relay-protocol/web-dtos.test.ts`
+Expected: PASS (all subscribe cases + the terminal regression).
+
+- [ ] **Step 6: Typecheck and rebuild the protocol dist**
+
+Run: `npx tsc -p packages/relay-protocol/tsconfig.json --noEmit`  → no errors.
+Run: `bun run build:relay-protocol`  → rebuilds `packages/relay-protocol/dist` (ends with the `assert:relay-protocol` runtime-export check) so downstream packages resolve the new message. Expected: "relay-protocol dist exports OK".
+
+- [ ] **Step 7: Commit** (controller performs git)
+
+```
+feat(protocol): add subscribe client message for per-instance routing
+
+Add { kind:"subscribe"; instanceIds:string[] } to WebClientMessage and
+restructure parseWebClientMessage so the instanceId/terminalId string
+guard gates only the terminal-* variants. Foundation for Track 4·B
+hub-side per-instance control-event scoping. No server-event change.
+```
+
+---
+
+### Task 2: Hub `WebGateway` — subscription registry + scoped broadcast
+
+**Files:**
+- Modify: `packages/relay/src/gateway/web-gateway.ts`
+- Test: `tests/unit/packages/relay/gateway/web-gateway.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new from Task 1 (routing keys on `WebServerEvent.kind`/`instanceId`, unchanged types).
+- Produces: `WebGateway.setSubscription(socket: WebSocketLike, instanceIds: string[]): void`; `broadcast` now scopes `control-event`s per subscription. Task 3 consumes `setSubscription`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/packages/relay/gateway/web-gateway.test.ts`. Add a control-event helper near the existing `evt` helper:
+
+```ts
+const ctrl = (instanceId: string): WebServerEvent => ({
+  kind: "control-event",
+  instanceId,
+  event: { type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "hi" },
+});
+```
+
+Then the tests:
+
+```ts
+test("a socket with no subscription receives all control-events (backward-compat)", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.broadcast("a1", ctrl("iA"));
+  gw.broadcast("a1", ctrl("iB"));
+  expect(s.sent.length).toBe(2);
+});
+
+test("after subscribe([iA]) a socket gets iA control-events but not iB", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  gw.broadcast("a1", ctrl("iA"));
+  gw.broadcast("a1", ctrl("iB"));
+  expect(s.sent.length).toBe(1);
+  const decoded = decodeEnvelope(s.sent[0]!);
+  expect(decoded.ok && parseWebServerEvent(decoded.envelope)).toEqual(ctrl("iA"));
+});
+
+test("instance-status and notice reach a subscribed socket regardless of subscription", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  gw.broadcast("a1", { kind: "instance-status", instanceId: "iB", online: false });
+  gw.broadcast("a1", { kind: "notice", instanceId: "iB", notice: { kind: "info", text: "hi" } as never });
+  expect(s.sent.length).toBe(2);
+});
+
+test("subscribe([]) blocks all control-events but still delivers status/notice", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, []);
+  gw.broadcast("a1", ctrl("iA"));
+  gw.broadcast("a1", { kind: "instance-status", instanceId: "iA", online: true });
+  expect(s.sent.length).toBe(1);
+});
+
+test("setSubscription replaces the prior set", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  gw.setSubscription(s as never, ["iB"]);
+  gw.broadcast("a1", ctrl("iA"));
+  gw.broadcast("a1", ctrl("iB"));
+  expect(s.sent.length).toBe(1); // only iB now
+});
+
+test("closing a socket clears its subscription (no leak)", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  s.close(); // fires the close handler → removes from byAccount AND subscriptions
+  // Re-register a fresh socket at the same account: with no subscription it defaults to all.
+  const s2 = new FakeSocket();
+  gw.register("a1", s2 as never);
+  gw.broadcast("a1", ctrl("iZ"));
+  expect(s2.sent.length).toBe(1);
+});
+
+test("backpressure still evicts an over-threshold socket for a subscribed control-event", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  s.bufferedAmount = 4 * 1024 * 1024 + 1;
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  gw.broadcast("a1", ctrl("iA"));
+  expect(s.sent.length).toBe(0);
+  expect(s.terminated).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test tests/unit/packages/relay/gateway/web-gateway.test.ts`
+Expected: FAIL — `gw.setSubscription` is not a function; the scoping tests fail (all control-events currently reach every socket).
+
+- [ ] **Step 3: Add the subscription registry field**
+
+In `packages/relay/src/gateway/web-gateway.ts`, inside `class WebGateway`, next to `private readonly byAccount = ...`, add:
+
+```ts
+  // Per-socket instance subscription. ABSENT from this map = "all" (a freshly-registered
+  // socket, or a legacy client that never sends `subscribe`) → backward-compatible.
+  private readonly subscriptions = new Map<WebSocketLike, Set<string>>();
+```
+
+- [ ] **Step 4: Add `setSubscription` and clear it on close**
+
+Add the method (e.g. after `register`):
+
+```ts
+  /** Replace a socket's instance subscription (full-set, idempotent). A socket not present
+   *  in the map receives every control-event; call with [] to receive none. */
+  setSubscription(socket: WebSocketLike, instanceIds: string[]): void {
+    this.subscriptions.set(socket, new Set(instanceIds));
+  }
+```
+
+In `register`'s `socket.on("close", ...)` handler, add the subscription cleanup alongside the existing `set.delete(socket)`:
+
+```ts
+    socket.on("close", () => {
+      set.delete(socket);
+      this.subscriptions.delete(socket);
+      if (set.size === 0) this.byAccount.delete(accountId);
+      this.options.logger?.debug("relay.web.disconnected", "web client disconnected", { accountId });
+    });
+```
+
+- [ ] **Step 5: Scope `control-event`s in `broadcast`**
+
+Replace the whole `broadcast` method with (only the `const scoped` line and the `if (scoped)` block are new; the `readyState`/backpressure/send body is A's, unchanged):
+
+```ts
+  broadcast(accountId: string, event: WebServerEvent): void {
+    const set = this.byAccount.get(accountId);
+    if (!set) return;
+    const data = encodeEnvelope(webEventEnvelope(event));
+    // control-events are scoped to the socket's instance subscription; a socket with no
+    // subscription (absent from the map) receives all. instance-status / notice are
+    // account-wide (the global instance list needs them regardless of the active instance).
+    const scoped = event.kind === "control-event";
+    for (const socket of set) {
+      if (scoped) {
+        const sub = this.subscriptions.get(socket);
+        if (sub && !sub.has(event.instanceId)) continue;
+      }
+      // One dead/throwing socket must not starve the remaining dashboards.
+      if (typeof socket.readyState === "number" && socket.readyState !== WS_OPEN) continue;
+      // Backpressure: a stalled client's send buffer grows without bound. Evict it (it
+      // reconnects and re-attaches, replaying the bounded scrollback) rather than OOM the hub.
+      if (typeof socket.bufferedAmount === "number" && socket.bufferedAmount > BACKPRESSURE_MAX) {
+        this.options.logger?.info("relay.web.backpressure_evict", "evicting slow web client", { accountId, bufferedAmount: socket.bufferedAmount });
+        try { socket.terminate?.(); } catch { /* already gone */ }
+        continue;
+      }
+      try {
+        socket.send(data);
+      } catch (err) {
+        this.options.logger?.error("relay.web.broadcast_failed", "broadcast send failed", { error: String(err) });
+      }
+    }
+  }
+```
+
+(`event.instanceId` is present on all three `WebServerEvent` kinds, so it type-checks on the union without narrowing.)
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `bun test tests/unit/packages/relay/gateway/web-gateway.test.ts`
+Expected: PASS (new subscription tests + the pre-existing broadcast/backpressure tests unchanged).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npx tsc -p packages/relay/tsconfig.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 8: Commit** (controller performs git)
+
+```
+feat(relay): scope control-event broadcast to per-socket subscription
+
+WebGateway tracks a per-socket instance subscription (absent = all, so
+legacy clients are unaffected). broadcast now delivers control-events only
+to sockets subscribed to the event's instance; instance-status/notice stay
+account-wide. Composes with A's readyState/backpressure guards. Track 4·B.
+```
+
+---
+
+### Task 3: Hub inbound — route `subscribe` to `setSubscription`
+
+**Files:**
+- Modify: `packages/relay/src/gateway/web-inbound.ts`, `packages/relay/src/server.ts`
+- Test: `tests/unit/packages/relay/terminal-web-inbound.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 `parseWebClientMessage` (returns `subscribe`), Task 2 `WebGateway.setSubscription`.
+- Produces: `handleWebClientMessage` gains a `socket` parameter and a `webGateway.setSubscription` dep; a `subscribe` frame updates the socket's subscription and is not forwarded to the connector.
+
+- [ ] **Step 1: Update the existing tests + add the subscribe test**
+
+In `tests/unit/packages/relay/terminal-web-inbound.test.ts`:
+
+Extend `deps(...)` to include the new `webGateway` capability, and thread a socket through the calls. Replace the `deps` helper with:
+
+```ts
+function deps(owned: boolean) {
+  return {
+    instances: { getOwned: mock((id: string, acc: string) => (owned && id === "i1" && acc === "a1" ? { id: "i1" } : undefined)) },
+    gateway: { sendEvent: mock(() => true) },
+    webGateway: { setSubscription: mock(() => {}) },
+  };
+}
+const sock = {} as never; // opaque socket handle; identity is all setSubscription needs
+```
+
+Update every existing `handleWebClientMessage(d as never, "a1", <raw>)` call to pass the socket: `handleWebClientMessage(d as never, "a1", sock, <raw>)`. Then add:
+
+```ts
+test("a subscribe frame updates the socket subscription and is NOT forwarded to the connector", () => {
+  const d = deps(true);
+  handleWebClientMessage(d as never, "a1", sock, encodeEnvelope(webClientEnvelope({ kind: "subscribe", instanceIds: ["i1", "i2"] })));
+  expect((d.webGateway.setSubscription as ReturnType<typeof mock>).mock.calls[0]).toEqual([sock, ["i1", "i2"]]);
+  expect((d.gateway.sendEvent as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test tests/unit/packages/relay/terminal-web-inbound.test.ts`
+Expected: FAIL — the signature has no `socket` param yet, and `subscribe` isn't handled (the subscribe test's `setSubscription` is never called; also the updated arity won't match).
+
+- [ ] **Step 3: Add the socket param + subscribe handling in `web-inbound.ts`**
+
+Replace `packages/relay/src/gateway/web-inbound.ts` with:
+
+```ts
+import { decodeEnvelope, MSG, parseWebClientMessage } from "@ganglion/xacpx-relay-protocol";
+import type { WebSocketLike } from "./web-gateway.js";
+
+export interface WebClientDeps {
+  instances: { getOwned(id: string, accountId: string): unknown };
+  gateway: { sendEvent(instanceId: string, type: string, payload: unknown): boolean };
+  webGateway: { setSubscription(socket: WebSocketLike, instanceIds: string[]): void };
+}
+
+/** Decode + route a browser→hub frame. `subscribe` updates this socket's instance
+ *  subscription (hub-local); terminal frames are authorized and forwarded to the connector. */
+export function handleWebClientMessage(deps: WebClientDeps, accountId: string, socket: WebSocketLike, raw: string): void {
+  const decoded = decodeEnvelope(raw);
+  if (!decoded.ok) return;
+  const msg = parseWebClientMessage(decoded.envelope);
+  if (!msg) return;
+  // Hub-local, inherently safe (only narrows this socket's own feed) — no ownership gate.
+  if (msg.kind === "subscribe") { deps.webGateway.setSubscription(socket, msg.instanceIds); return; }
+  if (!deps.instances.getOwned(msg.instanceId, accountId)) return; // ownership gate (connector actions)
+  if (msg.kind === "terminal-input") deps.gateway.sendEvent(msg.instanceId, MSG.terminalInput, { terminalId: msg.terminalId, data: msg.data });
+  else if (msg.kind === "terminal-resize") deps.gateway.sendEvent(msg.instanceId, MSG.terminalResize, { terminalId: msg.terminalId, cols: msg.cols, rows: msg.rows });
+  else if (msg.kind === "terminal-close") deps.gateway.sendEvent(msg.instanceId, MSG.terminalClose, { terminalId: msg.terminalId });
+}
+```
+
+- [ ] **Step 4: Pass the socket + webGateway dep at the call site in `server.ts`**
+
+In `packages/relay/src/server.ts`, the `/ws` message handler is currently:
+
+```ts
+        ws.on("message", (data: unknown) => handleWebClientMessage({ instances: runtime.instances, gateway: runtime.gateway }, account.id, String(data)));
+```
+
+Replace it with (adds `webGateway` to deps and passes `ws` as the socket):
+
+```ts
+        ws.on("message", (data: unknown) => handleWebClientMessage({ instances: runtime.instances, gateway: runtime.gateway, webGateway: runtime.webGateway }, account.id, ws, String(data)));
+```
+
+(`runtime.webGateway` is the `WebGateway` instance registered on the same `ws` a few lines above — same socket identity, so `setSubscription` keys correctly.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bun test tests/unit/packages/relay/terminal-web-inbound.test.ts`
+Expected: PASS (subscribe routes to `setSubscription`; terminal-* still forward; garbage still ignored).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc -p packages/relay/tsconfig.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 7: Commit** (controller performs git)
+
+```
+feat(relay): route subscribe frames to WebGateway.setSubscription
+
+handleWebClientMessage gains the socket handle; a subscribe frame updates
+that socket's instance subscription (hub-local, no ownership gate — it only
+narrows the socket's own feed) and is not forwarded to the connector.
+terminal-* frames are unchanged. Track 4·B.
+```
+
+---
+
+### Task 4: Web — send `subscribe` on connect/reconnect/instance-switch
+
+**Files:**
+- Modify: `packages/relay-web/src/api/events.ts`, `packages/relay-web/src/views/DashboardView.vue`
+- Test: `packages/relay-web/src/__tests__/events.test.ts`, `packages/relay-web/src/__tests__/dashboard.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 `subscribe` `WebClientMessage`; the existing `sendWebClientMessage` guarded-send.
+- Produces: `sendSubscribe(instanceIds: string[])` in `api/events.ts`; DashboardView calls it on socket-open and active-instance change.
+
+- [ ] **Step 1: Write the failing events.test.ts test**
+
+In `packages/relay-web/src/__tests__/events.test.ts`, extend `FakeWS` with a `send` spy, an OPEN `readyState`, and the `OPEN` static (so the guarded send in `sendSubscribe` passes), then add the test. Update the imports to add `sendSubscribe` from `../api/events` and `decodeEnvelope`, `parseWebClientMessage` from the protocol package.
+
+Extend `FakeWS`:
+
+```ts
+class FakeWS {
+  static instances: FakeWS[] = [];
+  static OPEN = 1;
+  readyState = 1;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => this.onclose?.());
+  constructor(public url: string) { FakeWS.instances.push(this); }
+}
+```
+
+Add the test:
+
+```ts
+it("sendSubscribe sends an encoded subscribe frame on the open socket", () => {
+  connectEvents(() => {});
+  const ws = FakeWS.instances[0];
+  ws.onopen?.(); // marks activeSocket usable
+  sendSubscribe(["iA", "iB"]);
+  expect(ws.send).toHaveBeenCalledTimes(1);
+  const decoded = decodeEnvelope(ws.send.mock.calls[0][0] as string);
+  if (!decoded.ok) throw new Error("decode failed");
+  expect(parseWebClientMessage(decoded.envelope)).toEqual({ kind: "subscribe", instanceIds: ["iA", "iB"] });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run packages/relay-web/src/__tests__/events.test.ts`
+Expected: FAIL — `sendSubscribe` is not exported.
+
+- [ ] **Step 3: Add `sendSubscribe` to `api/events.ts`**
+
+`sendWebClientMessage` already performs the guarded send for any `WebClientMessage`. Add a thin, named wrapper below it:
+
+```ts
+/** Tell the hub which instance(s) this socket is viewing, so it scopes control-events. */
+export function sendSubscribe(instanceIds: string[]): void {
+  sendWebClientMessage({ kind: "subscribe", instanceIds });
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npx vitest run packages/relay-web/src/__tests__/events.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing dashboard wiring test**
+
+In `packages/relay-web/src/__tests__/dashboard.test.ts`, the `vi.mock("../api/events", ...)` currently exports only `connectEvents`. Extend it to also export a `sendSubscribe` spy, and expose it for assertions:
+
+```ts
+const sendSubscribe = vi.fn();
+vi.mock("../api/events", () => ({
+  connectEvents: (onEvent: (e: unknown) => void, onStatus?: (online: boolean) => void) => {
+    captured.onEvent = onEvent;
+    captured.onStatus = onStatus;
+    return disconnect;
+  },
+  sendSubscribe,
+}));
+```
+
+Add `sendSubscribe.mockClear();` in `beforeEach`. Then add the test:
+
+```ts
+test("subscribes to the active instance on connect and on instance change", async () => {
+  const chat = useChatStore();
+  mount(DashboardView, { global: { stubs: { ChatPane: true, InstanceTree: true, "router-link": true } } });
+  await flushPromises();
+
+  // On connect, with no instance selected yet, subscribe to the empty set.
+  captured.onStatus?.(true);
+  expect(sendSubscribe).toHaveBeenLastCalledWith([]);
+
+  // Selecting an instance re-scopes the socket to it.
+  chat.select("iA", "backend");
+  await flushPromises();
+  expect(sendSubscribe).toHaveBeenLastCalledWith(["iA"]);
+});
+```
+
+- [ ] **Step 6: Run it to verify it fails**
+
+Run: `npx vitest run packages/relay-web/src/__tests__/dashboard.test.ts`
+Expected: FAIL — DashboardView does not call `sendSubscribe` yet.
+
+- [ ] **Step 7: Wire `sendSubscribe` into DashboardView**
+
+In `packages/relay-web/src/views/DashboardView.vue`:
+
+1. Add `sendSubscribe` to the `../api/events` import (which currently imports `connectEvents`):
+
+```ts
+import { connectEvents, sendSubscribe } from "../api/events";
+```
+
+2. In `onStatus(online)`, after `conn.setOnline(online)`, subscribe on (re)connect. The updated function:
+
+```ts
+function onStatus(online: boolean) {
+  conn.setOnline(online);
+  if (online) {
+    sendSubscribe(chat.instanceId ? [chat.instanceId] : []);
+    if (everOnline) void reloadSnapshot();
+    everOnline = true;
+  }
+}
+```
+
+3. Add a watch (place it near the other `watch(...)` calls, after `chat` is available) that re-subscribes when the active instance changes:
+
+```ts
+// Re-scope the hub fan-out whenever the viewed instance changes. The existing
+// loadSessions/loadFor watch is the self-heal for state that went stale while unsubscribed.
+watch(() => chat.instanceId, (id) => sendSubscribe(id ? [id] : []));
+```
+
+(Confirm `watch` is already imported from `vue` in this file — it is used elsewhere in the component. If not, add it to the `vue` import.)
+
+- [ ] **Step 8: Run both relay-web tests to verify they pass**
+
+Run: `npx vitest run packages/relay-web/src/__tests__/events.test.ts packages/relay-web/src/__tests__/dashboard.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Typecheck relay-web**
+
+Run: `npx vue-tsc --noEmit -p packages/relay-web/tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 10: Commit** (controller performs git)
+
+```
+feat(relay-web): subscribe to the active instance's event stream
+
+Add sendSubscribe(); DashboardView subscribes to the viewed instance on
+socket (re)connect and whenever the active instance changes, so the hub
+scopes control-events to it. Empty set before an instance is selected.
+Track 4·B (web half).
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Protocol `subscribe` message + parser restructure → Task 1. ✔
+- Per-socket subscription registry, absent=all, `setSubscription`, close cleanup, scoped `control-event` vs account-wide status/notice, composes with A guards → Task 2. ✔
+- Inbound `subscribe` → `setSubscription` (hub-local, no ownership gate), socket threaded from `server.ts`, terminal-* unchanged → Task 3. ✔
+- Web `sendSubscribe` on connect/reconnect/instance-change; empty set pre-selection; existing reload-on-switch is the self-heal → Task 4. ✔
+- Backward-compat (no-subscribe socket = all) → Task 2 Step 1 first test + the `broadcast` absent-map default. ✔
+- No `WebServerEvent` change; connector untouched → no task modifies either. ✔
+
+**Placeholder scan:** none — every code step carries complete code; every run step names the command + expected outcome.
+
+**Type consistency:** `WebClientMessage.subscribe` defined (T1) before use (T3 `web-inbound`, T4 `sendSubscribe`); `WebGateway.setSubscription(socket, instanceIds)` signature identical in T2 (definition), T3 (`WebClientDeps.webGateway`), and its call sites; `handleWebClientMessage(deps, accountId, socket, raw)` new arity applied in both `server.ts` (T3 Step 4) and every test call (T3 Step 1); `sendSubscribe(instanceIds: string[])` identical in `api/events.ts` (T4 Step 3), the events test (T4 Step 1), and the dashboard mock (T4 Step 5); `WebSocketLike` imported into `web-inbound.ts` from `./web-gateway.js` (T3 Step 3).
+
+**Cross-task build:** Task 1 Step 6 rebuilds the protocol dist so Task 3 (`@ganglion/xacpx-relay-protocol` → dist) and Task 4 (relay-web → dist) resolve `subscribe`. The controller must run `bun run build:relay-protocol` after Task 1 before dispatching Task 3.

--- a/docs/superpowers/specs/2026-07-13-track4-per-instance-subscription-design.md
+++ b/docs/superpowers/specs/2026-07-13-track4-per-instance-subscription-design.md
@@ -1,0 +1,222 @@
+# Track 4 · B — Per-instance Subscription Routing (Design Spec)
+
+Date: 2026-07-13
+Branch: `feat/track4-per-instance-subscription` (stacked on `feat/track4-terminal-stream-hardening` / A / PR #157)
+Track: 2026-07 architecture audit → Track 4 (runtime robustness), block B of 3.
+
+## Context
+
+Track 4 · B is the protocol-layer block of the runtime-robustness track. Like A,
+it is **behaviour-changing on purpose**, so verification is characterization tests
+for the new behaviour + regression guards for the contracts that must survive.
+
+### The amplification problem
+
+The hub fans every `WebServerEvent` to **all** of an account's sockets; the web
+filters client-side. End-to-end:
+
+```
+core control-event → connector → hub server.ts:163
+  → WebGateway.broadcast(accountId, { kind:"control-event", instanceId, event })
+  → web-gateway.ts: send to EVERY socket in byAccount   ← no per-instance scoping
+  → relay-web: ONE /ws socket; DashboardView.vue:234-238 fans every event to all stores
+```
+
+So a busy instance's streaming chunks (`turn-output`/`turn-thought`/`tool-event`)
+are delivered to every tab of the account — including tabs viewing a **different
+instance**. On a multi-tenant hub (one account controlling many instances) this is
+pure waste: cross-instance amplification × concurrent sessions × tabs.
+
+There is **no subscription mechanism today**: `WebClientMessage` is only
+`terminal-input`/`terminal-resize`/`terminal-close` (`web-dtos.ts:238-241`); the web
+receives everything and filters.
+
+### Why per-instance (not per-session)
+
+The web's `chat` store relies on receiving **all** sessions' events, for two
+things beyond the active view:
+- **Background unread/attention badges**: `unread` is set on `turn-finished` for a
+  non-viewed session (`chat.ts:362-367`); "working" comes from `turn-started`
+  building `liveTurns` (`chat.ts:298+`).
+- **Instant-switch pre-buffering**: `turn-output`/`tool-event`/`turn-thought` build
+  `liveTurns` for **every** session key, so switching to a background session
+  renders its in-progress turn immediately.
+
+Pure per-**session** routing would break both, requiring a rework of the web's
+attention/pre-buffer model (deferred). **Per-instance** routing keeps every
+active-instance event flowing exactly as today — badges, pre-buffering, terminals
+all unchanged — while cutting the cross-instance firehose. The connector→hub link
+is already per-instance and events already carry `instanceId`, so **the connector
+needs no change**.
+
+Decision (approved): **per-instance** granularity; within-instance per-session
+routing is out of scope (a possible follow-up "B2").
+
+## Goal & non-goals
+
+**Goal:** scope the hub→web `control-event` stream to the instance(s) a socket is
+viewing, with a backward-compatible protocol addition and no change to server
+event shapes.
+
+In scope:
+- A client→hub `subscribe` message declaring the socket's viewed instance set.
+- A per-socket subscription registry in `WebGateway` + subscription-scoped
+  `control-event` broadcast.
+- The web sending `subscribe` on connect/reconnect/instance-switch, plus a
+  refetch-on-switch to self-heal any staleness.
+
+**Non-goals (deferred / out of scope):**
+- Within-instance per-`(instance,session)` routing (would rework the web's
+  attention/pre-buffer model).
+- Any change to the web's badge/attention/pre-buffer/terminal store logic.
+- Any connector change.
+- Any `WebServerEvent` / `ControlEventDto` shape change.
+- Routing `instance-status` / `notice` (they stay account-wide — the global
+  instance list needs them regardless of the active instance).
+
+## Design
+
+### 1. Protocol — `relay-protocol/src/web-dtos.ts`
+
+Add one variant to `WebClientMessage` and to `parseWebClientMessage`:
+
+```ts
+{ kind: "subscribe"; instanceIds: string[] }
+```
+
+- Full-set **replace** (idempotent): each `subscribe` supersedes the socket's prior
+  set. Not a delta.
+- Validation in `parseWebClientMessage`: `kind === "subscribe"` requires
+  `Array.isArray(c.instanceIds)` and every element a `string`.
+- The existing `terminal-*` parsing (which requires `instanceId`/`terminalId`
+  strings) must **not** be applied to `subscribe` — restructure the parser so the
+  `instanceId`/`terminalId` string checks gate only the terminal variants.
+- No `WebServerEvent` change.
+
+### 2. Hub — `WebGateway` (`packages/relay/src/gateway/web-gateway.ts`)
+
+- Per-socket subscription registry: `private readonly subscriptions = new Map<WebSocketLike, Set<string>>()`.
+  - **Absent from the map = "all"** — the default for a freshly `register`ed socket
+    and for any client that never sends `subscribe`. This makes the change
+    backward-compatible and closes the connect→first-subscribe race (no events
+    dropped in that window).
+- `setSubscription(socket, instanceIds: string[]): void` — `this.subscriptions.set(socket, new Set(instanceIds))`.
+- `register`'s existing `on("close")` handler also deletes the socket from
+  `subscriptions` (no leak).
+- `broadcast(accountId, event)` routing:
+  - `event.kind === "instance-status" || event.kind === "notice"` → deliver to
+    **all** account sockets (current behaviour, unchanged).
+  - `event.kind === "control-event"` → deliver only to sockets whose subscription
+    is **absent** (all) OR whose set **has** `event.instanceId`.
+  - The A `bufferedAmount` backpressure guard and the `readyState` guard stay
+    per-socket in the loop and run for whichever sockets are selected.
+
+Factor the per-socket send (readyState guard + backpressure guard + try/send) so
+the subscription filter is a single readable predicate before it, not duplicated.
+
+**No ownership gate on `subscribe`:** `broadcast` already iterates only the
+event-owner account's socket set; a socket belongs to exactly one account.
+Subscribing to a foreign `instanceId` only adds a string that never matches this
+account's events → the socket receives *less*, never more. No cross-account leak is
+possible, so no authorization check is required on `subscribe`.
+
+### 3. Hub inbound — `web-inbound.ts` + `server.ts`
+
+- `handleWebClientMessage` gains the `socket` and a `gateway.setSubscription`
+  capability. On `msg.kind === "subscribe"` → `deps.gateway.setSubscription(socket, msg.instanceIds)`
+  and return (hub-local; **not** forwarded to the connector). The `terminal-*`
+  branches are unchanged (still `getOwned` gate + `gateway.sendEvent`).
+  - The `subscribe` branch runs **before** the `getOwned` ownership gate (that gate
+    guards connector-forwarded terminal actions; `subscribe` is hub-local and
+    inherently safe per above).
+- `server.ts:324` — the `ws.on("message", ...)` handler passes `ws` into
+  `handleWebClientMessage` so the subscribe can bind to that specific socket, and
+  includes `setSubscription` in the deps object.
+
+### 4. Web — `relay-web`
+
+Seams (verified): the single socket is created in `api/events.ts`
+`connectEvents(onEvent, onStatus?)`; `onStatus(true)` fires on the initial open
+**and every reconnect** (`socket.onopen`). The active instance is `chat.instanceId`
+(the chat store's selected instance). `DashboardView.vue` already `watch`es
+`chat.instanceId`/`chat.sessionAlias` and runs `loadSessions` + `tasks.loadFor` on
+change (~:187-214) — the refetch that self-heals staleness accrued while
+unsubscribed already exists.
+
+- `api/events.ts`: add `sendSubscribe(instanceIds: string[])` mirroring
+  `sendWebClientMessage` (encode a `subscribe` `WebClientMessage` on the active
+  socket; no-op if the socket is not OPEN).
+- In `DashboardView.vue`:
+  - Pass an `onStatus` to `connectEvents` (or extend the existing one) that, on
+    `online === true`, calls `sendSubscribe(chat.instanceId ? [chat.instanceId] : [])`
+    — re-subscribes after every (re)connect.
+  - Add a `watch(() => chat.instanceId)` that calls the same `sendSubscribe(...)` so
+    switching instances re-scopes the socket. (The existing `loadSessions`/`loadFor`
+    watch is the self-heal; no new refetch logic is needed.)
+- Before an instance is selected, `chat.instanceId` is empty → `sendSubscribe([])`,
+  so the socket gets only `instance-status`/`notice` until the user selects an
+  instance. Pre-selection data loads over RPC, not the socket, so nothing is lost.
+
+### Routing rule (approved: the simple rule)
+
+All `control-event`s are subscription-scoped; only `instance-status` / `notice`
+stay account-wide. Consequence: a **non-viewed** instance's `sessions-changed` /
+per-session `unread` do not update live; they refresh when the user switches to
+that instance (covered by the refetch-on-switch above). This keeps the hub routing
+to a single predicate (no per-event-type classification) and the staleness
+self-heals. (Considered and rejected: keeping the three rare instance-global
+control-events — `sessions-changed`/`workspaces-changed`/`orchestration-changed` —
+account-wide, which would preserve cross-instance sidebar freshness at the cost of
+an event-type classification the hub must maintain as new events are added.)
+
+## Verification (behaviour-changing → characterization + regression guards)
+
+Test files (all under `tests/unit/`, run per-file by `scripts/run-tests.mjs`;
+relay-web tests run under `vitest`, not bun):
+- `tests/unit/packages/relay-protocol/web-dtos.test.ts` (extend) — `subscribe` parse.
+- `tests/unit/packages/relay/gateway/web-gateway.test.ts` (extend) — subscription routing.
+- `tests/unit/packages/relay/` web-inbound coverage (extend or add) — subscribe → setSubscription; terminal-* unchanged.
+- `packages/relay-web/src/__tests__/` (extend, vitest) — sendSubscribe on open/switch.
+
+**Protocol:**
+- `parseWebClientMessage` round-trips `{ kind:"subscribe", instanceIds:["a","b"] }`.
+- Rejects `subscribe` with non-array / non-string-element `instanceIds`.
+- `terminal-input`/`resize`/`close` parsing unchanged (regression).
+
+**WebGateway:**
+- A socket that never subscribed receives all `control-event`s (backward-compat).
+- After `setSubscription(sock,["A"])`, `sock` receives a `control-event` for
+  instance A but **not** one for instance B.
+- `instance-status` and `notice` reach the socket regardless of subscription.
+- `setSubscription(sock,[])` → no `control-event`s, but still `instance-status`/`notice`.
+- `setSubscription` replaces (subscribe `["A"]` then `["B"]` → only B).
+- Socket close removes its subscription entry (no leak; a fresh socket at the same
+  identity would default to "all").
+- The A backpressure guard still evicts an over-threshold subscribed socket.
+
+**web-inbound:**
+- A `subscribe` frame calls `setSubscription(socket, instanceIds)` and is **not**
+  forwarded to the connector (`gateway.sendEvent` not called for it).
+- `terminal-*` frames still hit the `getOwned` gate + `gateway.sendEvent`.
+
+**Web:**
+- `subscribe([activeInstanceId])` is sent on socket open and on active-instance
+  change; re-sent on reconnect.
+
+## Risk & rollout
+
+- **Backward-compatible:** the hub defaults an un-subscribed socket to "all", so an
+  old web bundle (no `subscribe`) behaves exactly as today; the hub can ship before
+  the web.
+- **Documented behaviour change:** non-viewed instances' control-events (session
+  list refresh, per-session unread) go stale until the user switches to them;
+  `instance-status`/`notice` keep the instance list's online/notice state fresh.
+- **Composes with A:** the subscription filter sits in front of A's per-socket
+  `bufferedAmount` backpressure + `readyState` guards in the same `broadcast` loop.
+
+## Out of scope / follow-ups
+
+- **B2 (possible):** within-instance per-`(instance,session)` routing for the heavy
+  streams, which requires reworking the web's background attention/pre-buffer model
+  (two-tier light-vs-heavy event routing).
+- **C:** interactive-turn watchdog (policy-sensitive).

--- a/docs/superpowers/specs/2026-07-13-track4-per-instance-subscription-design.md
+++ b/docs/superpowers/specs/2026-07-13-track4-per-instance-subscription-design.md
@@ -138,10 +138,13 @@ possible, so no authorization check is required on `subscribe`.
 Seams (verified): the single socket is created in `api/events.ts`
 `connectEvents(onEvent, onStatus?)`; `onStatus(true)` fires on the initial open
 **and every reconnect** (`socket.onopen`). The active instance is `chat.instanceId`
-(the chat store's selected instance). `DashboardView.vue` already `watch`es
-`chat.instanceId`/`chat.sessionAlias` and runs `loadSessions` + `tasks.loadFor` on
-change (~:187-214) — the refetch that self-heals staleness accrued while
-unsubscribed already exists.
+(the chat store's selected instance). The real self-heal on switch is
+`InstanceTree`'s `onSelect` handler, which calls `chat.loadHistory()` (the
+persisted transcript for the newly-viewed session), **plus** the newly-added
+`chat.loadActiveTurns()` on the instance-change watch below (the global in-flight
+snapshot, which re-seeds any live turn + "working" dots that were dropped for this
+socket while it was subscribed elsewhere). There is no separate
+`loadSessions`/`loadFor` watch that serves as the self-heal.
 
 - `api/events.ts`: add `sendSubscribe(instanceIds: string[])` mirroring
   `sendWebClientMessage` (encode a `subscribe` `WebClientMessage` on the active
@@ -150,9 +153,10 @@ unsubscribed already exists.
   - Pass an `onStatus` to `connectEvents` (or extend the existing one) that, on
     `online === true`, calls `sendSubscribe(chat.instanceId ? [chat.instanceId] : [])`
     — re-subscribes after every (re)connect.
-  - Add a `watch(() => chat.instanceId)` that calls the same `sendSubscribe(...)` so
-    switching instances re-scopes the socket. (The existing `loadSessions`/`loadFor`
-    watch is the self-heal; no new refetch logic is needed.)
+  - Add a `watch(() => chat.instanceId)` that calls the same `sendSubscribe(...)`
+    **and**, when an instance is selected, `chat.loadActiveTurns()` — so switching
+    instances both re-scopes the socket and re-seeds any in-flight turn that
+    streamed while unsubscribed.
 - Before an instance is selected, `chat.instanceId` is empty → `sendSubscribe([])`,
   so the socket gets only `instance-status`/`notice` until the user selects an
   instance. Pre-selection data loads over RPC, not the socket, so nothing is lost.
@@ -211,6 +215,15 @@ relay-web tests run under `vitest`, not bun):
 - **Documented behaviour change:** non-viewed instances' control-events (session
   list refresh, per-session unread) go stale until the user switches to them;
   `instance-status`/`notice` keep the instance list's online/notice state fresh.
+  This also affects cross-instance **in-flight turn buffering**: a turn streaming
+  on a non-viewed instance is no longer pre-buffered live — it is re-seeded from
+  the global active-turns snapshot (`chat.loadActiveTurns()`) when the user
+  switches to that instance, not streamed incrementally while unsubscribed. More
+  importantly, a turn that **finishes** on a non-viewed instance while
+  unsubscribed produces **no unread dot**: its `turn-finished` event is dropped
+  by the subscription filter, and the active-turns snapshot only seeds in-flight
+  (not-yet-finished) turns, so that unread affordance is missed entirely — not
+  merely delayed — until the session is next opened directly.
 - **Composes with A:** the subscription filter sits in front of A's per-socket
   `bufferedAmount` backpressure + `readyState` guards in the same `broadcast` loop.
 

--- a/packages/relay-protocol/dist/index.js
+++ b/packages/relay-protocol/dist/index.js
@@ -253,6 +253,9 @@ function parseWebClientMessage(envelope) {
   if (typeof p !== "object" || p === null)
     return null;
   const c = p;
+  if (c.kind === "subscribe") {
+    return Array.isArray(c.instanceIds) && c.instanceIds.every((x) => typeof x === "string") ? p : null;
+  }
   if (typeof c.instanceId !== "string" || typeof c.terminalId !== "string")
     return null;
   if (c.kind === "terminal-input")

--- a/packages/relay-protocol/dist/web-dtos.d.ts
+++ b/packages/relay-protocol/dist/web-dtos.d.ts
@@ -105,6 +105,9 @@ export type WebClientMessage = {
     kind: "terminal-close";
     instanceId: string;
     terminalId: string;
+} | {
+    kind: "subscribe";
+    instanceIds: string[];
 };
 export declare function webClientEnvelope(msg: WebClientMessage): RelayEnvelope;
 export declare function parseWebClientMessage(envelope: RelayEnvelope): WebClientMessage | null;

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -238,7 +238,8 @@ export const WEB_CLIENT_TYPE = "web.client";
 export type WebClientMessage =
   | { kind: "terminal-input"; instanceId: string; terminalId: string; data: string }
   | { kind: "terminal-resize"; instanceId: string; terminalId: string; cols: number; rows: number }
-  | { kind: "terminal-close"; instanceId: string; terminalId: string };
+  | { kind: "terminal-close"; instanceId: string; terminalId: string }
+  | { kind: "subscribe"; instanceIds: string[] };
 
 export function webClientEnvelope(msg: WebClientMessage): RelayEnvelope {
   return { protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: WEB_CLIENT_TYPE, payload: msg };
@@ -249,6 +250,12 @@ export function parseWebClientMessage(envelope: RelayEnvelope): WebClientMessage
   const p = envelope.payload;
   if (typeof p !== "object" || p === null) return null;
   const c = p as Record<string, unknown>;
+  if (c.kind === "subscribe") {
+    return Array.isArray(c.instanceIds) && c.instanceIds.every((x) => typeof x === "string")
+      ? (p as WebClientMessage)
+      : null;
+  }
+  // terminal-* frames all require instanceId + terminalId strings.
   if (typeof c.instanceId !== "string" || typeof c.terminalId !== "string") return null;
   if (c.kind === "terminal-input") return typeof c.data === "string" ? (p as WebClientMessage) : null;
   if (c.kind === "terminal-resize") return typeof c.cols === "number" && typeof c.rows === "number" ? (p as WebClientMessage) : null;

--- a/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
@@ -8,6 +8,7 @@ import { mount, flushPromises } from "@vue/test-utils";
 vi.mock("../api/events", () => ({
   connectEvents: () => vi.fn(),
   sendWebClientMessage: vi.fn(),
+  sendSubscribe: vi.fn(),
 }));
 // DashboardView uses useRouter()/<router-link>; mock to avoid a real router.
 vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));

--- a/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-responsive.test.ts
@@ -6,6 +6,7 @@ import { mount, flushPromises } from "@vue/test-utils";
 const disconnect = vi.fn();
 vi.mock("../api/events", () => ({
   connectEvents: () => disconnect,
+  sendSubscribe: vi.fn(),
 }));
 vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 

--- a/packages/relay-web/src/__tests__/dashboard.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard.test.ts
@@ -7,12 +7,18 @@ import { mount, flushPromises } from "@vue/test-utils";
 // Capture the (onEvent, onStatus) callbacks so tests can drive reconnects.
 const disconnect = vi.fn();
 const captured: { onEvent?: (e: unknown) => void; onStatus?: (online: boolean) => void } = {};
+// `sendSubscribe` is read directly (not inside a deferred closure) when the
+// factory below builds its returned object, so — unlike `disconnect`, which is
+// only touched later inside a nested arrow function — it must be produced via
+// `vi.hoisted` to avoid a TDZ ReferenceError against the hoisted `vi.mock` call.
+const { sendSubscribe } = vi.hoisted(() => ({ sendSubscribe: vi.fn() }));
 vi.mock("../api/events", () => ({
   connectEvents: (onEvent: (e: unknown) => void, onStatus?: (online: boolean) => void) => {
     captured.onEvent = onEvent;
     captured.onStatus = onStatus;
     return disconnect;
   },
+  sendSubscribe,
 }));
 
 // DashboardView now uses useRouter()/<router-link>; mock to avoid a real router.
@@ -27,6 +33,7 @@ beforeEach(() => {
   setActivePinia(createPinia());
   captured.onEvent = undefined;
   captured.onStatus = undefined;
+  sendSubscribe.mockClear();
   vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ instances: [] }), { status: 200 })));
 });
 
@@ -79,4 +86,19 @@ test("re-pulls the snapshot on reconnect", async () => {
   captured.onStatus?.(true);
   await flushPromises();
   expect(spy).toHaveBeenCalled();
+});
+
+test("subscribes to the active instance on connect and on instance change", async () => {
+  const chat = useChatStore();
+  mount(DashboardView, { global: { stubs: { ChatPane: true, InstanceTree: true, "router-link": true } } });
+  await flushPromises();
+
+  // On connect, with no instance selected yet, subscribe to the empty set.
+  captured.onStatus?.(true);
+  expect(sendSubscribe).toHaveBeenLastCalledWith([]);
+
+  // Selecting an instance re-scopes the socket to it.
+  chat.select("iA", "backend");
+  await flushPromises();
+  expect(sendSubscribe).toHaveBeenLastCalledWith(["iA"]);
 });

--- a/packages/relay-web/src/__tests__/dashboard.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard.test.ts
@@ -111,3 +111,26 @@ test("subscribes to the active instance on connect and on instance change", asyn
   expect(sendSubscribe).toHaveBeenLastCalledWith(["iA"]);
   expect(loadActiveTurns).toHaveBeenCalledTimes(1);
 });
+
+test("re-subscribes on reconnect, not only on the first connect", async () => {
+  const chat = useChatStore();
+  vi.spyOn(chat, "loadActiveTurns").mockResolvedValue(undefined);
+  mount(DashboardView, { global: { stubs: { ChatPane: true, InstanceTree: true, "router-link": true } } });
+  await flushPromises();
+
+  // Establish a selected instance so the re-sent subscription payload is observable and non-empty.
+  chat.select("iA", "backend");
+  await flushPromises();
+  captured.onStatus?.(true);   // initial connect
+  sendSubscribe.mockClear();
+
+  // Drop, then reconnect. onStatus(true) on a RECONNECT must re-send the current subscription so
+  // the hub re-scopes the fresh socket — otherwise a reconnected client silently receives every
+  // instance's control-events (or none). A mutation that subscribed only on the first connect
+  // would leave sendSubscribe uncalled here.
+  captured.onStatus?.(false);
+  captured.onStatus?.(true);
+  await flushPromises();
+  expect(sendSubscribe).toHaveBeenCalledTimes(1);
+  expect(sendSubscribe).toHaveBeenLastCalledWith(["iA"]);
+});

--- a/packages/relay-web/src/__tests__/dashboard.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard.test.ts
@@ -98,11 +98,16 @@ test("subscribes to the active instance on connect and on instance change", asyn
   captured.onStatus?.(true);
   expect(sendSubscribe).toHaveBeenLastCalledWith([]);
 
+  // Clear the mount-time loadActiveTurns call (onMounted seeds it once) so the assertion below
+  // isolates the SWITCH-triggered re-seed — otherwise the check passes even if the watch's
+  // loadActiveTurns call were reverted.
+  loadActiveTurns.mockClear();
+
   // Selecting an instance re-scopes the socket to it, and re-seeds any in-flight turns that
   // were dropped for this socket while it was subscribed elsewhere (loadActiveTurns is the
   // global in-flight snapshot — the real self-heal on switch).
   chat.select("iA", "backend");
   await flushPromises();
   expect(sendSubscribe).toHaveBeenLastCalledWith(["iA"]);
-  expect(loadActiveTurns).toHaveBeenCalled();
+  expect(loadActiveTurns).toHaveBeenCalledTimes(1);
 });

--- a/packages/relay-web/src/__tests__/dashboard.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard.test.ts
@@ -90,6 +90,7 @@ test("re-pulls the snapshot on reconnect", async () => {
 
 test("subscribes to the active instance on connect and on instance change", async () => {
   const chat = useChatStore();
+  const loadActiveTurns = vi.spyOn(chat, "loadActiveTurns").mockResolvedValue(undefined);
   mount(DashboardView, { global: { stubs: { ChatPane: true, InstanceTree: true, "router-link": true } } });
   await flushPromises();
 
@@ -97,8 +98,11 @@ test("subscribes to the active instance on connect and on instance change", asyn
   captured.onStatus?.(true);
   expect(sendSubscribe).toHaveBeenLastCalledWith([]);
 
-  // Selecting an instance re-scopes the socket to it.
+  // Selecting an instance re-scopes the socket to it, and re-seeds any in-flight turns that
+  // were dropped for this socket while it was subscribed elsewhere (loadActiveTurns is the
+  // global in-flight snapshot — the real self-heal on switch).
   chat.select("iA", "backend");
   await flushPromises();
   expect(sendSubscribe).toHaveBeenLastCalledWith(["iA"]);
+  expect(loadActiveTurns).toHaveBeenCalled();
 });

--- a/packages/relay-web/src/__tests__/events.test.ts
+++ b/packages/relay-web/src/__tests__/events.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { connectEvents } from "../api/events";
+import { connectEvents, sendSubscribe } from "../api/events";
+import { decodeEnvelope, parseWebClientMessage } from "@ganglion/xacpx-relay-protocol";
 
 class FakeWS {
   static instances: FakeWS[] = [];
+  static OPEN = 1;
+  readyState = 1;
   onopen: (() => void) | null = null;
   onclose: (() => void) | null = null;
   onmessage: ((e: { data: string }) => void) | null = null;
+  send = vi.fn();
   close = vi.fn(() => this.onclose?.());
   constructor(public url: string) { FakeWS.instances.push(this); }
 }
@@ -35,5 +39,16 @@ describe("connectEvents", () => {
     vi.runOnlyPendingTimers();          // reconnect fires → new socket
     FakeWS.instances[1]?.onopen?.();
     expect(status).toEqual([true, false, true]);
+  });
+
+  it("sendSubscribe sends an encoded subscribe frame on the open socket", () => {
+    connectEvents(() => {});
+    const ws = FakeWS.instances[0];
+    ws.onopen?.(); // marks activeSocket usable
+    sendSubscribe(["iA", "iB"]);
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    const decoded = decodeEnvelope(ws.send.mock.calls[0][0] as string);
+    if (!decoded.ok) throw new Error("decode failed");
+    expect(parseWebClientMessage(decoded.envelope)).toEqual({ kind: "subscribe", instanceIds: ["iA", "iB"] });
   });
 });

--- a/packages/relay-web/src/api/events.ts
+++ b/packages/relay-web/src/api/events.ts
@@ -9,6 +9,11 @@ export function sendWebClientMessage(msg: WebClientMessage): void {
   }
 }
 
+/** Tell the hub which instance(s) this socket is viewing, so it scopes control-events. */
+export function sendSubscribe(instanceIds: string[]): void {
+  sendWebClientMessage({ kind: "subscribe", instanceIds });
+}
+
 /** Connects to the relay /ws fan-out and invokes `onEvent` for each web event. Auto-reconnects. */
 export function connectEvents(onEvent: (event: WebServerEvent) => void, onStatus?: (online: boolean) => void): () => void {
   let socket: WebSocket | null = null;

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -223,9 +223,13 @@ function onStatus(online: boolean) {
   }
 }
 
-// Re-scope the hub fan-out whenever the viewed instance changes. The existing
-// loadSessions/loadFor watch is the self-heal for state that went stale while unsubscribed.
-watch(() => chat.instanceId, (id) => sendSubscribe(id ? [id] : []));
+// Re-scope the hub fan-out to the viewed instance, and re-seed any in-flight turns that were
+// dropped for this socket while it was subscribed elsewhere (loadActiveTurns is the global
+// in-flight snapshot — the real self-heal, alongside onSelect's loadHistory).
+watch(() => chat.instanceId, (id) => {
+  sendSubscribe(id ? [id] : []);
+  if (id) void chat.loadActiveTurns().catch(() => {});
+});
 
 onMounted(async () => {
   window.addEventListener("keydown", onGlobalKey);

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { connectEvents } from "../api/events";
+import { connectEvents, sendSubscribe } from "../api/events";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore, loadPersistedSelection } from "../stores/chat";
 import { useTasksStore } from "../stores/tasks";
@@ -217,10 +217,15 @@ async function reloadSnapshot() {
 function onStatus(online: boolean) {
   conn.setOnline(online);
   if (online) {
+    sendSubscribe(chat.instanceId ? [chat.instanceId] : []);
     if (everOnline) void reloadSnapshot();
     everOnline = true;
   }
 }
+
+// Re-scope the hub fan-out whenever the viewed instance changes. The existing
+// loadSessions/loadFor watch is the self-heal for state that went stale while unsubscribed.
+watch(() => chat.instanceId, (id) => sendSubscribe(id ? [id] : []));
 
 onMounted(async () => {
   window.addEventListener("keydown", onGlobalKey);

--- a/packages/relay/src/gateway/web-gateway.ts
+++ b/packages/relay/src/gateway/web-gateway.ts
@@ -33,6 +33,9 @@ export interface WebGatewayOptions {
 /** Tracks authenticated browser sockets per account and fans events out to them. */
 export class WebGateway {
   private readonly byAccount = new Map<string, Set<WebSocketLike>>();
+  // Per-socket instance subscription. ABSENT from this map = "all" (a freshly-registered
+  // socket, or a legacy client that never sends `subscribe`) → backward-compatible.
+  private readonly subscriptions = new Map<WebSocketLike, Set<string>>();
 
   constructor(private readonly options: WebGatewayOptions = {}) {}
 
@@ -44,16 +47,31 @@ export class WebGateway {
     startHeartbeat(socket, this.options.heartbeatIntervalMs, undefined, this.options.logger);
     socket.on("close", () => {
       set.delete(socket);
+      this.subscriptions.delete(socket);
       if (set.size === 0) this.byAccount.delete(accountId);
       this.options.logger?.debug("relay.web.disconnected", "web client disconnected", { accountId });
     });
+  }
+
+  /** Replace a socket's instance subscription (full-set, idempotent). A socket not present
+   *  in the map receives every control-event; call with [] to receive none. */
+  setSubscription(socket: WebSocketLike, instanceIds: string[]): void {
+    this.subscriptions.set(socket, new Set(instanceIds));
   }
 
   broadcast(accountId: string, event: WebServerEvent): void {
     const set = this.byAccount.get(accountId);
     if (!set) return;
     const data = encodeEnvelope(webEventEnvelope(event));
+    // control-events are scoped to the socket's instance subscription; a socket with no
+    // subscription (absent from the map) receives all. instance-status / notice are
+    // account-wide (the global instance list needs them regardless of the active instance).
+    const scoped = event.kind === "control-event";
     for (const socket of set) {
+      if (scoped) {
+        const sub = this.subscriptions.get(socket);
+        if (sub && !sub.has(event.instanceId)) continue;
+      }
       // One dead/throwing socket must not starve the remaining dashboards.
       if (typeof socket.readyState === "number" && socket.readyState !== WS_OPEN) continue;
       // Backpressure: a stalled client's send buffer grows without bound. Evict it (it

--- a/packages/relay/src/gateway/web-inbound.ts
+++ b/packages/relay/src/gateway/web-inbound.ts
@@ -1,17 +1,22 @@
 import { decodeEnvelope, MSG, parseWebClientMessage } from "@ganglion/xacpx-relay-protocol";
+import type { WebSocketLike } from "./web-gateway.js";
 
 export interface WebClientDeps {
   instances: { getOwned(id: string, accountId: string): unknown };
   gateway: { sendEvent(instanceId: string, type: string, payload: unknown): boolean };
+  webGateway: { setSubscription(socket: WebSocketLike, instanceIds: string[]): void };
 }
 
-/** Decode + authorize + forward a browser→hub terminal frame as a connector event. */
-export function handleWebClientMessage(deps: WebClientDeps, accountId: string, raw: string): void {
+/** Decode + route a browser→hub frame. `subscribe` updates this socket's instance
+ *  subscription (hub-local); terminal frames are authorized and forwarded to the connector. */
+export function handleWebClientMessage(deps: WebClientDeps, accountId: string, socket: WebSocketLike, raw: string): void {
   const decoded = decodeEnvelope(raw);
   if (!decoded.ok) return;
   const msg = parseWebClientMessage(decoded.envelope);
   if (!msg) return;
-  if (!deps.instances.getOwned(msg.instanceId, accountId)) return; // ownership gate
+  // Hub-local, inherently safe (only narrows this socket's own feed) — no ownership gate.
+  if (msg.kind === "subscribe") { deps.webGateway.setSubscription(socket, msg.instanceIds); return; }
+  if (!deps.instances.getOwned(msg.instanceId, accountId)) return; // ownership gate (connector actions)
   if (msg.kind === "terminal-input") deps.gateway.sendEvent(msg.instanceId, MSG.terminalInput, { terminalId: msg.terminalId, data: msg.data });
   else if (msg.kind === "terminal-resize") deps.gateway.sendEvent(msg.instanceId, MSG.terminalResize, { terminalId: msg.terminalId, cols: msg.cols, rows: msg.rows });
   else if (msg.kind === "terminal-close") deps.gateway.sendEvent(msg.instanceId, MSG.terminalClose, { terminalId: msg.terminalId });

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -321,7 +321,7 @@ export async function startRelayServer(options: StartRelayOptions): Promise<Runn
       if (!account) { socket.destroy(); return; }
       webWss.handleUpgrade(req, socket, head, (ws) => {
         runtime.webGateway.register(account.id, ws);
-        ws.on("message", (data: unknown) => handleWebClientMessage({ instances: runtime.instances, gateway: runtime.gateway }, account.id, String(data)));
+        ws.on("message", (data: unknown) => handleWebClientMessage({ instances: runtime.instances, gateway: runtime.gateway, webGateway: runtime.webGateway }, account.id, ws, String(data)));
       });
       return;
     }

--- a/tests/unit/packages/relay-protocol/web-dtos.test.ts
+++ b/tests/unit/packages/relay-protocol/web-dtos.test.ts
@@ -1,10 +1,13 @@
 // tests/unit/packages/relay-protocol/web-dtos.test.ts
 import { expect, test } from "bun:test";
 import {
+  WEB_CLIENT_TYPE,
   WEB_EVENT_TYPE,
   decodeEnvelope,
   encodeEnvelope,
+  parseWebClientMessage,
   parseWebServerEvent,
+  webClientEnvelope,
   webEventEnvelope,
   type FsEntryDto,
   type FsListResult,
@@ -258,4 +261,33 @@ test("fs DTOs carry the tree-browser additions", () => {
   expect(list.sep).toBe("/");
   expect(payload.mode).toBe("content");
   expect(result.hits[0].line).toBe(3);
+});
+
+test("parseWebClientMessage round-trips a subscribe frame", () => {
+  const wire = encodeEnvelope(webClientEnvelope({ kind: "subscribe", instanceIds: ["a", "b"] }));
+  const decoded = decodeEnvelope(wire);
+  expect(decoded.ok).toBe(true);
+  if (!decoded.ok) return;
+  expect(parseWebClientMessage(decoded.envelope)).toEqual({ kind: "subscribe", instanceIds: ["a", "b"] });
+});
+
+test("parseWebClientMessage accepts an empty subscribe set", () => {
+  const wire = encodeEnvelope(webClientEnvelope({ kind: "subscribe", instanceIds: [] }));
+  const decoded = decodeEnvelope(wire);
+  if (!decoded.ok) throw new Error("decode failed");
+  expect(parseWebClientMessage(decoded.envelope)).toEqual({ kind: "subscribe", instanceIds: [] });
+});
+
+test("parseWebClientMessage rejects subscribe with a non-array / non-string instanceIds", () => {
+  const bad1 = { protocolVersion: 1, kind: "event", type: WEB_CLIENT_TYPE, payload: { kind: "subscribe", instanceIds: "nope" } } as never;
+  const bad2 = { protocolVersion: 1, kind: "event", type: WEB_CLIENT_TYPE, payload: { kind: "subscribe", instanceIds: [1, 2] } } as never;
+  expect(parseWebClientMessage(bad1)).toBeNull();
+  expect(parseWebClientMessage(bad2)).toBeNull();
+});
+
+test("parseWebClientMessage still round-trips terminal-input (regression)", () => {
+  const wire = encodeEnvelope(webClientEnvelope({ kind: "terminal-input", instanceId: "i1", terminalId: "t1", data: "ls\n" }));
+  const decoded = decodeEnvelope(wire);
+  if (!decoded.ok) throw new Error("decode failed");
+  expect(parseWebClientMessage(decoded.envelope)).toEqual({ kind: "terminal-input", instanceId: "i1", terminalId: "t1", data: "ls\n" });
 });

--- a/tests/unit/packages/relay/gateway/web-gateway.test.ts
+++ b/tests/unit/packages/relay/gateway/web-gateway.test.ts
@@ -16,6 +16,12 @@ class FakeSocket {
 
 const evt = (online: boolean): WebServerEvent => ({ kind: "instance-status", instanceId: "i1", online });
 
+const ctrl = (instanceId: string): WebServerEvent => ({
+  kind: "control-event",
+  instanceId,
+  event: { type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "hi" },
+});
+
 test("broadcast reaches only that account's sockets", () => {
   const gw = new WebGateway();
   const a = new FakeSocket(); const b = new FakeSocket(); const other = new FakeSocket();
@@ -133,4 +139,80 @@ test("one slow socket does not starve the healthy sockets in the same account", 
   expect(slow.sent.length).toBe(0);
   expect(slow.terminated).toBe(true);
   expect(good.sent.length).toBe(1);
+});
+
+test("a socket with no subscription receives all control-events (backward-compat)", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.broadcast("a1", ctrl("iA"));
+  gw.broadcast("a1", ctrl("iB"));
+  expect(s.sent.length).toBe(2);
+});
+
+test("after subscribe([iA]) a socket gets iA control-events but not iB", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  gw.broadcast("a1", ctrl("iA"));
+  gw.broadcast("a1", ctrl("iB"));
+  expect(s.sent.length).toBe(1);
+  const decoded = decodeEnvelope(s.sent[0]!);
+  expect(decoded.ok && parseWebServerEvent(decoded.envelope)).toEqual(ctrl("iA"));
+});
+
+test("instance-status and notice reach a subscribed socket regardless of subscription", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  gw.broadcast("a1", { kind: "instance-status", instanceId: "iB", online: false });
+  gw.broadcast("a1", { kind: "notice", instanceId: "iB", notice: { kind: "info", text: "hi" } as never });
+  expect(s.sent.length).toBe(2);
+});
+
+test("subscribe([]) blocks all control-events but still delivers status/notice", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, []);
+  gw.broadcast("a1", ctrl("iA"));
+  gw.broadcast("a1", { kind: "instance-status", instanceId: "iA", online: true });
+  expect(s.sent.length).toBe(1);
+});
+
+test("setSubscription replaces the prior set", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  gw.setSubscription(s as never, ["iB"]);
+  gw.broadcast("a1", ctrl("iA"));
+  gw.broadcast("a1", ctrl("iB"));
+  expect(s.sent.length).toBe(1); // only iB now
+});
+
+test("closing a socket clears its subscription (no leak)", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  s.close(); // fires the close handler → removes from byAccount AND subscriptions
+  // Re-register a fresh socket at the same account: with no subscription it defaults to all.
+  const s2 = new FakeSocket();
+  gw.register("a1", s2 as never);
+  gw.broadcast("a1", ctrl("iZ"));
+  expect(s2.sent.length).toBe(1);
+});
+
+test("backpressure still evicts an over-threshold socket for a subscribed control-event", () => {
+  const gw = new WebGateway();
+  const s = new FakeSocket();
+  s.bufferedAmount = 4 * 1024 * 1024 + 1;
+  gw.register("a1", s as never);
+  gw.setSubscription(s as never, ["iA"]);
+  gw.broadcast("a1", ctrl("iA"));
+  expect(s.sent.length).toBe(0);
+  expect(s.terminated).toBe(true);
 });

--- a/tests/unit/packages/relay/gateway/web-gateway.test.ts
+++ b/tests/unit/packages/relay/gateway/web-gateway.test.ts
@@ -193,17 +193,17 @@ test("setSubscription replaces the prior set", () => {
   expect(s.sent.length).toBe(1); // only iB now
 });
 
-test("closing a socket clears its subscription (no leak)", () => {
+test("closing a socket clears its subscription (re-registering the same socket defaults to all)", () => {
   const gw = new WebGateway();
   const s = new FakeSocket();
   gw.register("a1", s as never);
   gw.setSubscription(s as never, ["iA"]);
-  s.close(); // fires the close handler → removes from byAccount AND subscriptions
-  // Re-register a fresh socket at the same account: with no subscription it defaults to all.
-  const s2 = new FakeSocket();
-  gw.register("a1", s2 as never);
+  s.close(); // fires close handler → removes from byAccount AND subscriptions
+  // Re-register the SAME socket: if the ["iA"] entry leaked, it would still be scoped to iA
+  // and drop an iZ control-event. With the entry deleted, it defaults to "all" and receives it.
+  gw.register("a1", s as never);
   gw.broadcast("a1", ctrl("iZ"));
-  expect(s2.sent.length).toBe(1);
+  expect(s.sent.length).toBe(1);
 });
 
 test("backpressure still evicts an over-threshold socket for a subscribed control-event", () => {

--- a/tests/unit/packages/relay/terminal-web-inbound.test.ts
+++ b/tests/unit/packages/relay/terminal-web-inbound.test.ts
@@ -6,25 +6,27 @@ function deps(owned: boolean) {
   return {
     instances: { getOwned: mock((id: string, acc: string) => (owned && id === "i1" && acc === "a1" ? { id: "i1" } : undefined)) },
     gateway: { sendEvent: mock(() => true) },
+    webGateway: { setSubscription: mock(() => {}) },
   };
 }
+const sock = {} as never; // opaque socket handle; identity is all setSubscription needs
 
 test("owned terminal-input is forwarded as a gateway event", () => {
   const d = deps(true);
-  handleWebClientMessage(d as never, "a1", encodeEnvelope(webClientEnvelope({ kind: "terminal-input", instanceId: "i1", terminalId: "t1", data: "ls\n" })));
+  handleWebClientMessage(d as never, "a1", sock, encodeEnvelope(webClientEnvelope({ kind: "terminal-input", instanceId: "i1", terminalId: "t1", data: "ls\n" })));
   expect((d.gateway.sendEvent as ReturnType<typeof mock>).mock.calls[0]).toEqual(["i1", MSG.terminalInput, { terminalId: "t1", data: "ls\n" }]);
 });
 
 test("non-owned instance is dropped (no forward)", () => {
   const d = deps(false);
-  handleWebClientMessage(d as never, "a1", encodeEnvelope(webClientEnvelope({ kind: "terminal-input", instanceId: "i1", terminalId: "t1", data: "x" })));
+  handleWebClientMessage(d as never, "a1", sock, encodeEnvelope(webClientEnvelope({ kind: "terminal-input", instanceId: "i1", terminalId: "t1", data: "x" })));
   expect((d.gateway.sendEvent as ReturnType<typeof mock>).mock.calls.length).toBe(0);
 });
 
 test("resize/close map to their gateway event types", () => {
   const d = deps(true);
-  handleWebClientMessage(d as never, "a1", encodeEnvelope(webClientEnvelope({ kind: "terminal-resize", instanceId: "i1", terminalId: "t1", cols: 90, rows: 20 })));
-  handleWebClientMessage(d as never, "a1", encodeEnvelope(webClientEnvelope({ kind: "terminal-close", instanceId: "i1", terminalId: "t1" })));
+  handleWebClientMessage(d as never, "a1", sock, encodeEnvelope(webClientEnvelope({ kind: "terminal-resize", instanceId: "i1", terminalId: "t1", cols: 90, rows: 20 })));
+  handleWebClientMessage(d as never, "a1", sock, encodeEnvelope(webClientEnvelope({ kind: "terminal-close", instanceId: "i1", terminalId: "t1" })));
   const calls = (d.gateway.sendEvent as ReturnType<typeof mock>).mock.calls;
   expect(calls[0]).toEqual(["i1", MSG.terminalResize, { terminalId: "t1", cols: 90, rows: 20 }]);
   expect(calls[1]).toEqual(["i1", MSG.terminalClose, { terminalId: "t1" }]);
@@ -32,6 +34,13 @@ test("resize/close map to their gateway event types", () => {
 
 test("garbage upstream frame is ignored", () => {
   const d = deps(true);
-  handleWebClientMessage(d as never, "a1", "not json");
+  handleWebClientMessage(d as never, "a1", sock, "not json");
+  expect((d.gateway.sendEvent as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+});
+
+test("a subscribe frame updates the socket subscription and is NOT forwarded to the connector", () => {
+  const d = deps(true);
+  handleWebClientMessage(d as never, "a1", sock, encodeEnvelope(webClientEnvelope({ kind: "subscribe", instanceIds: ["i1", "i2"] })));
+  expect((d.webGateway.setSubscription as ReturnType<typeof mock>).mock.calls[0]).toEqual([sock, ["i1", "i2"]]);
   expect((d.gateway.sendEvent as ReturnType<typeof mock>).mock.calls.length).toBe(0);
 });


### PR DESCRIPTION
## Track 4 · B — Per-instance subscription routing

Second block of Track 4 (runtime robustness). Scopes the hub→web `control-event` firehose to the instance(s) a socket is actually viewing, killing **cross-instance amplification** (an account controlling many instances no longer fans every instance's stream to every tab). **Backward-compatible**, no server-event shape change, connector untouched.

> **Stacked on #157 (Track 4 · A).** Base is `feat/track4-terminal-stream-hardening`; retarget to `main` once #157 merges. B's `WebGateway.broadcast` change composes in front of A's `bufferedAmount`/`readyState` guards.

### The problem
The hub fanned every `WebServerEvent` to **all** of an account's sockets; the web filtered client-side. A busy instance's streaming chunks (`turn-output`/`thought`/`tool-event`) hit every tab of the account — including tabs viewing a *different* instance. There was no subscription mechanism at all.

### The change (4 layers)
1. **Protocol** — add `{ kind:"subscribe"; instanceIds:string[] }` to `WebClientMessage`; restructure `parseWebClientMessage` so the `instanceId`/`terminalId` guard gates only the `terminal-*` variants.
2. **Hub `WebGateway`** — a per-socket subscription registry (`Map<socket, Set<instanceId>>`). **Absent = "all"** (a legacy client that never subscribes, and the connect→first-subscribe gap, drop nothing). `broadcast` scopes `control-event`s to the socket's subscription; `instance-status`/`notice` stay account-wide (the global instance list needs them). Cleared on socket close.
3. **Hub inbound** — `handleWebClientMessage` gains the socket handle; a `subscribe` frame calls `setSubscription(socket, ids)` (hub-local, before the ownership gate — it only narrows the socket's own feed, so no cross-account leak is possible). `terminal-*` unchanged.
4. **Web** — `sendSubscribe()`; `DashboardView` subscribes to the viewed instance on socket (re)connect and whenever the active instance changes, and re-seeds in-flight turns (`loadActiveTurns`) on switch so a background instance's streaming turn is restored on switch.

### Behaviour change (documented tradeoff)
Per-instance (not per-session) was chosen so the web's badge/attention/pre-buffer logic for the *active* instance stays exactly as today. The tradeoff: a **non-viewed** instance's `control-event`s aren't delivered live — its session-list refresh + per-session state re-sync when you switch to it (`loadHistory` + `loadActiveTurns`). A turn that *finishes* on a non-viewed instance while unsubscribed produces no unread dot (found on next open). `instance-status`/`notice` keep the instance list's online/notice state fresh across all instances. Within-instance per-session routing is out of scope (a possible B2).

### Testing
- Protocol: `web-dtos.test.ts` (subscribe parse round-trip, malformed rejection, terminal regression).
- Hub gateway: `web-gateway.test.ts` (backward-compat all; scoped iA-not-iB; status/notice always; empty-set; replace; close-clears-subscription re-registering the SAME socket; backpressure still evicts a subscribed socket).
- Hub inbound: `terminal-web-inbound.test.ts` (subscribe → setSubscription, not forwarded; terminal-* still forwarded).
- Web (vitest): `events.test.ts` (sendSubscribe frame), `dashboard.test.ts` (subscribe on connect `[]` + on switch `["iA"]`; `loadActiveTurns` re-seed on switch, mutation-verified).
- Full relay-web vitest suite **93 files / 696 tests** green; `tsc -p packages/relay`, `tsc -p packages/relay-protocol`, and `vue-tsc` all clean.

### Review
Four per-task reviews (spec ✅ / quality Approved) + a whole-branch review (opus) that caught one real Important issue — the switch path never re-seeded in-flight turns (my spec had mis-stated the existing self-heal) — now fixed and mutation-verified, plus a focused re-review confirming closure.

Spec: `docs/superpowers/specs/2026-07-13-track4-per-instance-subscription-design.md`
Plan: `docs/superpowers/plans/2026-07-13-track4-per-instance-subscription.md`
