### PR TITLE
fix(relay-web): reconcile model switch timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ xacpx-relay add token        # prints the access token once
 xacpx-relay start            # defaults: --host 0.0.0.0 --http-port 8787
 
 # On each instance host:
-xacpx plugin add @ganglion/xacpx-channel-relay   # requires xacpx >= 0.11.0
+xacpx plugin add @ganglion/xacpx-channel-relay   # requires xacpx >= 0.17.0-beta.6
 xacpx channel add relay --url wss://relay.example.com --token <access-token> --name my-box
 xacpx restart
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "ws": "^8.20.0",
       },
       "peerDependencies": {
-        "xacpx": ">=0.11.0-0",
+        "xacpx": ">=0.17.0-beta.6",
       },
       "optionalPeers": [
         "xacpx",

--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -134,12 +134,17 @@ timeout，ControlService 会通过 `getSessionModel` 读取 transport 权威值�
 `control.session.model.timeout_reconciled` 事件；对账查询本身失败时，原始 timeout 继续作为
 RPC 错误返回，由 relay-web 浏览器诊断保留。同一逻辑会话的模型切换在 ControlService 内
 串行执行，旧 timeout 的查询/持久化必须完成后才允许下一次切换，避免旧对账覆盖新值；不同
-会话仍可并行。relay-web 同时用会话上下文与请求序号丢弃迟到响应，切换会话或连续选择模型时
-不会让旧响应污染当前 chip。
+会话仍可并行。relay-web 同时用会话上下文与请求序号丢弃迟到响应，并把最后确认的权威模型
+与当前乐观展示值分开保存；连续选择全部失败时回到权威值，而不是回到上一个乐观值。
 
 该 RPC 的 connector 侧 60 秒 response timeout 被显式豁免：一次 30 秒 set timeout 后还可能
-跟随一次 30 秒权威查询（bridge backstop 最坏为 45 秒 + 45 秒），由 hub 的 120 秒请求上限兜底，
-避免 connector 先返回错误而底层继续完成对账。
+跟随一次 30 秒权威查询（bridge backstop 最坏为 45 秒 + 45 秒）。Hub 在下行 request envelope
+中同时附带扣除 15 秒响应余量后的绝对 epoch work deadline 与 connector work budget；connector
+仅在两者齐全时取更早值。绝对值保证传输耗时不会吃掉响应余量，相对 budget 限制跨机时钟偏差。
+旧 Hub 或部分字段缺失时，connector fail closed，将 deadline 设为接收时刻，使请求在触碰
+transport 前失败，而不是恢复到无期限排队。
+串行队列出闸时，ControlService 会为最坏 90 秒的 set + readback 预留完整预算；剩余时间不足的
+请求在触碰 transport 前失败，避免排队重新吃掉 Hub 为状态变更保留的响应窗口。
 
 ### 事件总线覆盖范围
 

--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -132,7 +132,14 @@ timeout，ControlService 会通过 `getSessionModel` 读取 transport 权威值�
 `current`，不能盲目回滚到请求前的本地值。成功完成对账的 timeout 会把原始诊断
 （stage、命令及有界 stdout/stderr tail）记录到 app log 的
 `control.session.model.timeout_reconciled` 事件；对账查询本身失败时，原始 timeout 继续作为
-RPC 错误返回，由 relay-web 浏览器诊断保留。
+RPC 错误返回，由 relay-web 浏览器诊断保留。同一逻辑会话的模型切换在 ControlService 内
+串行执行，旧 timeout 的查询/持久化必须完成后才允许下一次切换，避免旧对账覆盖新值；不同
+会话仍可并行。relay-web 同时用会话上下文与请求序号丢弃迟到响应，切换会话或连续选择模型时
+不会让旧响应污染当前 chip。
+
+该 RPC 的 connector 侧 60 秒 response timeout 被显式豁免：一次 30 秒 set timeout 后还可能
+跟随一次 30 秒权威查询（bridge backstop 最坏为 45 秒 + 45 秒），由 hub 的 120 秒请求上限兜底，
+避免 connector 先返回错误而底层继续完成对账。
 
 ### 事件总线覆盖范围
 

--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -124,6 +124,16 @@ reset 在回合内重建了 transport 会话，但 reset handler 不发事件，
 await 必须留在 draining 守护窗口内，否则一个被中止且带排队项的回合会让新提示词插进来抢跑
 （由 golden fixture `aborted-queue-sessions-window` 钉住）。
 
+### 模型切换与 timeout 对账
+
+`control.session.model.set` 返回 `{ ok, current }`。正常切换时 `ok=true`；若 acpx 管理命令
+timeout，ControlService 会通过 `getSessionModel` 读取 transport 权威值、将该值（包括空值）写回
+逻辑会话，再返回 `current`。请求模型未实际生效时 `ok=false`，relay-web 必须采用返回的
+`current`，不能盲目回滚到请求前的本地值。成功完成对账的 timeout 会把原始诊断
+（stage、命令及有界 stdout/stderr tail）记录到 app log 的
+`control.session.model.timeout_reconciled` 事件；对账查询本身失败时，原始 timeout 继续作为
+RPC 错误返回，由 relay-web 浏览器诊断保留。
+
 ### 事件总线覆盖范围
 
 事件总线只保证「`ControlService` 自身发起的变更」会发事件；其它入口

--- a/docs/relay-deployment.md
+++ b/docs/relay-deployment.md
@@ -7,7 +7,7 @@
 ## 安装
 
 - **hub**：`npm i -g @ganglion/xacpx-relay` —— 提供 `xacpx-relay` 二进制；看板（`@ganglion/xacpx-relay-web`，private）已**内嵌在该包内**，随包出厂，无需单独安装/构建。
-- **连接器**（实例机）：`xacpx plugin add @ganglion/xacpx-channel-relay` —— 自动拉取 `@ganglion/xacpx-relay-protocol`；实例核心需 `xacpx ≥ 0.11.0`。
+- **连接器**（实例机）：`xacpx plugin add @ganglion/xacpx-channel-relay` —— 自动拉取 `@ganglion/xacpx-relay-protocol`；实例核心需 `xacpx ≥ 0.17.0-beta.6`（首个支持 model-set deadline 的版本）。
 - 从源码运行见文档站[自托管 Relay Hub](https://gadzan.github.io/xacpx/zh/guide/relay-self-hosting) 的「从源码运行」details；发布流程见 [relay-release.md](relay-release.md)。
 
 ## 快速上手（零参数）

--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -12,7 +12,9 @@
   3. `xacpx channel add relay --url <host> --token <access-token> --name home-pc`（连接器接入；`--url` 支持裸域名/IP[:端口]）
 - RPC 请求超时：`xacpx-relay start --request-timeout-ms <ms>` 限定网关 RPC 请求超时，默认 `120000`
   （共享常量 `DEFAULT_REQUEST_TIMEOUT_MS = 120s`，位于 packages/relay/src/gateway/instance-gateway.ts，
-  网关回退与服务端均复用之）；agent 冷启动慢 / 长 prompt 时可调大。
+  网关回退与服务端均复用之）；agent 冷启动慢 / 长 prompt 时可调大。Hub 会把均已扣除 15 秒
+  响应余量的绝对 work deadline 与相对 work budget 附在下行 request envelope 上，使
+  connector/core 在串行队列出闸时拒绝已来不及安全完成的状态变更；两字段任一缺失即 fail closed。
 - 安全：登录令牌（login token）以 sha256 哈希落盘（高熵随机令牌，无需 scrypt；scrypt 密码哈希已随密码登录一并移除）；所有 token/凭证哈希存储；登录限流按客户端 IP + 全局失败上限（有界，见阶段五）；
   凭证比较定时安全（`hashEquals`，见 src/auth.ts）；RPC 代理只放行
   control.* 且服务端覆写 chatKey(`relay:<accountId>`)/senderId/isOwner。

--- a/docs/relay-release.md
+++ b/docs/relay-release.md
@@ -10,7 +10,7 @@
         ▲                 ▲
         │                 │
 @ganglion/xacpx-relay     @ganglion/xacpx-channel-relay
-  (hub，bin: xacpx-relay；   (连接器；peerDep xacpx >= 0.11.0)
+  (hub，bin: xacpx-relay；   (连接器；peerDep xacpx >= 0.17.0-beta.6)
    已内嵌看板 relay-web)
 
 @ganglion/xacpx           (core；channel-relay 的 peer 依赖，独立发布)
@@ -24,7 +24,7 @@
 
 | 包 | npm | repo | 说明 |
 |---|---|---|---|
-| `@ganglion/xacpx` | 0.10.1 | 0.11.0 | **需先发 0.11.0**（channel-relay 的 peer 前置） |
+| `@ganglion/xacpx` | 用 `npm view` 核对 | 0.17.0-beta.5 | 下次 relay connector 发布前，需先发布含 model-set deadline API 的 0.17.0-beta.6 |
 | `@ganglion/xacpx-relay-protocol` | 未发布 | 0.1.0 | 首发 |
 | `@ganglion/xacpx-relay` | 未发布 | 0.1.0 | 首发（内嵌看板） |
 | `@ganglion/xacpx-channel-relay` | 未发布 | 0.1.0 | 首发 |
@@ -33,8 +33,8 @@
 
 ## 发布顺序
 
-1. **core `@ganglion/xacpx` 0.11.0** —— channel-relay 声明 `peerDependencies.xacpx >= 0.11.0`，
-   用户侧得能装到 0.11.0。
+1. **core `@ganglion/xacpx` 0.17.0-beta.6** —— channel-relay 声明
+   `peerDependencies.xacpx >= 0.17.0-beta.6`，必须先发布含 deadline-aware `setSessionModel` 的 core。
 2. **`@ganglion/xacpx-relay-protocol`** —— relay 和 channel-relay 都依赖它（`^0.1.0`）。
 3. **`@ganglion/xacpx-relay` + `@ganglion/xacpx-channel-relay`** —— 两者都依赖已发布的 protocol。
 
@@ -55,9 +55,9 @@ bun run verify:publish
 `verify:publish` + tag/版本一致性校验 + `npm publish`（用 `secrets.NPM_TOKEN`）+ 发 weacpx-compat shim。
 
 ```bash
-# 确认 root package.json 的 version 是 0.11.0
-git tag v0.11.0
-git push origin v0.11.0
+# 确认 root package.json 的 version 与目标 tag 一致（本轮为 0.17.0-beta.6）
+git tag v0.17.0-beta.6
+git push origin v0.17.0-beta.6
 ```
 
 ## 发布 relay 三包（tag 触发，已有 CI）
@@ -101,7 +101,7 @@ xacpx-relay start
 
 连接器侧：
 ```bash
-npm i -g @ganglion/xacpx@0.11.0        # 或更高
+npm i -g @ganglion/xacpx@0.17.0-beta.6  # 或更高
 xacpx channel add relay --url <host> --token <access-token>
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,7 +4,7 @@
 
 Keep the test directory and execution entry points clear, stable, and maintainable.
 
-Production code goes in `src/`, test code goes in `tests/`; don't scatter test files around the source directories anymore.
+Core production code goes in `src/`, and core tests go in `tests/`; don't scatter test files around source directories. The relay-web package has one explicit Vitest exception documented below.
 
 ## Directory Conventions
 
@@ -41,6 +41,18 @@ These tests should not enter the default `npm test`, to avoid local or CI instab
 Holds test helper functions, fixture builders, and test-only utilities.
 
 For now, if a helper is very small, you can inline it in the test file first; only extract it when reuse becomes obvious.
+
+### `packages/relay-web/src/__tests__/` (package exception)
+
+Relay-web component/store tests live beside that package under `src/__tests__/` because they require
+Vite's Vue transform and the package's jsdom/Vitest setup. Run them with:
+
+```bash
+bun run --cwd packages/relay-web test
+```
+
+The root `npm test` includes this suite through `test:web`. This is the only supported test-under-`src`
+exception; Node/core/package tests continue to live under `tests/unit/`.
 
 ## Default Commands
 
@@ -79,7 +91,7 @@ bun run build
 
 ## Rules When Adding New Tests
 
-1. New tests go in `tests/unit/` by default
+1. New tests go in `tests/unit/` by default; relay-web Vue/jsdom tests use its documented package exception
 2. The directory structure should mirror `src/` as much as possible
 3. Keep test file names as `*.test.ts`
 4. Avoid leaving temporary troubleshooting scripts at the repository root
@@ -96,7 +108,7 @@ Prefer `tests/smoke/` over `tests/unit/` in the following cases:
 
 ## Rules After the Migration
 
-- `src/` holds production code only
+- `src/` holds production code only, except `packages/relay-web/src/__tests__/` as documented above
 - `tests/` holds test code only
 - `scripts/` holds run scripts only, not test bodies
 

--- a/docs/zh/README_zh.md
+++ b/docs/zh/README_zh.md
@@ -181,7 +181,7 @@ xacpx-relay add token        # 仅打印一次 access token
 xacpx-relay start            # 默认：--host 0.0.0.0 --http-port 8787
 
 # 在每个实例主机上：
-xacpx plugin add @ganglion/xacpx-channel-relay   # 需要 xacpx >= 0.11.0
+xacpx plugin add @ganglion/xacpx-channel-relay   # 需要 xacpx >= 0.17.0-beta.6
 xacpx channel add relay --url wss://relay.example.com --token <access-token> --name my-box
 xacpx restart
 ```

--- a/packages/channel-relay/README.md
+++ b/packages/channel-relay/README.md
@@ -3,6 +3,8 @@
 Connector channel plugin: dials out from a local xacpx instance to a
 self-hosted @ganglion/xacpx-relay hub over WebSocket.
 
+Requires xacpx >= 0.17.0-beta.6 (the first deadline-aware control core).
+
 Pairing: `xacpx channel add relay --url ws://<relay-host>:8788 --token <pairing-token>`.
 On first connect the pairing token is exchanged for a long-lived instance
 credential stored at `<xacpx-home>/relay/credential.json` (never in config.json).

--- a/packages/channel-relay/package.json
+++ b/packages/channel-relay/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "xacpx": ">=0.11.0-0"
+    "xacpx": ">=0.17.0-beta.6"
   },
   "peerDependenciesMeta": {
     "xacpx": {

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -67,7 +67,8 @@ export const CONTROL_RPC_TIMEOUT_MS = 60_000;
 //     in duration.
 //   - sessionModelSet: a 30s set timeout can be followed by a 30s authoritative
 //     status read (or two 45s bridge backstops). A 60s connector response timer
-//     would race that reconciliation without cancelling the underlying work.
+//     would race that reconciliation without cancelling the underlying work;
+//     the Hub envelope budget instead prevents stale queued mutations from starting.
 // For all of these the hub's own 120s request timeout is the real backstop.
 const CONNECTOR_TIMEOUT_EXEMPT_TYPES: ReadonlySet<string> = new Set([
   MSG.prompt,
@@ -79,9 +80,10 @@ const CONNECTOR_TIMEOUT_EXEMPT_TYPES: ReadonlySet<string> = new Set([
 
 export interface ControlBridgeOptions {
   timeoutMs?: number;
-  /** Test seams for the dispatch timeout timer. */
+  /** Test seams for the dispatch timeout timer and request-deadline conversion. */
   setTimeoutFn?: (fn: () => void, ms: number) => unknown;
   clearTimeoutFn?: (timer: unknown) => void;
+  now?: () => number;
 }
 
 function controlRpcTimeoutMs(type: string, options: ControlBridgeOptions): number | undefined {
@@ -89,9 +91,27 @@ function controlRpcTimeoutMs(type: string, options: ControlBridgeOptions): numbe
   return options.timeoutMs ?? CONTROL_RPC_TIMEOUT_MS;
 }
 
+function modelSetDeadlineAt(envelope: RelayEnvelope, now: () => number): number | undefined {
+  if (envelope.type !== MSG.sessionModelSet) return undefined;
+  const receivedAt = now();
+  const absolute = envelope.requestDeadlineAt;
+  const budget = envelope.requestBudgetMs;
+  // The pair is intentional: the absolute cutoff preserves the Hub's response
+  // reserve across delivery delay, while the relative budget caps clock skew.
+  // A partial/legacy envelope cannot provide both guarantees, so fail closed.
+  if (
+    typeof absolute !== "number" || !Number.isFinite(absolute) || absolute <= 0
+    || typeof budget !== "number" || !Number.isFinite(budget) || budget <= 0
+  ) {
+    return receivedAt;
+  }
+  return Math.min(absolute, receivedAt + budget);
+}
+
 export function createControlBridge(control: ControlService, options: ControlBridgeOptions = {}): ControlBridge {
   const setTimeoutFn = options.setTimeoutFn ?? ((fn: () => void, ms: number) => setTimeout(fn, ms));
   const clearTimeoutFn = options.clearTimeoutFn ?? ((timer: unknown) => clearTimeout(timer as ReturnType<typeof setTimeout>));
+  const now = options.now ?? Date.now;
   return (envelope, respond) => {
     let settled = false;
     let timer: unknown;
@@ -112,7 +132,8 @@ export function createControlBridge(control: ControlService, options: ControlBri
       }, timeoutMs);
     }
 
-    void dispatchControlRequest(control, envelope)
+    const deadlineAt = modelSetDeadlineAt(envelope, now);
+    void dispatchControlRequest(control, envelope, deadlineAt)
       .then(respondOnce)
       .catch((error: unknown) => {
         respondOnce(errorPayload("internal", error instanceof Error ? error.message : String(error)));
@@ -120,7 +141,11 @@ export function createControlBridge(control: ControlService, options: ControlBri
   };
 }
 
-async function dispatchControlRequest(control: ControlService, envelope: RelayEnvelope): Promise<unknown> {
+async function dispatchControlRequest(
+  control: ControlService,
+  envelope: RelayEnvelope,
+  deadlineAt?: number,
+): Promise<unknown> {
   const payload = envelope.payload;
   switch (envelope.type) {
     case MSG.sessionsList: {
@@ -340,7 +365,9 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
       const input = parseControlPayload(MSG.sessionModelSet, payload);
       if (!input) return errorPayload("invalid-payload", `${MSG.sessionModelSet}: malformed payload`);
       if (!input.sessionAlias || !input.modelId) return errorPayload("bad-request", "sessionAlias and modelId are required");
-      const result = await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId);
+      const result = deadlineAt === undefined
+        ? await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId)
+        : await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId, { deadlineAt });
       return { ok: result.applied, current: result.current ?? null };
     }
     case MSG.terminalCreate: {

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -65,12 +65,16 @@ export const CONTROL_RPC_TIMEOUT_MS = 60_000;
 //     start, reporting failure while the session still gets created.
 //   - commandExecute: runs a slash command / agent command that is prompt-like
 //     in duration.
+//   - sessionModelSet: a 30s set timeout can be followed by a 30s authoritative
+//     status read (or two 45s bridge backstops). A 60s connector response timer
+//     would race that reconciliation without cancelling the underlying work.
 // For all of these the hub's own 120s request timeout is the real backstop.
 const CONNECTOR_TIMEOUT_EXEMPT_TYPES: ReadonlySet<string> = new Set([
   MSG.prompt,
   MSG.sessionsCreate,
   MSG.sessionsNativeList,
   MSG.commandExecute,
+  MSG.sessionModelSet,
 ]);
 
 export interface ControlBridgeOptions {

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -336,8 +336,8 @@ async function dispatchControlRequest(control: ControlService, envelope: RelayEn
       const input = parseControlPayload(MSG.sessionModelSet, payload);
       if (!input) return errorPayload("invalid-payload", `${MSG.sessionModelSet}: malformed payload`);
       if (!input.sessionAlias || !input.modelId) return errorPayload("bad-request", "sessionAlias and modelId are required");
-      await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId);
-      return { ok: true };
+      const result = await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId);
+      return { ok: result.applied, current: result.current ?? null };
     }
     case MSG.terminalCreate: {
       const input = parseControlPayload(MSG.terminalCreate, payload);

--- a/packages/channel-relay/src/index.ts
+++ b/packages/channel-relay/src/index.ts
@@ -9,7 +9,7 @@ export { relayCliProvider } from "./relay-provider.js";
 const plugin: XacpxPlugin = {
   apiVersion: 1,
   name: "@ganglion/xacpx-channel-relay",
-  minXacpxVersion: "0.11.0",
+  minXacpxVersion: "0.17.0-beta.6",
   channels: [
     {
       type: "relay",

--- a/packages/relay-protocol/dist/envelope.d.ts
+++ b/packages/relay-protocol/dist/envelope.d.ts
@@ -8,6 +8,10 @@ export interface RelayEnvelope {
     /** Namespaced message type, e.g. "instance.sessions.list". */
     type: string;
     payload?: unknown;
+    /** Hub wall-clock deadline (epoch ms) for this request. */
+    requestDeadlineAt?: number;
+    /** Conservative connector work budget, excluding Hub response headroom. */
+    requestBudgetMs?: number;
 }
 export type DecodeEnvelopeResult = {
     ok: true;

--- a/packages/relay-protocol/dist/index.js
+++ b/packages/relay-protocol/dist/index.js
@@ -35,6 +35,10 @@ function isEnvelopeShape(value) {
     return false;
   if (candidate.id !== undefined && typeof candidate.id !== "string")
     return false;
+  if (candidate.requestDeadlineAt !== undefined && (typeof candidate.requestDeadlineAt !== "number" || !Number.isFinite(candidate.requestDeadlineAt) || candidate.requestDeadlineAt <= 0))
+    return false;
+  if (candidate.requestBudgetMs !== undefined && (typeof candidate.requestBudgetMs !== "number" || !Number.isFinite(candidate.requestBudgetMs) || candidate.requestBudgetMs <= 0))
+    return false;
   if ((candidate.kind === "req" || candidate.kind === "res") && (typeof candidate.id !== "string" || candidate.id.length === 0))
     return false;
   return true;

--- a/packages/relay-protocol/dist/messages.d.ts
+++ b/packages/relay-protocol/dist/messages.d.ts
@@ -418,6 +418,12 @@ export interface SessionModelSetPayload {
     sessionAlias: string;
     modelId: string;
 }
+export interface SessionModelSetResult {
+    /** Whether the requested model was observed after the operation settled. */
+    ok: boolean;
+    /** Authoritative transport model after timeout reconciliation, if known. */
+    current?: string | null;
+}
 export interface SessionModelResult {
     /** The session's current model id, if known. */
     current?: string;

--- a/packages/relay-protocol/src/envelope.ts
+++ b/packages/relay-protocol/src/envelope.ts
@@ -10,6 +10,10 @@ export interface RelayEnvelope {
   /** Namespaced message type, e.g. "instance.sessions.list". */
   type: string;
   payload?: unknown;
+  /** Hub wall-clock deadline (epoch ms) for this request. */
+  requestDeadlineAt?: number;
+  /** Conservative connector work budget, excluding Hub response headroom. */
+  requestBudgetMs?: number;
 }
 
 export type DecodeEnvelopeResult =
@@ -49,6 +53,22 @@ function isEnvelopeShape(value: unknown): value is RelayEnvelope {
   if (candidate.kind !== "req" && candidate.kind !== "res" && candidate.kind !== "event") return false;
   if (typeof candidate.type !== "string" || candidate.type.trim().length === 0) return false;
   if (candidate.id !== undefined && typeof candidate.id !== "string") return false;
+  if (
+    candidate.requestDeadlineAt !== undefined
+    && (
+      typeof candidate.requestDeadlineAt !== "number"
+      || !Number.isFinite(candidate.requestDeadlineAt)
+      || candidate.requestDeadlineAt <= 0
+    )
+  ) return false;
+  if (
+    candidate.requestBudgetMs !== undefined
+    && (
+      typeof candidate.requestBudgetMs !== "number"
+      || !Number.isFinite(candidate.requestBudgetMs)
+      || candidate.requestBudgetMs <= 0
+    )
+  ) return false;
   if (
     (candidate.kind === "req" || candidate.kind === "res") &&
     (typeof candidate.id !== "string" || candidate.id.length === 0)

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -442,6 +442,13 @@ export interface SessionModelSetPayload {
   modelId: string;
 }
 
+export interface SessionModelSetResult {
+  /** Whether the requested model was observed after the operation settled. */
+  ok: boolean;
+  /** Authoritative transport model after timeout reconciliation, if known. */
+  current?: string | null;
+}
+
 export interface SessionModelResult {
   /** The session's current model id, if known. */
   current?: string;

--- a/packages/relay-web/src/__tests__/promptinput-model.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput-model.test.ts
@@ -9,12 +9,14 @@ vi.mock("../api/client", () => ({
 }));
 
 import PromptInput from "../components/PromptInput.vue";
+import { dismissToast, useToasts } from "../lib/use-toasts";
 
 let pinia: ReturnType<typeof createPinia>;
 beforeEach(() => {
   pinia = createPinia();
   setActivePinia(pinia);
   rpc.mockReset();
+  for (const toast of [...useToasts().value]) dismissToast(toast.id);
 });
 
 function flush() {
@@ -48,4 +50,20 @@ it("renders the model chip with the current model and lets you switch", async ()
 it("hides the chip when there is no session", () => {
   const w = mount(PromptInput, { props: {}, global: { plugins: [pinia] } });
   expect(w.find('[data-test="model-chip"]').exists()).toBe(false);
+});
+
+it("shows a model-switch failure through the global toast instead of beside the chip", async () => {
+  rpc.mockResolvedValueOnce({ current: "gpt-5.2[high]", available: ["gpt-5.2[high]", "gpt-5.2[low]"] });
+  const w = mount(PromptInput, { props: { instanceId: "i1", sessionAlias: "backend" }, global: { plugins: [pinia] } });
+  await flush();
+  await w.get('[data-test="model-chip"]').trigger("click");
+
+  rpc.mockResolvedValueOnce({ error: { code: "internal", message: "acpx command timed out during set-model after 30s" } });
+  const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  await w.findAll('[data-test="model-option"]')[1].trigger("click");
+  await flush();
+
+  expect(w.find('[data-test="model-error"]').exists()).toBe(false);
+  expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.modelSetFailed" });
+  log.mockRestore();
 });

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -147,6 +147,29 @@ describe("session-controls store", () => {
     expect(s.current).toBe("model-c");
   });
 
+  it("returns to the last authoritative model when two rapid selections both fail", async () => {
+    rpc.mockResolvedValueOnce({ current: "model-a", available: ["model-a", "model-b", "model-c"] });
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "backend");
+
+    let resolveB!: (value: unknown) => void;
+    let resolveC!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveB = resolve; }));
+    const pendingB = s.setModel("i1", "backend", "model-b");
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveC = resolve; }));
+    const pendingC = s.setModel("i1", "backend", "model-c");
+
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    resolveB({ error: { code: "internal", message: "model-b failed" } });
+    await pendingB;
+    resolveC({ error: { code: "internal", message: "model-c failed" } });
+    await pendingC;
+
+    expect(s.current).toBe("model-a");
+    expect(useToasts().value).toHaveLength(1);
+    log.mockRestore();
+  });
+
   it("a model selection supersedes a pending load without leaving loading stuck", async () => {
     let resolveLoad!: (value: unknown) => void;
     rpc.mockReturnValueOnce(new Promise((resolve) => { resolveLoad = resolve; }));

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -8,8 +8,13 @@ vi.mock("../api/client", () => ({
 }));
 
 import { useSessionControlsStore } from "../stores/session-controls";
+import { dismissToast, useToasts } from "../lib/use-toasts";
 
-beforeEach(() => { setActivePinia(createPinia()); rpc.mockReset(); });
+beforeEach(() => {
+  setActivePinia(createPinia());
+  rpc.mockReset();
+  for (const toast of [...useToasts().value]) dismissToast(toast.id);
+});
 
 describe("session-controls store", () => {
   it("loadModel fetches current + available (sending only sessionAlias)", async () => {
@@ -51,15 +56,39 @@ describe("session-controls store", () => {
     expect(s.current).toBe("claude-opus-4-8");
   });
 
-  it("setModel reverts current on an instance-side error payload", async () => {
+  it("setModel reverts current and reports a concise global toast on an instance-side error", async () => {
     rpc.mockResolvedValueOnce({ current: "gpt-5.2[high]", available: ["gpt-5.2[high]"] });
     const s = useSessionControlsStore();
     await s.loadModel("i1", "backend");
     expect(s.current).toBe("gpt-5.2[high]");
-    rpc.mockResolvedValueOnce({ error: { code: "internal", message: "requested model unsupported" } });
+    const detail = "acpx command timed out during set-model after 30s; stderr tail: adapter stalled";
+    rpc.mockResolvedValueOnce({ error: { code: "internal", message: detail } });
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const ok = await s.setModel("i1", "backend", "bogus");
     expect(ok).toBe(false);
-    expect(s.error).toContain("unsupported");
     expect(s.current).toBe("gpt-5.2[high]"); // reverted, not left on "bogus"
+    expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.modelSetFailed" });
+    expect(useToasts().value[0]?.params).toBeUndefined();
+    expect(log).toHaveBeenCalledWith("[relay-web] model switch failed", detail);
+    log.mockRestore();
+  });
+
+  it("setModel adopts the authoritative model returned by timeout reconciliation", async () => {
+    rpc.mockResolvedValueOnce({ current: "gpt-5.2[high]", available: ["gpt-5.2[high]"] });
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "backend");
+    rpc.mockResolvedValueOnce({ ok: false, current: "provider/fallback-model" });
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const ok = await s.setModel("i1", "backend", "claude-opus-4-8");
+
+    expect(ok).toBe(false);
+    expect(s.current).toBe("provider/fallback-model");
+    expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.modelSetFailed" });
+    expect(log).toHaveBeenCalledWith(
+      "[relay-web] model switch failed",
+      "requested claude-opus-4-8; authoritative model is provider/fallback-model",
+    );
+    log.mockRestore();
   });
 });

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -43,6 +43,23 @@ describe("session-controls store", () => {
     expect(s.available).toEqual([]);
   });
 
+  it("clears the previous session model while a new session is loading", async () => {
+    rpc.mockResolvedValueOnce({ current: "model-a", available: ["model-a"] });
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "session-a");
+
+    let resolveLoad!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveLoad = resolve; }));
+    const pendingLoad = s.loadModel("i1", "session-b");
+
+    expect(s.current).toBeUndefined();
+    expect(s.available).toEqual([]);
+    expect(s.loading).toBe(true);
+    resolveLoad({ current: "model-b", available: ["model-b"] });
+    await pendingLoad;
+    expect(s.current).toBe("model-b");
+  });
+
   it("setModel updates current optimistically before the RPC resolves", async () => {
     let resolveRpc!: (v: unknown) => void;
     rpc.mockReturnValueOnce(new Promise((r) => { resolveRpc = r; }));
@@ -90,5 +107,112 @@ describe("session-controls store", () => {
       "requested claude-opus-4-8; authoritative model is provider/fallback-model",
     );
     log.mockRestore();
+  });
+
+  it("ignores a model-set response that arrives after switching sessions", async () => {
+    rpc.mockResolvedValueOnce({ current: "model-a", available: ["model-a", "model-b"] });
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "session-a");
+
+    let resolveSet!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveSet = resolve; }));
+    const pendingSet = s.setModel("i1", "session-a", "model-b");
+
+    rpc.mockResolvedValueOnce({ current: "model-x", available: ["model-x"] });
+    await s.loadModel("i1", "session-b");
+    expect(s.current).toBe("model-x");
+
+    resolveSet({ ok: true, current: "model-b" });
+    await pendingSet;
+    expect(s.current).toBe("model-x");
+  });
+
+  it("keeps the latest selection when model-set responses arrive out of order", async () => {
+    rpc.mockResolvedValueOnce({ current: "model-a", available: ["model-a", "model-b", "model-c"] });
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "backend");
+
+    let resolveB!: (value: unknown) => void;
+    let resolveC!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveB = resolve; }));
+    const pendingB = s.setModel("i1", "backend", "model-b");
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveC = resolve; }));
+    const pendingC = s.setModel("i1", "backend", "model-c");
+
+    resolveC({ ok: true, current: "model-c" });
+    await pendingC;
+    resolveB({ ok: true, current: "model-b" });
+    await pendingB;
+
+    expect(s.current).toBe("model-c");
+  });
+
+  it("a model selection supersedes a pending load without leaving loading stuck", async () => {
+    let resolveLoad!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveLoad = resolve; }));
+    const s = useSessionControlsStore();
+    const pendingLoad = s.loadModel("i1", "backend");
+    expect(s.loading).toBe(true);
+
+    rpc.mockResolvedValueOnce({ ok: true, current: "model-b" });
+    await s.setModel("i1", "backend", "model-b");
+    expect(s.loading).toBe(false);
+
+    resolveLoad({ current: "model-a", available: ["model-a"] });
+    await pendingLoad;
+    expect(s.current).toBe("model-b");
+  });
+
+  it("does not toast a stale model-set failure from the previous session", async () => {
+    rpc.mockResolvedValueOnce({ current: "model-a", available: ["model-a", "model-b"] });
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "session-a");
+
+    let resolveSet!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveSet = resolve; }));
+    const pendingSet = s.setModel("i1", "session-a", "model-b");
+    rpc.mockResolvedValueOnce({ current: "model-x", available: ["model-x"] });
+    await s.loadModel("i1", "session-b");
+
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    resolveSet({ error: { code: "internal", message: "late failure" } });
+    await pendingSet;
+
+    expect(s.current).toBe("model-x");
+    expect(useToasts().value).toEqual([]);
+    expect(log).not.toHaveBeenCalled();
+    log.mockRestore();
+  });
+
+  it("reloads a session only after its pending model selection settles", async () => {
+    rpc.mockResolvedValueOnce({ current: "model-a", available: ["model-a", "model-b"] });
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "session-a");
+
+    let modelApplied = false;
+    let settleSet!: () => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => {
+      settleSet = () => {
+        modelApplied = true;
+        resolve({ ok: true, current: "model-b" });
+      };
+    }));
+    const pendingSet = s.setModel("i1", "session-a", "model-b");
+
+    rpc.mockResolvedValueOnce({ current: "model-x", available: ["model-x"] });
+    await s.loadModel("i1", "session-b");
+    rpc.mockImplementationOnce(async () => ({
+      current: modelApplied ? "model-b" : "model-a",
+      available: ["model-a", "model-b"],
+    }));
+    const pendingReload = s.loadModel("i1", "session-a");
+
+    // The set finishes while session A is active again. Its reload must not have
+    // queried the pre-set value and then discarded the authoritative set reply.
+    settleSet();
+    await pendingSet;
+    await pendingReload;
+
+    expect(s.current).toBe("model-b");
   });
 });

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -279,7 +279,6 @@ function onInput() {
               </button>
             </li>
           </ul>
-          <span v-if="controls.error" data-test="model-error" class="text-xs text-danger">{{ controls.error }}</span>
           <!-- context-usage meter: click to open the cost / token-breakdown popover -->
           <button v-if="context" type="button" data-test="context-meter"
                   class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded pl-0.5 hover:opacity-80"

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -77,6 +77,7 @@ export default {
     stop: "Stop",
     send: "Send",
     model: "model",
+    modelSetFailed: "Failed to switch model. Try again.",
     working: "Agent is working… (Esc to stop)",
     message: "Message",
     mermaidError: "Diagram failed to render",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -75,6 +75,7 @@ export default {
     stop: "停止",
     send: "发送",
     model: "模型",
+    modelSetFailed: "切换模型失败，请重试。",
     working: "Agent 正在工作…（按 Esc 停止）",
     message: "消息",
     mermaidError: "图表渲染失败",

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -17,10 +17,21 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   let activeContext: string | null = null;
   let requestRevision = 0;
   const pendingModelSets = new Map<string, Promise<void>>();
+  const authoritativeModels = new Map<string, { revision: number; current: string | undefined }>();
 
   const contextKey = (instanceId: string, alias: string): string => `${instanceId}\u0000${alias}`;
   const isCurrentRequest = (context: string, revision: number): boolean =>
     activeContext === context && requestRevision === revision;
+  function recordAuthoritativeModel(context: string, revision: number, model: string | undefined): void {
+    const existing = authoritativeModels.get(context);
+    if (!existing || revision >= existing.revision) {
+      authoritativeModels.set(context, { revision, current: model });
+    }
+  }
+  function rollbackModel(context: string, fallback: string | undefined): string | undefined {
+    const authoritative = authoritativeModels.get(context);
+    return authoritative ? authoritative.current : fallback;
+  }
 
   function clearModelState(): void {
     current.value = undefined;
@@ -55,6 +66,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
       if (!isCurrentRequest(context, revision)) return;
       if (isErrorPayload(r)) { clearModelState(); return; }
       current.value = typeof r.current === "string" ? r.current : undefined;
+      recordAuthoritativeModel(context, revision, current.value);
       // Never trust the wire to hand back an array — a malformed/partial result must
       // not blow up the composer's `available.length` reads (white-screens the input).
       available.value = Array.isArray(r.available) ? r.available : [];
@@ -83,30 +95,35 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
         const r = await api.rpc<SessionModelSetResult>(instanceId, "control.session.model.set", { sessionAlias: alias, modelId: id });
         if (isErrorPayload(r)) {
           if (isCurrentRequest(context, revision)) {
-            current.value = prev;
+            current.value = rollbackModel(context, prev);
             reportModelSwitchFailure(r.error.message);
           }
           return false;
         }
         if (r.ok === false) {
+          const observed = r.current === null
+            ? undefined
+            : typeof r.current === "string" ? r.current : rollbackModel(context, prev);
+          recordAuthoritativeModel(context, revision, observed);
           if (isCurrentRequest(context, revision)) {
-            current.value = r.current === null
-              ? undefined
-              : typeof r.current === "string" ? r.current : prev;
+            current.value = observed;
             reportModelSwitchFailure(
               `requested ${id}; authoritative model is ${r.current ?? "unknown"}`,
             );
           }
           return false;
         }
+        const observed = r.current === null
+          ? undefined
+          : typeof r.current === "string" ? r.current : id;
+        recordAuthoritativeModel(context, revision, observed);
         if (isCurrentRequest(context, revision)) {
-          if (r.current === null) current.value = undefined;
-          else if (typeof r.current === "string") current.value = r.current;
+          current.value = observed;
         }
         return true;
       } catch (e) {
         if (isCurrentRequest(context, revision)) {
-          current.value = prev;
+          current.value = rollbackModel(context, prev);
           reportModelSwitchFailure(e instanceof Error ? e.message : "set-failed");
         }
         return false;

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -14,26 +14,54 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   const current = ref<string | undefined>(undefined);
   const available = ref<string[]>([]);
   const loading = ref(false);
+  let activeContext: string | null = null;
+  let requestRevision = 0;
+  const pendingModelSets = new Map<string, Promise<void>>();
 
-  function reset(): void {
+  const contextKey = (instanceId: string, alias: string): string => `${instanceId}\u0000${alias}`;
+  const isCurrentRequest = (context: string, revision: number): boolean =>
+    activeContext === context && requestRevision === revision;
+
+  function clearModelState(): void {
     current.value = undefined;
     available.value = [];
   }
 
+  function reset(): void {
+    activeContext = null;
+    requestRevision += 1;
+    loading.value = false;
+    clearModelState();
+  }
+
   async function loadModel(instanceId: string | null, alias: string | null): Promise<void> {
     if (!instanceId || !alias) { reset(); return; }
+    const context = contextKey(instanceId, alias);
+    if (activeContext !== context) clearModelState();
+    activeContext = context;
+    const revision = ++requestRevision;
     loading.value = true;
     try {
+      // A remount/session round-trip can request a fresh read while an earlier
+      // selection for this same session is still being reconciled. Read only
+      // after the latest mutation settles, otherwise the load can publish the
+      // pre-mutation model and make the later set response look stale.
+      const pendingSet = pendingModelSets.get(context);
+      if (pendingSet) {
+        await pendingSet;
+        if (!isCurrentRequest(context, revision)) return;
+      }
       const r = await api.rpc<SessionModelResult>(instanceId, "control.session.model.get", { sessionAlias: alias });
-      if (isErrorPayload(r)) { reset(); return; }
+      if (!isCurrentRequest(context, revision)) return;
+      if (isErrorPayload(r)) { clearModelState(); return; }
       current.value = typeof r.current === "string" ? r.current : undefined;
       // Never trust the wire to hand back an array — a malformed/partial result must
       // not blow up the composer's `available.length` reads (white-screens the input).
       available.value = Array.isArray(r.available) ? r.available : [];
     } catch {
-      reset();
+      if (isCurrentRequest(context, revision)) clearModelState();
     } finally {
-      loading.value = false;
+      if (isCurrentRequest(context, revision)) loading.value = false;
     }
   }
 
@@ -41,31 +69,57 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     // Reflect the choice in the chip immediately. The backend `set` spawns acpx and can
     // take a second or two (or time out), so updating only AFTER the RPC left the chip
     // showing the old model until the next session switch. Revert if the switch fails.
+    const context = contextKey(instanceId, alias);
+    if (activeContext !== context) clearModelState();
+    activeContext = context;
     const prev = current.value;
+    const revision = ++requestRevision;
+    // This mutation supersedes any in-flight model load for the same UI store.
+    // Its stale finally block is intentionally ignored, so clear the spinner now.
+    loading.value = false;
     current.value = id;
+    const operation = (async (): Promise<boolean> => {
+      try {
+        const r = await api.rpc<SessionModelSetResult>(instanceId, "control.session.model.set", { sessionAlias: alias, modelId: id });
+        if (isErrorPayload(r)) {
+          if (isCurrentRequest(context, revision)) {
+            current.value = prev;
+            reportModelSwitchFailure(r.error.message);
+          }
+          return false;
+        }
+        if (r.ok === false) {
+          if (isCurrentRequest(context, revision)) {
+            current.value = r.current === null
+              ? undefined
+              : typeof r.current === "string" ? r.current : prev;
+            reportModelSwitchFailure(
+              `requested ${id}; authoritative model is ${r.current ?? "unknown"}`,
+            );
+          }
+          return false;
+        }
+        if (isCurrentRequest(context, revision)) {
+          if (r.current === null) current.value = undefined;
+          else if (typeof r.current === "string") current.value = r.current;
+        }
+        return true;
+      } catch (e) {
+        if (isCurrentRequest(context, revision)) {
+          current.value = prev;
+          reportModelSwitchFailure(e instanceof Error ? e.message : "set-failed");
+        }
+        return false;
+      }
+    })();
+    const settled = operation.then(() => undefined, () => undefined);
+    pendingModelSets.set(context, settled);
     try {
-      const r = await api.rpc<SessionModelSetResult>(instanceId, "control.session.model.set", { sessionAlias: alias, modelId: id });
-      if (isErrorPayload(r)) {
-        current.value = prev;
-        reportModelSwitchFailure(r.error.message);
-        return false;
+      return await operation;
+    } finally {
+      if (pendingModelSets.get(context) === settled) {
+        pendingModelSets.delete(context);
       }
-      if (r.ok === false) {
-        current.value = r.current === null
-          ? undefined
-          : typeof r.current === "string" ? r.current : prev;
-        reportModelSwitchFailure(
-          `requested ${id}; authoritative model is ${r.current ?? "unknown"}`,
-        );
-        return false;
-      }
-      if (r.current === null) current.value = undefined;
-      else if (typeof r.current === "string") current.value = r.current;
-      return true;
-    } catch (e) {
-      current.value = prev;
-      reportModelSwitchFailure(e instanceof Error ? e.message : "set-failed");
-      return false;
     }
   }
 

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -1,7 +1,12 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import { isErrorPayload, type SessionModelResult } from "@ganglion/xacpx-relay-protocol";
+import {
+  isErrorPayload,
+  type SessionModelResult,
+  type SessionModelSetResult,
+} from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
+import { pushToast } from "../lib/use-toasts";
 
 /** Per-session model controls for the composer chip. The hub stamps chatKey for
  *  these chat-scoped RPCs, so the web only sends sessionAlias. */
@@ -9,18 +14,15 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   const current = ref<string | undefined>(undefined);
   const available = ref<string[]>([]);
   const loading = ref(false);
-  const error = ref("");
 
   function reset(): void {
     current.value = undefined;
     available.value = [];
-    error.value = "";
   }
 
   async function loadModel(instanceId: string | null, alias: string | null): Promise<void> {
     if (!instanceId || !alias) { reset(); return; }
     loading.value = true;
-    error.value = "";
     try {
       const r = await api.rpc<SessionModelResult>(instanceId, "control.session.model.get", { sessionAlias: alias });
       if (isErrorPayload(r)) { reset(); return; }
@@ -36,22 +38,43 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   }
 
   async function setModel(instanceId: string, alias: string, id: string): Promise<boolean> {
-    error.value = "";
     // Reflect the choice in the chip immediately. The backend `set` spawns acpx and can
     // take a second or two (or time out), so updating only AFTER the RPC left the chip
     // showing the old model until the next session switch. Revert if the switch fails.
     const prev = current.value;
     current.value = id;
     try {
-      const r = await api.rpc<{ ok?: boolean }>(instanceId, "control.session.model.set", { sessionAlias: alias, modelId: id });
-      if (isErrorPayload(r)) { current.value = prev; error.value = r.error.message; return false; }
+      const r = await api.rpc<SessionModelSetResult>(instanceId, "control.session.model.set", { sessionAlias: alias, modelId: id });
+      if (isErrorPayload(r)) {
+        current.value = prev;
+        reportModelSwitchFailure(r.error.message);
+        return false;
+      }
+      if (r.ok === false) {
+        current.value = r.current === null
+          ? undefined
+          : typeof r.current === "string" ? r.current : prev;
+        reportModelSwitchFailure(
+          `requested ${id}; authoritative model is ${r.current ?? "unknown"}`,
+        );
+        return false;
+      }
+      if (r.current === null) current.value = undefined;
+      else if (typeof r.current === "string") current.value = r.current;
       return true;
     } catch (e) {
       current.value = prev;
-      error.value = e instanceof Error ? e.message : "set-failed";
+      reportModelSwitchFailure(e instanceof Error ? e.message : "set-failed");
       return false;
     }
   }
 
-  return { current, available, loading, error, reset, loadModel, setModel };
+  return { current, available, loading, reset, loadModel, setModel };
 });
+
+function reportModelSwitchFailure(detail: string): void {
+  // Keep command lines and captured output out of the compact composer UI. They remain
+  // available in browser diagnostics while the user sees the app's standard toast.
+  console.error("[relay-web] model switch failed", detail);
+  pushToast("error", "chat.modelSetFailed");
+}

--- a/packages/relay/src/gateway/instance-gateway.ts
+++ b/packages/relay/src/gateway/instance-gateway.ts
@@ -16,6 +16,7 @@ import { startHeartbeat } from "./heartbeat.js";
 
 /** Single authoritative default for the gateway RPC timeout, shared by the server layer. */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+export const REQUEST_RESPONSE_RESERVE_MS = 15_000;
 
 export interface GatewaySocket {
   send(data: string): void;
@@ -220,6 +221,10 @@ export class InstanceGateway {
     }
     const id = `relay-${++this.seq}`;
     const timeoutMs = this.deps.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    const requestBudgetMs = Math.max(timeoutMs - REQUEST_RESPONSE_RESERVE_MS, 1);
+    // This is the mutation work cutoff, not the Hub response timer. Keeping the
+    // reserve in both representations prevents delivery latency from consuming it.
+    const requestDeadlineAt = Date.now() + requestBudgetMs;
     return await new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
@@ -227,7 +232,13 @@ export class InstanceGateway {
       }, timeoutMs);
       this.pending.set(id, { resolve, reject, timer, instanceId });
       connection.socket.send(encodeEnvelope({
-        protocolVersion: RELAY_PROTOCOL_VERSION, kind: "req", id, type, payload,
+        protocolVersion: RELAY_PROTOCOL_VERSION,
+        kind: "req",
+        id,
+        type,
+        payload,
+        requestDeadlineAt,
+        requestBudgetMs,
       }));
     });
   }

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -18,9 +18,12 @@ import { runAgentSessionList } from "../transport/agent-session-list";
 import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../transport/codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../transport/acpx-session-files";
 import {
+  CommandTimeoutError,
   DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
   DEFAULT_SESSION_INIT_TIMEOUT_MS,
+  type AcpxCommandStage,
 } from "../transport/command-timeouts";
+export { CommandTimeoutError } from "../transport/command-timeouts";
 import type {
   EnsureSessionProgress,
   MissingOptionalDepErrorData,
@@ -66,17 +69,12 @@ interface CommandResult {
   stderr: string;
 }
 
-export class CommandTimeoutError extends Error {
-  constructor(readonly timeoutMs: number, command: string) {
-    super(`acpx command timed out after ${timeoutMs / 1000}s: ${command}`);
-    this.name = "CommandTimeoutError";
-  }
-}
-
 export interface CommandRunnerOptions {
   onStderrLine?: (line: string) => void;
   /** Kill the spawned process tree and reject with CommandTimeoutError when it runs longer than this. */
   timeoutMs?: number;
+  /** Stable operation name included in timeout diagnostics. */
+  stage?: AcpxCommandStage;
 }
 type CommandRunner = (command: string, args: string[], options?: CommandRunnerOptions) => Promise<CommandResult>;
 type SessionCreateRunner = (command: string, args: string[], cwd: string, options?: CommandRunnerOptions) => Promise<CommandResult>;
@@ -262,6 +260,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "has-session",
     });
 
     return { exists: result.code === 0 };
