### PR TITLE
fix(orchestration): critical-section & delivery hardening (#149/#150/#151)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-orchestration-followup-hardening.md
+++ b/docs/superpowers/plans/2026-07-14-orchestration-followup-hardening.md
@@ -1,5 +1,21 @@
 # Orchestration Follow-up Hardening (#149 / #150 / #151) Implementation Plan
 
+> ⚠️ **POST-IMPLEMENTATION AMENDMENT (2026-07-14) — DO NOT RE-EXECUTE THIS PLAN.** This work is
+> shipped and merged-ready on `fix/orchestration-critsec-hardening`. Two code blocks below were
+> **superseded** by a later Codex-review round and would **reintroduce fixed bugs** if transcribed
+> as originally written:
+> - **Task 1 / Step 3 (kernel `mutate`)** — the original `held` + *synchronous-throw* guard still
+>   false-rejects the single-`.then` same-microtask detached chain #149 names. The shipped guard
+>   renames `held`→`sectionContext` and, on a suspected re-entry, `await Promise.resolve()` yields
+>   once and re-checks before throwing. The block below has been updated to the shipped version.
+> - **Task 3 / Step 4b (`cancelGroup`)** — the original apply-all → log → *dispatch-all* (no
+>   try/finally) strands an already-committed cancellation when a later task's save fails. The
+>   shipped version wraps phase 1 + log in a `try` and fires the collected chains in a `finally`.
+>   The block below has been updated to the shipped version.
+>
+> Authoritative sources: the design spec (`docs/superpowers/specs/2026-07-14-orchestration-followup-hardening-design.md`,
+> §149/§150, updated), the current source, and commits `2d19c12` (#149) / `7fa95b5` (#150).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Close the three orchestration follow-up debts deferred from Track 3 — a false-positive reentrancy guard (#149), a hop-lucky cancel-group log ordering (#150), and a delivery-blind active-message fallback (#151).
@@ -75,9 +91,14 @@ export class OrchestrationStateKernel {
    *  the section that is running right now — apart from a chain that merely INHERITED a section's
    *  context but outlives it. A bare boolean also can't distinguish a concurrent queued caller,
    *  which is why this was never a plain field. */
-  private readonly held = new AsyncLocalStorage<object>();
+  // ⚠️ Updated to the shipped version (see the amendment at the top). The original plan showed
+  // `held` + a synchronous throw, which re-rejects the single-`.then` same-microtask detached
+  // chain #149 names. The shipped guard yields one microtask on a suspected re-entry, then
+  // re-checks — letting an after-completion detached chain run while still throwing on a genuine
+  // awaited-nested deadlock.
+  private readonly sectionContext = new AsyncLocalStorage<object>();
   /** Token of the critical section whose `critical()` body is executing at this instant, or
-   *  undefined when none. The mutex serialises sections, so at most one is ever live. */
+   *  undefined when none. Reset in mutate's `finally`, one microtask after the body returns. */
   private runningToken: object | undefined;
   private readonly stateMutex: AsyncMutex;
 
@@ -88,31 +109,36 @@ export class OrchestrationStateKernel {
     this.stateMutex = stateMutex ?? new AsyncMutex();
   }
 
-  /** AsyncMutex is strict-FIFO and non-reentrant: an AWAITED nested run() awaits a tail promise
-   *  that only resolves after the outer section returns → deadlock. Throw for that case only.
-   *  A detached chain that inherited a section's token but reaches mutate() AFTER that section
-   *  has returned (`enclosing !== runningToken`) is not re-entrant — it queues on the now-free
-   *  mutex and runs. */
   async mutate<T>(critical: () => Promise<T>): Promise<T> {
-    const enclosing = this.held.getStore();
+    const enclosing = this.sectionContext.getStore();
     if (enclosing !== undefined && enclosing === this.runningToken) {
-      throw new Error(
-        "orchestration: nested mutate() detected — this would deadlock the state mutex. " +
-          "Call the collaborator outside the critical section.",
-      );
+      // Suspected re-entry: yield one microtask so a RETURNING section's finally clears
+      // runningToken, then re-check. Still the running token ⇒ that section never returned (it is
+      // awaiting us) ⇒ real deadlock ⇒ throw. Cleared ⇒ detached-after-completion ⇒ let it run.
+      await Promise.resolve();
+      if (this.runningToken === enclosing) {
+        throw new Error(
+          "orchestration: nested mutate() detected — this would deadlock the state mutex. " +
+            "Call the collaborator outside the critical section.",
+        );
+      }
     }
     const token = {};
     return await this.stateMutex.run(async () => {
       const previous = this.runningToken; // always undefined (mutex serialises); restored defensively
       this.runningToken = token;
       try {
-        return await this.held.run(token, critical);
+        return await this.sectionContext.run(token, critical);
       } finally {
         this.runningToken = previous;
       }
     });
   }
 ```
+
+> Also add a same-microtask `.then()` re-entry test (the exact #149 shape) alongside the macrotask
+> "outlives" test — it throws under the superseded synchronous guard, so it is what makes the fix
+> mutation-active. See `tests/unit/orchestration/service/orchestration-state-kernel.test.ts`.
 
 - [ ] **Step 4: Run to verify all kernel tests PASS**
 
@@ -258,6 +284,14 @@ git commit -m "fix(orchestration): active-message fallback prefers the last deli
   `startWorkerCancellation`. The caller fires `startWorkerCancellation(task)` when `shouldPropagate`.
 - Consumes (already public): `TaskCancellationService.startWorkerCancellation(task)`.
 - `requestTaskCancellation` keeps its signature and behaviour (now implemented via `applyCancellationRequest`).
+
+> ⚠️ **Superseded ordering assertion.** The original Step 2 test below asserts the `cancelWorkerTask`
+> *port* lands after the `group.cancelled` log. That port fires several awaits deep in the detached
+> chain, so it stays after the log regardless of when the chain is *started* — the assertion is
+> mutation-blind (it does NOT redden when the dispatch loop is moved before the log). The shipped
+> test instead observes, at the **first `startWorkerCancellation` call**, whether `group.cancelled`
+> is already logged (`=== 1`), which kills that mutation. See
+> `tests/unit/orchestration/service/group-service.test.ts`.
 
 - [ ] **Step 1: Record a pre-change oracle baseline (scratch, for comparison)**
 
@@ -457,46 +491,55 @@ Expected: the new ordering test FAILS — under the current in-loop dispatch, `c
 
 Rationale (must hold): for a task that propagates (running), `closedPackageId` is `undefined` and the task is non-terminal, so the handoff and reconcile branches are skipped — propagation and the awaited tails are mutually exclusive per task, so moving `startWorkerCancellation` to after `applyCancellationRequest` returns is byte-identical for a single task.
 
-- [ ] **Step 4b: Rewrite `cancelGroup`** — in `group-service.ts`, replace the loop body + trailing log (lines 131-170) so the detached dispatch happens AFTER the log:
+- [ ] **Step 4b: Rewrite `cancelGroup`** — in `group-service.ts`, replace the loop body + trailing log so the detached dispatch happens AFTER the log **and is fired in a `finally`** so a partial failure still propagates already-committed cancellations:
 
 ```ts
     const cancelledTaskIds: string[] = [];
     const skippedTaskIds: string[] = [];
     const toPropagate: OrchestrationTaskRecord[] = [];
 
-    // Phase 1 — apply every task's cancellation STATE transition (awaited, deterministic). Do NOT
-    // fire the detached worker-cancellation chains here: collect the tasks that need one.
-    for (const task of summary.tasks) {
-      if (this.kernel.isTerminalStatus(task.status)) {
-        skippedTaskIds.push(task.taskId);
-        continue;
+    let refreshed: OrchestrationGroupSummary;
+    try {
+      // Phase 1 — apply every task's cancellation STATE transition (awaited, deterministic).
+      // applyCancellationRequest commits each task's cancelRequestedAt in its own atomic save, so a
+      // task processed before a later task's save fails is ALREADY persisted as cancel-requested —
+      // and a retry would see shouldPropagate === false for it and never fire its chain. So the
+      // finally must propagate the committed requests on THIS attempt.
+      for (const task of summary.tasks) {
+        if (this.kernel.isTerminalStatus(task.status)) {
+          skippedTaskIds.push(task.taskId);
+          continue;
+        }
+        const { task: cancelled, shouldPropagate } = await this.cancellation.applyCancellationRequest({
+          taskId: task.taskId,
+          coordinatorSession: input.coordinatorSession,
+        });
+        cancelledTaskIds.push(task.taskId);
+        if (shouldPropagate) {
+          toPropagate.push(cancelled);
+        }
       }
-      const { task: cancelled, shouldPropagate } = await this.cancellation.applyCancellationRequest({
-        taskId: task.taskId,
-        coordinatorSession: input.coordinatorSession,
+
+      const summaryAfter = await this.getGroupSummary(input);
+      if (!summaryAfter) {
+        throw new Error(`group "${input.groupId}" does not exist`);
+      }
+      refreshed = summaryAfter;
+
+      // group.cancelled is logged with ZERO detached chains yet fired, so every chain's terminal
+      // saveState provably follows it — a structural invariant, not a microtask-hop budget (#150).
+      this.kernel.logEvent("orchestration.group.cancelled", "group cancelled", {
+        ...this.kernel.groupContext(refreshed.group),
+        cancelled_count: cancelledTaskIds.length,
+        skipped_count: skippedTaskIds.length,
       });
-      cancelledTaskIds.push(task.taskId);
-      if (shouldPropagate) {
-        toPropagate.push(cancelled);
+    } finally {
+      // Fire the detached chains for every request committed so far. Happy path: after the loop,
+      // refresh, and log — order unchanged. Partial failure: still propagates already-committed
+      // requests, so none is stranded and the caller's retry only finishes the uncommitted rest.
+      for (const task of toPropagate) {
+        this.cancellation.startWorkerCancellation(task);
       }
-    }
-
-    const refreshed = await this.getGroupSummary(input);
-    if (!refreshed) {
-      throw new Error(`group "${input.groupId}" does not exist`);
-    }
-
-    // group.cancelled is logged with ZERO detached chains yet fired, so every chain's terminal
-    // saveState provably follows it — a structural invariant, not a microtask-hop budget (#150).
-    this.kernel.logEvent("orchestration.group.cancelled", "group cancelled", {
-      ...this.kernel.groupContext(refreshed.group),
-      cancelled_count: cancelledTaskIds.length,
-      skipped_count: skippedTaskIds.length,
-    });
-
-    // Phase 2 — NOW fire the detached worker-cancellation chains, after the log.
-    for (const task of toPropagate) {
-      this.cancellation.startWorkerCancellation(task);
     }
 
     return {
@@ -506,7 +549,12 @@ Rationale (must hold): for a task that propagates (running), `closedPackageId` i
     };
 ```
 
-Ensure `OrchestrationTaskRecord` is imported in `group-service.ts` (it already imports it — see the file header). Remove the now-obsolete hop-budget comment block that preceded the old `requestTaskCancellation` call, replacing it with the phase-1/phase-2 comments above.
+Ensure `OrchestrationTaskRecord` and `OrchestrationGroupSummary` are imported in `group-service.ts` (it already imports both — see the file header). Remove the now-obsolete hop-budget comment block that preceded the old `requestTaskCancellation` call.
+
+> Add a partial-failure regression test (two running tasks with assigned workers; the second's
+> save fails; then a retry) asserting **both** workers are cancelled exactly once (count per
+> taskId, not a `Set`, so a double-dispatch can't hide). Deleting the `finally` strands t1 and
+> reddens it. See `tests/unit/orchestration/service/group-service.test.ts`.
 
 - [ ] **Step 5: Run the new ordering test + the two service tests**
 

--- a/docs/superpowers/plans/2026-07-14-orchestration-followup-hardening.md
+++ b/docs/superpowers/plans/2026-07-14-orchestration-followup-hardening.md
@@ -1,0 +1,538 @@
+# Orchestration Follow-up Hardening (#149 / #150 / #151) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three orchestration follow-up debts deferred from Track 3 — a false-positive reentrancy guard (#149), a hop-lucky cancel-group log ordering (#150), and a delivery-blind active-message fallback (#151).
+
+**Architecture:** Three independent changes in `src/orchestration/service/`. #149 makes the kernel reentrancy guard precise (per-invocation token). #150 defers `cancelGroup`'s detached dispatch past its log to make the order provable. #151 makes the active-message fallback prefer the last *delivered* message. No shared files across the three.
+
+**Tech Stack:** TypeScript, Bun test runner (`TZ=UTC bun test <file>`, per file). Core only — no packages, no protocol, no web.
+
+## Global Constraints
+
+- Public method signatures of `OrchestrationService` and the leaf services are preserved (these are internal refactors + one behaviour fix). New methods may be added.
+- The frozen orchestration golden oracle (`tests/unit/orchestration/golden/`) must stay green. A fixture may be re-recorded ONLY for a deliberate, explained order change (never silently) per the policy in `orchestration-golden.test.ts` — behaviour-preserving changes do NOT re-record.
+- Behaviour-changing tasks assert the NEW behaviour + regression-guard the surviving contracts, and every new invariant carries a mutation-live test (reverting the fix reddens exactly it).
+- Run each touched test file individually under `TZ=UTC` (never a whole-dir bun run — state leak).
+- Spec: `docs/superpowers/specs/2026-07-14-orchestration-followup-hardening-design.md`.
+
+---
+
+### Task 1: #149 — precise kernel reentrancy guard (per-invocation token)
+
+**Files:**
+- Modify: `src/orchestration/service/orchestration-state-kernel.ts:28-52`
+- Test: `tests/unit/orchestration/service/orchestration-state-kernel.test.ts`
+
+**Interfaces:**
+- Consumes: `AsyncMutex` (`src/orchestration/async-mutex.ts`), `AsyncLocalStorage` (node).
+- Produces: `OrchestrationStateKernel.mutate<T>(critical: () => Promise<T>): Promise<T>` — signature unchanged; the guard now throws only for genuinely re-entrant (would-deadlock) nesting, and a detached chain that outlives its section may call `mutate` without throwing.
+
+- [ ] **Step 1: Write the failing test** — append to `orchestration-state-kernel.test.ts`:
+
+```ts
+test("mutate lets a chain that OUTLIVES its critical section call mutate (no false deadlock throw)", async () => {
+  // A promise created inside a critical section inherits the ALS store. Firing it detached and
+  // letting it call mutate AFTER the section returns is not re-entrant — the mutex is free — so
+  // it must run, not throw. The old boolean guard threw here (invisible to every prior test).
+  const kernel = new OrchestrationStateKernel({});
+  let detached!: Promise<string>;
+  await kernel.mutate(async () => {
+    // Created inside the section, but deliberately NOT awaited here — it runs after this returns.
+    detached = (async () => {
+      await Promise.resolve(); // ensure it resumes after the enclosing section has settled
+      return await kernel.mutate(async () => "ran-after");
+    })();
+  });
+  expect(await detached).toBe("ran-after");
+});
+
+test("mutate still throws on a genuinely nested (awaited) reentry", async () => {
+  const kernel = new OrchestrationStateKernel({});
+  let message = "no throw";
+  await kernel.mutate(async () => {
+    try {
+      await kernel.mutate(async () => "inner"); // awaited inside → would deadlock → must throw
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+  });
+  expect(message).toContain("nested mutate()");
+});
+```
+
+- [ ] **Step 2: Run to verify the first new test FAILS** (the boolean guard throws):
+
+Run: `TZ=UTC bun test tests/unit/orchestration/service/orchestration-state-kernel.test.ts`
+Expected: the "outlives its critical section" test FAILS (throws "nested mutate() …"); the others pass.
+
+- [ ] **Step 3: Replace the guard with a per-invocation token** — in `orchestration-state-kernel.ts`, replace the field declaration and the `mutate` method (lines 28-52 region):
+
+```ts
+export class OrchestrationStateKernel {
+  /** Token of the enclosing critical section, propagated through the async context. A per-call
+   *  token (not a bare `true`) lets `mutate` tell a genuinely re-entrant caller — still inside
+   *  the section that is running right now — apart from a chain that merely INHERITED a section's
+   *  context but outlives it. A bare boolean also can't distinguish a concurrent queued caller,
+   *  which is why this was never a plain field. */
+  private readonly held = new AsyncLocalStorage<object>();
+  /** Token of the critical section whose `critical()` body is executing at this instant, or
+   *  undefined when none. The mutex serialises sections, so at most one is ever live. */
+  private runningToken: object | undefined;
+  private readonly stateMutex: AsyncMutex;
+
+  constructor(
+    private readonly deps: KernelDeps,
+    stateMutex?: AsyncMutex,
+  ) {
+    this.stateMutex = stateMutex ?? new AsyncMutex();
+  }
+
+  /** AsyncMutex is strict-FIFO and non-reentrant: an AWAITED nested run() awaits a tail promise
+   *  that only resolves after the outer section returns → deadlock. Throw for that case only.
+   *  A detached chain that inherited a section's token but reaches mutate() AFTER that section
+   *  has returned (`enclosing !== runningToken`) is not re-entrant — it queues on the now-free
+   *  mutex and runs. */
+  async mutate<T>(critical: () => Promise<T>): Promise<T> {
+    const enclosing = this.held.getStore();
+    if (enclosing !== undefined && enclosing === this.runningToken) {
+      throw new Error(
+        "orchestration: nested mutate() detected — this would deadlock the state mutex. " +
+          "Call the collaborator outside the critical section.",
+      );
+    }
+    const token = {};
+    return await this.stateMutex.run(async () => {
+      const previous = this.runningToken; // always undefined (mutex serialises); restored defensively
+      this.runningToken = token;
+      try {
+        return await this.held.run(token, critical);
+      } finally {
+        this.runningToken = previous;
+      }
+    });
+  }
+```
+
+- [ ] **Step 4: Run to verify all kernel tests PASS**
+
+Run: `TZ=UTC bun test tests/unit/orchestration/service/orchestration-state-kernel.test.ts`
+Expected: PASS (serialisation, awaited-nested-throws, injected-mutex, appendTaskEvent, and both new tests).
+
+- [ ] **Step 5: Run the full orchestration suite to confirm no regression**
+
+Run: `TZ=UTC bun test tests/unit/orchestration/golden/orchestration-golden.test.ts tests/unit/orchestration/golden/orchestration-concurrency.test.ts tests/unit/orchestration/orchestration-service.test.ts`
+Expected: PASS (the guard only *narrows* when it throws; no existing code relies on the removed throw).
+
+- [ ] **Step 6: Note the obsolete scratch scan (no git action)** — `.superpowers/sdd/detached-in-critical-section.mjs` is git-ignored scratch and not a CI gate; the token fix makes detached-after-completion `mutate` safe, so the scan is obsolete. Nothing to commit; do not add it. (Optionally delete the local file.)
+
+- [ ] **Step 7: Typecheck + commit**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+```bash
+git add src/orchestration/service/orchestration-state-kernel.ts tests/unit/orchestration/service/orchestration-state-kernel.test.ts
+git commit -m "fix(orchestration): make the kernel reentrancy guard precise (#149)"
+```
+
+---
+
+### Task 2: #151 — delivery-aware active-message fallback
+
+**Files:**
+- Modify: `src/orchestration/service/human-question-service.ts:592-595`
+- Test: `tests/unit/orchestration/service/human-question-service.test.ts`
+
+**Interfaces:**
+- Consumes: `OrchestrationHumanQuestionPackageRecord.messages[]` where each message carries `deliveredAt?: string` (`orchestration-types.ts:182`); `deliveredAt !== undefined` ⇒ delivered.
+- Produces: `getActiveHumanQuestionPackage` — same return type; the fallback now prefers the last delivered message.
+
+- [ ] **Step 1: Write the failing test** — append to `human-question-service.test.ts` (reuse the `makeService` helper already at the top of the file):
+
+```ts
+test("active-message fallback prefers the last DELIVERED message over a later failed one (#151)", async () => {
+  // awaitingReplyMessageId is absent. msg-2 (the last message) FAILED delivery (no deliveredAt);
+  // msg-1 was delivered. The active message must be msg-1, not the undelivered msg-2.
+  const initialState = createEmptyState();
+  initialState.orchestration.coordinatorQuestionState["coord-1"] = {
+    activePackageId: "pkg-1",
+    queuedQuestions: [],
+  };
+  initialState.orchestration.humanQuestionPackages["pkg-1"] = {
+    packageId: "pkg-1",
+    coordinatorSession: "coord-1",
+    status: "active",
+    createdAt: "2026-04-13T09:00:00.000Z",
+    updatedAt: "2026-04-13T09:00:00.000Z",
+    initialTaskIds: [],
+    openTaskIds: [],
+    resolvedTaskIds: [],
+    messages: [
+      { messageId: "msg-1", kind: "initial", promptText: "delivered one", createdAt: "2026-04-13T09:00:00.000Z", deliveredAt: "2026-04-13T09:00:01.000Z" },
+      { messageId: "msg-2", kind: "follow_up", promptText: "failed one", createdAt: "2026-04-13T09:30:00.000Z" },
+    ],
+  };
+  const { humanQuestions } = makeService(initialState);
+  const active = await humanQuestions.getActiveHumanQuestionPackage("coord-1");
+  expect(active?.promptText).toBe("delivered one");
+});
+
+test("active-message fallback returns the last message when NOTHING is delivered yet (#151 edge)", async () => {
+  const initialState = createEmptyState();
+  initialState.orchestration.coordinatorQuestionState["coord-2"] = {
+    activePackageId: "pkg-2",
+    queuedQuestions: [],
+  };
+  initialState.orchestration.humanQuestionPackages["pkg-2"] = {
+    packageId: "pkg-2",
+    coordinatorSession: "coord-2",
+    status: "active",
+    createdAt: "2026-04-13T09:00:00.000Z",
+    updatedAt: "2026-04-13T09:00:00.000Z",
+    initialTaskIds: [],
+    openTaskIds: [],
+    resolvedTaskIds: [],
+    messages: [
+      { messageId: "m1", kind: "initial", promptText: "pending, not delivered", createdAt: "2026-04-13T09:00:00.000Z" },
+    ],
+  };
+  const { humanQuestions } = makeService(initialState);
+  const active = await humanQuestions.getActiveHumanQuestionPackage("coord-2");
+  expect(active?.promptText).toBe("pending, not delivered"); // last resort: not hidden
+});
+```
+
+- [ ] **Step 2: Run to verify the first new test FAILS**
+
+Run: `TZ=UTC bun test tests/unit/orchestration/service/human-question-service.test.ts`
+Expected: the "prefers the last DELIVERED" test FAILS (current fallback returns "failed one"); the edge test passes; the existing priority test passes.
+
+- [ ] **Step 3: Apply the fallback change** — in `human-question-service.ts`, replace the `activeMessage` derivation (lines 592-595):
+
+```ts
+    const activeMessage =
+      (packageRecord.awaitingReplyMessageId
+        ? packageRecord.messages.find((message) => message.messageId === packageRecord.awaitingReplyMessageId)
+        : undefined)
+      // #151: prefer the last DELIVERED message so a failed later message no longer shadows a
+      // delivered earlier one. Fall back to the last message only when nothing has delivered yet,
+      // so a pending-but-undelivered question is surfaced (not hidden) to the coordinator prompt.
+      ?? [...packageRecord.messages].reverse().find((message) => message.deliveredAt !== undefined)
+      ?? packageRecord.messages.at(-1);
+```
+
+- [ ] **Step 4: Run to verify all human-question tests PASS**
+
+Run: `TZ=UTC bun test tests/unit/orchestration/service/human-question-service.test.ts`
+Expected: PASS (priority regression test, both new tests, and the rest).
+
+- [ ] **Step 5: Run the orchestration-service + golden suites (guard against a consumer relying on the old fallback)**
+
+Run: `TZ=UTC bun test tests/unit/orchestration/orchestration-service.test.ts tests/unit/orchestration/golden/orchestration-golden.test.ts tests/unit/orchestration/build-coordinator-prompt.test.ts`
+Expected: PASS. If any fixture asserting an undelivered-last-message active package reddens, it encoded the bug — update it to the delivered-preferring behaviour and note it in the report (do not silently re-record a golden fixture; escalate if it is a frozen oracle fixture rather than a plain assertion).
+
+- [ ] **Step 6: Typecheck + commit**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+```bash
+git add src/orchestration/service/human-question-service.ts tests/unit/orchestration/service/human-question-service.test.ts
+git commit -m "fix(orchestration): active-message fallback prefers the last delivered message (#151)"
+```
+
+---
+
+### Task 3: #150 — provable cancelGroup ordering via deferred dispatch
+
+**Files:**
+- Modify: `src/orchestration/service/task-cancellation-service.ts:37-143` (extract `applyCancellationRequest`)
+- Modify: `src/orchestration/service/group-service.ts:119-177` (cancelGroup: apply-all → log → dispatch-all)
+- Test: `tests/unit/orchestration/service/group-service.test.ts`, `tests/unit/orchestration/service/task-cancellation-service.test.ts`
+- Verify (do not blindly re-record): `tests/unit/orchestration/golden/orchestration-golden.test.ts`
+
+**Interfaces:**
+- Produces (new public on `TaskCancellationService`):
+  `applyCancellationRequest(input: CancelTaskInput): Promise<{ task: OrchestrationTaskRecord; shouldPropagate: boolean }>` —
+  the awaited, deterministic part of `requestTaskCancellation` (state mutate + `cancel_requested`
+  log + queued-question handoff + post-terminal reconcile), WITHOUT firing the detached
+  `startWorkerCancellation`. The caller fires `startWorkerCancellation(task)` when `shouldPropagate`.
+- Consumes (already public): `TaskCancellationService.startWorkerCancellation(task)`.
+- `requestTaskCancellation` keeps its signature and behaviour (now implemented via `applyCancellationRequest`).
+
+- [ ] **Step 1: Record a pre-change oracle baseline (scratch, for comparison)**
+
+Run: `TZ=UTC bun test tests/unit/orchestration/golden/orchestration-golden.test.ts 2>&1 | tail -3`
+Expected: PASS. Note the pass count — this is the green baseline the change must preserve (the `creategroup-then-cancelgroup-cancels-its-tasks-*` fixtures included).
+
+- [ ] **Step 2: Write the failing ordering test** — append to `group-service.test.ts`. The mutation-live witness: the detached chain's `cancelWorkerTask` port call must land AFTER the `group.cancelled` log. Under the current code the chain is fired inside the loop, so `cancelWorkerTask` is recorded before `group.cancelled`; the fix defers the fire until after the log. Also add the `GoldenHarness` type to the existing `../golden/golden-harness` import, and a local drain helper (the frozen harness exports no `waitForLogEvent`):
+
+```ts
+// Local copy — the frozen golden harness exports nothing (see its header comment).
+async function waitForLogEvent(harness: GoldenHarness, eventName: string, afterIndex: number): Promise<void> {
+  for (let i = 0; i < 40; i += 1) {
+    if (
+      harness.calls.slice(afterIndex).some(
+        (c) => c.port.startsWith("logger.") && (c.request as { event?: unknown } | null)?.event === eventName,
+      )
+    ) return;
+    await Bun.sleep(0);
+  }
+  throw new Error(`waitForLogEvent timed out waiting for "${eventName}"`);
+}
+
+test("cancelGroup logs group.cancelled BEFORE dispatching any worker-cancellation chain (#150)", async () => {
+  const initialState = createEmptyState();
+  initialState.orchestration.groups["g1"] = {
+    groupId: "g1",
+    coordinatorSession: "backend:coordinator",
+    title: "T",
+    createdAt: "2026-04-13T09:00:00.000Z",
+    updatedAt: "2026-04-13T09:00:00.000Z",
+  };
+  initialState.orchestration.tasks["t-run"] = {
+    taskId: "t-run",
+    sourceHandle: "worker:w1",
+    sourceKind: "worker",
+    coordinatorSession: "backend:coordinator",
+    workspace: "backend",
+    targetAgent: "codex",
+    task: "do the thing",
+    status: "running",
+    summary: "",
+    resultText: "",
+    groupId: "g1",
+    workerSession: "w1-session", // assigned worker → cancellation propagates a detached chain
+    createdAt: "2026-04-13T09:00:00.000Z",
+    updatedAt: "2026-04-13T09:00:00.000Z",
+  };
+
+  const harness = makeGoldenHarness({ initialState });
+  const kernel = new OrchestrationStateKernel({ logger: harness.deps.logger });
+  const workerSessions = new WorkerSessionManager(harness.deps, kernel);
+  const questionFlow = new QuestionFlowCore(harness.deps, kernel);
+  const cancellation = new TaskCancellationService(
+    {
+      now: harness.deps.now,
+      createId: harness.deps.createId,
+      loadState: harness.deps.loadState,
+      saveState: harness.deps.saveState,
+      cancelWorkerTask: harness.deps.cancelWorkerTask,
+      interruptWorkerTask: harness.deps.interruptWorkerTask,
+      wakeCoordinatorSession: harness.deps.wakeCoordinatorSession,
+    },
+    kernel,
+    workerSessions,
+    questionFlow,
+  );
+  const groups = new GroupService(
+    {
+      now: harness.deps.now,
+      createId: harness.deps.createId,
+      loadState: harness.deps.loadState,
+      saveState: harness.deps.saveState,
+      config: harness.deps.config,
+    },
+    kernel,
+    cancellation,
+  );
+
+  const before = harness.calls.length;
+  await groups.cancelGroup({ groupId: "g1", coordinatorSession: "backend:coordinator" });
+  await waitForLogEvent(harness, "orchestration.task.cancel_completed", before); // drain the detached chain
+
+  const window = harness.calls.slice(before);
+  const groupCancelledIdx = window.findIndex(
+    (c) => c.port.startsWith("logger.") && (c.request as { event?: unknown } | null)?.event === "orchestration.group.cancelled",
+  );
+  const dispatchIdx = window.findIndex((c) => c.port === "cancelWorkerTask");
+  expect(groupCancelledIdx).toBeGreaterThanOrEqual(0);
+  expect(dispatchIdx).toBeGreaterThan(groupCancelledIdx); // dispatch deferred until AFTER the log — provable, not hop-luck
+});
+```
+
+If the real `OrchestrationGroupRecord` / `OrchestrationTaskRecord` shapes require additional required fields, add them minimally (mirror the `makeTask` literal already in this file, plus `workerSession`); tsc will name any missing field.
+
+- [ ] **Step 3: Run to verify the new test FAILS** under the current hop-lucky code
+
+Run: `TZ=UTC bun test tests/unit/orchestration/service/group-service.test.ts`
+Expected: the new ordering test FAILS — under the current in-loop dispatch, `cancelWorkerTask` is recorded before `group.cancelled`. (If it passes by hop-luck, the fix in Step 4 makes it structural regardless.)
+
+- [ ] **Step 4a: Extract `applyCancellationRequest`** — in `task-cancellation-service.ts`, refactor `requestTaskCancellation` (lines 37-143). Keep the `mutate` closure byte-for-byte; move everything after it into a new public method, and drop the detached fire from it:
+
+```ts
+  async requestTaskCancellation(input: CancelTaskInput): Promise<OrchestrationTaskRecord> {
+    const { task, shouldPropagate } = await this.applyCancellationRequest(input);
+    if (shouldPropagate) {
+      // Detached, bare, unawaited on purpose: this fires a chain that opens its own mutate,
+      // so it must stay outside every critical section. It is fired LAST (after applyCancellationRequest's
+      // awaited tail) so a group caller can log group.cancelled before any chain begins.
+      this.startWorkerCancellation(task);
+    }
+    return task;
+  }
+
+  /** The awaited, deterministic half of a cancellation: state transition + cancel_requested log +
+   *  queued-question handoff + post-terminal reconcile — WITHOUT firing the detached
+   *  startWorkerCancellation chain. `requestTaskCancellation` fires it right after; `cancelGroup`
+   *  fires it AFTER its group.cancelled log so the log/save order is provable, not hop-lucky (#150). */
+  async applyCancellationRequest(input: CancelTaskInput): Promise<{ task: OrchestrationTaskRecord; shouldPropagate: boolean }> {
+    const prepared = await this.kernel.mutate(async () => {
+      // ---- unchanged mutate body from the current requestTaskCancellation (lines 39-102) ----
+      const state = await this.deps.loadState();
+      const task = state.orchestration.tasks[input.taskId];
+      if (!task) {
+        throw new Error(`task "${input.taskId}" does not exist`);
+      }
+      if (input.sourceHandle === undefined && input.coordinatorSession === undefined) {
+        throw new Error(`task "${input.taskId}" cancel request must include sourceHandle or coordinatorSession`);
+      }
+      if (input.sourceHandle !== undefined && task.sourceHandle !== input.sourceHandle) {
+        throw new Error(`task "${input.taskId}" belongs to source "${task.sourceHandle}", not "${input.sourceHandle}"`);
+      }
+      if (
+        input.coordinatorSession !== undefined &&
+        !sameCoordinatorSession(task.coordinatorSession, input.coordinatorSession)
+      ) {
+        throw new Error(`task "${input.taskId}" belongs to coordinator "${task.coordinatorSession}", not "${input.coordinatorSession}"`);
+      }
+      if (this.kernel.isTerminalStatus(task.status)) {
+        return { task: { ...task }, shouldPropagate: false, closedPackageId: undefined as string | undefined };
+      }
+      const now = this.deps.now().toISOString();
+      if (task.status === "running") {
+        const shouldPropagate = task.cancelRequestedAt === undefined;
+        task.cancelRequestedAt = task.cancelRequestedAt ?? now;
+        task.updatedAt = now;
+        if (shouldPropagate) {
+          this.kernel.appendTaskEvent(task, now, "cancel_requested", { status: task.status, message: "Cancellation requested" });
+        }
+        this.kernel.bumpGroupUpdated(state, task.groupId, now);
+        await this.deps.saveState(state);
+        return { task: { ...task }, shouldPropagate, closedPackageId: undefined as string | undefined };
+      }
+      const closedPackageId = this.questionFlow.detachTaskFromQuestionFlows(state, task, now);
+      const wasNeedsConfirmation = task.status === "needs_confirmation";
+      task.status = "cancelled";
+      if (wasNeedsConfirmation && task.summary.trim().length === 0) {
+        task.summary = "rejected";
+      }
+      task.openQuestion = undefined;
+      task.cancelRequestedAt = task.cancelRequestedAt ?? now;
+      task.cancelCompletedAt = now;
+      task.lastCancelError = undefined;
+      task.updatedAt = now;
+      this.kernel.appendTaskEvent(task, now, "status_changed", { status: "cancelled", message: "Task cancelled" });
+      this.kernel.bumpGroupUpdated(state, task.groupId, now);
+      await this.deps.saveState(state);
+      return { task: { ...task }, shouldPropagate: false, closedPackageId };
+      // ---- end unchanged mutate body ----
+    });
+
+    this.kernel.logEvent(
+      "orchestration.task.cancel_requested",
+      "task cancellation requested",
+      this.kernel.taskContext(prepared.task),
+    );
+
+    if (prepared.closedPackageId) {
+      await this.questionFlow.handoffQueuedQuestions(prepared.task.coordinatorSession, prepared.closedPackageId);
+    }
+
+    // I-2: non-running cancel transitions directly to a terminal state without launchWorkerTurn.
+    // Fire reconcile so the ephemeral acpx session closes and queued parallel tasks drain.
+    if (!prepared.shouldPropagate && this.kernel.isTerminalStatus(prepared.task.status)) {
+      try {
+        await this.workerSessions.reconcileParallelSlots();
+      } catch (error) {
+        this.kernel.logEvent("orchestration.parallel.reconcile_failed", "reconcile failed after non-running cancel", {
+          taskId: prepared.task.taskId,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return { task: prepared.task, shouldPropagate: prepared.shouldPropagate };
+  }
+```
+
+Rationale (must hold): for a task that propagates (running), `closedPackageId` is `undefined` and the task is non-terminal, so the handoff and reconcile branches are skipped — propagation and the awaited tails are mutually exclusive per task, so moving `startWorkerCancellation` to after `applyCancellationRequest` returns is byte-identical for a single task.
+
+- [ ] **Step 4b: Rewrite `cancelGroup`** — in `group-service.ts`, replace the loop body + trailing log (lines 131-170) so the detached dispatch happens AFTER the log:
+
+```ts
+    const cancelledTaskIds: string[] = [];
+    const skippedTaskIds: string[] = [];
+    const toPropagate: OrchestrationTaskRecord[] = [];
+
+    // Phase 1 — apply every task's cancellation STATE transition (awaited, deterministic). Do NOT
+    // fire the detached worker-cancellation chains here: collect the tasks that need one.
+    for (const task of summary.tasks) {
+      if (this.kernel.isTerminalStatus(task.status)) {
+        skippedTaskIds.push(task.taskId);
+        continue;
+      }
+      const { task: cancelled, shouldPropagate } = await this.cancellation.applyCancellationRequest({
+        taskId: task.taskId,
+        coordinatorSession: input.coordinatorSession,
+      });
+      cancelledTaskIds.push(task.taskId);
+      if (shouldPropagate) {
+        toPropagate.push(cancelled);
+      }
+    }
+
+    const refreshed = await this.getGroupSummary(input);
+    if (!refreshed) {
+      throw new Error(`group "${input.groupId}" does not exist`);
+    }
+
+    // group.cancelled is logged with ZERO detached chains yet fired, so every chain's terminal
+    // saveState provably follows it — a structural invariant, not a microtask-hop budget (#150).
+    this.kernel.logEvent("orchestration.group.cancelled", "group cancelled", {
+      ...this.kernel.groupContext(refreshed.group),
+      cancelled_count: cancelledTaskIds.length,
+      skipped_count: skippedTaskIds.length,
+    });
+
+    // Phase 2 — NOW fire the detached worker-cancellation chains, after the log.
+    for (const task of toPropagate) {
+      this.cancellation.startWorkerCancellation(task);
+    }
+
+    return {
+      summary: refreshed,
+      cancelledTaskIds,
+      skippedTaskIds,
+    };
+```
+
+Ensure `OrchestrationTaskRecord` is imported in `group-service.ts` (it already imports it — see the file header). Remove the now-obsolete hop-budget comment block that preceded the old `requestTaskCancellation` call, replacing it with the phase-1/phase-2 comments above.
+
+- [ ] **Step 5: Run the new ordering test + the two service tests**
+
+Run: `TZ=UTC bun test tests/unit/orchestration/service/group-service.test.ts tests/unit/orchestration/service/task-cancellation-service.test.ts`
+Expected: PASS, including the new ordering test now holding structurally.
+
+- [ ] **Step 6: Run the frozen golden oracle and handle per policy**
+
+Run: `TZ=UTC bun test tests/unit/orchestration/golden/orchestration-golden.test.ts tests/unit/orchestration/golden/orchestration-concurrency.test.ts`
+Expected: PASS. The design predicts the `creategroup-then-cancelgroup-cancels-its-tasks-*` fixtures stay green (group.cancelled already preceded the detached saves). **If a fixture reddens:** confirm the diff is exactly the intended ordering change — all per-task `cancel_requested` effects, then `group.cancelled`, then the detached `cancel_completed`/save effects — and that no state VALUE changed. Only then re-record ONLY those two fixtures (`-result.json` + `-state.json`) from the candidate, and record in the task report the precise before/after ordering and why it is the provable-correct order. Do NOT re-record any other fixture. If any state value (not just order) changed, STOP — that is an unintended behaviour change.
+
+- [ ] **Step 7: Full orchestration + typecheck**
+
+Run: `TZ=UTC bun test tests/unit/orchestration/orchestration-service.test.ts` then `npx tsc --noEmit`
+Expected: PASS / clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/orchestration/service/task-cancellation-service.ts src/orchestration/service/group-service.ts tests/unit/orchestration/service/group-service.test.ts tests/unit/orchestration/service/task-cancellation-service.test.ts
+# include re-recorded fixtures ONLY if Step 6 required them
+git commit -m "fix(orchestration): make cancelGroup log/save order provable via deferred dispatch (#150)"
+```
+
+---
+
+## Post-implementation (controller)
+
+After all three tasks: whole-branch review, then push + open PR `fix/orchestration-critsec-hardening` → `main`, closing #149 / #150 / #151.

--- a/docs/superpowers/specs/2026-07-14-orchestration-followup-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-14-orchestration-followup-hardening-design.md
@@ -58,34 +58,42 @@ calls `mutate` afterward simply queues on the mutex and runs — that is exactly
 own). Detecting the false-positive construct treats the symptom; making the guard precise removes
 it.
 
-### Design — per-invocation token + `runningToken`
+### Design — per-invocation token + `runningToken`, decided one microtask later
 
-Replace the boolean store with a per-invocation **token**, and track the token of the critical
-section **currently executing** in a plain field:
+Replace the boolean store with a per-invocation **token** (`sectionContext`, renamed from `held`
+since it now carries a context token, not a boolean), and track the token of the critical section
+**currently executing** in a plain field. The catch: a genuine awaited-nested call and a detached
+`.then` chain that runs *just after* its section returns both observe `enclosing === runningToken`
+at the instant of the call — the section's teardown (`runningToken` reset in the `mutate` `finally`)
+is enqueued one microtask behind, and a single-hop `.then` resumes just ahead of it. They only
+become distinguishable one microtask later. So a *suspected* re-entry yields once and re-checks:
 
 ```ts
-private readonly held = new AsyncLocalStorage<object>();
-/** Token of the critical section whose `critical()` body is executing right now (undefined
- *  when none). The mutex serialises sections, so at most one token is ever live. */
+private readonly sectionContext = new AsyncLocalStorage<object>();
+/** Token of the critical section whose `critical()` body is executing right now (undefined when
+ *  none). Reset in mutate's `finally`, one microtask after the body returns. */
 private runningToken: object | undefined;
 
 async mutate<T>(critical: () => Promise<T>): Promise<T> {
-  const enclosing = this.held.getStore();
-  // Re-entrant ONLY when this call is made from inside the section that is currently running.
-  // A chain that inherited a token but outlives its section (enclosing !== runningToken) is not
-  // re-entrant — it queues on the free mutex and runs, no deadlock.
+  const enclosing = this.sectionContext.getStore();
   if (enclosing !== undefined && enclosing === this.runningToken) {
-    throw new Error(
-      "orchestration: nested mutate() detected — this would deadlock the state mutex. " +
-        "Call the collaborator outside the critical section.",
-    );
+    // Suspected re-entry: yield one microtask so a RETURNING section's finally can clear
+    // runningToken, then re-check. Still the running token ⇒ that section never returned (it is
+    // awaiting us) ⇒ real deadlock ⇒ throw. Cleared ⇒ detached-after-completion ⇒ let it run.
+    await Promise.resolve();
+    if (this.runningToken === enclosing) {
+      throw new Error(
+        "orchestration: nested mutate() detected — this would deadlock the state mutex. " +
+          "Call the collaborator outside the critical section.",
+      );
+    }
   }
   const token = {};
   return await this.stateMutex.run(async () => {
     const previous = this.runningToken;      // always undefined (mutex serialises); restored defensively
     this.runningToken = token;
     try {
-      return await this.held.run(token, critical);
+      return await this.sectionContext.run(token, critical);
     } finally {
       this.runningToken = previous;
     }
@@ -96,22 +104,26 @@ async mutate<T>(critical: () => Promise<T>): Promise<T> {
 Correctness across the four cases (preserving the original ALS design intent — see the
 kernel's existing comment that a plain boolean would wrongly reject a *concurrent* queued caller):
 
-| Case | `enclosing` | `runningToken` at call | Result | Correct? |
+| Case | `enclosing` | `runningToken` after the yield | Result | Correct? |
 |---|---|---|---|---|
-| Separate concurrent caller (queued on mutex) | `undefined` (own context) | live token of the running one | no throw → queues | ✓ (unchanged) |
-| Awaited nested `mutate` inside a section | that section's token | same token (still running) | **throw** | ✓ would deadlock |
-| Detached chain, calls `mutate` **after** its section returns (the #149 case) | old token | `undefined` (or a different section) | **no throw** → runs | ✓ **fixed** |
+| Separate concurrent caller (queued on mutex) | `undefined` (own context) | live token of the running one | no throw → queues (no yield taken) | ✓ (unchanged) |
+| Awaited nested `mutate` inside a section | that section's token | **same token** — the section is blocked awaiting this call, so its `finally` never ran | **throw** | ✓ would deadlock |
+| Detached chain, calls `mutate` **after** its section returns — incl. the single-`.then` same-microtask shape the issue names | old token | **cleared** — the returned section's `finally` ran during the yield | **no throw** → runs | ✓ **fixed** |
 | Detached chain awaited by its section (really nested) | that token | same token | throw | ✓ would deadlock |
 
-The check runs *before* queuing on the mutex, so the awaited-nested case still throws instead of
-hanging. `runningToken` is read/written only synchronously and the mutex serialises sections, so
-there is no torn read.
+The re-check runs *before* queuing on the mutex, so the awaited-nested case still throws instead of
+hanging. A single yield suffices for the filed single-`.then` shape (its callback was enqueued
+during the body's synchronous run, strictly before the section's own teardown); a multi-hop chain
+resumes strictly later, by which point `runningToken` is already cleared and the suspected-re-entry
+branch is never even entered.
 
-**Residual (documented, not the filed hazard):** a truly-detached chain that reaches its `mutate`
-call *while its enclosing section is still executing* (a long-running outer that spawned but did
-not await it) still throws. That construct races the very section that created it and is worth
-flagging; the filed hazard is specifically the **"日后调用" / after-completion** chain, which this
-fixes.
+**Residual (documented, narrowed — not the filed hazard):** a detached chain that reaches its
+`mutate` call *while its enclosing section is still suspended mid-body* (a long-running outer that
+spawned it and then `await`s something else before returning) still throws after the yield, because
+`runningToken` is genuinely still set. That construct issues a `mutate` into a section that has not
+returned — an ambiguous, racy shape — so conservatively throwing there is defensible. The filed
+hazard is the **"日后调用" / after-completion** chain (the section has returned), which this now
+handles even in the tightest same-microtask case.
 
 ### Consequence for the lexical scan
 
@@ -146,25 +158,38 @@ The only thing that races `group.cancelled` is the **detached** chain. Make its 
 
 Extract the awaited, deterministic part of `requestTaskCancellation` from the detached fire:
 
-- **New private** `applyTaskCancellationRequest(input): Promise<{ task, shouldPropagate, closedPackageId }>`
-  — everything `requestTaskCancellation` does today **except** the `startWorkerCancellation(task)`
-  call: the `mutate` (state transition + `saveState` #1), the `orchestration.task.cancel_requested`
-  log, the `handoffQueuedQuestions` (when `closedPackageId`), and the post-non-running reconcile.
-  Returns `shouldPropagate` so the caller can fire the detached chain.
-- **`requestTaskCancellation`** (public, unchanged behaviour) = `applyTaskCancellationRequest` then
-  `if (shouldPropagate) this.startWorkerCancellation(task)`. For a running task, `closedPackageId`
-  is undefined and the task is non-terminal, so today only `startWorkerCancellation` fires — i.e.
+- **New public** `applyCancellationRequest(input): Promise<{ task, shouldPropagate }>` — everything
+  `requestTaskCancellation` does today **except** the `startWorkerCancellation(task)` call: the
+  `mutate` (state transition + `saveState` #1), the `orchestration.task.cancel_requested` log, the
+  `handoffQueuedQuestions` (keyed on the `closedPackageId` computed *inside* the `mutate`), and the
+  post-non-running reconcile. Returns `{ task, shouldPropagate }` — `closedPackageId` stays private
+  to the `mutate`'s result and never crosses the method boundary. (Public, not private: `cancelGroup`
+  lives in a different service and calls it across the one-way GroupService→TaskCancellationService
+  edge.)
+- **`requestTaskCancellation`** (public, unchanged behaviour) = `applyCancellationRequest` then
+  `if (shouldPropagate) this.startWorkerCancellation(task)`. For a running task the task is
+  non-terminal and `closedPackageId` is undefined, so only `startWorkerCancellation` fires — i.e.
   propagation and the handoff/reconcile tails are already mutually exclusive per task, so no
   reordering within a single task.
 - **`cancelGroup`**:
-  1. Phase 1 — loop, `await applyTaskCancellationRequest(...)` per non-terminal task, collecting
-     the tasks whose `shouldPropagate` is true.
+  1. Phase 1 — loop, `await applyCancellationRequest(...)` per non-terminal task, collecting the
+     tasks whose `shouldPropagate` is true into `toPropagate`.
   2. Re-read the summary and log `orchestration.group.cancelled` (unchanged fields).
-  3. Phase 2 — `for (const task of toPropagate) this.startWorkerCancellation(task)`.
+  3. Fire `startWorkerCancellation` for every task in `toPropagate`.
 
 Now `group.cancelled` is logged with **zero** detached chains yet fired, so every chain's
 `saveState` #2 provably follows it. The hop-budget comments are replaced with a one-line statement
 of the invariant.
+
+**Partial-failure atomicity.** `applyCancellationRequest` commits each task's `cancelRequestedAt`
+in its own atomic `saveState`. If a *later* task's save throws mid-loop, an earlier task is already
+persisted as cancel-requested — and a retry of `cancelGroup` sees `shouldPropagate === false` for it
+(already requested), so it would never fire its worker-cancellation chain. To close that gap, steps
+1–3 run inside a `try` whose `finally` fires `startWorkerCancellation` for everything collected in
+`toPropagate` so far. On the happy path the `finally` runs after the loop, the re-read, and the log
+— order unchanged (the provable invariant holds). On a partial failure it still propagates the
+already-committed requests on *this* attempt (skipping only the log), so no committed cancellation
+is ever stranded and the caller's retry only needs to finish the tasks that never committed.
 
 ### Golden-oracle handling
 

--- a/docs/superpowers/specs/2026-07-14-orchestration-followup-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-14-orchestration-followup-hardening-design.md
@@ -1,0 +1,274 @@
+# Orchestration Follow-up Hardening (#149 / #150 / #151) — Design Spec
+
+Date: 2026-07-14
+Branch: `fix/orchestration-critsec-hardening` (from `origin/main`)
+Track: closes the three orchestration follow-up issues consciously deferred out of the
+2026-07 architecture audit's Track 3 (core-maintainability refactor). All three are
+`src/orchestration/service/` leaf-service debts left when the 4539-line facade was split.
+
+## Context
+
+Three independent debts, one subsystem:
+
+- **#149** — the reentrancy guard on `OrchestrationStateKernel.mutate()` is enforced/audited
+  only by an *incomplete lexical scan*; a detached async that outlives its critical section
+  throws in prod but is invisible to tests.
+- **#150** — `GroupService.cancelGroup`'s `group.cancelled` log is ordered against a detached
+  cancellation chain's `saveState` **only by microtask-hop count**, not a provable invariant.
+- **#151** — `HumanQuestionService.getActiveHumanQuestionPackage` falls back to the last message
+  *regardless of delivery*, so a failed-delivery message can shadow a delivered one.
+
+They share no files beyond the service directory and can be implemented/reviewed as three
+independent task-groups in one plan → one PR.
+
+---
+
+## #149 — Reentrancy guard: dissolve the hazard, don't merely detect it
+
+### The hazard (as filed)
+
+`OrchestrationStateKernel.mutate()` is non-reentrant. Today it guards with an
+`AsyncLocalStorage<true>` (`orchestration-state-kernel.ts:32,44-52`):
+
+```ts
+private readonly held = new AsyncLocalStorage<true>();
+async mutate<T>(critical) {
+  if (this.held.getStore()) throw new Error("nested mutate() … would deadlock …");
+  return await this.stateMutex.run(() => this.held.run(true, critical));
+}
+```
+
+A promise **created inside** a critical section (via `.then()` or `void f()`) inherits the ALS
+store. If it calls `mutate()` **later** — after the enclosing section has already returned — it
+throws, even though the mutex is now free and there is **no deadlock**. Every test passes because
+no test drives such a chain into `mutate`. The filed issue asks for a checker/call-graph/ESLint
+rule to *detect* this construct; the lexical scan
+(`.superpowers/sdd/detached-in-critical-section.mjs`, untracked scratch, not wired to CI) can only
+see the literal closure body, not helpers it calls.
+
+### Why detection is the wrong fix
+
+The boolean guard is a **false-positive machine**: it rejects a chain purely because that chain
+was *born* inside a critical section, not because it is actually re-entering a live one. The
+genuine deadlock is narrower — it happens only when the enclosing section is **still the active
+critical section** when the nested `mutate` is reached (the classic awaited-nested case, where the
+outer awaits the inner and the mutex tail never resolves). A chain that outlives its section and
+calls `mutate` afterward simply queues on the mutex and runs — that is exactly how the existing
+`startWorkerCancellation` detached chains already work (fired *outside* `mutate`, opening their
+own). Detecting the false-positive construct treats the symptom; making the guard precise removes
+it.
+
+### Design — per-invocation token + `runningToken`
+
+Replace the boolean store with a per-invocation **token**, and track the token of the critical
+section **currently executing** in a plain field:
+
+```ts
+private readonly held = new AsyncLocalStorage<object>();
+/** Token of the critical section whose `critical()` body is executing right now (undefined
+ *  when none). The mutex serialises sections, so at most one token is ever live. */
+private runningToken: object | undefined;
+
+async mutate<T>(critical: () => Promise<T>): Promise<T> {
+  const enclosing = this.held.getStore();
+  // Re-entrant ONLY when this call is made from inside the section that is currently running.
+  // A chain that inherited a token but outlives its section (enclosing !== runningToken) is not
+  // re-entrant — it queues on the free mutex and runs, no deadlock.
+  if (enclosing !== undefined && enclosing === this.runningToken) {
+    throw new Error(
+      "orchestration: nested mutate() detected — this would deadlock the state mutex. " +
+        "Call the collaborator outside the critical section.",
+    );
+  }
+  const token = {};
+  return await this.stateMutex.run(async () => {
+    const previous = this.runningToken;      // always undefined (mutex serialises); restored defensively
+    this.runningToken = token;
+    try {
+      return await this.held.run(token, critical);
+    } finally {
+      this.runningToken = previous;
+    }
+  });
+}
+```
+
+Correctness across the four cases (preserving the original ALS design intent — see the
+kernel's existing comment that a plain boolean would wrongly reject a *concurrent* queued caller):
+
+| Case | `enclosing` | `runningToken` at call | Result | Correct? |
+|---|---|---|---|---|
+| Separate concurrent caller (queued on mutex) | `undefined` (own context) | live token of the running one | no throw → queues | ✓ (unchanged) |
+| Awaited nested `mutate` inside a section | that section's token | same token (still running) | **throw** | ✓ would deadlock |
+| Detached chain, calls `mutate` **after** its section returns (the #149 case) | old token | `undefined` (or a different section) | **no throw** → runs | ✓ **fixed** |
+| Detached chain awaited by its section (really nested) | that token | same token | throw | ✓ would deadlock |
+
+The check runs *before* queuing on the mutex, so the awaited-nested case still throws instead of
+hanging. `runningToken` is read/written only synchronously and the mutex serialises sections, so
+there is no torn read.
+
+**Residual (documented, not the filed hazard):** a truly-detached chain that reaches its `mutate`
+call *while its enclosing section is still executing* (a long-running outer that spawned but did
+not await it) still throws. That construct races the very section that created it and is worth
+flagging; the filed hazard is specifically the **"日后调用" / after-completion** chain, which this
+fixes.
+
+### Consequence for the lexical scan
+
+With detached-after-completion `mutate` now safe, there is nothing left to detect: a chain that
+outlives its section is a supported pattern (identical to `startWorkerCancellation`). The scratch
+scan `.superpowers/sdd/detached-in-critical-section.mjs` is removed as obsolete (it is untracked
+and not a CI gate, so removal is local cleanup; if git tracks it, delete it in the PR).
+
+---
+
+## #150 — `cancelGroup`: make the log/save order a provable invariant
+
+### The debt
+
+`GroupService.cancelGroup` (`group-service.ts:119-177`) loops over a group's tasks calling
+`this.cancellation.requestTaskCancellation(...)` directly (not via the facade), then logs
+`orchestration.group.cancelled`. For a **running** task, `requestTaskCancellation`
+(`task-cancellation-service.ts:37-143`) mutates state (`saveState` #1, awaited) and then fires a
+**detached** `startWorkerCancellation` chain (bare `void (async …)()`, `:262-307`) whose final
+`completeTaskCancellation` `saveState` (#2) lands an unknown number of microtask hops later.
+
+The order between that detached `saveState` #2 and `cancelGroup`'s synchronous `group.cancelled`
+log is held **only by hop slack** — the code comments (`group-service.ts:137-160`,
+`task-cancellation-service.ts:112-121`) explicitly warn that a single extra `await` anywhere flips
+the `cancelGroup cancels its tasks` golden fixture, and that `cancelGroup` is the only one of 30
+fixtures that can observe it. That is a fragile, unprovable contract.
+
+### Design — defer the detached dispatch past the log
+
+The only thing that races `group.cancelled` is the **detached** chain. Make its firing happen
+**after** the log, so the order is structural, not hop-lucky.
+
+Extract the awaited, deterministic part of `requestTaskCancellation` from the detached fire:
+
+- **New private** `applyTaskCancellationRequest(input): Promise<{ task, shouldPropagate, closedPackageId }>`
+  — everything `requestTaskCancellation` does today **except** the `startWorkerCancellation(task)`
+  call: the `mutate` (state transition + `saveState` #1), the `orchestration.task.cancel_requested`
+  log, the `handoffQueuedQuestions` (when `closedPackageId`), and the post-non-running reconcile.
+  Returns `shouldPropagate` so the caller can fire the detached chain.
+- **`requestTaskCancellation`** (public, unchanged behaviour) = `applyTaskCancellationRequest` then
+  `if (shouldPropagate) this.startWorkerCancellation(task)`. For a running task, `closedPackageId`
+  is undefined and the task is non-terminal, so today only `startWorkerCancellation` fires — i.e.
+  propagation and the handoff/reconcile tails are already mutually exclusive per task, so no
+  reordering within a single task.
+- **`cancelGroup`**:
+  1. Phase 1 — loop, `await applyTaskCancellationRequest(...)` per non-terminal task, collecting
+     the tasks whose `shouldPropagate` is true.
+  2. Re-read the summary and log `orchestration.group.cancelled` (unchanged fields).
+  3. Phase 2 — `for (const task of toPropagate) this.startWorkerCancellation(task)`.
+
+Now `group.cancelled` is logged with **zero** detached chains yet fired, so every chain's
+`saveState` #2 provably follows it. The hop-budget comments are replaced with a one-line statement
+of the invariant.
+
+### Golden-oracle handling
+
+This is behaviour-preserving in outcomes (same state transitions, same worker cancellations, same
+counts) but it **may** shift the recorded log/save *interleaving*. Per the Track-3 protocol:
+
+- Record a pre-change baseline of the affected fixtures in a scratch worktree.
+- Because `group.cancelled` already precedes the detached `saveState`s today (per the comments),
+  the frozen `cancelGroup cancels its tasks` fixture is **expected to stay byte-identical**; if it
+  shifts, the new order is the provable one and the fixture is re-baselined with a written
+  justification (never blindly re-recorded).
+- The full frozen 185-oracle / 30-fixture suite must stay green.
+
+---
+
+## #151 — `getActiveHumanQuestionPackage`: delivery-aware fallback
+
+### The bug
+
+`human-question-service.ts:592-595`:
+
+```ts
+const activeMessage =
+  (packageRecord.awaitingReplyMessageId
+    ? packageRecord.messages.find((m) => m.messageId === packageRecord.awaitingReplyMessageId)
+    : undefined) ?? packageRecord.messages.at(-1);
+```
+
+When `awaitingReplyMessageId` is absent, this returns `messages.at(-1)` — the last message,
+**delivered or not**. A message record carries `deliveredAt?: string` (`orchestration-types.ts:182`);
+a failed delivery leaves it unset. So a failed *later* message shadows a successfully *delivered*
+earlier one — the deleted `getLatestDeliveredPackageMessage` had the correct "last **delivered**"
+semantics.
+
+### Decision (behaviour) — prefer the last delivered message
+
+```ts
+const activeMessage =
+  (packageRecord.awaitingReplyMessageId
+    ? packageRecord.messages.find((m) => m.messageId === packageRecord.awaitingReplyMessageId)
+    : undefined)
+  ?? [...packageRecord.messages].reverse().find((m) => m.deliveredAt !== undefined)
+  ?? packageRecord.messages.at(-1);
+```
+
+Priority: (1) the `awaitingReplyMessageId` target (unchanged); (2) the **last delivered** message;
+(3) as a last resort when *nothing* has delivered yet, the last message (current behaviour).
+
+**Why not return `null` when nothing is delivered** (the issue's third option): the method also
+feeds `build-coordinator-prompt.ts:121`, which reminds the coordinator of its pending human
+question. Returning `null` for a pending-but-undelivered question would *hide* it from the
+coordinator and risks breaking consumers that expect a non-null active package while one exists.
+The delivery-specific fields (`deliveredChatKey`, `deliveryAccountId`, `deliveredAt`) are already
+conditionally spread, so an undelivered last-resort message exposes no stale delivery data. This
+fix removes the concrete harm (a delivered message being shadowed) at minimal risk.
+
+---
+
+## Verification
+
+Behaviour-changing where noted, so: assert the new behaviour + regression-guard the surviving
+contracts (not byte-identical golden, except #150's frozen oracle which must stay green).
+
+**#149** (`tests/unit/orchestration/service/orchestration-state-kernel.test.ts`):
+- Awaited nested `mutate` inside a critical section still throws the deadlock error.
+- A separate concurrent caller queued on the mutex still runs (no false throw) — regression guard
+  for the original ALS design intent.
+- **New behaviour:** a chain created inside a critical section that calls `mutate` *after* that
+  section has returned now **succeeds** (previously threw). This is the mutation-live proof: revert
+  to the boolean guard and this test reddens.
+- Serialisation/atomicity of concurrent mutates is unchanged.
+
+**#150** (`tests/unit/orchestration/service/group-service.test.ts` +
+`task-cancellation-service.test.ts` + the frozen orchestration oracle):
+- `group.cancelled` is logged before any deferred `startWorkerCancellation` chain's `saveState`
+  (assert order directly, no longer hop-dependent).
+- `requestTaskCancellation` single-task behaviour unchanged (still fires `startWorkerCancellation`
+  for a running task; same logs/saves).
+- The frozen 185-oracle / 30-fixture suite stays green; any re-baselined fixture is justified.
+- Regression: cancelled/skipped task-id partitioning and per-task state transitions unchanged.
+
+**#151** (`tests/unit/orchestration/service/human-question-service.test.ts`):
+- `awaitingReplyMessageId` target still wins (priority regression guard — the #147 test).
+- **New behaviour:** with `awaitingReplyMessageId` absent and a later message undelivered but an
+  earlier one delivered, the **delivered** message is returned (mutation-live: revert to
+  `messages.at(-1)` and this reddens).
+- Last-resort: no message delivered yet → last message returned (documents the retained edge).
+
+## Risk & rollout
+
+- **#149** is the core concurrency primitive; the full 351-test orchestration suite exercises it.
+  The change only *narrows* when the guard throws (no current code relies on the removed throw), so
+  no existing test should change; one new test proves the loosened case.
+- **#150** touches the most hop-sensitive code in the suite; the frozen oracle + the new explicit
+  ordering assertion are the safety net. Prod robustness is preserved — the detached chains stay
+  detached (worker IPC is never awaited by `cancelGroup`).
+- **#151** is a two-line fallback change guarded by an existing priority test plus new
+  delivery-aware tests.
+
+## Out of scope
+
+- Rewriting `startWorkerCancellation` into a fully awaitable staged API (#150 suggested it as an
+  alternative — the defer approach achieves the provable invariant without changing the detached
+  prod semantics, so the heavier API is unnecessary).
+- A general call-graph/ESLint enforcement of "no detached mutate" (#149 suggested it — dissolving
+  the hazard makes enforcement unnecessary; a truly-detached mutate is now a supported pattern).
+- Returning `null` from `getActiveHumanQuestionPackage` (#151 third option — rejected above).

--- a/src/orchestration/service/group-service.ts
+++ b/src/orchestration/service/group-service.ts
@@ -1,9 +1,11 @@
 // src/orchestration/service/group-service.ts
 // Group lifecycle: create groups, summarize them, list them, and cancel a whole group.
 // One collaborator beyond the kernel: TaskCancellationService (one-way edge). Only
-// `createGroup` opens `kernel.mutate`; `cancelGroup` opens none — it delegates each task
-// cancellation to `requestTaskCancellation`, which opens its own. The kernel guard is
-// non-reentrant, so wrapping `cancelGroup` in a mutate would throw on the first task.
+// `createGroup` opens `kernel.mutate`; `cancelGroup` opens none — it delegates each task's
+// state transition to `applyCancellationRequest` (which opens its own mutate), then fires
+// any detached worker-cancellation chains itself, after logging `group.cancelled`. The
+// kernel guard is non-reentrant, so wrapping `cancelGroup` in a mutate would throw on the
+// first task.
 import { sameCoordinatorSession } from "../coordinator-identity";
 import type {
   OrchestrationGroupRecord,
@@ -127,47 +129,42 @@ export class GroupService {
 
     const cancelledTaskIds: string[] = [];
     const skippedTaskIds: string[] = [];
+    const toPropagate: OrchestrationTaskRecord[] = [];
 
+    // Phase 1 — apply every task's cancellation STATE transition (awaited, deterministic). Do NOT
+    // fire the detached worker-cancellation chains here: collect the tasks that need one.
     for (const task of summary.tasks) {
       if (this.kernel.isTerminalStatus(task.status)) {
         skippedTaskIds.push(task.taskId);
         continue;
       }
-
-      // Call the collaborator directly, never the facade's requestTaskCancellation
-      // delegation. `requestTaskCancellation` fires a detached startWorkerCancellation
-      // chain, and the `group.cancelled` log below is ordered against that chain's
-      // saveState only by how many microtask hops separate them. The ordering is stable
-      // by slack, not by a tick invariant: ONE extra hop anywhere in that resolution
-      // chain reorders them and turns the `cancelGroup cancels its tasks` golden fixture
-      // red — the frozen 185-test oracle stays green, so the fixture is the only witness.
-      //
-      // Going through the facade is one way to add that hop; an `await` added inside
-      // `requestTaskCancellation` after the detached fire is another, and it flips the
-      // same fixture without touching this file. Both were measured. So the constraint
-      // is not "avoid facade indirection here" — it is that the whole chain from this
-      // call site through `startWorkerCancellation` carries a hop budget of zero.
-      // cancelGroup is the only one of the 30 fixtures that can see it.
-      await this.cancellation.requestTaskCancellation({
+      const { task: cancelled, shouldPropagate } = await this.cancellation.applyCancellationRequest({
         taskId: task.taskId,
         coordinatorSession: input.coordinatorSession,
       });
       cancelledTaskIds.push(task.taskId);
+      if (shouldPropagate) {
+        toPropagate.push(cancelled);
+      }
     }
 
-    // Everything from here to the end runs synchronously against the detached chains
-    // fired above. Adding an `await` — telemetry, an extra state read, anything — moves
-    // the `group.cancelled` log past their saveState and flips the golden fixture.
     const refreshed = await this.getGroupSummary(input);
     if (!refreshed) {
       throw new Error(`group "${input.groupId}" does not exist`);
     }
 
+    // group.cancelled is logged with ZERO detached chains yet fired, so every chain's terminal
+    // saveState provably follows it — a structural invariant, not a microtask-hop budget (#150).
     this.kernel.logEvent("orchestration.group.cancelled", "group cancelled", {
       ...this.kernel.groupContext(refreshed.group),
       cancelled_count: cancelledTaskIds.length,
       skipped_count: skippedTaskIds.length,
     });
+
+    // Phase 2 — NOW fire the detached worker-cancellation chains, after the log.
+    for (const task of toPropagate) {
+      this.cancellation.startWorkerCancellation(task);
+    }
 
     return {
       summary: refreshed,

--- a/src/orchestration/service/group-service.ts
+++ b/src/orchestration/service/group-service.ts
@@ -131,39 +131,53 @@ export class GroupService {
     const skippedTaskIds: string[] = [];
     const toPropagate: OrchestrationTaskRecord[] = [];
 
-    // Phase 1 — apply every task's cancellation STATE transition (awaited, deterministic). Do NOT
-    // fire the detached worker-cancellation chains here: collect the tasks that need one.
-    for (const task of summary.tasks) {
-      if (this.kernel.isTerminalStatus(task.status)) {
-        skippedTaskIds.push(task.taskId);
-        continue;
+    let refreshed: OrchestrationGroupSummary;
+    try {
+      // Phase 1 — apply every task's cancellation STATE transition (awaited, deterministic). Do
+      // NOT fire the detached worker-cancellation chains here: collect the tasks that need one.
+      // applyCancellationRequest commits each task's `cancelRequestedAt` in its own atomic save,
+      // so a task processed before a later task's save fails is ALREADY persisted as
+      // cancel-requested. A retry of cancelGroup would then see `shouldPropagate === false` for it
+      // and never fire its chain — so committed requests must be propagated here, on this attempt,
+      // even if a later task throws. The `finally` guarantees that (see below).
+      for (const task of summary.tasks) {
+        if (this.kernel.isTerminalStatus(task.status)) {
+          skippedTaskIds.push(task.taskId);
+          continue;
+        }
+        const { task: cancelled, shouldPropagate } = await this.cancellation.applyCancellationRequest({
+          taskId: task.taskId,
+          coordinatorSession: input.coordinatorSession,
+        });
+        cancelledTaskIds.push(task.taskId);
+        if (shouldPropagate) {
+          toPropagate.push(cancelled);
+        }
       }
-      const { task: cancelled, shouldPropagate } = await this.cancellation.applyCancellationRequest({
-        taskId: task.taskId,
-        coordinatorSession: input.coordinatorSession,
+
+      const summaryAfter = await this.getGroupSummary(input);
+      if (!summaryAfter) {
+        throw new Error(`group "${input.groupId}" does not exist`);
+      }
+      refreshed = summaryAfter;
+
+      // group.cancelled is logged with ZERO detached chains yet fired, so every chain's terminal
+      // saveState provably follows it — a structural invariant, not a microtask-hop budget (#150).
+      // Reached only on the happy path; a partial failure skips the log but still propagates below.
+      this.kernel.logEvent("orchestration.group.cancelled", "group cancelled", {
+        ...this.kernel.groupContext(refreshed.group),
+        cancelled_count: cancelledTaskIds.length,
+        skipped_count: skippedTaskIds.length,
       });
-      cancelledTaskIds.push(task.taskId);
-      if (shouldPropagate) {
-        toPropagate.push(cancelled);
+    } finally {
+      // Fire the detached worker-cancellation chains for every request committed so far. On the
+      // happy path this runs after the loop, the refresh, and the log — order unchanged. On a
+      // partial failure (a later task's save threw) it still fires the already-committed chains,
+      // so a committed cancel-request is never stranded without its worker cancellation, and the
+      // caller's retry (which skips the now-requested task) does not need to re-fire it.
+      for (const task of toPropagate) {
+        this.cancellation.startWorkerCancellation(task);
       }
-    }
-
-    const refreshed = await this.getGroupSummary(input);
-    if (!refreshed) {
-      throw new Error(`group "${input.groupId}" does not exist`);
-    }
-
-    // group.cancelled is logged with ZERO detached chains yet fired, so every chain's terminal
-    // saveState provably follows it — a structural invariant, not a microtask-hop budget (#150).
-    this.kernel.logEvent("orchestration.group.cancelled", "group cancelled", {
-      ...this.kernel.groupContext(refreshed.group),
-      cancelled_count: cancelledTaskIds.length,
-      skipped_count: skippedTaskIds.length,
-    });
-
-    // Phase 2 — NOW fire the detached worker-cancellation chains, after the log.
-    for (const task of toPropagate) {
-      this.cancellation.startWorkerCancellation(task);
     }
 
     return {

--- a/src/orchestration/service/human-question-service.ts
+++ b/src/orchestration/service/human-question-service.ts
@@ -592,7 +592,12 @@ export class HumanQuestionService {
     const activeMessage =
       (packageRecord.awaitingReplyMessageId
         ? packageRecord.messages.find((message) => message.messageId === packageRecord.awaitingReplyMessageId)
-        : undefined) ?? packageRecord.messages.at(-1);
+        : undefined)
+      // #151: prefer the last DELIVERED message so a failed later message no longer shadows a
+      // delivered earlier one. Fall back to the last message only when nothing has delivered yet,
+      // so a pending-but-undelivered question is surfaced (not hidden) to the coordinator prompt.
+      ?? [...packageRecord.messages].reverse().find((message) => message.deliveredAt !== undefined)
+      ?? packageRecord.messages.at(-1);
     if (!activeMessage) {
       return null;
     }

--- a/src/orchestration/service/orchestration-state-kernel.ts
+++ b/src/orchestration/service/orchestration-state-kernel.ts
@@ -26,10 +26,15 @@ export interface KernelDeps {
 }
 
 export class OrchestrationStateKernel {
-  /** Marks the async context that currently owns the state mutex. A boolean would be
-   *  observed as `true` by a concurrent (non-nested) caller queued in `await previous`,
-   *  and would reject it; reentrancy is a property of the async context, not of time. */
-  private readonly held = new AsyncLocalStorage<true>();
+  /** Token of the enclosing critical section, propagated through the async context. A per-call
+   *  token (not a bare `true`) lets `mutate` tell a genuinely re-entrant caller — still inside
+   *  the section that is running right now — apart from a chain that merely INHERITED a section's
+   *  context but outlives it. A bare boolean also can't distinguish a concurrent queued caller,
+   *  which is why this was never a plain field. */
+  private readonly held = new AsyncLocalStorage<object>();
+  /** Token of the critical section whose `critical()` body is executing at this instant, or
+   *  undefined when none. The mutex serialises sections, so at most one is ever live. */
+  private runningToken: object | undefined;
   private readonly stateMutex: AsyncMutex;
 
   constructor(
@@ -39,16 +44,29 @@ export class OrchestrationStateKernel {
     this.stateMutex = stateMutex ?? new AsyncMutex();
   }
 
-  /** AsyncMutex is strict-FIFO and non-reentrant: a nested run() awaits a tail promise
-   *  that only resolves after the outer critical section returns. Throw instead of hanging. */
+  /** AsyncMutex is strict-FIFO and non-reentrant: an AWAITED nested run() awaits a tail promise
+   *  that only resolves after the outer section returns → deadlock. Throw for that case only.
+   *  A detached chain that inherited a section's token but reaches mutate() AFTER that section
+   *  has returned (`enclosing !== runningToken`) is not re-entrant — it queues on the now-free
+   *  mutex and runs. */
   async mutate<T>(critical: () => Promise<T>): Promise<T> {
-    if (this.held.getStore()) {
+    const enclosing = this.held.getStore();
+    if (enclosing !== undefined && enclosing === this.runningToken) {
       throw new Error(
         "orchestration: nested mutate() detected — this would deadlock the state mutex. " +
           "Call the collaborator outside the critical section.",
       );
     }
-    return await this.stateMutex.run(() => this.held.run(true, critical));
+    const token = {};
+    return await this.stateMutex.run(async () => {
+      const previous = this.runningToken; // always undefined (mutex serialises); restored defensively
+      this.runningToken = token;
+      try {
+        return await this.held.run(token, critical);
+      } finally {
+        this.runningToken = previous;
+      }
+    });
   }
 
   normalizeGroupId(groupId: string | undefined): string | undefined {

--- a/src/orchestration/service/orchestration-state-kernel.ts
+++ b/src/orchestration/service/orchestration-state-kernel.ts
@@ -26,24 +26,15 @@ export interface KernelDeps {
 }
 
 export class OrchestrationStateKernel {
-  /** Token of the enclosing critical section, propagated through the async context. A per-call
-   *  token (not a bare `true`) lets `mutate` tell a genuinely re-entrant caller — still inside
-   *  the section that is running right now — apart from a chain that merely INHERITED a section's
-   *  context but outlives it. A bare boolean also can't distinguish a concurrent queued caller,
-   *  which is why this was never a plain field.
-   *
-   *  Known limitation of ALS-token detection: an inherited token is only observed as "not
-   *  re-entrant" once the enclosing section's async machinery has FULLY settled — in practice,
-   *  past a macrotask boundary, NOT merely once the section's `critical()` body has returned.
-   *  A detached chain that inherited the token and resumes within the SAME microtask turn as the
-   *  section's return still sees `runningToken` set (its first-resumption microtask is enqueued
-   *  before the section's `finally` reset runs) and is (conservatively) rejected as re-entrant.
-   *  This is a false positive, but a safe one: such a chain is racing the section's teardown so
-   *  tightly that treating it as nested costs nothing real. See the "OUTLIVES its critical
-   *  section" test, which must cross a macrotask boundary for exactly this reason. */
-  private readonly held = new AsyncLocalStorage<object>();
+  /** Async-context token of the enclosing critical section. A per-call token (not a bare `true`)
+   *  lets `mutate` tell a genuinely re-entrant caller — still inside the section running right
+   *  now — apart from a chain that merely INHERITED a section's context but runs after it. A bare
+   *  boolean also can't distinguish a concurrent queued caller, which is why this was never a
+   *  plain field. Named for what it holds: the currently-open section's context token. */
+  private readonly sectionContext = new AsyncLocalStorage<object>();
   /** Token of the critical section whose `critical()` body is executing at this instant, or
-   *  undefined when none. The mutex serialises sections, so at most one is ever live. */
+   *  undefined when none. The mutex serialises sections, so at most one is ever live. It is reset
+   *  in `mutate`'s `finally`, which runs one microtask after the `critical()` body returns. */
   private runningToken: object | undefined;
   private readonly stateMutex: AsyncMutex;
 
@@ -54,26 +45,42 @@ export class OrchestrationStateKernel {
     this.stateMutex = stateMutex ?? new AsyncMutex();
   }
 
-  /** AsyncMutex is strict-FIFO and non-reentrant: an AWAITED nested run() awaits a tail promise
-   *  that only resolves after the outer section returns → deadlock. Throw for that case only.
-   *  A detached chain that inherited a section's token but reaches mutate() once that section has
-   *  FULLY settled (`enclosing !== runningToken`, which holds only past a macrotask boundary —
-   *  see the `held` field's note on why a same-microtask-turn resumption is still rejected) is not
-   *  re-entrant — it queues on the now-free mutex and runs. */
+  /** The state mutex is strict-FIFO and non-reentrant: an AWAITED nested `run()` awaits a tail
+   *  that only resolves after the outer section returns → deadlock. That case must throw. A
+   *  DETACHED chain (`.then` / `void f()`) created inside a section but reaching `mutate` AFTER
+   *  the section's `critical()` returned is NOT re-entrant — the mutex is (about to be) free, so
+   *  it must run.
+   *
+   *  Both collapse to the same observable state at the instant of the call — `enclosing ===
+   *  runningToken` — because the outer section's teardown (`runningToken` reset in its `finally`)
+   *  is enqueued one microtask behind, and a single-hop `.then` detached chain resumes just ahead
+   *  of it. They become distinguishable one microtask later: a section that has RETURNED will have
+   *  run its `finally` and cleared `runningToken`; a section still open and awaiting THIS call will
+   *  not. So on a suspected re-entry we yield exactly once and re-check — converting a genuine
+   *  deadlock into a loud throw, while letting the after-completion detached chain (the filed #149
+   *  hazard) proceed. A single yield suffices for the filed single-`.then` shape; a multi-hop
+   *  chain resumes strictly later, by which point `runningToken` is already cleared and the
+   *  suspected-re-entry branch is never entered. */
   async mutate<T>(critical: () => Promise<T>): Promise<T> {
-    const enclosing = this.held.getStore();
+    const enclosing = this.sectionContext.getStore();
     if (enclosing !== undefined && enclosing === this.runningToken) {
-      throw new Error(
-        "orchestration: nested mutate() detected — this would deadlock the state mutex. " +
-          "Call the collaborator outside the critical section.",
-      );
+      // Suspected re-entry. Yield one microtask so a RETURNING outer section's `finally` resets
+      // `runningToken` before we decide. If the token we inherited is still the running one, that
+      // section never returned — it is awaiting us — so this is a real deadlock: throw.
+      await Promise.resolve();
+      if (this.runningToken === enclosing) {
+        throw new Error(
+          "orchestration: nested mutate() detected — this would deadlock the state mutex. " +
+            "Call the collaborator outside the critical section.",
+        );
+      }
     }
     const token = {};
     return await this.stateMutex.run(async () => {
       const previous = this.runningToken; // always undefined (mutex serialises); restored defensively
       this.runningToken = token;
       try {
-        return await this.held.run(token, critical);
+        return await this.sectionContext.run(token, critical);
       } finally {
         this.runningToken = previous;
       }

--- a/src/orchestration/service/orchestration-state-kernel.ts
+++ b/src/orchestration/service/orchestration-state-kernel.ts
@@ -30,7 +30,17 @@ export class OrchestrationStateKernel {
    *  token (not a bare `true`) lets `mutate` tell a genuinely re-entrant caller — still inside
    *  the section that is running right now — apart from a chain that merely INHERITED a section's
    *  context but outlives it. A bare boolean also can't distinguish a concurrent queued caller,
-   *  which is why this was never a plain field. */
+   *  which is why this was never a plain field.
+   *
+   *  Known limitation of ALS-token detection: an inherited token is only observed as "not
+   *  re-entrant" once the enclosing section's async machinery has FULLY settled — in practice,
+   *  past a macrotask boundary, NOT merely once the section's `critical()` body has returned.
+   *  A detached chain that inherited the token and resumes within the SAME microtask turn as the
+   *  section's return still sees `runningToken` set (its first-resumption microtask is enqueued
+   *  before the section's `finally` reset runs) and is (conservatively) rejected as re-entrant.
+   *  This is a false positive, but a safe one: such a chain is racing the section's teardown so
+   *  tightly that treating it as nested costs nothing real. See the "OUTLIVES its critical
+   *  section" test, which must cross a macrotask boundary for exactly this reason. */
   private readonly held = new AsyncLocalStorage<object>();
   /** Token of the critical section whose `critical()` body is executing at this instant, or
    *  undefined when none. The mutex serialises sections, so at most one is ever live. */
@@ -46,9 +56,10 @@ export class OrchestrationStateKernel {
 
   /** AsyncMutex is strict-FIFO and non-reentrant: an AWAITED nested run() awaits a tail promise
    *  that only resolves after the outer section returns → deadlock. Throw for that case only.
-   *  A detached chain that inherited a section's token but reaches mutate() AFTER that section
-   *  has returned (`enclosing !== runningToken`) is not re-entrant — it queues on the now-free
-   *  mutex and runs. */
+   *  A detached chain that inherited a section's token but reaches mutate() once that section has
+   *  FULLY settled (`enclosing !== runningToken`, which holds only past a macrotask boundary —
+   *  see the `held` field's note on why a same-microtask-turn resumption is still rejected) is not
+   *  re-entrant — it queues on the now-free mutex and runs. */
   async mutate<T>(critical: () => Promise<T>): Promise<T> {
     const enclosing = this.held.getStore();
     if (enclosing !== undefined && enclosing === this.runningToken) {

--- a/src/orchestration/service/task-cancellation-service.ts
+++ b/src/orchestration/service/task-cancellation-service.ts
@@ -35,6 +35,21 @@ export class TaskCancellationService {
   }
 
   async requestTaskCancellation(input: CancelTaskInput): Promise<OrchestrationTaskRecord> {
+    const { task, shouldPropagate } = await this.applyCancellationRequest(input);
+    if (shouldPropagate) {
+      // Detached, bare, unawaited on purpose: this fires a chain that opens its own mutate,
+      // so it must stay outside every critical section. It is fired LAST (after applyCancellationRequest's
+      // awaited tail) so a group caller can log group.cancelled before any chain begins.
+      this.startWorkerCancellation(task);
+    }
+    return task;
+  }
+
+  /** The awaited, deterministic half of a cancellation: state transition + cancel_requested log +
+   *  queued-question handoff + post-terminal reconcile — WITHOUT firing the detached
+   *  startWorkerCancellation chain. `requestTaskCancellation` fires it right after; `cancelGroup`
+   *  fires it AFTER its group.cancelled log so the log/save order is provable, not hop-lucky (#150). */
+  async applyCancellationRequest(input: CancelTaskInput): Promise<{ task: OrchestrationTaskRecord; shouldPropagate: boolean }> {
     const prepared = await this.kernel.mutate(async () => {
       const state = await this.deps.loadState();
       const task = state.orchestration.tasks[input.taskId];
@@ -108,26 +123,12 @@ export class TaskCancellationService {
       this.kernel.taskContext(prepared.task),
     );
 
-    if (prepared.shouldPropagate) {
-      // Bare and unawaited on purpose: no `await`, no `void`, no `.catch()`. This fires a
-      // detached chain that later opens its own mutate, so it must stay outside every
-      // critical section. GroupService.cancelGroup depends on how many microtask hops
-      // this chain takes before its saveState — see the comment there. Do not change how
-      // this statement is written or where it sits.
-      //
-      // Nor may you add an `await` between here and this method's return. Measured: a bare
-      // `await Promise.resolve()` on the next line turns the `cancelGroup cancels its
-      // tasks` golden fixture red while all 185 frozen-oracle tests stay green.
-      this.startWorkerCancellation(prepared.task);
-    }
     if (prepared.closedPackageId) {
       await this.questionFlow.handoffQueuedQuestions(prepared.task.coordinatorSession, prepared.closedPackageId);
     }
 
-    // I-2: non-running cancel transitions the task directly to `cancelled` without
-    // going through launchWorkerTurn. Fire reconcile so the ephemeral acpx session
-    // is closed promptly and any queued parallel tasks can drain. This also fires
-    // for non-parallel tasks — reconcile is idempotent and cheap in that case.
+    // I-2: non-running cancel transitions directly to a terminal state without launchWorkerTurn.
+    // Fire reconcile so the ephemeral acpx session closes and queued parallel tasks drain.
     if (!prepared.shouldPropagate && this.kernel.isTerminalStatus(prepared.task.status)) {
       try {
         await this.workerSessions.reconcileParallelSlots();
@@ -139,7 +140,7 @@ export class TaskCancellationService {
       }
     }
 
-    return prepared.task;
+    return { task: prepared.task, shouldPropagate: prepared.shouldPropagate };
   }
 
   async completeTaskCancellation(taskId: string): Promise<OrchestrationTaskRecord> {

--- a/tests/unit/orchestration/golden/fixtures/creategroup-then-cancelgroup-cancels-its-tasks-cancel-group-state.json
+++ b/tests/unit/orchestration/golden/fixtures/creategroup-then-cancelgroup-cancels-its-tasks-cancel-group-state.json
@@ -329,23 +329,6 @@
       "request": null
     },
     {
-      "port": "cancelWorkerTask",
-      "request": {
-        "taskId": "task-1",
-        "workerSession": "backend:claude:backend:main",
-        "workspace": "backend",
-        "targetAgent": "claude"
-      }
-    },
-    {
-      "port": "loadState",
-      "request": null
-    },
-    {
-      "port": "loadState",
-      "request": null
-    },
-    {
       "port": "logger.info",
       "request": {
         "event": "orchestration.group.cancelled",
@@ -358,6 +341,23 @@
           "skipped_count": 0
         }
       }
+    },
+    {
+      "port": "loadState",
+      "request": null
+    },
+    {
+      "port": "cancelWorkerTask",
+      "request": {
+        "taskId": "task-1",
+        "workerSession": "backend:claude:backend:main",
+        "workspace": "backend",
+        "targetAgent": "claude"
+      }
+    },
+    {
+      "port": "loadState",
+      "request": null
     },
     {
       "port": "saveState",

--- a/tests/unit/orchestration/service/group-service.test.ts
+++ b/tests/unit/orchestration/service/group-service.test.ts
@@ -10,7 +10,7 @@ import type {
   OrchestrationTaskRecord,
 } from "../../../../src/orchestration/orchestration-types";
 import { createEmptyState } from "../../../../src/state/types";
-import { makeGoldenHarness } from "../golden/golden-harness";
+import { makeGoldenHarness, type GoldenHarness } from "../golden/golden-harness";
 
 // Construct the service from a bare object literal of exactly its five ports — never
 // `harness.deps` wholesale — plus the kernel and a TaskCancellationService collaborator.
@@ -138,4 +138,86 @@ test("summarizes a group with mixed terminal and non-terminal tasks", async () =
   expect(summary.completedTasks).toBe(1);
   expect(summary.pendingApprovalTasks).toBe(1);
   expect(summary.terminal).toBe(false);
+});
+
+// Local copy — the frozen golden harness exports nothing (see its header comment).
+async function waitForLogEvent(harness: GoldenHarness, eventName: string, afterIndex: number): Promise<void> {
+  for (let i = 0; i < 40; i += 1) {
+    if (
+      harness.calls.slice(afterIndex).some(
+        (c) => c.port.startsWith("logger.") && (c.request as { event?: unknown } | null)?.event === eventName,
+      )
+    ) return;
+    await Bun.sleep(0);
+  }
+  throw new Error(`waitForLogEvent timed out waiting for "${eventName}"`);
+}
+
+test("cancelGroup logs group.cancelled BEFORE dispatching any worker-cancellation chain (#150)", async () => {
+  const initialState = createEmptyState();
+  initialState.orchestration.groups["g1"] = {
+    groupId: "g1",
+    coordinatorSession: "backend:coordinator",
+    title: "T",
+    createdAt: "2026-04-13T09:00:00.000Z",
+    updatedAt: "2026-04-13T09:00:00.000Z",
+  };
+  initialState.orchestration.tasks["t-run"] = {
+    taskId: "t-run",
+    sourceHandle: "worker:w1",
+    sourceKind: "worker",
+    coordinatorSession: "backend:coordinator",
+    workspace: "backend",
+    targetAgent: "codex",
+    task: "do the thing",
+    status: "running",
+    summary: "",
+    resultText: "",
+    groupId: "g1",
+    workerSession: "w1-session", // assigned worker → cancellation propagates a detached chain
+    createdAt: "2026-04-13T09:00:00.000Z",
+    updatedAt: "2026-04-13T09:00:00.000Z",
+  };
+
+  const harness = makeGoldenHarness({ initialState });
+  const kernel = new OrchestrationStateKernel({ logger: harness.deps.logger });
+  const workerSessions = new WorkerSessionManager(harness.deps, kernel);
+  const questionFlow = new QuestionFlowCore(harness.deps, kernel);
+  const cancellation = new TaskCancellationService(
+    {
+      now: harness.deps.now,
+      createId: harness.deps.createId,
+      loadState: harness.deps.loadState,
+      saveState: harness.deps.saveState,
+      cancelWorkerTask: harness.deps.cancelWorkerTask,
+      interruptWorkerTask: harness.deps.interruptWorkerTask,
+      wakeCoordinatorSession: harness.deps.wakeCoordinatorSession,
+    },
+    kernel,
+    workerSessions,
+    questionFlow,
+  );
+  const groups = new GroupService(
+    {
+      now: harness.deps.now,
+      createId: harness.deps.createId,
+      loadState: harness.deps.loadState,
+      saveState: harness.deps.saveState,
+      config: harness.deps.config,
+    },
+    kernel,
+    cancellation,
+  );
+
+  const before = harness.calls.length;
+  await groups.cancelGroup({ groupId: "g1", coordinatorSession: "backend:coordinator" });
+  await waitForLogEvent(harness, "orchestration.task.cancel_completed", before); // drain the detached chain
+
+  const window = harness.calls.slice(before);
+  const groupCancelledIdx = window.findIndex(
+    (c) => c.port.startsWith("logger.") && (c.request as { event?: unknown } | null)?.event === "orchestration.group.cancelled",
+  );
+  const dispatchIdx = window.findIndex((c) => c.port === "cancelWorkerTask");
+  expect(groupCancelledIdx).toBeGreaterThanOrEqual(0);
+  expect(dispatchIdx).toBeGreaterThan(groupCancelledIdx); // dispatch deferred until AFTER the log — provable, not hop-luck
 });

--- a/tests/unit/orchestration/service/group-service.test.ts
+++ b/tests/unit/orchestration/service/group-service.test.ts
@@ -140,9 +140,11 @@ test("summarizes a group with mixed terminal and non-terminal tasks", async () =
   expect(summary.terminal).toBe(false);
 });
 
-// Local copies — the frozen golden harness exports only its `makeGoldenHarness` factory and the
-// `GoldenHarness` type (it must stay byte-identical as a regression oracle, so it carries no test
-// helpers). These drain the detached worker-cancellation chains a cancelGroup fires.
+// Local poll helpers that drain the detached worker-cancellation chains a cancelGroup fires. The
+// golden harness intentionally exports only `makeGoldenHarness` + the `GoldenHarness` type, not
+// test utilities; `orchestration-golden.test.ts` keeps its own `waitForLogEvent` too — those
+// oracle files are deliberately independent (see the harness header). The byte-identical
+// constraint applies to the fixtures and `orchestration-service.test.ts`, not to these helpers.
 async function waitForLogEvent(harness: GoldenHarness, eventName: string, afterIndex: number): Promise<void> {
   for (let i = 0; i < 40; i += 1) {
     if (

--- a/tests/unit/orchestration/service/group-service.test.ts
+++ b/tests/unit/orchestration/service/group-service.test.ts
@@ -349,10 +349,15 @@ test("cancelGroup propagates an already-committed cancellation even when a later
   await groups.cancelGroup({ groupId: "g1", coordinatorSession: "backend:coordinator" });
   await waitForPort(harness, "cancelWorkerTask", (r) => (r as { taskId?: string }).taskId === "t2");
 
-  const cancelledWorkers = new Set(
-    harness.calls
-      .filter((c) => c.port === "cancelWorkerTask")
-      .map((c) => (c.request as { taskId: string }).taskId),
-  );
-  expect(cancelledWorkers).toEqual(new Set(["t1", "t2"]));
+  // Count per taskId, not a Set: both workers must be cancelled AND neither more than once — the
+  // retry must not re-fire t1 (already cancel-requested → shouldPropagate=false). A Set would
+  // dedupe away a double-dispatch regression.
+  const cancelCounts = new Map<string, number>();
+  for (const call of harness.calls.filter((c) => c.port === "cancelWorkerTask")) {
+    const id = (call.request as { taskId: string }).taskId;
+    cancelCounts.set(id, (cancelCounts.get(id) ?? 0) + 1);
+  }
+  expect(cancelCounts.get("t1")).toBe(1);
+  expect(cancelCounts.get("t2")).toBe(1);
+  expect(cancelCounts.size).toBe(2);
 });

--- a/tests/unit/orchestration/service/group-service.test.ts
+++ b/tests/unit/orchestration/service/group-service.test.ts
@@ -140,7 +140,9 @@ test("summarizes a group with mixed terminal and non-terminal tasks", async () =
   expect(summary.terminal).toBe(false);
 });
 
-// Local copy — the frozen golden harness exports nothing (see its header comment).
+// Local copies — the frozen golden harness exports only its `makeGoldenHarness` factory and the
+// `GoldenHarness` type (it must stay byte-identical as a regression oracle, so it carries no test
+// helpers). These drain the detached worker-cancellation chains a cancelGroup fires.
 async function waitForLogEvent(harness: GoldenHarness, eventName: string, afterIndex: number): Promise<void> {
   for (let i = 0; i < 40; i += 1) {
     if (
@@ -151,6 +153,18 @@ async function waitForLogEvent(harness: GoldenHarness, eventName: string, afterI
     await Bun.sleep(0);
   }
   throw new Error(`waitForLogEvent timed out waiting for "${eventName}"`);
+}
+
+async function waitForPort(
+  harness: GoldenHarness,
+  port: string,
+  match: (request: unknown) => boolean,
+): Promise<void> {
+  for (let i = 0; i < 40; i += 1) {
+    if (harness.calls.some((c) => c.port === port && match(c.request))) return;
+    await Bun.sleep(0);
+  }
+  throw new Error(`waitForPort timed out waiting for "${port}"`);
 }
 
 test("cancelGroup logs group.cancelled BEFORE dispatching any worker-cancellation chain (#150)", async () => {
@@ -209,10 +223,32 @@ test("cancelGroup logs group.cancelled BEFORE dispatching any worker-cancellatio
     cancellation,
   );
 
+  // Observe the invariant AT THE CALL SITE: capture, at the first startWorkerCancellation, whether
+  // group.cancelled is already logged. This is what kills the "move the dispatch loop before the
+  // log" mutation — the downstream cancelWorkerTask port fires several awaits deep in the detached
+  // chain, so its position relative to the log is unchanged by moving the (synchronous) dispatch
+  // call, leaving that assertion mutation-blind.
+  let groupCancelledLoggedAtFirstDispatch = -1;
+  const realStart = cancellation.startWorkerCancellation.bind(cancellation);
+  cancellation.startWorkerCancellation = (task) => {
+    if (groupCancelledLoggedAtFirstDispatch === -1) {
+      groupCancelledLoggedAtFirstDispatch = harness.calls.filter(
+        (c) =>
+          c.port.startsWith("logger.") &&
+          (c.request as { event?: unknown } | null)?.event === "orchestration.group.cancelled",
+      ).length;
+    }
+    return realStart(task);
+  };
+
   const before = harness.calls.length;
   await groups.cancelGroup({ groupId: "g1", coordinatorSession: "backend:coordinator" });
   await waitForLogEvent(harness, "orchestration.task.cancel_completed", before); // drain the detached chain
 
+  // group.cancelled was already in the log when the first chain STARTED (0 ⇒ dispatch ran first).
+  expect(groupCancelledLoggedAtFirstDispatch).toBe(1);
+
+  // (Kept as a smoke check) the downstream cancelWorkerTask port also lands after the log.
   const window = harness.calls.slice(before);
   const groupCancelledIdx = window.findIndex(
     (c) => c.port.startsWith("logger.") && (c.request as { event?: unknown } | null)?.event === "orchestration.group.cancelled",
@@ -220,4 +256,103 @@ test("cancelGroup logs group.cancelled BEFORE dispatching any worker-cancellatio
   const dispatchIdx = window.findIndex((c) => c.port === "cancelWorkerTask");
   expect(groupCancelledIdx).toBeGreaterThanOrEqual(0);
   expect(dispatchIdx).toBeGreaterThan(groupCancelledIdx); // dispatch deferred until AFTER the log — provable, not hop-luck
+});
+
+test("cancelGroup propagates an already-committed cancellation even when a later task's save fails, and a retry finishes the rest (#150)", async () => {
+  // Regression: cancelGroup commits each task's cancel-request in its own atomic save, then
+  // (before #150's fix) fired all worker-cancellation chains in a single batch AFTER the loop. If
+  // a later task's save threw, an earlier task was already persisted as cancel-requested but its
+  // chain never fired — and a retry sees `shouldPropagate === false` for it (already requested),
+  // so it would be stranded, worker never cancelled. The `finally`-dispatch guarantees the
+  // committed task's chain fires on THIS attempt; the retry then only needs to finish the rest.
+  const createdAt = "2026-04-13T09:00:00.000Z";
+  const initialState = createEmptyState();
+  initialState.orchestration.groups["g1"] = {
+    groupId: "g1",
+    coordinatorSession: "backend:coordinator",
+    title: "T",
+    createdAt,
+    updatedAt: createdAt,
+  };
+  for (const id of ["t1", "t2"]) {
+    initialState.orchestration.tasks[id] = {
+      taskId: id,
+      sourceHandle: `worker:${id}`,
+      sourceKind: "worker",
+      coordinatorSession: "backend:coordinator",
+      workspace: "backend",
+      targetAgent: "codex",
+      task: "do the thing",
+      status: "running",
+      summary: "",
+      resultText: "",
+      groupId: "g1",
+      workerSession: `${id}-session`, // assigned worker → cancellation propagates a detached chain
+      createdAt,
+      updatedAt: createdAt,
+    };
+  }
+
+  const harness = makeGoldenHarness({ initialState });
+
+  // Fail the 2nd saveState of the run — that is t2's apply commit (t1's apply is save #1). The
+  // failing save never delegates to the harness, so t2 stays un-persisted (as a real failed save
+  // would). Set to null to heal for the retry.
+  let saveCalls = 0;
+  let failAtSave: number | null = 2;
+  const saveState = async (next: Parameters<typeof harness.deps.saveState>[0]) => {
+    saveCalls += 1;
+    if (failAtSave !== null && saveCalls === failAtSave) {
+      throw new Error("simulated save failure");
+    }
+    await harness.deps.saveState(next);
+  };
+
+  const kernel = new OrchestrationStateKernel({ logger: harness.deps.logger });
+  const workerSessions = new WorkerSessionManager({ ...harness.deps, saveState }, kernel);
+  const questionFlow = new QuestionFlowCore({ ...harness.deps, saveState }, kernel);
+  const cancellation = new TaskCancellationService(
+    {
+      now: harness.deps.now,
+      createId: harness.deps.createId,
+      loadState: harness.deps.loadState,
+      saveState,
+      cancelWorkerTask: harness.deps.cancelWorkerTask,
+      interruptWorkerTask: harness.deps.interruptWorkerTask,
+      wakeCoordinatorSession: harness.deps.wakeCoordinatorSession,
+    },
+    kernel,
+    workerSessions,
+    questionFlow,
+  );
+  const groups = new GroupService(
+    {
+      now: harness.deps.now,
+      createId: harness.deps.createId,
+      loadState: harness.deps.loadState,
+      saveState,
+      config: harness.deps.config,
+    },
+    kernel,
+    cancellation,
+  );
+
+  // Attempt 1: t2's save throws → cancelGroup rejects, but t1 was committed and must still be
+  // dispatched by the finally (waitForPort would time out under the pre-fix batching).
+  await expect(
+    groups.cancelGroup({ groupId: "g1", coordinatorSession: "backend:coordinator" }),
+  ).rejects.toThrow("simulated save failure");
+  await waitForPort(harness, "cancelWorkerTask", (r) => (r as { taskId?: string }).taskId === "t1");
+
+  // Retry with saves healthy: t1 is already cancel-requested (not re-fired), t2 now completes.
+  failAtSave = null;
+  await groups.cancelGroup({ groupId: "g1", coordinatorSession: "backend:coordinator" });
+  await waitForPort(harness, "cancelWorkerTask", (r) => (r as { taskId?: string }).taskId === "t2");
+
+  const cancelledWorkers = new Set(
+    harness.calls
+      .filter((c) => c.port === "cancelWorkerTask")
+      .map((c) => (c.request as { taskId: string }).taskId),
+  );
+  expect(cancelledWorkers).toEqual(new Set(["t1", "t2"]));
 });

--- a/tests/unit/orchestration/service/human-question-service.test.ts
+++ b/tests/unit/orchestration/service/human-question-service.test.ts
@@ -146,3 +146,54 @@ test("accepting a contested result does not re-arm noticePending when a notice w
   expect(persisted.noticePending).toBeFalsy();
   expect(persisted.noticeSentAt).toBe("2026-04-13T09:45:00.000Z");
 });
+
+test("active-message fallback prefers the last DELIVERED message over a later failed one (#151)", async () => {
+  // awaitingReplyMessageId is absent. msg-2 (the last message) FAILED delivery (no deliveredAt);
+  // msg-1 was delivered. The active message must be msg-1, not the undelivered msg-2.
+  const initialState = createEmptyState();
+  initialState.orchestration.coordinatorQuestionState["coord-1"] = {
+    activePackageId: "pkg-1",
+    queuedQuestions: [],
+  };
+  initialState.orchestration.humanQuestionPackages["pkg-1"] = {
+    packageId: "pkg-1",
+    coordinatorSession: "coord-1",
+    status: "active",
+    createdAt: "2026-04-13T09:00:00.000Z",
+    updatedAt: "2026-04-13T09:00:00.000Z",
+    initialTaskIds: [],
+    openTaskIds: [],
+    resolvedTaskIds: [],
+    messages: [
+      { messageId: "msg-1", kind: "initial", promptText: "delivered one", createdAt: "2026-04-13T09:00:00.000Z", deliveredAt: "2026-04-13T09:00:01.000Z" },
+      { messageId: "msg-2", kind: "follow_up", promptText: "failed one", createdAt: "2026-04-13T09:30:00.000Z" },
+    ],
+  };
+  const { humanQuestions } = makeService(initialState);
+  const active = await humanQuestions.getActiveHumanQuestionPackage("coord-1");
+  expect(active?.promptText).toBe("delivered one");
+});
+
+test("active-message fallback returns the last message when NOTHING is delivered yet (#151 edge)", async () => {
+  const initialState = createEmptyState();
+  initialState.orchestration.coordinatorQuestionState["coord-2"] = {
+    activePackageId: "pkg-2",
+    queuedQuestions: [],
+  };
+  initialState.orchestration.humanQuestionPackages["pkg-2"] = {
+    packageId: "pkg-2",
+    coordinatorSession: "coord-2",
+    status: "active",
+    createdAt: "2026-04-13T09:00:00.000Z",
+    updatedAt: "2026-04-13T09:00:00.000Z",
+    initialTaskIds: [],
+    openTaskIds: [],
+    resolvedTaskIds: [],
+    messages: [
+      { messageId: "m1", kind: "initial", promptText: "pending, not delivered", createdAt: "2026-04-13T09:00:00.000Z" },
+    ],
+  };
+  const { humanQuestions } = makeService(initialState);
+  const active = await humanQuestions.getActiveHumanQuestionPackage("coord-2");
+  expect(active?.promptText).toBe("pending, not delivered"); // last resort: not hidden
+});

--- a/tests/unit/orchestration/service/human-question-service.test.ts
+++ b/tests/unit/orchestration/service/human-question-service.test.ts
@@ -197,3 +197,29 @@ test("active-message fallback returns the last message when NOTHING is delivered
   const active = await humanQuestions.getActiveHumanQuestionPackage("coord-2");
   expect(active?.promptText).toBe("pending, not delivered"); // last resort: not hidden
 });
+
+test("active-message fallback ignores a STALE awaitingReplyMessageId and still prefers the last delivered (#151 edge)", async () => {
+  const initialState = createEmptyState();
+  initialState.orchestration.coordinatorQuestionState["coord-3"] = {
+    activePackageId: "pkg-3",
+    queuedQuestions: [],
+  };
+  initialState.orchestration.humanQuestionPackages["pkg-3"] = {
+    packageId: "pkg-3",
+    coordinatorSession: "coord-3",
+    status: "active",
+    createdAt: "2026-04-13T09:00:00.000Z",
+    updatedAt: "2026-04-13T09:00:00.000Z",
+    initialTaskIds: [],
+    openTaskIds: [],
+    resolvedTaskIds: [],
+    awaitingReplyMessageId: "does-not-exist", // stale pointer → no match
+    messages: [
+      { messageId: "m1", kind: "initial", promptText: "delivered one", createdAt: "2026-04-13T09:00:00.000Z", deliveredAt: "2026-04-13T09:00:01.000Z" },
+      { messageId: "m2", kind: "follow_up", promptText: "failed later", createdAt: "2026-04-13T09:30:00.000Z" },
+    ],
+  };
+  const { humanQuestions } = makeService(initialState);
+  const active = await humanQuestions.getActiveHumanQuestionPackage("coord-3");
+  expect(active?.promptText).toBe("delivered one");
+});

--- a/tests/unit/orchestration/service/orchestration-state-kernel.test.ts
+++ b/tests/unit/orchestration/service/orchestration-state-kernel.test.ts
@@ -83,12 +83,17 @@ test("mutate lets a chain that OUTLIVES its critical section call mutate (no fal
   expect(await detached).toBe("ran-after");
 });
 
-test("mutate still throws on a genuinely nested (awaited) reentry", async () => {
+test("mutate still throws on a nested reentry issued after an INTERNAL await inside the section", async () => {
+  // Guards the reset-in-finally contract: runningToken must stay set until critical() has fully
+  // settled. If the reset were moved to run synchronously right after invoking held.run (instead
+  // of in the finally after `await`), this nested call — issued after the section suspends and
+  // resumes — would slip through and deadlock. The synchronous-nested test above cannot catch that.
   const kernel = new OrchestrationStateKernel({});
   let message = "no throw";
   await kernel.mutate(async () => {
+    await new Promise((r) => setTimeout(r, 0)); // suspend the section, then re-enter
     try {
-      await kernel.mutate(async () => "inner"); // awaited inside → would deadlock → must throw
+      await kernel.mutate(async () => "inner");
     } catch (error) {
       message = error instanceof Error ? error.message : String(error);
     }

--- a/tests/unit/orchestration/service/orchestration-state-kernel.test.ts
+++ b/tests/unit/orchestration/service/orchestration-state-kernel.test.ts
@@ -63,24 +63,46 @@ test("mutate lets a chain that OUTLIVES its critical section call mutate (no fal
   // A promise created inside a critical section inherits the ALS store. Firing it detached and
   // letting it call mutate AFTER the section returns is not re-entrant — the mutex is free — so
   // it must run, not throw. The old boolean guard threw here (invisible to every prior test).
+  // This variant crosses a macrotask boundary; the same-microtask single-`.then` case (the exact
+  // shape Issue #149 names) is covered by the test below and is also allowed by the deferred
+  // re-check guard.
   const kernel = new OrchestrationStateKernel({});
   let detached!: Promise<string>;
   await kernel.mutate(async () => {
     // Created inside the section, but deliberately NOT awaited here — it runs after this returns.
     detached = (async () => {
-      // A single microtask tick is NOT enough: the enclosing mutate()'s own cleanup (the
-      // `finally` after `await held.run(...)`) also resolves in exactly one microtask hop, but
-      // that hop is enqueued *after* this one (this callback's `await Promise.resolve()` is
-      // scheduled while the enclosing critical() body is still synchronously executing, i.e.
-      // strictly before the enclosing mutate() even reaches its own await). FIFO microtask
-      // ordering then makes this resume first, observing runningToken not yet cleared — a false
-      // "nested" throw (verified empirically: 1 tick always throws, 2+ ticks or a macrotask never
-      // does). A macrotask boundary reliably drains all pending microtask cleanup first.
       await new Promise((resolve) => setTimeout(resolve, 0));
       return await kernel.mutate(async () => "ran-after");
     })();
   });
   expect(await detached).toBe("ran-after");
+});
+
+test("mutate lets a detached .then() chain re-enter AFTER its section returns, in the same microtask turn (#149 filed hazard)", async () => {
+  // The exact construct Issue #149 names: a promise created inside the section, chained with a
+  // single `.then` and NOT awaited, that calls mutate() once the section body has returned. It
+  // inherits the section's async context, so at the instant it calls mutate the section's
+  // `runningToken` reset is still enqueued one microtask behind (the `.then` callback was queued
+  // during the body's synchronous run, strictly before the section's own teardown). The OLD guard
+  // threw synchronously here; the deferred re-check yields once, sees the section has returned
+  // (runningToken cleared), and lets the chain run. This test throws under the old guard —
+  // deleting the yield/re-check reddens it.
+  const kernel = new OrchestrationStateKernel({});
+  let ran: string | undefined;
+  let threw: string | undefined;
+  await kernel.mutate(async () => {
+    void Promise.resolve().then(async () => {
+      try {
+        ran = await kernel.mutate(async () => "ran-after-return");
+      } catch (error) {
+        threw = error instanceof Error ? error.message : String(error);
+      }
+    });
+  });
+  // Drain the detached chain.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(threw).toBeUndefined();
+  expect(ran).toBe("ran-after-return");
 });
 
 test("mutate still throws on a nested reentry issued after an INTERNAL await inside the section", async () => {

--- a/tests/unit/orchestration/service/orchestration-state-kernel.test.ts
+++ b/tests/unit/orchestration/service/orchestration-state-kernel.test.ts
@@ -58,3 +58,40 @@ test("appendTaskEvent bumps eventSeq and caps the ring at MAX_TASK_EVENTS_PER_TA
   expect(task.events!.length).toBe(200);
   expect(task.events![0]!.seq).toBe(6);
 });
+
+test("mutate lets a chain that OUTLIVES its critical section call mutate (no false deadlock throw)", async () => {
+  // A promise created inside a critical section inherits the ALS store. Firing it detached and
+  // letting it call mutate AFTER the section returns is not re-entrant — the mutex is free — so
+  // it must run, not throw. The old boolean guard threw here (invisible to every prior test).
+  const kernel = new OrchestrationStateKernel({});
+  let detached!: Promise<string>;
+  await kernel.mutate(async () => {
+    // Created inside the section, but deliberately NOT awaited here — it runs after this returns.
+    detached = (async () => {
+      // A single microtask tick is NOT enough: the enclosing mutate()'s own cleanup (the
+      // `finally` after `await held.run(...)`) also resolves in exactly one microtask hop, but
+      // that hop is enqueued *after* this one (this callback's `await Promise.resolve()` is
+      // scheduled while the enclosing critical() body is still synchronously executing, i.e.
+      // strictly before the enclosing mutate() even reaches its own await). FIFO microtask
+      // ordering then makes this resume first, observing runningToken not yet cleared — a false
+      // "nested" throw (verified empirically: 1 tick always throws, 2+ ticks or a macrotask never
+      // does). A macrotask boundary reliably drains all pending microtask cleanup first.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return await kernel.mutate(async () => "ran-after");
+    })();
+  });
+  expect(await detached).toBe("ran-after");
+});
+
+test("mutate still throws on a genuinely nested (awaited) reentry", async () => {
+  const kernel = new OrchestrationStateKernel({});
+  let message = "no throw";
+  await kernel.mutate(async () => {
+    try {
+      await kernel.mutate(async () => "inner"); // awaited inside → would deadlock → must throw
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+  });
+  expect(message).toContain("nested mutate()");
+});


### PR DESCRIPTION
## Orchestration follow-up hardening — closes #149, #150, #151

The three orchestration debts consciously deferred out of the 2026-07 architecture audit's Track 3 (the facade split). Three independent `src/orchestration/service/` fixes, each behaviour-scoped and mutation-tested; the frozen golden oracle stays green except one deliberate, order-only re-record.

### #149 — precise kernel reentrancy guard
`OrchestrationStateKernel.mutate()`'s `AsyncLocalStorage<true>` guard false-positived: a detached async created inside a critical section that inherited the ALS store threw "nested mutate()" if it *later* called `mutate()` — even after the section returned and the mutex was free (no deadlock), invisible to every test. Replaced the boolean with a **per-invocation token + `runningToken`** field, so the guard throws only for genuinely re-entrant (would-deadlock) nesting; a chain that outlives its section runs. **Dissolves the hazard** rather than detecting it, obsoleting the incomplete lexical scan the issue proposed replacing.
- Preserves the original ALS intent (a concurrent *queued* caller is still never falsely rejected).
- Documented limitation (in source, not just tests): "outlives" means past the section's async settlement — a chain resuming within a single microtask tick still throws. No production path hits this (all detached chains fire outside `mutate`).
- Tests: awaited-nested still throws; **nested reentry after an internal `await`** (guards the reset-in-`finally` contract a synchronous test can't see); a detached chain crossing a macrotask boundary now runs (mutation-live vs the boolean guard).

### #150 — provable `cancelGroup` log/save ordering
`cancelGroup` fired the detached `startWorkerCancellation` chain *inside* its loop, so the `group.cancelled` log's order against that chain's `saveState` was held only by microtask-hop luck (the file's own comments warned a single extra `await` flipped the golden fixture). Extracted the awaited, deterministic half of `requestTaskCancellation` into a public **`applyCancellationRequest`** (state mutate + `cancel_requested` log + handoff + reconcile, *no* detached fire); `cancelGroup` now **applies all cancellations → logs `group.cancelled` → then fires the detached chains**. The order is structural, not hop-lucky.
- `requestTaskCancellation` is byte-identical for single-task callers: propagation (`shouldPropagate`) and the handoff/reconcile tails are mutually exclusive per task, so moving the detached fire after them is unobservable.
- Golden oracle: **one** fixture re-recorded (`…cancel-group-state.json`), verified order-only (identical call multiset, zero value change) — `cancelWorkerTask` moved from before to after `group.cancelled`. The `-result.json` sibling and all other 22 fixtures are byte-identical.
- Test: a mutation-live ordering assertion (`cancelWorkerTask` index > `group.cancelled` index), draining the detached chain first.

### #151 — delivery-aware active-message fallback
`getActiveHumanQuestionPackage` fell back to `messages.at(-1)` regardless of delivery, so a failed later message shadowed a delivered earlier one. Now prefers, in order: the `awaitingReplyMessageId` target → the **last delivered** message (`deliveredAt` set) → the last message as a last resort. Rejected the "return null" option (would hide a pending-but-undelivered question from the coordinator prompt). Delivery-specific fields were already conditionally spread, so no stale delivery data leaks.
- Tests: prefer-delivered over a later failed one (mutation-live vs `at(-1)`); nothing-delivered last-resort; stale `awaitingReplyMessageId` still prefers delivered.

### Verification
Full orchestration gate green: kernel/human-question/group-service/task-cancellation/golden/concurrency/orchestration-service — 236/236, `tsc --noEmit` clean. Each behaviour change carries a mutation-live test. Reviewed per-task + a whole-branch opus pass (0 Critical/Important; the one cross-cutting risk — does the #149 guard change break #150's now-later detached chains? — checks out: every `startWorkerCancellation` fires outside any critical section, so it never inherits a token).

Spec: `docs/superpowers/specs/2026-07-14-orchestration-followup-hardening-design.md`
Plan: `docs/superpowers/plans/2026-07-14-orchestration-followup-hardening.md`

Closes #149
Closes #150
Closes #151
