### PR TITLE
fix(relay-web): failed send turns the bubble red immediately (not on next message)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,7 +4,7 @@
 
 Keep the test directory and execution entry points clear, stable, and maintainable.
 
-Production code goes in `src/`, test code goes in `tests/`; don't scatter test files around the source directories anymore.
+Core production code goes in `src/`, and core tests go in `tests/`; don't scatter test files around source directories. The relay-web package has one explicit Vitest exception documented below.
 
 ## Directory Conventions
 
@@ -41,6 +41,18 @@ These tests should not enter the default `npm test`, to avoid local or CI instab
 Holds test helper functions, fixture builders, and test-only utilities.
 
 For now, if a helper is very small, you can inline it in the test file first; only extract it when reuse becomes obvious.
+
+### `packages/relay-web/src/__tests__/` (package exception)
+
+Relay-web component/store tests live beside that package under `src/__tests__/` because they require
+Vite's Vue transform and the package's jsdom/Vitest setup. Run them with:
+
+```bash
+bun run --cwd packages/relay-web test
+```
+
+The root `npm test` includes this suite through `test:web`. This is the only supported test-under-`src`
+exception; Node/core/package tests continue to live under `tests/unit/`.
 
 ## Default Commands
 
@@ -79,7 +91,7 @@ bun run build
 
 ## Rules When Adding New Tests
 
-1. New tests go in `tests/unit/` by default
+1. New tests go in `tests/unit/` by default; relay-web Vue/jsdom tests use its documented package exception
 2. The directory structure should mirror `src/` as much as possible
 3. Keep test file names as `*.test.ts`
 4. Avoid leaving temporary troubleshooting scripts at the repository root
@@ -96,7 +108,7 @@ Prefer `tests/smoke/` over `tests/unit/` in the following cases:
 
 ## Rules After the Migration
 
-- `src/` holds production code only
+- `src/` holds production code only, except `packages/relay-web/src/__tests__/` as documented above
 - `tests/` holds test code only
 - `scripts/` holds run scripts only, not test bodies
 

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -2,6 +2,7 @@
 import { setActivePinia, createPinia } from "pinia";
 import { beforeEach, expect, it, test, vi } from "vitest";
 import { mount } from "@vue/test-utils";
+import { nextTick, watch } from "vue";
 
 const rpc = vi.fn();
 vi.mock("../api/client", () => ({
@@ -265,6 +266,30 @@ test("surfaces an error when send fails", async () => {
   await chat.send("hello");
   expect(chat.error).toBe("instance-offline");
   expect(chat.sending).toBe(false);
+});
+
+test("a failed send flips the bubble to failed REACTIVELY (not only on the next push)", async () => {
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  // Mirror MessageList's template dependency: it reads `m.failed` on each row. Watch that and
+  // record every reactive transition. The bug: send() mutated `failed` on the RAW optimistic
+  // object, which never trips Vue's proxy set-trap — so this watcher would only observe the
+  // flip on a later array push, exactly matching "the bubble goes red only after I type again".
+  const observed: boolean[] = [];
+  watch(
+    () => chat.messages.some((m) => m.failed === true),
+    (v) => observed.push(v),
+    { flush: "sync" },
+  );
+  rpc.mockResolvedValueOnce({ ok: false, errorMessage: "boom" });
+  await chat.send("hi");
+  await nextTick();
+  expect(chat.messages).toHaveLength(1);
+  expect(chat.messages[0]!.failed).toBe(true); // final value is correct either way
+  expect(chat.error).toBe("boom");
+  // The reactive proof: the watcher must have seen the transition to `true` with no further
+  // list mutation. On the raw-mutation bug this stays [] (or all false) and the assertion fails.
+  expect(observed).toContain(true);
 });
 
 test("resend drops the failed attempt and re-sends, leaving one clean entry on success", async () => {

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -384,6 +384,11 @@ export const useChatStore = defineStore("chat", () => {
         : {}),
     };
     messages.value.push(optimistic);
+    // `optimistic` above is the RAW object; the array element is a reactive proxy. Mutating the
+    // raw ref (optimistic.failed = true) never trips Vue's set-trap, so the failed bubble would
+    // only surface on the next list change (the next message). Mark failure through the proxy so
+    // the bubble turns red — and shows Failed/Resend — the instant the send errors.
+    const entry = messages.value[messages.value.length - 1]!;
     try {
       // The web dashboard is GUI-first: every message — including `/`-prefixed text —
       // is sent as a prompt so it streams as a normal turn. xacpx slash commands are
@@ -397,13 +402,13 @@ export const useChatStore = defineStore("chat", () => {
       });
       if (res && res.ok === false) {
         error.value = res.errorMessage ?? "prompt-failed";
-        optimistic.failed = true;
+        entry.failed = true;
       }
     } catch (e) {
       const isTimeout = e instanceof ApiError && (e.status === 504 || e.code === "timeout");
       if (!isTimeout) {
         error.value = e instanceof ApiError ? e.code : "send-failed";
-        optimistic.failed = true;
+        entry.failed = true;
       }
     } finally {
       sending.value = false;


### PR DESCRIPTION
## Bug
When a message send errors, only a toast appeared. The message bubble didn't turn red and showed no **Failed to send** / **Resend** affordance — until the user typed the *next* message, at which point the previous bubble finally went red.

## Root cause
`chat.send()` pushed a **raw** `optimistic` object into the reactive `messages` array, then on error set `optimistic.failed = true` on that **raw reference**. In Vue 3 the array element is a reactive *proxy*; mutating the underlying raw object bypasses the proxy's set-trap, so no re-render is scheduled. The value was correct but invisible until the next array push (the next message) forced `MessageList` to re-evaluate `m.failed`.

## Fix
Capture the reactive array element after `push` and mutate **that** (`entry.failed = true`) in both the `ok === false` and `catch` branches.

## Test
Adds a reactivity-catching regression test that watches the same `m.failed` dependency `MessageList` renders and asserts the watcher observes the flip **with no further push**. Verified red on the raw-mutation bug, green after the fix. Full relay-web suite 746/746, tsc clean.