### PR TITLE
fix(relay-web): reconcile model switch timeouts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "weacpx-console",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "acpx": "^0.11.0",
+        "acpx": "^0.12.0",
         "node-pty": "^1.1.0",
         "proper-lockfile": "^4.1.2",
         "protobufjs": "^7.5.6",
@@ -39,7 +39,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.4",
+      "version": "0.3.3-beta.5",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.19",
+      "version": "0.9.12-beta.20",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },
@@ -88,7 +88,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.11",
+      "version": "0.1.12",
     },
     "packages/relay-web": {
       "name": "@ganglion/xacpx-relay-web",
@@ -142,7 +142,7 @@
     },
   },
   "packages": {
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.25.1", "https://registry.npmmirror.com/@agentclientprotocol/sdk/-/sdk-0.25.1.tgz", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.2.1", "https://registry.npmmirror.com/@agentclientprotocol/sdk/-/sdk-1.2.1.tgz", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA=="],
 
     "@algolia/abtesting": ["@algolia/abtesting@1.19.0", "https://registry.npmmirror.com/@algolia/abtesting/-/abtesting-1.19.0.tgz", { "dependencies": { "@algolia/client-common": "5.53.0", "@algolia/requester-browser-xhr": "5.53.0", "@algolia/requester-fetch": "5.53.0", "@algolia/requester-node-http": "5.53.0" } }, "sha512-Lhnez3hhXHk25lfxLAMxvkP4fmN3+1RgADhD2ssMDBYuAsDVReeyP+3SGRx+ntq8ijMrLqUyfvO72TB6jsTteQ=="],
 
@@ -830,7 +830,7 @@
 
     "acorn": ["acorn@8.17.0", "https://registry.npmmirror.com/acorn/-/acorn-8.17.0.tgz", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
-    "acpx": ["acpx@0.11.0", "https://registry.npmmirror.com/acpx/-/acpx-0.11.0.tgz", { "dependencies": { "@agentclientprotocol/sdk": "^0.25.0", "commander": "^15.0.0", "skillflag": "^0.1.4", "tsx": "^4.22.4", "zod": "^4.4.3" }, "bin": { "acpx": "dist/cli.js" } }, "sha512-l42LJFmd6kvbr1UytvwWmr5Mdy/v9l3FM6Necs01PWbjUIkxjCdxg97duqoRfRqxtDAfnNPb1IlgIf2ZgMZQqA=="],
+    "acpx": ["acpx@0.12.0", "https://registry.npmmirror.com/acpx/-/acpx-0.12.0.tgz", { "dependencies": { "@agentclientprotocol/sdk": "^1.1.0", "commander": "^15.0.0", "skillflag": "^0.2.0", "tsx": "^4.23.0", "zod": "^4.4.3" }, "bin": { "acpx": "dist/cli.js" } }, "sha512-APYpN04XFWrCGuSBvM4HTKWWFH8uSIuzc+qI7aCGeVdP9o4euZeBosFEkmNUHvBOop0XBemg6d8RsNvzXN3Mgw=="],
 
     "agent-base": ["agent-base@7.1.4", "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -1698,7 +1698,7 @@
 
     "sisteransi": ["sisteransi@1.0.5", "https://registry.npmmirror.com/sisteransi/-/sisteransi-1.0.5.tgz", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
-    "skillflag": ["skillflag@0.1.4", "https://registry.npmmirror.com/skillflag/-/skillflag-0.1.4.tgz", { "dependencies": { "@clack/prompts": "^1.0.1", "tar-stream": "^3.1.7" }, "bin": { "skill-install": "dist/bin/skill-install.js", "skillflag": "dist/bin/skillflag.js" } }, "sha512-egFg+XCF5sloOWdtzxZivTX7n4UDj5pxQoY33wbT8h+YSDjMQJ76MZUg2rXQIBXmIDtlZhLgirS1g/3R5/qaHA=="],
+    "skillflag": ["skillflag@0.2.0", "https://registry.npmmirror.com/skillflag/-/skillflag-0.2.0.tgz", { "dependencies": { "@clack/prompts": "^1.0.1", "tar-stream": "^3.1.7" }, "bin": { "skillflag": "dist/bin/skillflag.js", "skill-install": "dist/bin/skill-install.js" } }, "sha512-7ZmEpBeEoPLc+hqZ/StAnCO/hulgEPANzPyZgOM/CZ5zc3b0ApSp3URavY5POM/OKyi5d9+UC/Q21OoiYC2kJw=="],
 
     "smob": ["smob@1.6.2", "https://registry.npmmirror.com/smob/-/smob-1.6.2.tgz", {}, "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw=="],
 
@@ -1806,7 +1806,7 @@
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "https://registry.npmmirror.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
-    "tsx": ["tsx@4.22.4", "https://registry.npmmirror.com/tsx/-/tsx-4.22.4.tgz", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
+    "tsx": ["tsx@4.23.1", "https://registry.npmmirror.com/tsx/-/tsx-4.23.1.tgz", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
 
     "type-fest": ["type-fest@0.16.0", "https://registry.npmmirror.com/type-fest/-/type-fest-0.16.0.tgz", {}, "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="],
 

--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -124,6 +124,16 @@ reset 在回合内重建了 transport 会话，但 reset handler 不发事件，
 await 必须留在 draining 守护窗口内，否则一个被中止且带排队项的回合会让新提示词插进来抢跑
 （由 golden fixture `aborted-queue-sessions-window` 钉住）。
 
+### 模型切换与 timeout 对账
+
+`control.session.model.set` 返回 `{ ok, current }`。正常切换时 `ok=true`；若 acpx 管理命令
+timeout，ControlService 会通过 `getSessionModel` 读取 transport 权威值、将该值（包括空值）写回
+逻辑会话，再返回 `current`。请求模型未实际生效时 `ok=false`，relay-web 必须采用返回的
+`current`，不能盲目回滚到请求前的本地值。成功完成对账的 timeout 会把原始诊断
+（stage、命令及有界 stdout/stderr tail）记录到 app log 的
+`control.session.model.timeout_reconciled` 事件；对账查询本身失败时，原始 timeout 继续作为
+RPC 错误返回，由 relay-web 浏览器诊断保留。
+
 ### 事件总线覆盖范围
 
 事件总线只保证「`ControlService` 自身发起的变更」会发事件；其它入口

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "acpx": "^0.11.0",
+        "acpx": "^0.12.0",
         "node-pty": "^1.1.0",
         "proper-lockfile": "^4.1.2",
         "protobufjs": "^7.5.6",
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.25.1.tgz",
-      "integrity": "sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/@agentclientprotocol/sdk/-/sdk-1.2.1.tgz",
+      "integrity": "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -1983,21 +1983,31 @@
       "license": "Apache-2.0"
     },
     "node_modules/@clack/core": {
-      "version": "1.2.0",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmmirror.com/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
       "license": "MIT",
       "dependencies": {
-        "fast-wrap-ansi": "^0.1.3",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.2.0",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.2.0",
-        "fast-string-width": "^1.1.0",
-        "fast-wrap-ansi": "^0.1.3",
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -4767,15 +4777,15 @@
       }
     },
     "node_modules/acpx": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/acpx/-/acpx-0.11.0.tgz",
-      "integrity": "sha512-l42LJFmd6kvbr1UytvwWmr5Mdy/v9l3FM6Necs01PWbjUIkxjCdxg97duqoRfRqxtDAfnNPb1IlgIf2ZgMZQqA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmmirror.com/acpx/-/acpx-0.12.0.tgz",
+      "integrity": "sha512-APYpN04XFWrCGuSBvM4HTKWWFH8uSIuzc+qI7aCGeVdP9o4euZeBosFEkmNUHvBOop0XBemg6d8RsNvzXN3Mgw==",
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.25.0",
+        "@agentclientprotocol/sdk": "^1.1.0",
         "commander": "^15.0.0",
-        "skillflag": "^0.1.4",
-        "tsx": "^4.22.4",
+        "skillflag": "^0.2.0",
+        "tsx": "^4.23.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -5071,7 +5081,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmmirror.com/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -5142,7 +5154,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmmirror.com/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -5155,7 +5169,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.6.0",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmmirror.com/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -5176,24 +5192,19 @@
         }
       }
     },
-    "node_modules/bare-os": {
-      "version": "3.8.7",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
     "node_modules/bare-path": {
-      "version": "3.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/bare-stream": {
-      "version": "2.12.0",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmmirror.com/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "b4a": "^1.8.1",
         "streamx": "^2.25.0",
         "teex": "^1.0.1"
       },
@@ -5215,7 +5226,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.0",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmmirror.com/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -6905,6 +6918,8 @@
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -7001,6 +7016,8 @@
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmmirror.com/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -7041,14 +7058,18 @@
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
-      "version": "1.2.1",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
-      "version": "1.1.0",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
       "license": "MIT",
       "dependencies": {
-        "fast-string-truncated-width": "^1.2.0"
+        "fast-string-truncated-width": "^3.0.2"
       }
     },
     "node_modules/fast-uri": {
@@ -7066,10 +7087,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.1.6",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmmirror.com/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "license": "MIT",
       "dependencies": {
-        "fast-string-width": "^1.1.0"
+        "fast-string-width": "^3.0.2"
       }
     },
     "node_modules/fastq": {
@@ -10374,10 +10397,14 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
     "node_modules/skillflag": {
-      "version": "0.1.4",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/skillflag/-/skillflag-0.2.0.tgz",
+      "integrity": "sha512-7ZmEpBeEoPLc+hqZ/StAnCO/hulgEPANzPyZgOM/CZ5zc3b0ApSp3URavY5POM/OKyi5d9+UC/Q21OoiYC2kJw==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.1",
@@ -10531,7 +10558,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.25.0",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmmirror.com/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -10895,7 +10924,9 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.8",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -10906,6 +10937,8 @@
     },
     "node_modules/teex": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -10968,6 +11001,8 @@
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -11183,9 +11218,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmmirror.com/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "acpx": "^0.11.0",
+    "acpx": "^0.12.0",
     "node-pty": "^1.1.0",
     "proper-lockfile": "^4.1.2",
     "protobufjs": "^7.5.6",

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -336,8 +336,8 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
       const input = parseControlPayload(MSG.sessionModelSet, payload);
       if (!input) return errorPayload("invalid-payload", `${MSG.sessionModelSet}: malformed payload`);
       if (!input.sessionAlias || !input.modelId) return errorPayload("bad-request", "sessionAlias and modelId are required");
-      await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId);
-      return { ok: true };
+      const result = await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId);
+      return { ok: result.applied, current: result.current ?? null };
     }
     case MSG.terminalCreate: {
       const input = parseControlPayload(MSG.terminalCreate, payload);

--- a/packages/relay-protocol/dist/messages.d.ts
+++ b/packages/relay-protocol/dist/messages.d.ts
@@ -418,6 +418,12 @@ export interface SessionModelSetPayload {
     sessionAlias: string;
     modelId: string;
 }
+export interface SessionModelSetResult {
+    /** Whether the requested model was observed after the operation settled. */
+    ok: boolean;
+    /** Authoritative transport model after timeout reconciliation, if known. */
+    current?: string | null;
+}
 export interface SessionModelResult {
     /** The session's current model id, if known. */
     current?: string;

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -442,6 +442,13 @@ export interface SessionModelSetPayload {
   modelId: string;
 }
 
+export interface SessionModelSetResult {
+  /** Whether the requested model was observed after the operation settled. */
+  ok: boolean;
+  /** Authoritative transport model after timeout reconciliation, if known. */
+  current?: string | null;
+}
+
 export interface SessionModelResult {
   /** The session's current model id, if known. */
   current?: string;

--- a/packages/relay-web/src/__tests__/promptinput-model.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput-model.test.ts
@@ -9,12 +9,14 @@ vi.mock("../api/client", () => ({
 }));
 
 import PromptInput from "../components/PromptInput.vue";
+import { dismissToast, useToasts } from "../lib/use-toasts";
 
 let pinia: ReturnType<typeof createPinia>;
 beforeEach(() => {
   pinia = createPinia();
   setActivePinia(pinia);
   rpc.mockReset();
+  for (const toast of [...useToasts().value]) dismissToast(toast.id);
 });
 
 function flush() {
@@ -48,4 +50,20 @@ it("renders the model chip with the current model and lets you switch", async ()
 it("hides the chip when there is no session", () => {
   const w = mount(PromptInput, { props: {}, global: { plugins: [pinia] } });
   expect(w.find('[data-test="model-chip"]').exists()).toBe(false);
+});
+
+it("shows a model-switch failure through the global toast instead of beside the chip", async () => {
+  rpc.mockResolvedValueOnce({ current: "gpt-5.2[high]", available: ["gpt-5.2[high]", "gpt-5.2[low]"] });
+  const w = mount(PromptInput, { props: { instanceId: "i1", sessionAlias: "backend" }, global: { plugins: [pinia] } });
+  await flush();
+  await w.get('[data-test="model-chip"]').trigger("click");
+
+  rpc.mockResolvedValueOnce({ error: { code: "internal", message: "acpx command timed out during set-model after 30s" } });
+  const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  await w.findAll('[data-test="model-option"]')[1].trigger("click");
+  await flush();
+
+  expect(w.find('[data-test="model-error"]').exists()).toBe(false);
+  expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.modelSetFailed" });
+  log.mockRestore();
 });

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -8,8 +8,13 @@ vi.mock("../api/client", () => ({
 }));
 
 import { useSessionControlsStore } from "../stores/session-controls";
+import { dismissToast, useToasts } from "../lib/use-toasts";
 
-beforeEach(() => { setActivePinia(createPinia()); rpc.mockReset(); });
+beforeEach(() => {
+  setActivePinia(createPinia());
+  rpc.mockReset();
+  for (const toast of [...useToasts().value]) dismissToast(toast.id);
+});
 
 describe("session-controls store", () => {
   it("loadModel fetches current + available (sending only sessionAlias)", async () => {
@@ -51,15 +56,39 @@ describe("session-controls store", () => {
     expect(s.current).toBe("claude-opus-4-8");
   });
 
-  it("setModel reverts current on an instance-side error payload", async () => {
+  it("setModel reverts current and reports a concise global toast on an instance-side error", async () => {
     rpc.mockResolvedValueOnce({ current: "gpt-5.2[high]", available: ["gpt-5.2[high]"] });
     const s = useSessionControlsStore();
     await s.loadModel("i1", "backend");
     expect(s.current).toBe("gpt-5.2[high]");
-    rpc.mockResolvedValueOnce({ error: { code: "internal", message: "requested model unsupported" } });
+    const detail = "acpx command timed out during set-model after 30s; stderr tail: adapter stalled";
+    rpc.mockResolvedValueOnce({ error: { code: "internal", message: detail } });
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const ok = await s.setModel("i1", "backend", "bogus");
     expect(ok).toBe(false);
-    expect(s.error).toContain("unsupported");
     expect(s.current).toBe("gpt-5.2[high]"); // reverted, not left on "bogus"
+    expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.modelSetFailed" });
+    expect(useToasts().value[0]?.params).toBeUndefined();
+    expect(log).toHaveBeenCalledWith("[relay-web] model switch failed", detail);
+    log.mockRestore();
+  });
+
+  it("setModel adopts the authoritative model returned by timeout reconciliation", async () => {
+    rpc.mockResolvedValueOnce({ current: "gpt-5.2[high]", available: ["gpt-5.2[high]"] });
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "backend");
+    rpc.mockResolvedValueOnce({ ok: false, current: "provider/fallback-model" });
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const ok = await s.setModel("i1", "backend", "claude-opus-4-8");
+
+    expect(ok).toBe(false);
+    expect(s.current).toBe("provider/fallback-model");
+    expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.modelSetFailed" });
+    expect(log).toHaveBeenCalledWith(
+      "[relay-web] model switch failed",
+      "requested claude-opus-4-8; authoritative model is provider/fallback-model",
+    );
+    log.mockRestore();
   });
 });

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -279,7 +279,6 @@ function onInput() {
               </button>
             </li>
           </ul>
-          <span v-if="controls.error" data-test="model-error" class="text-xs text-danger">{{ controls.error }}</span>
           <!-- context-usage meter: click to open the cost / token-breakdown popover -->
           <button v-if="context" type="button" data-test="context-meter"
                   class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded pl-0.5 hover:opacity-80"

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -77,6 +77,7 @@ export default {
     stop: "Stop",
     send: "Send",
     model: "model",
+    modelSetFailed: "Failed to switch model. Try again.",
     working: "Agent is working… (Esc to stop)",
     message: "Message",
     mermaidError: "Diagram failed to render",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -75,6 +75,7 @@ export default {
     stop: "停止",
     send: "发送",
     model: "模型",
+    modelSetFailed: "切换模型失败，请重试。",
     working: "Agent 正在工作…（按 Esc 停止）",
     message: "消息",
     mermaidError: "图表渲染失败",

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -1,7 +1,12 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import { isErrorPayload, type SessionModelResult } from "@ganglion/xacpx-relay-protocol";
+import {
+  isErrorPayload,
+  type SessionModelResult,
+  type SessionModelSetResult,
+} from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
+import { pushToast } from "../lib/use-toasts";
 
 /** Per-session model controls for the composer chip. The hub stamps chatKey for
  *  these chat-scoped RPCs, so the web only sends sessionAlias. */
@@ -9,18 +14,15 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   const current = ref<string | undefined>(undefined);
   const available = ref<string[]>([]);
   const loading = ref(false);
-  const error = ref("");
 
   function reset(): void {
     current.value = undefined;
     available.value = [];
-    error.value = "";
   }
 
   async function loadModel(instanceId: string | null, alias: string | null): Promise<void> {
     if (!instanceId || !alias) { reset(); return; }
     loading.value = true;
-    error.value = "";
     try {
       const r = await api.rpc<SessionModelResult>(instanceId, "control.session.model.get", { sessionAlias: alias });
       if (isErrorPayload(r)) { reset(); return; }
@@ -36,22 +38,43 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   }
 
   async function setModel(instanceId: string, alias: string, id: string): Promise<boolean> {
-    error.value = "";
     // Reflect the choice in the chip immediately. The backend `set` spawns acpx and can
     // take a second or two (or time out), so updating only AFTER the RPC left the chip
     // showing the old model until the next session switch. Revert if the switch fails.
     const prev = current.value;
     current.value = id;
     try {
-      const r = await api.rpc<{ ok?: boolean }>(instanceId, "control.session.model.set", { sessionAlias: alias, modelId: id });
-      if (isErrorPayload(r)) { current.value = prev; error.value = r.error.message; return false; }
+      const r = await api.rpc<SessionModelSetResult>(instanceId, "control.session.model.set", { sessionAlias: alias, modelId: id });
+      if (isErrorPayload(r)) {
+        current.value = prev;
+        reportModelSwitchFailure(r.error.message);
+        return false;
+      }
+      if (r.ok === false) {
+        current.value = r.current === null
+          ? undefined
+          : typeof r.current === "string" ? r.current : prev;
+        reportModelSwitchFailure(
+          `requested ${id}; authoritative model is ${r.current ?? "unknown"}`,
+        );
+        return false;
+      }
+      if (r.current === null) current.value = undefined;
+      else if (typeof r.current === "string") current.value = r.current;
       return true;
     } catch (e) {
       current.value = prev;
-      error.value = e instanceof Error ? e.message : "set-failed";
+      reportModelSwitchFailure(e instanceof Error ? e.message : "set-failed");
       return false;
     }
   }
 
-  return { current, available, loading, error, reset, loadModel, setModel };
+  return { current, available, loading, reset, loadModel, setModel };
 });
+
+function reportModelSwitchFailure(detail: string): void {
+  // Keep command lines and captured output out of the compact composer UI. They remain
+  // available in browser diagnostics while the user sees the app's standard toast.
+  console.error("[relay-web] model switch failed", detail);
+  pushToast("error", "chat.modelSetFailed");
+}

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -18,9 +18,12 @@ import { runAgentSessionList } from "../transport/agent-session-list";
 import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../transport/codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../transport/acpx-session-files";
 import {
+  CommandTimeoutError,
   DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
   DEFAULT_SESSION_INIT_TIMEOUT_MS,
+  type AcpxCommandStage,
 } from "../transport/command-timeouts";
+export { CommandTimeoutError } from "../transport/command-timeouts";
 import type {
   EnsureSessionProgress,
   MissingOptionalDepErrorData,
@@ -66,17 +69,12 @@ interface CommandResult {
   stderr: string;
 }
 
-export class CommandTimeoutError extends Error {
-  constructor(readonly timeoutMs: number, command: string) {
-    super(`acpx command timed out after ${timeoutMs / 1000}s: ${command}`);
-    this.name = "CommandTimeoutError";
-  }
-}
-
 export interface CommandRunnerOptions {
   onStderrLine?: (line: string) => void;
   /** Kill the spawned process tree and reject with CommandTimeoutError when it runs longer than this. */
   timeoutMs?: number;
+  /** Stable operation name included in timeout diagnostics. */
+  stage?: AcpxCommandStage;
 }
 type CommandRunner = (command: string, args: string[], options?: CommandRunnerOptions) => Promise<CommandResult>;
 type SessionCreateRunner = (command: string, args: string[], cwd: string, options?: CommandRunnerOptions) => Promise<CommandResult>;
@@ -262,6 +260,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "has-session",
     });
 
     return { exists: result.code === 0 };
@@ -290,6 +289,7 @@ export class BridgeRuntime {
       const spawnSpec = resolveSpawnCommand(this.command, this.buildSessionArgs(input, tailArgs));
       const result = await this.run(spawnSpec.command, spawnSpec.args, {
         timeoutMs: Math.max(deadline - Date.now(), 1),
+        stage: "session-history",
       });
       if (result.code === 0) {
         return { text: result.stdout.trimEnd() };
@@ -534,6 +534,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "read-session-record",
     });
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "sessions show failed");
@@ -568,6 +569,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "set-mode",
     });
 
     if (result.code !== 0) {
@@ -594,6 +596,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "set-model",
     });
 
     if (result.code !== 0) {
@@ -616,6 +619,7 @@ export class BridgeRuntime {
     ], { format: "json" }));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "get-session-model",
     });
 
     if (result.code !== 0) {
@@ -646,6 +650,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "cancel",
     });
 
     if (result.code !== 0) {
@@ -671,6 +676,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "remove-session",
     });
 
     if (result.code === 0) {
@@ -812,7 +818,11 @@ export function spawnCapture(
             const kill = options.killProcessTreeFn
               ?? ((pid: number) => terminateProcessTree(pid, { detachedProcessGroup: false }));
             void kill(child.pid ?? 0);
-            reject(new CommandTimeoutError(options.timeoutMs!, [command, ...args].join(" ")));
+            reject(new CommandTimeoutError(options.timeoutMs!, [command, ...args].join(" "), {
+              stage: options.stage,
+              stdout,
+              stderr,
+            }));
           }, options.timeoutMs)
         : undefined;
 

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -13,7 +13,7 @@ import {
 import { PromptCommandError } from "../transport/prompt-output";
 import type { PromptMedia, PromptMediaInput } from "../transport/types";
 import { BridgeRequestScheduler, type BridgeRequestLane } from "./bridge-request-scheduler";
-import { BridgeRuntime, EnsureSessionFailedError } from "./bridge-runtime";
+import { BridgeRuntime, CommandTimeoutError, EnsureSessionFailedError } from "./bridge-runtime";
 
 interface BridgeRequest {
   id: string;
@@ -85,6 +85,17 @@ export class BridgeServer {
       const promptDetails = error instanceof PromptCommandError
         ? { details: { exitCode: error.exitCode, stdout: error.stdout, stderr: error.stderr } }
         : {};
+      const timeoutDetails = error instanceof CommandTimeoutError
+        ? {
+            timeout: {
+              timeoutMs: error.timeoutMs,
+              command: error.command,
+              ...(error.stage ? { stage: error.stage } : {}),
+              ...(error.stdoutTail ? { stdoutTail: error.stdoutTail } : {}),
+              ...(error.stderrTail ? { stderrTail: error.stderrTail } : {}),
+            },
+          }
+        : {};
       return `${JSON.stringify({
         id: requestId,
         ok: false,
@@ -93,6 +104,7 @@ export class BridgeServer {
           message,
           ...ensureSessionFields,
           ...promptDetails,
+          ...timeoutDetails,
         },
       } satisfies BridgeResponse)}\n`;
     }

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -27,6 +27,8 @@ import type { UploadStore } from "./upload-store.js";
 import { SessionTurnRunner } from "./session-turn-runner";
 import { TurnQueue } from "./turn-queue";
 import { buildControlMetadata, type TurnIdleTimeoutDetail } from "./turn-support";
+import { isCommandTimeoutError } from "../transport/command-timeouts";
+import type { AppLogger } from "../logging/app-logger";
 
 export interface ControlSessionInfo {
   alias: string;
@@ -68,6 +70,7 @@ export interface ControlWorkspaceInfo {
 }
 
 export interface ControlServiceDeps {
+  logger?: Pick<AppLogger, "error">;
   agent: Pick<ChatAgent, "chat">;
   sessions: Pick<
     SessionService,
@@ -267,12 +270,47 @@ export class ControlService {
   }
 
   /** Switch a session's model (acpx validates the id) and persist the override. */
-  async setSessionModel(chatKey: string, alias: string, modelId: string): Promise<void> {
+  async setSessionModel(
+    chatKey: string,
+    alias: string,
+    modelId: string,
+  ): Promise<{ current?: string; applied: boolean }> {
     const session = await this.resolveControlSession(chatKey, alias);
     if (!session) throw new Error("session not found");
     if (!this.deps.transport.setModel) throw new Error("the active transport does not support switching models");
-    await this.deps.transport.setModel(session, modelId);
+    try {
+      await this.deps.transport.setModel(session, modelId);
+    } catch (error) {
+      // A process timeout is ambiguous: acpx may have applied the model before it
+      // stopped responding. Read back the authoritative transport state so the
+      // persisted logical session and relay-web's optimistic chip cannot diverge.
+      if (!isCommandTimeoutError(error) || !this.deps.transport.getSessionModel) throw error;
+      let observed: { current?: string; available: string[] };
+      try {
+        observed = await this.deps.transport.getSessionModel(session);
+      } catch {
+        // Preserve the original timeout; reconciliation is best-effort diagnostics.
+        throw error;
+      }
+      await this.deps.sessions.setSessionModel(session.alias, observed.current);
+      try {
+        await this.deps.logger?.error(
+          "control.session.model.timeout_reconciled",
+          "Model switch timed out; adopted authoritative transport state",
+          {
+            sessionAlias: session.alias,
+            requestedModel: modelId,
+            observedModel: observed.current ?? null,
+            timeout: error instanceof Error ? error.message : String(error),
+          },
+        );
+      } catch {
+        // Logging is diagnostic only; reconciliation already succeeded.
+      }
+      return { current: observed.current, applied: observed.current === modelId };
+    }
     await this.deps.sessions.setSessionModel(session.alias, modelId);
+    return { current: modelId, applied: true };
   }
 
   /** Set (or clear) a session's relay-web display label and persist it. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -797,6 +797,7 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
     60 * 60 * 1000,
   );
   const control = new ControlService({
+    logger,
     agent,
     sessions,
     transport,

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -18,6 +18,7 @@ import { getLocale } from "../../i18n";
 import { resolveDefaultXacpxCommand } from "../acpx-queue-owner-launcher";
 import {
   BRIDGE_REQUEST_TIMEOUT_GRACE_MS,
+  CommandTimeoutError,
   DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
   DEFAULT_SESSION_INIT_TIMEOUT_MS,
 } from "../command-timeouts";
@@ -148,7 +149,9 @@ export class AcpxBridgeClient {
       if (timeoutMs !== undefined) {
         timer = setTimeoutFn(() => {
           if (this.pending.delete(id)) {
-            reject(new Error(`bridge request "${method}" timed out after ${timeoutMs}ms`));
+            reject(method === "setModel"
+              ? new CommandTimeoutError(timeoutMs, `bridge request "${method}"`, { stage: "set-model" })
+              : new Error(`bridge request "${method}" timed out after ${timeoutMs}ms`));
           }
         }, timeoutMs);
       }
@@ -247,6 +250,19 @@ export class AcpxBridgeClient {
     this.pending.delete(response.id);
     if (response.ok) {
       pending.resolve(response.result);
+      return;
+    }
+
+    if (response.error.timeout) {
+      pending.reject(new CommandTimeoutError(
+        response.error.timeout.timeoutMs,
+        response.error.timeout.command,
+        {
+          stage: response.error.timeout.stage,
+          stdout: response.error.timeout.stdoutTail,
+          stderr: response.error.timeout.stderrTail,
+        },
+      ));
       return;
     }
 

--- a/src/transport/acpx-bridge/acpx-bridge-protocol.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-protocol.ts
@@ -1,5 +1,6 @@
 import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
 import type { AgentCommand, UsageBreakdown, UsageCost } from "../types";
+import type { AcpxCommandStage } from "../command-timeouts";
 
 export type BridgeMethod =
   | "ping"
@@ -55,6 +56,13 @@ export interface BridgeErrorResponse {
       exitCode?: number;
       stdout?: string;
       stderr?: string;
+    };
+    timeout?: {
+      timeoutMs: number;
+      command: string;
+      stage?: AcpxCommandStage;
+      stdoutTail?: string;
+      stderrTail?: string;
     };
   };
 }

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -34,7 +34,11 @@ import { resolveToolEventMode, type ToolEventMode } from "../tool-event-mode.js"
 import { runAgentSessionList } from "../agent-session-list";
 import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../acpx-session-files";
-import { DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS } from "../command-timeouts";
+import {
+  CommandTimeoutError,
+  DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
+  type AcpxCommandStage,
+} from "../command-timeouts";
 import {
   buildPermissionArgs as sharedBuildPermissionArgs,
   buildSessionArgs as sharedBuildSessionArgs,
@@ -71,6 +75,18 @@ interface CommandResult {
 interface RunOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
+  stage?: AcpxCommandStage;
+}
+
+function managementTimeoutError(
+  args: string[],
+  options: RunOptions,
+  output: { stdout?: string; stderr?: string } = {},
+): CommandTimeoutError {
+  return new CommandTimeoutError(options.timeoutMs!, renderCommandForError(args), {
+    stage: options.stage,
+    ...output,
+  });
 }
 
 interface PromptStreamProcess {
@@ -115,7 +131,7 @@ async function defaultRunner(command: string, args: string[], options?: RunOptio
     const timeoutId = options?.timeoutMs
       ? setTimeout(() => {
           onAbort();
-          reject(new Error(`acpx command timed out after ${options.timeoutMs}ms: ${renderCommandForError(args)}`));
+          reject(managementTimeoutError(args, options, { stdout, stderr }));
         }, options.timeoutMs)
       : undefined;
 
@@ -165,7 +181,7 @@ async function defaultPtyRunner(command: string, args: string[], options?: RunOp
     const timeoutId = options?.timeoutMs
       ? setTimeout(() => {
           onAbort();
-          reject(new Error(`acpx command timed out after ${options.timeoutMs}ms: ${renderCommandForError(args)}`));
+          reject(managementTimeoutError(args, options, { stdout: output }));
         }, options.timeoutMs)
       : undefined;
 
@@ -294,6 +310,7 @@ export class AcpxCliTransport implements SessionTransport {
       const args = this.buildArgs(session, tail);
       const result = await this.runCommandWithTimeout(this.runCommand, args, {
         timeoutMs: Math.max(deadline - Date.now(), 1),
+        stage: "session-history",
       });
       if (result.code === 0) {
         return { text: result.stdout.trimEnd() };
@@ -374,7 +391,7 @@ export class AcpxCliTransport implements SessionTransport {
       "-s",
       session.transportSession,
       modeId,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "set-mode" });
   }
 
   // acpx's generic config setter: `<agent> set -s <name> model '<id>'`. Build args
@@ -388,7 +405,7 @@ export class AcpxCliTransport implements SessionTransport {
       session.transportSession,
       "model",
       modelId,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "set-model" });
   }
 
   // Read the session's current model and the agent-advertised available ids from
@@ -402,6 +419,7 @@ export class AcpxCliTransport implements SessionTransport {
       : [...prefix, session.agent, ...tail];
     const result = await this.runCommandWithTimeout(this.runCommand, args, {
       timeoutMs: this.managementCommandTimeoutMs,
+      stage: "get-session-model",
     });
     if (result.code !== 0) {
       const detail = normalizeCommandError(result) ?? `command failed with exit code ${result.code}`;
@@ -423,7 +441,7 @@ export class AcpxCliTransport implements SessionTransport {
       "cancel",
       "-s",
       session.transportSession,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "cancel" });
     return {
       cancelled: true,
       message: output.trim(),
@@ -457,7 +475,7 @@ export class AcpxCliTransport implements SessionTransport {
       "sessions",
       "close",
       session.transportSession,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "remove-session" });
     if (result.code === 0) {
       return;
     }
@@ -502,7 +520,7 @@ export class AcpxCliTransport implements SessionTransport {
       "sessions",
       "show",
       session.transportSession,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "has-session" });
 
     return result.code === 0;
   }
@@ -527,7 +545,7 @@ export class AcpxCliTransport implements SessionTransport {
       "sessions",
       "show",
       session.transportSession,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "read-session-record" });
     if (result.code !== 0) {
       const detail = normalizeCommandError(result) ?? `command failed with exit code ${result.code}`;
       throw new Error(detail);
@@ -581,9 +599,7 @@ export class AcpxCliTransport implements SessionTransport {
       new Promise<CommandResult>((_, reject) => {
         timeoutId = setTimeout(() => {
           reject(
-            new Error(
-              `acpx command timed out after ${options.timeoutMs}ms: ${renderCommandForError(args)}`,
-            ),
+            managementTimeoutError(args, options),
           );
           abortController.abort();
         }, options.timeoutMs);

--- a/src/transport/command-timeouts.ts
+++ b/src/transport/command-timeouts.ts
@@ -31,3 +31,59 @@ export const DEFAULT_SESSION_INIT_TIMEOUT_MS = 120_000;
  * responses.
  */
 export const BRIDGE_REQUEST_TIMEOUT_GRACE_MS = 15_000;
+
+const COMMAND_OUTPUT_TAIL_CHARS = 2_000;
+
+/** Stable diagnostic stages shared by both acpx transports. */
+export type AcpxCommandStage =
+  | "has-session"
+  | "session-history"
+  | "read-session-record"
+  | "set-mode"
+  | "set-model"
+  | "get-session-model"
+  | "cancel"
+  | "remove-session";
+
+/** Timeout from a one-shot acpx command, with bounded diagnostics safe to retain. */
+export class CommandTimeoutError extends Error {
+  readonly stage?: AcpxCommandStage;
+  readonly stdoutTail?: string;
+  readonly stderrTail?: string;
+
+  constructor(
+    readonly timeoutMs: number,
+    readonly command: string,
+    detail: { stage?: AcpxCommandStage; stdout?: string; stderr?: string } = {},
+  ) {
+    const stdoutTail = captureOutputTail(detail.stdout);
+    const stderrTail = captureOutputTail(detail.stderr);
+    const output = [
+      stdoutTail ? `stdout tail: ${stdoutTail}` : "",
+      stderrTail ? `stderr tail: ${stderrTail}` : "",
+    ].filter(Boolean).join("; ");
+    super(
+      `acpx command timed out${detail.stage ? ` during ${detail.stage}` : ""} after ${formatTimeout(timeoutMs)}: ${command}`
+      + (output ? `; ${output}` : ""),
+    );
+    this.name = "CommandTimeoutError";
+    this.stage = detail.stage;
+    this.stdoutTail = stdoutTail;
+    this.stderrTail = stderrTail;
+  }
+}
+
+function formatTimeout(timeoutMs: number): string {
+  return timeoutMs >= 1_000 ? `${timeoutMs / 1_000}s` : `${timeoutMs}ms`;
+}
+
+function captureOutputTail(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) return undefined;
+  return normalized.slice(-COMMAND_OUTPUT_TAIL_CHARS);
+}
+
+/** Structured identity check used before state-changing timeout reconciliation. */
+export function isCommandTimeoutError(error: unknown): boolean {
+  return error instanceof CommandTimeoutError;
+}

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -302,13 +302,25 @@ interface FakeSpawnChildOptions {
   pid: number;
   /** When set, fire the close handler with this exit code on the next tick. */
   closeWithCode?: number;
+  stdout?: string;
+  stderr?: string;
 }
 
 function makeFakeSpawnChild(options: FakeSpawnChildOptions) {
   return {
     pid: options.pid,
-    stdout: { setEncoding: () => {}, on: () => {} },
-    stderr: { setEncoding: () => {}, on: () => {} },
+    stdout: {
+      setEncoding: () => {},
+      on: (event: string, handler: (chunk: string) => void) => {
+        if (event === "data" && options.stdout) handler(options.stdout);
+      },
+    },
+    stderr: {
+      setEncoding: () => {},
+      on: (event: string, handler: (chunk: string) => void) => {
+        if (event === "data" && options.stderr) handler(options.stderr);
+      },
+    },
     on: (event: string, handler: (code: number | null) => void) => {
       if (event === "close" && options.closeWithCode !== undefined) {
         setTimeout(() => handler(options.closeWithCode!), 0);
@@ -565,6 +577,36 @@ test("a hung management command kills the spawned tree and rejects with CommandT
 
   expect(caught).toBeInstanceOf(CommandTimeoutError);
   expect(killed).toEqual([777]);
+});
+
+test("a set-model timeout identifies its stage and preserves captured output tails", async () => {
+  const spawnFn = (() => makeFakeSpawnChild({
+    pid: 778,
+    stdout: "adapter initialized\nwaiting for response\n",
+    stderr: "model update dispatched\nprovider did not acknowledge\n",
+  })) as never;
+  const runtime = new BridgeRuntime(
+    "acpx",
+    (command, args, options?: CommandRunnerOptions) => spawnCapture(command, args, {
+      ...options,
+      spawnFn,
+      killProcessTreeFn: async () => {},
+    }),
+    undefined,
+    { managementCommandTimeoutMs: 20 },
+  );
+
+  let caught: unknown;
+  try {
+    await runtime.setModel({ agent: "codex", cwd: "/repo", name: "demo", modelId: "gpt-5.2[high]" });
+  } catch (error) {
+    caught = error;
+  }
+
+  expect(caught).toBeInstanceOf(CommandTimeoutError);
+  expect((caught as Error).message).toContain("during set-model");
+  expect((caught as Error).message).toContain("stdout tail: adapter initialized\nwaiting for response");
+  expect((caught as Error).message).toContain("stderr tail: model update dispatched\nprovider did not acknowledge");
 });
 
 test("prompt starts queue owner with orchestration MCP identity", async () => {

--- a/tests/unit/bridge/bridge-server.test.ts
+++ b/tests/unit/bridge/bridge-server.test.ts
@@ -3,7 +3,7 @@ import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { BridgeRuntime, EnsureSessionFailedError } from "../../../src/bridge/bridge-runtime";
+import { BridgeRuntime, CommandTimeoutError, EnsureSessionFailedError } from "../../../src/bridge/bridge-runtime";
 import { BridgeServer } from "../../../src/bridge/bridge-server";
 import { PromptCommandError } from "../../../src/transport/prompt-output";
 
@@ -1375,6 +1375,39 @@ test("includes prompt diagnostics in bridge error responses", async () => {
   ).resolves.toEqual(
     '{"id":"3","ok":false,"error":{"code":"BRIDGE_INTERNAL_ERROR","message":"command failed with exit code 5","details":{"exitCode":5,"stdout":"partial stdout","stderr":"partial stderr"}}}\n',
   );
+});
+
+test("serializes management timeout identity and bounded diagnostics", async () => {
+  const runtime = {
+    setModel: async () => {
+      throw new CommandTimeoutError(30_000, "acpx codex set model", {
+        stage: "set-model",
+        stdout: "adapter started",
+        stderr: "provider stalled",
+      });
+    },
+  } as unknown as BridgeRuntime;
+  const server = new BridgeServer(runtime);
+
+  const response = await server.handleLine(JSON.stringify({
+    id: "timeout-1",
+    method: "setModel",
+    params: { agent: "codex", cwd: "/repo", name: "demo", modelId: "gpt-5.2[high]" },
+  }));
+
+  expect(JSON.parse(response)).toMatchObject({
+    id: "timeout-1",
+    ok: false,
+    error: {
+      timeout: {
+        timeoutMs: 30_000,
+        command: "acpx codex set model",
+        stage: "set-model",
+        stdoutTail: "adapter started",
+        stderrTail: "provider stalled",
+      },
+    },
+  });
 });
 
 test("returns structured error for invalid json input", async () => {

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { ControlService } from "../../../src/control/control-service";
+import { CommandTimeoutError } from "../../../src/transport/command-timeouts";
 
 const session = {
   alias: "internal-backend",
@@ -12,6 +13,7 @@ const session = {
 
 function makeDeps() {
   const calls: string[] = [];
+  const logs: Array<{ event: string; message: string; context?: Record<string, unknown> }> = [];
   const deps = {
     sessions: {
       resolveAliasForChat: async (_chatKey: string, alias: string) => `internal-${alias}`,
@@ -22,9 +24,14 @@ function makeDeps() {
       getSessionModel: async (s: typeof session) => ({ current: s.model, available: ["gpt-5.2[high]", "gpt-5.2[low]"] }),
       setModel: async (s: typeof session, id: string) => { calls.push(`transport:${s.alias}:${id}`); },
     },
+    logger: {
+      error: async (event: string, message: string, context?: Record<string, unknown>) => {
+        logs.push({ event, message, context });
+      },
+    },
     events: { emit: () => {} },
   };
-  return { deps, calls };
+  return { deps, calls, logs };
 }
 
 test("getSessionModel returns current + available for a resolved session", async () => {
@@ -44,8 +51,80 @@ test("getSessionModel returns an empty list when the session is not found", asyn
 test("setSessionModel switches the transport model and persists by alias", async () => {
   const { deps, calls } = makeDeps();
   const control = new ControlService(deps as never);
-  await control.setSessionModel("relay:acc", "backend", "claude-opus-4-8");
+  await expect(control.setSessionModel("relay:acc", "backend", "claude-opus-4-8")).resolves.toEqual({
+    current: "claude-opus-4-8",
+    applied: true,
+  });
   expect(calls).toEqual(["transport:internal-backend:claude-opus-4-8", "persist:internal-backend:claude-opus-4-8"]);
+});
+
+test("setSessionModel reconciles a timed-out switch that acpx actually applied", async () => {
+  const { deps, calls, logs } = makeDeps();
+  deps.transport.setModel = async () => {
+    calls.push("transport:internal-backend:claude-opus-4-8");
+    throw new CommandTimeoutError(30_000, "acpx set model", { stage: "set-model" });
+  };
+  deps.transport.getSessionModel = async () => {
+    calls.push("query:internal-backend");
+    return { current: "claude-opus-4-8", available: ["claude-opus-4-8"] };
+  };
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionModel("relay:acc", "backend", "claude-opus-4-8")).resolves.toEqual({
+    current: "claude-opus-4-8",
+    applied: true,
+  });
+  expect(calls).toEqual([
+    "transport:internal-backend:claude-opus-4-8",
+    "query:internal-backend",
+    "persist:internal-backend:claude-opus-4-8",
+  ]);
+  expect(logs).toEqual([{
+    event: "control.session.model.timeout_reconciled",
+    message: "Model switch timed out; adopted authoritative transport state",
+    context: {
+      sessionAlias: "internal-backend",
+      requestedModel: "claude-opus-4-8",
+      observedModel: "claude-opus-4-8",
+      timeout: "acpx command timed out during set-model after 30s: acpx set model",
+    },
+  }]);
+});
+
+test("setSessionModel adopts the authoritative model when a timed-out switch produced a third value", async () => {
+  const { deps, calls } = makeDeps();
+  deps.transport.setModel = async () => {
+    throw new CommandTimeoutError(30_000, "acpx set model", { stage: "set-model" });
+  };
+  deps.transport.getSessionModel = async () => ({
+    current: "provider/fallback-model",
+    available: ["gpt-5.2[high]", "claude-opus-4-8", "provider/fallback-model"],
+  });
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionModel("relay:acc", "backend", "claude-opus-4-8")).resolves.toEqual({
+    current: "provider/fallback-model",
+    applied: false,
+  });
+  expect(calls).toEqual(["persist:internal-backend:provider/fallback-model"]);
+});
+
+test("setSessionModel does not reconcile unrelated provider errors that merely mention a timeout", async () => {
+  const { deps, calls, logs } = makeDeps();
+  deps.transport.setModel = async () => {
+    throw new Error("provider request timed out while validating credentials");
+  };
+  deps.transport.getSessionModel = async () => {
+    calls.push("query");
+    return { current: "provider/fallback-model", available: [] };
+  };
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionModel("relay:acc", "backend", "claude-opus-4-8")).rejects.toThrow(
+    "provider request timed out",
+  );
+  expect(calls).toEqual([]);
+  expect(logs).toEqual([]);
 });
 
 test("setSessionModel throws when the transport cannot switch models", async () => {

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -94,6 +94,19 @@ test("queue.cancel dispatches to cancelQueuedItem and returns its result", async
   expect(calls.cancelQueuedItem?.[0]).toEqual({ chatKey: "relay:acct", alias: "a", itemId: "q1" });
 });
 
+test("session.model.set returns the authoritative reconciled model", async () => {
+  const { control } = makeFakeControl({
+    setSessionModel: async () => ({ current: "provider/fallback-model", applied: false }),
+  });
+  const bridge = createControlBridge(control as never);
+
+  expect(await dispatch(bridge, req(MSG.sessionModelSet, {
+    chatKey: "relay:acct",
+    sessionAlias: "a",
+    modelId: "requested-model",
+  }))).toEqual({ ok: false, current: "provider/fallback-model" });
+});
+
 test("sessions.native.list lists, and sessions.create forwards agentSessionId for native resume", async () => {
   const created: unknown[] = [];
   const { control } = makeFakeControl({

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
@@ -16,6 +16,7 @@ import {
 import { encodeBridgeRequest } from "../../../../src/transport/acpx-bridge/acpx-bridge-protocol";
 import { PromptCommandError } from "../../../../src/transport/prompt-output";
 import { MissingOptionalDepError } from "../../../../src/recovery/errors";
+import { CommandTimeoutError } from "../../../../src/transport/command-timeouts";
 
 test("encodes a bridge request as ndjson", () => {
   expect(
@@ -47,6 +48,41 @@ test("rejects responses with bridge error payloads", async () => {
   client.handleLine('{"id":"1","ok":false,"error":{"code":"PING_FAILED","message":"boom"}}');
 
   await expect(pending).rejects.toThrow("boom");
+});
+
+test("reconstructs management timeout identity and diagnostics from bridge errors", async () => {
+  const client = new AcpxBridgeClient(() => {});
+  const pending = client.request("setModel", {});
+
+  client.handleLine(JSON.stringify({
+    id: "1",
+    ok: false,
+    error: {
+      code: "BRIDGE_INTERNAL_ERROR",
+      message: "timeout",
+      timeout: {
+        timeoutMs: 30_000,
+        command: "acpx codex set model",
+        stage: "set-model",
+        stdoutTail: "adapter started",
+        stderrTail: "provider stalled",
+      },
+    },
+  }));
+
+  try {
+    await pending;
+    throw new Error("expected rejection");
+  } catch (error) {
+    expect(error).toBeInstanceOf(CommandTimeoutError);
+    expect(error).toMatchObject({
+      timeoutMs: 30_000,
+      command: "acpx codex set model",
+      stage: "set-model",
+      stdoutTail: "adapter started",
+      stderrTail: "provider stalled",
+    });
+  }
 });
 
 test("reconstructs prompt command diagnostics from bridge error payloads", async () => {

--- a/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
@@ -89,6 +89,7 @@ test("setModel issues `set ... model <id>` with the new model consistently", asy
   expect(args.slice(setIdx)).toEqual(["set", "-s", "backend:api-fix", "model", "claude-opus-4-8"]);
   // global --model agrees with the new id (not a stale old one)
   expect(args[args.indexOf("--model") + 1]).toBe("claude-opus-4-8");
+  expect(run.mock.calls[0][2]).toMatchObject({ stage: "set-model" });
 });
 
 test("getSessionModel parses status json for current + available models", async () => {

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -901,7 +901,7 @@ test("times out a hung management command, aborts the spawn, and rejects", async
     run as never,
   );
 
-  await expect(transport.cancel(session)).rejects.toThrow(/timed out after 20ms/);
+  await expect(transport.cancel(session)).rejects.toThrow(/timed out during cancel after 20ms/);
   expect(aborted).toBe(true);
 });
 
@@ -912,7 +912,7 @@ test("times out a hung sessions close (removeSession) instead of hanging forever
     run as never,
   );
 
-  await expect(transport.removeSession(session)).rejects.toThrow(/timed out after 20ms/);
+  await expect(transport.removeSession(session)).rejects.toThrow(/timed out during remove-session after 20ms/);
 });
 
 test("concatenates agent message chunks across thought and tool-call boundaries", async () => {


### PR DESCRIPTION
## Summary

- show model-switch failures through the global toast instead of rendering raw command errors beside the composer model chip
- preserve structured management-timeout diagnostics across both transports and the bridge (`stage`, command, and bounded stdout/stderr tails)
- reconcile ambiguous model-set timeouts against the authoritative acpx state, persist the observed model, and return it to relay-web

## Root cause

The model-set management process can exceed its 30-second bound after applying some or all of the change. The previous error path treated every timeout as a definite failure: relay-web blindly restored its optimistic previous value, while the transport could already be using a different model. The raw timeout was also rendered inline in the compact composer UI, and bridge serialization discarded its structured identity.

## Impact

Users now get a concise, localized toast. Successful timeout reconciliation keeps the logical session, relay response, and model chip aligned with acpx. Operators retain the original timeout stage, command, and bounded output tails in app/browser diagnostics.

## Validation

- `npx tsc --noEmit`
- `bun run build:channel-relay`
- `bun run build:relay-web`
- affected core suites: 193 tests passed
- relay control bridge: 34 tests passed
- affected relay-web suites: 11 tests passed
- independent Standards and Spec reviews: approve, no findings

The complete core/web runs encountered pre-existing fixed-timeout flakes under suite-level load; each failing unrelated test passed when rerun in isolation.
