### PR TITLE
release: beta cut — core 0.17.0-beta.6 + relay stack (protocol 0.1.13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.5",
+  "version": "0.17.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.5",
+      "version": "0.17.0-beta.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -13141,14 +13141,14 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.5",
+      "version": "0.3.3-beta.6",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0"
       },
       "peerDependencies": {
-        "xacpx": ">=0.11.0-0"
+        "xacpx": ">=0.17.0-beta.6"
       },
       "peerDependenciesMeta": {
         "xacpx": {
@@ -13183,7 +13183,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.20",
+      "version": "0.9.12-beta.21",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -13200,7 +13200,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT"
     },
     "packages/relay-web": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.5",
+  "version": "0.17.0-beta.6",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/channel-relay/package.json
+++ b/packages/channel-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-relay",
-  "version": "0.3.3-beta.5",
+  "version": "0.3.3-beta.6",
   "description": "Relay hub connector channel plugin for xacpx.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay-protocol/package.json
+++ b/packages/relay-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay-protocol",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Shared wire protocol types and codecs for the xacpx relay hub.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.20",
+  "version": "0.9.12-beta.21",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.5", () => {
+test("root package version is 0.17.0-beta.6", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.5");
+  expect(pkg.version).toBe("0.17.0-beta.6");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.5",
+  "version": "0.17.0-beta.6",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.5"
+    "@ganglion/xacpx": "^0.17.0-beta.6"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Beta release covering everything merged since `0.17.0-beta.5` (#163, #165, #166, #167).

| Package | From | To | dist-tag |
|---|---|---|---|
| `@ganglion/xacpx` | 0.17.0-beta.5 | **0.17.0-beta.6** | next |
| `@ganglion/xacpx-relay-protocol` | 0.1.12 | **0.1.13** | latest |
| `@ganglion/xacpx-relay` | 0.9.12-beta.20 | **0.9.12-beta.21** | next |
| `@ganglion/xacpx-channel-relay` | 0.3.3-beta.5 | **0.3.3-beta.6** | next |

`channel-feishu` / `channel-yuanbao` unchanged since last release — not bumped. `relay-web` is private and ships embedded in `relay`. relay-protocol is a **stable** patch (consumers pin `^0.1.0`; a beta on `next` wouldn't resolve).

## Contents
- acpx dep 0.11.0 → 0.12.0 (#163)
- model-switch timeout reconciliation across transports/bridge/relay-web (#165)
- relay-web failed-send bubble reactivity (#166)
- relay-web mermaid node labels (`htmlLabels:false`) + fit-to-container (#167)

Also syncs weacpx-compat shim, `package-metadata.test.ts` root-version assertion, and `package-lock.json`.

After merge: tags in order `v0.17.0-beta.6` → `relay-protocol-v0.1.13` → `relay-v0.9.12-beta.21` → `channel-relay-v0.3.3-beta.6`.