### PR TITLE
release: beta cut — core 0.17.0-beta.5 + relay stack (protocol 0.1.12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.4",
+  "version": "0.17.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.4",
+      "version": "0.17.0-beta.5",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -13106,7 +13106,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.4",
+      "version": "0.3.3-beta.5",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -13148,7 +13148,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.19",
+      "version": "0.9.12-beta.20",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -13165,7 +13165,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT"
     },
     "packages/relay-web": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.4",
+  "version": "0.17.0-beta.5",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/channel-relay/package.json
+++ b/packages/channel-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-relay",
-  "version": "0.3.3-beta.4",
+  "version": "0.3.3-beta.5",
   "description": "Relay hub connector channel plugin for xacpx.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay-protocol/package.json
+++ b/packages/relay-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay-protocol",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Shared wire protocol types and codecs for the xacpx relay hub.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.19",
+  "version": "0.9.12-beta.20",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.4", () => {
+test("root package version is 0.17.0-beta.5", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.4");
+  expect(pkg.version).toBe("0.17.0-beta.5");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.4",
+  "version": "0.17.0-beta.5",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.4"
+    "@ganglion/xacpx": "^0.17.0-beta.5"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Beta release covering everything merged since #136.

## Version bumps
| Package | From | To | dist-tag |
|---|---|---|---|
| `@ganglion/xacpx` | 0.17.0-beta.4 | **0.17.0-beta.5** | next |
| `@ganglion/xacpx-relay-protocol` | 0.1.11 | **0.1.12** | latest |
| `@ganglion/xacpx-relay` | 0.9.12-beta.19 | **0.9.12-beta.20** | next |
| `@ganglion/xacpx-channel-relay` | 0.3.3-beta.4 | **0.3.3-beta.5** | next |

`channel-feishu` / `channel-yuanbao` unchanged since last release — not bumped. `relay-web` is private and ships embedded in `relay`.

relay-protocol is a **stable** patch (consumers pin `^0.1.0`; a beta on `next` wouldn't resolve).

## Notable content
weixin logging unification, orchestration #146/#153/#160 hardening, track4 #157–159, relay/relay-web #161 Mermaid + inline/fullscreen pan/zoom, protocol web-dtos + validate-primitives.

Also syncs weacpx-compat shim, `package-metadata.test.ts` root-version assertion, and `package-lock.json`.

After merge: push tags in order `v0.17.0-beta.5` → `relay-protocol-v0.1.12` → `relay-v0.9.12-beta.20` → `channel-relay-v0.3.3-beta.5` (per-package CI publishes).