### PR TITLE
feat(relay-web): render mermaid diagrams in chat markdown

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.3",
+      "version": "0.3.3-beta.4",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.16",
+      "version": "0.9.12-beta.19",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },
@@ -88,7 +88,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.10",
+      "version": "0.1.11",
     },
     "packages/relay-web": {
       "name": "@ganglion/xacpx-relay-web",
@@ -119,6 +119,7 @@
         "ghostty-web": "^0.4.0",
         "lucide-vue-next": "^1.0.0",
         "markdown-it": "^14.2.0",
+        "mermaid": "^11",
         "pinia": "^2.2.0",
         "remend": "^1.3.0",
         "vue": "^3.5.0",
@@ -180,6 +181,8 @@
     "@algolia/requester-node-http": ["@algolia/requester-node-http@5.53.0", "https://registry.npmmirror.com/@algolia/requester-node-http/-/requester-node-http-5.53.0.tgz", { "dependencies": { "@algolia/client-common": "5.53.0" } }, "sha512-6mF9LZMUk0QqWvrnxkxBqhswwz6Xfiwy6/gmTzL5HrlhdVG3ITAqGV2k3XmVThP1h0Ulc3VQwiNCD7/Nr4JNlQ=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "https://registry.npmmirror.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "https://registry.npmmirror.com/@antfu/install-pkg/-/install-pkg-1.1.0.tgz", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
     "@apideck/better-ajv-errors": ["@apideck/better-ajv-errors@0.3.7", "https://registry.npmmirror.com/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz", { "dependencies": { "jsonpointer": "^5.0.1", "leven": "^3.1.0" }, "peerDependencies": { "ajv": ">=8" } }, "sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw=="],
 
@@ -367,6 +370,10 @@
 
     "@babel/types": ["@babel/types@7.29.7", "https://registry.npmmirror.com/@babel/types/-/types-7.29.7.tgz", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "https://registry.npmmirror.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "https://registry.npmmirror.com/@chevrotain/types/-/types-11.1.2.tgz", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
     "@clack/core": ["@clack/core@1.2.0", "https://registry.npmmirror.com/@clack/core/-/core-1.2.0.tgz", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
 
     "@clack/prompts": ["@clack/prompts@1.2.0", "https://registry.npmmirror.com/@clack/prompts/-/prompts-1.2.0.tgz", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
@@ -497,6 +504,8 @@
 
     "@iconify/types": ["@iconify/types@2.0.0", "https://registry.npmmirror.com/@iconify/types/-/types-2.0.0.tgz", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
+    "@iconify/utils": ["@iconify/utils@3.1.4", "https://registry.npmmirror.com/@iconify/utils/-/utils-3.1.4.tgz", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
+
     "@intlify/core-base": ["@intlify/core-base@9.14.5", "https://registry.npmmirror.com/@intlify/core-base/-/core-base-9.14.5.tgz", { "dependencies": { "@intlify/message-compiler": "9.14.5", "@intlify/shared": "9.14.5" } }, "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA=="],
 
     "@intlify/message-compiler": ["@intlify/message-compiler@9.14.5", "https://registry.npmmirror.com/@intlify/message-compiler/-/message-compiler-9.14.5.tgz", { "dependencies": { "@intlify/shared": "9.14.5", "source-map-js": "^1.0.2" } }, "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ=="],
@@ -544,6 +553,8 @@
     "@lobehub/icons-static-svg": ["@lobehub/icons-static-svg@1.91.0", "https://registry.npmmirror.com/@lobehub/icons-static-svg/-/icons-static-svg-1.91.0.tgz", {}, "sha512-ZDflEq0uUvAkH4WK4h3qNvvY09ts4OqUb5azD7A0xKfcuYhffGwB1Q/As2RguZYq4Gh4v925CJ8iodiClzc4zw=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.3", "https://registry.npmmirror.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz", {}, "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "https://registry.npmmirror.com/@mermaid-js/parser/-/parser-1.2.0.tgz", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -655,7 +666,71 @@
 
     "@trickfilm400/rollup-plugin-off-main-thread": ["@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1", "https://registry.npmmirror.com/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz", { "dependencies": { "ejs": "^3.1.10", "json5": "^2.2.3", "magic-string": "^0.30.21", "string.prototype.matchall": "^4.0.12" } }, "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "https://registry.npmmirror.com/@types/d3/-/d3-7.4.3.tgz", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "https://registry.npmmirror.com/@types/d3-array/-/d3-array-3.2.2.tgz", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "https://registry.npmmirror.com/@types/d3-axis/-/d3-axis-3.0.6.tgz", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "https://registry.npmmirror.com/@types/d3-brush/-/d3-brush-3.0.6.tgz", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "https://registry.npmmirror.com/@types/d3-chord/-/d3-chord-3.0.6.tgz", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "https://registry.npmmirror.com/@types/d3-color/-/d3-color-3.1.3.tgz", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "https://registry.npmmirror.com/@types/d3-contour/-/d3-contour-3.0.6.tgz", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "https://registry.npmmirror.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "https://registry.npmmirror.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "https://registry.npmmirror.com/@types/d3-drag/-/d3-drag-3.0.7.tgz", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "https://registry.npmmirror.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "https://registry.npmmirror.com/@types/d3-ease/-/d3-ease-3.0.2.tgz", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "https://registry.npmmirror.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "https://registry.npmmirror.com/@types/d3-force/-/d3-force-3.0.10.tgz", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "https://registry.npmmirror.com/@types/d3-format/-/d3-format-3.0.4.tgz", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "https://registry.npmmirror.com/@types/d3-geo/-/d3-geo-3.1.0.tgz", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "https://registry.npmmirror.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "https://registry.npmmirror.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "https://registry.npmmirror.com/@types/d3-path/-/d3-path-3.1.1.tgz", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "https://registry.npmmirror.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "https://registry.npmmirror.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "https://registry.npmmirror.com/@types/d3-random/-/d3-random-3.0.4.tgz", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "https://registry.npmmirror.com/@types/d3-scale/-/d3-scale-4.0.9.tgz", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "https://registry.npmmirror.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "https://registry.npmmirror.com/@types/d3-selection/-/d3-selection-3.0.11.tgz", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "https://registry.npmmirror.com/@types/d3-shape/-/d3-shape-3.1.8.tgz", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "https://registry.npmmirror.com/@types/d3-time/-/d3-time-3.0.4.tgz", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "https://registry.npmmirror.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "https://registry.npmmirror.com/@types/d3-timer/-/d3-timer-3.0.2.tgz", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "https://registry.npmmirror.com/@types/d3-transition/-/d3-transition-3.0.9.tgz", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "https://registry.npmmirror.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "https://registry.npmmirror.com/@types/estree/-/estree-1.0.9.tgz", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "https://registry.npmmirror.com/@types/geojson/-/geojson-7946.0.16.tgz", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "https://registry.npmmirror.com/@types/hast/-/hast-3.0.4.tgz", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -686,6 +761,8 @@
     "@types/ws": ["@types/ws@8.18.1", "https://registry.npmmirror.com/@types/ws/-/ws-8.18.1.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.3.1.tgz", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "https://registry.npmmirror.com/@upsetjs/venn.js/-/venn.js-2.0.0.tgz", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "https://registry.npmmirror.com/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
 
@@ -895,6 +972,8 @@
 
     "cors": ["cors@2.8.6", "https://registry.npmmirror.com/cors/-/cors-2.8.6.tgz", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
+    "cose-base": ["cose-base@1.0.3", "https://registry.npmmirror.com/cose-base/-/cose-base-1.0.3.tgz", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "crelt": ["crelt@1.0.7", "https://registry.npmmirror.com/crelt/-/crelt-1.0.7.tgz", {}, "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -907,6 +986,78 @@
 
     "csstype": ["csstype@3.2.3", "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.34.0", "https://registry.npmmirror.com/cytoscape/-/cytoscape-3.34.0.tgz", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "https://registry.npmmirror.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "https://registry.npmmirror.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "https://registry.npmmirror.com/d3/-/d3-7.9.0.tgz", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "https://registry.npmmirror.com/d3-array/-/d3-array-3.2.4.tgz", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "https://registry.npmmirror.com/d3-axis/-/d3-axis-3.0.0.tgz", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "https://registry.npmmirror.com/d3-brush/-/d3-brush-3.0.0.tgz", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "https://registry.npmmirror.com/d3-chord/-/d3-chord-3.0.1.tgz", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "https://registry.npmmirror.com/d3-color/-/d3-color-3.1.0.tgz", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "https://registry.npmmirror.com/d3-contour/-/d3-contour-4.0.2.tgz", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "https://registry.npmmirror.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "https://registry.npmmirror.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "https://registry.npmmirror.com/d3-drag/-/d3-drag-3.0.0.tgz", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "https://registry.npmmirror.com/d3-dsv/-/d3-dsv-3.0.1.tgz", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "https://registry.npmmirror.com/d3-ease/-/d3-ease-3.0.1.tgz", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "https://registry.npmmirror.com/d3-fetch/-/d3-fetch-3.0.1.tgz", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "https://registry.npmmirror.com/d3-force/-/d3-force-3.0.0.tgz", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "https://registry.npmmirror.com/d3-format/-/d3-format-3.1.2.tgz", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "https://registry.npmmirror.com/d3-geo/-/d3-geo-3.1.1.tgz", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "https://registry.npmmirror.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "https://registry.npmmirror.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "https://registry.npmmirror.com/d3-path/-/d3-path-3.1.0.tgz", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "https://registry.npmmirror.com/d3-polygon/-/d3-polygon-3.0.1.tgz", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "https://registry.npmmirror.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "https://registry.npmmirror.com/d3-random/-/d3-random-3.0.1.tgz", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "https://registry.npmmirror.com/d3-sankey/-/d3-sankey-0.12.3.tgz", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "https://registry.npmmirror.com/d3-scale/-/d3-scale-4.0.2.tgz", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "https://registry.npmmirror.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "https://registry.npmmirror.com/d3-shape/-/d3-shape-3.2.0.tgz", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "https://registry.npmmirror.com/d3-time/-/d3-time-3.1.0.tgz", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "https://registry.npmmirror.com/d3-time-format/-/d3-time-format-4.1.0.tgz", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "https://registry.npmmirror.com/d3-timer/-/d3-timer-3.0.1.tgz", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "https://registry.npmmirror.com/d3-transition/-/d3-transition-3.0.1.tgz", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "https://registry.npmmirror.com/d3-zoom/-/d3-zoom-3.0.0.tgz", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "https://registry.npmmirror.com/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
     "data-urls": ["data-urls@5.0.0", "https://registry.npmmirror.com/data-urls/-/data-urls-5.0.0.tgz", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "https://registry.npmmirror.com/data-view-buffer/-/data-view-buffer-1.0.2.tgz", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
@@ -914,6 +1065,8 @@
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "https://registry.npmmirror.com/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "https://registry.npmmirror.com/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "dayjs": ["dayjs@1.11.21", "https://registry.npmmirror.com/dayjs/-/dayjs-1.11.21.tgz", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "de-indent": ["de-indent@1.0.2", "https://registry.npmmirror.com/de-indent/-/de-indent-1.0.2.tgz", {}, "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg=="],
 
@@ -928,6 +1081,8 @@
     "define-data-property": ["define-data-property@1.1.4", "https://registry.npmmirror.com/define-data-property/-/define-data-property-1.1.4.tgz", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "https://registry.npmmirror.com/define-properties/-/define-properties-1.2.1.tgz", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "delaunator": ["delaunator@5.1.0", "https://registry.npmmirror.com/delaunator/-/delaunator-5.1.0.tgz", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -978,6 +1133,8 @@
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "https://registry.npmmirror.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.1", "https://registry.npmmirror.com/es-to-primitive/-/es-to-primitive-1.3.1.tgz", { "dependencies": { "es-abstract-get": "^1.0.0", "es-errors": "^1.3.0", "is-callable": "^1.2.7", "is-date-object": "^1.1.0", "is-symbol": "^1.1.1" } }, "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g=="],
+
+    "es-toolkit": ["es-toolkit@1.49.0", "https://registry.npmmirror.com/es-toolkit/-/es-toolkit-1.49.0.tgz", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
 
     "esbuild": ["esbuild@0.21.5", "https://registry.npmmirror.com/esbuild/-/esbuild-0.21.5.tgz", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -1081,6 +1238,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "https://registry.npmmirror.com/hachure-fill/-/hachure-fill-0.5.2.tgz", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "has-bigints": ["has-bigints@1.1.0", "https://registry.npmmirror.com/has-bigints/-/has-bigints-1.1.0.tgz", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
     "has-property-descriptors": ["has-property-descriptors@1.0.2", "https://registry.npmmirror.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
@@ -1117,11 +1276,15 @@
 
     "idb": ["idb@7.1.1", "https://registry.npmmirror.com/idb/-/idb-7.1.1.tgz", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
 
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "https://registry.npmmirror.com/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "inherits": ["inherits@2.0.4", "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "https://registry.npmmirror.com/ini/-/ini-1.3.8.tgz", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "internal-slot": ["internal-slot@1.1.0", "https://registry.npmmirror.com/internal-slot/-/internal-slot-1.1.0.tgz", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@1.0.1", "https://registry.npmmirror.com/internmap/-/internmap-1.0.1.tgz", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "ip-address": ["ip-address@10.1.0", "https://registry.npmmirror.com/ip-address/-/ip-address-10.1.0.tgz", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -1229,6 +1392,12 @@
 
     "jsonpointer": ["jsonpointer@5.0.1", "https://registry.npmmirror.com/jsonpointer/-/jsonpointer-5.0.1.tgz", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
+    "katex": ["katex@0.16.47", "https://registry.npmmirror.com/katex/-/katex-0.16.47.tgz", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "https://registry.npmmirror.com/khroma/-/khroma-2.1.0.tgz", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "layout-base": ["layout-base@1.0.2", "https://registry.npmmirror.com/layout-base/-/layout-base-1.0.2.tgz", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
     "leven": ["leven@3.1.0", "https://registry.npmmirror.com/leven/-/leven-3.1.0.tgz", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
     "lilconfig": ["lilconfig@3.1.3", "https://registry.npmmirror.com/lilconfig/-/lilconfig-3.1.3.tgz", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
@@ -1236,6 +1405,8 @@
     "lines-and-columns": ["lines-and-columns@1.2.4", "https://registry.npmmirror.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "linkify-it": ["linkify-it@5.0.1", "https://registry.npmmirror.com/linkify-it/-/linkify-it-5.0.1.tgz", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "https://registry.npmmirror.com/lodash-es/-/lodash-es-4.18.1.tgz", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "https://registry.npmmirror.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
@@ -1261,6 +1432,8 @@
 
     "markdown-it": ["markdown-it@14.2.0", "https://registry.npmmirror.com/markdown-it/-/markdown-it-14.2.0.tgz", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.1", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ=="],
 
+    "marked": ["marked@16.4.2", "https://registry.npmmirror.com/marked/-/marked-16.4.2.tgz", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "https://registry.npmmirror.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
@@ -1272,6 +1445,8 @@
     "merge-descriptors": ["merge-descriptors@2.0.0", "https://registry.npmmirror.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "mermaid": ["mermaid@11.16.0", "https://registry.npmmirror.com/mermaid/-/mermaid-11.16.0.tgz", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "https://registry.npmmirror.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 
@@ -1339,11 +1514,15 @@
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "https://registry.npmmirror.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
+    "package-manager-detector": ["package-manager-detector@1.7.0", "https://registry.npmmirror.com/package-manager-detector/-/package-manager-detector-1.7.0.tgz", {}, "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ=="],
+
     "parse5": ["parse5@7.3.0", "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "parseurl": ["parseurl@1.3.3", "https://registry.npmmirror.com/parseurl/-/parseurl-1.3.3.tgz", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-browserify": ["path-browserify@1.0.1", "https://registry.npmmirror.com/path-browserify/-/path-browserify-1.0.1.tgz", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "https://registry.npmmirror.com/path-data-parser/-/path-data-parser-0.1.0.tgz", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
     "path-key": ["path-key@3.1.1", "https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1370,6 +1549,10 @@
     "pirates": ["pirates@4.0.7", "https://registry.npmmirror.com/pirates/-/pirates-4.0.7.tgz", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "https://registry.npmmirror.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "https://registry.npmmirror.com/points-on-curve/-/points-on-curve-0.2.0.tgz", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "https://registry.npmmirror.com/points-on-path/-/points-on-path-0.2.1.tgz", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "https://registry.npmmirror.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1453,13 +1636,19 @@
 
     "rfdc": ["rfdc@1.4.1", "https://registry.npmmirror.com/rfdc/-/rfdc-1.4.1.tgz", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "https://registry.npmmirror.com/robust-predicates/-/robust-predicates-3.0.3.tgz", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.61.0", "https://registry.npmmirror.com/rollup/-/rollup-4.61.0.tgz", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.61.0", "@rollup/rollup-android-arm64": "4.61.0", "@rollup/rollup-darwin-arm64": "4.61.0", "@rollup/rollup-darwin-x64": "4.61.0", "@rollup/rollup-freebsd-arm64": "4.61.0", "@rollup/rollup-freebsd-x64": "4.61.0", "@rollup/rollup-linux-arm-gnueabihf": "4.61.0", "@rollup/rollup-linux-arm-musleabihf": "4.61.0", "@rollup/rollup-linux-arm64-gnu": "4.61.0", "@rollup/rollup-linux-arm64-musl": "4.61.0", "@rollup/rollup-linux-loong64-gnu": "4.61.0", "@rollup/rollup-linux-loong64-musl": "4.61.0", "@rollup/rollup-linux-ppc64-gnu": "4.61.0", "@rollup/rollup-linux-ppc64-musl": "4.61.0", "@rollup/rollup-linux-riscv64-gnu": "4.61.0", "@rollup/rollup-linux-riscv64-musl": "4.61.0", "@rollup/rollup-linux-s390x-gnu": "4.61.0", "@rollup/rollup-linux-x64-gnu": "4.61.0", "@rollup/rollup-linux-x64-musl": "4.61.0", "@rollup/rollup-openbsd-x64": "4.61.0", "@rollup/rollup-openharmony-arm64": "4.61.0", "@rollup/rollup-win32-arm64-msvc": "4.61.0", "@rollup/rollup-win32-ia32-msvc": "4.61.0", "@rollup/rollup-win32-x64-gnu": "4.61.0", "@rollup/rollup-win32-x64-msvc": "4.61.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g=="],
+
+    "roughjs": ["roughjs@4.6.6", "https://registry.npmmirror.com/roughjs/-/roughjs-4.6.6.tgz", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
     "router": ["router@2.2.0", "https://registry.npmmirror.com/router/-/router-2.2.0.tgz", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.7.1", "https://registry.npmmirror.com/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
 
     "run-parallel": ["run-parallel@1.2.0", "https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rw": ["rw@1.3.3", "https://registry.npmmirror.com/rw/-/rw-1.3.3.tgz", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "https://registry.npmmirror.com/safe-array-concat/-/safe-array-concat-1.1.4.tgz", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
 
@@ -1557,6 +1746,8 @@
 
     "style-mod": ["style-mod@4.1.3", "https://registry.npmmirror.com/style-mod/-/style-mod-4.1.3.tgz", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
+    "stylis": ["stylis@4.4.0", "https://registry.npmmirror.com/stylis/-/stylis-4.4.0.tgz", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
     "sucrase": ["sucrase@3.35.1", "https://registry.npmmirror.com/sucrase/-/sucrase-3.35.1.tgz", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
     "superjson": ["superjson@2.2.6", "https://registry.npmmirror.com/superjson/-/superjson-2.2.6.tgz", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
@@ -1611,6 +1802,8 @@
 
     "trim-lines": ["trim-lines@3.0.1", "https://registry.npmmirror.com/trim-lines/-/trim-lines-3.0.1.tgz", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
+    "ts-dedent": ["ts-dedent@2.3.0", "https://registry.npmmirror.com/ts-dedent/-/ts-dedent-2.3.0.tgz", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
+
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "https://registry.npmmirror.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "tsx": ["tsx@4.22.4", "https://registry.npmmirror.com/tsx/-/tsx-4.22.4.tgz", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
@@ -1664,6 +1857,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "https://registry.npmmirror.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@14.0.1", "https://registry.npmmirror.com/uuid/-/uuid-14.0.1.tgz", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vary": ["vary@1.1.2", "https://registry.npmmirror.com/vary/-/vary-1.1.2.tgz", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -1773,6 +1968,8 @@
 
     "zwitch": ["zwitch@2.0.4", "https://registry.npmmirror.com/zwitch/-/zwitch-2.0.4.tgz", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@antfu/install-pkg/tinyexec": ["tinyexec@1.2.4", "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.2.4.tgz", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "@babel/core/semver": ["semver@6.3.1", "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "https://registry.npmmirror.com/lru-cache/-/lru-cache-5.1.1.tgz", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1805,6 +2002,16 @@
 
     "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "https://registry.npmmirror.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "https://registry.npmmirror.com/cose-base/-/cose-base-2.2.0.tgz", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "https://registry.npmmirror.com/commander/-/commander-7.2.0.tgz", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "https://registry.npmmirror.com/d3-array/-/d3-array-2.12.1.tgz", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "https://registry.npmmirror.com/d3-shape/-/d3-shape-1.3.7.tgz", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "editorconfig/commander": ["commander@10.0.1", "https://registry.npmmirror.com/commander/-/commander-10.0.1.tgz", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
     "es-abstract-get/es-object-atoms": ["es-object-atoms@1.1.2", "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
@@ -1820,6 +2027,8 @@
     "function.prototype.name/hasown": ["hasown@2.0.4", "https://registry.npmmirror.com/hasown/-/hasown-2.0.4.tgz", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "is-regex/hasown": ["hasown@2.0.4", "https://registry.npmmirror.com/hasown/-/hasown-2.0.4.tgz", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "katex/commander": ["commander@8.3.0", "https://registry.npmmirror.com/commander/-/commander-8.3.0.tgz", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "parse5/entities": ["entities@6.0.1", "https://registry.npmmirror.com/entities/-/entities-6.0.1.tgz", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -1868,6 +2077,10 @@
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "write-file-atomic/signal-exit": ["signal-exit@4.1.0", "https://registry.npmmirror.com/signal-exit/-/signal-exit-4.1.0.tgz", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "https://registry.npmmirror.com/layout-base/-/layout-base-2.0.1.tgz", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "https://registry.npmmirror.com/d3-path/-/d3-path-1.0.9.tgz", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -144,6 +144,11 @@ DOMPurify（svg profile）净化，并按 `theme+源码` 缓存；`StreamMarkdow
 打补丁之后再水合——绝不在流式中途做（半截 fence 会解析失败），并在主题切换时重新水合。
 非法图表保留源码作为代码块兜底。非 relay-web 频道（微信/终端）仍为纯文本。
 
+已渲染的图表支持平移/缩放：**内联**（`inline-mermaid.ts` 就地增强——Ctrl/⌘+滚轮缩放、鼠标拖拽平移、
+双指捏合；单指仍滚动页面）配一条 − / 复位 / + / ⤢ 控件条；点 ⤢ 打开**全屏**查看器（`MermaidViewer.vue`，
+平滑滚轮/单指拖拽/双指缩放 + Esc/✕/点空白关闭）。两种模式共用纯 `pan-zoom.ts` 控制器与
+`pan-zoom-gestures.ts` 手势装配；均复用已注入 DOM 的（已净化）SVG，不重新解析。
+
 ## 响应式 / 移动端布局
 
 - `DashboardView.vue` 桌面（`lg:` ≥1024px）保持三栏静态布局；窄屏下：

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -135,6 +135,16 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   自带非 scoped 的 `.stream-md` 样式（Tailwind preflight 会清掉元素样式，需手动补回标题/列表/代码块等）。
 - `MessageList.vue`：**`out` 方向（agent 输出）与流气泡走 `StreamMarkdown`**；`in`（用户输入）保持纯文本 `<pre>` 不渲染 markdown。
 
+### Mermaid diagrams
+
+` ```mermaid ` fences render to SVG. Pipeline: `render-markdown` emits a
+`<pre class="mermaid-block" data-mermaid="<base64 source>">` placeholder (fence override);
+`render-mermaid` lazily `import('mermaid')`s, renders each placeholder to SVG under
+`securityLevel: "strict"`, DOMPurifies it (svg profile), and caches by `theme+source`;
+`StreamMarkdown.vue` hydrates after `v-html` patches — never mid-stream (a partial fence
+would fail to parse), re-hydrating on theme change. Malformed diagrams keep the source as a
+code fallback. Non-relay-web channels (WeChat/terminal) remain text-only.
+
 ## 响应式 / 移动端布局
 
 - `DashboardView.vue` 桌面（`lg:` ≥1024px）保持三栏静态布局；窄屏下：

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -135,15 +135,14 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   自带非 scoped 的 `.stream-md` 样式（Tailwind preflight 会清掉元素样式，需手动补回标题/列表/代码块等）。
 - `MessageList.vue`：**`out` 方向（agent 输出）与流气泡走 `StreamMarkdown`**；`in`（用户输入）保持纯文本 `<pre>` 不渲染 markdown。
 
-### Mermaid diagrams
+### Mermaid 图表渲染
 
-` ```mermaid ` fences render to SVG. Pipeline: `render-markdown` emits a
-`<pre class="mermaid-block" data-mermaid="<base64 source>">` placeholder (fence override);
-`render-mermaid` lazily `import('mermaid')`s, renders each placeholder to SVG under
-`securityLevel: "strict"`, DOMPurifies it (svg profile), and caches by `theme+source`;
-`StreamMarkdown.vue` hydrates after `v-html` patches — never mid-stream (a partial fence
-would fail to parse), re-hydrating on theme change. Malformed diagrams keep the source as a
-code fallback. Non-relay-web channels (WeChat/terminal) remain text-only.
+` ```mermaid ` 代码块会渲染成 SVG 图表。管线：`render-markdown` 通过 fence 覆写发出
+`<pre class="mermaid-block" data-mermaid="<base64 源码>">` 占位符；`render-mermaid` 按需
+`import('mermaid')` 懒加载，在 `securityLevel: "strict"` 下把每个占位符渲染为 SVG，再经
+DOMPurify（svg profile）净化，并按 `theme+源码` 缓存；`StreamMarkdown.vue` 在 `v-html`
+打补丁之后再水合——绝不在流式中途做（半截 fence 会解析失败），并在主题切换时重新水合。
+非法图表保留源码作为代码块兜底。非 relay-web 频道（微信/终端）仍为纯文本。
 
 ## 响应式 / 移动端布局
 

--- a/docs/superpowers/plans/2026-07-14-web-mermaid-panzoom.md
+++ b/docs/superpowers/plans/2026-07-14-web-mermaid-panzoom.md
@@ -1,213 +1,328 @@
-# Web Mermaid Pan/Zoom Implementation Plan
+# Web Mermaid Pan/Zoom Implementation Plan (inline + fullscreen)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** Make rendered Mermaid diagrams pan/zoomable — clicking a diagram opens a fullscreen viewer with drag-pan, wheel-zoom, pinch-zoom, on-screen controls, and reset.
+**Goal:** Rendered Mermaid diagrams are pan/zoomable **inline** (Ctrl/⌘+wheel zoom, mouse-drag pan, two-finger pinch; one-finger touch still scrolls the page) and **fullscreen** via a ⤢ button (plain wheel, one-finger drag, pinch).
 
-**Architecture:** Three additive seams in `packages/relay-web`. A pure `pan-zoom` transform controller; a `MermaidViewer.vue` fullscreen overlay that wires DOM gestures to it; and a click handler in `StreamMarkdown.vue` that opens the viewer with a rendered block's SVG. `render-mermaid.ts` is unchanged.
+**Architecture:** `pan-zoom.ts` (pure controller, DONE) + `pan-zoom-gestures.ts` (shared DOM gesture wiring, mode flags) + `MermaidViewer.vue` (fullscreen overlay) + `inline-mermaid.ts` (in-place enhancement of a rendered block) + `StreamMarkdown.vue` wiring. `render-mermaid.ts` is unchanged.
 
-**Tech Stack:** Vue 3, `lucide-vue-next` icons, the existing `useModalA11y` composable, Vitest (jsdom) + @vue/test-utils.
+**Tech Stack:** Vue 3, `lucide-vue-next` icons, existing `useModalA11y`, Vitest (jsdom) + @vue/test-utils.
 
 ## Global Constraints
 
-- All code in `packages/relay-web`. Tests run with `npx vitest run` **from `packages/relay-web`** — never `bun test` (jsdom-dependent).
-- No new npm dependency (pan/zoom is hand-rolled; icons come from the existing `lucide-vue-next`).
-- Security: the viewer displays the SAME SVG string `render-mermaid` already produced and DOMPurified before injecting inline — read back from the live DOM, never re-parsed or re-fetched.
-- The existing mermaid hydration / streaming / theme logic in `StreamMarkdown.vue` and all of `render-mermaid.ts` must stay unchanged.
-- Overlay conventions: use `useModalA11y(dialogEl, close)` (Esc + focus trap + focus restore); the panel needs `ref`, `tabindex="-1" role="dialog" aria-modal="true"`. The viewer is rendered under `v-if` in the parent so it mounts on open / unmounts on close.
-- YAGNI: no inline gestures, no fit-to-screen auto-scale, no export, no minimap.
+- All code in `packages/relay-web`. Tests: `npx vitest run` from `packages/relay-web` — never `bun test`.
+- No new npm dependency.
+- Security: inline enhancement and the viewer operate on the SVG `render-mermaid` already produced and DOMPurified — moved/re-displayed, never re-parsed. mermaid stays `securityLevel: "strict"`.
+- `render-mermaid.ts` and the existing hydration/streaming/theme logic in `StreamMarkdown.vue` stay behaviourally unchanged (StreamMarkdown gains only the enhance + viewer wiring).
+- Inline must never hijack the page: wheel zoom requires Ctrl/⌘; one-finger touch is left to the browser (`touch-action: pan-y`). Fullscreen owns all gestures (`touch-action: none`).
+- Task 1 (`pan-zoom.ts`) is already implemented and committed — do not touch it.
 
 ---
 
-### Task 1: `pan-zoom` transform controller
+### Task 2: `pan-zoom-gestures.ts` — shared gesture wiring
 
 **Files:**
-- Create: `packages/relay-web/src/lib/pan-zoom.ts`
-- Test: `packages/relay-web/src/__tests__/pan-zoom.test.ts`
+- Create: `packages/relay-web/src/lib/pan-zoom-gestures.ts`
+- Test: `packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts`
 
 **Interfaces:**
-- Produces: `createPanZoom(opts?: { minScale?: number; maxScale?: number }): PanZoom` where `PanZoom` has `readonly state: { scale; x; y }`, `zoomAt(factor, cx, cy)`, `panBy(dx, dy)`, `reset()`, `toTransform(): string`. Consumed by Task 2.
+- Consumes: `PanZoom` type from `./pan-zoom`.
+- Produces: `attachPanZoomGestures(el, pz, onChange, opts?): () => void` and `interface GestureOptions { wheelRequiresModifier?: boolean; oneFingerTouchPan?: boolean }`. Consumed by Tasks 3 and 4.
 
 - [ ] **Step 1: Write the failing tests**
 
-Create `packages/relay-web/src/__tests__/pan-zoom.test.ts`:
+Create `packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts`:
 ```ts
-import { expect, test } from "vitest";
+import { afterEach, expect, test } from "vitest";
 import { createPanZoom } from "../lib/pan-zoom";
+import { attachPanZoomGestures } from "../lib/pan-zoom-gestures";
 
-test("starts at identity and formats a transform-origin:0,0 transform", () => {
+let detach: (() => void) | null = null;
+afterEach(() => { detach?.(); detach = null; document.body.innerHTML = ""; });
+
+// jsdom lacks real WheelEvent/PointerEvent/TouchEvent ergonomics; dispatch a bare Event with the
+// properties the handlers read assigned onto it.
+function fire(el: EventTarget, type: string, props: Record<string, unknown>): void {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(e, props);
+  el.dispatchEvent(e);
+}
+function el(): HTMLElement {
+  const d = document.createElement("div");
+  document.body.appendChild(d);
+  return d;
+}
+
+test("wheelRequiresModifier: plain wheel is a no-op, Ctrl+wheel zooms", () => {
+  const target = el();
   const pz = createPanZoom();
-  expect(pz.state).toEqual({ scale: 1, x: 0, y: 0 });
-  expect(pz.toTransform()).toBe("translate(0px, 0px) scale(1)");
+  detach = attachPanZoomGestures(target, pz, () => {}, { wheelRequiresModifier: true });
+  fire(target, "wheel", { deltaY: -100, clientX: 0, clientY: 0 });
+  expect(pz.state.scale).toBe(1); // plain wheel ignored → page scrolls
+  fire(target, "wheel", { deltaY: -100, ctrlKey: true, clientX: 0, clientY: 0 });
+  expect(pz.state.scale).toBeCloseTo(1.1);
 });
 
-test("zoomAt keeps the point under the cursor stationary", () => {
+test("without wheelRequiresModifier a plain wheel zooms", () => {
+  const target = el();
   const pz = createPanZoom();
-  pz.zoomAt(2, 100, 0); // zoom 2x centered on viewport x=100
-  // content point that was under x=100 must still be under x=100: x = 100 - (100-0)*(2/1) = -100
-  expect(pz.state.scale).toBe(2);
-  expect(pz.state.x).toBe(-100);
-  expect(pz.state.y).toBe(0);
+  detach = attachPanZoomGestures(target, pz, () => {});
+  fire(target, "wheel", { deltaY: 100, clientX: 0, clientY: 0 });
+  expect(pz.state.scale).toBeCloseTo(1 / 1.1);
 });
 
-test("zoomAt clamps scale to [minScale, maxScale]", () => {
-  const pz = createPanZoom({ minScale: 0.5, maxScale: 4 });
-  pz.zoomAt(100, 0, 0);
-  expect(pz.state.scale).toBe(4);
-  pz.zoomAt(0.0001, 0, 0);
-  expect(pz.state.scale).toBe(0.5);
+test("mouse pointer drag pans", () => {
+  const target = el();
+  const pz = createPanZoom();
+  detach = attachPanZoomGestures(target, pz, () => {});
+  fire(target, "pointerdown", { pointerType: "mouse", pointerId: 1, clientX: 0, clientY: 0 });
+  fire(target, "pointermove", { pointerType: "mouse", pointerId: 1, clientX: 25, clientY: 40 });
+  fire(target, "pointerup", { pointerType: "mouse", pointerId: 1 });
+  expect(pz.state.x).toBe(25);
+  expect(pz.state.y).toBe(40);
 });
 
-test("panBy accumulates and reset returns to identity", () => {
+test("two-finger touch pinch zooms", () => {
+  const target = el();
   const pz = createPanZoom();
-  pz.panBy(10, 20);
-  pz.panBy(5, -5);
-  expect(pz.state).toEqual({ scale: 1, x: 15, y: 15 });
-  pz.zoomAt(2, 50, 50);
-  pz.reset();
-  expect(pz.state).toEqual({ scale: 1, x: 0, y: 0 });
-  expect(pz.toTransform()).toBe("translate(0px, 0px) scale(1)");
+  detach = attachPanZoomGestures(target, pz, () => {});
+  fire(target, "touchstart", { touches: [{ clientX: 0, clientY: 0 }, { clientX: 10, clientY: 0 }] });
+  fire(target, "touchmove", { touches: [{ clientX: 0, clientY: 0 }, { clientX: 20, clientY: 0 }] });
+  expect(pz.state.scale).toBeCloseTo(2); // distance 10 → 20
+});
+
+test("detach stops all gestures", () => {
+  const target = el();
+  const pz = createPanZoom();
+  const d = attachPanZoomGestures(target, pz, () => {});
+  d();
+  fire(target, "wheel", { deltaY: -100, clientX: 0, clientY: 0 });
+  expect(pz.state.scale).toBe(1);
 });
 ```
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `cd packages/relay-web && npx vitest run src/__tests__/pan-zoom.test.ts`
-Expected: FAIL — `../lib/pan-zoom` does not exist.
+Run: `cd packages/relay-web && npx vitest run src/__tests__/pan-zoom-gestures.test.ts`
+Expected: FAIL — module does not exist.
 
-- [ ] **Step 3: Implement `pan-zoom.ts`**
+- [ ] **Step 3: Implement `pan-zoom-gestures.ts`**
 
-Create `packages/relay-web/src/lib/pan-zoom.ts`:
+Create `packages/relay-web/src/lib/pan-zoom-gestures.ts`:
 ```ts
-// Pure, framework-free pan/zoom transform state. The consumer applies `toTransform()` to an
-// element with `transform-origin: 0 0`. Kept DOM-free so the geometry is unit-testable.
-export interface PanZoomState {
-  scale: number;
-  x: number;
-  y: number;
+import type { PanZoom } from "./pan-zoom";
+
+export interface GestureOptions {
+  /** Zoom on wheel only when Ctrl/⌘ is held (inline). Default false. */
+  wheelRequiresModifier?: boolean;
+  /** Pan on a single touch (fullscreen). Default false — one finger scrolls the page. */
+  oneFingerTouchPan?: boolean;
 }
 
-export interface PanZoom {
-  readonly state: PanZoomState;
-  /** Multiply scale by `factor`, keeping viewport point (cx, cy) stationary. Clamps scale. */
-  zoomAt(factor: number, cx: number, cy: number): void;
-  panBy(dx: number, dy: number): void;
-  reset(): void;
-  /** CSS transform for a `transform-origin: 0 0` element. */
-  toTransform(): string;
+interface Pointish {
+  clientX: number;
+  clientY: number;
 }
 
-export function createPanZoom(opts: { minScale?: number; maxScale?: number } = {}): PanZoom {
-  const minScale = opts.minScale ?? 0.2;
-  const maxScale = opts.maxScale ?? 8;
-  const state: PanZoomState = { scale: 1, x: 0, y: 0 };
+/**
+ * Attach wheel/pointer/touch pan-zoom gestures on `el`, driving `pz` and calling `onChange` after
+ * every state change. Mouse drag always pans; touch panning is one-finger only when opted in;
+ * wheel zoom can require a modifier. Returns a detach function that removes every listener.
+ */
+export function attachPanZoomGestures(
+  el: HTMLElement,
+  pz: PanZoom,
+  onChange: () => void,
+  opts: GestureOptions = {},
+): () => void {
+  const wheelRequiresModifier = opts.wheelRequiresModifier ?? false;
+  const oneFingerTouchPan = opts.oneFingerTouchPan ?? false;
 
-  return {
-    state,
-    zoomAt(factor, cx, cy) {
-      const next = Math.min(maxScale, Math.max(minScale, state.scale * factor));
-      if (next === state.scale) return;
-      // Solve for the translation that pins content point ((cx - x)/scale) under (cx, cy).
-      state.x = cx - (cx - state.x) * (next / state.scale);
-      state.y = cy - (cy - state.y) * (next / state.scale);
-      state.scale = next;
-    },
-    panBy(dx, dy) {
-      state.x += dx;
-      state.y += dy;
-    },
-    reset() {
-      state.scale = 1;
-      state.x = 0;
-      state.y = 0;
-    },
-    toTransform() {
-      return `translate(${state.x}px, ${state.y}px) scale(${state.scale})`;
-    },
+  function origin(): { left: number; top: number } {
+    const r = el.getBoundingClientRect();
+    return { left: r.left, top: r.top };
+  }
+  function pinchDistance(a: Pointish, b: Pointish): number {
+    return Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+  }
+
+  function onWheel(e: WheelEvent): void {
+    if (wheelRequiresModifier && !e.ctrlKey && !e.metaKey) return; // let the page scroll
+    e.preventDefault();
+    const { left, top } = origin();
+    pz.zoomAt(e.deltaY < 0 ? 1.1 : 1 / 1.1, e.clientX - left, e.clientY - top);
+    onChange();
+  }
+
+  let dragging = false;
+  let dragId: number | null = null;
+  let lastX = 0;
+  let lastY = 0;
+  function onPointerDown(e: PointerEvent): void {
+    if (e.pointerType !== "mouse") return; // touch handled below
+    dragging = true;
+    dragId = e.pointerId;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    try {
+      el.setPointerCapture?.(e.pointerId);
+    } catch {
+      /* jsdom / unsupported */
+    }
+  }
+  function onPointerMove(e: PointerEvent): void {
+    if (!dragging || e.pointerId !== dragId) return;
+    pz.panBy(e.clientX - lastX, e.clientY - lastY);
+    lastX = e.clientX;
+    lastY = e.clientY;
+    onChange();
+  }
+  function onPointerUp(e: PointerEvent): void {
+    if (e.pointerId === dragId) {
+      dragging = false;
+      dragId = null;
+    }
+  }
+
+  let pinching = false;
+  let prevDist = 0;
+  let touchPanning = false;
+  let touchX = 0;
+  let touchY = 0;
+  function onTouchStart(e: TouchEvent): void {
+    if (e.touches.length === 2) {
+      pinching = true;
+      touchPanning = false;
+      prevDist = pinchDistance(e.touches[0]!, e.touches[1]!);
+    } else if (e.touches.length === 1 && oneFingerTouchPan) {
+      touchPanning = true;
+      touchX = e.touches[0]!.clientX;
+      touchY = e.touches[0]!.clientY;
+    }
+  }
+  function onTouchMove(e: TouchEvent): void {
+    if (pinching && e.touches.length === 2) {
+      e.preventDefault();
+      const { left, top } = origin();
+      const dist = pinchDistance(e.touches[0]!, e.touches[1]!);
+      if (prevDist > 0) {
+        const midX = (e.touches[0]!.clientX + e.touches[1]!.clientX) / 2 - left;
+        const midY = (e.touches[0]!.clientY + e.touches[1]!.clientY) / 2 - top;
+        pz.zoomAt(dist / prevDist, midX, midY);
+        onChange();
+      }
+      prevDist = dist;
+    } else if (touchPanning && e.touches.length === 1) {
+      e.preventDefault();
+      pz.panBy(e.touches[0]!.clientX - touchX, e.touches[0]!.clientY - touchY);
+      touchX = e.touches[0]!.clientX;
+      touchY = e.touches[0]!.clientY;
+      onChange();
+    }
+  }
+  function onTouchEnd(e: TouchEvent): void {
+    if (e.touches.length < 2) {
+      pinching = false;
+      prevDist = 0;
+    }
+    if (e.touches.length === 0) {
+      touchPanning = false;
+    }
+  }
+
+  el.addEventListener("wheel", onWheel, { passive: false });
+  el.addEventListener("pointerdown", onPointerDown);
+  el.addEventListener("pointermove", onPointerMove);
+  el.addEventListener("pointerup", onPointerUp);
+  el.addEventListener("pointercancel", onPointerUp);
+  el.addEventListener("touchstart", onTouchStart, { passive: false });
+  el.addEventListener("touchmove", onTouchMove, { passive: false });
+  el.addEventListener("touchend", onTouchEnd);
+
+  return () => {
+    el.removeEventListener("wheel", onWheel);
+    el.removeEventListener("pointerdown", onPointerDown);
+    el.removeEventListener("pointermove", onPointerMove);
+    el.removeEventListener("pointerup", onPointerUp);
+    el.removeEventListener("pointercancel", onPointerUp);
+    el.removeEventListener("touchstart", onTouchStart);
+    el.removeEventListener("touchmove", onTouchMove);
+    el.removeEventListener("touchend", onTouchEnd);
   };
 }
 ```
 
 - [ ] **Step 4: Run to verify they pass**
 
-Run: `cd packages/relay-web && npx vitest run src/__tests__/pan-zoom.test.ts`
-Expected: PASS (4 tests).
+Run: `cd packages/relay-web && npx vitest run src/__tests__/pan-zoom-gestures.test.ts`
+Expected: PASS (5 tests). jsdom's `getBoundingClientRect` returns zeros, so origins are (0,0) — the assertions account for that.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Typecheck + commit**
 
 ```bash
-git add packages/relay-web/src/lib/pan-zoom.ts packages/relay-web/src/__tests__/pan-zoom.test.ts
-git commit -m "feat(relay-web): pure pan/zoom transform controller"
+cd packages/relay-web && npx vue-tsc --noEmit && cd ../..
+git add packages/relay-web/src/lib/pan-zoom-gestures.ts packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
+git commit -m "feat(relay-web): shared pan/zoom gesture wiring (wheel/drag/pinch)"
 ```
 
 ---
 
-### Task 2: `MermaidViewer.vue` fullscreen overlay
+### Task 3: `MermaidViewer.vue` — fullscreen overlay
 
 **Files:**
 - Create: `packages/relay-web/src/components/MermaidViewer.vue`
 - Test: `packages/relay-web/src/__tests__/mermaidviewer.test.ts`
 
 **Interfaces:**
-- Consumes: `createPanZoom` (Task 1); `useModalA11y` from `../lib/use-modal-a11y`; icons from `lucide-vue-next`.
-- Produces: a component with prop `svg: string` and emit `close`. Rendered only when open (parent `v-if`).
+- Consumes: `createPanZoom` (`../lib/pan-zoom`), `attachPanZoomGestures` (`../lib/pan-zoom-gestures`), `useModalA11y` (`../lib/use-modal-a11y`), icons from `lucide-vue-next`.
+- Produces: component with prop `svg: string`, emit `close`. Rendered only while open (parent `v-if`).
 
 - [ ] **Step 1: Write the failing tests**
 
-Create `packages/relay-web/src/__tests__/mermaidviewer.test.ts`:
+Create `packages/relay-web/src/__tests__/mermaidviewer.test.ts`. NOTE: Teleport puts the overlay in `document.body`, so query there (NOT `wrapper.get`):
 ```ts
 import { afterEach, expect, test } from "vitest";
 import { mount } from "@vue/test-utils";
 import MermaidViewer from "../components/MermaidViewer.vue";
 
 const SVG = '<svg data-test="diagram"><text>hi</text></svg>';
+afterEach(() => { document.body.innerHTML = ""; document.body.style.overflow = ""; });
 
-afterEach(() => {
-  document.body.innerHTML = "";
-  document.body.style.overflow = "";
-});
-
-function content(): HTMLElement | null {
-  return document.body.querySelector(".mv-content");
+const q = (sel: string) => document.body.querySelector(sel) as HTMLElement | null;
+function fire(el: EventTarget, type: string, props: Record<string, unknown>): void {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(e, props);
+  el.dispatchEvent(e);
 }
 
 test("teleports and renders the svg; locks body scroll while open", () => {
   const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
-  expect(document.body.querySelector('[data-test="diagram"]')).not.toBeNull();
+  expect(q('[data-test="diagram"]')).not.toBeNull();
   expect(document.body.style.overflow).toBe("hidden");
   wrapper.unmount();
-  expect(document.body.style.overflow).toBe(""); // restored
+  expect(document.body.style.overflow).toBe("");
 });
 
-test("wheel and the zoom-in control change the transform; reset restores it", async () => {
+test("wheel changes the transform; reset restores it", async () => {
   const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
-  const before = content()!.style.transform;
-  const stage = document.body.querySelector(".mv-stage")!;
-  stage.dispatchEvent(new WheelEvent("wheel", { deltaY: -100, bubbles: true, cancelable: true }));
+  const content = q(".mv-content")!;
+  const before = content.style.transform;
+  fire(q(".mv-stage")!, "wheel", { deltaY: -100, clientX: 0, clientY: 0 });
   await wrapper.vm.$nextTick();
-  expect(content()!.style.transform).not.toBe(before);
-  await wrapper.get('[aria-label="Reset"]').trigger("click");
-  expect(content()!.style.transform).toBe("translate(0px, 0px) scale(1)");
+  expect(content.style.transform).not.toBe(before);
+  q('[aria-label="Reset"]')!.click();
+  await wrapper.vm.$nextTick();
+  expect(content.style.transform).toBe("translate(0px, 0px) scale(1)");
   wrapper.unmount();
 });
 
-test("pointer drag pans the content", async () => {
+test("Escape, close button, and background click each emit close", async () => {
   const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
-  const stage = wrapper.get(".mv-stage");
-  await stage.trigger("pointerdown", { pointerId: 1, clientX: 0, clientY: 0 });
-  await stage.trigger("pointermove", { pointerId: 1, clientX: 30, clientY: 40 });
-  await stage.trigger("pointerup", { pointerId: 1 });
-  expect(content()!.style.transform).toBe("translate(30px, 40px) scale(1)");
-  wrapper.unmount();
-});
-
-test("close button, backdrop click, and Escape each emit close", async () => {
-  const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
-  await wrapper.get('[aria-label="Close"]').trigger("click");
-  expect(wrapper.emitted("close")).toHaveLength(1);
   document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+  q('[aria-label="Close"]')!.click();
+  q(".mv-stage")!.click(); // background (target === stage)
   await wrapper.vm.$nextTick();
-  expect(wrapper.emitted("close")!.length).toBeGreaterThanOrEqual(2);
+  expect(wrapper.emitted("close")!.length).toBeGreaterThanOrEqual(3);
   wrapper.unmount();
 });
 ```
@@ -215,7 +330,7 @@ test("close button, backdrop click, and Escape each emit close", async () => {
 - [ ] **Step 2: Run to verify they fail**
 
 Run: `cd packages/relay-web && npx vitest run src/__tests__/mermaidviewer.test.ts`
-Expected: FAIL — `../components/MermaidViewer.vue` does not exist.
+Expected: FAIL — component does not exist.
 
 - [ ] **Step 3: Implement `MermaidViewer.vue`**
 
@@ -225,10 +340,10 @@ Create `packages/relay-web/src/components/MermaidViewer.vue`:
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import { X, ZoomIn, ZoomOut, RotateCcw } from "lucide-vue-next";
 import { createPanZoom } from "../lib/pan-zoom";
+import { attachPanZoomGestures } from "../lib/pan-zoom-gestures";
 import { useModalA11y } from "../lib/use-modal-a11y";
 
-// Rendered only while open (parent v-if), so mount/unmount === open/close: useModalA11y and the
-// body-scroll lock hook straight into the component lifecycle.
+// Rendered only while open (parent v-if) → mount/unmount == open/close.
 defineProps<{ svg: string }>();
 const emit = defineEmits<{ close: [] }>();
 
@@ -236,112 +351,38 @@ const dialogEl = ref<HTMLElement | null>(null);
 const stageEl = ref<HTMLElement | null>(null);
 const transform = ref("translate(0px, 0px) scale(1)");
 const pz = createPanZoom();
-
 function apply(): void {
   transform.value = pz.toTransform();
 }
 
 useModalA11y(dialogEl, () => emit("close"));
 
-function stageRect(): DOMRect | null {
-  return stageEl.value?.getBoundingClientRect() ?? null;
-}
-
-function onWheel(e: WheelEvent): void {
-  e.preventDefault();
-  const rect = stageRect();
-  if (!rect) return;
-  pz.zoomAt(e.deltaY < 0 ? 1.1 : 1 / 1.1, e.clientX - rect.left, e.clientY - rect.top);
-  apply();
-}
-
-// Pointer drag (mouse or a single touch). A two-finger pinch takes over via the touch handlers.
-let dragging = false;
-let activePointer: number | null = null;
-let lastX = 0;
-let lastY = 0;
-function onPointerDown(e: PointerEvent): void {
-  if (pinchActive) return;
-  dragging = true;
-  activePointer = e.pointerId;
-  lastX = e.clientX;
-  lastY = e.clientY;
-  stageEl.value?.setPointerCapture?.(e.pointerId);
-}
-function onPointerMove(e: PointerEvent): void {
-  if (!dragging || e.pointerId !== activePointer) return;
-  pz.panBy(e.clientX - lastX, e.clientY - lastY);
-  lastX = e.clientX;
-  lastY = e.clientY;
-  apply();
-}
-function onPointerUp(e: PointerEvent): void {
-  if (e.pointerId === activePointer) {
-    dragging = false;
-    activePointer = null;
+let detach: (() => void) | null = null;
+let prevOverflow = "";
+onMounted(() => {
+  if (stageEl.value) {
+    detach = attachPanZoomGestures(stageEl.value, pz, apply, { oneFingerTouchPan: true });
   }
-}
-
-// Pinch zoom (two touches).
-let pinchActive = false;
-let pinchDist = 0;
-function dist(t: TouchList): number {
-  return Math.hypot(t[0]!.clientX - t[1]!.clientX, t[0]!.clientY - t[1]!.clientY);
-}
-function onTouchStart(e: TouchEvent): void {
-  if (e.touches.length === 2) {
-    pinchActive = true;
-    dragging = false;
-    pinchDist = dist(e.touches);
-  }
-}
-function onTouchMove(e: TouchEvent): void {
-  if (!pinchActive || e.touches.length !== 2) return;
-  e.preventDefault();
-  const rect = stageRect();
-  if (!rect || pinchDist === 0) {
-    pinchDist = e.touches.length === 2 ? dist(e.touches) : 0;
-    return;
-  }
-  const d = dist(e.touches);
-  const midX = (e.touches[0]!.clientX + e.touches[1]!.clientX) / 2 - rect.left;
-  const midY = (e.touches[0]!.clientY + e.touches[1]!.clientY) / 2 - rect.top;
-  pz.zoomAt(d / pinchDist, midX, midY);
-  pinchDist = d;
-  apply();
-}
-function onTouchEnd(e: TouchEvent): void {
-  if (e.touches.length < 2) {
-    pinchActive = false;
-    pinchDist = 0;
-  }
-}
+  prevOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+});
+onBeforeUnmount(() => {
+  detach?.();
+  document.body.style.overflow = prevOverflow;
+});
 
 function zoomButton(factor: number): void {
-  const rect = stageRect();
-  pz.zoomAt(factor, rect ? rect.width / 2 : 0, rect ? rect.height / 2 : 0);
+  const r = stageEl.value?.getBoundingClientRect();
+  pz.zoomAt(factor, r ? r.width / 2 : 0, r ? r.height / 2 : 0);
   apply();
 }
 function reset(): void {
   pz.reset();
   apply();
 }
-
-// Background (not the diagram) click closes, but only when it wasn't a drag.
-function onStagePointerUp(e: PointerEvent): void {
-  const wasDrag = e.pointerId === activePointer && (Math.abs(e.clientX - lastX) > 4 || Math.abs(e.clientY - lastY) > 4);
-  onPointerUp(e);
-  if (!wasDrag && e.target === stageEl.value) emit("close");
+function onStageClick(e: MouseEvent): void {
+  if (e.target === stageEl.value) emit("close"); // background, not the diagram
 }
-
-let prevOverflow = "";
-onMounted(() => {
-  prevOverflow = document.body.style.overflow;
-  document.body.style.overflow = "hidden";
-});
-onBeforeUnmount(() => {
-  document.body.style.overflow = prevOverflow;
-});
 </script>
 
 <template>
@@ -354,18 +395,7 @@ onBeforeUnmount(() => {
       aria-modal="true"
       aria-label="Diagram viewer"
     >
-      <div
-        ref="stageEl"
-        class="mv-stage"
-        @wheel="onWheel"
-        @pointerdown="onPointerDown"
-        @pointermove="onPointerMove"
-        @pointerup="onStagePointerUp"
-        @pointercancel="onPointerUp"
-        @touchstart="onTouchStart"
-        @touchmove="onTouchMove"
-        @touchend="onTouchEnd"
-      >
+      <div ref="stageEl" class="mv-stage" @click="onStageClick">
         <!-- eslint-disable-next-line vue/no-v-html -- SVG already DOMPurify-sanitized by render-mermaid -->
         <div class="mv-content" :style="{ transform }" v-html="svg" />
       </div>
@@ -392,7 +422,7 @@ onBeforeUnmount(() => {
   inset: 0;
   overflow: hidden;
   cursor: grab;
-  touch-action: none; /* the overlay owns all gestures; no page scroll behind it */
+  touch-action: none;
 }
 .mv-stage:active {
   cursor: grabbing;
@@ -429,17 +459,12 @@ onBeforeUnmount(() => {
 </style>
 ```
 
-- [ ] **Step 4: Run to verify they pass**
+- [ ] **Step 4: Run tests + typecheck**
 
-Run: `cd packages/relay-web && npx vitest run src/__tests__/mermaidviewer.test.ts`
-Expected: PASS (4 tests). If jsdom's `getBoundingClientRect` returns zeros, wheel/zoom still change scale (center at 0,0), so the transform still differs from identity — the assertions hold.
+Run: `cd packages/relay-web && npx vitest run src/__tests__/mermaidviewer.test.ts && npx vue-tsc --noEmit`
+Expected: PASS (3 tests) + clean typecheck.
 
-- [ ] **Step 5: Typecheck**
-
-Run: `cd packages/relay-web && npx vue-tsc --noEmit`
-Expected: clean.
-
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add packages/relay-web/src/components/MermaidViewer.vue packages/relay-web/src/__tests__/mermaidviewer.test.ts
@@ -448,7 +473,188 @@ git commit -m "feat(relay-web): fullscreen mermaid viewer with pan/zoom"
 
 ---
 
-### Task 3: Open the viewer from `StreamMarkdown` on click (+ affordance CSS + docs)
+### Task 4: `inline-mermaid.ts` — in-place enhancement
+
+**Files:**
+- Create: `packages/relay-web/src/lib/inline-mermaid.ts`
+- Test: `packages/relay-web/src/__tests__/inline-mermaid.test.ts`
+
+**Interfaces:**
+- Consumes: `createPanZoom`, `attachPanZoomGestures`.
+- Produces: `enhanceMermaidBlock(block: HTMLElement, opts: { onExpand: () => void }): () => void`. Consumed by Task 5.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/relay-web/src/__tests__/inline-mermaid.test.ts`:
+```ts
+import { afterEach, expect, test } from "vitest";
+import { enhanceMermaidBlock } from "../lib/inline-mermaid";
+
+afterEach(() => { document.body.innerHTML = ""; });
+function fire(el: EventTarget, type: string, props: Record<string, unknown>): void {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(e, props);
+  el.dispatchEvent(e);
+}
+function makeBlock(): HTMLElement {
+  const block = document.createElement("pre");
+  block.className = "mermaid-block mermaid-rendered";
+  block.innerHTML = '<svg data-test="d"><text>x</text></svg>';
+  document.body.appendChild(block);
+  return block;
+}
+
+test("wraps the svg in a viewport and adds a 4-button controls bar", () => {
+  const block = makeBlock();
+  enhanceMermaidBlock(block, { onExpand: () => {} });
+  expect(block.querySelector('.mmd-viewport .mmd-transform svg[data-test="d"]')).not.toBeNull();
+  expect(block.querySelectorAll(".mmd-controls button").length).toBe(4);
+});
+
+test("Ctrl+wheel zooms; a plain wheel does not (page keeps scrolling)", () => {
+  const block = makeBlock();
+  enhanceMermaidBlock(block, { onExpand: () => {} });
+  const viewport = block.querySelector(".mmd-viewport")!;
+  const wrap = block.querySelector(".mmd-transform") as HTMLElement;
+  fire(viewport, "wheel", { deltaY: -100, clientX: 0, clientY: 0 });
+  expect(wrap.style.transform === "" || wrap.style.transform === "translate(0px, 0px) scale(1)").toBe(true);
+  fire(viewport, "wheel", { deltaY: -100, ctrlKey: true, clientX: 0, clientY: 0 });
+  expect(wrap.style.transform).toContain("scale(1.1)");
+});
+
+test("reset restores the transform; the ⤢ button calls onExpand", () => {
+  let expanded = 0;
+  const block = makeBlock();
+  enhanceMermaidBlock(block, { onExpand: () => { expanded += 1; } });
+  (block.querySelector('[aria-label="Zoom in"]') as HTMLElement).click();
+  (block.querySelector('[aria-label="Reset"]') as HTMLElement).click();
+  expect((block.querySelector(".mmd-transform") as HTMLElement).style.transform).toBe("translate(0px, 0px) scale(1)");
+  (block.querySelector('[aria-label="Fullscreen"]') as HTMLElement).click();
+  expect(expanded).toBe(1);
+});
+
+test("detach removes gesture listeners", () => {
+  const block = makeBlock();
+  const detach = enhanceMermaidBlock(block, { onExpand: () => {} });
+  detach();
+  const wrap = block.querySelector(".mmd-transform") as HTMLElement;
+  const before = wrap.style.transform;
+  fire(block.querySelector(".mmd-viewport")!, "wheel", { deltaY: -100, ctrlKey: true, clientX: 0, clientY: 0 });
+  expect(wrap.style.transform).toBe(before);
+});
+
+test("a block with no svg is a no-op returning a safe detach", () => {
+  const block = document.createElement("pre");
+  block.className = "mermaid-block mermaid-rendered";
+  document.body.appendChild(block);
+  const detach = enhanceMermaidBlock(block, { onExpand: () => {} });
+  expect(block.querySelector(".mmd-viewport")).toBeNull();
+  expect(() => detach()).not.toThrow();
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/inline-mermaid.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `inline-mermaid.ts`**
+
+Create `packages/relay-web/src/lib/inline-mermaid.ts`:
+```ts
+import { createPanZoom } from "./pan-zoom";
+import { attachPanZoomGestures } from "./pan-zoom-gestures";
+
+interface ZoomControl {
+  label: string;
+  glyph: string;
+  factor: number; // 0 === reset
+}
+const ZOOM_CONTROLS: ZoomControl[] = [
+  { label: "Zoom out", glyph: "−", factor: 0.8 }, // −
+  { label: "Reset", glyph: "↺", factor: 0 }, // ↺
+  { label: "Zoom in", glyph: "+", factor: 1.25 },
+];
+
+/**
+ * Enhance a rendered `pre.mermaid-block`: move its injected `<svg>` into a bounded pan/zoom
+ * viewport (Ctrl/⌘+wheel zoom, mouse-drag pan, two-finger pinch; one finger still scrolls the
+ * page), and add a controls bar (− / reset / + / ⤢). The ⤢ button calls `onExpand`. Returns a
+ * detach that removes every listener. A block without an `<svg>` is a no-op.
+ */
+export function enhanceMermaidBlock(block: HTMLElement, opts: { onExpand: () => void }): () => void {
+  const svg = block.querySelector("svg");
+  if (!svg) return () => {};
+
+  const viewport = document.createElement("div");
+  viewport.className = "mmd-viewport";
+  const wrapper = document.createElement("div");
+  wrapper.className = "mmd-transform";
+  wrapper.appendChild(svg); // moves the svg out of the <pre>
+  viewport.appendChild(wrapper);
+
+  const pz = createPanZoom();
+  const apply = (): void => {
+    wrapper.style.transform = pz.toTransform();
+  };
+
+  const bar = document.createElement("div");
+  bar.className = "mmd-controls";
+  const buttonDetachers: Array<() => void> = [];
+
+  const addButton = (label: string, glyph: string, handler: (e: Event) => void): void => {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.setAttribute("aria-label", label);
+    b.textContent = glyph;
+    b.addEventListener("click", handler);
+    buttonDetachers.push(() => b.removeEventListener("click", handler));
+    bar.appendChild(b);
+  };
+
+  for (const control of ZOOM_CONTROLS) {
+    addButton(control.label, control.glyph, (e) => {
+      e.stopPropagation();
+      if (control.factor === 0) {
+        pz.reset();
+      } else {
+        const r = viewport.getBoundingClientRect();
+        pz.zoomAt(control.factor, r.width / 2, r.height / 2);
+      }
+      apply();
+    });
+  }
+  addButton("Fullscreen", "⤢", (e) => {
+    e.stopPropagation();
+    opts.onExpand();
+  });
+
+  block.replaceChildren(viewport, bar);
+
+  const detachGestures = attachPanZoomGestures(viewport, pz, apply, { wheelRequiresModifier: true });
+
+  return () => {
+    detachGestures();
+    for (const d of buttonDetachers) d();
+  };
+}
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/inline-mermaid.test.ts && npx vue-tsc --noEmit`
+Expected: PASS (5 tests) + clean typecheck.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/relay-web/src/lib/inline-mermaid.ts packages/relay-web/src/__tests__/inline-mermaid.test.ts
+git commit -m "feat(relay-web): inline pan/zoom enhancement for rendered mermaid blocks"
+```
+
+---
+
+### Task 5: Wire inline + fullscreen into `StreamMarkdown` (+ CSS + docs)
 
 **Files:**
 - Modify: `packages/relay-web/src/components/StreamMarkdown.vue`
@@ -456,137 +662,237 @@ git commit -m "feat(relay-web): fullscreen mermaid viewer with pan/zoom"
 - Modify: `docs/relay-web-module.md`
 
 **Interfaces:**
-- Consumes: `MermaidViewer.vue` (Task 2). Opens it with a rendered block's `svg` outerHTML.
+- Consumes: `enhanceMermaidBlock` (`../lib/inline-mermaid`), `MermaidViewer.vue`.
 
 - [ ] **Step 1: Write the failing tests**
 
-Add to `packages/relay-web/src/__tests__/streammarkdown.test.ts`. Make the mocked `hydrateMermaidBlocks` mark blocks rendered and inject an SVG so a click has something to read; stub `MermaidViewer` so the assertion is on its `svg` prop, not teleported DOM:
+Add to `packages/relay-web/src/__tests__/streammarkdown.test.ts`. The existing file mocks `../lib/render-mermaid` with a `hydrate` `vi.fn`. For these cases, give that mock a body that marks blocks rendered and injects an svg, so there is a rendered block to enhance:
 ```ts
-// In the existing vi.mock("../lib/render-mermaid", ...), make hydrate mark blocks rendered:
-//   hydrateMermaidBlocks: async (root: HTMLElement) => {
+import MermaidViewer from "../components/MermaidViewer.vue";
+
+// In a test that needs a rendered block, set the shared hydrate mock to actually render:
+//   hydrate.mockImplementation(async (root: HTMLElement) => {
 //     root.querySelectorAll("pre.mermaid-block").forEach((b) => {
 //       b.classList.add("mermaid-rendered");
 //       b.innerHTML = '<svg data-test="d"><text>x</text></svg>';
 //     });
-//   },
-//   resetMermaidBlocks: () => {},
+//   });
 
-import MermaidViewer from "../components/MermaidViewer.vue";
-
-test("clicking a rendered mermaid block opens the viewer with its svg", async () => {
+test("a rendered mermaid block is enhanced with an inline pan/zoom viewport + controls", async () => {
+  hydrate.mockImplementation(async (root: HTMLElement) => {
+    root.querySelectorAll("pre.mermaid-block").forEach((b) => {
+      b.classList.add("mermaid-rendered");
+      b.innerHTML = '<svg data-test="d"><text>x</text></svg>';
+    });
+  });
   const wrapper = mount(StreamMarkdown, {
     props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false },
     global: { stubs: { MermaidViewer: true } },
   });
   await nextTick();
   await nextTick();
-  expect(wrapper.findComponent(MermaidViewer).exists()).toBe(false); // closed initially
-  await wrapper.get("pre.mermaid-block.mermaid-rendered").trigger("click");
-  const viewer = wrapper.findComponent(MermaidViewer);
-  expect(viewer.exists()).toBe(true);
-  expect(viewer.props("svg")).toContain('data-test="d"');
+  expect(wrapper.element.querySelector(".mmd-viewport")).not.toBeNull();
+  expect(wrapper.element.querySelectorAll(".mmd-controls button").length).toBe(4);
+  // idempotent: a second hydrate pass must not double-enhance
+  await wrapper.setProps({ streaming: false });
+  await nextTick();
+  expect(wrapper.element.querySelectorAll(".mmd-viewport").length).toBe(1);
+  hydrate.mockImplementation(async () => {});
   wrapper.unmount();
 });
 
-test("clicking ordinary rendered text does not open the viewer", async () => {
+test("clicking the ⤢ button opens the fullscreen viewer with the diagram svg", async () => {
+  hydrate.mockImplementation(async (root: HTMLElement) => {
+    root.querySelectorAll("pre.mermaid-block").forEach((b) => {
+      b.classList.add("mermaid-rendered");
+      b.innerHTML = '<svg data-test="d"><text>x</text></svg>';
+    });
+  });
   const wrapper = mount(StreamMarkdown, {
-    props: { text: "just some **text**", streaming: false },
+    props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false },
     global: { stubs: { MermaidViewer: true } },
   });
   await nextTick();
-  await wrapper.get(".stream-md").trigger("click");
+  await nextTick();
   expect(wrapper.findComponent(MermaidViewer).exists()).toBe(false);
+  (wrapper.element.querySelector('[aria-label="Fullscreen"]') as HTMLElement).click();
+  await nextTick();
+  const viewer = wrapper.findComponent(MermaidViewer);
+  expect(viewer.exists()).toBe(true);
+  expect(viewer.props("svg")).toContain('data-test="d"');
+  hydrate.mockImplementation(async () => {});
   wrapper.unmount();
 });
 ```
-(If the file's `vi.mock("../lib/render-mermaid", ...)` is currently a no-op hydrate, update it to the rendering mock shown in the comment above so `.mermaid-rendered` blocks exist to click. Keep any other existing streammarkdown tests working — the streaming-guard tests only assert hydrate was/ wasn't called, which the new mock still supports if you keep the `vi.fn()` wrapper; wrap the rendering body inside the existing `hydrate` mock fn.)
+(Keep the pre-existing streammarkdown tests working: they rely on `hydrate` being a `vi.fn` — restore `hydrate.mockImplementation(async () => {})` at the end of each new test, or set it in a `beforeEach`. If the shared mock isn't a resettable `vi.fn`, adapt to whatever the file already uses; the key is that the default hydrate does nothing so the streaming/theme tests are unaffected.)
 
 - [ ] **Step 2: Run to verify they fail**
 
 Run: `cd packages/relay-web && npx vitest run src/__tests__/streammarkdown.test.ts`
-Expected: FAIL — StreamMarkdown neither imports MermaidViewer nor opens it on click.
+Expected: FAIL — StreamMarkdown does not enhance blocks or render the viewer.
 
-- [ ] **Step 3: Wire the click handler into `StreamMarkdown.vue`**
+- [ ] **Step 3: Wire `StreamMarkdown.vue`**
 
-In `<script setup>`, add the import and state, and a click handler:
+Add imports:
 ```ts
+import { enhanceMermaidBlock } from "../lib/inline-mermaid";
 import MermaidViewer from "./MermaidViewer.vue";
 ```
-Add near the other refs:
+Add state + helpers near the other refs (after `let hydrateChain`):
 ```ts
-// Clicking a fully-rendered mermaid diagram opens the fullscreen pan/zoom viewer. Delegated on the
-// root so it survives v-html re-renders; reads the SVG already in the DOM (no re-parse).
 const viewerSvg = ref<string | null>(null);
-function onRootClick(event: MouseEvent): void {
-  const target = event.target as HTMLElement | null;
-  const block = target?.closest?.("pre.mermaid-block.mermaid-rendered");
-  const svg = block?.querySelector("svg")?.outerHTML;
-  if (svg) viewerSvg.value = svg;
+let enhanceDetachers: Array<() => void> = [];
+function detachEnhancers(): void {
+  for (const d of enhanceDetachers) d();
+  enhanceDetachers = [];
+}
+// After hydration, give each freshly-rendered diagram inline pan/zoom + a ⤢ that opens the
+// fullscreen viewer. `data-mmd-enhanced` keeps a re-hydration from wrapping the same block twice.
+function enhanceRenderedBlocks(root: HTMLElement): void {
+  root
+    .querySelectorAll<HTMLElement>("pre.mermaid-block.mermaid-rendered:not([data-mmd-enhanced])")
+    .forEach((block) => {
+      block.setAttribute("data-mmd-enhanced", "1");
+      enhanceDetachers.push(
+        enhanceMermaidBlock(block, {
+          onExpand: () => {
+            viewerSvg.value = block.querySelector("svg")?.outerHTML ?? null;
+          },
+        }),
+      );
+    });
 }
 ```
-Update the template root and add the viewer:
+Change `scheduleHydrate` to detach enhancers on reset and enhance after hydration:
+```ts
+function scheduleHydrate(reset: boolean): void {
+  if (props.streaming) return;
+  hydrateChain = hydrateChain
+    .then(async () => {
+      await nextTick();
+      if (disposed || rootEl.value === null) return;
+      if (reset) {
+        detachEnhancers();
+        resetMermaidBlocks(rootEl.value);
+      }
+      await hydrateMermaidBlocks(rootEl.value, theme.mode);
+      if (!disposed && rootEl.value !== null) enhanceRenderedBlocks(rootEl.value);
+    })
+    .catch(() => {});
+}
+```
+Extend the unmount hook to detach enhancers:
+```ts
+onBeforeUnmount(() => {
+  disposed = true;
+  cancelTimer();
+  detachEnhancers();
+});
+```
+(If the existing `onBeforeUnmount` only calls `cancelTimer()`, add `detachEnhancers()` and keep the `disposed = true` that is already there.)
+
+Update the template to render the viewer (the root `<div>` stays exactly as-is):
 ```html
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -- input is sanitized by renderMarkdown (DOMPurify) -->
-  <div ref="rootEl" class="stream-md text-sm" v-html="html" @click="onRootClick" />
+  <div ref="rootEl" class="stream-md text-sm" v-html="html" />
   <MermaidViewer v-if="viewerSvg" :svg="viewerSvg" @close="viewerSvg = null" />
 </template>
 ```
-(Note: the template currently has a single self-closing root `<div>`. Vue 3 allows multiple root nodes, so adding the sibling `<MermaidViewer>` is fine.)
 
-- [ ] **Step 4: Add the click affordance CSS**
+- [ ] **Step 4: Add inline CSS to the same file's non-scoped `<style>`**
 
-Append to the `<style>` block in `StreamMarkdown.vue` (after the `.mermaid-error` rule from the base feature):
+Append after the `.mermaid-error` rule:
 ```css
-/* A rendered diagram is clickable → opens the pan/zoom viewer. Signal it with a zoom cursor and
-   a hover ⤢ badge (on the <pre>, which is a real element, so ::after is safe over v-html SVG). */
+/* Inline pan/zoom: the enhancer replaces the rendered <pre> content with a bounded viewport + a
+   controls bar. The <pre> is the positioning context for the controls. */
 .stream-md .mermaid-block.mermaid-rendered {
-  cursor: zoom-in;
   position: relative;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
 }
-.stream-md .mermaid-block.mermaid-rendered::after {
-  content: "⤢";
+.stream-md .mmd-viewport {
+  max-height: 420px;
+  overflow: hidden;
+  border: 1px solid rgb(var(--c-border));
+  border-radius: 8px;
+  background: rgb(var(--c-bg));
+  box-shadow: var(--shadow-e1);
+  touch-action: pan-y; /* one finger scrolls the page; the enhancer handles pinch + mouse drag */
+  cursor: grab;
+}
+.stream-md .mmd-viewport:active {
+  cursor: grabbing;
+}
+.stream-md .mmd-transform {
+  transform-origin: 0 0;
+  width: max-content;
+}
+.stream-md .mmd-transform svg {
+  display: block;
+}
+.stream-md .mmd-controls {
   position: absolute;
   top: 6px;
-  right: 8px;
+  right: 6px;
+  display: flex;
+  gap: 4px;
+  opacity: 0.5;
+  transition: opacity 0.12s;
+}
+.stream-md .mermaid-block.mermaid-rendered:hover .mmd-controls,
+.stream-md .mermaid-block.mermaid-rendered:focus-within .mmd-controls {
+  opacity: 1;
+}
+.stream-md .mmd-controls button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
   font-size: 14px;
   line-height: 1;
-  color: rgb(var(--c-fg-muted));
-  opacity: 0;
-  transition: opacity 0.12s;
-  pointer-events: none;
+  border-radius: 6px;
+  border: 1px solid rgb(var(--c-border));
+  background: rgb(var(--c-surface));
+  color: rgb(var(--c-fg));
 }
-.stream-md .mermaid-block.mermaid-rendered:hover::after {
-  opacity: 0.85;
+.stream-md .mmd-controls button:hover {
+  background: rgb(var(--c-bg-raised, var(--c-surface)));
 }
 ```
 
 - [ ] **Step 5: Run the full relay-web suite + typecheck**
 
 Run: `cd packages/relay-web && npx vitest run && npx vue-tsc --noEmit`
-Expected: new StreamMarkdown cases pass; all pre-existing tests still pass; typecheck clean.
+Expected: new cases pass; all pre-existing tests still pass; typecheck clean.
 
 - [ ] **Step 6: Document it**
 
-In `docs/relay-web-module.md`, extend the `### Mermaid 图表渲染` subsection with one line:
+In `docs/relay-web-module.md`, extend the `### Mermaid 图表渲染` subsection with:
 ```markdown
-点击已渲染的图表会打开全屏查看器（`MermaidViewer.vue` + 纯 `pan-zoom.ts` 控制器）：拖拽平移、
-滚轮/双指缩放、缩放/复位按钮、Esc/✕/点空白关闭。查看器复用已注入 DOM 的（已净化）SVG，不重新解析。
+已渲染的图表支持平移/缩放：**内联**（`inline-mermaid.ts` 就地增强——Ctrl/⌘+滚轮缩放、鼠标拖拽平移、
+双指捏合；单指仍滚动页面）配一条 − / 复位 / + / ⤢ 控件条；点 ⤢ 打开**全屏**查看器（`MermaidViewer.vue`，
+平滑滚轮/单指拖拽/双指缩放 + Esc/✕/点空白关闭）。两种模式共用纯 `pan-zoom.ts` 控制器与
+`pan-zoom-gestures.ts` 手势装配；均复用已注入 DOM 的（已净化）SVG，不重新解析。
 ```
 
 - [ ] **Step 7: Commit**
 
 ```bash
 git add packages/relay-web/src/components/StreamMarkdown.vue packages/relay-web/src/__tests__/streammarkdown.test.ts docs/relay-web-module.md
-git commit -m "feat(relay-web): open pan/zoom viewer when a mermaid diagram is clicked"
+git commit -m "feat(relay-web): inline + fullscreen pan/zoom for mermaid diagrams"
 ```
 
 ---
 
 ## Self-Review
 
-**Spec coverage:** pure controller (Task 1) ✓; fullscreen viewer with drag/wheel/pinch/controls/close/scroll-lock/a11y (Task 2) ✓; click-to-open from StreamMarkdown + affordance + docs (Task 3) ✓.
+**Spec coverage:** gestures module (Task 2) ✓; fullscreen viewer (Task 3) ✓; inline enhancer (Task 4) ✓; StreamMarkdown wiring both modes + CSS + docs (Task 5) ✓. `pan-zoom.ts` (Task 1) already done.
 
 **Placeholder scan:** every code step has complete code; no TBD.
 
-**Type consistency:** `createPanZoom(): PanZoom` used identically in Task 1 (def) and Task 2 (consumer). `MermaidViewer` prop `svg: string` / emit `close` identical across Task 2 (def + tests) and Task 3 (usage + tests). The click handler reads `pre.mermaid-block.mermaid-rendered` — the exact class `render-mermaid` sets on success.
+**Type consistency:** `attachPanZoomGestures(el, pz, onChange, opts?)` and `GestureOptions` identical across Task 2 (def), Task 3, Task 4. `PanZoom` from `pan-zoom.ts` consumed unchanged. `enhanceMermaidBlock(block, { onExpand })` identical in Task 4 (def) and Task 5 (call). `MermaidViewer` prop `svg: string` / emit `close` identical in Task 3 and Task 5. The enhancer/viewer select `pre.mermaid-block.mermaid-rendered` — the class `render-mermaid` sets on success.

--- a/docs/superpowers/plans/2026-07-14-web-mermaid-panzoom.md
+++ b/docs/superpowers/plans/2026-07-14-web-mermaid-panzoom.md
@@ -1,0 +1,592 @@
+# Web Mermaid Pan/Zoom Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make rendered Mermaid diagrams pan/zoomable — clicking a diagram opens a fullscreen viewer with drag-pan, wheel-zoom, pinch-zoom, on-screen controls, and reset.
+
+**Architecture:** Three additive seams in `packages/relay-web`. A pure `pan-zoom` transform controller; a `MermaidViewer.vue` fullscreen overlay that wires DOM gestures to it; and a click handler in `StreamMarkdown.vue` that opens the viewer with a rendered block's SVG. `render-mermaid.ts` is unchanged.
+
+**Tech Stack:** Vue 3, `lucide-vue-next` icons, the existing `useModalA11y` composable, Vitest (jsdom) + @vue/test-utils.
+
+## Global Constraints
+
+- All code in `packages/relay-web`. Tests run with `npx vitest run` **from `packages/relay-web`** — never `bun test` (jsdom-dependent).
+- No new npm dependency (pan/zoom is hand-rolled; icons come from the existing `lucide-vue-next`).
+- Security: the viewer displays the SAME SVG string `render-mermaid` already produced and DOMPurified before injecting inline — read back from the live DOM, never re-parsed or re-fetched.
+- The existing mermaid hydration / streaming / theme logic in `StreamMarkdown.vue` and all of `render-mermaid.ts` must stay unchanged.
+- Overlay conventions: use `useModalA11y(dialogEl, close)` (Esc + focus trap + focus restore); the panel needs `ref`, `tabindex="-1" role="dialog" aria-modal="true"`. The viewer is rendered under `v-if` in the parent so it mounts on open / unmounts on close.
+- YAGNI: no inline gestures, no fit-to-screen auto-scale, no export, no minimap.
+
+---
+
+### Task 1: `pan-zoom` transform controller
+
+**Files:**
+- Create: `packages/relay-web/src/lib/pan-zoom.ts`
+- Test: `packages/relay-web/src/__tests__/pan-zoom.test.ts`
+
+**Interfaces:**
+- Produces: `createPanZoom(opts?: { minScale?: number; maxScale?: number }): PanZoom` where `PanZoom` has `readonly state: { scale; x; y }`, `zoomAt(factor, cx, cy)`, `panBy(dx, dy)`, `reset()`, `toTransform(): string`. Consumed by Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/relay-web/src/__tests__/pan-zoom.test.ts`:
+```ts
+import { expect, test } from "vitest";
+import { createPanZoom } from "../lib/pan-zoom";
+
+test("starts at identity and formats a transform-origin:0,0 transform", () => {
+  const pz = createPanZoom();
+  expect(pz.state).toEqual({ scale: 1, x: 0, y: 0 });
+  expect(pz.toTransform()).toBe("translate(0px, 0px) scale(1)");
+});
+
+test("zoomAt keeps the point under the cursor stationary", () => {
+  const pz = createPanZoom();
+  pz.zoomAt(2, 100, 0); // zoom 2x centered on viewport x=100
+  // content point that was under x=100 must still be under x=100: x = 100 - (100-0)*(2/1) = -100
+  expect(pz.state.scale).toBe(2);
+  expect(pz.state.x).toBe(-100);
+  expect(pz.state.y).toBe(0);
+});
+
+test("zoomAt clamps scale to [minScale, maxScale]", () => {
+  const pz = createPanZoom({ minScale: 0.5, maxScale: 4 });
+  pz.zoomAt(100, 0, 0);
+  expect(pz.state.scale).toBe(4);
+  pz.zoomAt(0.0001, 0, 0);
+  expect(pz.state.scale).toBe(0.5);
+});
+
+test("panBy accumulates and reset returns to identity", () => {
+  const pz = createPanZoom();
+  pz.panBy(10, 20);
+  pz.panBy(5, -5);
+  expect(pz.state).toEqual({ scale: 1, x: 15, y: 15 });
+  pz.zoomAt(2, 50, 50);
+  pz.reset();
+  expect(pz.state).toEqual({ scale: 1, x: 0, y: 0 });
+  expect(pz.toTransform()).toBe("translate(0px, 0px) scale(1)");
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/pan-zoom.test.ts`
+Expected: FAIL — `../lib/pan-zoom` does not exist.
+
+- [ ] **Step 3: Implement `pan-zoom.ts`**
+
+Create `packages/relay-web/src/lib/pan-zoom.ts`:
+```ts
+// Pure, framework-free pan/zoom transform state. The consumer applies `toTransform()` to an
+// element with `transform-origin: 0 0`. Kept DOM-free so the geometry is unit-testable.
+export interface PanZoomState {
+  scale: number;
+  x: number;
+  y: number;
+}
+
+export interface PanZoom {
+  readonly state: PanZoomState;
+  /** Multiply scale by `factor`, keeping viewport point (cx, cy) stationary. Clamps scale. */
+  zoomAt(factor: number, cx: number, cy: number): void;
+  panBy(dx: number, dy: number): void;
+  reset(): void;
+  /** CSS transform for a `transform-origin: 0 0` element. */
+  toTransform(): string;
+}
+
+export function createPanZoom(opts: { minScale?: number; maxScale?: number } = {}): PanZoom {
+  const minScale = opts.minScale ?? 0.2;
+  const maxScale = opts.maxScale ?? 8;
+  const state: PanZoomState = { scale: 1, x: 0, y: 0 };
+
+  return {
+    state,
+    zoomAt(factor, cx, cy) {
+      const next = Math.min(maxScale, Math.max(minScale, state.scale * factor));
+      if (next === state.scale) return;
+      // Solve for the translation that pins content point ((cx - x)/scale) under (cx, cy).
+      state.x = cx - (cx - state.x) * (next / state.scale);
+      state.y = cy - (cy - state.y) * (next / state.scale);
+      state.scale = next;
+    },
+    panBy(dx, dy) {
+      state.x += dx;
+      state.y += dy;
+    },
+    reset() {
+      state.scale = 1;
+      state.x = 0;
+      state.y = 0;
+    },
+    toTransform() {
+      return `translate(${state.x}px, ${state.y}px) scale(${state.scale})`;
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/pan-zoom.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/relay-web/src/lib/pan-zoom.ts packages/relay-web/src/__tests__/pan-zoom.test.ts
+git commit -m "feat(relay-web): pure pan/zoom transform controller"
+```
+
+---
+
+### Task 2: `MermaidViewer.vue` fullscreen overlay
+
+**Files:**
+- Create: `packages/relay-web/src/components/MermaidViewer.vue`
+- Test: `packages/relay-web/src/__tests__/mermaidviewer.test.ts`
+
+**Interfaces:**
+- Consumes: `createPanZoom` (Task 1); `useModalA11y` from `../lib/use-modal-a11y`; icons from `lucide-vue-next`.
+- Produces: a component with prop `svg: string` and emit `close`. Rendered only when open (parent `v-if`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/relay-web/src/__tests__/mermaidviewer.test.ts`:
+```ts
+import { afterEach, expect, test } from "vitest";
+import { mount } from "@vue/test-utils";
+import MermaidViewer from "../components/MermaidViewer.vue";
+
+const SVG = '<svg data-test="diagram"><text>hi</text></svg>';
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  document.body.style.overflow = "";
+});
+
+function content(): HTMLElement | null {
+  return document.body.querySelector(".mv-content");
+}
+
+test("teleports and renders the svg; locks body scroll while open", () => {
+  const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
+  expect(document.body.querySelector('[data-test="diagram"]')).not.toBeNull();
+  expect(document.body.style.overflow).toBe("hidden");
+  wrapper.unmount();
+  expect(document.body.style.overflow).toBe(""); // restored
+});
+
+test("wheel and the zoom-in control change the transform; reset restores it", async () => {
+  const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
+  const before = content()!.style.transform;
+  const stage = document.body.querySelector(".mv-stage")!;
+  stage.dispatchEvent(new WheelEvent("wheel", { deltaY: -100, bubbles: true, cancelable: true }));
+  await wrapper.vm.$nextTick();
+  expect(content()!.style.transform).not.toBe(before);
+  await wrapper.get('[aria-label="Reset"]').trigger("click");
+  expect(content()!.style.transform).toBe("translate(0px, 0px) scale(1)");
+  wrapper.unmount();
+});
+
+test("pointer drag pans the content", async () => {
+  const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
+  const stage = wrapper.get(".mv-stage");
+  await stage.trigger("pointerdown", { pointerId: 1, clientX: 0, clientY: 0 });
+  await stage.trigger("pointermove", { pointerId: 1, clientX: 30, clientY: 40 });
+  await stage.trigger("pointerup", { pointerId: 1 });
+  expect(content()!.style.transform).toBe("translate(30px, 40px) scale(1)");
+  wrapper.unmount();
+});
+
+test("close button, backdrop click, and Escape each emit close", async () => {
+  const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
+  await wrapper.get('[aria-label="Close"]').trigger("click");
+  expect(wrapper.emitted("close")).toHaveLength(1);
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+  await wrapper.vm.$nextTick();
+  expect(wrapper.emitted("close")!.length).toBeGreaterThanOrEqual(2);
+  wrapper.unmount();
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/mermaidviewer.test.ts`
+Expected: FAIL — `../components/MermaidViewer.vue` does not exist.
+
+- [ ] **Step 3: Implement `MermaidViewer.vue`**
+
+Create `packages/relay-web/src/components/MermaidViewer.vue`:
+```vue
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import { X, ZoomIn, ZoomOut, RotateCcw } from "lucide-vue-next";
+import { createPanZoom } from "../lib/pan-zoom";
+import { useModalA11y } from "../lib/use-modal-a11y";
+
+// Rendered only while open (parent v-if), so mount/unmount === open/close: useModalA11y and the
+// body-scroll lock hook straight into the component lifecycle.
+defineProps<{ svg: string }>();
+const emit = defineEmits<{ close: [] }>();
+
+const dialogEl = ref<HTMLElement | null>(null);
+const stageEl = ref<HTMLElement | null>(null);
+const transform = ref("translate(0px, 0px) scale(1)");
+const pz = createPanZoom();
+
+function apply(): void {
+  transform.value = pz.toTransform();
+}
+
+useModalA11y(dialogEl, () => emit("close"));
+
+function stageRect(): DOMRect | null {
+  return stageEl.value?.getBoundingClientRect() ?? null;
+}
+
+function onWheel(e: WheelEvent): void {
+  e.preventDefault();
+  const rect = stageRect();
+  if (!rect) return;
+  pz.zoomAt(e.deltaY < 0 ? 1.1 : 1 / 1.1, e.clientX - rect.left, e.clientY - rect.top);
+  apply();
+}
+
+// Pointer drag (mouse or a single touch). A two-finger pinch takes over via the touch handlers.
+let dragging = false;
+let activePointer: number | null = null;
+let lastX = 0;
+let lastY = 0;
+function onPointerDown(e: PointerEvent): void {
+  if (pinchActive) return;
+  dragging = true;
+  activePointer = e.pointerId;
+  lastX = e.clientX;
+  lastY = e.clientY;
+  stageEl.value?.setPointerCapture?.(e.pointerId);
+}
+function onPointerMove(e: PointerEvent): void {
+  if (!dragging || e.pointerId !== activePointer) return;
+  pz.panBy(e.clientX - lastX, e.clientY - lastY);
+  lastX = e.clientX;
+  lastY = e.clientY;
+  apply();
+}
+function onPointerUp(e: PointerEvent): void {
+  if (e.pointerId === activePointer) {
+    dragging = false;
+    activePointer = null;
+  }
+}
+
+// Pinch zoom (two touches).
+let pinchActive = false;
+let pinchDist = 0;
+function dist(t: TouchList): number {
+  return Math.hypot(t[0]!.clientX - t[1]!.clientX, t[0]!.clientY - t[1]!.clientY);
+}
+function onTouchStart(e: TouchEvent): void {
+  if (e.touches.length === 2) {
+    pinchActive = true;
+    dragging = false;
+    pinchDist = dist(e.touches);
+  }
+}
+function onTouchMove(e: TouchEvent): void {
+  if (!pinchActive || e.touches.length !== 2) return;
+  e.preventDefault();
+  const rect = stageRect();
+  if (!rect || pinchDist === 0) {
+    pinchDist = e.touches.length === 2 ? dist(e.touches) : 0;
+    return;
+  }
+  const d = dist(e.touches);
+  const midX = (e.touches[0]!.clientX + e.touches[1]!.clientX) / 2 - rect.left;
+  const midY = (e.touches[0]!.clientY + e.touches[1]!.clientY) / 2 - rect.top;
+  pz.zoomAt(d / pinchDist, midX, midY);
+  pinchDist = d;
+  apply();
+}
+function onTouchEnd(e: TouchEvent): void {
+  if (e.touches.length < 2) {
+    pinchActive = false;
+    pinchDist = 0;
+  }
+}
+
+function zoomButton(factor: number): void {
+  const rect = stageRect();
+  pz.zoomAt(factor, rect ? rect.width / 2 : 0, rect ? rect.height / 2 : 0);
+  apply();
+}
+function reset(): void {
+  pz.reset();
+  apply();
+}
+
+// Background (not the diagram) click closes, but only when it wasn't a drag.
+function onStagePointerUp(e: PointerEvent): void {
+  const wasDrag = e.pointerId === activePointer && (Math.abs(e.clientX - lastX) > 4 || Math.abs(e.clientY - lastY) > 4);
+  onPointerUp(e);
+  if (!wasDrag && e.target === stageEl.value) emit("close");
+}
+
+let prevOverflow = "";
+onMounted(() => {
+  prevOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+});
+onBeforeUnmount(() => {
+  document.body.style.overflow = prevOverflow;
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      ref="dialogEl"
+      class="mermaid-viewer"
+      tabindex="-1"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Diagram viewer"
+    >
+      <div
+        ref="stageEl"
+        class="mv-stage"
+        @wheel="onWheel"
+        @pointerdown="onPointerDown"
+        @pointermove="onPointerMove"
+        @pointerup="onStagePointerUp"
+        @pointercancel="onPointerUp"
+        @touchstart="onTouchStart"
+        @touchmove="onTouchMove"
+        @touchend="onTouchEnd"
+      >
+        <!-- eslint-disable-next-line vue/no-v-html -- SVG already DOMPurify-sanitized by render-mermaid -->
+        <div class="mv-content" :style="{ transform }" v-html="svg" />
+      </div>
+      <div class="mv-controls">
+        <button type="button" aria-label="Zoom out" @click="zoomButton(0.8)"><ZoomOut :size="18" /></button>
+        <button type="button" aria-label="Reset" @click="reset()"><RotateCcw :size="18" /></button>
+        <button type="button" aria-label="Zoom in" @click="zoomButton(1.25)"><ZoomIn :size="18" /></button>
+        <button type="button" aria-label="Close" @click="emit('close')"><X :size="18" /></button>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.mermaid-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgb(var(--c-bg) / 0.92);
+  backdrop-filter: blur(2px);
+}
+.mv-stage {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: none; /* the overlay owns all gestures; no page scroll behind it */
+}
+.mv-stage:active {
+  cursor: grabbing;
+}
+.mv-content {
+  transform-origin: 0 0;
+  width: max-content;
+}
+.mv-content :deep(svg) {
+  display: block;
+}
+.mv-controls {
+  position: absolute;
+  top: calc(0.75rem + env(safe-area-inset-top));
+  right: 0.75rem;
+  display: flex;
+  gap: 0.35rem;
+}
+.mv-controls button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  border: 1px solid rgb(var(--c-border));
+  background: rgb(var(--c-surface));
+  color: rgb(var(--c-fg));
+  box-shadow: var(--shadow-e1);
+}
+.mv-controls button:hover {
+  background: rgb(var(--c-bg-raised, var(--c-surface)));
+}
+</style>
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/mermaidviewer.test.ts`
+Expected: PASS (4 tests). If jsdom's `getBoundingClientRect` returns zeros, wheel/zoom still change scale (center at 0,0), so the transform still differs from identity — the assertions hold.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd packages/relay-web && npx vue-tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/relay-web/src/components/MermaidViewer.vue packages/relay-web/src/__tests__/mermaidviewer.test.ts
+git commit -m "feat(relay-web): fullscreen mermaid viewer with pan/zoom"
+```
+
+---
+
+### Task 3: Open the viewer from `StreamMarkdown` on click (+ affordance CSS + docs)
+
+**Files:**
+- Modify: `packages/relay-web/src/components/StreamMarkdown.vue`
+- Test: `packages/relay-web/src/__tests__/streammarkdown.test.ts` (add cases)
+- Modify: `docs/relay-web-module.md`
+
+**Interfaces:**
+- Consumes: `MermaidViewer.vue` (Task 2). Opens it with a rendered block's `svg` outerHTML.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/relay-web/src/__tests__/streammarkdown.test.ts`. Make the mocked `hydrateMermaidBlocks` mark blocks rendered and inject an SVG so a click has something to read; stub `MermaidViewer` so the assertion is on its `svg` prop, not teleported DOM:
+```ts
+// In the existing vi.mock("../lib/render-mermaid", ...), make hydrate mark blocks rendered:
+//   hydrateMermaidBlocks: async (root: HTMLElement) => {
+//     root.querySelectorAll("pre.mermaid-block").forEach((b) => {
+//       b.classList.add("mermaid-rendered");
+//       b.innerHTML = '<svg data-test="d"><text>x</text></svg>';
+//     });
+//   },
+//   resetMermaidBlocks: () => {},
+
+import MermaidViewer from "../components/MermaidViewer.vue";
+
+test("clicking a rendered mermaid block opens the viewer with its svg", async () => {
+  const wrapper = mount(StreamMarkdown, {
+    props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false },
+    global: { stubs: { MermaidViewer: true } },
+  });
+  await nextTick();
+  await nextTick();
+  expect(wrapper.findComponent(MermaidViewer).exists()).toBe(false); // closed initially
+  await wrapper.get("pre.mermaid-block.mermaid-rendered").trigger("click");
+  const viewer = wrapper.findComponent(MermaidViewer);
+  expect(viewer.exists()).toBe(true);
+  expect(viewer.props("svg")).toContain('data-test="d"');
+  wrapper.unmount();
+});
+
+test("clicking ordinary rendered text does not open the viewer", async () => {
+  const wrapper = mount(StreamMarkdown, {
+    props: { text: "just some **text**", streaming: false },
+    global: { stubs: { MermaidViewer: true } },
+  });
+  await nextTick();
+  await wrapper.get(".stream-md").trigger("click");
+  expect(wrapper.findComponent(MermaidViewer).exists()).toBe(false);
+  wrapper.unmount();
+});
+```
+(If the file's `vi.mock("../lib/render-mermaid", ...)` is currently a no-op hydrate, update it to the rendering mock shown in the comment above so `.mermaid-rendered` blocks exist to click. Keep any other existing streammarkdown tests working — the streaming-guard tests only assert hydrate was/ wasn't called, which the new mock still supports if you keep the `vi.fn()` wrapper; wrap the rendering body inside the existing `hydrate` mock fn.)
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/streammarkdown.test.ts`
+Expected: FAIL — StreamMarkdown neither imports MermaidViewer nor opens it on click.
+
+- [ ] **Step 3: Wire the click handler into `StreamMarkdown.vue`**
+
+In `<script setup>`, add the import and state, and a click handler:
+```ts
+import MermaidViewer from "./MermaidViewer.vue";
+```
+Add near the other refs:
+```ts
+// Clicking a fully-rendered mermaid diagram opens the fullscreen pan/zoom viewer. Delegated on the
+// root so it survives v-html re-renders; reads the SVG already in the DOM (no re-parse).
+const viewerSvg = ref<string | null>(null);
+function onRootClick(event: MouseEvent): void {
+  const target = event.target as HTMLElement | null;
+  const block = target?.closest?.("pre.mermaid-block.mermaid-rendered");
+  const svg = block?.querySelector("svg")?.outerHTML;
+  if (svg) viewerSvg.value = svg;
+}
+```
+Update the template root and add the viewer:
+```html
+<template>
+  <!-- eslint-disable-next-line vue/no-v-html -- input is sanitized by renderMarkdown (DOMPurify) -->
+  <div ref="rootEl" class="stream-md text-sm" v-html="html" @click="onRootClick" />
+  <MermaidViewer v-if="viewerSvg" :svg="viewerSvg" @close="viewerSvg = null" />
+</template>
+```
+(Note: the template currently has a single self-closing root `<div>`. Vue 3 allows multiple root nodes, so adding the sibling `<MermaidViewer>` is fine.)
+
+- [ ] **Step 4: Add the click affordance CSS**
+
+Append to the `<style>` block in `StreamMarkdown.vue` (after the `.mermaid-error` rule from the base feature):
+```css
+/* A rendered diagram is clickable → opens the pan/zoom viewer. Signal it with a zoom cursor and
+   a hover ⤢ badge (on the <pre>, which is a real element, so ::after is safe over v-html SVG). */
+.stream-md .mermaid-block.mermaid-rendered {
+  cursor: zoom-in;
+  position: relative;
+}
+.stream-md .mermaid-block.mermaid-rendered::after {
+  content: "⤢";
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  font-size: 14px;
+  line-height: 1;
+  color: rgb(var(--c-fg-muted));
+  opacity: 0;
+  transition: opacity 0.12s;
+  pointer-events: none;
+}
+.stream-md .mermaid-block.mermaid-rendered:hover::after {
+  opacity: 0.85;
+}
+```
+
+- [ ] **Step 5: Run the full relay-web suite + typecheck**
+
+Run: `cd packages/relay-web && npx vitest run && npx vue-tsc --noEmit`
+Expected: new StreamMarkdown cases pass; all pre-existing tests still pass; typecheck clean.
+
+- [ ] **Step 6: Document it**
+
+In `docs/relay-web-module.md`, extend the `### Mermaid 图表渲染` subsection with one line:
+```markdown
+点击已渲染的图表会打开全屏查看器（`MermaidViewer.vue` + 纯 `pan-zoom.ts` 控制器）：拖拽平移、
+滚轮/双指缩放、缩放/复位按钮、Esc/✕/点空白关闭。查看器复用已注入 DOM 的（已净化）SVG，不重新解析。
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/relay-web/src/components/StreamMarkdown.vue packages/relay-web/src/__tests__/streammarkdown.test.ts docs/relay-web-module.md
+git commit -m "feat(relay-web): open pan/zoom viewer when a mermaid diagram is clicked"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** pure controller (Task 1) ✓; fullscreen viewer with drag/wheel/pinch/controls/close/scroll-lock/a11y (Task 2) ✓; click-to-open from StreamMarkdown + affordance + docs (Task 3) ✓.
+
+**Placeholder scan:** every code step has complete code; no TBD.
+
+**Type consistency:** `createPanZoom(): PanZoom` used identically in Task 1 (def) and Task 2 (consumer). `MermaidViewer` prop `svg: string` / emit `close` identical across Task 2 (def + tests) and Task 3 (usage + tests). The click handler reads `pre.mermaid-block.mermaid-rendered` — the exact class `render-mermaid` sets on success.

--- a/docs/superpowers/plans/2026-07-14-web-mermaid-rendering.md
+++ b/docs/superpowers/plans/2026-07-14-web-mermaid-rendering.md
@@ -1,0 +1,654 @@
+# Web Mermaid Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render ```` ```mermaid ```` fenced blocks in relay-web chat markdown as sanitized SVG diagrams, leaving all other markdown rendering byte-for-byte unchanged.
+
+**Architecture:** Three seams over the existing sync-render + `v-html` pipeline. (1) `render-markdown` emits a placeholder `<pre class="mermaid-block" data-mermaid="<base64>">` for mermaid fences. (2) A new `render-mermaid` module lazily loads `mermaid`, renders each placeholder to sanitized SVG (theme-keyed cache, error-tolerant). (3) `StreamMarkdown.vue` drives hydration after `v-html` patches — never mid-stream, re-hydrating on theme change.
+
+**Tech Stack:** Vue 3, `markdown-it`, `dompurify`, `mermaid` (v11, dynamically imported), Vitest (jsdom), Bun/npm workspaces.
+
+## Global Constraints
+
+- Package: all code lives in `packages/relay-web`. Tests run with `npx vitest run` **from `packages/relay-web`** (never `bun test` — jsdom-dependent). Ref: memory `relay-web 单测要用 vitest 不能 bun test`.
+- Adding a dependency to a workspace package REQUIRES syncing the root npm lock: `npm install --package-lock-only` at repo root (CI `test.yml` runs `npm ci`). Ref: memory `给 packages/* 加依赖要同步根 npm lock`.
+- Security: agent output is untrusted. Diagram source must never be interpreted as markup by markdown-it (base64 in a data attribute), mermaid runs `securityLevel: "strict"`, and the rendered SVG passes through `DOMPurify.sanitize(..., { USE_PROFILES: { svg: true, svgFilters: true } })` before injection.
+- No `Math.random`/`Date.now` for render ids — use a module-scoped counter.
+- YAGNI: no pan/zoom, no export, no server-side render, no fallback syntax highlighting. Non-relay-web channels unchanged.
+- Existing markdown behaviour (tables, links, code fences other than mermaid, streaming heal via `remend`, 80ms throttle) must stay unchanged — verified by the existing passing tests.
+
+---
+
+### Task 1: Add the `mermaid` dependency and sync locks
+
+**Files:**
+- Modify: `packages/relay-web/package.json` (add `mermaid` to `dependencies`)
+- Modify: `bun.lock` (root, regenerated)
+- Modify: `package-lock.json` (root, regenerated)
+
+**Interfaces:**
+- Produces: the `mermaid` module (with bundled TypeScript types) resolvable from `packages/relay-web`, so `import('mermaid')` typechecks in Task 3.
+
+- [ ] **Step 1: Add the dependency**
+
+Run from repo root:
+```bash
+cd packages/relay-web && bun add mermaid@^11 && cd ../..
+```
+Expected: `package.json` gains `"mermaid": "^11.x.x"` under `dependencies`; `bun.lock` updates.
+
+- [ ] **Step 2: Sync the root npm lockfile**
+
+Run from repo root:
+```bash
+npm install --package-lock-only
+```
+Expected: `package-lock.json` gains the `mermaid` entry and its transitive deps. This is mandatory — CI runs `npm ci`.
+
+- [ ] **Step 3: Verify resolution and that nothing else broke**
+
+Run:
+```bash
+cd packages/relay-web && npx vue-tsc --noEmit && npx vitest run && cd ../..
+```
+Expected: typecheck passes, existing tests pass. (No new code yet — this only confirms the dep add is clean.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/relay-web/package.json bun.lock package-lock.json
+git commit -m "build(relay-web): add mermaid dependency for diagram rendering"
+```
+
+---
+
+### Task 2: Emit a placeholder for mermaid fences in `render-markdown`
+
+**Files:**
+- Create: `packages/relay-web/src/lib/mermaid-source.ts`
+- Modify: `packages/relay-web/src/lib/render-markdown.ts`
+- Test: `packages/relay-web/src/__tests__/render-markdown.test.ts` (add cases)
+
+**Interfaces:**
+- Produces: `encodeMermaidSource(src: string): string` and `decodeMermaidSource(encoded: string): string` (UTF-8-safe base64, exact inverses). `decodeMermaidSource` is consumed by Task 3.
+- Produces: mermaid fences render to `<pre class="mermaid-block" data-mermaid="<base64>"><code>…escaped…</code></pre>`; `data-mermaid` and the class survive DOMPurify. All non-mermaid fences render unchanged.
+
+- [ ] **Step 1: Write the failing test for the encode/decode round-trip**
+
+Add to `packages/relay-web/src/__tests__/render-markdown.test.ts`:
+```ts
+import { encodeMermaidSource, decodeMermaidSource } from "../lib/mermaid-source";
+
+test("mermaid source base64 round-trips including non-ASCII and special chars", () => {
+  const src = "graph TD\n  A[开始] --> B{判断?}\n  B -->|是/yes| C[\"</code> & <script>\"]";
+  const encoded = encodeMermaidSource(src);
+  expect(encoded).toMatch(/^[A-Za-z0-9+/=]+$/); // base64 alphabet only — safe in an attribute
+  expect(decodeMermaidSource(encoded)).toBe(src);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/render-markdown.test.ts`
+Expected: FAIL — `../lib/mermaid-source` does not exist.
+
+- [ ] **Step 3: Create the encode/decode module**
+
+Create `packages/relay-web/src/lib/mermaid-source.ts`:
+```ts
+// UTF-8-safe base64 for carrying a mermaid diagram's source through an HTML data
+// attribute. `btoa` only handles Latin-1, so encode to UTF-8 bytes first (the classic
+// `encodeURIComponent`/`escape` bridge) — diagram labels are frequently non-ASCII.
+
+/** Encode a diagram's source to attribute-safe base64 (alphabet `[A-Za-z0-9+/=]`). */
+export function encodeMermaidSource(src: string): string {
+  return btoa(unescape(encodeURIComponent(src)));
+}
+
+/** Inverse of {@link encodeMermaidSource}. */
+export function decodeMermaidSource(encoded: string): string {
+  return decodeURIComponent(escape(atob(encoded)));
+}
+```
+
+- [ ] **Step 4: Run the round-trip test to verify it passes**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/render-markdown.test.ts`
+Expected: the round-trip test PASSES (fence-override tests below still to come).
+
+- [ ] **Step 5: Write the failing tests for the fence override**
+
+Add to `packages/relay-web/src/__tests__/render-markdown.test.ts`:
+```ts
+import { renderMarkdown } from "../lib/render-markdown";
+
+test("a mermaid fence becomes a placeholder carrying the base64 source", () => {
+  const html = renderMarkdown("```mermaid\ngraph TD\n  A --> B\n```");
+  expect(html).toContain('class="mermaid-block"');
+  const match = html.match(/data-mermaid="([^"]+)"/);
+  expect(match).not.toBeNull();
+  expect(decodeMermaidSource(match![1]!)).toBe("graph TD\n  A --> B\n");
+  // The visible fallback keeps the (escaped) source, never blank.
+  expect(html).toContain("graph TD");
+});
+
+test("a mermaid fence source cannot inject markup", () => {
+  const html = renderMarkdown("```mermaid\n<script>alert(1)</script>\n```");
+  expect(html).not.toContain("<script>alert(1)</script>"); // escaped in fallback, raw source only in base64
+});
+
+test("a non-mermaid fence is rendered unchanged (no mermaid-block class)", () => {
+  const html = renderMarkdown("```ts\nconst a = 1;\n```");
+  expect(html).not.toContain("mermaid-block");
+  expect(html).toContain("<pre"); // ordinary code block
+  expect(html).toContain("const a = 1;");
+});
+```
+
+- [ ] **Step 6: Run to verify they fail**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/render-markdown.test.ts`
+Expected: FAIL — mermaid fences currently render as ordinary code blocks (no `mermaid-block`).
+
+- [ ] **Step 7: Add the fence override to `render-markdown.ts`**
+
+In `packages/relay-web/src/lib/render-markdown.ts`, add the import at the top:
+```ts
+import { encodeMermaidSource } from "./mermaid-source";
+```
+Then, immediately after the existing `md.renderer.rules.table_close = ...` line, add:
+```ts
+// Intercept ```mermaid fences: emit a placeholder carrying the diagram source as
+// attribute-safe base64. render-mermaid hydrates it into SVG after the HTML is mounted.
+// The escaped <code> is the fallback shown before hydration, while streaming, and on
+// render error. All other fences fall through to markdown-it's default renderer.
+const defaultFence =
+  md.renderer.rules.fence ??
+  ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options));
+md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+  const token = tokens[idx]!;
+  const info = token.info.trim().split(/\s+/g)[0]?.toLowerCase() ?? "";
+  if (info !== "mermaid") {
+    return defaultFence(tokens, idx, options, env, self);
+  }
+  const encoded = encodeMermaidSource(token.content);
+  const fallback = md.utils.escapeHtml(token.content);
+  return `<pre class="mermaid-block" data-mermaid="${encoded}"><code>${fallback}</code></pre>`;
+};
+```
+
+- [ ] **Step 8: Run all render-markdown tests to verify they pass**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/render-markdown.test.ts src/__tests__/normalize-markdown.test.ts`
+Expected: PASS — new mermaid cases pass, all pre-existing markdown cases still pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/relay-web/src/lib/mermaid-source.ts packages/relay-web/src/lib/render-markdown.ts packages/relay-web/src/__tests__/render-markdown.test.ts
+git commit -m "feat(relay-web): emit placeholder for mermaid fences in render-markdown"
+```
+
+---
+
+### Task 3: `render-mermaid` — lazy, cached, error-tolerant SVG hydration
+
+**Files:**
+- Create: `packages/relay-web/src/lib/render-mermaid.ts`
+- Test: `packages/relay-web/src/__tests__/render-mermaid.test.ts`
+
+**Interfaces:**
+- Consumes: `decodeMermaidSource` from `./mermaid-source`; the placeholder shape from Task 2 (`pre.mermaid-block[data-mermaid]`).
+- Produces:
+  - `type MermaidTheme = "dark" | "light"`
+  - `hydrateMermaidBlocks(root: HTMLElement, theme: MermaidTheme): Promise<void>` — renders every un-rendered block under `root`; never throws.
+  - `resetMermaidBlocks(root: HTMLElement): void` — reverts rendered blocks to their code fallback (for a theme re-render).
+  - `__setMermaidLoaderForTest(loader: null | (() => Promise<MermaidLike>)): void` — injects a fake loader and resets module state (cache/counter/init) for tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/relay-web/src/__tests__/render-mermaid.test.ts`:
+```ts
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  hydrateMermaidBlocks,
+  resetMermaidBlocks,
+  __setMermaidLoaderForTest,
+  type MermaidTheme,
+} from "../lib/render-mermaid";
+import { encodeMermaidSource } from "../lib/mermaid-source";
+
+function block(src: string): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML = `<pre class="mermaid-block" data-mermaid="${encodeMermaidSource(src)}"><code>${src}</code></pre>`;
+  return root;
+}
+
+afterEach(() => __setMermaidLoaderForTest(null));
+
+test("hydrate replaces the placeholder with sanitized SVG and marks it done", async () => {
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({
+      initialize: () => {},
+      render: async (_id: string, text: string) => ({
+        svg: `<svg data-src="${text.length}"><text>ok</text><script>alert(1)</script></svg>`,
+      }),
+    }),
+  );
+  const root = block("graph TD\n A-->B");
+  await hydrateMermaidBlocks(root, "dark");
+  const pre = root.querySelector("pre.mermaid-block")!;
+  expect(pre.querySelector("svg")).not.toBeNull();
+  expect(pre.querySelector("script")).toBeNull(); // DOMPurify svg profile strips it
+  expect(pre.getAttribute("data-mermaid-done")).toBe("1");
+  expect(pre.classList.contains("mermaid-rendered")).toBe(true);
+});
+
+test("hydrate caches by theme+source: identical re-hydrate does not re-invoke render", async () => {
+  const render = vi.fn(async (_id: string, _text: string) => ({ svg: "<svg><text>x</text></svg>" }));
+  __setMermaidLoaderForTest(() => Promise.resolve({ initialize: () => {}, render }));
+  const a = block("graph TD\n A-->B");
+  const b = block("graph TD\n A-->B");
+  await hydrateMermaidBlocks(a, "dark");
+  await hydrateMermaidBlocks(b, "dark");
+  expect(render).toHaveBeenCalledTimes(1); // second block served from cache
+  await hydrateMermaidBlocks(block("graph TD\n A-->B"), "light");
+  expect(render).toHaveBeenCalledTimes(2); // different theme → separate render
+});
+
+test("a failing render marks the block as error and keeps the code fallback", async () => {
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({ initialize: () => {}, render: async () => { throw new Error("bad diagram"); } }),
+  );
+  const root = block("not a diagram");
+  await hydrateMermaidBlocks(root, "dark"); // must not throw
+  const pre = root.querySelector("pre.mermaid-block")!;
+  expect(pre.getAttribute("data-mermaid-done")).toBe("error");
+  expect(pre.classList.contains("mermaid-error")).toBe(true);
+  expect(pre.querySelector("code")?.textContent).toBe("not a diagram");
+  expect(pre.querySelector("svg")).toBeNull();
+});
+
+test("resetMermaidBlocks reverts a rendered block to its code fallback", async () => {
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({ initialize: () => {}, render: async () => ({ svg: "<svg><text>x</text></svg>" }) }),
+  );
+  const root = block("graph TD\n A-->B");
+  await hydrateMermaidBlocks(root, "dark");
+  resetMermaidBlocks(root);
+  const pre = root.querySelector("pre.mermaid-block")!;
+  expect(pre.hasAttribute("data-mermaid-done")).toBe(false);
+  expect(pre.querySelector("svg")).toBeNull();
+  expect(pre.querySelector("code")?.textContent).toBe("graph TD\n A-->B");
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/render-mermaid.test.ts`
+Expected: FAIL — `../lib/render-mermaid` does not exist.
+
+- [ ] **Step 3: Implement `render-mermaid.ts`**
+
+Create `packages/relay-web/src/lib/render-mermaid.ts`:
+```ts
+import DOMPurify from "dompurify";
+import { decodeMermaidSource } from "./mermaid-source";
+
+export type MermaidTheme = "dark" | "light";
+
+/** The minimal slice of the mermaid module this code uses (kept narrow for the test seam). */
+export interface MermaidLike {
+  initialize(config: Record<string, unknown>): void;
+  render(id: string, text: string): Promise<{ svg: string }>;
+}
+
+let loaderOverride: null | (() => Promise<MermaidLike>) = null;
+let modPromise: Promise<MermaidLike> | null = null;
+let initializedTheme: MermaidTheme | null = null;
+let seq = 0;
+const svgCache = new Map<string, string>();
+
+/** Test seam: inject a fake loader and reset all module state. Pass null to restore. */
+export function __setMermaidLoaderForTest(loader: null | (() => Promise<MermaidLike>)): void {
+  loaderOverride = loader;
+  modPromise = null;
+  initializedTheme = null;
+  seq = 0;
+  svgCache.clear();
+}
+
+function loadMermaid(): Promise<MermaidLike> {
+  if (loaderOverride) return loaderOverride();
+  if (!modPromise) {
+    // Dynamic import keeps mermaid (and its d3/dagre/cytoscape deps) out of the main chunk.
+    modPromise = import("mermaid").then((m) => m.default as unknown as MermaidLike);
+  }
+  return modPromise;
+}
+
+async function getMermaid(theme: MermaidTheme): Promise<MermaidLike> {
+  const mermaid = await loadMermaid();
+  if (initializedTheme !== theme) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      theme: theme === "dark" ? "dark" : "default",
+    });
+    initializedTheme = theme;
+  }
+  return mermaid;
+}
+
+/**
+ * Render every un-hydrated `pre.mermaid-block` under `root` to sanitized SVG. Results are
+ * cached by `theme + source`. Errors are contained per-block (marked `data-mermaid-done="error"`,
+ * code fallback preserved); this function never rejects.
+ */
+export async function hydrateMermaidBlocks(root: HTMLElement, theme: MermaidTheme): Promise<void> {
+  const blocks = Array.from(
+    root.querySelectorAll<HTMLElement>('pre.mermaid-block[data-mermaid]:not([data-mermaid-done])'),
+  );
+  if (blocks.length === 0) return;
+
+  let mermaid: MermaidLike;
+  try {
+    mermaid = await getMermaid(theme);
+  } catch {
+    return; // mermaid failed to load — leave every block on its source fallback
+  }
+
+  for (const block of blocks) {
+    if (block.getAttribute("data-mermaid-done")) continue; // re-check: a concurrent pass may have claimed it
+    const source = decodeMermaidSource(block.getAttribute("data-mermaid") ?? "");
+    const key = `${theme}:${source}`;
+    try {
+      let svg = svgCache.get(key);
+      if (svg === undefined) {
+        seq += 1;
+        const rendered = await mermaid.render(`mmd-${seq}`, source);
+        svg = DOMPurify.sanitize(rendered.svg, { USE_PROFILES: { svg: true, svgFilters: true } });
+        svgCache.set(key, svg);
+      }
+      block.innerHTML = svg;
+      block.setAttribute("data-mermaid-done", "1");
+      block.classList.add("mermaid-rendered");
+    } catch {
+      block.setAttribute("data-mermaid-done", "error");
+      block.classList.add("mermaid-error");
+      // Leave the <code> fallback in place so the user still sees the diagram source.
+    }
+  }
+}
+
+/**
+ * Revert already-hydrated blocks under `root` to their code fallback so they can be
+ * re-rendered (e.g. after a theme switch). The `data-mermaid` base64 is the source of truth.
+ */
+export function resetMermaidBlocks(root: HTMLElement): void {
+  const blocks = Array.from(
+    root.querySelectorAll<HTMLElement>("pre.mermaid-block[data-mermaid-done]"),
+  );
+  for (const block of blocks) {
+    const source = decodeMermaidSource(block.getAttribute("data-mermaid") ?? "");
+    const code = document.createElement("code");
+    code.textContent = source;
+    block.replaceChildren(code);
+    block.removeAttribute("data-mermaid-done");
+    block.classList.remove("mermaid-rendered", "mermaid-error");
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/render-mermaid.test.ts`
+Expected: PASS — all four cases.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd packages/relay-web && npx vue-tsc --noEmit`
+Expected: passes (confirms `import('mermaid')` resolves against the dep from Task 1).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/relay-web/src/lib/render-mermaid.ts packages/relay-web/src/__tests__/render-mermaid.test.ts
+git commit -m "feat(relay-web): lazy, cached, error-tolerant mermaid SVG hydration"
+```
+
+---
+
+### Task 4: Drive hydration from `StreamMarkdown.vue` (+ styling + docs)
+
+**Files:**
+- Modify: `packages/relay-web/src/components/StreamMarkdown.vue`
+- Test: `packages/relay-web/src/__tests__/streammarkdown.test.ts` (add cases)
+- Modify: `docs/relay-web-module.md` (note the mermaid seam)
+
+**Interfaces:**
+- Consumes: `hydrateMermaidBlocks`, `resetMermaidBlocks` from `../lib/render-mermaid`; `useThemeStore` from `../stores/theme`.
+- Produces: hydration is driven only when `streaming` is false; theme change re-hydrates; unmount is safe.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/relay-web/src/__tests__/streammarkdown.test.ts` (mock the render-mermaid module so no real mermaid loads):
+```ts
+import { vi } from "vitest";
+
+const hydrate = vi.fn(async () => {});
+const reset = vi.fn(() => {});
+vi.mock("../lib/render-mermaid", () => ({
+  hydrateMermaidBlocks: (...a: unknown[]) => hydrate(...a),
+  resetMermaidBlocks: (...a: unknown[]) => reset(...a),
+}));
+
+// ...inside the existing describe/suite, after mount helpers:
+
+test("does not hydrate mermaid while streaming", async () => {
+  hydrate.mockClear();
+  const wrapper = mount(StreamMarkdown, { props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: true } });
+  await nextTick();
+  await nextTick();
+  expect(hydrate).not.toHaveBeenCalled();
+  wrapper.unmount();
+});
+
+test("hydrates mermaid once streaming ends", async () => {
+  hydrate.mockClear();
+  const wrapper = mount(StreamMarkdown, { props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: true } });
+  await nextTick();
+  await wrapper.setProps({ streaming: false });
+  await nextTick();
+  await nextTick();
+  expect(hydrate).toHaveBeenCalled();
+  wrapper.unmount();
+});
+
+test("hydrates a non-streaming (finalized) message on mount", async () => {
+  hydrate.mockClear();
+  const wrapper = mount(StreamMarkdown, { props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false } });
+  await nextTick();
+  await nextTick();
+  expect(hydrate).toHaveBeenCalled();
+  wrapper.unmount();
+});
+```
+(If the test file does not already import `nextTick`, `mount`, and a Pinia setup, mirror the existing imports/`setActivePinia(createPinia())` pattern used by the other tests in this file.)
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/streammarkdown.test.ts`
+Expected: FAIL — `hydrate` is never called (component does no hydration yet).
+
+- [ ] **Step 3: Wire hydration into `StreamMarkdown.vue`**
+
+Replace the `<script setup>` block of `packages/relay-web/src/components/StreamMarkdown.vue` with (changes: template ref, theme store, hydration scheduling; the existing throttle logic is preserved verbatim):
+```ts
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { renderMarkdown } from "../lib/render-markdown";
+import { hydrateMermaidBlocks, resetMermaidBlocks } from "../lib/render-mermaid";
+import { useThemeStore } from "../stores/theme";
+
+const props = defineProps<{ text: string; streaming?: boolean }>();
+
+// While streaming, every appended chunk grows `text`, and re-parsing the WHOLE buffer
+// (healing + markdown-it + DOMPurify) per chunk is O(n²) over the turn. Throttle the parse
+// to one render per THROTTLE_MS with a trailing call, so the last chunk always lands. The
+// non-streaming path renders synchronously on every change, exactly like the old computed.
+const THROTTLE_MS = 80;
+
+const theme = useThemeStore();
+const rootEl = ref<HTMLElement | null>(null);
+const html = ref("");
+let timer: ReturnType<typeof setTimeout> | null = null;
+let lastRenderAt = 0;
+let disposed = false;
+
+function cancelTimer(): void {
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+// Mermaid blocks are hydrated only when NOT streaming: a mid-stream fence (auto-closed by
+// remend) holds a partial diagram that mermaid would fail to parse. During streaming the
+// block shows its source (the <code> fallback); the finalized render hydrates it to SVG.
+function scheduleHydrate(reset: boolean): void {
+  if (props.streaming) return;
+  void nextTick(() => {
+    if (disposed || rootEl.value === null) return;
+    if (reset) resetMermaidBlocks(rootEl.value);
+    void hydrateMermaidBlocks(rootEl.value, theme.mode);
+  });
+}
+
+function render(): void {
+  lastRenderAt = Date.now();
+  html.value = renderMarkdown(props.text, { streaming: props.streaming });
+  scheduleHydrate(false);
+}
+
+render(); // initial synchronous render (also seeds the throttle clock)
+onMounted(() => scheduleHydrate(false)); // rootEl exists only after mount
+
+watch(
+  () => props.text,
+  () => {
+    if (!props.streaming) {
+      cancelTimer();
+      render();
+      return;
+    }
+    const elapsed = Date.now() - lastRenderAt;
+    if (elapsed >= THROTTLE_MS) {
+      cancelTimer();
+      render();
+      return;
+    }
+    // Trailing edge: one pending render picks up whatever `text` holds when it fires.
+    if (timer === null) {
+      timer = setTimeout(() => {
+        timer = null;
+        render();
+      }, THROTTLE_MS - elapsed);
+    }
+  },
+);
+
+// Streaming ended (or toggled): drop any pending throttled render and paint the
+// final full text immediately — the closing frame must never lag or be skipped.
+watch(
+  () => props.streaming,
+  () => {
+    cancelTimer();
+    render();
+  },
+);
+
+// Theme switched: re-theme any already-rendered diagrams (the SVG cache is theme-keyed).
+watch(
+  () => theme.mode,
+  () => scheduleHydrate(true),
+);
+
+onBeforeUnmount(() => {
+  disposed = true;
+  cancelTimer();
+});
+</script>
+```
+Then update the template's root element to bind the ref:
+```html
+<template>
+  <!-- eslint-disable-next-line vue/no-v-html -- input is sanitized by renderMarkdown (DOMPurify) -->
+  <div ref="rootEl" class="stream-md text-sm" v-html="html" />
+</template>
+```
+
+- [ ] **Step 4: Add mermaid block styling to the same file's `<style>`**
+
+Append to the `<style>` block in `StreamMarkdown.vue` (after the `.stream-md hr` rule):
+```css
+/* Mermaid: the pre.mermaid-block is a code-styled fallback until hydrated. Once rendered,
+   center the SVG and let a wide diagram scroll like a wide table instead of overflowing. */
+.stream-md .mermaid-block.mermaid-rendered {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  overflow-x: auto;
+  text-align: center;
+}
+.stream-md .mermaid-block.mermaid-rendered svg {
+  max-width: 100%;
+  height: auto;
+}
+.stream-md .mermaid-block.mermaid-error {
+  border-color: rgb(var(--c-danger, var(--c-border)));
+}
+```
+
+- [ ] **Step 5: Run the component + full relay-web suite**
+
+Run: `cd packages/relay-web && npx vitest run`
+Expected: new StreamMarkdown cases pass; all pre-existing tests (streammarkdown, messagelist, chat, render-markdown, etc.) still pass.
+
+- [ ] **Step 6: Typecheck the whole package**
+
+Run: `cd packages/relay-web && npx vue-tsc --noEmit`
+Expected: passes.
+
+- [ ] **Step 7: Document the seam**
+
+In `docs/relay-web-module.md`, add a short subsection under the markdown/rendering area (match the file's existing heading style):
+```markdown
+### Mermaid diagrams
+
+` ```mermaid ` fences render to SVG. Pipeline: `render-markdown` emits a
+`<pre class="mermaid-block" data-mermaid="<base64 source>">` placeholder (fence override);
+`render-mermaid` lazily `import('mermaid')`s, renders each placeholder to SVG under
+`securityLevel: "strict"`, DOMPurifies it (svg profile), and caches by `theme+source`;
+`StreamMarkdown.vue` hydrates after `v-html` patches — never mid-stream (a partial fence
+would fail to parse), re-hydrating on theme change. Malformed diagrams keep the source as a
+code fallback. Non-relay-web channels (WeChat/terminal) remain text-only.
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/relay-web/src/components/StreamMarkdown.vue packages/relay-web/src/__tests__/streammarkdown.test.ts docs/relay-web-module.md
+git commit -m "feat(relay-web): render mermaid diagrams in chat markdown"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** library decision (Task 1) ✓; placeholder emission + base64 + security (Task 2) ✓; lazy/cached/error-tolerant/theme-keyed hydration (Task 3) ✓; streaming-gated hydration + theme re-render + unmount safety + styling + docs (Task 4) ✓. All spec test bullets map to a task's tests.
+
+**Placeholder scan:** every code step contains full code; no TBD/TODO.
+
+**Type consistency:** `MermaidTheme = "dark"|"light"` matches `theme.mode` (`ThemeMode = "dark"|"light"`). `hydrateMermaidBlocks(root, theme)` / `resetMermaidBlocks(root)` signatures identical across Task 3 (definition), Task 3 tests, and Task 4 (call sites + mock). `encodeMermaidSource`/`decodeMermaidSource` inverse pair used in Tasks 2 and 3. Placeholder shape `pre.mermaid-block[data-mermaid]` identical across producer (Task 2), hydrator/selector (Task 3), and tests.

--- a/docs/superpowers/specs/2026-07-14-web-mermaid-panzoom-design.md
+++ b/docs/superpowers/specs/2026-07-14-web-mermaid-panzoom-design.md
@@ -1,70 +1,92 @@
 # Web Mermaid Pan/Zoom — Design
 
-**Date:** 2026-07-14
-**Status:** Approved (standing autonomy directive)
-**Scope:** `packages/relay-web` — make rendered Mermaid diagrams pan/zoomable. Extends the Mermaid rendering feature (branch `feat/relay-web-mermaid`, PR #161); this was the explicit "out of scope / YAGNI" item there, now requested.
+**Date:** 2026-07-14 (revised 2026-07-15: inline + fullscreen, per user)
+**Status:** Approved (standing autonomy directive; UX shape confirmed by user = inline **and** fullscreen)
+**Scope:** `packages/relay-web` — make rendered Mermaid diagrams pan/zoomable both **inline** and in a **fullscreen** viewer. Extends the Mermaid rendering feature (branch `feat/relay-web-mermaid`, PR #161).
 
 ## Goal
 
-Let a user inspect a complex Mermaid diagram by panning and zooming it. Clicking a rendered diagram opens a fullscreen **viewer overlay** with drag-to-pan, wheel-zoom, pinch-zoom, on-screen zoom controls, and reset; Esc / ✕ / backdrop closes it. Inline diagrams render exactly as today (static, horizontally scrollable) but gain a `zoom-in` cursor and a subtle hint that they are clickable.
+A rendered Mermaid diagram is pan/zoomable **in place** (inline), and can be opened **fullscreen** for deeper inspection:
 
-## Why a fullscreen viewer (not inline gestures)
+- **Inline:** drag to pan (mouse), **Ctrl/⌘+wheel** to zoom (plain wheel still scrolls the page; trackpad pinch, which the browser reports as `ctrlKey` wheel, zooms naturally), two-finger pinch to zoom on touch (one-finger touch still scrolls the page). A small controls bar (− / reset / + / ⤢ expand) appears on the diagram.
+- **Fullscreen:** clicking ⤢ opens an overlay where the diagram fills the screen — drag-pan (mouse or one finger), plain wheel-zoom, pinch-zoom, the same − / reset / + controls, and close via Esc / ✕ / background click.
 
-Inline pan/zoom in a scrolling chat fights the page: wheel-zoom hijacks page scroll, and one-finger drag-to-pan blocks touch scrolling (a known, painful conflict). A fullscreen overlay has no competing page scroll, so wheel-zoom, one-finger drag-pan, and pinch-zoom are all natural and unambiguous. It is also the conventional pattern for diagrams/images in a feed. Inline diagrams stay simple and readable.
+Both modes share one transform controller and one gesture-wiring module, differing only in a few flags.
+
+## Conflict avoidance (why the two modes differ)
+
+Inline lives inside a scrolling chat, so it must never hijack the page: wheel zooms **only** with a modifier, and one-finger touch is left to the browser (`touch-action: pan-y`) so vertical scrolling still works; only two-finger pinch and mouse-drag are captured. Fullscreen has no page behind it (`touch-action: none`), so plain wheel, one-finger drag, and pinch are all free.
 
 ## Architecture
 
-Three additive seams. `render-mermaid.ts` is **unchanged** — the viewer reads the SVG already injected into the DOM.
+Four seams; `render-mermaid.ts` is **unchanged** — inline enhancement and the viewer both read the SVG it already injected.
 
-### 1. `lib/pan-zoom.ts` — a pure, framework-free transform controller
+### 1. `lib/pan-zoom.ts` — pure transform controller (DONE, Task 1, committed)
+
+`createPanZoom(opts?) → { state, zoomAt(factor,cx,cy), panBy(dx,dy), reset(), toTransform() }`. Pure, DOM-free, unit-tested.
+
+### 2. `lib/pan-zoom-gestures.ts` — shared DOM gesture wiring
 
 ```ts
-export interface PanZoomState { scale: number; x: number; y: number; }
-export interface PanZoom {
-  readonly state: PanZoomState;
-  /** Multiply scale by `factor`, keeping viewport point (cx, cy) stationary. Clamps scale. */
-  zoomAt(factor: number, cx: number, cy: number): void;
-  panBy(dx: number, dy: number): void;
-  reset(): void;
-  /** CSS transform for a `transform-origin: 0 0` element: `translate(Xpx, Ypx) scale(S)`. */
-  toTransform(): string;
+export interface GestureOptions {
+  /** Zoom on wheel only when Ctrl/⌘ is held (inline). Default false (fullscreen: always zoom). */
+  wheelRequiresModifier?: boolean;
+  /** Pan on a single touch (fullscreen). Default false (inline: one finger scrolls the page). */
+  oneFingerTouchPan?: boolean;
 }
-export function createPanZoom(opts?: { minScale?: number; maxScale?: number }): PanZoom;
+/** Attach wheel/pointer/touch gestures on `el`, driving `pz` and calling `onChange` after every
+ *  change. Returns a detach function that removes every listener. Mouse-drag always pans. */
+export function attachPanZoomGestures(
+  el: HTMLElement,
+  pz: PanZoom,
+  onChange: () => void,
+  opts?: GestureOptions,
+): () => void;
 ```
 
-- `state` starts at `{ scale: 1, x: 0, y: 0 }`.
-- `zoomAt`: `next = clamp(scale * factor, min, max)`; `x = cx - (cx - x) * (next / scale)` (same for y); then `scale = next`. Keeps the point under the cursor fixed. Defaults `minScale = 0.2`, `maxScale = 8`.
-- Pure and synchronous → fully unit-testable without a DOM.
+- **Wheel:** if `wheelRequiresModifier` and neither Ctrl nor ⌘ is held → do nothing (page scrolls). Otherwise `preventDefault` and `zoomAt(deltaY<0 ? 1.1 : 1/1.1, x, y)` where `(x,y)` is the pointer relative to `el`'s bounding rect.
+- **Mouse drag** (`pointerdown`/`move`/`up`, `pointerType === "mouse"`): pan by pointer delta; capture the pointer.
+- **Touch:** two touches → pinch (`zoomAt(dist/prevDist, midX, midY)`, `preventDefault`); one touch → pan **only if** `oneFingerTouchPan` (else ignored so the page scrolls).
+- Returns `detach()` removing all listeners. Guards `setPointerCapture` (may be absent in jsdom).
 
-### 2. `components/MermaidViewer.vue` — the fullscreen overlay
+### 3. `components/MermaidViewer.vue` — fullscreen overlay
 
-- **Props:** `svg: string | null` (non-null ⇒ open). **Emits:** `close`.
-- `Teleport` to `body`. A backdrop covers the screen; a full-size **stage** hosts a wrapper `<div>` whose `transform` is bound to `panzoom.toTransform()` (with `transform-origin: 0 0`), containing the diagram via `v-html="svg"` (already DOMPurify-sanitized upstream — no re-sanitize needed, but the value is only ever an app-produced SVG string).
-- **Interactions on the stage:**
-  - `wheel` → `preventDefault`; `zoomAt(factor, e.clientX - rectLeft, e.clientY - rectTop)` where `factor = e.deltaY < 0 ? 1.1 : 1/1.1`.
-  - Pointer drag (mouse or single touch via Pointer Events) → `panBy(dx, dy)`.
-  - Two-finger touch → pinch-zoom: track the two touches, `zoomAt(newDist / prevDist, midX, midY)`; the midpoint also pans naturally.
-- **Controls** (fixed corner, always visible): zoom − / reset / zoom + / close ✕. Zoom buttons call `zoomAt(1.25|0.8, viewportCenterX, viewportCenterY)`.
-- **Keyboard:** `Esc` closes; `+` / `-` / `0` (reset) optional.
-- **Lifecycle:** while open, lock body scroll (`overflow: hidden`) and restore on close; `reset()` the controller on open; move focus to the close button; `role="dialog"` `aria-modal="true"`. All listeners are removed on unmount / close.
-- Theme-aware backdrop (light/dark), consistent with the app.
+- Prop `svg: string`, emit `close`; rendered only while open (parent `v-if`) so mount/unmount = open/close.
+- `Teleport` to `body`; a full-screen stage holds a `transform`-bound wrapper with `v-html="svg"` (already sanitized upstream). Uses `createPanZoom` + `attachPanZoomGestures(stage, pz, apply, { oneFingerTouchPan: true })` (plain wheel, one-finger drag, pinch).
+- Controls (− / reset / + / ✕). `useModalA11y` (Esc + focus trap + focus restore). Body-scroll lock while open. Background (non-diagram) click closes. `role="dialog" aria-modal="true"`.
+- Theme-aware backdrop.
 
-### 3. `StreamMarkdown.vue` — open the viewer on click
+### 4. `lib/inline-mermaid.ts` — inline enhancement of a rendered block
 
-- Add one delegated `@click` on the root: if `event.target.closest("pre.mermaid-block.mermaid-rendered")` exists, read its `querySelector("svg")?.outerHTML`, set `viewerSvg.value` to it (opens the viewer). Non-mermaid clicks are ignored. Only fully-rendered blocks match (not `mermaid-error`, not the un-hydrated fallback).
-- Render `<MermaidViewer :svg="viewerSvg" @close="viewerSvg = null" />` once per instance (it teleports; only one is open at a time in practice).
-- CSS: `.mermaid-block.mermaid-rendered { cursor: zoom-in; }` plus a subtle hover affordance (a small ⤢ badge or outline) signalling "click to zoom". The existing hydration/streaming/theme logic is untouched.
+```ts
+/** Wrap a rendered `pre.mermaid-block`'s SVG in a pan/zoom viewport with an inline controls bar
+ *  (− / reset / + / ⤢). Returns a detach function. `onExpand` is called by the ⤢ button. */
+export function enhanceMermaidBlock(block: HTMLElement, opts: { onExpand: () => void }): () => void;
+```
+
+- Moves the injected `<svg>` into `<div class="mmd-viewport"><div class="mmd-transform">…svg…</div></div>` (viewport: bounded height, `overflow: hidden`, `touch-action: pan-y`; transform wrapper: `transform-origin: 0 0`).
+- `createPanZoom` + `attachPanZoomGestures(viewport, pz, apply, { wheelRequiresModifier: true })` (Ctrl+wheel, mouse-drag, pinch; one-finger scrolls).
+- Appends a controls bar (− / reset / + / ⤢). ⤢ calls `opts.onExpand()`.
+- `detach()` removes listeners; the wrapper DOM is discarded when StreamMarkdown next re-renders the markdown.
+
+### 5. `components/StreamMarkdown.vue` — wire both modes
+
+- After each hydration pass, for every `pre.mermaid-block.mermaid-rendered:not([data-mmd-enhanced])`: `enhanceMermaidBlock(block, { onExpand: () => openViewer(block) })`, mark `data-mmd-enhanced`, and keep its detach fn. `openViewer` reads the block's `svg` outerHTML into `viewerSvg` (opens `<MermaidViewer v-if="viewerSvg">`).
+- Detach all enhancers on unmount and before re-hydrating (a fresh v-html render replaces the nodes).
+- The existing hydration / streaming / theme logic is otherwise untouched; the mermaid `render-mermaid.ts` module is untouched.
 
 ## Security
 
-No new surface: the viewer displays the SAME SVG string `render-mermaid` already produced and DOMPurified before injecting inline. The click handler reads it back from the live DOM and re-displays it; it is not re-parsed or re-fetched. mermaid still runs `securityLevel: "strict"`.
+No new surface: inline enhancement and the viewer both operate on the SAME SVG `render-mermaid` already produced and DOMPurified before injection. It is moved/re-displayed, never re-parsed or re-fetched. mermaid still runs `securityLevel: "strict"`.
 
 ## Testing
 
-- **`pan-zoom` (pure):** `zoomAt` keeps the target point fixed (assert resulting x/y math); scale clamps at min/max; `panBy` adds to x/y; `reset` returns to `{1,0,0}`; `toTransform()` formats correctly.
-- **`MermaidViewer` (jsdom + @vue/test-utils):** with a non-null `svg` it teleports and renders the SVG; a `wheel` event changes the wrapper's `transform`; a pointer drag pans (transform x/y change); the zoom-in / zoom-out / reset controls update the transform; `Esc`, backdrop click, and ✕ each emit `close`; body scroll is locked while open and restored after; `svg = null` renders nothing.
-- **`StreamMarkdown`:** clicking a rendered `.mermaid-block.mermaid-rendered` opens the viewer with that block's SVG; clicking ordinary text does not; clicking a `mermaid-error` block does not.
+- **`pan-zoom`** (pure): done.
+- **`pan-zoom-gestures`** (jsdom): on a test element — Ctrl+wheel zooms while plain wheel is a no-op when `wheelRequiresModifier`; plain wheel zooms when not; mouse pointer drag pans; a two-touch move pinch-zooms; `detach()` stops all of them.
+- **`MermaidViewer`** (jsdom + @vue/test-utils, querying `document.body` for teleported nodes): renders the svg; wheel and the +/reset controls change the transform; a pointer drag pans; Esc / ✕ / background click emit `close`; body scroll locked while open and restored after.
+- **`inline-mermaid`** (jsdom): enhancing a rendered block wraps the svg and adds a controls bar; Ctrl+wheel zooms (transform changes) but plain wheel does not; the +/reset controls work; ⤢ calls `onExpand`; `detach()` removes listeners.
+- **`StreamMarkdown`**: a rendered block gets enhanced (viewport + controls appear) once; clicking ⤢ opens the viewer with the block's svg; ordinary text clicks do not; enhancement is not duplicated across re-hydrations.
 
 ## Out of Scope (YAGNI)
 
-Inline (non-overlay) gestures; fit-to-screen auto-scaling on open (start at scale 1, centered; reset returns there); export/download; minimap; rotation; per-diagram zoom persistence. Non-relay-web channels (WeChat/terminal) remain text-only.
+Fit-to-screen auto-scale on open (start at scale 1; reset returns there); export/download; minimap; rotation; zoom persistence across renders. Non-relay-web channels (WeChat/terminal) remain text-only.

--- a/docs/superpowers/specs/2026-07-14-web-mermaid-panzoom-design.md
+++ b/docs/superpowers/specs/2026-07-14-web-mermaid-panzoom-design.md
@@ -1,0 +1,70 @@
+# Web Mermaid Pan/Zoom — Design
+
+**Date:** 2026-07-14
+**Status:** Approved (standing autonomy directive)
+**Scope:** `packages/relay-web` — make rendered Mermaid diagrams pan/zoomable. Extends the Mermaid rendering feature (branch `feat/relay-web-mermaid`, PR #161); this was the explicit "out of scope / YAGNI" item there, now requested.
+
+## Goal
+
+Let a user inspect a complex Mermaid diagram by panning and zooming it. Clicking a rendered diagram opens a fullscreen **viewer overlay** with drag-to-pan, wheel-zoom, pinch-zoom, on-screen zoom controls, and reset; Esc / ✕ / backdrop closes it. Inline diagrams render exactly as today (static, horizontally scrollable) but gain a `zoom-in` cursor and a subtle hint that they are clickable.
+
+## Why a fullscreen viewer (not inline gestures)
+
+Inline pan/zoom in a scrolling chat fights the page: wheel-zoom hijacks page scroll, and one-finger drag-to-pan blocks touch scrolling (a known, painful conflict). A fullscreen overlay has no competing page scroll, so wheel-zoom, one-finger drag-pan, and pinch-zoom are all natural and unambiguous. It is also the conventional pattern for diagrams/images in a feed. Inline diagrams stay simple and readable.
+
+## Architecture
+
+Three additive seams. `render-mermaid.ts` is **unchanged** — the viewer reads the SVG already injected into the DOM.
+
+### 1. `lib/pan-zoom.ts` — a pure, framework-free transform controller
+
+```ts
+export interface PanZoomState { scale: number; x: number; y: number; }
+export interface PanZoom {
+  readonly state: PanZoomState;
+  /** Multiply scale by `factor`, keeping viewport point (cx, cy) stationary. Clamps scale. */
+  zoomAt(factor: number, cx: number, cy: number): void;
+  panBy(dx: number, dy: number): void;
+  reset(): void;
+  /** CSS transform for a `transform-origin: 0 0` element: `translate(Xpx, Ypx) scale(S)`. */
+  toTransform(): string;
+}
+export function createPanZoom(opts?: { minScale?: number; maxScale?: number }): PanZoom;
+```
+
+- `state` starts at `{ scale: 1, x: 0, y: 0 }`.
+- `zoomAt`: `next = clamp(scale * factor, min, max)`; `x = cx - (cx - x) * (next / scale)` (same for y); then `scale = next`. Keeps the point under the cursor fixed. Defaults `minScale = 0.2`, `maxScale = 8`.
+- Pure and synchronous → fully unit-testable without a DOM.
+
+### 2. `components/MermaidViewer.vue` — the fullscreen overlay
+
+- **Props:** `svg: string | null` (non-null ⇒ open). **Emits:** `close`.
+- `Teleport` to `body`. A backdrop covers the screen; a full-size **stage** hosts a wrapper `<div>` whose `transform` is bound to `panzoom.toTransform()` (with `transform-origin: 0 0`), containing the diagram via `v-html="svg"` (already DOMPurify-sanitized upstream — no re-sanitize needed, but the value is only ever an app-produced SVG string).
+- **Interactions on the stage:**
+  - `wheel` → `preventDefault`; `zoomAt(factor, e.clientX - rectLeft, e.clientY - rectTop)` where `factor = e.deltaY < 0 ? 1.1 : 1/1.1`.
+  - Pointer drag (mouse or single touch via Pointer Events) → `panBy(dx, dy)`.
+  - Two-finger touch → pinch-zoom: track the two touches, `zoomAt(newDist / prevDist, midX, midY)`; the midpoint also pans naturally.
+- **Controls** (fixed corner, always visible): zoom − / reset / zoom + / close ✕. Zoom buttons call `zoomAt(1.25|0.8, viewportCenterX, viewportCenterY)`.
+- **Keyboard:** `Esc` closes; `+` / `-` / `0` (reset) optional.
+- **Lifecycle:** while open, lock body scroll (`overflow: hidden`) and restore on close; `reset()` the controller on open; move focus to the close button; `role="dialog"` `aria-modal="true"`. All listeners are removed on unmount / close.
+- Theme-aware backdrop (light/dark), consistent with the app.
+
+### 3. `StreamMarkdown.vue` — open the viewer on click
+
+- Add one delegated `@click` on the root: if `event.target.closest("pre.mermaid-block.mermaid-rendered")` exists, read its `querySelector("svg")?.outerHTML`, set `viewerSvg.value` to it (opens the viewer). Non-mermaid clicks are ignored. Only fully-rendered blocks match (not `mermaid-error`, not the un-hydrated fallback).
+- Render `<MermaidViewer :svg="viewerSvg" @close="viewerSvg = null" />` once per instance (it teleports; only one is open at a time in practice).
+- CSS: `.mermaid-block.mermaid-rendered { cursor: zoom-in; }` plus a subtle hover affordance (a small ⤢ badge or outline) signalling "click to zoom". The existing hydration/streaming/theme logic is untouched.
+
+## Security
+
+No new surface: the viewer displays the SAME SVG string `render-mermaid` already produced and DOMPurified before injecting inline. The click handler reads it back from the live DOM and re-displays it; it is not re-parsed or re-fetched. mermaid still runs `securityLevel: "strict"`.
+
+## Testing
+
+- **`pan-zoom` (pure):** `zoomAt` keeps the target point fixed (assert resulting x/y math); scale clamps at min/max; `panBy` adds to x/y; `reset` returns to `{1,0,0}`; `toTransform()` formats correctly.
+- **`MermaidViewer` (jsdom + @vue/test-utils):** with a non-null `svg` it teleports and renders the SVG; a `wheel` event changes the wrapper's `transform`; a pointer drag pans (transform x/y change); the zoom-in / zoom-out / reset controls update the transform; `Esc`, backdrop click, and ✕ each emit `close`; body scroll is locked while open and restored after; `svg = null` renders nothing.
+- **`StreamMarkdown`:** clicking a rendered `.mermaid-block.mermaid-rendered` opens the viewer with that block's SVG; clicking ordinary text does not; clicking a `mermaid-error` block does not.
+
+## Out of Scope (YAGNI)
+
+Inline (non-overlay) gestures; fit-to-screen auto-scaling on open (start at scale 1, centered; reset returns there); export/download; minimap; rotation; per-diagram zoom persistence. Non-relay-web channels (WeChat/terminal) remain text-only.

--- a/docs/superpowers/specs/2026-07-14-web-mermaid-rendering-design.md
+++ b/docs/superpowers/specs/2026-07-14-web-mermaid-rendering-design.md
@@ -1,0 +1,84 @@
+# Web Mermaid Rendering — Design
+
+**Date:** 2026-07-14
+**Status:** Approved (standing autonomy directive)
+**Scope:** `packages/relay-web` — render ```` ```mermaid ```` fenced code blocks in chat/turn markdown as SVG diagrams.
+
+## Goal
+
+When an agent's message contains a ```` ```mermaid ```` fenced block, the relay-web dashboard renders it as an interactive-quality SVG diagram (flowchart, sequence, gantt, class, state, ER, pie, gitgraph, …) instead of showing raw diagram source. Everything else about markdown rendering stays byte-for-byte unchanged.
+
+## Library Decision
+
+**Use the official `mermaid` package (v11), dynamically imported.**
+
+Rationale (researched 2026-07-14):
+- Mermaid's grammar is *defined by* this library; no lightweight alternative parses the full grammar. Rejected: `mermaid-cli`/mmdc (Node/puppeteer, not browser), hand-rolled d3 (= rewriting mermaid), server-side pre-render (relay is incremental/streaming; client render is simpler and message volume is low).
+- Cost is bundle size (~hundreds of KB gzip, pulls d3/dagre/cytoscape). Mitigation: `import('mermaid')` on first encounter keeps it out of the main chunk; the module promise is cached.
+- Fits the existing stack: current pipeline is `markdown-it(html:false)` → `DOMPurify.sanitize` with **no syntax highlighter** (fences are plain `<pre><code>`), so nothing conflicts. relay gateway sets **no CSP**, so SVG injection is unobstructed; mermaid v11 needs no web worker. `dompurify` is already a dependency.
+
+## Architecture
+
+Three seams, matching the existing sync-render + `v-html` architecture:
+
+### 1. `render-markdown.ts` — emit a placeholder for mermaid fences (sync)
+
+Override markdown-it's `fence` rule: when the fence info string is `mermaid`, emit a placeholder instead of `<pre><code>`:
+
+```html
+<pre class="mermaid-block" data-mermaid="<base64(source)>"><code>…escaped source…</code></pre>
+```
+
+- `data-mermaid` carries the **base64-encoded** diagram source — the render seam's source of truth (avoids HTML-unescaping ambiguity). Base64 is inert to DOMPurify and survives sanitization (`ALLOW_DATA_ATTR` defaults true).
+- The visible `<code>` holds the escaped source as a **fallback / loading state**: before hydration, during streaming, and on render error, the user sees the diagram source, never a blank.
+- All other fences (```` ```ts ````, plain ```` ``` ````, etc.) route to the default renderer — **unchanged**.
+- Encoding uses a UTF-8-safe base64 (`btoa(unescape(encodeURIComponent(src)))`) so non-ASCII diagram labels round-trip.
+
+### 2. `render-mermaid.ts` — hydrate placeholders into SVG (async, lazy, cached)
+
+New module. Public surface:
+
+```ts
+export type MermaidTheme = "dark" | "light";
+/** Hydrate every un-rendered `.mermaid-block` under `root` into sanitized SVG. */
+export function hydrateMermaidBlocks(root: HTMLElement, theme: MermaidTheme): Promise<void>;
+/** Test seam: override the mermaid module loader. */
+export function __setMermaidLoaderForTest(loader: null | (() => Promise<MermaidLike>)): void;
+```
+
+Behaviour:
+- Selects `pre.mermaid-block[data-mermaid]:not([data-mermaid-done])` under `root`.
+- Lazy-loads mermaid once via `import('mermaid')`; caches the module promise. Initializes with `{ startOnLoad: false, securityLevel: "strict", theme: theme === "dark" ? "dark" : "default" }`. Strict mode strips click handlers and inline HTML labels.
+- For each block: decode source, compute a cache key `` `${theme}:${source}` ``. Consult a module-level `Map<string,string>` SVG cache; on miss call `mermaid.render(uniqueId, source)`, then `DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } })`, and store in cache.
+- Replace the block's `innerHTML` with the sanitized SVG, set `data-mermaid-done="1"`, add class `mermaid-rendered`.
+- **Error handling:** if `mermaid.render` throws (malformed/partial diagram), mark the block `data-mermaid-done="error"`, add class `mermaid-error`, and leave the `<code>` fallback visible with a small error affordance. Never throw out of `hydrateMermaidBlocks` — one bad diagram must not break the message or sibling diagrams.
+- Unique render id: a module-scoped incrementing counter (`mmd-0`, `mmd-1`, …) — deterministic, no `Math.random`.
+
+### 3. `StreamMarkdown.vue` — drive hydration after `v-html` patches
+
+- Keep the existing throttled sync render of `html.value` unchanged.
+- **Do NOT hydrate while `streaming` is true.** A mid-stream fence is auto-closed by `remend` but the diagram body is partial → mermaid would error and flicker. During streaming the mermaid block shows its source (the `<code>` fallback), which is informative and cheap (the O(n²)-per-tick concern is avoided — no expensive render on the hot path).
+- Hydrate when `streaming` is false: on mount (historical/finalized messages) and on the streaming→false transition (the existing `watch(() => props.streaming)` already forces a final `render()` — hydrate in its `nextTick`).
+- Read the current theme from `useThemeStore().mode`. **Watch it:** on theme change, reset rendered blocks (clear `data-mermaid-done`, restore the code fallback) and re-hydrate with the new theme. The SVG cache is theme-keyed, so a re-toggle is cheap.
+- All DOM work is guarded by `nextTick` + an unmount flag so a late async hydration never touches a torn-down component.
+
+## Security
+
+Defense in depth, consistent with the existing `html:false` + DOMPurify pattern:
+1. Diagram source reaches the renderer only via base64 in a data attribute — never interpreted as markup by markdown-it.
+2. mermaid `securityLevel: "strict"` — no click bindings, no raw HTML labels.
+3. The rendered SVG is run through DOMPurify (SVG profile) before injection — strips any `<script>`, event handlers, or `javascript:` URLs.
+
+## Styling
+
+Mermaid emits its own theme-driven colours. Add minimal `.stream-md .mermaid-block`/`.mermaid-rendered`/`.mermaid-error` rules: centered SVG, `max-width:100%` with horizontal scroll for wide diagrams (reuse the table-wrap scrollbar treatment), and a muted error border/label for the error state. No pan/zoom in this scope (YAGNI — diagrams scroll like wide tables).
+
+## Testing
+
+- **`render-markdown`:** mermaid fence → emits `pre.mermaid-block[data-mermaid]` with round-trippable base64 source + escaped `<code>` fallback; non-mermaid fences unchanged; a mermaid source containing `<script>`/`</code>` stays inert (base64 + escaped fallback, no executable markup after DOMPurify); non-ASCII labels round-trip.
+- **`render-mermaid`:** with an injected fake mermaid loader — hydrate replaces placeholder with sanitized SVG + marks done; second hydrate of same source does **not** re-invoke `render` (cache hit); different theme → separate render (theme-keyed cache); a loader whose `render` rejects → block marked `mermaid-error`, code fallback preserved, no throw; `<script>` inside the fake SVG is stripped by the DOMPurify pass.
+- **`StreamMarkdown`:** `streaming=true` leaves the block as source (hydrate not called); streaming→false triggers hydrate; theme change re-hydrates; component unmount mid-hydration does not throw.
+
+## Out of Scope (YAGNI)
+
+Pan/zoom/fullscreen, diagram export, non-relay-web channels (WeChat/terminal stay text), server-side pre-render, syntax highlighting of the fallback code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -318,6 +318,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@antfu/install-pkg/node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@apideck/better-ajv-errors": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
@@ -1948,6 +1970,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmmirror.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmmirror.com/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@clack/core": {
       "version": "1.2.0",
       "license": "MIT",
@@ -2841,8 +2875,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmmirror.com/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
     },
     "node_modules/@intlify/core-base": {
       "version": "9.14.5",
@@ -3088,6 +3132,15 @@
       "resolved": "https://registry.npmmirror.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
       "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
       "license": "MIT"
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -3820,11 +3873,270 @@
         "node": ">=12"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmmirror.com/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmmirror.com/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmmirror.com/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmmirror.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmmirror.com/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -3943,6 +4255,16 @@
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
@@ -5390,6 +5712,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.7",
       "resolved": "https://registry.npmmirror.com/crelt/-/crelt-1.0.7.tgz",
@@ -5458,6 +5789,528 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmmirror.com/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmmirror.com/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmmirror.com/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmmirror.com/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmmirror.com/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmmirror.com/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -5525,6 +6378,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmmirror.com/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -5609,6 +6468,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -5933,6 +6801,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmmirror.com/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -6614,6 +7492,12 @@
       "version": "4.2.11",
       "license": "ISC"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmmirror.com/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6845,6 +7729,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
@@ -6869,6 +7763,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -7578,6 +8481,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmmirror.com/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7626,6 +8565,12 @@
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmmirror.com/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -7736,6 +8681,18 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmmirror.com/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
@@ -7796,6 +8753,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmmirror.com/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromark-util-character": {
@@ -8182,6 +9168,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -8220,6 +9212,12 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
       "license": "MIT"
     },
     "node_modules/path-key": {
@@ -8383,6 +9381,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmmirror.com/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8937,6 +9951,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.61.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
@@ -8983,6 +10003,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmmirror.com/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "license": "MIT",
@@ -9027,6 +10059,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
@@ -9739,6 +10777,12 @@
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmmirror.com/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -10122,6 +11166,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -10488,6 +11541,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmmirror.com/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -12131,6 +13197,7 @@
         "ghostty-web": "^0.4.0",
         "lucide-vue-next": "^1.0.0",
         "markdown-it": "^14.2.0",
+        "mermaid": "^11",
         "pinia": "^2.2.0",
         "remend": "^1.3.0",
         "vue": "^3.5.0",

--- a/packages/relay-web/package.json
+++ b/packages/relay-web/package.json
@@ -11,7 +11,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "ghostty-web": "^0.4.0",
     "@codemirror/commands": "^6.0.0",
     "@codemirror/lang-css": "^6.0.0",
     "@codemirror/lang-html": "^6.0.0",
@@ -34,8 +33,10 @@
     "@lobehub/icons-static-svg": "^1.91.0",
     "codemirror": "^6.0.0",
     "dompurify": "^3.4.10",
+    "ghostty-web": "^0.4.0",
     "lucide-vue-next": "^1.0.0",
     "markdown-it": "^14.2.0",
+    "mermaid": "^11",
     "pinia": "^2.2.0",
     "remend": "^1.3.0",
     "vue": "^3.5.0",

--- a/packages/relay-web/src/__tests__/inline-mermaid.test.ts
+++ b/packages/relay-web/src/__tests__/inline-mermaid.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, test } from "vitest";
+import { enhanceMermaidBlock } from "../lib/inline-mermaid";
+
+afterEach(() => { document.body.innerHTML = ""; });
+function fire(el: EventTarget, type: string, props: Record<string, unknown>): void {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(e, props);
+  el.dispatchEvent(e);
+}
+function makeBlock(): HTMLElement {
+  const block = document.createElement("pre");
+  block.className = "mermaid-block mermaid-rendered";
+  block.innerHTML = '<svg data-test="d"><text>x</text></svg>';
+  document.body.appendChild(block);
+  return block;
+}
+
+test("wraps the svg in a viewport and adds a 4-button controls bar", () => {
+  const block = makeBlock();
+  enhanceMermaidBlock(block, { onExpand: () => {} });
+  expect(block.querySelector('.mmd-viewport .mmd-transform svg[data-test="d"]')).not.toBeNull();
+  expect(block.querySelectorAll(".mmd-controls button").length).toBe(4);
+});
+
+test("Ctrl+wheel zooms; a plain wheel does not (page keeps scrolling)", () => {
+  const block = makeBlock();
+  enhanceMermaidBlock(block, { onExpand: () => {} });
+  const viewport = block.querySelector(".mmd-viewport")!;
+  const wrap = block.querySelector(".mmd-transform") as HTMLElement;
+  fire(viewport, "wheel", { deltaY: -100, clientX: 0, clientY: 0 });
+  expect(wrap.style.transform === "" || wrap.style.transform === "translate(0px, 0px) scale(1)").toBe(true);
+  fire(viewport, "wheel", { deltaY: -100, ctrlKey: true, clientX: 0, clientY: 0 });
+  expect(wrap.style.transform).toContain("scale(1.1)");
+});
+
+test("reset restores the transform; the ⤢ button calls onExpand", () => {
+  let expanded = 0;
+  const block = makeBlock();
+  enhanceMermaidBlock(block, { onExpand: () => { expanded += 1; } });
+  (block.querySelector('[aria-label="Zoom in"]') as HTMLElement).click();
+  (block.querySelector('[aria-label="Reset"]') as HTMLElement).click();
+  expect((block.querySelector(".mmd-transform") as HTMLElement).style.transform).toBe("translate(0px, 0px) scale(1)");
+  (block.querySelector('[aria-label="Fullscreen"]') as HTMLElement).click();
+  expect(expanded).toBe(1);
+});
+
+test("detach removes gesture listeners", () => {
+  const block = makeBlock();
+  const detach = enhanceMermaidBlock(block, { onExpand: () => {} });
+  detach();
+  const wrap = block.querySelector(".mmd-transform") as HTMLElement;
+  const before = wrap.style.transform;
+  fire(block.querySelector(".mmd-viewport")!, "wheel", { deltaY: -100, ctrlKey: true, clientX: 0, clientY: 0 });
+  expect(wrap.style.transform).toBe(before);
+});
+
+test("a block with no svg is a no-op returning a safe detach", () => {
+  const block = document.createElement("pre");
+  block.className = "mermaid-block mermaid-rendered";
+  document.body.appendChild(block);
+  const detach = enhanceMermaidBlock(block, { onExpand: () => {} });
+  expect(block.querySelector(".mmd-viewport")).toBeNull();
+  expect(() => detach()).not.toThrow();
+});

--- a/packages/relay-web/src/__tests__/mermaidviewer.test.ts
+++ b/packages/relay-web/src/__tests__/mermaidviewer.test.ts
@@ -42,3 +42,19 @@ test("Escape, close button, and background click each emit close", async () => {
   expect(wrapper.emitted("close")!.length).toBeGreaterThanOrEqual(3);
   wrapper.unmount();
 });
+
+test("a drag on the empty backdrop does not close; only a stationary click does", async () => {
+  const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
+  const stage = q(".mv-stage")!;
+  // pointer moved between down and click → a drag-pan, not a close
+  fire(stage, "pointerdown", { clientX: 0, clientY: 0 });
+  fire(stage, "click", { clientX: 60, clientY: 60 });
+  await wrapper.vm.$nextTick();
+  expect(wrapper.emitted("close")).toBeFalsy();
+  // stationary click on the backdrop → close
+  fire(stage, "pointerdown", { clientX: 10, clientY: 10 });
+  fire(stage, "click", { clientX: 10, clientY: 10 });
+  await wrapper.vm.$nextTick();
+  expect(wrapper.emitted("close")).toHaveLength(1);
+  wrapper.unmount();
+});

--- a/packages/relay-web/src/__tests__/mermaidviewer.test.ts
+++ b/packages/relay-web/src/__tests__/mermaidviewer.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, expect, test } from "vitest";
+import { mount } from "@vue/test-utils";
+import MermaidViewer from "../components/MermaidViewer.vue";
+
+const SVG = '<svg data-test="diagram"><text>hi</text></svg>';
+afterEach(() => { document.body.innerHTML = ""; document.body.style.overflow = ""; });
+
+const q = (sel: string) => document.body.querySelector(sel) as HTMLElement | null;
+function fire(el: EventTarget, type: string, props: Record<string, unknown>): void {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(e, props);
+  el.dispatchEvent(e);
+}
+
+test("teleports and renders the svg; locks body scroll while open", () => {
+  const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
+  expect(q('[data-test="diagram"]')).not.toBeNull();
+  expect(document.body.style.overflow).toBe("hidden");
+  wrapper.unmount();
+  expect(document.body.style.overflow).toBe("");
+});
+
+test("wheel changes the transform; reset restores it", async () => {
+  const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
+  const content = q(".mv-content")!;
+  const before = content.style.transform;
+  fire(q(".mv-stage")!, "wheel", { deltaY: -100, clientX: 0, clientY: 0 });
+  await wrapper.vm.$nextTick();
+  expect(content.style.transform).not.toBe(before);
+  q('[aria-label="Reset"]')!.click();
+  await wrapper.vm.$nextTick();
+  expect(content.style.transform).toBe("translate(0px, 0px) scale(1)");
+  wrapper.unmount();
+});
+
+test("Escape, close button, and background click each emit close", async () => {
+  const wrapper = mount(MermaidViewer, { props: { svg: SVG } });
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+  q('[aria-label="Close"]')!.click();
+  q(".mv-stage")!.click(); // background (target === stage)
+  await wrapper.vm.$nextTick();
+  expect(wrapper.emitted("close")!.length).toBeGreaterThanOrEqual(3);
+  wrapper.unmount();
+});

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -1,9 +1,16 @@
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
 import MessageList from "../components/MessageList.vue";
 import type { ChatMessage, LiveTurn } from "../stores/chat";
 import ToolCallPanel from "../components/ToolCallPanel.vue";
 import ToolStepCard from "../components/ToolStepCard.vue";
+
+// StreamMarkdown (rendered for "out" messages) reads useThemeStore() to re-hydrate mermaid
+// diagrams on theme change, so every mount here needs an active Pinia instance.
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
 
 function msg(partial: Partial<ChatMessage>): ChatMessage {
   return {

--- a/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
+++ b/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
@@ -75,6 +75,32 @@ test("with oneFingerTouchPan a single-finger drag pans", () => {
   expect(pz.state.y).toBe(40);
 });
 
+test("detach removes every listener it registered (per-listener, same handler reference)", () => {
+  // Behavioral checks can't isolate a single leaked listener (e.g. a stray pointerdown is inert
+  // once pointermove is gone). Record every (type, handler) attach registers, then assert each is
+  // removed with the SAME reference — so dropping any one removeEventListener reddens this.
+  const target = el();
+  const pz = createPanZoom();
+  const added: Array<[string, unknown]> = [];
+  const removed: Array<[string, unknown]> = [];
+  const origAdd = target.addEventListener.bind(target);
+  const origRemove = target.removeEventListener.bind(target);
+  target.addEventListener = ((type: string, fn: unknown, o?: unknown) => {
+    added.push([type, fn]);
+    return origAdd(type, fn as EventListener, o as AddEventListenerOptions);
+  }) as typeof target.addEventListener;
+  target.removeEventListener = ((type: string, fn: unknown, o?: unknown) => {
+    removed.push([type, fn]);
+    return origRemove(type, fn as EventListener, o as EventListenerOptions);
+  }) as typeof target.removeEventListener;
+
+  const d = attachPanZoomGestures(target, pz, () => {}, { oneFingerTouchPan: true });
+  d();
+
+  expect(added.length).toBe(8); // wheel, pointer{down,move,up,cancel}, touch{start,move,end}
+  for (const pair of added) expect(removed).toContainEqual(pair);
+});
+
 test("detach stops all gestures — wheel, pointer-drag, and pinch listeners are all removed", () => {
   const target = el();
   const pz = createPanZoom();

--- a/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
+++ b/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
@@ -75,11 +75,21 @@ test("with oneFingerTouchPan a single-finger drag pans", () => {
   expect(pz.state.y).toBe(40);
 });
 
-test("detach stops all gestures", () => {
+test("detach stops all gestures — wheel, pointer-drag, and pinch listeners are all removed", () => {
   const target = el();
   const pz = createPanZoom();
-  const d = attachPanZoomGestures(target, pz, () => {});
+  const d = attachPanZoomGestures(target, pz, () => {}, { oneFingerTouchPan: true });
   d();
+  // Wheel: no zoom.
   fire(target, "wheel", { deltaY: -100, clientX: 0, clientY: 0 });
+  expect(pz.state.scale).toBe(1);
+  // Mouse pointer drag: no pan (pointerdown listener gone, so move/up were never armed).
+  fire(target, "pointerdown", { pointerType: "mouse", pointerId: 1, clientX: 0, clientY: 0 });
+  fire(target, "pointermove", { pointerType: "mouse", pointerId: 1, clientX: 25, clientY: 40 });
+  expect(pz.state.x).toBe(0);
+  expect(pz.state.y).toBe(0);
+  // Two-finger pinch: no zoom (touchstart listener gone).
+  fire(target, "touchstart", { touches: [{ clientX: 0, clientY: 0 }, { clientX: 10, clientY: 0 }] });
+  fire(target, "touchmove", { touches: [{ clientX: 0, clientY: 0 }, { clientX: 20, clientY: 0 }] });
   expect(pz.state.scale).toBe(1);
 });

--- a/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
+++ b/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
@@ -75,22 +75,24 @@ test("with oneFingerTouchPan a single-finger drag pans", () => {
   expect(pz.state.y).toBe(40);
 });
 
-test("detach removes every listener it registered (per-listener, same handler reference)", () => {
+test("detach removes every listener it registered (per-listener, matching handler AND capture)", () => {
   // Behavioral checks can't isolate a single leaked listener (e.g. a stray pointerdown is inert
-  // once pointermove is gone). Record every (type, handler) attach registers, then assert each is
-  // removed with the SAME reference — so dropping any one removeEventListener reddens this.
+  // once pointermove is gone). Record every (type, handler, capture) attach registers, then assert
+  // each is removed with the SAME triple — the DOM matches removeEventListener on type+handler+
+  // capture, so including capture catches a single add flipped to capture:true without its remove.
+  const capture = (o: unknown): boolean => (typeof o === "boolean" ? o : !!(o as { capture?: boolean })?.capture);
   const target = el();
   const pz = createPanZoom();
-  const added: Array<[string, unknown]> = [];
-  const removed: Array<[string, unknown]> = [];
+  const added: Array<[string, unknown, boolean]> = [];
+  const removed: Array<[string, unknown, boolean]> = [];
   const origAdd = target.addEventListener.bind(target);
   const origRemove = target.removeEventListener.bind(target);
   target.addEventListener = ((type: string, fn: unknown, o?: unknown) => {
-    added.push([type, fn]);
+    added.push([type, fn, capture(o)]);
     return origAdd(type, fn as EventListener, o as AddEventListenerOptions);
   }) as typeof target.addEventListener;
   target.removeEventListener = ((type: string, fn: unknown, o?: unknown) => {
-    removed.push([type, fn]);
+    removed.push([type, fn, capture(o)]);
     return origRemove(type, fn as EventListener, o as EventListenerOptions);
   }) as typeof target.removeEventListener;
 
@@ -98,7 +100,7 @@ test("detach removes every listener it registered (per-listener, same handler re
   d();
 
   expect(added.length).toBe(8); // wheel, pointer{down,move,up,cancel}, touch{start,move,end}
-  for (const pair of added) expect(removed).toContainEqual(pair);
+  for (const triple of added) expect(removed).toContainEqual(triple);
 });
 
 test("detach stops all gestures — wheel, pointer-drag, and pinch listeners are all removed", () => {

--- a/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
+++ b/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, expect, test } from "vitest";
+import { createPanZoom } from "../lib/pan-zoom";
+import { attachPanZoomGestures } from "../lib/pan-zoom-gestures";
+
+let detach: (() => void) | null = null;
+afterEach(() => { detach?.(); detach = null; document.body.innerHTML = ""; });
+
+// jsdom lacks real WheelEvent/PointerEvent/TouchEvent ergonomics; dispatch a bare Event with the
+// properties the handlers read assigned onto it.
+function fire(el: EventTarget, type: string, props: Record<string, unknown>): void {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(e, props);
+  el.dispatchEvent(e);
+}
+function el(): HTMLElement {
+  const d = document.createElement("div");
+  document.body.appendChild(d);
+  return d;
+}
+
+test("wheelRequiresModifier: plain wheel is a no-op, Ctrl+wheel zooms", () => {
+  const target = el();
+  const pz = createPanZoom();
+  detach = attachPanZoomGestures(target, pz, () => {}, { wheelRequiresModifier: true });
+  fire(target, "wheel", { deltaY: -100, clientX: 0, clientY: 0 });
+  expect(pz.state.scale).toBe(1); // plain wheel ignored → page scrolls
+  fire(target, "wheel", { deltaY: -100, ctrlKey: true, clientX: 0, clientY: 0 });
+  expect(pz.state.scale).toBeCloseTo(1.1);
+});
+
+test("without wheelRequiresModifier a plain wheel zooms", () => {
+  const target = el();
+  const pz = createPanZoom();
+  detach = attachPanZoomGestures(target, pz, () => {});
+  fire(target, "wheel", { deltaY: 100, clientX: 0, clientY: 0 });
+  expect(pz.state.scale).toBeCloseTo(1 / 1.1);
+});
+
+test("mouse pointer drag pans", () => {
+  const target = el();
+  const pz = createPanZoom();
+  detach = attachPanZoomGestures(target, pz, () => {});
+  fire(target, "pointerdown", { pointerType: "mouse", pointerId: 1, clientX: 0, clientY: 0 });
+  fire(target, "pointermove", { pointerType: "mouse", pointerId: 1, clientX: 25, clientY: 40 });
+  fire(target, "pointerup", { pointerType: "mouse", pointerId: 1 });
+  expect(pz.state.x).toBe(25);
+  expect(pz.state.y).toBe(40);
+});
+
+test("two-finger touch pinch zooms", () => {
+  const target = el();
+  const pz = createPanZoom();
+  detach = attachPanZoomGestures(target, pz, () => {});
+  fire(target, "touchstart", { touches: [{ clientX: 0, clientY: 0 }, { clientX: 10, clientY: 0 }] });
+  fire(target, "touchmove", { touches: [{ clientX: 0, clientY: 0 }, { clientX: 20, clientY: 0 }] });
+  expect(pz.state.scale).toBeCloseTo(2); // distance 10 → 20
+});
+
+test("detach stops all gestures", () => {
+  const target = el();
+  const pz = createPanZoom();
+  const d = attachPanZoomGestures(target, pz, () => {});
+  d();
+  fire(target, "wheel", { deltaY: -100, clientX: 0, clientY: 0 });
+  expect(pz.state.scale).toBe(1);
+});

--- a/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
+++ b/packages/relay-web/src/__tests__/pan-zoom-gestures.test.ts
@@ -56,6 +56,25 @@ test("two-finger touch pinch zooms", () => {
   expect(pz.state.scale).toBeCloseTo(2); // distance 10 → 20
 });
 
+test("without oneFingerTouchPan a single-finger drag is ignored (page keeps scrolling)", () => {
+  const target = el();
+  const pz = createPanZoom();
+  detach = attachPanZoomGestures(target, pz, () => {}); // default: oneFingerTouchPan false
+  fire(target, "touchstart", { touches: [{ clientX: 0, clientY: 0 }] });
+  fire(target, "touchmove", { touches: [{ clientX: 30, clientY: 40 }] });
+  expect(pz.state).toEqual({ scale: 1, x: 0, y: 0 }); // not panned — the anti-hijack default
+});
+
+test("with oneFingerTouchPan a single-finger drag pans", () => {
+  const target = el();
+  const pz = createPanZoom();
+  detach = attachPanZoomGestures(target, pz, () => {}, { oneFingerTouchPan: true });
+  fire(target, "touchstart", { touches: [{ clientX: 0, clientY: 0 }] });
+  fire(target, "touchmove", { touches: [{ clientX: 30, clientY: 40 }] });
+  expect(pz.state.x).toBe(30);
+  expect(pz.state.y).toBe(40);
+});
+
 test("detach stops all gestures", () => {
   const target = el();
   const pz = createPanZoom();

--- a/packages/relay-web/src/__tests__/pan-zoom.test.ts
+++ b/packages/relay-web/src/__tests__/pan-zoom.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+import { createPanZoom } from "../lib/pan-zoom";
+
+test("starts at identity and formats a transform-origin:0,0 transform", () => {
+  const pz = createPanZoom();
+  expect(pz.state).toEqual({ scale: 1, x: 0, y: 0 });
+  expect(pz.toTransform()).toBe("translate(0px, 0px) scale(1)");
+});
+
+test("zoomAt keeps the point under the cursor stationary", () => {
+  const pz = createPanZoom();
+  pz.zoomAt(2, 100, 0); // zoom 2x centered on viewport x=100
+  // content point that was under x=100 must still be under x=100: x = 100 - (100-0)*(2/1) = -100
+  expect(pz.state.scale).toBe(2);
+  expect(pz.state.x).toBe(-100);
+  expect(pz.state.y).toBe(0);
+});
+
+test("zoomAt clamps scale to [minScale, maxScale]", () => {
+  const pz = createPanZoom({ minScale: 0.5, maxScale: 4 });
+  pz.zoomAt(100, 0, 0);
+  expect(pz.state.scale).toBe(4);
+  pz.zoomAt(0.0001, 0, 0);
+  expect(pz.state.scale).toBe(0.5);
+});
+
+test("panBy accumulates and reset returns to identity", () => {
+  const pz = createPanZoom();
+  pz.panBy(10, 20);
+  pz.panBy(5, -5);
+  expect(pz.state).toEqual({ scale: 1, x: 15, y: 15 });
+  pz.zoomAt(2, 50, 50);
+  pz.reset();
+  expect(pz.state).toEqual({ scale: 1, x: 0, y: 0 });
+  expect(pz.toTransform()).toBe("translate(0px, 0px) scale(1)");
+});

--- a/packages/relay-web/src/__tests__/render-markdown.test.ts
+++ b/packages/relay-web/src/__tests__/render-markdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderMarkdown } from "../lib/render-markdown";
+import { encodeMermaidSource, decodeMermaidSource } from "../lib/mermaid-source";
 
 describe("renderMarkdown", () => {
   it("renders basic markdown structure", () => {
@@ -86,5 +87,34 @@ describe("renderMarkdown", () => {
 
   it("returns an empty string for empty input", () => {
     expect(renderMarkdown("")).toBe("");
+  });
+
+  it("mermaid source base64 round-trips including non-ASCII and special chars", () => {
+    const src = "graph TD\n  A[开始] --> B{判断?}\n  B -->|是/yes| C[\"</code> & <script>\"]";
+    const encoded = encodeMermaidSource(src);
+    expect(encoded).toMatch(/^[A-Za-z0-9+/=]+$/); // base64 alphabet only — safe in an attribute
+    expect(decodeMermaidSource(encoded)).toBe(src);
+  });
+
+  it("a mermaid fence becomes a placeholder carrying the base64 source", () => {
+    const html = renderMarkdown("```mermaid\ngraph TD\n  A --> B\n```");
+    expect(html).toContain('class="mermaid-block"');
+    const match = html.match(/data-mermaid="([^"]+)"/);
+    expect(match).not.toBeNull();
+    expect(decodeMermaidSource(match![1]!)).toBe("graph TD\n  A --> B\n");
+    // The visible fallback keeps the (escaped) source, never blank.
+    expect(html).toContain("graph TD");
+  });
+
+  it("a mermaid fence source cannot inject markup", () => {
+    const html = renderMarkdown("```mermaid\n<script>alert(1)</script>\n```");
+    expect(html).not.toContain("<script>alert(1)</script>"); // escaped in fallback, raw source only in base64
+  });
+
+  it("a non-mermaid fence is rendered unchanged (no mermaid-block class)", () => {
+    const html = renderMarkdown("```ts\nconst a = 1;\n```");
+    expect(html).not.toContain("mermaid-block");
+    expect(html).toContain("<pre"); // ordinary code block
+    expect(html).toContain("const a = 1;");
   });
 });

--- a/packages/relay-web/src/__tests__/render-markdown.test.ts
+++ b/packages/relay-web/src/__tests__/render-markdown.test.ts
@@ -96,6 +96,11 @@ describe("renderMarkdown", () => {
     expect(decodeMermaidSource(encoded)).toBe(src);
   });
 
+  it("preserves a leading BOM through the round-trip (ignoreBOM decoder)", () => {
+    const src = "﻿graph TD\n  A --> B";
+    expect(decodeMermaidSource(encodeMermaidSource(src))).toBe(src);
+  });
+
   it("a mermaid fence becomes a placeholder carrying the base64 source", () => {
     const html = renderMarkdown("```mermaid\ngraph TD\n  A --> B\n```");
     expect(html).toContain('class="mermaid-block"');

--- a/packages/relay-web/src/__tests__/render-markdown.test.ts
+++ b/packages/relay-web/src/__tests__/render-markdown.test.ts
@@ -111,6 +111,24 @@ describe("renderMarkdown", () => {
     expect(html).not.toContain("<script>alert(1)</script>"); // escaped in fallback, raw source only in base64
   });
 
+  it("encodeMermaidSource is total on a lone surrogate (byte-safe, does not throw)", () => {
+    // `unescape(encodeURIComponent(...))` throws URIError on an unpaired surrogate; TextEncoder
+    // substitutes U+FFFD instead. This must never throw — it runs with no error isolation.
+    expect(() => encodeMermaidSource("\uD800")).not.toThrow();
+    expect(decodeMermaidSource(encodeMermaidSource("\uD800"))).toBe("�");
+  });
+
+  it("a mermaid fence containing a lone surrogate does not crash the whole render", () => {
+    const src = "graph TD\n  A[stray \uD800 unit] --> B";
+    // Old encoding threw here, taking down the entire message render, not just the diagram.
+    expect(() => renderMarkdown("```mermaid\n" + src + "\n```")).not.toThrow();
+    const html = renderMarkdown("```mermaid\n" + src + "\n```");
+    expect(html).toContain('class="mermaid-block"');
+    const match = html.match(/data-mermaid="([^"]+)"/);
+    expect(match).not.toBeNull();
+    expect(decodeMermaidSource(match![1]!)).toBe("graph TD\n  A[stray � unit] --> B\n");
+  });
+
   it("a non-mermaid fence is rendered unchanged (no mermaid-block class)", () => {
     const html = renderMarkdown("```ts\nconst a = 1;\n```");
     expect(html).not.toContain("mermaid-block");

--- a/packages/relay-web/src/__tests__/render-mermaid.test.ts
+++ b/packages/relay-web/src/__tests__/render-mermaid.test.ts
@@ -81,6 +81,29 @@ test("shouldAbort after render resolves: SVG is never committed to a torn-down D
   expect(pre.querySelector("code")?.textContent).toBe("graph TD\n A-->B");
 });
 
+test("shouldAbort after render REJECTS: error state is not written to a torn-down DOM", async () => {
+  // The failure branch must honor the same abort contract as the success branch: if the component
+  // unmounts / resumes streaming while mermaid.render is in flight and it then rejects, the stale
+  // block must NOT be marked error either — it stays on its untouched code fallback.
+  let rejected = false;
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({
+      initialize: () => {},
+      render: async () => {
+        rejected = true;
+        throw new Error("boom");
+      },
+    }),
+  );
+  const root = block("graph TD\n A-->B");
+  await hydrateMermaidBlocks(root, "dark", () => rejected); // false at loop entry, true after the reject
+  const pre = root.querySelector("pre.mermaid-block")!;
+  expect(rejected).toBe(true); // render did run and reject — abort is post-await, not a skip-before-start
+  expect(pre.hasAttribute("data-mermaid-done")).toBe(false);
+  expect(pre.classList.contains("mermaid-error")).toBe(false);
+  expect(pre.querySelector("code")?.textContent).toBe("graph TD\n A-->B");
+});
+
 test("shouldAbort true before the loop: no block is touched", async () => {
   const render = vi.fn(async () => ({ svg: "<svg><text>x</text></svg>" }));
   __setMermaidLoaderForTest(() => Promise.resolve({ initialize: () => {}, render }));

--- a/packages/relay-web/src/__tests__/render-mermaid.test.ts
+++ b/packages/relay-web/src/__tests__/render-mermaid.test.ts
@@ -58,6 +58,38 @@ test("a failing render marks the block as error and keeps the code fallback", as
   expect(pre.querySelector("svg")).toBeNull();
 });
 
+test("shouldAbort after render resolves: SVG is never committed to a torn-down DOM", async () => {
+  // The component captured this root, then unmounted (or resumed streaming) while mermaid.render
+  // was in flight. shouldAbort flips true once render resolves, so the block must stay on its
+  // code fallback — no innerHTML rewrite, no data-mermaid-done, no mermaid-rendered class.
+  let rendered = false;
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({
+      initialize: () => {},
+      render: async () => {
+        rendered = true;
+        return { svg: "<svg><text>x</text></svg>" };
+      },
+    }),
+  );
+  const root = block("graph TD\n A-->B");
+  await hydrateMermaidBlocks(root, "dark", () => rendered); // false at loop entry, true after render
+  const pre = root.querySelector("pre.mermaid-block")!;
+  expect(rendered).toBe(true); // render did run — the abort is post-await, not a skip-before-start
+  expect(pre.hasAttribute("data-mermaid-done")).toBe(false);
+  expect(pre.querySelector("svg")).toBeNull();
+  expect(pre.querySelector("code")?.textContent).toBe("graph TD\n A-->B");
+});
+
+test("shouldAbort true before the loop: no block is touched", async () => {
+  const render = vi.fn(async () => ({ svg: "<svg><text>x</text></svg>" }));
+  __setMermaidLoaderForTest(() => Promise.resolve({ initialize: () => {}, render }));
+  const root = block("graph TD\n A-->B");
+  await hydrateMermaidBlocks(root, "dark", () => true);
+  expect(render).not.toHaveBeenCalled(); // aborted before starting any block
+  expect(root.querySelector("pre.mermaid-block")!.hasAttribute("data-mermaid-done")).toBe(false);
+});
+
 test("resetMermaidBlocks reverts a rendered block to its code fallback", async () => {
   __setMermaidLoaderForTest(() =>
     Promise.resolve({ initialize: () => {}, render: async () => ({ svg: "<svg><text>x</text></svg>" }) }),

--- a/packages/relay-web/src/__tests__/render-mermaid.test.ts
+++ b/packages/relay-web/src/__tests__/render-mermaid.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  hydrateMermaidBlocks,
+  resetMermaidBlocks,
+  __setMermaidLoaderForTest,
+  type MermaidTheme,
+} from "../lib/render-mermaid";
+import { encodeMermaidSource } from "../lib/mermaid-source";
+
+function block(src: string): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML = `<pre class="mermaid-block" data-mermaid="${encodeMermaidSource(src)}"><code>${src}</code></pre>`;
+  return root;
+}
+
+afterEach(() => __setMermaidLoaderForTest(null));
+
+test("hydrate replaces the placeholder with sanitized SVG and marks it done", async () => {
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({
+      initialize: () => {},
+      render: async (_id: string, text: string) => ({
+        svg: `<svg data-src="${text.length}"><text>ok</text><script>alert(1)</script></svg>`,
+      }),
+    }),
+  );
+  const root = block("graph TD\n A-->B");
+  await hydrateMermaidBlocks(root, "dark");
+  const pre = root.querySelector("pre.mermaid-block")!;
+  expect(pre.querySelector("svg")).not.toBeNull();
+  expect(pre.querySelector("script")).toBeNull(); // DOMPurify svg profile strips it
+  expect(pre.getAttribute("data-mermaid-done")).toBe("1");
+  expect(pre.classList.contains("mermaid-rendered")).toBe(true);
+});
+
+test("hydrate caches by theme+source: identical re-hydrate does not re-invoke render", async () => {
+  const render = vi.fn(async (_id: string, _text: string) => ({ svg: "<svg><text>x</text></svg>" }));
+  __setMermaidLoaderForTest(() => Promise.resolve({ initialize: () => {}, render }));
+  const a = block("graph TD\n A-->B");
+  const b = block("graph TD\n A-->B");
+  await hydrateMermaidBlocks(a, "dark");
+  await hydrateMermaidBlocks(b, "dark");
+  expect(render).toHaveBeenCalledTimes(1); // second block served from cache
+  await hydrateMermaidBlocks(block("graph TD\n A-->B"), "light");
+  expect(render).toHaveBeenCalledTimes(2); // different theme → separate render
+});
+
+test("a failing render marks the block as error and keeps the code fallback", async () => {
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({ initialize: () => {}, render: async () => { throw new Error("bad diagram"); } }),
+  );
+  const root = block("not a diagram");
+  await hydrateMermaidBlocks(root, "dark"); // must not throw
+  const pre = root.querySelector("pre.mermaid-block")!;
+  expect(pre.getAttribute("data-mermaid-done")).toBe("error");
+  expect(pre.classList.contains("mermaid-error")).toBe(true);
+  expect(pre.querySelector("code")?.textContent).toBe("not a diagram");
+  expect(pre.querySelector("svg")).toBeNull();
+});
+
+test("resetMermaidBlocks reverts a rendered block to its code fallback", async () => {
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({ initialize: () => {}, render: async () => ({ svg: "<svg><text>x</text></svg>" }) }),
+  );
+  const root = block("graph TD\n A-->B");
+  await hydrateMermaidBlocks(root, "dark");
+  resetMermaidBlocks(root);
+  const pre = root.querySelector("pre.mermaid-block")!;
+  expect(pre.hasAttribute("data-mermaid-done")).toBe(false);
+  expect(pre.querySelector("svg")).toBeNull();
+  expect(pre.querySelector("code")?.textContent).toBe("graph TD\n A-->B");
+});

--- a/packages/relay-web/src/__tests__/streammarkdown.test.ts
+++ b/packages/relay-web/src/__tests__/streammarkdown.test.ts
@@ -22,10 +22,35 @@ vi.mock("../lib/render-mermaid", () => ({
   resetMermaidBlocks: (...a: unknown[]) => reset(...a),
 }));
 
+// Mock the inline enhancer so the tests can assert the WIRING (enhance called once per rendered
+// block, viewer opened on ⤢) via call count — the real enhancer is covered by inline-mermaid.test.ts.
+// The stand-in produces just enough DOM (a .mmd-viewport keeping the svg, a Fullscreen button wired
+// to onExpand) for those assertions.
+const enhanceCalls: HTMLElement[] = [];
+vi.mock("../lib/inline-mermaid", () => ({
+  enhanceMermaidBlock: (block: HTMLElement, opts: { onExpand: () => void }) => {
+    enhanceCalls.push(block);
+    const svg = block.querySelector("svg");
+    const viewport = document.createElement("div");
+    viewport.className = "mmd-viewport";
+    if (svg) viewport.appendChild(svg);
+    const bar = document.createElement("div");
+    bar.className = "mmd-controls";
+    for (let i = 0; i < 3; i += 1) bar.appendChild(document.createElement("button"));
+    const expand = document.createElement("button");
+    expand.setAttribute("aria-label", "Fullscreen");
+    expand.addEventListener("click", () => opts.onExpand());
+    bar.appendChild(expand);
+    block.replaceChildren(viewport, bar);
+    return () => {};
+  },
+}));
+
 beforeEach(() => {
   vi.useFakeTimers();
   setActivePinia(createPinia());
   renderSpy.mockClear();
+  enhanceCalls.length = 0;
 });
 afterEach(() => {
   vi.useRealTimers();
@@ -161,15 +186,12 @@ describe("StreamMarkdown mermaid hydration", () => {
     wrapper.unmount();
   });
 
-  test("a rendered mermaid block is enhanced with an inline pan/zoom viewport + controls", async () => {
-    // Mount schedules hydrate through a chained promise with several microtask hops, so — like
-    // the "serializes hydration" test above — use real timers + flushPromises to reliably drain
-    // it instead of guessing a fixed nextTick count.
+  test("a rendered mermaid block is enhanced exactly once (idempotent across the mount double-schedule)", async () => {
+    // Mount schedules hydrate twice (module-level render() + onMounted). Each pass runs through a
+    // chained promise with several microtask hops, so use real timers + flushPromises to drain it.
     vi.useRealTimers();
-    // hydrate's inferred type is `(..._args: unknown[]) => Promise<void>` (see the file's rest-
-    // param note up top), so the mock body takes rest args and casts internally rather than
-    // declaring a concrete `root: HTMLElement` param, which fails typecheck as a param variance
-    // violation.
+    // hydrate's inferred type is `(..._args: unknown[]) => Promise<void>`, so take rest args and
+    // cast internally rather than a concrete `root: HTMLElement` param (param-variance typecheck).
     hydrate.mockImplementation(async (...args: unknown[]) => {
       renderFirstMermaidBlock(args[0] as HTMLElement);
     });
@@ -179,18 +201,45 @@ describe("StreamMarkdown mermaid hydration", () => {
     });
     await flushPromises();
     expect(wrapper.element.querySelector(".mmd-viewport")).not.toBeNull();
-    expect(wrapper.element.querySelectorAll(".mmd-controls button").length).toBe(4);
-    // idempotent: a second hydrate pass must not double-enhance
-    await wrapper.setProps({ streaming: false });
+    // The `:not([data-mmd-enhanced])` guard means the block is enhanced ONCE despite two hydrate
+    // passes on mount. Without the guard this is 2 — the assertion that actually locks it.
+    expect(enhanceCalls.length).toBe(1);
+    hydrate.mockImplementation(async () => {});
+    wrapper.unmount();
+  });
+
+  test("re-enhances a diagram after a theme switch (reset + re-hydrate)", async () => {
+    vi.useRealTimers();
+    hydrate.mockImplementation(async (...args: unknown[]) => {
+      renderFirstMermaidBlock(args[0] as HTMLElement);
+    });
+    // reset mimics the real resetMermaidBlocks: it rebuilds each block to an un-rendered fallback
+    // and does NOT clear `data-mmd-enhanced` (clearing that marker is StreamMarkdown's job — the
+    // bug this test locks: without it, the re-rendered block is skipped and loses pan/zoom).
+    reset.mockImplementation((...args: unknown[]) => {
+      (args[0] as HTMLElement).querySelectorAll("pre.mermaid-block").forEach((b) => {
+        b.classList.remove("mermaid-rendered");
+        b.innerHTML = "<code>graph TD</code>";
+      });
+    });
+    const themeStore = useThemeStore();
+    const wrapper = mount(StreamMarkdown, {
+      props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false },
+      global: { stubs: { MermaidViewer: true } },
+    });
     await flushPromises();
-    expect(wrapper.element.querySelectorAll(".mmd-viewport").length).toBe(1);
+    expect(enhanceCalls.length).toBe(1); // enhanced on mount
+    themeStore.set(themeStore.mode === "dark" ? "light" : "dark"); // → scheduleHydrate(reset = true)
+    await flushPromises();
+    // The reset cleared the enhancement DOM and marker; the re-hydrated block must be enhanced again.
+    expect(enhanceCalls.length).toBe(2);
+    expect(wrapper.element.querySelector(".mmd-viewport")).not.toBeNull();
+    reset.mockImplementation(() => {});
     hydrate.mockImplementation(async () => {});
     wrapper.unmount();
   });
 
   test("clicking the ⤢ button opens the fullscreen viewer with the diagram svg", async () => {
-    // Same rationale as above: real timers + flushPromises to drain the chained hydrate, and the
-    // rest-args form to keep hydrate.mockImplementation typechecking.
     vi.useRealTimers();
     hydrate.mockImplementation(async (...args: unknown[]) => {
       renderFirstMermaidBlock(args[0] as HTMLElement);

--- a/packages/relay-web/src/__tests__/streammarkdown.test.ts
+++ b/packages/relay-web/src/__tests__/streammarkdown.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
+import { createPinia, setActivePinia } from "pinia";
 import StreamMarkdown from "../components/StreamMarkdown.vue";
 import { renderMarkdown } from "../lib/render-markdown";
+import { useThemeStore } from "../stores/theme";
 
 // Count parses without paying for the real pipeline (healing + markdown-it + DOMPurify).
 vi.mock("../lib/render-markdown", () => ({
@@ -10,8 +12,18 @@ vi.mock("../lib/render-markdown", () => ({
 }));
 const renderSpy = vi.mocked(renderMarkdown);
 
+// Explicit rest-param signatures (rather than 0-arity) so the `(...a) => fn(...a)` spread
+// wrappers below typecheck: TS rejects spreading a non-tuple array into a fixed-arity call.
+const hydrate = vi.fn(async (..._args: unknown[]) => {});
+const reset = vi.fn((..._args: unknown[]) => {});
+vi.mock("../lib/render-mermaid", () => ({
+  hydrateMermaidBlocks: (...a: unknown[]) => hydrate(...a),
+  resetMermaidBlocks: (...a: unknown[]) => reset(...a),
+}));
+
 beforeEach(() => {
   vi.useFakeTimers();
+  setActivePinia(createPinia());
   renderSpy.mockClear();
 });
 afterEach(() => {
@@ -75,5 +87,59 @@ describe("StreamMarkdown streaming throttle", () => {
     const calls = renderSpy.mock.calls.length;
     vi.advanceTimersByTime(200);
     expect(renderSpy).toHaveBeenCalledTimes(calls);
+  });
+});
+
+describe("StreamMarkdown mermaid hydration", () => {
+  test("does not hydrate mermaid while streaming", async () => {
+    hydrate.mockClear();
+    const wrapper = mount(StreamMarkdown, { props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: true } });
+    await nextTick();
+    await nextTick();
+    expect(hydrate).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  test("hydrates mermaid once streaming ends", async () => {
+    hydrate.mockClear();
+    const wrapper = mount(StreamMarkdown, { props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: true } });
+    await nextTick();
+    await wrapper.setProps({ streaming: false });
+    await nextTick();
+    await nextTick();
+    expect(hydrate).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  test("hydrates a non-streaming (finalized) message on mount", async () => {
+    hydrate.mockClear();
+    const wrapper = mount(StreamMarkdown, { props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false } });
+    await nextTick();
+    await nextTick();
+    expect(hydrate).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  // Amendment: hydrateMermaidBlocks is async, and two overlapping schedule triggers on the
+  // same root (e.g. rapid theme toggles) could otherwise run concurrently. scheduleHydrate
+  // chains through a per-instance promise so only one hydration pass runs at a time.
+  test("serializes hydration — overlapping triggers never run concurrently", async () => {
+    vi.useRealTimers(); // this test drives real async timing via the mocked hydrate's setTimeout
+    let inFlight = 0;
+    let maxInFlight = 0;
+    hydrate.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight -= 1;
+    });
+    const themeStore = useThemeStore();
+    const wrapper = mount(StreamMarkdown, { props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false } });
+    themeStore.set("light");
+    themeStore.set("dark"); // two rapid re-hydrate triggers
+    await new Promise((r) => setTimeout(r, 40));
+    expect(maxInFlight).toBe(1);
+    hydrate.mockImplementation(async () => {}); // restore for other tests
+    wrapper.unmount();
   });
 });

--- a/packages/relay-web/src/__tests__/streammarkdown.test.ts
+++ b/packages/relay-web/src/__tests__/streammarkdown.test.ts
@@ -27,8 +27,13 @@ vi.mock("../lib/render-mermaid", () => ({
 // The stand-in produces just enough DOM (a .mmd-viewport keeping the svg, a Fullscreen button wired
 // to onExpand) for those assertions.
 const enhanceCalls: HTMLElement[] = [];
+// Each enhance returns a detacher that records its id here, so tests can assert that a
+// re-render (or unmount) actually detaches the previous block's enhancers.
+const detachCalls: number[] = [];
+let enhanceSeq = 0;
 vi.mock("../lib/inline-mermaid", () => ({
   enhanceMermaidBlock: (block: HTMLElement, opts: { onExpand: () => void }) => {
+    const id = (enhanceSeq += 1);
     enhanceCalls.push(block);
     const svg = block.querySelector("svg");
     const viewport = document.createElement("div");
@@ -42,7 +47,7 @@ vi.mock("../lib/inline-mermaid", () => ({
     expand.addEventListener("click", () => opts.onExpand());
     bar.appendChild(expand);
     block.replaceChildren(viewport, bar);
-    return () => {};
+    return () => detachCalls.push(id);
   },
 }));
 
@@ -51,6 +56,8 @@ beforeEach(() => {
   setActivePinia(createPinia());
   renderSpy.mockClear();
   enhanceCalls.length = 0;
+  detachCalls.length = 0;
+  enhanceSeq = 0;
 });
 afterEach(() => {
   vi.useRealTimers();
@@ -235,6 +242,55 @@ describe("StreamMarkdown mermaid hydration", () => {
     expect(enhanceCalls.length).toBe(2);
     expect(wrapper.element.querySelector(".mmd-viewport")).not.toBeNull();
     reset.mockImplementation(() => {});
+    hydrate.mockImplementation(async () => {});
+    wrapper.unmount();
+  });
+
+  test("a queued hydration that releases after streaming resumed does not hydrate (re-checks streaming)", async () => {
+    // Pass 1 (mount, streaming=false) is held in-flight; while it is parked, streaming flips back
+    // to true. When pass 1 releases and the chained pass runs, it must see streaming=true and bail
+    // — otherwise it hydrates a diagram whose source is still mid-stream. The guard is the
+    // in-callback `hydrationStale()` recheck; without it this second hydrate fires.
+    vi.useRealTimers();
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let calls = 0;
+    hydrate.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) await gate; // park the first pass
+    });
+    const wrapper = mount(StreamMarkdown, {
+      props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false },
+      global: { stubs: { MermaidViewer: true } },
+    });
+    await nextTick();
+    await wrapper.setProps({ streaming: true }); // resume streaming while pass 1 is parked
+    release(); // let the chain drain
+    await flushPromises();
+    expect(calls).toBe(1); // the queued follow-up bailed on the streaming recheck
+    hydrate.mockImplementation(async () => {});
+    wrapper.unmount();
+  });
+
+  test("a plain (finalized) text re-render detaches the previous block's enhancers", async () => {
+    // Replacing v-html discards the enhanced viewport DOM; render() must detach its listeners
+    // rather than strand them until the next theme switch/unmount. Observed via the detacher the
+    // enhancer mock returns (records its id in detachCalls). Without the detach in render() this
+    // stays empty and the assertion fails.
+    vi.useRealTimers();
+    hydrate.mockImplementation(async (...args: unknown[]) => {
+      renderFirstMermaidBlock(args[0] as HTMLElement);
+    });
+    const wrapper = mount(StreamMarkdown, {
+      props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false },
+      global: { stubs: { MermaidViewer: true } },
+    });
+    await flushPromises();
+    expect(enhanceCalls.length).toBe(1);
+    expect(detachCalls).toEqual([]); // enhanced, nothing detached yet
+    await wrapper.setProps({ text: "```mermaid\ngraph TD\nA-->C\n```" }); // finalized change → render()
+    await flushPromises();
+    expect(detachCalls).toContain(1); // the first block's enhancer was detached on the re-render
     hydrate.mockImplementation(async () => {});
     wrapper.unmount();
   });

--- a/packages/relay-web/src/__tests__/streammarkdown.test.ts
+++ b/packages/relay-web/src/__tests__/streammarkdown.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { createPinia, setActivePinia } from "pinia";
 import StreamMarkdown from "../components/StreamMarkdown.vue";
+import MermaidViewer from "../components/MermaidViewer.vue";
 import { renderMarkdown } from "../lib/render-markdown";
 import { useThemeStore } from "../stores/theme";
 
@@ -90,6 +91,23 @@ describe("StreamMarkdown streaming throttle", () => {
   });
 });
 
+// renderMarkdown is mocked to a bare `<p>` (see top of file), so no real pre.mermaid-block ever
+// lands in the DOM from the render step. This stands one up itself the first time hydrate runs,
+// then marks it rendered + injects an svg — mirroring the real hydrateMermaidBlocks' idempotency
+// (only touch un-rendered blocks) so a second, overlapping hydrate pass (module-level render() +
+// onMounted both schedule one on initial mount) does not re-clobber an already-enhanced block.
+function renderFirstMermaidBlock(root: HTMLElement): void {
+  if (root.querySelectorAll("pre.mermaid-block").length === 0) {
+    const b = document.createElement("pre");
+    b.className = "mermaid-block";
+    root.appendChild(b);
+  }
+  root.querySelectorAll("pre.mermaid-block:not(.mermaid-rendered)").forEach((b) => {
+    b.classList.add("mermaid-rendered");
+    b.innerHTML = '<svg data-test="d"><text>x</text></svg>';
+  });
+}
+
 describe("StreamMarkdown mermaid hydration", () => {
   test("does not hydrate mermaid while streaming", async () => {
     hydrate.mockClear();
@@ -140,6 +158,55 @@ describe("StreamMarkdown mermaid hydration", () => {
     await new Promise((r) => setTimeout(r, 40));
     expect(maxInFlight).toBe(1);
     hydrate.mockImplementation(async () => {}); // restore for other tests
+    wrapper.unmount();
+  });
+
+  test("a rendered mermaid block is enhanced with an inline pan/zoom viewport + controls", async () => {
+    // Mount schedules hydrate through a chained promise with several microtask hops, so — like
+    // the "serializes hydration" test above — use real timers + flushPromises to reliably drain
+    // it instead of guessing a fixed nextTick count.
+    vi.useRealTimers();
+    // hydrate's inferred type is `(..._args: unknown[]) => Promise<void>` (see the file's rest-
+    // param note up top), so the mock body takes rest args and casts internally rather than
+    // declaring a concrete `root: HTMLElement` param, which fails typecheck as a param variance
+    // violation.
+    hydrate.mockImplementation(async (...args: unknown[]) => {
+      renderFirstMermaidBlock(args[0] as HTMLElement);
+    });
+    const wrapper = mount(StreamMarkdown, {
+      props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false },
+      global: { stubs: { MermaidViewer: true } },
+    });
+    await flushPromises();
+    expect(wrapper.element.querySelector(".mmd-viewport")).not.toBeNull();
+    expect(wrapper.element.querySelectorAll(".mmd-controls button").length).toBe(4);
+    // idempotent: a second hydrate pass must not double-enhance
+    await wrapper.setProps({ streaming: false });
+    await flushPromises();
+    expect(wrapper.element.querySelectorAll(".mmd-viewport").length).toBe(1);
+    hydrate.mockImplementation(async () => {});
+    wrapper.unmount();
+  });
+
+  test("clicking the ⤢ button opens the fullscreen viewer with the diagram svg", async () => {
+    // Same rationale as above: real timers + flushPromises to drain the chained hydrate, and the
+    // rest-args form to keep hydrate.mockImplementation typechecking.
+    vi.useRealTimers();
+    hydrate.mockImplementation(async (...args: unknown[]) => {
+      renderFirstMermaidBlock(args[0] as HTMLElement);
+    });
+    const wrapper = mount(StreamMarkdown, {
+      props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false },
+      global: { stubs: { MermaidViewer: true } },
+    });
+    await flushPromises();
+    expect(wrapper.findComponent(MermaidViewer).exists()).toBe(false);
+    (wrapper.element.querySelector('[aria-label="Fullscreen"]') as HTMLElement).click();
+    await nextTick();
+    const viewer = wrapper.findComponent(MermaidViewer);
+    expect(viewer.exists()).toBe(true);
+    expect(viewer.props("svg")).toContain('data-test="d"');
+    hydrate.mockImplementation(async () => {});
     wrapper.unmount();
   });
 });

--- a/packages/relay-web/src/__tests__/streammarkdown.test.ts
+++ b/packages/relay-web/src/__tests__/streammarkdown.test.ts
@@ -295,6 +295,61 @@ describe("StreamMarkdown mermaid hydration", () => {
     wrapper.unmount();
   });
 
+  test("unmount mid-hydration: the abort predicate reaches INTO the hydrator and reports torn-down", async () => {
+    // Component-level teardown-during-hydration. The contract Codex flagged: the guard must reach
+    // INTO the hydrator, not merely gate the caller. We capture the 3rd arg (shouldAbort) the
+    // component hands hydrateMermaidBlocks, sample it AFTER unmount, and assert it reports stale —
+    // and that no post-hydrate enhancement touched the torn-down block. If the component stopped
+    // passing the predicate, `sampled` stays null and this reddens.
+    vi.useRealTimers();
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let entered!: () => void;
+    const enteredP = new Promise<void>((r) => (entered = r));
+    let sampled: boolean | null = null;
+    hydrate.mockImplementation(async (...args: unknown[]) => {
+      const shouldAbort = args[2] as (() => boolean) | undefined;
+      entered(); // signal hydration is now in-flight (before any unmount)
+      await gate; // park here until after unmount
+      sampled = shouldAbort ? shouldAbort() : null;
+      renderFirstMermaidBlock(args[0] as HTMLElement);
+    });
+    const wrapper = mount(StreamMarkdown, {
+      props: { text: "```mermaid\ngraph TD\nA-->B\n```", streaming: false },
+      global: { stubs: { MermaidViewer: true } },
+    });
+    await enteredP; // hydrate is genuinely parked in-flight — not short-circuited before it ran
+    wrapper.unmount(); // tear down while hydration is parked
+    release(); // resolve against the disposed component
+    await flushPromises();
+    expect(sampled).toBe(true); // hydrator was handed a live predicate that reports torn-down
+    expect(enhanceCalls.length).toBe(0); // disposed → no enhancement of a torn-down block
+    hydrate.mockImplementation(async () => {});
+  });
+
+  test("a failed diagram gets a localized muted error label (spec error affordance)", async () => {
+    vi.useRealTimers();
+    hydrate.mockImplementation(async (...args: unknown[]) => {
+      const root = args[0] as HTMLElement;
+      if (root.querySelectorAll("pre.mermaid-block").length === 0) {
+        const b = document.createElement("pre");
+        b.className = "mermaid-block mermaid-error"; // a render that failed keeps its code fallback
+        b.innerHTML = "<code>bad diagram</code>";
+        root.appendChild(b);
+      }
+    });
+    const wrapper = mount(StreamMarkdown, {
+      props: { text: "```mermaid\nbad\n```", streaming: false },
+      global: { stubs: { MermaidViewer: true } },
+    });
+    await flushPromises();
+    const errBlock = wrapper.element.querySelector("pre.mermaid-block.mermaid-error");
+    // Label text comes from i18n (en default); without labelErrorBlocks the attribute is absent.
+    expect(errBlock?.getAttribute("data-mmd-error-label")).toBe("Diagram failed to render");
+    hydrate.mockImplementation(async () => {});
+    wrapper.unmount();
+  });
+
   test("clicking the ⤢ button opens the fullscreen viewer with the diagram svg", async () => {
     vi.useRealTimers();
     hydrate.mockImplementation(async (...args: unknown[]) => {

--- a/packages/relay-web/src/components/MermaidViewer.vue
+++ b/packages/relay-web/src/components/MermaidViewer.vue
@@ -42,8 +42,18 @@ function reset(): void {
   pz.reset();
   apply();
 }
+// Background (not the diagram) click closes — but a drag-to-pan that starts and ends on the empty
+// stage also synthesizes a click, so ignore it if the pointer moved beyond a small threshold.
+let downX = 0;
+let downY = 0;
+function onStagePointerDown(e: PointerEvent): void {
+  downX = e.clientX;
+  downY = e.clientY;
+}
 function onStageClick(e: MouseEvent): void {
-  if (e.target === stageEl.value) emit("close"); // background, not the diagram
+  if (e.target !== stageEl.value) return; // clicked the diagram, not the backdrop
+  if (Math.abs(e.clientX - downX) > 4 || Math.abs(e.clientY - downY) > 4) return; // was a drag
+  emit("close");
 }
 </script>
 
@@ -57,7 +67,7 @@ function onStageClick(e: MouseEvent): void {
       aria-modal="true"
       aria-label="Diagram viewer"
     >
-      <div ref="stageEl" class="mv-stage" @click="onStageClick">
+      <div ref="stageEl" class="mv-stage" @pointerdown="onStagePointerDown" @click="onStageClick">
         <!-- eslint-disable-next-line vue/no-v-html -- SVG already DOMPurify-sanitized by render-mermaid -->
         <div class="mv-content" :style="{ transform }" v-html="svg" />
       </div>

--- a/packages/relay-web/src/components/MermaidViewer.vue
+++ b/packages/relay-web/src/components/MermaidViewer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import { X, ZoomIn, ZoomOut, RotateCcw } from "lucide-vue-next";
-import { createPanZoom, ZOOM_IN_FACTOR, ZOOM_OUT_FACTOR } from "../lib/pan-zoom";
+import { createPanZoom, zoomToRectCenter, ZOOM_IN_FACTOR, ZOOM_OUT_FACTOR } from "../lib/pan-zoom";
 import { attachPanZoomGestures } from "../lib/pan-zoom-gestures";
 import { useModalA11y } from "../lib/use-modal-a11y";
 
@@ -12,9 +12,9 @@ const emit = defineEmits<{ close: [] }>();
 const dialogEl = ref<HTMLElement | null>(null);
 const stageEl = ref<HTMLElement | null>(null);
 const transform = ref("translate(0px, 0px) scale(1)");
-const pz = createPanZoom();
+const panZoom = createPanZoom();
 function apply(): void {
-  transform.value = pz.toTransform();
+  transform.value = panZoom.toTransform();
 }
 
 useModalA11y(dialogEl, () => emit("close"));
@@ -23,7 +23,7 @@ let detach: (() => void) | null = null;
 let prevOverflow = "";
 onMounted(() => {
   if (stageEl.value) {
-    detach = attachPanZoomGestures(stageEl.value, pz, apply, { oneFingerTouchPan: true });
+    detach = attachPanZoomGestures(stageEl.value, panZoom, apply, { oneFingerTouchPan: true });
   }
   prevOverflow = document.body.style.overflow;
   document.body.style.overflow = "hidden";
@@ -34,12 +34,12 @@ onBeforeUnmount(() => {
 });
 
 function zoomButton(factor: number): void {
-  const r = stageEl.value?.getBoundingClientRect();
-  pz.zoomAt(factor, r ? r.width / 2 : 0, r ? r.height / 2 : 0);
+  const r = stageEl.value?.getBoundingClientRect() ?? { width: 0, height: 0 };
+  zoomToRectCenter(panZoom, r, factor);
   apply();
 }
 function reset(): void {
-  pz.reset();
+  panZoom.reset();
   apply();
 }
 // Background (not the diagram) click closes — but a drag-to-pan that starts and ends on the empty

--- a/packages/relay-web/src/components/MermaidViewer.vue
+++ b/packages/relay-web/src/components/MermaidViewer.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import { X, ZoomIn, ZoomOut, RotateCcw } from "lucide-vue-next";
+import { createPanZoom } from "../lib/pan-zoom";
+import { attachPanZoomGestures } from "../lib/pan-zoom-gestures";
+import { useModalA11y } from "../lib/use-modal-a11y";
+
+// Rendered only while open (parent v-if) → mount/unmount == open/close.
+defineProps<{ svg: string }>();
+const emit = defineEmits<{ close: [] }>();
+
+const dialogEl = ref<HTMLElement | null>(null);
+const stageEl = ref<HTMLElement | null>(null);
+const transform = ref("translate(0px, 0px) scale(1)");
+const pz = createPanZoom();
+function apply(): void {
+  transform.value = pz.toTransform();
+}
+
+useModalA11y(dialogEl, () => emit("close"));
+
+let detach: (() => void) | null = null;
+let prevOverflow = "";
+onMounted(() => {
+  if (stageEl.value) {
+    detach = attachPanZoomGestures(stageEl.value, pz, apply, { oneFingerTouchPan: true });
+  }
+  prevOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+});
+onBeforeUnmount(() => {
+  detach?.();
+  document.body.style.overflow = prevOverflow;
+});
+
+function zoomButton(factor: number): void {
+  const r = stageEl.value?.getBoundingClientRect();
+  pz.zoomAt(factor, r ? r.width / 2 : 0, r ? r.height / 2 : 0);
+  apply();
+}
+function reset(): void {
+  pz.reset();
+  apply();
+}
+function onStageClick(e: MouseEvent): void {
+  if (e.target === stageEl.value) emit("close"); // background, not the diagram
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      ref="dialogEl"
+      class="mermaid-viewer"
+      tabindex="-1"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Diagram viewer"
+    >
+      <div ref="stageEl" class="mv-stage" @click="onStageClick">
+        <!-- eslint-disable-next-line vue/no-v-html -- SVG already DOMPurify-sanitized by render-mermaid -->
+        <div class="mv-content" :style="{ transform }" v-html="svg" />
+      </div>
+      <div class="mv-controls">
+        <button type="button" aria-label="Zoom out" @click="zoomButton(0.8)"><ZoomOut :size="18" /></button>
+        <button type="button" aria-label="Reset" @click="reset()"><RotateCcw :size="18" /></button>
+        <button type="button" aria-label="Zoom in" @click="zoomButton(1.25)"><ZoomIn :size="18" /></button>
+        <button type="button" aria-label="Close" @click="emit('close')"><X :size="18" /></button>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.mermaid-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgb(var(--c-bg) / 0.92);
+  backdrop-filter: blur(2px);
+}
+.mv-stage {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: none;
+}
+.mv-stage:active {
+  cursor: grabbing;
+}
+.mv-content {
+  transform-origin: 0 0;
+  width: max-content;
+}
+.mv-content :deep(svg) {
+  display: block;
+}
+.mv-controls {
+  position: absolute;
+  top: calc(0.75rem + env(safe-area-inset-top));
+  right: 0.75rem;
+  display: flex;
+  gap: 0.35rem;
+}
+.mv-controls button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  border: 1px solid rgb(var(--c-border));
+  background: rgb(var(--c-surface));
+  color: rgb(var(--c-fg));
+  box-shadow: var(--shadow-e1);
+}
+.mv-controls button:hover {
+  background: rgb(var(--c-bg-raised, var(--c-surface)));
+}
+</style>

--- a/packages/relay-web/src/components/MermaidViewer.vue
+++ b/packages/relay-web/src/components/MermaidViewer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import { X, ZoomIn, ZoomOut, RotateCcw } from "lucide-vue-next";
-import { createPanZoom } from "../lib/pan-zoom";
+import { createPanZoom, ZOOM_IN_FACTOR, ZOOM_OUT_FACTOR } from "../lib/pan-zoom";
 import { attachPanZoomGestures } from "../lib/pan-zoom-gestures";
 import { useModalA11y } from "../lib/use-modal-a11y";
 
@@ -72,9 +72,9 @@ function onStageClick(e: MouseEvent): void {
         <div class="mv-content" :style="{ transform }" v-html="svg" />
       </div>
       <div class="mv-controls">
-        <button type="button" aria-label="Zoom out" @click="zoomButton(0.8)"><ZoomOut :size="18" /></button>
+        <button type="button" aria-label="Zoom out" @click="zoomButton(ZOOM_OUT_FACTOR)"><ZoomOut :size="18" /></button>
         <button type="button" aria-label="Reset" @click="reset()"><RotateCcw :size="18" /></button>
-        <button type="button" aria-label="Zoom in" @click="zoomButton(1.25)"><ZoomIn :size="18" /></button>
+        <button type="button" aria-label="Zoom in" @click="zoomButton(ZOOM_IN_FACTOR)"><ZoomIn :size="18" /></button>
         <button type="button" aria-label="Close" @click="emit('close')"><X :size="18" /></button>
       </div>
     </div>

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -2,6 +2,8 @@
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { renderMarkdown } from "../lib/render-markdown";
 import { hydrateMermaidBlocks, resetMermaidBlocks } from "../lib/render-mermaid";
+import { enhanceMermaidBlock } from "../lib/inline-mermaid";
+import MermaidViewer from "./MermaidViewer.vue";
 import { useThemeStore } from "../stores/theme";
 
 const props = defineProps<{ text: string; streaming?: boolean }>();
@@ -34,14 +36,42 @@ function cancelTimer(): void {
 // theme toggles) could otherwise run concurrently. Chain every call through a per-instance
 // promise so only one hydration pass runs at a time; a failed pass must not break the chain.
 let hydrateChain: Promise<void> = Promise.resolve();
+
+const viewerSvg = ref<string | null>(null);
+let enhanceDetachers: Array<() => void> = [];
+function detachEnhancers(): void {
+  for (const d of enhanceDetachers) d();
+  enhanceDetachers = [];
+}
+// After hydration, give each freshly-rendered diagram inline pan/zoom + a ⤢ that opens the
+// fullscreen viewer. `data-mmd-enhanced` keeps a re-hydration from wrapping the same block twice.
+function enhanceRenderedBlocks(root: HTMLElement): void {
+  root
+    .querySelectorAll<HTMLElement>("pre.mermaid-block.mermaid-rendered:not([data-mmd-enhanced])")
+    .forEach((block) => {
+      block.setAttribute("data-mmd-enhanced", "1");
+      enhanceDetachers.push(
+        enhanceMermaidBlock(block, {
+          onExpand: () => {
+            viewerSvg.value = block.querySelector("svg")?.outerHTML ?? null;
+          },
+        }),
+      );
+    });
+}
+
 function scheduleHydrate(reset: boolean): void {
   if (props.streaming) return;
   hydrateChain = hydrateChain
     .then(async () => {
       await nextTick();
       if (disposed || rootEl.value === null) return;
-      if (reset) resetMermaidBlocks(rootEl.value);
+      if (reset) {
+        detachEnhancers();
+        resetMermaidBlocks(rootEl.value);
+      }
       await hydrateMermaidBlocks(rootEl.value, theme.mode);
+      if (!disposed && rootEl.value !== null) enhanceRenderedBlocks(rootEl.value);
     })
     .catch(() => {}); // one failed pass must not break the chain
 }
@@ -98,12 +128,14 @@ watch(
 onBeforeUnmount(() => {
   disposed = true;
   cancelTimer();
+  detachEnhancers();
 });
 </script>
 
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -- input is sanitized by renderMarkdown (DOMPurify) -->
   <div ref="rootEl" class="stream-md text-sm" v-html="html" />
+  <MermaidViewer v-if="viewerSvg" :svg="viewerSvg" @close="viewerSvg = null" />
 </template>
 
 <style>
@@ -255,5 +287,64 @@ onBeforeUnmount(() => {
 }
 .stream-md .mermaid-block.mermaid-error {
   border-color: rgb(var(--c-danger, var(--c-border)));
+}
+/* Inline pan/zoom: the enhancer replaces the rendered <pre> content with a bounded viewport + a
+   controls bar. The <pre> is the positioning context for the controls. */
+.stream-md .mermaid-block.mermaid-rendered {
+  position: relative;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
+}
+.stream-md .mmd-viewport {
+  max-height: 420px;
+  overflow: hidden;
+  border: 1px solid rgb(var(--c-border));
+  border-radius: 8px;
+  background: rgb(var(--c-bg));
+  box-shadow: var(--shadow-e1);
+  touch-action: pan-y; /* one finger scrolls the page; the enhancer handles pinch + mouse drag */
+  cursor: grab;
+}
+.stream-md .mmd-viewport:active {
+  cursor: grabbing;
+}
+.stream-md .mmd-transform {
+  transform-origin: 0 0;
+  width: max-content;
+}
+.stream-md .mmd-transform svg {
+  display: block;
+}
+.stream-md .mmd-controls {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  gap: 4px;
+  opacity: 0.5;
+  transition: opacity 0.12s;
+}
+.stream-md .mermaid-block.mermaid-rendered:hover .mmd-controls,
+.stream-md .mermaid-block.mermaid-rendered:focus-within .mmd-controls {
+  opacity: 1;
+}
+.stream-md .mmd-controls button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  font-size: 14px;
+  line-height: 1;
+  border-radius: 6px;
+  border: 1px solid rgb(var(--c-border));
+  background: rgb(var(--c-surface));
+  color: rgb(var(--c-fg));
+}
+.stream-md .mmd-controls button:hover {
+  background: rgb(var(--c-bg-raised, var(--c-surface)));
 }
 </style>

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -62,29 +62,43 @@ function enhanceRenderedBlocks(root: HTMLElement): void {
     });
 }
 
+// A hydration pass is stale — must not touch the DOM — if the component was disposed, streaming
+// resumed, or the root is gone. Checked when the queued callback finally runs (an earlier pass may
+// have been in-flight across a streaming/unmount transition) AND, via hydrateMermaidBlocks'
+// shouldAbort hook, again after each async render before it commits SVG.
+function hydrationStale(): boolean {
+  return disposed || props.streaming === true || rootEl.value === null;
+}
+
 function scheduleHydrate(reset: boolean): void {
   if (props.streaming) return;
   hydrateChain = hydrateChain
     .then(async () => {
       await nextTick();
-      if (disposed || rootEl.value === null) return;
+      if (hydrationStale()) return;
+      const root = rootEl.value;
+      if (root === null) return; // narrows for TS; hydrationStale already ruled it out
       if (reset) {
         detachEnhancers();
         // resetMermaidBlocks rebuilds each block's children, so drop the enhancement marker too —
         // otherwise the re-rendered SVG is skipped by enhanceRenderedBlocks and loses pan/zoom.
-        rootEl.value
+        root
           .querySelectorAll("pre.mermaid-block[data-mmd-enhanced]")
           .forEach((block) => block.removeAttribute("data-mmd-enhanced"));
-        resetMermaidBlocks(rootEl.value);
+        resetMermaidBlocks(root);
       }
-      await hydrateMermaidBlocks(rootEl.value, theme.mode);
-      if (!disposed && rootEl.value !== null) enhanceRenderedBlocks(rootEl.value);
+      await hydrateMermaidBlocks(root, theme.mode, hydrationStale);
+      if (!hydrationStale()) enhanceRenderedBlocks(root);
     })
     .catch(() => {}); // one failed pass must not break the chain
 }
 
 function render(): void {
   lastRenderAt = Date.now();
+  // Replacing v-html discards the current DOM, including any enhanced mermaid viewports; detach
+  // their listeners first so a plain (finalized) re-render doesn't strand them until the next
+  // theme switch or unmount. The freshly rendered HTML gets its own enhancers after hydration.
+  detachEnhancers();
   html.value = renderMarkdown(props.text, { streaming: props.streaming });
   scheduleHydrate(false);
 }

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { renderMarkdown } from "../lib/render-markdown";
 import { hydrateMermaidBlocks, resetMermaidBlocks } from "../lib/render-mermaid";
 import { enhanceMermaidBlock } from "../lib/inline-mermaid";
 import MermaidViewer from "./MermaidViewer.vue";
 import { useThemeStore } from "../stores/theme";
+
+const { t } = useI18n();
 
 const props = defineProps<{ text: string; streaming?: boolean }>();
 
@@ -62,6 +65,16 @@ function enhanceRenderedBlocks(root: HTMLElement): void {
     });
 }
 
+// A block whose diagram failed to render keeps its <code> source (spec fallback); tag it with a
+// localized label the CSS `::before` renders muted, so the failure is legible instead of just a
+// tinted border. The label text sits in a data-attr (i18n lives here, not in the DOM-only lib);
+// it is inert once the `.mermaid-error` class is gone, so no cleanup is needed on reset.
+function labelErrorBlocks(root: HTMLElement): void {
+  root
+    .querySelectorAll<HTMLElement>("pre.mermaid-block.mermaid-error:not([data-mmd-error-label])")
+    .forEach((block) => block.setAttribute("data-mmd-error-label", t("chat.mermaidError")));
+}
+
 // A hydration pass is stale — must not touch the DOM — if the component was disposed, streaming
 // resumed, or the root is gone. Checked when the queued callback finally runs (an earlier pass may
 // have been in-flight across a streaming/unmount transition) AND, via hydrateMermaidBlocks'
@@ -88,7 +101,10 @@ function scheduleHydrate(reset: boolean): void {
         resetMermaidBlocks(root);
       }
       await hydrateMermaidBlocks(root, theme.mode, hydrationStale);
-      if (!hydrationStale()) enhanceRenderedBlocks(root);
+      if (!hydrationStale()) {
+        enhanceRenderedBlocks(root);
+        labelErrorBlocks(root);
+      }
     })
     .catch(() => {}); // one failed pass must not break the chain
 }
@@ -305,6 +321,14 @@ onBeforeUnmount(() => {
 }
 .stream-md .mermaid-block.mermaid-error {
   border-color: rgb(var(--c-danger, var(--c-border)));
+}
+/* Muted caption above the preserved source so a failed render reads as failed, not just tinted. */
+.stream-md .mermaid-block.mermaid-error::before {
+  content: attr(data-mmd-error-label);
+  display: block;
+  margin-bottom: 0.4em;
+  color: rgb(var(--c-fg-muted));
+  font-size: 12px;
 }
 .stream-md .mmd-viewport {
   max-height: 420px;

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -44,7 +44,9 @@ function detachEnhancers(): void {
   enhanceDetachers = [];
 }
 // After hydration, give each freshly-rendered diagram inline pan/zoom + a ⤢ that opens the
-// fullscreen viewer. `data-mmd-enhanced` keeps a re-hydration from wrapping the same block twice.
+// fullscreen viewer. `data-mmd-enhanced` keeps the double-schedule-on-mount from wrapping the same
+// block twice; it is cleared on a reset pass (below) because resetMermaidBlocks rebuilds the block
+// from scratch, so the fresh SVG must be re-enhanced.
 function enhanceRenderedBlocks(root: HTMLElement): void {
   root
     .querySelectorAll<HTMLElement>("pre.mermaid-block.mermaid-rendered:not([data-mmd-enhanced])")
@@ -68,6 +70,11 @@ function scheduleHydrate(reset: boolean): void {
       if (disposed || rootEl.value === null) return;
       if (reset) {
         detachEnhancers();
+        // resetMermaidBlocks rebuilds each block's children, so drop the enhancement marker too —
+        // otherwise the re-rendered SVG is skipped by enhanceRenderedBlocks and loses pan/zoom.
+        rootEl.value
+          .querySelectorAll("pre.mermaid-block[data-mmd-enhanced]")
+          .forEach((block) => block.removeAttribute("data-mmd-enhanced"));
         resetMermaidBlocks(rootEl.value);
       }
       await hydrateMermaidBlocks(rootEl.value, theme.mode);
@@ -271,25 +278,9 @@ onBeforeUnmount(() => {
   border-top: 1px solid rgb(var(--c-border));
   margin: 0.8em 0;
 }
-/* Mermaid: the pre.mermaid-block is a code-styled fallback until hydrated. Once rendered,
-   center the SVG and let a wide diagram scroll like a wide table instead of overflowing. */
-.stream-md .mermaid-block.mermaid-rendered {
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  padding: 0;
-  overflow-x: auto;
-  text-align: center;
-}
-.stream-md .mermaid-block.mermaid-rendered svg {
-  max-width: 100%;
-  height: auto;
-}
-.stream-md .mermaid-block.mermaid-error {
-  border-color: rgb(var(--c-danger, var(--c-border)));
-}
-/* Inline pan/zoom: the enhancer replaces the rendered <pre> content with a bounded viewport + a
-   controls bar. The <pre> is the positioning context for the controls. */
+/* Mermaid: the pre.mermaid-block is a code-styled fallback until hydrated. Once rendered, the
+   inline enhancer replaces its content with a bounded pan/zoom viewport + a controls bar, so the
+   <pre> itself is just the positioning context — strip its code styling and let the viewport clip. */
 .stream-md .mermaid-block.mermaid-rendered {
   position: relative;
   padding: 0;
@@ -297,6 +288,9 @@ onBeforeUnmount(() => {
   background: transparent;
   box-shadow: none;
   overflow: visible;
+}
+.stream-md .mermaid-block.mermaid-error {
+  border-color: rgb(var(--c-danger, var(--c-border)));
 }
 .stream-md .mmd-viewport {
   max-height: 420px;

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref, watch } from "vue";
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { renderMarkdown } from "../lib/render-markdown";
+import { hydrateMermaidBlocks, resetMermaidBlocks } from "../lib/render-mermaid";
+import { useThemeStore } from "../stores/theme";
 
 const props = defineProps<{ text: string; streaming?: boolean }>();
 
@@ -10,9 +12,12 @@ const props = defineProps<{ text: string; streaming?: boolean }>();
 // non-streaming path renders synchronously on every change, exactly like the old computed.
 const THROTTLE_MS = 80;
 
+const theme = useThemeStore();
+const rootEl = ref<HTMLElement | null>(null);
 const html = ref("");
 let timer: ReturnType<typeof setTimeout> | null = null;
 let lastRenderAt = 0;
+let disposed = false;
 
 function cancelTimer(): void {
   if (timer !== null) {
@@ -21,12 +26,34 @@ function cancelTimer(): void {
   }
 }
 
+// Mermaid blocks are hydrated only when NOT streaming: a mid-stream fence (auto-closed by
+// remend) holds a partial diagram that mermaid would fail to parse. During streaming the
+// block shows its source (the <code> fallback); the finalized render hydrates it to SVG.
+//
+// hydrateMermaidBlocks is async, so two overlapping triggers on the same root (e.g. rapid
+// theme toggles) could otherwise run concurrently. Chain every call through a per-instance
+// promise so only one hydration pass runs at a time; a failed pass must not break the chain.
+let hydrateChain: Promise<void> = Promise.resolve();
+function scheduleHydrate(reset: boolean): void {
+  if (props.streaming) return;
+  hydrateChain = hydrateChain
+    .then(async () => {
+      await nextTick();
+      if (disposed || rootEl.value === null) return;
+      if (reset) resetMermaidBlocks(rootEl.value);
+      await hydrateMermaidBlocks(rootEl.value, theme.mode);
+    })
+    .catch(() => {}); // one failed pass must not break the chain
+}
+
 function render(): void {
   lastRenderAt = Date.now();
   html.value = renderMarkdown(props.text, { streaming: props.streaming });
+  scheduleHydrate(false);
 }
 
 render(); // initial synchronous render (also seeds the throttle clock)
+onMounted(() => scheduleHydrate(false)); // rootEl exists only after mount
 
 watch(
   () => props.text,
@@ -62,12 +89,21 @@ watch(
   },
 );
 
-onBeforeUnmount(cancelTimer);
+// Theme switched: re-theme any already-rendered diagrams (the SVG cache is theme-keyed).
+watch(
+  () => theme.mode,
+  () => scheduleHydrate(true),
+);
+
+onBeforeUnmount(() => {
+  disposed = true;
+  cancelTimer();
+});
 </script>
 
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -- input is sanitized by renderMarkdown (DOMPurify) -->
-  <div class="stream-md text-sm" v-html="html" />
+  <div ref="rootEl" class="stream-md text-sm" v-html="html" />
 </template>
 
 <style>
@@ -202,5 +238,22 @@ onBeforeUnmount(cancelTimer);
   border: none;
   border-top: 1px solid rgb(var(--c-border));
   margin: 0.8em 0;
+}
+/* Mermaid: the pre.mermaid-block is a code-styled fallback until hydrated. Once rendered,
+   center the SVG and let a wide diagram scroll like a wide table instead of overflowing. */
+.stream-md .mermaid-block.mermaid-rendered {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  overflow-x: auto;
+  text-align: center;
+}
+.stream-md .mermaid-block.mermaid-rendered svg {
+  max-width: 100%;
+  height: auto;
+}
+.stream-md .mermaid-block.mermaid-error {
+  border-color: rgb(var(--c-danger, var(--c-border)));
 }
 </style>

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -79,6 +79,7 @@ export default {
     model: "model",
     working: "Agent is working… (Esc to stop)",
     message: "Message",
+    mermaidError: "Diagram failed to render",
     jumpLatest: "↓ Latest",
     queuedHeader: "Queued",
     queueCancelAria: "Remove from queue",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -77,6 +77,7 @@ export default {
     model: "模型",
     working: "Agent 正在工作…（按 Esc 停止）",
     message: "消息",
+    mermaidError: "图表渲染失败",
     jumpLatest: "↓ 最新",
     queuedHeader: "排队中",
     queueCancelAria: "从队列移除",

--- a/packages/relay-web/src/lib/inline-mermaid.ts
+++ b/packages/relay-web/src/lib/inline-mermaid.ts
@@ -1,4 +1,4 @@
-import { createPanZoom, ZOOM_IN_FACTOR, ZOOM_OUT_FACTOR } from "./pan-zoom";
+import { createPanZoom, zoomToRectCenter, ZOOM_IN_FACTOR, ZOOM_OUT_FACTOR } from "./pan-zoom";
 import { attachPanZoomGestures } from "./pan-zoom-gestures";
 
 interface ZoomControl {
@@ -29,9 +29,9 @@ export function enhanceMermaidBlock(block: HTMLElement, opts: { onExpand: () => 
   wrapper.appendChild(svg); // moves the svg out of the <pre>
   viewport.appendChild(wrapper);
 
-  const pz = createPanZoom();
+  const panZoom = createPanZoom();
   const apply = (): void => {
-    wrapper.style.transform = pz.toTransform();
+    wrapper.style.transform = panZoom.toTransform();
   };
 
   const bar = document.createElement("div");
@@ -52,10 +52,9 @@ export function enhanceMermaidBlock(block: HTMLElement, opts: { onExpand: () => 
     addButton(control.label, control.glyph, (e) => {
       e.stopPropagation();
       if (control.factor === 0) {
-        pz.reset();
+        panZoom.reset();
       } else {
-        const r = viewport.getBoundingClientRect();
-        pz.zoomAt(control.factor, r.width / 2, r.height / 2);
+        zoomToRectCenter(panZoom, viewport.getBoundingClientRect(), control.factor);
       }
       apply();
     });
@@ -67,7 +66,7 @@ export function enhanceMermaidBlock(block: HTMLElement, opts: { onExpand: () => 
 
   block.replaceChildren(viewport, bar);
 
-  const detachGestures = attachPanZoomGestures(viewport, pz, apply, { wheelRequiresModifier: true });
+  const detachGestures = attachPanZoomGestures(viewport, panZoom, apply, { wheelRequiresModifier: true });
 
   return () => {
     detachGestures();

--- a/packages/relay-web/src/lib/inline-mermaid.ts
+++ b/packages/relay-web/src/lib/inline-mermaid.ts
@@ -1,4 +1,4 @@
-import { createPanZoom } from "./pan-zoom";
+import { createPanZoom, ZOOM_IN_FACTOR, ZOOM_OUT_FACTOR } from "./pan-zoom";
 import { attachPanZoomGestures } from "./pan-zoom-gestures";
 
 interface ZoomControl {
@@ -7,9 +7,9 @@ interface ZoomControl {
   factor: number; // 0 === reset
 }
 const ZOOM_CONTROLS: ZoomControl[] = [
-  { label: "Zoom out", glyph: "−", factor: 0.8 }, // −
+  { label: "Zoom out", glyph: "−", factor: ZOOM_OUT_FACTOR }, // −
   { label: "Reset", glyph: "↺", factor: 0 }, // ↺
-  { label: "Zoom in", glyph: "+", factor: 1.25 },
+  { label: "Zoom in", glyph: "+", factor: ZOOM_IN_FACTOR },
 ];
 
 /**

--- a/packages/relay-web/src/lib/inline-mermaid.ts
+++ b/packages/relay-web/src/lib/inline-mermaid.ts
@@ -1,0 +1,76 @@
+import { createPanZoom } from "./pan-zoom";
+import { attachPanZoomGestures } from "./pan-zoom-gestures";
+
+interface ZoomControl {
+  label: string;
+  glyph: string;
+  factor: number; // 0 === reset
+}
+const ZOOM_CONTROLS: ZoomControl[] = [
+  { label: "Zoom out", glyph: "−", factor: 0.8 }, // −
+  { label: "Reset", glyph: "↺", factor: 0 }, // ↺
+  { label: "Zoom in", glyph: "+", factor: 1.25 },
+];
+
+/**
+ * Enhance a rendered `pre.mermaid-block`: move its injected `<svg>` into a bounded pan/zoom
+ * viewport (Ctrl/⌘+wheel zoom, mouse-drag pan, two-finger pinch; one finger still scrolls the
+ * page), and add a controls bar (− / reset / + / ⤢). The ⤢ button calls `onExpand`. Returns a
+ * detach that removes every listener. A block without an `<svg>` is a no-op.
+ */
+export function enhanceMermaidBlock(block: HTMLElement, opts: { onExpand: () => void }): () => void {
+  const svg = block.querySelector("svg");
+  if (!svg) return () => {};
+
+  const viewport = document.createElement("div");
+  viewport.className = "mmd-viewport";
+  const wrapper = document.createElement("div");
+  wrapper.className = "mmd-transform";
+  wrapper.appendChild(svg); // moves the svg out of the <pre>
+  viewport.appendChild(wrapper);
+
+  const pz = createPanZoom();
+  const apply = (): void => {
+    wrapper.style.transform = pz.toTransform();
+  };
+
+  const bar = document.createElement("div");
+  bar.className = "mmd-controls";
+  const buttonDetachers: Array<() => void> = [];
+
+  const addButton = (label: string, glyph: string, handler: (e: Event) => void): void => {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.setAttribute("aria-label", label);
+    b.textContent = glyph;
+    b.addEventListener("click", handler);
+    buttonDetachers.push(() => b.removeEventListener("click", handler));
+    bar.appendChild(b);
+  };
+
+  for (const control of ZOOM_CONTROLS) {
+    addButton(control.label, control.glyph, (e) => {
+      e.stopPropagation();
+      if (control.factor === 0) {
+        pz.reset();
+      } else {
+        const r = viewport.getBoundingClientRect();
+        pz.zoomAt(control.factor, r.width / 2, r.height / 2);
+      }
+      apply();
+    });
+  }
+  addButton("Fullscreen", "⤢", (e) => {
+    e.stopPropagation();
+    opts.onExpand();
+  });
+
+  block.replaceChildren(viewport, bar);
+
+  const detachGestures = attachPanZoomGestures(viewport, pz, apply, { wheelRequiresModifier: true });
+
+  return () => {
+    detachGestures();
+    for (const d of buttonDetachers) d();
+  };
+}

--- a/packages/relay-web/src/lib/mermaid-source.ts
+++ b/packages/relay-web/src/lib/mermaid-source.ts
@@ -1,0 +1,13 @@
+// UTF-8-safe base64 for carrying a mermaid diagram's source through an HTML data
+// attribute. `btoa` only handles Latin-1, so encode to UTF-8 bytes first (the classic
+// `encodeURIComponent`/`escape` bridge) — diagram labels are frequently non-ASCII.
+
+/** Encode a diagram's source to attribute-safe base64 (alphabet `[A-Za-z0-9+/=]`). */
+export function encodeMermaidSource(src: string): string {
+  return btoa(unescape(encodeURIComponent(src)));
+}
+
+/** Inverse of {@link encodeMermaidSource}. */
+export function decodeMermaidSource(encoded: string): string {
+  return decodeURIComponent(escape(atob(encoded)));
+}

--- a/packages/relay-web/src/lib/mermaid-source.ts
+++ b/packages/relay-web/src/lib/mermaid-source.ts
@@ -19,5 +19,7 @@ export function decodeMermaidSource(encoded: string): string {
   const binary = atob(encoded);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
-  return new TextDecoder().decode(bytes);
+  // ignoreBOM keeps a leading U+FEFF as a literal char so the round-trip is exact (the default
+  // decoder silently strips it).
+  return new TextDecoder("utf-8", { ignoreBOM: true }).decode(bytes);
 }

--- a/packages/relay-web/src/lib/mermaid-source.ts
+++ b/packages/relay-web/src/lib/mermaid-source.ts
@@ -1,13 +1,23 @@
 // UTF-8-safe base64 for carrying a mermaid diagram's source through an HTML data
-// attribute. `btoa` only handles Latin-1, so encode to UTF-8 bytes first (the classic
-// `encodeURIComponent`/`escape` bridge) — diagram labels are frequently non-ASCII.
+// attribute. `btoa` only handles Latin-1, so encode to UTF-8 bytes first — diagram
+// labels are frequently non-ASCII. We use TextEncoder rather than the classic
+// `unescape(encodeURIComponent(...))` bridge because `encodeURIComponent` throws a
+// URIError on a lone surrogate (e.g. a stray `\uD800` in agent output); this runs
+// inside the markdown render with no error isolation, so a single bad code unit would
+// crash the whole message. TextEncoder is total: it maps unpaired surrogates to U+FFFD.
 
 /** Encode a diagram's source to attribute-safe base64 (alphabet `[A-Za-z0-9+/=]`). */
 export function encodeMermaidSource(src: string): string {
-  return btoa(unescape(encodeURIComponent(src)));
+  const bytes = new TextEncoder().encode(src);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
 }
 
 /** Inverse of {@link encodeMermaidSource}. */
 export function decodeMermaidSource(encoded: string): string {
-  return decodeURIComponent(escape(atob(encoded)));
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
 }

--- a/packages/relay-web/src/lib/pan-zoom-gestures.ts
+++ b/packages/relay-web/src/lib/pan-zoom-gestures.ts
@@ -13,13 +13,13 @@ interface Pointish {
 }
 
 /**
- * Attach wheel/pointer/touch pan-zoom gestures on `el`, driving `pz` and calling `onChange` after
+ * Attach wheel/pointer/touch pan-zoom gestures on `el`, driving `panZoom` and calling `onChange` after
  * every state change. Mouse drag always pans; touch panning is one-finger only when opted in;
  * wheel zoom can require a modifier. Returns a detach function that removes every listener.
  */
 export function attachPanZoomGestures(
   el: HTMLElement,
-  pz: PanZoom,
+  panZoom: PanZoom,
   onChange: () => void,
   opts: GestureOptions = {},
 ): () => void {
@@ -38,7 +38,7 @@ export function attachPanZoomGestures(
     if (wheelRequiresModifier && !e.ctrlKey && !e.metaKey) return; // let the page scroll
     e.preventDefault();
     const { left, top } = origin();
-    pz.zoomAt(e.deltaY < 0 ? 1.1 : 1 / 1.1, e.clientX - left, e.clientY - top);
+    panZoom.zoomAt(e.deltaY < 0 ? 1.1 : 1 / 1.1, e.clientX - left, e.clientY - top);
     onChange();
   }
 
@@ -60,7 +60,7 @@ export function attachPanZoomGestures(
   }
   function onPointerMove(e: PointerEvent): void {
     if (!dragging || e.pointerId !== dragId) return;
-    pz.panBy(e.clientX - lastX, e.clientY - lastY);
+    panZoom.panBy(e.clientX - lastX, e.clientY - lastY);
     lastX = e.clientX;
     lastY = e.clientY;
     onChange();
@@ -96,13 +96,13 @@ export function attachPanZoomGestures(
       if (prevDist > 0) {
         const midX = (e.touches[0]!.clientX + e.touches[1]!.clientX) / 2 - left;
         const midY = (e.touches[0]!.clientY + e.touches[1]!.clientY) / 2 - top;
-        pz.zoomAt(dist / prevDist, midX, midY);
+        panZoom.zoomAt(dist / prevDist, midX, midY);
         onChange();
       }
       prevDist = dist;
     } else if (touchPanning && e.touches.length === 1) {
       e.preventDefault();
-      pz.panBy(e.touches[0]!.clientX - touchX, e.touches[0]!.clientY - touchY);
+      panZoom.panBy(e.touches[0]!.clientX - touchX, e.touches[0]!.clientY - touchY);
       touchX = e.touches[0]!.clientX;
       touchY = e.touches[0]!.clientY;
       onChange();

--- a/packages/relay-web/src/lib/pan-zoom-gestures.ts
+++ b/packages/relay-web/src/lib/pan-zoom-gestures.ts
@@ -1,0 +1,140 @@
+import type { PanZoom } from "./pan-zoom";
+
+export interface GestureOptions {
+  /** Zoom on wheel only when Ctrl/⌘ is held (inline). Default false. */
+  wheelRequiresModifier?: boolean;
+  /** Pan on a single touch (fullscreen). Default false — one finger scrolls the page. */
+  oneFingerTouchPan?: boolean;
+}
+
+interface Pointish {
+  clientX: number;
+  clientY: number;
+}
+
+/**
+ * Attach wheel/pointer/touch pan-zoom gestures on `el`, driving `pz` and calling `onChange` after
+ * every state change. Mouse drag always pans; touch panning is one-finger only when opted in;
+ * wheel zoom can require a modifier. Returns a detach function that removes every listener.
+ */
+export function attachPanZoomGestures(
+  el: HTMLElement,
+  pz: PanZoom,
+  onChange: () => void,
+  opts: GestureOptions = {},
+): () => void {
+  const wheelRequiresModifier = opts.wheelRequiresModifier ?? false;
+  const oneFingerTouchPan = opts.oneFingerTouchPan ?? false;
+
+  function origin(): { left: number; top: number } {
+    const r = el.getBoundingClientRect();
+    return { left: r.left, top: r.top };
+  }
+  function pinchDistance(a: Pointish, b: Pointish): number {
+    return Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+  }
+
+  function onWheel(e: WheelEvent): void {
+    if (wheelRequiresModifier && !e.ctrlKey && !e.metaKey) return; // let the page scroll
+    e.preventDefault();
+    const { left, top } = origin();
+    pz.zoomAt(e.deltaY < 0 ? 1.1 : 1 / 1.1, e.clientX - left, e.clientY - top);
+    onChange();
+  }
+
+  let dragging = false;
+  let dragId: number | null = null;
+  let lastX = 0;
+  let lastY = 0;
+  function onPointerDown(e: PointerEvent): void {
+    if (e.pointerType !== "mouse") return; // touch handled below
+    dragging = true;
+    dragId = e.pointerId;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    try {
+      el.setPointerCapture?.(e.pointerId);
+    } catch {
+      /* jsdom / unsupported */
+    }
+  }
+  function onPointerMove(e: PointerEvent): void {
+    if (!dragging || e.pointerId !== dragId) return;
+    pz.panBy(e.clientX - lastX, e.clientY - lastY);
+    lastX = e.clientX;
+    lastY = e.clientY;
+    onChange();
+  }
+  function onPointerUp(e: PointerEvent): void {
+    if (e.pointerId === dragId) {
+      dragging = false;
+      dragId = null;
+    }
+  }
+
+  let pinching = false;
+  let prevDist = 0;
+  let touchPanning = false;
+  let touchX = 0;
+  let touchY = 0;
+  function onTouchStart(e: TouchEvent): void {
+    if (e.touches.length === 2) {
+      pinching = true;
+      touchPanning = false;
+      prevDist = pinchDistance(e.touches[0]!, e.touches[1]!);
+    } else if (e.touches.length === 1 && oneFingerTouchPan) {
+      touchPanning = true;
+      touchX = e.touches[0]!.clientX;
+      touchY = e.touches[0]!.clientY;
+    }
+  }
+  function onTouchMove(e: TouchEvent): void {
+    if (pinching && e.touches.length === 2) {
+      e.preventDefault();
+      const { left, top } = origin();
+      const dist = pinchDistance(e.touches[0]!, e.touches[1]!);
+      if (prevDist > 0) {
+        const midX = (e.touches[0]!.clientX + e.touches[1]!.clientX) / 2 - left;
+        const midY = (e.touches[0]!.clientY + e.touches[1]!.clientY) / 2 - top;
+        pz.zoomAt(dist / prevDist, midX, midY);
+        onChange();
+      }
+      prevDist = dist;
+    } else if (touchPanning && e.touches.length === 1) {
+      e.preventDefault();
+      pz.panBy(e.touches[0]!.clientX - touchX, e.touches[0]!.clientY - touchY);
+      touchX = e.touches[0]!.clientX;
+      touchY = e.touches[0]!.clientY;
+      onChange();
+    }
+  }
+  function onTouchEnd(e: TouchEvent): void {
+    if (e.touches.length < 2) {
+      pinching = false;
+      prevDist = 0;
+    }
+    if (e.touches.length === 0) {
+      touchPanning = false;
+    }
+  }
+
+  el.addEventListener("wheel", onWheel, { passive: false });
+  el.addEventListener("pointerdown", onPointerDown);
+  el.addEventListener("pointermove", onPointerMove);
+  el.addEventListener("pointerup", onPointerUp);
+  el.addEventListener("pointercancel", onPointerUp);
+  el.addEventListener("touchstart", onTouchStart, { passive: false });
+  el.addEventListener("touchmove", onTouchMove, { passive: false });
+  el.addEventListener("touchend", onTouchEnd);
+
+  return () => {
+    el.removeEventListener("wheel", onWheel);
+    el.removeEventListener("pointerdown", onPointerDown);
+    el.removeEventListener("pointermove", onPointerMove);
+    el.removeEventListener("pointerup", onPointerUp);
+    el.removeEventListener("pointercancel", onPointerUp);
+    el.removeEventListener("touchstart", onTouchStart);
+    el.removeEventListener("touchmove", onTouchMove);
+    el.removeEventListener("touchend", onTouchEnd);
+  };
+}

--- a/packages/relay-web/src/lib/pan-zoom.ts
+++ b/packages/relay-web/src/lib/pan-zoom.ts
@@ -1,5 +1,11 @@
 // Pure, framework-free pan/zoom transform state. The consumer applies `toTransform()` to an
 // element with `transform-origin: 0 0`. Kept DOM-free so the geometry is unit-testable.
+
+// Shared step factors for the − / + zoom buttons, so the inline enhancer and the fullscreen
+// viewer step by the same amount (and can't drift). One click out then in returns to ~1×.
+export const ZOOM_IN_FACTOR = 1.25;
+export const ZOOM_OUT_FACTOR = 0.8;
+
 export interface PanZoomState {
   scale: number;
   x: number;

--- a/packages/relay-web/src/lib/pan-zoom.ts
+++ b/packages/relay-web/src/lib/pan-zoom.ts
@@ -1,0 +1,47 @@
+// Pure, framework-free pan/zoom transform state. The consumer applies `toTransform()` to an
+// element with `transform-origin: 0 0`. Kept DOM-free so the geometry is unit-testable.
+export interface PanZoomState {
+  scale: number;
+  x: number;
+  y: number;
+}
+
+export interface PanZoom {
+  readonly state: PanZoomState;
+  /** Multiply scale by `factor`, keeping viewport point (cx, cy) stationary. Clamps scale. */
+  zoomAt(factor: number, cx: number, cy: number): void;
+  panBy(dx: number, dy: number): void;
+  reset(): void;
+  /** CSS transform for a `transform-origin: 0 0` element. */
+  toTransform(): string;
+}
+
+export function createPanZoom(opts: { minScale?: number; maxScale?: number } = {}): PanZoom {
+  const minScale = opts.minScale ?? 0.2;
+  const maxScale = opts.maxScale ?? 8;
+  const state: PanZoomState = { scale: 1, x: 0, y: 0 };
+
+  return {
+    state,
+    zoomAt(factor, cx, cy) {
+      const next = Math.min(maxScale, Math.max(minScale, state.scale * factor));
+      if (next === state.scale) return;
+      // Solve for the translation that pins content point ((cx - x)/scale) under (cx, cy).
+      state.x = cx - (cx - state.x) * (next / state.scale);
+      state.y = cy - (cy - state.y) * (next / state.scale);
+      state.scale = next;
+    },
+    panBy(dx, dy) {
+      state.x += dx;
+      state.y += dy;
+    },
+    reset() {
+      state.scale = 1;
+      state.x = 0;
+      state.y = 0;
+    },
+    toTransform() {
+      return `translate(${state.x}px, ${state.y}px) scale(${state.scale})`;
+    },
+  };
+}

--- a/packages/relay-web/src/lib/pan-zoom.ts
+++ b/packages/relay-web/src/lib/pan-zoom.ts
@@ -22,6 +22,19 @@ export interface PanZoom {
   toTransform(): string;
 }
 
+/**
+ * Zoom `panZoom` by `factor` around the center of `rect` (a getBoundingClientRect-shaped size).
+ * Shared by the inline − / + buttons and the fullscreen viewer so the "take midpoint → zoomAt"
+ * step lives in one place.
+ */
+export function zoomToRectCenter(
+  panZoom: PanZoom,
+  rect: { width: number; height: number },
+  factor: number,
+): void {
+  panZoom.zoomAt(factor, rect.width / 2, rect.height / 2);
+}
+
 export function createPanZoom(opts: { minScale?: number; maxScale?: number } = {}): PanZoom {
   const minScale = opts.minScale ?? 0.2;
   const maxScale = opts.maxScale ?? 8;

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -2,6 +2,7 @@ import MarkdownIt from "markdown-it";
 import DOMPurify from "dompurify";
 import remend from "remend";
 import { normalizeMarkdownTables } from "./normalize-markdown";
+import { encodeMermaidSource } from "./mermaid-source";
 
 // Single shared parser. html:false escapes any raw HTML in the markdown source,
 // so agent output cannot inject markup; DOMPurify is a second, defense-in-depth pass
@@ -17,6 +18,24 @@ const md = new MarkdownIt({
 // which would collapse its column layout into a stacked single column.
 md.renderer.rules.table_open = () => '<div class="md-table-wrap"><table>';
 md.renderer.rules.table_close = () => "</table></div>";
+
+// Intercept ```mermaid fences: emit a placeholder carrying the diagram source as
+// attribute-safe base64. render-mermaid hydrates it into SVG after the HTML is mounted.
+// The escaped <code> is the fallback shown before hydration, while streaming, and on
+// render error. All other fences fall through to markdown-it's default renderer.
+const defaultFence =
+  md.renderer.rules.fence ??
+  ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options));
+md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+  const token = tokens[idx]!;
+  const info = token.info.trim().split(/\s+/g)[0]?.toLowerCase() ?? "";
+  if (info !== "mermaid") {
+    return defaultFence(tokens, idx, options, env, self);
+  }
+  const encoded = encodeMermaidSource(token.content);
+  const fallback = md.utils.escapeHtml(token.content);
+  return `<pre class="mermaid-block" data-mermaid="${encoded}"><code>${fallback}</code></pre>`;
+};
 
 // Force every surviving link to open safely in a new tab. Registered once at module
 // load; DOMPurify is a singleton and this app only sanitizes through this module.

--- a/packages/relay-web/src/lib/render-mermaid.ts
+++ b/packages/relay-web/src/lib/render-mermaid.ts
@@ -50,8 +50,16 @@ async function getMermaid(theme: MermaidTheme): Promise<MermaidLike> {
  * Render every un-hydrated `pre.mermaid-block` under `root` to sanitized SVG. Results are
  * cached by `theme + source`. Errors are contained per-block (marked `data-mermaid-done="error"`,
  * code fallback preserved); this function never rejects.
+ *
+ * `shouldAbort`, when supplied, is consulted before every DOM commit — both before starting a
+ * block and again after the async `mermaid.render` resolves — so a component that unmounts (or
+ * resumes streaming) mid-render never has SVG written into its torn-down or now-partial DOM.
  */
-export async function hydrateMermaidBlocks(root: HTMLElement, theme: MermaidTheme): Promise<void> {
+export async function hydrateMermaidBlocks(
+  root: HTMLElement,
+  theme: MermaidTheme,
+  shouldAbort?: () => boolean,
+): Promise<void> {
   const blocks = Array.from(
     root.querySelectorAll<HTMLElement>('pre.mermaid-block[data-mermaid]:not([data-mermaid-done])'),
   );
@@ -65,6 +73,7 @@ export async function hydrateMermaidBlocks(root: HTMLElement, theme: MermaidThem
   }
 
   for (const block of blocks) {
+    if (shouldAbort?.()) return; // component torn down / streaming resumed — stop touching the DOM
     if (block.getAttribute("data-mermaid-done")) continue; // re-check: a concurrent pass may have claimed it
     const source = decodeMermaidSource(block.getAttribute("data-mermaid") ?? "");
     const key = `${theme}:${source}`;
@@ -76,6 +85,7 @@ export async function hydrateMermaidBlocks(root: HTMLElement, theme: MermaidThem
         svg = DOMPurify.sanitize(rendered.svg, { USE_PROFILES: { svg: true, svgFilters: true } });
         svgCache.set(key, svg);
       }
+      if (shouldAbort?.()) return; // re-check after the await: DOM may have been torn down mid-render
       block.innerHTML = svg;
       block.setAttribute("data-mermaid-done", "1");
       block.classList.add("mermaid-rendered");

--- a/packages/relay-web/src/lib/render-mermaid.ts
+++ b/packages/relay-web/src/lib/render-mermaid.ts
@@ -1,0 +1,106 @@
+import DOMPurify from "dompurify";
+import { decodeMermaidSource } from "./mermaid-source";
+
+export type MermaidTheme = "dark" | "light";
+
+/** The minimal slice of the mermaid module this code uses (kept narrow for the test seam). */
+export interface MermaidLike {
+  initialize(config: Record<string, unknown>): void;
+  render(id: string, text: string): Promise<{ svg: string }>;
+}
+
+let loaderOverride: null | (() => Promise<MermaidLike>) = null;
+let modPromise: Promise<MermaidLike> | null = null;
+let initializedTheme: MermaidTheme | null = null;
+let seq = 0;
+const svgCache = new Map<string, string>();
+
+/** Test seam: inject a fake loader and reset all module state. Pass null to restore. */
+export function __setMermaidLoaderForTest(loader: null | (() => Promise<MermaidLike>)): void {
+  loaderOverride = loader;
+  modPromise = null;
+  initializedTheme = null;
+  seq = 0;
+  svgCache.clear();
+}
+
+function loadMermaid(): Promise<MermaidLike> {
+  if (loaderOverride) return loaderOverride();
+  if (!modPromise) {
+    // Dynamic import keeps mermaid (and its d3/dagre/cytoscape deps) out of the main chunk.
+    modPromise = import("mermaid").then((m) => m.default as unknown as MermaidLike);
+  }
+  return modPromise;
+}
+
+async function getMermaid(theme: MermaidTheme): Promise<MermaidLike> {
+  const mermaid = await loadMermaid();
+  if (initializedTheme !== theme) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      theme: theme === "dark" ? "dark" : "default",
+    });
+    initializedTheme = theme;
+  }
+  return mermaid;
+}
+
+/**
+ * Render every un-hydrated `pre.mermaid-block` under `root` to sanitized SVG. Results are
+ * cached by `theme + source`. Errors are contained per-block (marked `data-mermaid-done="error"`,
+ * code fallback preserved); this function never rejects.
+ */
+export async function hydrateMermaidBlocks(root: HTMLElement, theme: MermaidTheme): Promise<void> {
+  const blocks = Array.from(
+    root.querySelectorAll<HTMLElement>('pre.mermaid-block[data-mermaid]:not([data-mermaid-done])'),
+  );
+  if (blocks.length === 0) return;
+
+  let mermaid: MermaidLike;
+  try {
+    mermaid = await getMermaid(theme);
+  } catch {
+    return; // mermaid failed to load — leave every block on its source fallback
+  }
+
+  for (const block of blocks) {
+    if (block.getAttribute("data-mermaid-done")) continue; // re-check: a concurrent pass may have claimed it
+    const source = decodeMermaidSource(block.getAttribute("data-mermaid") ?? "");
+    const key = `${theme}:${source}`;
+    try {
+      let svg = svgCache.get(key);
+      if (svg === undefined) {
+        seq += 1;
+        const rendered = await mermaid.render(`mmd-${seq}`, source);
+        svg = DOMPurify.sanitize(rendered.svg, { USE_PROFILES: { svg: true, svgFilters: true } });
+        svgCache.set(key, svg);
+      }
+      block.innerHTML = svg;
+      block.setAttribute("data-mermaid-done", "1");
+      block.classList.add("mermaid-rendered");
+    } catch {
+      block.setAttribute("data-mermaid-done", "error");
+      block.classList.add("mermaid-error");
+      // Leave the <code> fallback in place so the user still sees the diagram source.
+    }
+  }
+}
+
+/**
+ * Revert already-hydrated blocks under `root` to their code fallback so they can be
+ * re-rendered (e.g. after a theme switch). The `data-mermaid` base64 is the source of truth.
+ */
+export function resetMermaidBlocks(root: HTMLElement): void {
+  const blocks = Array.from(
+    root.querySelectorAll<HTMLElement>("pre.mermaid-block[data-mermaid-done]"),
+  );
+  for (const block of blocks) {
+    const source = decodeMermaidSource(block.getAttribute("data-mermaid") ?? "");
+    const code = document.createElement("code");
+    code.textContent = source;
+    block.replaceChildren(code);
+    block.removeAttribute("data-mermaid-done");
+    block.classList.remove("mermaid-rendered", "mermaid-error");
+  }
+}

--- a/packages/relay-web/src/lib/render-mermaid.ts
+++ b/packages/relay-web/src/lib/render-mermaid.ts
@@ -90,6 +90,7 @@ export async function hydrateMermaidBlocks(
       block.setAttribute("data-mermaid-done", "1");
       block.classList.add("mermaid-rendered");
     } catch {
+      if (shouldAbort?.()) return; // torn down / streaming resumed during a FAILED render — same as the success path, don't touch stale DOM
       block.setAttribute("data-mermaid-done", "error");
       block.classList.add("mermaid-error");
       // Leave the <code> fallback in place so the user still sees the diagram source.


### PR DESCRIPTION
## What

Render ```` ```mermaid ```` fenced code blocks in the relay-web chat as SVG diagrams (flowchart / sequence / gantt / class / state / ER / pie / gitgraph …). Everything else about markdown rendering is byte-for-byte unchanged.

## Library decision (researched)

Uses the official **`mermaid`** (v11), **dynamically imported**. Mermaid's grammar is defined by this library — no lightweight alternative parses the full grammar; `mermaid-cli` is Node/puppeteer-only. Dynamic `import('mermaid')` keeps it (and its d3/dagre/cytoscape deps) out of the main chunk; the module promise is cached. Fits the existing stack: current pipeline is `markdown-it(html:false)` → DOMPurify with no syntax highlighter, and the relay gateway sets no CSP.

## Architecture (three seams over the existing sync-render + `v-html` pipeline)

1. **`render-markdown`** — a `fence` override emits `<pre class="mermaid-block" data-mermaid="<base64 source>"><code>…escaped…</code></pre>` for mermaid fences; all other fences fall through unchanged.
2. **`render-mermaid`** (new) — lazily loads mermaid, renders each placeholder to SVG under `securityLevel:"strict"`, DOMPurifies it (`{ USE_PROFILES: { svg: true, svgFilters: true } }`), caches by `theme+source`, and is error-tolerant (a malformed diagram keeps its source as a code fallback and never throws).
3. **`StreamMarkdown.vue`** — hydrates placeholders after `v-html` patches, **never mid-stream** (a partial fence would fail to parse), re-hydrating on theme change, **serialized per instance** (a promise chain prevents overlapping passes), and safe on unmount (`disposed` guard).

## Security (three layers, defense-in-depth)

Untrusted agent output never reaches the DOM as markup: source travels only as base64 in a data attribute + an HTML-escaped `<code>` fallback; mermaid runs `securityLevel:"strict"`; the rendered SVG is DOMPurified (svg profile, not weakened) before injection.

## Testing

Full relay-web suite **94 files / 709 tests pass**, `vue-tsc --noEmit` clean. New coverage: base64 round-trip (incl. non-ASCII + injection payloads), fence placeholder + injection-inert + non-mermaid-unchanged, hydrate→sanitized-SVG + theme-keyed cache-hit + error-tolerance + reset, and StreamMarkdown streaming-gate + theme re-render + **serialization (mutation-verified: fails without the promise chain)**.

## Process

Built via the superpowers pipeline (spec → plan → subagent-driven implementation with per-task review → whole-branch opus review = **Ready to merge, 0 Critical/Important**). Spec: `docs/superpowers/specs/2026-07-14-web-mermaid-rendering-design.md`. Plan: `docs/superpowers/plans/2026-07-14-web-mermaid-rendering.md`.

### Known minors (non-blocking, logged for triage)
- `svgCache` is unbounded (no eviction) — low footprint, cleared on reload; a bounded LRU is the only worthwhile future follow-up.
- Info-string edge cases and the `resetMermaidBlocks`-on-theme-change path are exercised but not each independently asserted.