@@ -290,6 +289,7 @@ export class BridgeRuntime {
       const spawnSpec = resolveSpawnCommand(this.command, this.buildSessionArgs(input, tailArgs));
       const result = await this.run(spawnSpec.command, spawnSpec.args, {
         timeoutMs: Math.max(deadline - Date.now(), 1),
+        stage: "session-history",
       });
       if (result.code === 0) {
         return { text: result.stdout.trimEnd() };
@@ -534,6 +534,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "read-session-record",
     });
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "sessions show failed");
@@ -568,6 +569,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "set-mode",
     });
 
     if (result.code !== 0) {
@@ -594,6 +596,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "set-model",
     });
 
     if (result.code !== 0) {
@@ -616,6 +619,7 @@ export class BridgeRuntime {
     ], { format: "json" }));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "get-session-model",
     });
 
     if (result.code !== 0) {
@@ -646,6 +650,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "cancel",
     });
 
     if (result.code !== 0) {
@@ -671,6 +676,7 @@ export class BridgeRuntime {
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, {
       timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "remove-session",
     });
 
     if (result.code === 0) {
@@ -812,7 +818,11 @@ export function spawnCapture(
             const kill = options.killProcessTreeFn
               ?? ((pid: number) => terminateProcessTree(pid, { detachedProcessGroup: false }));
             void kill(child.pid ?? 0);
-            reject(new CommandTimeoutError(options.timeoutMs!, [command, ...args].join(" ")));
+            reject(new CommandTimeoutError(options.timeoutMs!, [command, ...args].join(" "), {
+              stage: options.stage,
+              stdout,
+              stderr,
+            }));
           }, options.timeoutMs)
         : undefined;
 

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -274,6 +274,7 @@ export class BridgeRuntime {
     lines: number;
   }): Promise<{ text: string }> {
     const candidates = [
+      ["sessions", "history", input.name, "--limit", String(input.lines)],
       ["sessions", "history", "quiet", "-s", input.name, String(input.lines)],
       ["sessions", "history", "quiet", input.name, String(input.lines)],
       ["sessions", "history", "-s", input.name, "--tail", String(input.lines)],

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -13,7 +13,7 @@ import {
 import { PromptCommandError } from "../transport/prompt-output";
 import type { PromptMedia, PromptMediaInput } from "../transport/types";
 import { BridgeRequestScheduler, type BridgeRequestLane } from "./bridge-request-scheduler";
-import { BridgeRuntime, EnsureSessionFailedError } from "./bridge-runtime";
+import { BridgeRuntime, CommandTimeoutError, EnsureSessionFailedError } from "./bridge-runtime";
 
 interface BridgeRequest {
   id: string;
@@ -85,6 +85,17 @@ export class BridgeServer {
       const promptDetails = error instanceof PromptCommandError
         ? { details: { exitCode: error.exitCode, stdout: error.stdout, stderr: error.stderr } }
         : {};
+      const timeoutDetails = error instanceof CommandTimeoutError
+        ? {
+            timeout: {
+              timeoutMs: error.timeoutMs,
+              command: error.command,
+              ...(error.stage ? { stage: error.stage } : {}),
+              ...(error.stdoutTail ? { stdoutTail: error.stdoutTail } : {}),
+              ...(error.stderrTail ? { stderrTail: error.stderrTail } : {}),
+            },
+          }
+        : {};
       return `${JSON.stringify({
         id: requestId,
         ok: false,
@@ -93,6 +104,7 @@ export class BridgeServer {
           message,
           ...ensureSessionFields,
           ...promptDetails,
+          ...timeoutDetails,
         },
       } satisfies BridgeResponse)}\n`;
     }

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -27,6 +27,8 @@ import type { UploadStore } from "./upload-store.js";
 import { SessionTurnRunner } from "./session-turn-runner";
 import { TurnQueue } from "./turn-queue";
 import { buildControlMetadata, type TurnIdleTimeoutDetail } from "./turn-support";
+import { isCommandTimeoutError } from "../transport/command-timeouts";
+import type { AppLogger } from "../logging/app-logger";
 
 export interface ControlSessionInfo {
   alias: string;
@@ -68,6 +70,7 @@ export interface ControlWorkspaceInfo {
 }
 
 export interface ControlServiceDeps {
+  logger?: Pick<AppLogger, "error">;
   agent: Pick<ChatAgent, "chat">;
   sessions: Pick<
     SessionService,
@@ -267,12 +270,47 @@ export class ControlService {
   }
 
   /** Switch a session's model (acpx validates the id) and persist the override. */
-  async setSessionModel(chatKey: string, alias: string, modelId: string): Promise<void> {
+  async setSessionModel(
+    chatKey: string,
+    alias: string,
+    modelId: string,
+  ): Promise<{ current?: string; applied: boolean }> {
     const session = await this.resolveControlSession(chatKey, alias);
     if (!session) throw new Error("session not found");
     if (!this.deps.transport.setModel) throw new Error("the active transport does not support switching models");
-    await this.deps.transport.setModel(session, modelId);
+    try {
+      await this.deps.transport.setModel(session, modelId);
+    } catch (error) {
+      // A process timeout is ambiguous: acpx may have applied the model before it
+      // stopped responding. Read back the authoritative transport state so the
+      // persisted logical session and relay-web's optimistic chip cannot diverge.
+      if (!isCommandTimeoutError(error) || !this.deps.transport.getSessionModel) throw error;
+      let observed: { current?: string; available: string[] };
+      try {
+        observed = await this.deps.transport.getSessionModel(session);
+      } catch {
+        // Preserve the original timeout; reconciliation is best-effort diagnostics.
+        throw error;
+      }
+      await this.deps.sessions.setSessionModel(session.alias, observed.current);
+      try {
+        await this.deps.logger?.error(
+          "control.session.model.timeout_reconciled",
+          "Model switch timed out; adopted authoritative transport state",
+          {
+            sessionAlias: session.alias,
+            requestedModel: modelId,
+            observedModel: observed.current ?? null,
+            timeout: error instanceof Error ? error.message : String(error),
+          },
+        );
+      } catch {
+        // Logging is diagnostic only; reconciliation already succeeded.
+      }
+      return { current: observed.current, applied: observed.current === modelId };
+    }
     await this.deps.sessions.setSessionModel(session.alias, modelId);
+    return { current: modelId, applied: true };
   }
 
   /** Set (or clear) a session's relay-web display label and persist it. */

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -27,8 +27,21 @@ import type { UploadStore } from "./upload-store.js";
 import { SessionTurnRunner } from "./session-turn-runner";
 import { TurnQueue } from "./turn-queue";
 import { buildControlMetadata, type TurnIdleTimeoutDetail } from "./turn-support";
-import { isCommandTimeoutError } from "../transport/command-timeouts";
+import {
+  BRIDGE_REQUEST_TIMEOUT_GRACE_MS,
+  DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
+  isCommandTimeoutError,
+} from "../transport/command-timeouts";
 import type { AppLogger } from "../logging/app-logger";
+
+const MODEL_SET_SETTLE_BUDGET_MS = 2 * (
+  DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS + BRIDGE_REQUEST_TIMEOUT_GRACE_MS
+);
+
+export interface ModelSetRequestOptions {
+  /** Connector-side deadline derived from the Hub request lifetime. */
+  deadlineAt?: number;
+}
 
 export interface ControlSessionInfo {
   alias: string;
@@ -71,6 +84,8 @@ export interface ControlWorkspaceInfo {
 
 export interface ControlServiceDeps {
   logger?: Pick<AppLogger, "error">;
+  /** Test seam for queue-deadline decisions. */
+  now?: () => number;
   agent: Pick<ChatAgent, "chat">;
   sessions: Pick<
     SessionService,
@@ -275,12 +290,20 @@ export class ControlService {
     chatKey: string,
     alias: string,
     modelId: string,
+    options: ModelSetRequestOptions = {},
   ): Promise<{ current?: string; applied: boolean }> {
     const session = await this.resolveControlSession(chatKey, alias);
     if (!session) throw new Error("session not found");
     const setModel = this.deps.transport.setModel?.bind(this.deps.transport);
     if (!setModel) throw new Error("the active transport does not support switching models");
     return await this.runModelSetExclusive(session.alias, async () => {
+      if (
+        typeof options.deadlineAt === "number"
+        && Number.isFinite(options.deadlineAt)
+        && (this.deps.now?.() ?? Date.now()) + MODEL_SET_SETTLE_BUDGET_MS > options.deadlineAt
+      ) {
+        throw new Error("model switch deadline is too close to safely start the queued operation");
+      }
       try {
         await setModel(session, modelId);
       } catch (error) {

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -179,6 +179,7 @@ export interface ControlExecuteCommandInput {
 export class ControlService {
   private readonly runner: SessionTurnRunner;
   private readonly turnQueue: TurnQueue;
+  private readonly modelSetTails = new Map<string, Promise<void>>();
 
   constructor(private readonly deps: ControlServiceDeps) {
     this.runner = new SessionTurnRunner(deps);
@@ -277,40 +278,62 @@ export class ControlService {
   ): Promise<{ current?: string; applied: boolean }> {
     const session = await this.resolveControlSession(chatKey, alias);
     if (!session) throw new Error("session not found");
-    if (!this.deps.transport.setModel) throw new Error("the active transport does not support switching models");
+    const setModel = this.deps.transport.setModel?.bind(this.deps.transport);
+    if (!setModel) throw new Error("the active transport does not support switching models");
+    return await this.runModelSetExclusive(session.alias, async () => {
+      try {
+        await setModel(session, modelId);
+      } catch (error) {
+        // A process timeout is ambiguous: acpx may have applied the model before it
+        // stopped responding. Read back the authoritative transport state so the
+        // persisted logical session and relay-web's optimistic chip cannot diverge.
+        if (!isCommandTimeoutError(error) || !this.deps.transport.getSessionModel) throw error;
+        let observed: { current?: string; available: string[] };
+        try {
+          observed = await this.deps.transport.getSessionModel(session);
+        } catch {
+          // Preserve the original timeout; reconciliation is best-effort diagnostics.
+          throw error;
+        }
+        await this.deps.sessions.setSessionModel(session.alias, observed.current);
+        try {
+          await this.deps.logger?.error(
+            "control.session.model.timeout_reconciled",
+            "Model switch timed out; adopted authoritative transport state",
+            {
+              sessionAlias: session.alias,
+              requestedModel: modelId,
+              observedModel: observed.current ?? null,
+              timeout: error instanceof Error ? error.message : String(error),
+            },
+          );
+        } catch {
+          // Logging is diagnostic only; reconciliation already succeeded.
+        }
+        return { current: observed.current, applied: observed.current === modelId };
+      }
+      await this.deps.sessions.setSessionModel(session.alias, modelId);
+      return { current: modelId, applied: true };
+    });
+  }
+
+  /** Serialize model mutations per logical session so stale reconciliation cannot win last. */
+  private async runModelSetExclusive<T>(sessionAlias: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.modelSetTails.get(sessionAlias) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const tail = previous.catch(() => {}).then(() => gate);
+    this.modelSetTails.set(sessionAlias, tail);
+
+    await previous.catch(() => {});
     try {
-      await this.deps.transport.setModel(session, modelId);
-    } catch (error) {
-      // A process timeout is ambiguous: acpx may have applied the model before it
-      // stopped responding. Read back the authoritative transport state so the
-      // persisted logical session and relay-web's optimistic chip cannot diverge.
-      if (!isCommandTimeoutError(error) || !this.deps.transport.getSessionModel) throw error;
-      let observed: { current?: string; available: string[] };
-      try {
-        observed = await this.deps.transport.getSessionModel(session);
-      } catch {
-        // Preserve the original timeout; reconciliation is best-effort diagnostics.
-        throw error;
+      return await operation();
+    } finally {
+      release();
+      if (this.modelSetTails.get(sessionAlias) === tail) {
+        this.modelSetTails.delete(sessionAlias);
       }
-      await this.deps.sessions.setSessionModel(session.alias, observed.current);
-      try {
-        await this.deps.logger?.error(
-          "control.session.model.timeout_reconciled",
-          "Model switch timed out; adopted authoritative transport state",
-          {
-            sessionAlias: session.alias,
-            requestedModel: modelId,
-            observedModel: observed.current ?? null,
-            timeout: error instanceof Error ? error.message : String(error),
-          },
-        );
-      } catch {
-        // Logging is diagnostic only; reconciliation already succeeded.
-      }
-      return { current: observed.current, applied: observed.current === modelId };
     }
-    await this.deps.sessions.setSessionModel(session.alias, modelId);
-    return { current: modelId, applied: true };
   }
 
   /** Set (or clear) a session's relay-web display label and persist it. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -797,6 +797,7 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
     60 * 60 * 1000,
   );
   const control = new ControlService({
+    logger,
     agent,
     sessions,
     transport,

--- a/src/plugins/compatibility.ts
+++ b/src/plugins/compatibility.ts
@@ -18,12 +18,16 @@ export const WEACPX_PLUGIN_API_VERSION = XACPX_PLUGIN_API_VERSION;
 export const WEACPX_PLUGIN_API_SUPPORTED_VERSIONS = XACPX_PLUGIN_API_SUPPORTED_VERSIONS;
 export const WEACPX_PLUGIN_MIN_CORE_VERSION = XACPX_PLUGIN_MIN_CORE_VERSION;
 
-const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+type CoreVersion = [number, number, number];
+interface ParsedSemver {
+  core: CoreVersion;
+  prerelease: string[];
+}
 
-// For compatibility checks we treat a prerelease build (e.g. `0.4.0-beta.0`)
-// as its base release (`0.4.0`). Plugins built against the upcoming stable
-// version need to load on its prereleases without authors having to declare
-// every prerelease tag in `minWeacpxVersion`.
+// Stable minimums/ranges retain the historical behavior of treating a running
+// prerelease (e.g. `0.4.0-beta.0`) as its base release (`0.4.0`). An explicitly
+// prerelease minimum bypasses this normalization so beta.6 can reject beta.5.
 export function normalizeCoreVersionForCompat(version: string): string {
   const dashIdx = version.indexOf("-");
   const plusIdx = version.indexOf("+");
@@ -35,22 +39,45 @@ export function normalizeCoreVersionForCompat(version: string): string {
 export function compareSemver(a: string, b: string): -1 | 0 | 1 {
   const lhs = parseSemverStrict(a);
   const rhs = parseSemverStrict(b);
-  for (let i = 0; i < 3; i += 1) {
-    if (lhs[i]! < rhs[i]!) return -1;
-    if (lhs[i]! > rhs[i]!) return 1;
+  const coreOrder = cmpTuple(lhs.core, rhs.core);
+  if (coreOrder !== 0) return coreOrder;
+  return comparePrerelease(lhs.prerelease, rhs.prerelease);
+}
+
+function parseSemverStrict(value: string): ParsedSemver {
+  const match = SEMVER_RE.exec(value);
+  if (!match) throw new Error(`malformed semver: ${value}`);
+  const prerelease = match[4]?.split(".") ?? [];
+  if (prerelease.some((part) => /^\d+$/.test(part) && part.length > 1 && part.startsWith("0"))) {
+    throw new Error(`malformed semver: ${value}`);
+  }
+  return {
+    core: [Number(match[1]!), Number(match[2]!), Number(match[3]!)],
+    prerelease,
+  };
+}
+
+function comparePrerelease(a: string[], b: string[]): -1 | 0 | 1 {
+  if (a.length === 0) return b.length === 0 ? 0 : 1;
+  if (b.length === 0) return -1;
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const lhs = a[i];
+    const rhs = b[i];
+    if (lhs === undefined) return -1;
+    if (rhs === undefined) return 1;
+    if (lhs === rhs) continue;
+    const lhsNumeric = /^\d+$/.test(lhs);
+    const rhsNumeric = /^\d+$/.test(rhs);
+    if (lhsNumeric && rhsNumeric) return Number(lhs) < Number(rhs) ? -1 : 1;
+    if (lhsNumeric !== rhsNumeric) return lhsNumeric ? -1 : 1;
+    return lhs < rhs ? -1 : 1;
   }
   return 0;
 }
 
-function parseSemverStrict(value: string): [number, number, number] {
-  const match = SEMVER_RE.exec(value);
-  if (!match) throw new Error(`malformed semver: ${value}`);
-  return [Number(match[1]!), Number(match[2]!), Number(match[3]!)];
-}
-
 interface ParsedRange {
   kind: "exact" | "gte" | "caret";
-  base: [number, number, number];
+  base: CoreVersion;
   raw: string;
 }
 
@@ -58,20 +85,20 @@ function parseRange(requirement: string): ParsedRange {
   const trimmed = requirement.trim();
   if (!trimmed) throw new Error("empty version requirement");
   if (trimmed.startsWith(">=")) {
-    return { kind: "gte", base: parseSemverStrict(trimmed.slice(2).trim()), raw: trimmed };
+    return { kind: "gte", base: parseCoreVersionStrict(trimmed.slice(2).trim()), raw: trimmed };
   }
   if (trimmed.startsWith("^")) {
-    return { kind: "caret", base: parseSemverStrict(trimmed.slice(1).trim()), raw: trimmed };
+    return { kind: "caret", base: parseCoreVersionStrict(trimmed.slice(1).trim()), raw: trimmed };
   }
   if (trimmed.startsWith(">") || trimmed.startsWith("<") || trimmed.startsWith("~") || trimmed.includes(" ")) {
     throw new Error(`unsupported version requirement: ${requirement}`);
   }
-  return { kind: "exact", base: parseSemverStrict(trimmed), raw: trimmed };
+  return { kind: "exact", base: parseCoreVersionStrict(trimmed), raw: trimmed };
 }
 
 export function isVersionSatisfied(current: string, requirement: string): boolean {
   const range = parseRange(requirement);
-  const cur = parseSemverStrict(current);
+  const cur = parseCoreVersionStrict(current);
   switch (range.kind) {
     case "exact":
       return cur[0] === range.base[0] && cur[1] === range.base[1] && cur[2] === range.base[2];
@@ -89,7 +116,13 @@ export function isVersionSatisfied(current: string, requirement: string): boolea
   }
 }
 
-function cmpTuple(a: [number, number, number], b: [number, number, number]): -1 | 0 | 1 {
+function parseCoreVersionStrict(value: string): CoreVersion {
+  const parsed = parseSemverStrict(value);
+  if (parsed.prerelease.length > 0) throw new Error(`malformed semver: ${value}`);
+  return parsed.core;
+}
+
+function cmpTuple(a: CoreVersion, b: CoreVersion): -1 | 0 | 1 {
   for (let i = 0; i < 3; i += 1) {
     if (a[i]! < b[i]!) return -1;
     if (a[i]! > b[i]!) return 1;
@@ -147,7 +180,8 @@ export function validatePluginCompatibility(
     }
     let satisfied: boolean;
     try {
-      satisfied = compareSemver(normalizedCurrent, minVersion) >= 0;
+      const minIsPrerelease = parseSemverStrict(minVersion).prerelease.length > 0;
+      satisfied = compareSemver(minIsPrerelease ? currentXacpxVersion : normalizedCurrent, minVersion) >= 0;
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       throw new Error(t().pluginCli.compatInvalidMinVersionDetail(packageName, minVersionField, detail));

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -18,6 +18,7 @@ import { getLocale } from "../../i18n";
 import { resolveDefaultXacpxCommand } from "../acpx-queue-owner-launcher";
 import {
   BRIDGE_REQUEST_TIMEOUT_GRACE_MS,
+  CommandTimeoutError,
   DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
   DEFAULT_SESSION_INIT_TIMEOUT_MS,
 } from "../command-timeouts";
@@ -148,7 +149,9 @@ export class AcpxBridgeClient {
       if (timeoutMs !== undefined) {
         timer = setTimeoutFn(() => {
           if (this.pending.delete(id)) {
-            reject(new Error(`bridge request "${method}" timed out after ${timeoutMs}ms`));
+            reject(method === "setModel"
+              ? new CommandTimeoutError(timeoutMs, `bridge request "${method}"`, { stage: "set-model" })
+              : new Error(`bridge request "${method}" timed out after ${timeoutMs}ms`));
           }
         }, timeoutMs);
       }
@@ -247,6 +250,19 @@ export class AcpxBridgeClient {
     this.pending.delete(response.id);
     if (response.ok) {
       pending.resolve(response.result);
+      return;
+    }
+
+    if (response.error.timeout) {
+      pending.reject(new CommandTimeoutError(
+        response.error.timeout.timeoutMs,
+        response.error.timeout.command,
+        {
+          stage: response.error.timeout.stage,
+          stdout: response.error.timeout.stdoutTail,
+          stderr: response.error.timeout.stderrTail,
+        },
+      ));
       return;
     }
 

--- a/src/transport/acpx-bridge/acpx-bridge-protocol.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-protocol.ts
@@ -1,5 +1,6 @@
 import type { PlanEntry, ToolUseEvent } from "../../channels/types.js";
 import type { AgentCommand, UsageBreakdown, UsageCost } from "../types";
+import type { AcpxCommandStage } from "../command-timeouts";
 
 export type BridgeMethod =
   | "ping"
@@ -55,6 +56,13 @@ export interface BridgeErrorResponse {
       exitCode?: number;
       stdout?: string;
       stderr?: string;
+    };
+    timeout?: {
+      timeoutMs: number;
+      command: string;
+      stage?: AcpxCommandStage;
+      stdoutTail?: string;
+      stderrTail?: string;
     };
   };
 }

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -34,7 +34,11 @@ import { resolveToolEventMode, type ToolEventMode } from "../tool-event-mode.js"
 import { runAgentSessionList } from "../agent-session-list";
 import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../acpx-session-files";
-import { DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS } from "../command-timeouts";
+import {
+  CommandTimeoutError,
+  DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
+  type AcpxCommandStage,
+} from "../command-timeouts";
 import {
   buildPermissionArgs as sharedBuildPermissionArgs,
   buildSessionArgs as sharedBuildSessionArgs,
@@ -71,6 +75,18 @@ interface CommandResult {
 interface RunOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
+  stage?: AcpxCommandStage;
+}
+
+function managementTimeoutError(
+  args: string[],
+  options: RunOptions,
+  output: { stdout?: string; stderr?: string } = {},
+): CommandTimeoutError {
+  return new CommandTimeoutError(options.timeoutMs!, renderCommandForError(args), {
+    stage: options.stage,
+    ...output,
+  });
 }
 
 interface PromptStreamProcess {
@@ -115,7 +131,7 @@ async function defaultRunner(command: string, args: string[], options?: RunOptio
     const timeoutId = options?.timeoutMs
       ? setTimeout(() => {
           onAbort();
-          reject(new Error(`acpx command timed out after ${options.timeoutMs}ms: ${renderCommandForError(args)}`));
+          reject(managementTimeoutError(args, options, { stdout, stderr }));
         }, options.timeoutMs)
       : undefined;
 
@@ -165,7 +181,7 @@ async function defaultPtyRunner(command: string, args: string[], options?: RunOp
     const timeoutId = options?.timeoutMs
       ? setTimeout(() => {
           onAbort();
-          reject(new Error(`acpx command timed out after ${options.timeoutMs}ms: ${renderCommandForError(args)}`));
+          reject(managementTimeoutError(args, options, { stdout: output }));
         }, options.timeoutMs)
       : undefined;
 
@@ -294,6 +310,7 @@ export class AcpxCliTransport implements SessionTransport {
       const args = this.buildArgs(session, tail);
       const result = await this.runCommandWithTimeout(this.runCommand, args, {
         timeoutMs: Math.max(deadline - Date.now(), 1),
+        stage: "session-history",
       });
       if (result.code === 0) {
         return { text: result.stdout.trimEnd() };
@@ -374,7 +391,7 @@ export class AcpxCliTransport implements SessionTransport {
       "-s",
       session.transportSession,
       modeId,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "set-mode" });
   }
 
   // acpx's generic config setter: `<agent> set -s <name> model '<id>'`. Build args
@@ -388,7 +405,7 @@ export class AcpxCliTransport implements SessionTransport {
       session.transportSession,
       "model",
       modelId,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "set-model" });
   }
 
   // Read the session's current model and the agent-advertised available ids from
@@ -402,6 +419,7 @@ export class AcpxCliTransport implements SessionTransport {
       : [...prefix, session.agent, ...tail];
     const result = await this.runCommandWithTimeout(this.runCommand, args, {
       timeoutMs: this.managementCommandTimeoutMs,
+      stage: "get-session-model",
     });
     if (result.code !== 0) {
       const detail = normalizeCommandError(result) ?? `command failed with exit code ${result.code}`;
@@ -423,7 +441,7 @@ export class AcpxCliTransport implements SessionTransport {
       "cancel",
       "-s",
       session.transportSession,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "cancel" });
     return {
       cancelled: true,
       message: output.trim(),
@@ -457,7 +475,7 @@ export class AcpxCliTransport implements SessionTransport {
       "sessions",
       "close",
       session.transportSession,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "remove-session" });
     if (result.code === 0) {
       return;
     }
@@ -502,7 +520,7 @@ export class AcpxCliTransport implements SessionTransport {
       "sessions",
       "show",
       session.transportSession,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "has-session" });
 
     return result.code === 0;
   }
@@ -527,7 +545,7 @@ export class AcpxCliTransport implements SessionTransport {
       "sessions",
       "show",
       session.transportSession,
-    ]), { timeoutMs: this.managementCommandTimeoutMs });
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "read-session-record" });
     if (result.code !== 0) {
       const detail = normalizeCommandError(result) ?? `command failed with exit code ${result.code}`;
       throw new Error(detail);
@@ -581,9 +599,7 @@ export class AcpxCliTransport implements SessionTransport {
       new Promise<CommandResult>((_, reject) => {
         timeoutId = setTimeout(() => {
           reject(
-            new Error(
-              `acpx command timed out after ${options.timeoutMs}ms: ${renderCommandForError(args)}`,
-            ),
+            managementTimeoutError(args, options),
           );
           abortController.abort();
         }, options.timeoutMs);

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -295,6 +295,7 @@ export class AcpxCliTransport implements SessionTransport {
 
   async tailSessionHistory(session: ResolvedSession, lines: number): Promise<{ text: string }> {
     const candidates = [
+      ["sessions", "history", session.transportSession, "--limit", String(lines)],
       ["sessions", "history", "quiet", "-s", session.transportSession, String(lines)],
       ["sessions", "history", "quiet", session.transportSession, String(lines)],
       ["sessions", "history", "-s", session.transportSession, "--tail", String(lines)],

--- a/src/transport/command-timeouts.ts
+++ b/src/transport/command-timeouts.ts
@@ -31,3 +31,59 @@ export const DEFAULT_SESSION_INIT_TIMEOUT_MS = 120_000;
  * responses.
  */
 export const BRIDGE_REQUEST_TIMEOUT_GRACE_MS = 15_000;
+
+const COMMAND_OUTPUT_TAIL_CHARS = 2_000;
+
+/** Stable diagnostic stages shared by both acpx transports. */
+export type AcpxCommandStage =
+  | "has-session"
+  | "session-history"
+  | "read-session-record"
+  | "set-mode"
+  | "set-model"
+  | "get-session-model"
+  | "cancel"
+  | "remove-session";
+
+/** Timeout from a one-shot acpx command, with bounded diagnostics safe to retain. */
+export class CommandTimeoutError extends Error {
+  readonly stage?: AcpxCommandStage;
+  readonly stdoutTail?: string;
+  readonly stderrTail?: string;
+
+  constructor(
+    readonly timeoutMs: number,
+    readonly command: string,
+    detail: { stage?: AcpxCommandStage; stdout?: string; stderr?: string } = {},
+  ) {
+    const stdoutTail = captureOutputTail(detail.stdout);
+    const stderrTail = captureOutputTail(detail.stderr);
+    const output = [
+      stdoutTail ? `stdout tail: ${stdoutTail}` : "",
+      stderrTail ? `stderr tail: ${stderrTail}` : "",
+    ].filter(Boolean).join("; ");
+    super(
+      `acpx command timed out${detail.stage ? ` during ${detail.stage}` : ""} after ${formatTimeout(timeoutMs)}: ${command}`
+      + (output ? `; ${output}` : ""),
+    );
+    this.name = "CommandTimeoutError";
+    this.stage = detail.stage;
+    this.stdoutTail = stdoutTail;
+    this.stderrTail = stderrTail;
+  }
+}
+
+function formatTimeout(timeoutMs: number): string {
+  return timeoutMs >= 1_000 ? `${timeoutMs / 1_000}s` : `${timeoutMs}ms`;
+}
+
+function captureOutputTail(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) return undefined;
+  return normalized.slice(-COMMAND_OUTPUT_TAIL_CHARS);
+}
+
+/** Structured identity check used before state-changing timeout reconciliation. */
+export function isCommandTimeoutError(error: unknown): boolean {
+  return error instanceof CommandTimeoutError;
+}

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -580,10 +580,12 @@ test("a hung management command kills the spawned tree and rejects with CommandT
 });
 
 test("a set-model timeout identifies its stage and preserves captured output tails", async () => {
+  const stdoutTail = "O".repeat(2_000);
+  const stderrTail = "E".repeat(2_000);
   const spawnFn = (() => makeFakeSpawnChild({
     pid: 778,
-    stdout: "adapter initialized\nwaiting for response\n",
-    stderr: "model update dispatched\nprovider did not acknowledge\n",
+    stdout: `discarded stdout\n${stdoutTail}\n`,
+    stderr: `discarded stderr\n${stderrTail}\n`,
   })) as never;
   const runtime = new BridgeRuntime(
     "acpx",
@@ -605,8 +607,7 @@ test("a set-model timeout identifies its stage and preserves captured output tai
 
   expect(caught).toBeInstanceOf(CommandTimeoutError);
   expect((caught as Error).message).toContain("during set-model");
-  expect((caught as Error).message).toContain("stdout tail: adapter initialized\nwaiting for response");
-  expect((caught as Error).message).toContain("stderr tail: model update dispatched\nprovider did not acknowledge");
+  expect(caught).toMatchObject({ stdoutTail, stderrTail });
 });
 
 test("prompt starts queue owner with orchestration MCP identity", async () => {

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -302,13 +302,25 @@ interface FakeSpawnChildOptions {
   pid: number;
   /** When set, fire the close handler with this exit code on the next tick. */
   closeWithCode?: number;
+  stdout?: string;
+  stderr?: string;
 }
 
 function makeFakeSpawnChild(options: FakeSpawnChildOptions) {
   return {
     pid: options.pid,
-    stdout: { setEncoding: () => {}, on: () => {} },
-    stderr: { setEncoding: () => {}, on: () => {} },
+    stdout: {
+      setEncoding: () => {},
+      on: (event: string, handler: (chunk: string) => void) => {
+        if (event === "data" && options.stdout) handler(options.stdout);
+      },
+    },
+    stderr: {
+      setEncoding: () => {},
+      on: (event: string, handler: (chunk: string) => void) => {
+        if (event === "data" && options.stderr) handler(options.stderr);
+      },
+    },
     on: (event: string, handler: (code: number | null) => void) => {
       if (event === "close" && options.closeWithCode !== undefined) {
         setTimeout(() => handler(options.closeWithCode!), 0);
@@ -565,6 +577,36 @@ test("a hung management command kills the spawned tree and rejects with CommandT
 
   expect(caught).toBeInstanceOf(CommandTimeoutError);
   expect(killed).toEqual([777]);
+});
+
+test("a set-model timeout identifies its stage and preserves captured output tails", async () => {
+  const spawnFn = (() => makeFakeSpawnChild({
+    pid: 778,
+    stdout: "adapter initialized\nwaiting for response\n",
+    stderr: "model update dispatched\nprovider did not acknowledge\n",
+  })) as never;
+  const runtime = new BridgeRuntime(
+    "acpx",
+    (command, args, options?: CommandRunnerOptions) => spawnCapture(command, args, {
+      ...options,
+      spawnFn,
+      killProcessTreeFn: async () => {},
+    }),
+    undefined,
+    { managementCommandTimeoutMs: 20 },
+  );
+
+  let caught: unknown;
+  try {
+    await runtime.setModel({ agent: "codex", cwd: "/repo", name: "demo", modelId: "gpt-5.2[high]" });
+  } catch (error) {
+    caught = error;
+  }
+
+  expect(caught).toBeInstanceOf(CommandTimeoutError);
+  expect((caught as Error).message).toContain("during set-model");
+  expect((caught as Error).message).toContain("stdout tail: adapter initialized\nwaiting for response");
+  expect((caught as Error).message).toContain("stderr tail: model update dispatched\nprovider did not acknowledge");
 });
 
 test("prompt starts queue owner with orchestration MCP identity", async () => {

--- a/tests/unit/bridge/bridge-server.test.ts
+++ b/tests/unit/bridge/bridge-server.test.ts
@@ -22,7 +22,7 @@ test("returns whether a named session exists", async () => {
   ).resolves.toEqual({ exists: true });
 });
 
-test("tails session history via sessions history quiet in bridge runtime", async () => {
+test("tails session history via the acpx 0.12 --limit syntax in bridge runtime", async () => {
   const calls: string[][] = [];
   const runtime = new BridgeRuntime("acpx", async (_command, args) => {
     calls.push(args);
@@ -47,9 +47,8 @@ test("tails session history via sessions history quiet in bridge runtime", async
     "codex",
     "sessions",
     "history",
-    "quiet",
-    "-s",
     "demo",
+    "--limit",
     "10",
   ]]);
 });

--- a/tests/unit/bridge/bridge-server.test.ts
+++ b/tests/unit/bridge/bridge-server.test.ts
@@ -3,7 +3,7 @@ import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { BridgeRuntime, EnsureSessionFailedError } from "../../../src/bridge/bridge-runtime";
+import { BridgeRuntime, CommandTimeoutError, EnsureSessionFailedError } from "../../../src/bridge/bridge-runtime";
 import { BridgeServer } from "../../../src/bridge/bridge-server";
 import { PromptCommandError } from "../../../src/transport/prompt-output";
 
@@ -1375,6 +1375,39 @@ test("includes prompt diagnostics in bridge error responses", async () => {
   ).resolves.toEqual(
     '{"id":"3","ok":false,"error":{"code":"BRIDGE_INTERNAL_ERROR","message":"command failed with exit code 5","details":{"exitCode":5,"stdout":"partial stdout","stderr":"partial stderr"}}}\n',
   );
+});
+
+test("serializes management timeout identity and bounded diagnostics", async () => {
+  const runtime = {
+    setModel: async () => {
+      throw new CommandTimeoutError(30_000, "acpx codex set model", {
+        stage: "set-model",
+        stdout: "adapter started",
+        stderr: "provider stalled",
+      });
+    },
+  } as unknown as BridgeRuntime;
+  const server = new BridgeServer(runtime);
+
+  const response = await server.handleLine(JSON.stringify({
+    id: "timeout-1",
+    method: "setModel",
+    params: { agent: "codex", cwd: "/repo", name: "demo", modelId: "gpt-5.2[high]" },
+  }));
+
+  expect(JSON.parse(response)).toMatchObject({
+    id: "timeout-1",
+    ok: false,
+    error: {
+      timeout: {
+        timeoutMs: 30_000,
+        command: "acpx codex set model",
+        stage: "set-model",
+        stdoutTail: "adapter started",
+        stderrTail: "provider stalled",
+      },
+    },
+  });
 });
 
 test("returns structured error for invalid json input", async () => {

--- a/tests/unit/bridge/golden/bridge-argv-oracle.test.ts
+++ b/tests/unit/bridge/golden/bridge-argv-oracle.test.ts
@@ -192,6 +192,7 @@ test("tail-history", () =>
       { code: 1, stdout: "", stderr: "" },
       { code: 1, stdout: "", stderr: "" },
       { code: 1, stdout: "", stderr: "" },
+      { code: 1, stdout: "", stderr: "" },
     ],
     run: (runtime) => runtime.tailSessionHistory({ ...makeBridgeInput(), lines: 20 }),
   }));

--- a/tests/unit/bridge/golden/fixtures/tail-history.json
+++ b/tests/unit/bridge/golden/fixtures/tail-history.json
@@ -1,5 +1,6 @@
 {
   "record": [
+    "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions history backend:demo --limit 20 @30000)",
     "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions history quiet -s backend:demo 20 @30000)",
     "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions history quiet backend:demo 20 @30000)",
     "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions history -s backend:demo --tail 20 @30000)",

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -149,6 +149,60 @@ test("setSessionModel serializes timeout reconciliation with a newer switch for 
   ]);
 });
 
+test("setSessionModel rejects viable requests only after queue aging makes their deadline unsafe", async () => {
+  const { deps, calls } = makeDeps();
+  let now = 1_000;
+  (deps as typeof deps & { now: () => number }).now = () => now;
+  let releaseFirst!: () => void;
+  let markFirstStarted!: () => void;
+  const firstStarted = new Promise<void>((resolve) => { markFirstStarted = resolve; });
+  deps.transport.setModel = async (s: typeof session, id: string) => {
+    calls.push(`transport:${s.alias}:${id}`);
+    if (id === "model-b") {
+      markFirstStarted();
+      await new Promise<void>((resolve) => { releaseFirst = resolve; });
+    }
+  };
+  const control = new ControlService(deps as never);
+
+  const first = control.setSessionModel("relay:acc", "backend", "model-b");
+  await firstStarted;
+  const deadlineAt = now + 90_100;
+  const second = control.setSessionModel(
+    "relay:acc",
+    "backend",
+    "model-c",
+    { deadlineAt },
+  );
+  const third = control.setSessionModel(
+    "relay:acc",
+    "backend",
+    "model-d",
+    { deadlineAt },
+  );
+  const secondRejected = second.then(
+    () => false,
+    (error: unknown) => error instanceof Error && error.message.includes("deadline"),
+  );
+  const thirdRejected = third.then(
+    () => false,
+    (error: unknown) => error instanceof Error && error.message.includes("deadline"),
+  );
+
+  // Let both requests finish alias resolution and enter the same-session queue
+  // while their deadline is still viable; only the wait behind model-b ages it out.
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+  now += 200;
+  releaseFirst();
+  await first;
+  expect(await secondRejected).toBe(true);
+  expect(await thirdRejected).toBe(true);
+  expect(calls).not.toContain("transport:internal-backend:model-c");
+  expect(calls).not.toContain("persist:internal-backend:model-c");
+  expect(calls).not.toContain("transport:internal-backend:model-d");
+  expect(calls).not.toContain("persist:internal-backend:model-d");
+});
+
 test("setSessionModel does not reconcile unrelated provider errors that merely mention a timeout", async () => {
   const { deps, calls, logs } = makeDeps();
   deps.transport.setModel = async () => {

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -109,6 +109,46 @@ test("setSessionModel adopts the authoritative model when a timed-out switch pro
   expect(calls).toEqual(["persist:internal-backend:provider/fallback-model"]);
 });
 
+test("setSessionModel serializes timeout reconciliation with a newer switch for the same session", async () => {
+  const { deps, calls } = makeDeps();
+  let resolveObserved!: (value: { current?: string; available: string[] }) => void;
+  let markQueryStarted!: () => void;
+  const queryStarted = new Promise<void>((resolve) => { markQueryStarted = resolve; });
+  deps.transport.setModel = async (s: typeof session, id: string) => {
+    calls.push(`transport:${s.alias}:${id}`);
+    if (id === "model-b") {
+      throw new CommandTimeoutError(30_000, "acpx set model", { stage: "set-model" });
+    }
+  };
+  deps.transport.getSessionModel = async () => {
+    calls.push("query:internal-backend");
+    markQueryStarted();
+    return await new Promise((resolve) => { resolveObserved = resolve; });
+  };
+  const control = new ControlService(deps as never);
+
+  const first = control.setSessionModel("relay:acc", "backend", "model-b");
+  await queryStarted;
+  const second = control.setSessionModel("relay:acc", "backend", "model-c");
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+
+  expect(calls).toEqual([
+    "transport:internal-backend:model-b",
+    "query:internal-backend",
+  ]);
+
+  resolveObserved({ current: "model-b", available: ["model-b", "model-c"] });
+  await expect(first).resolves.toEqual({ current: "model-b", applied: true });
+  await expect(second).resolves.toEqual({ current: "model-c", applied: true });
+  expect(calls).toEqual([
+    "transport:internal-backend:model-b",
+    "query:internal-backend",
+    "persist:internal-backend:model-b",
+    "transport:internal-backend:model-c",
+    "persist:internal-backend:model-c",
+  ]);
+});
+
 test("setSessionModel does not reconcile unrelated provider errors that merely mention a timeout", async () => {
   const { deps, calls, logs } = makeDeps();
   deps.transport.setModel = async () => {

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { ControlService } from "../../../src/control/control-service";
+import { CommandTimeoutError } from "../../../src/transport/command-timeouts";
 
 const session = {
   alias: "internal-backend",
@@ -12,6 +13,7 @@ const session = {
 
 function makeDeps() {
   const calls: string[] = [];
+  const logs: Array<{ event: string; message: string; context?: Record<string, unknown> }> = [];
   const deps = {
     sessions: {
       resolveAliasForChat: async (_chatKey: string, alias: string) => `internal-${alias}`,
@@ -22,9 +24,14 @@ function makeDeps() {
       getSessionModel: async (s: typeof session) => ({ current: s.model, available: ["gpt-5.2[high]", "gpt-5.2[low]"] }),
       setModel: async (s: typeof session, id: string) => { calls.push(`transport:${s.alias}:${id}`); },
     },
+    logger: {
+      error: async (event: string, message: string, context?: Record<string, unknown>) => {
+        logs.push({ event, message, context });
+      },
+    },
     events: { emit: () => {} },
   };
-  return { deps, calls };
+  return { deps, calls, logs };
 }
 
 test("getSessionModel returns current + available for a resolved session", async () => {
@@ -44,8 +51,80 @@ test("getSessionModel returns an empty list when the session is not found", asyn
 test("setSessionModel switches the transport model and persists by alias", async () => {
   const { deps, calls } = makeDeps();
   const control = new ControlService(deps as never);
-  await control.setSessionModel("relay:acc", "backend", "claude-opus-4-8");
+  await expect(control.setSessionModel("relay:acc", "backend", "claude-opus-4-8")).resolves.toEqual({
+    current: "claude-opus-4-8",
+    applied: true,
+  });
   expect(calls).toEqual(["transport:internal-backend:claude-opus-4-8", "persist:internal-backend:claude-opus-4-8"]);
+});
+
+test("setSessionModel reconciles a timed-out switch that acpx actually applied", async () => {
+  const { deps, calls, logs } = makeDeps();
+  deps.transport.setModel = async () => {
+    calls.push("transport:internal-backend:claude-opus-4-8");
+    throw new CommandTimeoutError(30_000, "acpx set model", { stage: "set-model" });
+  };
+  deps.transport.getSessionModel = async () => {
+    calls.push("query:internal-backend");
+    return { current: "claude-opus-4-8", available: ["claude-opus-4-8"] };
+  };
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionModel("relay:acc", "backend", "claude-opus-4-8")).resolves.toEqual({
+    current: "claude-opus-4-8",
+    applied: true,
+  });
+  expect(calls).toEqual([
+    "transport:internal-backend:claude-opus-4-8",
+    "query:internal-backend",
+    "persist:internal-backend:claude-opus-4-8",
+  ]);
+  expect(logs).toEqual([{
+    event: "control.session.model.timeout_reconciled",
+    message: "Model switch timed out; adopted authoritative transport state",
+    context: {
+      sessionAlias: "internal-backend",
+      requestedModel: "claude-opus-4-8",
+      observedModel: "claude-opus-4-8",
+      timeout: "acpx command timed out during set-model after 30s: acpx set model",
+    },
+  }]);
+});
+
+test("setSessionModel adopts the authoritative model when a timed-out switch produced a third value", async () => {
+  const { deps, calls } = makeDeps();
+  deps.transport.setModel = async () => {
+    throw new CommandTimeoutError(30_000, "acpx set model", { stage: "set-model" });
+  };
+  deps.transport.getSessionModel = async () => ({
+    current: "provider/fallback-model",
+    available: ["gpt-5.2[high]", "claude-opus-4-8", "provider/fallback-model"],
+  });
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionModel("relay:acc", "backend", "claude-opus-4-8")).resolves.toEqual({
+    current: "provider/fallback-model",
+    applied: false,
+  });
+  expect(calls).toEqual(["persist:internal-backend:provider/fallback-model"]);
+});
+
+test("setSessionModel does not reconcile unrelated provider errors that merely mention a timeout", async () => {
+  const { deps, calls, logs } = makeDeps();
+  deps.transport.setModel = async () => {
+    throw new Error("provider request timed out while validating credentials");
+  };
+  deps.transport.getSessionModel = async () => {
+    calls.push("query");
+    return { current: "provider/fallback-model", available: [] };
+  };
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionModel("relay:acc", "backend", "claude-opus-4-8")).rejects.toThrow(
+    "provider request timed out",
+  );
+  expect(calls).toEqual([]);
+  expect(logs).toEqual([]);
 });
 
 test("setSessionModel throws when the transport cannot switch models", async () => {

--- a/tests/unit/packages/channel-relay/channel-relay-plugin.test.ts
+++ b/tests/unit/packages/channel-relay/channel-relay-plugin.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import plugin from "../../../../packages/channel-relay/src/index";
+import { validatePluginCompatibility } from "../../../../src/plugins/compatibility";
+
+test("relay connector requires the first deadline-aware xacpx core", () => {
+  const pkg = JSON.parse(readFileSync("packages/channel-relay/package.json", "utf8"));
+
+  expect(plugin.minXacpxVersion).toBe("0.17.0-beta.6");
+  expect(pkg.peerDependencies.xacpx).toBe(">=0.17.0-beta.6");
+
+  expect(() => validatePluginCompatibility(plugin, {
+    packageName: plugin.name,
+    currentXacpxVersion: "0.17.0-beta.5",
+  })).toThrow();
+  expect(() => validatePluginCompatibility(plugin, {
+    packageName: plugin.name,
+    currentXacpxVersion: "0.17.0-beta.6",
+  })).not.toThrow();
+  expect(() => validatePluginCompatibility(plugin, {
+    packageName: plugin.name,
+    currentXacpxVersion: "0.17.0",
+  })).not.toThrow();
+});

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -107,6 +107,109 @@ test("session.model.set returns the authoritative reconciled model", async () =>
   }))).toEqual({ ok: false, current: "provider/fallback-model" });
 });
 
+test("session.model.set uses the earlier of the Hub deadline and connector work budget", async () => {
+  const calls: unknown[][] = [];
+  const { control } = makeFakeControl({
+    setSessionModel: async (...args: unknown[]) => {
+      calls.push(args);
+      return { current: "model-b", applied: true };
+    },
+  });
+  const bridge = createControlBridge(control as never, { now: () => 5_000 } as never);
+  const envelope = {
+    ...req(MSG.sessionModelSet, {
+      chatKey: "relay:acct",
+      sessionAlias: "a",
+      modelId: "model-b",
+    }),
+    requestDeadlineAt: 120_000,
+    requestBudgetMs: 105_000,
+  } as RelayEnvelope;
+
+  await dispatch(bridge, envelope);
+
+  expect(calls).toEqual([[
+    "relay:acct",
+    "a",
+    "model-b",
+    { deadlineAt: 110_000 },
+  ]]);
+});
+
+test("session.model.set delivery delay cannot consume the Hub response reserve", async () => {
+  const calls: unknown[][] = [];
+  const { control } = makeFakeControl({
+    setSessionModel: async (...args: unknown[]) => {
+      calls.push(args);
+      return { current: "model-b", applied: true };
+    },
+  });
+  // Hub H=0, timeout=45s and reserve=15s: both wire fields carry a 30s
+  // work allowance. Delivery at t=20s must retain the absolute t=30s cutoff,
+  // rather than restart a fresh 30s budget at the connector.
+  const bridge = createControlBridge(control as never, { now: () => 20_000 } as never);
+  await dispatch(bridge, {
+    ...req(MSG.sessionModelSet, {
+      chatKey: "relay:acct",
+      sessionAlias: "a",
+      modelId: "model-b",
+    }),
+    requestDeadlineAt: 30_000,
+    requestBudgetMs: 30_000,
+  });
+
+  expect(calls[0]?.[3]).toEqual({ deadlineAt: 30_000 });
+});
+
+test("session.model.set fails closed when an older Hub omits its request deadline", async () => {
+  const calls: unknown[][] = [];
+  const { control } = makeFakeControl({
+    setSessionModel: async (...args: unknown[]) => {
+      calls.push(args);
+      return { current: "model-b", applied: true };
+    },
+  });
+  const bridge = createControlBridge(control as never, { now: () => 5_000 } as never);
+
+  await dispatch(bridge, req(MSG.sessionModelSet, {
+    chatKey: "relay:acct",
+    sessionAlias: "a",
+    modelId: "model-b",
+  }));
+
+  expect(calls[0]?.[3]).toEqual({ deadlineAt: 5_000 });
+});
+
+test("session.model.set fails closed when either Hub deadline field is missing", async () => {
+  const deadlines: unknown[] = [];
+  const { control } = makeFakeControl({
+    setSessionModel: async (...args: unknown[]) => {
+      deadlines.push(args[3]);
+      return { current: "model-b", applied: true };
+    },
+  });
+  const bridge = createControlBridge(control as never, { now: () => 5_000 } as never);
+  const payload = {
+    chatKey: "relay:acct",
+    sessionAlias: "a",
+    modelId: "model-b",
+  };
+
+  await dispatch(bridge, {
+    ...req(MSG.sessionModelSet, payload),
+    requestDeadlineAt: 100_000,
+  });
+  await dispatch(bridge, {
+    ...req(MSG.sessionModelSet, payload),
+    requestBudgetMs: 95_000,
+  });
+
+  expect(deadlines).toEqual([
+    { deadlineAt: 5_000 },
+    { deadlineAt: 5_000 },
+  ]);
+});
+
 test("sessions.native.list lists, and sessions.create forwards agentSessionId for native resume", async () => {
   const created: unknown[] = [];
   const { control } = makeFakeControl({

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -465,12 +465,18 @@ test("core-bounded / long RPC types are exempt from the connector timeout", asyn
     createSession: () => new Promise(() => {}),
     listNativeSessions: () => new Promise(() => {}),
     executeCommand: () => new Promise(() => {}),
+    setSessionModel: () => new Promise(() => {}),
   });
   const bridge = createControlBridge(control as never, seams);
 
   bridge(req(MSG.sessionsCreate, { chatKey: "relay:acct", alias: "a", agent: "codex", workspace: "ws" }), () => {});
   bridge(req(MSG.sessionsNativeList, { chatKey: "relay:acct", agent: "codex", workspace: "ws" }), () => {});
   bridge(req(MSG.commandExecute, { chatKey: "relay:acct", command: "/status" }), () => {});
+  bridge(req(MSG.sessionModelSet, {
+    chatKey: "relay:acct",
+    sessionAlias: "a",
+    modelId: "model-b",
+  }), () => {});
 
   // No timer armed for any exempt type.
   expect(seams.armed).toHaveLength(0);

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -94,6 +94,19 @@ test("queue.cancel dispatches to cancelQueuedItem and returns its result", async
   expect(calls.cancelQueuedItem?.[0]).toEqual({ chatKey: "relay:acct", alias: "a", itemId: "q1" });
 });
 
+test("session.model.set returns the authoritative reconciled model", async () => {
+  const { control } = makeFakeControl({
+    setSessionModel: async () => ({ current: "provider/fallback-model", applied: false }),
+  });
+  const bridge = createControlBridge(control as never);
+
+  expect(await dispatch(bridge, req(MSG.sessionModelSet, {
+    chatKey: "relay:acct",
+    sessionAlias: "a",
+    modelId: "requested-model",
+  }))).toEqual({ ok: false, current: "provider/fallback-model" });
+});
+
 test("sessions.native.list lists, and sessions.create forwards agentSessionId for native resume", async () => {
   const created: unknown[] = [];
   const { control } = makeFakeControl({

--- a/tests/unit/packages/relay-protocol/envelope.test.ts
+++ b/tests/unit/packages/relay-protocol/envelope.test.ts
@@ -14,6 +14,8 @@ test("encode/decode roundtrips a request envelope", () => {
     id: "req-1",
     type: "instance.sessions.list",
     payload: { chatKey: "relay:acct-1" },
+    requestDeadlineAt: 1_800_000_000_000,
+    requestBudgetMs: 105_000,
   };
 
   const decoded = decodeEnvelope(encodeEnvelope(envelope));
@@ -60,6 +62,13 @@ test("decode rejects structurally invalid envelopes", () => {
     ok: false,
     error: "invalid-envelope",
   });
+  expect(decodeEnvelope(JSON.stringify({
+    protocolVersion: 1,
+    kind: "req",
+    id: "1",
+    type: "x",
+    requestBudgetMs: 0,
+  }))).toEqual({ ok: false, error: "invalid-envelope" });
 });
 
 test("decode reports version mismatch with detail", () => {

--- a/tests/unit/packages/relay/gateway.test.ts
+++ b/tests/unit/packages/relay/gateway.test.ts
@@ -13,7 +13,7 @@ import { AccountStore } from "../../../../packages/relay/src/stores/accounts";
 import { InstanceStore } from "../../../../packages/relay/src/stores/instances";
 import { InstanceGateway } from "../../../../packages/relay/src/gateway/instance-gateway";
 
-async function makeGateway() {
+async function makeGateway(requestTimeoutMs = 500) {
   const db = await createSqlDriver(":memory:");
   initSchema(db);
   const accounts = new AccountStore(db);
@@ -23,7 +23,7 @@ async function makeGateway() {
   const gateway = new InstanceGateway({
     instances,
     accounts,
-    requestTimeoutMs: 500,
+    requestTimeoutMs,
     onEvent: (instanceId, accountId, envelope) => events.push({ instanceId, accountId, type: envelope.type }),
   });
   const wss = new WebSocketServer({ port: 0 });
@@ -83,9 +83,11 @@ test("sendRequest round-trips through an authed instance; offline and timeout re
     type: MSG.instanceAuth, payload: { instanceId: redeemed.instanceId, credential: redeemed.credential },
   }));
   await nextMessage(socket); // auth res
+  let forwardedRequest: RelayEnvelope | undefined;
   socket.on("message", (data) => {
     const decoded = decodeEnvelope(String(data));
     if (decoded.ok && decoded.envelope.kind === "req" && decoded.envelope.type === MSG.sessionsList) {
+      forwardedRequest = decoded.envelope;
       socket.send(encodeEnvelope({
         protocolVersion: RELAY_PROTOCOL_VERSION, kind: "res", id: decoded.envelope.id,
         type: decoded.envelope.type, payload: { sessions: [] },
@@ -93,9 +95,45 @@ test("sendRequest round-trips through an authed instance; offline and timeout re
     }
     // requests of other types are ignored -> sendRequest times out
   });
+  const requestStartedAt = Date.now();
   const result = await gateway.sendRequest(redeemed.instanceId, MSG.sessionsList, {});
   expect(result).toEqual({ sessions: [] });
+  expect(forwardedRequest?.requestBudgetMs).toBe(1);
+  expect(forwardedRequest?.requestDeadlineAt).toBeGreaterThanOrEqual(requestStartedAt);
+  expect(forwardedRequest?.requestDeadlineAt).toBeLessThan(requestStartedAt + 100);
   await expect(gateway.sendRequest(redeemed.instanceId, MSG.prompt, {})).rejects.toThrow("timeout");
+  socket.close();
+  wss.close();
+});
+
+test("sendRequest publishes an absolute work deadline that preserves the response reserve", async () => {
+  const { gateway, instances, account, wss, url } = await makeGateway(45_000);
+  const redeemed = instances.redeemPairingToken(
+    instances.issuePairingToken(account.id, "pc", 600_000).token,
+  )!;
+  const socket = await connect(url);
+  socket.send(encodeEnvelope({
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "req", id: "hs-1",
+    type: MSG.instanceAuth, payload: { instanceId: redeemed.instanceId, credential: redeemed.credential },
+  }));
+  await nextMessage(socket);
+  let forwardedRequest: RelayEnvelope | undefined;
+  socket.on("message", (data) => {
+    const decoded = decodeEnvelope(String(data));
+    if (!decoded.ok || decoded.envelope.kind !== "req") return;
+    forwardedRequest = decoded.envelope;
+    socket.send(encodeEnvelope({
+      protocolVersion: RELAY_PROTOCOL_VERSION, kind: "res", id: decoded.envelope.id,
+      type: decoded.envelope.type, payload: { sessions: [] },
+    }));
+  });
+
+  const requestStartedAt = Date.now();
+  await gateway.sendRequest(redeemed.instanceId, MSG.sessionsList, {});
+
+  expect(forwardedRequest?.requestBudgetMs).toBe(30_000);
+  expect(forwardedRequest?.requestDeadlineAt).toBeGreaterThanOrEqual(requestStartedAt + 30_000);
+  expect(forwardedRequest?.requestDeadlineAt).toBeLessThan(requestStartedAt + 31_000);
   socket.close();
   wss.close();
 });

--- a/tests/unit/plugins/plugin-compatibility.test.ts
+++ b/tests/unit/plugins/plugin-compatibility.test.ts
@@ -21,6 +21,14 @@ test("compareSemver orders patch/minor/major", () => {
   expect(compareSemver("10.0.0", "9.0.0")).toBe(1);
 });
 
+test("compareSemver orders prereleases before their release and by identifiers", () => {
+  expect(compareSemver("0.17.0-beta.5", "0.17.0-beta.6")).toBe(-1);
+  expect(compareSemver("0.17.0-beta.6", "0.17.0-beta.6")).toBe(0);
+  expect(compareSemver("0.17.0-beta.10", "0.17.0-beta.6")).toBe(1);
+  expect(compareSemver("0.17.0", "0.17.0-beta.6")).toBe(1);
+  expect(compareSemver("0.17.0-beta.6+build.1", "0.17.0-beta.6+build.2")).toBe(0);
+});
+
 test("compareSemver throws on malformed versions", () => {
   expect(() => compareSemver("0.3", "0.3.3")).toThrow();
   expect(() => compareSemver("not-a-version", "0.3.3")).toThrow();

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
@@ -16,6 +16,7 @@ import {
 import { encodeBridgeRequest } from "../../../../src/transport/acpx-bridge/acpx-bridge-protocol";
 import { PromptCommandError } from "../../../../src/transport/prompt-output";
 import { MissingOptionalDepError } from "../../../../src/recovery/errors";
+import { CommandTimeoutError } from "../../../../src/transport/command-timeouts";
 
 test("encodes a bridge request as ndjson", () => {
   expect(
@@ -47,6 +48,41 @@ test("rejects responses with bridge error payloads", async () => {
   client.handleLine('{"id":"1","ok":false,"error":{"code":"PING_FAILED","message":"boom"}}');
 
   await expect(pending).rejects.toThrow("boom");
+});
+
+test("reconstructs management timeout identity and diagnostics from bridge errors", async () => {
+  const client = new AcpxBridgeClient(() => {});
+  const pending = client.request("setModel", {});
+
+  client.handleLine(JSON.stringify({
+    id: "1",
+    ok: false,
+    error: {
+      code: "BRIDGE_INTERNAL_ERROR",
+      message: "timeout",
+      timeout: {
+        timeoutMs: 30_000,
+        command: "acpx codex set model",
+        stage: "set-model",
+        stdoutTail: "adapter started",
+        stderrTail: "provider stalled",
+      },
+    },
+  }));
+
+  try {
+    await pending;
+    throw new Error("expected rejection");
+  } catch (error) {
+    expect(error).toBeInstanceOf(CommandTimeoutError);
+    expect(error).toMatchObject({
+      timeoutMs: 30_000,
+      command: "acpx codex set model",
+      stage: "set-model",
+      stdoutTail: "adapter started",
+      stderrTail: "provider stalled",
+    });
+  }
 });
 
 test("reconstructs prompt command diagnostics from bridge error payloads", async () => {

--- a/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
@@ -89,6 +89,7 @@ test("setModel issues `set ... model <id>` with the new model consistently", asy
   expect(args.slice(setIdx)).toEqual(["set", "-s", "backend:api-fix", "model", "claude-opus-4-8"]);
   // global --model agrees with the new id (not a stale old one)
   expect(args[args.indexOf("--model") + 1]).toBe("claude-opus-4-8");
+  expect(run.mock.calls[0][2]).toMatchObject({ stage: "set-model" });
 });
 
 test("getSessionModel parses status json for current + available models", async () => {

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { AcpxCliTransport } from "../../../../src/transport/acpx-cli/acpx-cli-transport";
+import { CommandTimeoutError } from "../../../../src/transport/command-timeouts";
 import type { AcpxQueueOwnerLauncher } from "../../../../src/transport/acpx-queue-owner-launcher";
 import type { ResolvedSession } from "../../../../src/transport/types";
 import { QuotaManager } from "../../../../src/weixin/messaging/quota-manager";
@@ -389,7 +390,7 @@ test("uses PTY when resuming an alias-based session", async () => {
   ], expect.objectContaining({ timeoutMs: 120_000 }));
 });
 
-test("tails session history by invoking sessions history quiet", async () => {
+test("tails session history with the acpx 0.12 --limit syntax", async () => {
   const run = mock(async () => ({ code: 0, stdout: "history", stderr: "" }));
   const transport = new AcpxCliTransport({ command: "acpx" }, run);
 
@@ -407,9 +408,8 @@ test("tails session history by invoking sessions history quiet", async () => {
     "./node_modules/.bin/codex-acp",
     "sessions",
     "history",
-    "quiet",
-    "-s",
     "backend:api-fix",
+    "--limit",
     "20",
     // Shared deadline across history candidates: bounded by the management timeout.
   ], expect.objectContaining({ timeoutMs: expect.any(Number) }));
@@ -903,6 +903,35 @@ test("times out a hung management command, aborts the spawn, and rejects", async
 
   await expect(transport.cancel(session)).rejects.toThrow(/timed out during cancel after 20ms/);
   expect(aborted).toBe(true);
+});
+
+test("a real CLI runner timeout preserves only the final 2000 output characters", async () => {
+  const stdoutTail = "O".repeat(2_000);
+  const stderrTail = "E".repeat(2_000);
+  await withFakeAcpxScript(`
+process.stdout.write("discarded stdout\\n" + "O".repeat(2000));
+process.stderr.write("discarded stderr\\n" + "E".repeat(2000));
+setInterval(() => {}, 1000);
+`, async (scriptPath) => {
+    const transport = new AcpxCliTransport({
+      command: scriptPath,
+      managementCommandTimeoutMs: 500,
+    });
+
+    let caught: unknown;
+    try {
+      await transport.setModel(session, "model-b");
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(CommandTimeoutError);
+    expect(caught).toMatchObject({
+      stage: "set-model",
+      stdoutTail,
+      stderrTail,
+    });
+  });
 });
 
 test("times out a hung sessions close (removeSession) instead of hanging forever", async () => {

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -901,7 +901,7 @@ test("times out a hung management command, aborts the spawn, and rejects", async
     run as never,
   );
 
-  await expect(transport.cancel(session)).rejects.toThrow(/timed out after 20ms/);
+  await expect(transport.cancel(session)).rejects.toThrow(/timed out during cancel after 20ms/);
   expect(aborted).toBe(true);
 });
 
@@ -912,7 +912,7 @@ test("times out a hung sessions close (removeSession) instead of hanging forever
     run as never,
   );
 
-  await expect(transport.removeSession(session)).rejects.toThrow(/timed out after 20ms/);
+  await expect(transport.removeSession(session)).rejects.toThrow(/timed out during remove-session after 20ms/);
 });
 
 test("concatenates agent message chunks across thought and tool-call boundaries", async () => {

--- a/tests/unit/transport/golden/cli-argv-oracle.test.ts
+++ b/tests/unit/transport/golden/cli-argv-oracle.test.ts
@@ -169,6 +169,7 @@ test("tail-history", () =>
       { code: 1, stdout: "", stderr: "" },
       { code: 1, stdout: "", stderr: "" },
       { code: 1, stdout: "", stderr: "" },
+      { code: 1, stdout: "", stderr: "" },
     ],
     run: (transport) => transport.tailSessionHistory(makeCliSession(), 20),
   }));

--- a/tests/unit/transport/golden/fixtures/cli/tail-history.json
+++ b/tests/unit/transport/golden/fixtures/cli/tail-history.json
@@ -1,5 +1,6 @@
 {
   "record": [
+    "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions history backend:demo --limit 20 @30000)",
     "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions history quiet -s backend:demo 20 @30000)",
     "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions history quiet backend:demo 20 @30000)",
     "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions history -s backend:demo --tail 20 @30000)",


### PR DESCRIPTION
## Summary

- show model-switch failures through the global toast instead of rendering raw command errors beside the composer model chip
- preserve structured management-timeout diagnostics across both transports and the bridge (`stage`, command, and bounded stdout/stderr tails)
- reconcile ambiguous model-set timeouts against the authoritative acpx state, persist the observed model, and return it to relay-web

## Root cause

The model-set management process can exceed its 30-second bound after applying some or all of the change. The previous error path treated every timeout as a definite failure: relay-web blindly restored its optimistic previous value, while the transport could already be using a different model. The raw timeout was also rendered inline in the compact composer UI, and bridge serialization discarded its structured identity.

## Impact

Users now get a concise, localized toast. Successful timeout reconciliation keeps the logical session, relay response, and model chip aligned with acpx. Operators retain the original timeout stage, command, and bounded output tails in app/browser diagnostics.

## Validation

- `npx tsc --noEmit`
- `bun run build:channel-relay`
- `bun run build:relay-web`
- affected core suites: 193 tests passed
- relay control bridge: 34 tests passed
- affected relay-web suites: 11 tests passed
- independent Standards and Spec reviews: approve, no findings

The complete core/web runs encountered pre-existing fixed-timeout flakes under suite-level load; each failing unrelated test passed when rerun in isolation.
