### PR TITLE
feat: manage pinned ACP adapter versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,8 @@ There are two session concepts:
 
 ### Managed ACP Adapters
 
-- `src/adapters/` owns xacpx's exact Codex/Claude adapter defaults, the `xacpx adapter` CLI, and the ACP initialize probe used before saving a local version override.
-- Runtime resolution keeps an explicit `agents.<name>.command` highest priority; otherwise Codex/Claude use the configured or release-default exact npx pin.
+- `src/adapters/` owns xacpx's exact Codex/Claude adapter defaults, the `xacpx adapter` CLI, adapter-only npm registry policy, and the ACP initialize probe used before saving a local version override.
+- Runtime resolution keeps an explicit `agents.<name>.command` highest priority; otherwise Codex/Claude use the configured or release-default exact npx pin through `transport.adapterRegistry`, which defaults to the public npm registry rather than the machine npm default.
 - User-facing commands and configuration are documented in [`docs/cli-reference.md`](docs/cli-reference.md) and [`docs/config-reference.md`](docs/config-reference.md).
 
 ### Test Layout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,12 @@ There are two session concepts:
 2. Bundled `acpx` in `node_modules`
 3. `acpx` in shell `PATH`
 
+### Managed ACP Adapters
+
+- `src/adapters/` owns xacpx's exact Codex/Claude adapter defaults, the `xacpx adapter` CLI, and the ACP initialize probe used before saving a local version override.
+- Runtime resolution keeps an explicit `agents.<name>.command` highest priority; otherwise Codex/Claude use the configured or release-default exact npx pin.
+- User-facing commands and configuration are documented in [`docs/cli-reference.md`](docs/cli-reference.md) and [`docs/config-reference.md`](docs/config-reference.md).
+
 ### Test Layout
 
 - `tests/unit/` - Mirror of `src/` structure, `*.test.ts` files. Run by default.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The essentials to get going. Full references: **CLI → [cli-reference.md](./doc
 | `xacpx login` / `logout` | Log in / out of WeChat |
 | `xacpx start` / `stop` / `restart` / `status` | Manage the background service |
 | `xacpx update` | Update xacpx and installed plugins |
+| `xacpx adapter list` / `update <name>` | Inspect or opt in to verified Codex/Claude ACP adapter pins |
 | `xacpx doctor` | Run environment diagnostics |
 | `xacpx channel add <name>` | Add a message channel (Feishu / Yuanbao / …) |
 | `xacpx ws add` / `xacpx agent add <name>` | Register a workspace / agent |

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The essentials to get going. Full references: **CLI → [cli-reference.md](./doc
 | `xacpx login` / `logout` | Log in / out of WeChat |
 | `xacpx start` / `stop` / `restart` / `status` | Manage the background service |
 | `xacpx update` | Update xacpx and installed plugins |
-| `xacpx adapter list` / `update <name>` | Inspect or opt in to verified Codex/Claude ACP adapter pins |
+| `xacpx adapter list` / `update <name>` / `registry` | Manage verified Codex/Claude ACP adapter pins and their npm registry |
 | `xacpx doctor` | Run environment diagnostics |
 | `xacpx channel add <name>` | Add a message channel (Feishu / Yuanbao / …) |
 | `xacpx ws add` / `xacpx agent add <name>` | Register a workspace / agent |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -24,6 +24,9 @@ commands (sent inside WeChat / Feishu / Yuanbao), see [commands.md](./commands.m
 | `xacpx agent list` | List agents registered on this machine |
 | `xacpx agent add <name>` | Add an agent from a built-in template; an existing agent of the same name with a different config is not overwritten |
 | `xacpx agent rm <name>` | Remove an agent |
+| `xacpx adapter list\|check [codex\|claude]` | Inspect effective managed ACP adapter versions and optionally compare them with npm |
+| `xacpx adapter update <codex\|claude>` / `xacpx adapter update --all` | Verify and save the latest published adapter version locally |
+| `xacpx adapter set <codex\|claude> <version>` / `reset <codex\|claude>` | Verify an exact version override, or return to this xacpx release's tested default |
 | `xacpx workspace list` | List workspaces registered on this machine |
 | `xacpx workspace add [name] [--raw]` | Register the current directory as a workspace; without `name`, uses the current directory name, and names with special characters are normalized automatically |
 | `xacpx workspace rm <name>` | Remove a workspace |
@@ -102,7 +105,23 @@ factory-droid, factorydroid, iflow, kilocode, kimi, kiro,
 opencode, qoder, qwen, trae
 ```
 
-These templates only write `driver`; the actual launch command is resolved by acpx. For example, `/agent add kimi` saves `{ "driver": "kimi" }`. For config fields see [config-reference.md](./config-reference.md).
+These templates only write `driver`. xacpx supplies exact npx pins for the managed `codex` and `claude` adapters; other launch commands follow the normal runtime/acpx resolution path. For example, `/agent add kimi` saves `{ "driver": "kimi" }`. For config fields see [config-reference.md](./config-reference.md).
+
+## `adapter` CLI
+
+Codex and Claude adapters are downloaded through npm's exec cache at runtime, so they do not increase xacpx's installed dependency size. xacpx nevertheless owns an exact tested default for each package instead of accepting acpx's moving range.
+
+```bash
+xacpx adapter list                 # local-only; no registry request
+xacpx adapter check               # compare both effective pins with npm latest
+xacpx adapter check codex
+xacpx adapter update codex        # opt in to latest after an ACP initialize probe
+xacpx adapter update --all        # all probes must pass before one config write
+xacpx adapter set codex 1.1.2     # exact semver only; verifies before saving
+xacpx adapter reset codex         # remove local override; use release default
+```
+
+`set` and `update` use a package/bin allowlist and structured process arguments. A candidate must exist in npm and answer a real ACP protocol-version-1 `initialize` request before `transport.adapterVersions` is written. If any `update --all` probe fails, none of its candidates are saved. Changes are never applied automatically at daemon startup; after a successful mutation, run `xacpx restart`.
 
 ## `doctor`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -27,6 +27,7 @@ commands (sent inside WeChat / Feishu / Yuanbao), see [commands.md](./commands.m
 | `xacpx adapter list\|check [codex\|claude]` | Inspect effective managed ACP adapter versions and optionally compare them with npm |
 | `xacpx adapter update <codex\|claude>` / `xacpx adapter update --all` | Verify and save the latest published adapter version locally |
 | `xacpx adapter set <codex\|claude> <version>` / `reset <codex\|claude>` | Verify an exact version override, or return to this xacpx release's tested default |
+| `xacpx adapter registry [set <url>\|reset]` | Show, change, or reset the npm registry used only for managed adapters |
 | `xacpx workspace list` | List workspaces registered on this machine |
 | `xacpx workspace add [name] [--raw]` | Register the current directory as a workspace; without `name`, uses the current directory name, and names with special characters are normalized automatically |
 | `xacpx workspace rm <name>` | Remove a workspace |
@@ -119,9 +120,14 @@ xacpx adapter update codex        # opt in to latest after an ACP initialize pro
 xacpx adapter update --all        # all probes must pass before one config write
 xacpx adapter set codex 1.1.2     # exact semver only; verifies before saving
 xacpx adapter reset codex         # remove local override; use release default
+xacpx adapter registry            # show effective registry and its source
+xacpx adapter registry set https://npm.company.example/repository/npm-group/
+xacpx adapter registry reset      # return to the public npm registry
 ```
 
 `set` and `update` use a package/bin allowlist and structured process arguments. A candidate must exist in npm and answer a real ACP protocol-version-1 `initialize` request before `transport.adapterVersions` is written. If any `update --all` probe fails, none of its candidates are saved. Changes are never applied automatically at daemon startup; after a successful mutation, run `xacpx restart`.
+
+The adapter registry defaults to `https://registry.npmjs.org/`, independently of both the machine's generic npm registry and an existing `@agentclientprotocol:registry` scope mapping. It is used consistently for latest-version queries, exact-version checks, verification downloads, and runtime `npx` launches. Set a company registry only if it proxies or hosts `@agentclientprotocol/codex-acp` and `@agentclientprotocol/claude-agent-acp`. Registry authentication stays in npm's scoped `.npmrc`; credentials in the URL are rejected.
 
 ## `doctor`
 

--- a/docs/code-wiki.md
+++ b/docs/code-wiki.md
@@ -144,7 +144,7 @@ The assembly point is in `buildApp()`: it injects capabilities such as worker di
   - foreground `run`
   - `login/logout` (a wrapper around the channel)
   - `workspace`/`channel`, these "local config management" commands
-  - `adapter` version management: exact built-in defaults and command generation live in [src/adapters/adapter-catalog.ts](../src/adapters/adapter-catalog.ts); registry validation/ACP initialize probing and atomic config persistence are coordinated by [src/adapters/adapter-cli.ts](../src/adapters/adapter-cli.ts)
+  - `adapter` management: exact built-in defaults and runtime command generation live in [src/adapters/adapter-catalog.ts](../src/adapters/adapter-catalog.ts); registry policy/validation lives in [src/adapters/adapter-registry.ts](../src/adapters/adapter-registry.ts); npm queries and ACP initialize probing live in [src/adapters/adapter-npm.ts](../src/adapters/adapter-npm.ts) and [src/adapters/adapter-verifier.ts](../src/adapters/adapter-verifier.ts); CLI persistence is coordinated by [src/adapters/adapter-cli.ts](../src/adapters/adapter-cli.ts)
   - `mcp-stdio` (MCP server startup and identity rules)
 
 ### 5.2 App Assembly (src/main.ts)

--- a/docs/code-wiki.md
+++ b/docs/code-wiki.md
@@ -144,6 +144,7 @@ The assembly point is in `buildApp()`: it injects capabilities such as worker di
   - foreground `run`
   - `login/logout` (a wrapper around the channel)
   - `workspace`/`channel`, these "local config management" commands
+  - `adapter` version management: exact built-in defaults and command generation live in [src/adapters/adapter-catalog.ts](../src/adapters/adapter-catalog.ts); registry validation/ACP initialize probing and atomic config persistence are coordinated by [src/adapters/adapter-cli.ts](../src/adapters/adapter-cli.ts)
   - `mcp-stdio` (MCP server startup and identity rules)
 
 ### 5.2 App Assembly (src/main.ts)
@@ -241,6 +242,8 @@ ConsoleAgent is the adaptation layer from "channel message protocol → router p
 ### 5.7 Transport (src/transport/*)
 
 Unified boundary: `SessionTransport`: [transport/types.ts](../src/transport/types.ts#L46-L64)
+
+Before entering that boundary, [resolve-agent-command.ts](../src/config/resolve-agent-command.ts) resolves an explicit per-agent command first, then xacpx's exact managed Codex/Claude npx pin, then the local/native fallback for other drivers. Generated managed commands recorded in session state are derived state: [SessionService](../src/sessions/session-service.ts) refreshes them from the current configured/default pin after restart, while preserving genuinely custom recorded commands.
 
 - `ensureSession()`: creates/ensures the underlying session exists for a given `ResolvedSession`, and can report back `EnsureSessionProgress` (spawn/initializing/ready or note)
 - `prompt()`: sends a prompt, supporting a reply callback (streaming) and `PromptOptions` (media, onSegment)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -15,7 +15,11 @@ If you want to manage WeChat/Feishu message channels, see [`docs/channel-managem
     "sessionInitTimeoutMs": 120000,
     "permissionMode": "approve-all",
     "nonInteractivePermissions": "deny",
-    "queueOwnerTtlSeconds": 1800
+    "queueOwnerTtlSeconds": 1800,
+    "adapterVersions": {
+      "codex": "1.1.4",
+      "claude": "0.59.0"
+    }
   },
   "logging": {
     "level": "info",
@@ -90,6 +94,17 @@ How xacpx communicates with the acpx backend.
 | `queueOwnerTtlSeconds` | `number` | No | acpx queue owner idle time-to-live (seconds), passed through to the prompt command as `acpx --ttl <value>`. Defaults to `1800` (30 minutes); `0` = live forever. See the "Reducing agent cold starts" notes below |
 | `turnIdleTimeoutSeconds` | `number` | No | Inactivity watchdog for in-flight agent turns. If a turn produces no streamed agent activity (output/tool/thought/usage/plan/command event) for this many seconds, it is aborted and reported as `Turn timed out due to inactivity`, reclaiming its slot. The timer resets on every streamed event, so long but actively-working turns are unaffected — **but a single tool call that stays silent for the whole window (e.g. `sleep`, a long compile/clone with no interleaved output) will still trip it**; raise this value or set `0` for workloads with long silent operations. Defaults to `600` (10 minutes); `0` disables the watchdog. Each reclaim is logged as `control.turn.idle_timeout` (with the session and the concrete threshold) for diagnosis |
 | `preferLocalAgents` | `boolean` | No | Prefer a locally-installed native agent CLI over acpx's `npx -y <pkg>` fallback when one is on `PATH` (currently the unpinned-npx drivers `opencode` and `kilocode`). Avoids a per-cold-start npm-registry fetch — faster and immune to network blips (e.g. `ECONNRESET` during agent init). Defaults to `true`; set `false` to always use acpx's default resolution. A per-agent `command` override still takes precedence |
+| `adapterVersions` | `{ "codex"?: string, "claude"?: string }` | No | Local exact-version overrides for xacpx-managed ACP adapters. Values must be exact semver versions, not ranges or tags. Omitted entries use xacpx's tested defaults (`codex` `1.1.4`, `claude` `0.59.0` in this release). Prefer the `xacpx adapter` CLI below over editing this object by hand |
+
+### Managed ACP adapter versions
+
+xacpx does not install the Codex or Claude adapter as a package dependency. For these two drivers it passes an exact `npx -y <package>@<version>` command to acpx. Resolution priority is:
+
+1. Explicit `agents.<name>.command` (fully user-managed)
+2. `transport.adapterVersions.<driver>`
+3. The exact version tested and shipped by this xacpx release
+
+Use `xacpx adapter list` to inspect local effective versions, `xacpx adapter check` to compare with npm, and `xacpx adapter update <name>` (or `--all`) to opt in to a newer version. `set` and `update` first confirm the exact package version is published and complete a real ACP `initialize` probe; the config is changed only if that probe succeeds. Adapter version changes require `xacpx restart`. xacpx never updates these pins automatically during daemon startup.
 
 ### `type` Options
 
@@ -441,14 +456,14 @@ The registered agent mapping, keyed by agent name (used by `/agent add`, `/sessi
 | Field | Type | Required | Description |
 |------|------|------|------|
 | `driver` | `string` | Yes | Agent driver type, passed as the first positional argument to acpx |
-| `command` | `string` | No | Explicitly specify the raw command for a custom agent. When omitted, acpx's default behavior is used |
+| `command` | `string` | No | Explicitly specify the raw command for an agent. This has highest priority, including over xacpx-managed Codex/Claude adapter pins |
 | `model` | `string` | No | Default LLM model id for this agent's sessions (e.g. `gpt-5.2[high]`), passed to acpx as `--model`. A session-level model (`/session new --model` or `/model`) overrides it. When omitted, the agent adapter's default is used |
 
 Notes:
 
-- For built-in templates, it is recommended to write only `driver` and let `acpx` resolve the corresponding alias itself
+- For built-in templates, write only `driver`; xacpx pins Codex/Claude adapters, while other drivers use the normal runtime/acpx resolution path
 - `agent.command` is mainly for custom agents; it is not recommended to hand-write a raw command for a built-in driver
-- The legacy `codex` raw command configuration is automatically ignored on load, falling back to `acpx codex ...`
+- The legacy `codex` shim command is automatically ignored on load, falling back to xacpx's current managed Codex adapter pin
 
 ### Built-in Templates
 
@@ -456,8 +471,8 @@ The following built-in templates are used when you send `/agent add <name>` via 
 
 | Template Name | driver | command |
 |--------|--------|---------|
-| `codex` | `"codex"` | None (uses acpx default) |
-| `claude` | `"claude"` | None (uses acpx default) |
+| `codex` | `"codex"` | None (uses xacpx managed pin) |
+| `claude` | `"claude"` | None (uses xacpx managed pin) |
 | `pi` | `"pi"` | None (uses acpx default) |
 | `openclaw` | `"openclaw"` | None (uses acpx default) |
 | `gemini` | `"gemini"` | None (uses acpx default) |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -16,6 +16,7 @@ If you want to manage WeChat/Feishu message channels, see [`docs/channel-managem
     "permissionMode": "approve-all",
     "nonInteractivePermissions": "deny",
     "queueOwnerTtlSeconds": 1800,
+    "adapterRegistry": "https://registry.npmjs.org/",
     "adapterVersions": {
       "codex": "1.1.4",
       "claude": "0.59.0"
@@ -95,16 +96,27 @@ How xacpx communicates with the acpx backend.
 | `turnIdleTimeoutSeconds` | `number` | No | Inactivity watchdog for in-flight agent turns. If a turn produces no streamed agent activity (output/tool/thought/usage/plan/command event) for this many seconds, it is aborted and reported as `Turn timed out due to inactivity`, reclaiming its slot. The timer resets on every streamed event, so long but actively-working turns are unaffected — **but a single tool call that stays silent for the whole window (e.g. `sleep`, a long compile/clone with no interleaved output) will still trip it**; raise this value or set `0` for workloads with long silent operations. Defaults to `600` (10 minutes); `0` disables the watchdog. Each reclaim is logged as `control.turn.idle_timeout` (with the session and the concrete threshold) for diagnosis |
 | `preferLocalAgents` | `boolean` | No | Prefer a locally-installed native agent CLI over acpx's `npx -y <pkg>` fallback when one is on `PATH` (currently the unpinned-npx drivers `opencode` and `kilocode`). Avoids a per-cold-start npm-registry fetch — faster and immune to network blips (e.g. `ECONNRESET` during agent init). Defaults to `true`; set `false` to always use acpx's default resolution. A per-agent `command` override still takes precedence |
 | `adapterVersions` | `{ "codex"?: string, "claude"?: string }` | No | Local exact-version overrides for xacpx-managed ACP adapters. Values must be exact semver versions, not ranges or tags. Omitted entries use xacpx's tested defaults (`codex` `1.1.4`, `claude` `0.59.0` in this release). Prefer the `xacpx adapter` CLI below over editing this object by hand |
+| `adapterRegistry` | `string` | No | npm registry used only for xacpx-managed Codex/Claude adapters. Defaults to `https://registry.npmjs.org/` and does **not** inherit the machine/company npm default. Change it with `xacpx adapter registry set <url>`; only credential-free HTTP(S) URLs are accepted |
 
 ### Managed ACP adapter versions
 
-xacpx does not install the Codex or Claude adapter as a package dependency. For these two drivers it passes an exact `npx -y <package>@<version>` command to acpx. Resolution priority is:
+xacpx does not install the Codex or Claude adapter as a package dependency. For these two drivers it passes an exact `npx -y --registry=<registry> <package>@<version>` command to acpx. Resolution priority is:
 
 1. Explicit `agents.<name>.command` (fully user-managed)
 2. `transport.adapterVersions.<driver>`
 3. The exact version tested and shipped by this xacpx release
 
 Use `xacpx adapter list` to inspect local effective versions, `xacpx adapter check` to compare with npm, and `xacpx adapter update <name>` (or `--all`) to opt in to a newer version. `set` and `update` first confirm the exact package version is published and complete a real ACP `initialize` probe; the config is changed only if that probe succeeds. Adapter version changes require `xacpx restart`. xacpx never updates these pins automatically during daemon startup.
+
+All adapter version lookups, publication checks, verification downloads, and runtime `npx` launches use the effective `adapterRegistry`. The default is always the public npm registry; xacpx explicitly overrides both npm's generic registry and any `.npmrc` mapping for the `@agentclientprotocol` scope. A company registry can be selected explicitly when it proxies that scope:
+
+```bash
+xacpx adapter registry
+xacpx adapter registry set https://npm.company.example/repository/npm-group/
+xacpx adapter registry reset   # return to https://registry.npmjs.org/
+```
+
+Registry URLs must not include credentials; configure registry-scoped authentication in npm's normal `.npmrc` instead. Restart the daemon after changing the registry.
 
 ### `type` Options
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,3 +31,20 @@ Currently the more clearly known values are:
 - `cursor`: `agent`, `plan`, `ask`
 
 If you're unsure whether a value works, check the corresponding agent's docs first; if you get it wrong, you'll usually get an error such as an invalid argument.
+
+## Why does an adapter download fail with npm E404?
+
+`E404` usually means the selected registry does not contain or proxy the `@agentclientprotocol` adapter packages. New xacpx releases default managed adapter operations to the public npm registry, independently of the machine's generic or scope-specific company npm registry. Inspect the effective value with:
+
+```bash
+xacpx adapter registry
+```
+
+To use the public registry explicitly:
+
+```bash
+xacpx adapter registry set https://registry.npmjs.org/
+xacpx restart
+```
+
+If company policy requires a private registry, ask its administrator to proxy or allowlist the `@agentclientprotocol` scope, then configure that registry with `xacpx adapter registry set <url>`. Put any registry-scoped token in `.npmrc`; xacpx rejects credentials embedded in the URL. `xacpx adapter check` is a quick way to verify that both managed packages are visible before creating another session.

--- a/src/adapters/adapter-catalog.ts
+++ b/src/adapters/adapter-catalog.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_ADAPTER_REGISTRY, adapterRegistryNpmArgs } from "./adapter-registry";
+
 export const MANAGED_ADAPTERS = {
   codex: {
     packageName: "@agentclientprotocol/codex-acp",
@@ -37,24 +39,39 @@ export function effectiveAdapterVersion(
   return overrides?.[id] ?? MANAGED_ADAPTERS[id].defaultVersion;
 }
 
-export function buildManagedAdapterCommand(id: ManagedAdapterId, version: string): string {
+export function buildManagedAdapterCommand(
+  id: ManagedAdapterId,
+  version: string,
+  registry: string = DEFAULT_ADAPTER_REGISTRY,
+): string {
   if (!isExactAdapterVersion(version)) throw new Error(`invalid adapter version: ${version}`);
   const spec = MANAGED_ADAPTERS[id];
-  return `npx -y ${spec.packageName}@${version}`;
+  return `npx -y ${adapterRegistryNpmArgs(registry).join(" ")} ${spec.packageName}@${version}`;
 }
 
 export function resolveManagedAdapterCommand(
   driver: string,
   overrides?: AdapterVersionOverrides,
+  registry?: string,
 ): string | undefined {
   if (!isManagedAdapterId(driver)) return undefined;
-  return buildManagedAdapterCommand(driver, effectiveAdapterVersion(driver, overrides));
+  return buildManagedAdapterCommand(driver, effectiveAdapterVersion(driver, overrides), registry);
 }
 
 export function isManagedAdapterCommand(driver: string, command: string | undefined): boolean {
   if (!command || !isManagedAdapterId(driver)) return false;
-  const prefix = `npx -y ${MANAGED_ADAPTERS[driver].packageName}@`;
-  return command.startsWith(prefix) && command.length > prefix.length && !/\s/.test(command.slice(prefix.length));
+  const packagePrefix = `${MANAGED_ADAPTERS[driver].packageName}@`;
+  const parts = command.split(" ");
+  const hasLegacyShape = parts.length === 3 && parts[0] === "npx" && parts[1] === "-y";
+  const hasRegistryShape = Boolean((parts.length === 4 || parts.length === 5)
+    && parts[0] === "npx"
+    && parts[1] === "-y"
+    && parts[2]?.startsWith("--registry=")
+    && (parts.length === 4 || parts[3]?.startsWith("--@agentclientprotocol:registry=")));
+  const packageValue = parts.at(-1) ?? "";
+  return (hasLegacyShape || hasRegistryShape)
+    && packageValue.startsWith(packagePrefix)
+    && packageValue.length > packagePrefix.length;
 }
 
 /** A recorded generated command is derived state, so a newer configured/default

--- a/src/adapters/adapter-catalog.ts
+++ b/src/adapters/adapter-catalog.ts
@@ -1,0 +1,71 @@
+export const MANAGED_ADAPTERS = {
+  codex: {
+    packageName: "@agentclientprotocol/codex-acp",
+    binName: "codex-acp",
+    defaultVersion: "1.1.4",
+  },
+  claude: {
+    packageName: "@agentclientprotocol/claude-agent-acp",
+    binName: "claude-agent-acp",
+    defaultVersion: "0.59.0",
+  },
+} as const;
+
+export type ManagedAdapterId = keyof typeof MANAGED_ADAPTERS;
+export type AdapterVersionOverrides = Partial<Record<ManagedAdapterId, string>>;
+
+const EXACT_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+export function isManagedAdapterId(value: string): value is ManagedAdapterId {
+  return Object.hasOwn(MANAGED_ADAPTERS, value);
+}
+
+export function listManagedAdapterIds(): ManagedAdapterId[] {
+  return Object.keys(MANAGED_ADAPTERS) as ManagedAdapterId[];
+}
+
+export function isExactAdapterVersion(value: string): boolean {
+  if (!EXACT_SEMVER.test(value)) return false;
+  const prerelease = value.split("+", 1)[0]!.split("-", 2)[1];
+  return !prerelease?.split(".").some((identifier) => /^0\d+$/.test(identifier));
+}
+
+export function effectiveAdapterVersion(
+  id: ManagedAdapterId,
+  overrides: AdapterVersionOverrides | undefined,
+): string {
+  return overrides?.[id] ?? MANAGED_ADAPTERS[id].defaultVersion;
+}
+
+export function buildManagedAdapterCommand(id: ManagedAdapterId, version: string): string {
+  if (!isExactAdapterVersion(version)) throw new Error(`invalid adapter version: ${version}`);
+  const spec = MANAGED_ADAPTERS[id];
+  return `npx -y ${spec.packageName}@${version}`;
+}
+
+export function resolveManagedAdapterCommand(
+  driver: string,
+  overrides?: AdapterVersionOverrides,
+): string | undefined {
+  if (!isManagedAdapterId(driver)) return undefined;
+  return buildManagedAdapterCommand(driver, effectiveAdapterVersion(driver, overrides));
+}
+
+export function isManagedAdapterCommand(driver: string, command: string | undefined): boolean {
+  if (!command || !isManagedAdapterId(driver)) return false;
+  const prefix = `npx -y ${MANAGED_ADAPTERS[driver].packageName}@`;
+  return command.startsWith(prefix) && command.length > prefix.length && !/\s/.test(command.slice(prefix.length));
+}
+
+/** A recorded generated command is derived state, so a newer configured/default
+ * version replaces it. Truly custom commands remain sticky for session identity. */
+export function preferCurrentManagedAdapterCommand(
+  driver: string,
+  recorded: string | undefined,
+  current: string | undefined,
+): string | undefined {
+  if (current && isManagedAdapterCommand(driver, current) && (!recorded || isManagedAdapterCommand(driver, recorded))) {
+    return current;
+  }
+  return recorded ?? current;
+}

--- a/src/adapters/adapter-catalog.ts
+++ b/src/adapters/adapter-catalog.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_ADAPTER_REGISTRY, adapterRegistryNpmArgs } from "./adapter-registry";
+import {
+  DEFAULT_ADAPTER_REGISTRY,
+  adapterRegistryNpmArgs,
+  normalizeAdapterRegistry,
+} from "./adapter-registry";
 
 export const MANAGED_ADAPTERS = {
   codex: {
@@ -59,8 +63,17 @@ export function resolveManagedAdapterCommand(
 }
 
 export function isManagedAdapterCommand(driver: string, command: string | undefined): boolean {
-  if (!command || !isManagedAdapterId(driver)) return false;
-  const packagePrefix = `${MANAGED_ADAPTERS[driver].packageName}@`;
+  return isManagedAdapterId(driver) && parseManagedAdapterCommand(command)?.id === driver;
+}
+
+export function managedAdapterRegistryFromCommand(command: string | undefined): string | undefined {
+  return parseManagedAdapterCommand(command)?.registry;
+}
+
+function parseManagedAdapterCommand(
+  command: string | undefined,
+): { id: ManagedAdapterId; registry?: string } | undefined {
+  if (!command) return undefined;
   const parts = command.split(" ");
   const hasLegacyShape = parts.length === 3 && parts[0] === "npx" && parts[1] === "-y";
   const hasRegistryShape = Boolean((parts.length === 4 || parts.length === 5)
@@ -68,10 +81,27 @@ export function isManagedAdapterCommand(driver: string, command: string | undefi
     && parts[1] === "-y"
     && parts[2]?.startsWith("--registry=")
     && (parts.length === 4 || parts[3]?.startsWith("--@agentclientprotocol:registry=")));
+  if (!hasLegacyShape && !hasRegistryShape) return undefined;
+
   const packageValue = parts.at(-1) ?? "";
-  return (hasLegacyShape || hasRegistryShape)
-    && packageValue.startsWith(packagePrefix)
-    && packageValue.length > packagePrefix.length;
+  const id = listManagedAdapterIds().find((candidate) => {
+    const prefix = `${MANAGED_ADAPTERS[candidate].packageName}@`;
+    return packageValue.startsWith(prefix) && packageValue.length > prefix.length;
+  });
+  if (!id) return undefined;
+  if (hasLegacyShape) return { id };
+
+  const genericRegistry = parts[2]!.slice("--registry=".length);
+  const scopedRegistry = parts.length === 5
+    ? parts[3]!.slice("--@agentclientprotocol:registry=".length)
+    : genericRegistry;
+  try {
+    const registry = normalizeAdapterRegistry(genericRegistry);
+    if (normalizeAdapterRegistry(scopedRegistry) !== registry) return undefined;
+    return { id, registry };
+  } catch {
+    return undefined;
+  }
 }
 
 /** A recorded generated command is derived state, so a newer configured/default

--- a/src/adapters/adapter-cli.ts
+++ b/src/adapters/adapter-cli.ts
@@ -1,0 +1,157 @@
+import {
+  MANAGED_ADAPTERS,
+  effectiveAdapterVersion,
+  isExactAdapterVersion,
+  isManagedAdapterId,
+  listManagedAdapterIds,
+  type AdapterVersionOverrides,
+  type ManagedAdapterId,
+} from "./adapter-catalog";
+import { t } from "../i18n";
+
+export interface AdapterCliDeps {
+  loadVersions: () => Promise<AdapterVersionOverrides>;
+  /** Replaces only transport.adapterVersions in one atomic config write. */
+  saveVersions: (versions: AdapterVersionOverrides) => Promise<void>;
+  getLatestVersion: (id: ManagedAdapterId) => Promise<string | null>;
+  versionExists: (id: ManagedAdapterId, version: string) => Promise<boolean>;
+  verifyVersion: (id: ManagedAdapterId, version: string) => Promise<void>;
+  print: (line: string) => void;
+}
+
+export async function handleAdapterCli(args: string[], deps: AdapterCliDeps): Promise<number | null> {
+  const command = args[0];
+  if (command === "list" && args.length === 1) return await listAdapters(deps);
+  if (command === "check" && args.length <= 2) return await checkAdapters(args[1], deps);
+  if (command === "set" && args.length === 3) return await setAdapter(args[1], args[2], deps);
+  if (command === "reset" && args.length === 2) return await resetAdapter(args[1], deps);
+  if (command === "update" && args.length === 2) {
+    const target = args[1]!;
+    return await updateAdapters(target === "--all" ? listManagedAdapterIds() : [target], deps);
+  }
+  return null;
+}
+
+async function listAdapters(deps: AdapterCliDeps): Promise<number> {
+  const versions = await deps.loadVersions();
+  deps.print(t().cli.adapterListHeader);
+  for (const id of listManagedAdapterIds()) {
+    deps.print(t().cli.adapterListRow(
+      id,
+      effectiveAdapterVersion(id, versions),
+      MANAGED_ADAPTERS[id].defaultVersion,
+      versions[id] ? t().cli.adapterSourceConfigured : t().cli.adapterSourceDefault,
+    ));
+  }
+  return 0;
+}
+
+async function checkAdapters(rawId: string | undefined, deps: AdapterCliDeps): Promise<number> {
+  const ids = rawId ? resolveIds([rawId], deps) : listManagedAdapterIds();
+  if (!ids) return 1;
+  const versions = await deps.loadVersions();
+  for (const id of ids) {
+    const latest = await deps.getLatestVersion(id);
+    if (!latest) {
+      deps.print(t().cli.adapterLatestUnavailable(id));
+      return 1;
+    }
+    deps.print(t().cli.adapterCheckRow(id, effectiveAdapterVersion(id, versions), latest));
+  }
+  return 0;
+}
+
+async function setAdapter(rawId: string | undefined, rawVersion: string | undefined, deps: AdapterCliDeps): Promise<number> {
+  const ids = resolveIds(rawId ? [rawId] : [], deps);
+  if (!ids || !rawVersion) return 1;
+  const version = rawVersion.trim();
+  if (!isExactAdapterVersion(version)) {
+    deps.print(t().cli.adapterInvalidVersion(rawVersion));
+    return 1;
+  }
+  const id = ids[0]!;
+  try {
+    if (!await deps.versionExists(id, version)) {
+      deps.print(t().cli.adapterVersionUnavailable(id, version));
+      return 1;
+    }
+    deps.print(t().cli.adapterVerifying(id, version));
+    await deps.verifyVersion(id, version);
+    const versions = await deps.loadVersions();
+    await deps.saveVersions({ ...versions, [id]: version });
+    deps.print(t().cli.adapterSaved(id, version));
+    deps.print(t().cli.adapterRestartRequired);
+    return 0;
+  } catch (error) {
+    deps.print(t().cli.adapterFailed(id, error instanceof Error ? error.message : String(error)));
+    return 1;
+  }
+}
+
+async function updateAdapters(rawIds: string[], deps: AdapterCliDeps): Promise<number> {
+  const ids = resolveIds(rawIds, deps);
+  if (!ids) return 1;
+  const current = await deps.loadVersions();
+  const candidates: Array<{ id: ManagedAdapterId; version: string }> = [];
+  for (const id of ids) {
+    const latest = await deps.getLatestVersion(id);
+    if (!latest) {
+      deps.print(t().cli.adapterLatestUnavailable(id));
+      return 1;
+    }
+    if (!isExactAdapterVersion(latest)) {
+      deps.print(t().cli.adapterInvalidVersion(latest));
+      return 1;
+    }
+    if (effectiveAdapterVersion(id, current) === latest) {
+      deps.print(t().cli.adapterAlreadyLatest(id, latest));
+      continue;
+    }
+    candidates.push({ id, version: latest });
+  }
+
+  const next = { ...current };
+  let verifyingId: ManagedAdapterId = ids[0]!;
+  try {
+    for (const candidate of candidates) {
+      verifyingId = candidate.id;
+      deps.print(t().cli.adapterVerifying(candidate.id, candidate.version));
+      await deps.verifyVersion(candidate.id, candidate.version);
+      next[candidate.id] = candidate.version;
+    }
+    if (candidates.length === 0) return 0;
+    await deps.saveVersions(next);
+    for (const candidate of candidates) deps.print(t().cli.adapterSaved(candidate.id, candidate.version));
+    deps.print(t().cli.adapterRestartRequired);
+    return 0;
+  } catch (error) {
+    deps.print(t().cli.adapterFailed(verifyingId, error instanceof Error ? error.message : String(error)));
+    return 1;
+  }
+}
+
+async function resetAdapter(rawId: string | undefined, deps: AdapterCliDeps): Promise<number> {
+  const ids = resolveIds(rawId ? [rawId] : [], deps);
+  if (!ids) return 1;
+  const id = ids[0]!;
+  const versions = await deps.loadVersions();
+  const next = { ...versions };
+  delete next[id];
+  await deps.saveVersions(next);
+  deps.print(t().cli.adapterReset(id, effectiveAdapterVersion(id, next)));
+  deps.print(t().cli.adapterRestartRequired);
+  return 0;
+}
+
+function resolveIds(rawIds: string[], deps: Pick<AdapterCliDeps, "print">): ManagedAdapterId[] | null {
+  const result: ManagedAdapterId[] = [];
+  for (const rawId of rawIds) {
+    const id = rawId?.trim();
+    if (!id || !isManagedAdapterId(id)) {
+      deps.print(t().cli.adapterUnsupported(id || ""));
+      return null;
+    }
+    if (!result.includes(id)) result.push(id);
+  }
+  return result.length > 0 ? result : null;
+}

--- a/src/adapters/adapter-cli.ts
+++ b/src/adapters/adapter-cli.ts
@@ -8,26 +8,66 @@ import {
   type ManagedAdapterId,
 } from "./adapter-catalog";
 import { t } from "../i18n";
+import {
+  DEFAULT_ADAPTER_REGISTRY,
+  describeAdapterRegistryError,
+  effectiveAdapterRegistry,
+  normalizeAdapterRegistry,
+} from "./adapter-registry";
 
 export interface AdapterCliDeps {
   loadVersions: () => Promise<AdapterVersionOverrides>;
   /** Replaces only transport.adapterVersions in one atomic config write. */
   saveVersions: (versions: AdapterVersionOverrides) => Promise<void>;
-  getLatestVersion: (id: ManagedAdapterId) => Promise<string | null>;
-  versionExists: (id: ManagedAdapterId, version: string) => Promise<boolean>;
-  verifyVersion: (id: ManagedAdapterId, version: string) => Promise<void>;
+  loadRegistry: () => Promise<string | undefined>;
+  /** Sets transport.adapterRegistry; undefined removes the override. */
+  saveRegistry: (registry: string | undefined) => Promise<void>;
+  getLatestVersion: (id: ManagedAdapterId, registry: string) => Promise<string | null>;
+  versionExists: (id: ManagedAdapterId, version: string, registry: string) => Promise<boolean>;
+  verifyVersion: (id: ManagedAdapterId, version: string, registry: string) => Promise<void>;
   print: (line: string) => void;
 }
 
 export async function handleAdapterCli(args: string[], deps: AdapterCliDeps): Promise<number | null> {
   const command = args[0];
   if (command === "list" && args.length === 1) return await listAdapters(deps);
+  if (command === "registry") return await handleRegistry(args.slice(1), deps);
   if (command === "check" && args.length <= 2) return await checkAdapters(args[1], deps);
   if (command === "set" && args.length === 3) return await setAdapter(args[1], args[2], deps);
   if (command === "reset" && args.length === 2) return await resetAdapter(args[1], deps);
   if (command === "update" && args.length === 2) {
     const target = args[1]!;
     return await updateAdapters(target === "--all" ? listManagedAdapterIds() : [target], deps);
+  }
+  return null;
+}
+
+async function handleRegistry(args: string[], deps: AdapterCliDeps): Promise<number | null> {
+  if (args.length === 0) {
+    const configured = await deps.loadRegistry();
+    deps.print(t().cli.adapterRegistryCurrent(
+      effectiveAdapterRegistry(configured),
+      configured ? t().cli.adapterSourceConfigured : t().cli.adapterSourceDefault,
+    ));
+    return 0;
+  }
+  if (args.length === 2 && args[0] === "set") {
+    try {
+      const registry = normalizeAdapterRegistry(args[1]!);
+      await deps.saveRegistry(registry);
+      deps.print(t().cli.adapterRegistrySaved(registry));
+      deps.print(t().cli.adapterRestartRequired);
+      return 0;
+    } catch (error) {
+      deps.print(t().cli.adapterInvalidRegistry(error instanceof Error ? error.message : String(error)));
+      return 1;
+    }
+  }
+  if (args.length === 1 && args[0] === "reset") {
+    await deps.saveRegistry(undefined);
+    deps.print(t().cli.adapterRegistryReset(DEFAULT_ADAPTER_REGISTRY));
+    deps.print(t().cli.adapterRestartRequired);
+    return 0;
   }
   return null;
 }
@@ -50,8 +90,15 @@ async function checkAdapters(rawId: string | undefined, deps: AdapterCliDeps): P
   const ids = rawId ? resolveIds([rawId], deps) : listManagedAdapterIds();
   if (!ids) return 1;
   const versions = await deps.loadVersions();
+  const registry = effectiveAdapterRegistry(await deps.loadRegistry());
   for (const id of ids) {
-    const latest = await deps.getLatestVersion(id);
+    let latest: string | null;
+    try {
+      latest = await deps.getLatestVersion(id, registry);
+    } catch (error) {
+      deps.print(t().cli.adapterFailed(id, describeAdapterRegistryError(error)));
+      return 1;
+    }
     if (!latest) {
       deps.print(t().cli.adapterLatestUnavailable(id));
       return 1;
@@ -70,20 +117,21 @@ async function setAdapter(rawId: string | undefined, rawVersion: string | undefi
     return 1;
   }
   const id = ids[0]!;
+  const registry = effectiveAdapterRegistry(await deps.loadRegistry());
   try {
-    if (!await deps.versionExists(id, version)) {
+    if (!await deps.versionExists(id, version, registry)) {
       deps.print(t().cli.adapterVersionUnavailable(id, version));
       return 1;
     }
     deps.print(t().cli.adapterVerifying(id, version));
-    await deps.verifyVersion(id, version);
+    await deps.verifyVersion(id, version, registry);
     const versions = await deps.loadVersions();
     await deps.saveVersions({ ...versions, [id]: version });
     deps.print(t().cli.adapterSaved(id, version));
     deps.print(t().cli.adapterRestartRequired);
     return 0;
   } catch (error) {
-    deps.print(t().cli.adapterFailed(id, error instanceof Error ? error.message : String(error)));
+    deps.print(t().cli.adapterFailed(id, describeAdapterRegistryError(error)));
     return 1;
   }
 }
@@ -92,9 +140,16 @@ async function updateAdapters(rawIds: string[], deps: AdapterCliDeps): Promise<n
   const ids = resolveIds(rawIds, deps);
   if (!ids) return 1;
   const current = await deps.loadVersions();
+  const registry = effectiveAdapterRegistry(await deps.loadRegistry());
   const candidates: Array<{ id: ManagedAdapterId; version: string }> = [];
   for (const id of ids) {
-    const latest = await deps.getLatestVersion(id);
+    let latest: string | null;
+    try {
+      latest = await deps.getLatestVersion(id, registry);
+    } catch (error) {
+      deps.print(t().cli.adapterFailed(id, describeAdapterRegistryError(error)));
+      return 1;
+    }
     if (!latest) {
       deps.print(t().cli.adapterLatestUnavailable(id));
       return 1;
@@ -116,7 +171,7 @@ async function updateAdapters(rawIds: string[], deps: AdapterCliDeps): Promise<n
     for (const candidate of candidates) {
       verifyingId = candidate.id;
       deps.print(t().cli.adapterVerifying(candidate.id, candidate.version));
-      await deps.verifyVersion(candidate.id, candidate.version);
+      await deps.verifyVersion(candidate.id, candidate.version, registry);
       next[candidate.id] = candidate.version;
     }
     if (candidates.length === 0) return 0;
@@ -125,7 +180,7 @@ async function updateAdapters(rawIds: string[], deps: AdapterCliDeps): Promise<n
     deps.print(t().cli.adapterRestartRequired);
     return 0;
   } catch (error) {
-    deps.print(t().cli.adapterFailed(verifyingId, error instanceof Error ? error.message : String(error)));
+    deps.print(t().cli.adapterFailed(verifyingId, describeAdapterRegistryError(error)));
     return 1;
   }
 }

--- a/src/adapters/adapter-npm.ts
+++ b/src/adapters/adapter-npm.ts
@@ -1,0 +1,76 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { MANAGED_ADAPTERS, type ManagedAdapterId } from "./adapter-catalog";
+import {
+  AdapterRegistryPackageNotFoundError,
+  adapterRegistryNpmArgs,
+  effectiveAdapterRegistry,
+} from "./adapter-registry";
+
+export async function getAdapterNpmVersion(
+  id: ManagedAdapterId,
+  version: string | undefined,
+  registry: string,
+): Promise<string | null> {
+  const adapter = MANAGED_ADAPTERS[id];
+  const packageSpec = version ? `${adapter.packageName}@${version}` : adapter.packageName;
+  const normalizedRegistry = effectiveAdapterRegistry(registry);
+  const npm = resolveNpmCommand();
+  const result = await runCapture(npm.command, [
+    ...npm.prefixArgs,
+    "view",
+    packageSpec,
+    "version",
+    "--json",
+    ...adapterRegistryNpmArgs(normalizedRegistry),
+  ]);
+  if (result.code !== 0) {
+    if (version && /no match.*\bversion\b|no matching version|notarget/i.test(result.stderr)) {
+      return null;
+    }
+    if (/\bE404\b|\b404\s+Not\s+Found\b/i.test(result.stderr)) {
+      throw new AdapterRegistryPackageNotFoundError(normalizedRegistry);
+    }
+    return null;
+  }
+  const raw = result.stdout.trim();
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return typeof parsed === "string" ? parsed : null;
+  } catch {
+    return raw.replace(/^"|"$/g, "") || null;
+  }
+}
+
+export function resolveNpmCommand(): { command: string; prefixArgs: string[] } {
+  if (process.platform !== "win32") return { command: "npm", prefixArgs: [] };
+
+  const candidates = [
+    process.env.npm_execpath,
+    join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+  ];
+  const npmCli = candidates.find((candidate): candidate is string =>
+    typeof candidate === "string" && /npm-cli\.(?:c?js)$/i.test(candidate) && existsSync(candidate));
+  if (!npmCli) throw new Error("cannot locate npm-cli.js for shell-free adapter operations");
+  return { command: process.execPath, prefixArgs: [npmCli] };
+}
+
+async function runCapture(
+  command: string,
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, { shell: false, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+    child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+}

--- a/src/adapters/adapter-npm.ts
+++ b/src/adapters/adapter-npm.ts
@@ -7,6 +7,7 @@ import {
   AdapterRegistryPackageNotFoundError,
   adapterRegistryNpmArgs,
   effectiveAdapterRegistry,
+  isAdapterRegistryNotFoundOutput,
 } from "./adapter-registry";
 
 export async function getAdapterNpmVersion(
@@ -30,7 +31,7 @@ export async function getAdapterNpmVersion(
     if (version && /no match.*\bversion\b|no matching version|notarget/i.test(result.stderr)) {
       return null;
     }
-    if (/\bE404\b|\b404\s+Not\s+Found\b/i.test(result.stderr)) {
+    if (isAdapterRegistryNotFoundOutput(result.stderr)) {
       throw new AdapterRegistryPackageNotFoundError(normalizedRegistry);
     }
     return null;

--- a/src/adapters/adapter-registry.ts
+++ b/src/adapters/adapter-registry.ts
@@ -1,0 +1,70 @@
+export const DEFAULT_ADAPTER_REGISTRY = "https://registry.npmjs.org/";
+
+export class AdapterRegistryPackageNotFoundError extends Error {
+  readonly code = "E404";
+
+  constructor(readonly registry: string) {
+    super(`adapter package was not found in npm registry ${registry}`);
+    this.name = "AdapterRegistryPackageNotFoundError";
+  }
+}
+
+/** Validates and canonicalizes a registry URL before it reaches config or argv. */
+export function normalizeAdapterRegistry(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed !== value || /\s/.test(value)) {
+    throw new Error("adapter registry must be an http(s) URL without whitespace");
+  }
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error("adapter registry must be a valid http(s) URL");
+  }
+  if ((url.protocol !== "https:" && url.protocol !== "http:") || !url.hostname) {
+    throw new Error("adapter registry must be an http(s) URL");
+  }
+  if (url.username || url.password) {
+    throw new Error("adapter registry must not contain credentials; configure npm auth separately");
+  }
+  if (url.search || url.hash) {
+    throw new Error("adapter registry must not contain a query string or fragment");
+  }
+  if (!url.pathname.endsWith("/")) url.pathname += "/";
+  const normalized = url.toString();
+  // The runtime value is embedded in acpx's agent-command string. Restrict it
+  // to URL characters that cannot become shell/control syntax in downstream
+  // command parsing; npm credentials belong in the user's scoped npm config.
+  if (!/^[A-Za-z0-9._~:/@%+\[\]-]+$/.test(normalized)) {
+    throw new Error("adapter registry contains unsupported command characters");
+  }
+  return normalized;
+}
+
+export function effectiveAdapterRegistry(configured: string | undefined): string {
+  return configured ? normalizeAdapterRegistry(configured) : DEFAULT_ADAPTER_REGISTRY;
+}
+
+/** npm chooses a scope-specific registry over the generic registry, so both
+ * flags are required to override company .npmrc files deterministically. */
+export function adapterRegistryNpmArgs(registry: string): string[] {
+  const normalized = effectiveAdapterRegistry(registry);
+  return [
+    `--registry=${normalized}`,
+    `--@agentclientprotocol:registry=${normalized}`,
+  ];
+}
+
+export function adapterRegistryE404Guidance(registry: string): string {
+  return [
+    `npm registry ${registry} returned E404 for the adapter package.`,
+    `Run \`xacpx adapter registry set ${DEFAULT_ADAPTER_REGISTRY}\` to use the public npm registry,`,
+    "or ask your registry administrator to proxy/allowlist the @agentclientprotocol scope.",
+  ].join(" ");
+}
+
+export function describeAdapterRegistryError(error: unknown): string {
+  return error instanceof AdapterRegistryPackageNotFoundError
+    ? adapterRegistryE404Guidance(error.registry)
+    : error instanceof Error ? error.message : String(error);
+}

--- a/src/adapters/adapter-registry.ts
+++ b/src/adapters/adapter-registry.ts
@@ -63,6 +63,10 @@ export function adapterRegistryE404Guidance(registry: string): string {
   ].join(" ");
 }
 
+export function isAdapterRegistryNotFoundOutput(output: string): boolean {
+  return /\bE404\b|\b404\s+Not\s+Found\b/i.test(output);
+}
+
 export function describeAdapterRegistryError(error: unknown): string {
   return error instanceof AdapterRegistryPackageNotFoundError
     ? adapterRegistryE404Guidance(error.registry)

--- a/src/adapters/adapter-registry.ts
+++ b/src/adapters/adapter-registry.ts
@@ -67,6 +67,12 @@ export function isAdapterRegistryNotFoundOutput(output: string): boolean {
   return /\bE404\b|\b404\s+Not\s+Found\b/i.test(output);
 }
 
+/** Runtime errors can also contain API/model 404s. Only classify them as an
+ * adapter registry failure when npm itself is present in the diagnostic. */
+export function isNpmAdapterRegistryNotFoundOutput(output: string): boolean {
+  return /\bnpm\b/i.test(output) && isAdapterRegistryNotFoundOutput(output);
+}
+
 export function describeAdapterRegistryError(error: unknown): string {
   return error instanceof AdapterRegistryPackageNotFoundError
     ? adapterRegistryE404Guidance(error.registry)

--- a/src/adapters/adapter-verifier.ts
+++ b/src/adapters/adapter-verifier.ts
@@ -8,6 +8,7 @@ import {
   adapterRegistryNpmArgs,
   adapterRegistryE404Guidance,
   effectiveAdapterRegistry,
+  isAdapterRegistryNotFoundOutput,
 } from "./adapter-registry";
 
 const DEFAULT_VERIFY_TIMEOUT_MS = 120_000;
@@ -95,7 +96,7 @@ export async function verifyAcpInitialize(
       child.once("error", (error) => finish(new Error(`failed to start adapter: ${error.message}`)));
       child.once("close", (code, signal) => {
         if (settled) return;
-        if (options.adapterRegistry && /\bE404\b|\b404\s+Not\s+Found\b/i.test(stderr)) {
+        if (options.adapterRegistry && isAdapterRegistryNotFoundOutput(stderr)) {
           finish(new Error(adapterRegistryE404Guidance(effectiveAdapterRegistry(options.adapterRegistry))));
           return;
         }

--- a/src/adapters/adapter-verifier.ts
+++ b/src/adapters/adapter-verifier.ts
@@ -1,0 +1,157 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { terminateProcessTree } from "../process/terminate-process-tree";
+import { MANAGED_ADAPTERS, type ManagedAdapterId } from "./adapter-catalog";
+
+const DEFAULT_VERIFY_TIMEOUT_MS = 120_000;
+const OUTPUT_LIMIT = 64 * 1024;
+
+interface VerifyOptions {
+  timeoutMs?: number;
+}
+
+interface JsonRpcResponse {
+  id?: unknown;
+  result?: { protocolVersion?: unknown };
+  error?: { message?: unknown; data?: unknown };
+}
+
+/** Runs a structured ACP initialize probe and tears down the process tree afterward. */
+export async function verifyAcpInitialize(
+  command: string,
+  args: string[],
+  options: VerifyOptions = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS;
+  const detached = process.platform !== "win32";
+  const child = spawn(command, args, {
+    detached,
+    shell: false,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stderr = "";
+  let stdoutBuffer = "";
+  let settled = false;
+  let timer: NodeJS.Timeout | undefined;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const finish = (error?: Error): void => {
+        if (settled) return;
+        settled = true;
+        if (error) reject(error);
+        else resolve();
+      };
+
+      timer = setTimeout(() => {
+        finish(new Error(`ACP initialize timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk: string) => {
+        stderr = appendLimited(stderr, chunk);
+      });
+
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdoutBuffer = appendLimited(stdoutBuffer, chunk);
+        for (;;) {
+          const newline = stdoutBuffer.indexOf("\n");
+          if (newline < 0) break;
+          const line = stdoutBuffer.slice(0, newline).trim();
+          stdoutBuffer = stdoutBuffer.slice(newline + 1);
+          if (!line) continue;
+          let response: JsonRpcResponse;
+          try {
+            response = JSON.parse(line) as JsonRpcResponse;
+          } catch {
+            continue;
+          }
+          if (response.id !== 0) continue;
+          if (response.error) {
+            const detail = typeof response.error.message === "string"
+              ? response.error.message
+              : "adapter returned an ACP initialize error";
+            finish(new Error(detail));
+            return;
+          }
+          if (response.result?.protocolVersion !== 1) {
+            finish(new Error(`adapter returned unsupported ACP protocolVersion ${String(response.result?.protocolVersion)}`));
+            return;
+          }
+          finish();
+          return;
+        }
+      });
+
+      child.once("error", (error) => finish(new Error(`failed to start adapter: ${error.message}`)));
+      child.once("close", (code, signal) => {
+        if (settled) return;
+        const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
+        finish(new Error(`adapter exited before ACP initialize completed (code=${String(code)}, signal=${String(signal)})${suffix}`));
+      });
+
+      child.stdin.on("error", (error) => finish(new Error(`failed to send ACP initialize: ${error.message}`)));
+      // Keep stdin open until the response arrives. ACP adapters treat EOF as client
+      // disconnect; ending immediately can race an async initialize and yield code 0
+      // with no response (observed with codex-acp 1.x).
+      child.stdin.write(`${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 0,
+        method: "initialize",
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: {
+            fs: { readTextFile: true, writeTextFile: true },
+            terminal: true,
+          },
+          clientInfo: { name: "xacpx-adapter-check", version: "1" },
+        },
+      })}\n`);
+    });
+  } finally {
+    if (timer) clearTimeout(timer);
+    child.stdin.destroy();
+    child.stdout.destroy();
+    child.stderr.destroy();
+    await terminateProcessTree(child.pid ?? 0, { detachedProcessGroup: detached });
+  }
+}
+
+/** Downloads the exact package version through npm's exec cache, then probes ACP. */
+export async function verifyAdapterVersion(id: ManagedAdapterId, version: string): Promise<void> {
+  const adapter = MANAGED_ADAPTERS[id];
+  const npm = resolveNpmCommand();
+  await verifyAcpInitialize(npm.command, [
+    ...npm.prefixArgs,
+    "exec",
+    "--yes",
+    `--package=${adapter.packageName}@${version}`,
+    "--",
+    adapter.binName,
+  ]);
+}
+
+function resolveNpmCommand(): { command: string; prefixArgs: string[] } {
+  if (process.platform !== "win32") return { command: "npm", prefixArgs: [] };
+
+  // Never route package specs through a command shell. Official Node installers
+  // place npm-cli.js beside node.exe; npm-run scripts also expose its exact path.
+  const candidates = [
+    process.env.npm_execpath,
+    join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+  ];
+  const npmCli = candidates.find((candidate): candidate is string =>
+    typeof candidate === "string" && /npm-cli\.(?:c?js)$/i.test(candidate) && existsSync(candidate));
+  if (!npmCli) {
+    throw new Error("cannot locate npm-cli.js for shell-free adapter verification");
+  }
+  return { command: process.execPath, prefixArgs: [npmCli] };
+}
+
+function appendLimited(current: string, chunk: string): string {
+  const next = current + chunk;
+  return next.length <= OUTPUT_LIMIT ? next : next.slice(next.length - OUTPUT_LIMIT);
+}

--- a/src/adapters/adapter-verifier.ts
+++ b/src/adapters/adapter-verifier.ts
@@ -1,15 +1,21 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
 
 import { terminateProcessTree } from "../process/terminate-process-tree";
 import { MANAGED_ADAPTERS, type ManagedAdapterId } from "./adapter-catalog";
+import { resolveNpmCommand } from "./adapter-npm";
+import {
+  DEFAULT_ADAPTER_REGISTRY,
+  adapterRegistryNpmArgs,
+  adapterRegistryE404Guidance,
+  effectiveAdapterRegistry,
+} from "./adapter-registry";
 
 const DEFAULT_VERIFY_TIMEOUT_MS = 120_000;
 const OUTPUT_LIMIT = 64 * 1024;
 
 interface VerifyOptions {
   timeoutMs?: number;
+  adapterRegistry?: string;
 }
 
 interface JsonRpcResponse {
@@ -89,6 +95,10 @@ export async function verifyAcpInitialize(
       child.once("error", (error) => finish(new Error(`failed to start adapter: ${error.message}`)));
       child.once("close", (code, signal) => {
         if (settled) return;
+        if (options.adapterRegistry && /\bE404\b|\b404\s+Not\s+Found\b/i.test(stderr)) {
+          finish(new Error(adapterRegistryE404Guidance(effectiveAdapterRegistry(options.adapterRegistry))));
+          return;
+        }
         const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
         finish(new Error(`adapter exited before ACP initialize completed (code=${String(code)}, signal=${String(signal)})${suffix}`));
       });
@@ -121,34 +131,23 @@ export async function verifyAcpInitialize(
 }
 
 /** Downloads the exact package version through npm's exec cache, then probes ACP. */
-export async function verifyAdapterVersion(id: ManagedAdapterId, version: string): Promise<void> {
+export async function verifyAdapterVersion(
+  id: ManagedAdapterId,
+  version: string,
+  registry: string = DEFAULT_ADAPTER_REGISTRY,
+): Promise<void> {
   const adapter = MANAGED_ADAPTERS[id];
   const npm = resolveNpmCommand();
+  const normalizedRegistry = effectiveAdapterRegistry(registry);
   await verifyAcpInitialize(npm.command, [
     ...npm.prefixArgs,
     "exec",
     "--yes",
+    ...adapterRegistryNpmArgs(normalizedRegistry),
     `--package=${adapter.packageName}@${version}`,
     "--",
     adapter.binName,
-  ]);
-}
-
-function resolveNpmCommand(): { command: string; prefixArgs: string[] } {
-  if (process.platform !== "win32") return { command: "npm", prefixArgs: [] };
-
-  // Never route package specs through a command shell. Official Node installers
-  // place npm-cli.js beside node.exe; npm-run scripts also expose its exact path.
-  const candidates = [
-    process.env.npm_execpath,
-    join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
-  ];
-  const npmCli = candidates.find((candidate): candidate is string =>
-    typeof candidate === "string" && /npm-cli\.(?:c?js)$/i.test(candidate) && existsSync(candidate));
-  if (!npmCli) {
-    throw new Error("cannot locate npm-cli.js for shell-free adapter verification");
-  }
-  return { command: process.execPath, prefixArgs: [npmCli] };
+  ], { adapterRegistry: normalizedRegistry });
 }
 
 function appendLimited(current: string, chunk: string): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,9 +42,9 @@ import { toDisplaySessionAlias } from "./channels/channel-scope";
 import { renderLaterList } from "./scheduled/scheduled-render";
 import { ScheduledTaskService, normalizeId } from "./scheduled/scheduled-service";
 import { maybeRunFirstUseOnboarding, type FirstRunOnboardingPlan } from "./onboarding.js";
-import { getLatestNpmVersion, handleUpdateCli, type UpdateCliDeps } from "./cli-update.js";
+import { handleUpdateCli, type UpdateCliDeps } from "./cli-update.js";
 import { handleAdapterCli, type AdapterCliDeps } from "./adapters/adapter-cli";
-import { MANAGED_ADAPTERS } from "./adapters/adapter-catalog";
+import { getAdapterNpmVersion } from "./adapters/adapter-npm";
 import { verifyAdapterVersion } from "./adapters/adapter-verifier";
 import type { AppConfig } from "./config/types";
 import type { AppState } from "./state/types";
@@ -921,9 +921,11 @@ function createAdapterCliDeps(input: {
   const defaults: AdapterCliDeps = {
     loadVersions: async () => (await (await getStore()).load()).transport.adapterVersions ?? {},
     saveVersions: async (versions) => { await (await getStore()).replaceAdapterVersions(versions); },
-    getLatestVersion: async (id) => await getLatestNpmVersion(MANAGED_ADAPTERS[id].packageName),
-    versionExists: async (id, version) =>
-      await getLatestNpmVersion(`${MANAGED_ADAPTERS[id].packageName}@${version}`) === version,
+    loadRegistry: async () => (await (await getStore()).load()).transport.adapterRegistry,
+    saveRegistry: async (registry) => { await (await getStore()).updateTransport({ adapterRegistry: registry }); },
+    getLatestVersion: async (id, registry) => await getAdapterNpmVersion(id, undefined, registry),
+    versionExists: async (id, version, registry) =>
+      await getAdapterNpmVersion(id, version, registry) === version,
     verifyVersion: verifyAdapterVersion,
     print: input.print,
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,7 +42,10 @@ import { toDisplaySessionAlias } from "./channels/channel-scope";
 import { renderLaterList } from "./scheduled/scheduled-render";
 import { ScheduledTaskService, normalizeId } from "./scheduled/scheduled-service";
 import { maybeRunFirstUseOnboarding, type FirstRunOnboardingPlan } from "./onboarding.js";
-import { handleUpdateCli, type UpdateCliDeps } from "./cli-update.js";
+import { getLatestNpmVersion, handleUpdateCli, type UpdateCliDeps } from "./cli-update.js";
+import { handleAdapterCli, type AdapterCliDeps } from "./adapters/adapter-cli";
+import { MANAGED_ADAPTERS } from "./adapters/adapter-catalog";
+import { verifyAdapterVersion } from "./adapters/adapter-verifier";
 import type { AppConfig } from "./config/types";
 import type { AppState } from "./state/types";
 import { readVersion } from "./version.js";
@@ -257,6 +260,7 @@ interface CliDeps {
   channelCliDeps?: Partial<ChannelCliDeps>;
   pluginCliDeps?: Partial<PluginCliDeps>;
   updateCliDeps?: Partial<UpdateCliDeps>;
+  adapterCliDeps?: Partial<AdapterCliDeps>;
   loadConfiguredPluginsForChannelCli?: () => Promise<void>;
   isInteractive?: () => boolean;
   promptText?: (message: string) => Promise<string>;
@@ -367,6 +371,17 @@ export async function runCli(args: string[], deps: CliDeps = {}): Promise<number
         for (const line of t().cli.helpLines) {
           print(line);
         }
+        return 1;
+      }
+      return result;
+    }
+    case "adapter": {
+      const result = await handleAdapterCli(args.slice(1), createAdapterCliDeps({
+        print,
+        overrides: deps.adapterCliDeps,
+      }));
+      if (result === null) {
+        for (const line of t().cli.helpLines) print(line);
         return 1;
       }
       return result;
@@ -895,6 +910,24 @@ async function createCliConfigStore(): Promise<ConfigStore> {
   const configPath = resolveConfigPathForCurrentEnv();
   await ensureConfigExists(configPath);
   return new ConfigStore(configPath);
+}
+
+function createAdapterCliDeps(input: {
+  print: (line: string) => void;
+  overrides?: Partial<AdapterCliDeps>;
+}): AdapterCliDeps {
+  let storePromise: Promise<ConfigStore> | undefined;
+  const getStore = (): Promise<ConfigStore> => storePromise ??= createCliConfigStore();
+  const defaults: AdapterCliDeps = {
+    loadVersions: async () => (await (await getStore()).load()).transport.adapterVersions ?? {},
+    saveVersions: async (versions) => { await (await getStore()).replaceAdapterVersions(versions); },
+    getLatestVersion: async (id) => await getLatestNpmVersion(MANAGED_ADAPTERS[id].packageName),
+    versionExists: async (id, version) =>
+      await getLatestNpmVersion(`${MANAGED_ADAPTERS[id].packageName}@${version}`) === version,
+    verifyVersion: verifyAdapterVersion,
+    print: input.print,
+  };
+  return { ...defaults, ...input.overrides, print: input.overrides?.print ?? input.print };
 }
 
 export async function resolveLoginChannelForCli(): Promise<ReturnType<typeof createMessageChannel>> {

--- a/src/commands/handlers/native-session-handler.ts
+++ b/src/commands/handlers/native-session-handler.ts
@@ -1,4 +1,4 @@
-import { resolveRuntimeAgentCommand } from "../../config/resolve-agent-command";
+import { resolveConfiguredAgentCommand } from "../../config/resolve-agent-command";
 import { getChannelIdFromChatKey, scopeDisplayAliasToInternal, toDisplaySessionAlias } from "../../channels/channel-scope";
 import type { AgentSession, AgentSessionListQuery, AgentSessionListResult, ResolvedSession } from "../../transport/types";
 import { allocateWorkspaceName, sanitizeWorkspaceName } from "../workspace-name";
@@ -258,7 +258,7 @@ async function resolveNativeTarget(
   return {
     agent,
     agentDisplayName: displayAgentName(agent),
-    agentCommand: resolveRuntimeAgentCommand(agentConfig.driver, agentConfig.command, context.config?.transport.preferLocalAgents !== false),
+    agentCommand: resolveConfiguredAgentCommand(agentConfig, context.config?.transport),
     driver: agentConfig.driver,
     workspace: workspaceResolution.workspace,
     workspaceLabel: workspaceResolution.workspaceLabel,

--- a/src/commands/handlers/session-recovery-handler.ts
+++ b/src/commands/handlers/session-recovery-handler.ts
@@ -6,7 +6,7 @@ import { quoteWorkspaceNameIfNeeded } from "../workspace-name";
 import { t } from "../../i18n";
 import {
   DEFAULT_ADAPTER_REGISTRY,
-  isAdapterRegistryNotFoundOutput,
+  isNpmAdapterRegistryNotFoundOutput,
 } from "../../adapters/adapter-registry";
 import { managedAdapterRegistryFromCommand } from "../../adapters/adapter-catalog";
 
@@ -102,7 +102,7 @@ export function renderSessionCreationError(session: ResolvedSession, error: unkn
 
 function renderAdapterRegistryError(session: ResolvedSession, message: string): RouterResponse | null {
   const registry = managedAdapterRegistryFromCommand(session.agentCommand);
-  if (!registry || !isAdapterRegistryNotFoundOutput(message)) return null;
+  if (!registry || !isNpmAdapterRegistryNotFoundOutput(message)) return null;
   return {
     text: t().recovery.adapterRegistryE404(registry, DEFAULT_ADAPTER_REGISTRY),
   };

--- a/src/commands/handlers/session-recovery-handler.ts
+++ b/src/commands/handlers/session-recovery-handler.ts
@@ -4,9 +4,16 @@ import { isPartialPromptOutputError, summarizeTransportError } from "../transpor
 import { AutoInstallFailedError } from "../../recovery/errors";
 import { quoteWorkspaceNameIfNeeded } from "../workspace-name";
 import { t } from "../../i18n";
+import {
+  DEFAULT_ADAPTER_REGISTRY,
+  isAdapterRegistryNotFoundOutput,
+} from "../../adapters/adapter-registry";
+import { managedAdapterRegistryFromCommand } from "../../adapters/adapter-catalog";
 
 export function renderTransportError(session: ResolvedSession, error: unknown): RouterResponse {
   const message = error instanceof Error ? error.message : String(error);
+  const registryError = renderAdapterRegistryError(session, message);
+  if (registryError) return registryError;
 
   if (message.includes("No acpx session found")) {
     if (session.transient) {
@@ -78,11 +85,27 @@ export function renderSessionCreationError(session: ResolvedSession, error: unkn
 
   const message = error instanceof Error ? error.message : String(error);
 
+  const registryError = renderAdapterRegistryError(session, message);
+  if (registryError) return {
+    text: [
+      t().recovery.sessionCreationFailed,
+      registryError.text,
+    ].join("\n"),
+  };
+
   if (message.includes("timed out") && message.includes("sessions new")) {
     return renderSessionCreationFailure(session, message);
   }
 
   throw error;
+}
+
+function renderAdapterRegistryError(session: ResolvedSession, message: string): RouterResponse | null {
+  const registry = managedAdapterRegistryFromCommand(session.agentCommand);
+  if (!registry || !isAdapterRegistryNotFoundOutput(message)) return null;
+  return {
+    text: t().recovery.adapterRegistryE404(registry, DEFAULT_ADAPTER_REGISTRY),
+  };
 }
 
 export function renderSessionCreationVerificationError(session: ResolvedSession): RouterResponse {

--- a/src/commands/session-control-service.ts
+++ b/src/commands/session-control-service.ts
@@ -3,7 +3,7 @@ import type { AppConfig } from "../config/types";
 import type { AppLogger } from "../logging/app-logger";
 import type { SessionService } from "../sessions/session-service";
 import type { AgentSession, ResolvedSession, SessionTransport } from "../transport/types";
-import { resolveRuntimeAgentCommand } from "../config/resolve-agent-command";
+import { resolveConfiguredAgentCommand } from "../config/resolve-agent-command";
 import type { OrchestrationRouterOps } from "./router-types";
 import type { TransportInvoker } from "./transport-invoker";
 
@@ -227,11 +227,7 @@ export class SessionControlService {
     if (!agentConfig || !workspaceConfig) {
       throw new Error(`unknown agent "${agent}" or workspace "${workspace}"`);
     }
-    const agentCommand = resolveRuntimeAgentCommand(
-      agentConfig.driver,
-      agentConfig.command,
-      this.config?.transport.preferLocalAgents !== false,
-    );
+    const agentCommand = resolveConfiguredAgentCommand(agentConfig, this.config?.transport);
     const result = await listAgentSessions({
       agent,
       ...(agentCommand ? { agentCommand } : {}),

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { withPrivateFileLock } from "../util/private-file.js";
 
 import { loadConfig, parseConfig } from "./load-config";
+import type { AdapterVersionOverrides } from "../adapters/adapter-catalog";
 import type { AgentConfig, AppConfig, ChannelRuntimeConfig, PluginConfig } from "./types";
 
 /**
@@ -96,6 +97,18 @@ export class ConfigStore {
   async updateTransport(patch: Partial<AppConfig["transport"]>): Promise<AppConfig> {
     return await this.patchRaw((raw) => {
       applyRecordPatch(ensureRecordAt(raw, "transport"), patch);
+    });
+  }
+
+  /** Replaces only xacpx-managed adapter pins; unrelated transport keys stay untouched. */
+  async replaceAdapterVersions(versions: AdapterVersionOverrides): Promise<AppConfig> {
+    return await this.patchRaw((raw) => {
+      const transport = ensureRecordAt(raw, "transport");
+      if (Object.keys(versions).length === 0) {
+        delete transport.adapterVersions;
+      } else {
+        transport.adapterVersions = clonePlain(versions);
+      }
     });
   }
 

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -4,6 +4,7 @@ import {
   isManagedAdapterId,
   type AdapterVersionOverrides,
 } from "../adapters/adapter-catalog";
+import { normalizeAdapterRegistry } from "../adapters/adapter-registry";
 
 import { normalizeWorkspacePath } from "../commands/workspace-path";
 import { isLegacyPluginPackageName, normalizePluginPackageName } from "../plugins/plugin-renames";
@@ -173,6 +174,7 @@ export function parseConfig(
     throw new Error("transport.sessionInitTimeoutMs must be a positive number");
   }
   const adapterVersions = parseAdapterVersions(transport.adapterVersions);
+  const adapterRegistry = parseAdapterRegistry(transport.adapterRegistry);
   if (
     "permissionMode" in transport &&
     transport.permissionMode !== "approve-all" &&
@@ -351,6 +353,7 @@ export function parseConfig(
       ...(typeof transport.permissionPolicy === "string" ? { permissionPolicy: transport.permissionPolicy } : {}),
       ...(typeof transport.preferLocalAgents === "boolean" ? { preferLocalAgents: transport.preferLocalAgents } : {}),
       ...(adapterVersions ? { adapterVersions } : {}),
+      ...(adapterRegistry ? { adapterRegistry } : {}),
       ...(typeof transport.turnIdleTimeoutSeconds === "number"
         ? { turnIdleTimeoutSeconds: transport.turnIdleTimeoutSeconds }
         : {}),
@@ -423,6 +426,17 @@ function parseAdapterVersions(raw: unknown): AdapterVersionOverrides | undefined
     result[id] = value;
   }
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function parseAdapterRegistry(raw: unknown): string | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "string") throw new Error("transport.adapterRegistry must be an http(s) URL");
+  try {
+    return normalizeAdapterRegistry(raw);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`transport.adapterRegistry is invalid: ${detail}`);
+  }
 }
 
 function parsePluginConfig(raw: unknown, index: number): PluginConfig {

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -1,4 +1,9 @@
 import { readFile } from "node:fs/promises";
+import {
+  isExactAdapterVersion,
+  isManagedAdapterId,
+  type AdapterVersionOverrides,
+} from "../adapters/adapter-catalog";
 
 import { normalizeWorkspacePath } from "../commands/workspace-path";
 import { isLegacyPluginPackageName, normalizePluginPackageName } from "../plugins/plugin-renames";
@@ -167,6 +172,7 @@ export function parseConfig(
   ) {
     throw new Error("transport.sessionInitTimeoutMs must be a positive number");
   }
+  const adapterVersions = parseAdapterVersions(transport.adapterVersions);
   if (
     "permissionMode" in transport &&
     transport.permissionMode !== "approve-all" &&
@@ -344,6 +350,7 @@ export function parseConfig(
         : {}),
       ...(typeof transport.permissionPolicy === "string" ? { permissionPolicy: transport.permissionPolicy } : {}),
       ...(typeof transport.preferLocalAgents === "boolean" ? { preferLocalAgents: transport.preferLocalAgents } : {}),
+      ...(adapterVersions ? { adapterVersions } : {}),
       ...(typeof transport.turnIdleTimeoutSeconds === "number"
         ? { turnIdleTimeoutSeconds: transport.turnIdleTimeoutSeconds }
         : {}),
@@ -400,6 +407,22 @@ export function parseConfig(
         }
       : {}),
   };
+}
+
+function parseAdapterVersions(raw: unknown): AdapterVersionOverrides | undefined {
+  if (raw === undefined) return undefined;
+  if (!isRecord(raw)) throw new Error("transport.adapterVersions must be an object");
+  const result: AdapterVersionOverrides = {};
+  for (const [id, value] of Object.entries(raw)) {
+    if (!isManagedAdapterId(id)) {
+      throw new Error(`transport.adapterVersions contains unsupported adapter ${id}`);
+    }
+    if (typeof value !== "string" || !isExactAdapterVersion(value)) {
+      throw new Error(`transport.adapterVersions.${id} must be an exact semver version`);
+    }
+    result[id] = value;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function parsePluginConfig(raw: unknown, index: number): PluginConfig {

--- a/src/config/resolve-agent-command.ts
+++ b/src/config/resolve-agent-command.ts
@@ -1,4 +1,6 @@
 import { resolveLocalAgentCommand } from "./local-agent-bin";
+import { resolveManagedAdapterCommand, type AdapterVersionOverrides } from "../adapters/adapter-catalog";
+import type { AgentConfig, TransportConfig } from "./types";
 
 export function resolveAgentCommand(
   driver: string,
@@ -17,8 +19,8 @@ export function resolveAgentCommand(
 
 /**
  * Agent command for the RUNTIME spawn/reap paths. An explicit per-agent `command`
- * always wins; otherwise, when `preferLocal` (default true), prefer a locally-installed
- * native CLI over acpx's npx fallback; otherwise undefined (acpx resolves the driver).
+ * always wins. Managed codex/claude drivers then use xacpx's exact npx pin; only
+ * unmanaged drivers fall through to the optional locally-installed native CLI.
  *
  * Use this — not bare resolveAgentCommand — wherever an agentCommand is built to spawn
  * OR reap a queue owner, so both resolve identically (a mismatch would orphan the owner).
@@ -29,12 +31,29 @@ export function resolveRuntimeAgentCommand(
   driver: string,
   command: string | undefined,
   preferLocal = true,
+  adapterVersions?: AdapterVersionOverrides,
 ): string | undefined {
   const explicit = resolveAgentCommand(driver, command);
   if (explicit) {
     return explicit;
   }
+  const managed = resolveManagedAdapterCommand(driver, adapterVersions);
+  if (managed) return managed;
   return preferLocal ? resolveLocalAgentCommand(driver) : undefined;
+}
+
+/** Config-shaped entrypoint used by every runtime spawn/list/reap path. Keeping
+ * this decomposition here prevents those identity-sensitive paths from drifting. */
+export function resolveConfiguredAgentCommand(
+  agent: Pick<AgentConfig, "driver" | "command">,
+  transport?: Pick<TransportConfig, "preferLocalAgents" | "adapterVersions">,
+): string | undefined {
+  return resolveRuntimeAgentCommand(
+    agent.driver,
+    agent.command,
+    transport?.preferLocalAgents !== false,
+    transport?.adapterVersions,
+  );
 }
 
 export function isLegacyCodexCommand(command: string): boolean {

--- a/src/config/resolve-agent-command.ts
+++ b/src/config/resolve-agent-command.ts
@@ -32,12 +32,13 @@ export function resolveRuntimeAgentCommand(
   command: string | undefined,
   preferLocal = true,
   adapterVersions?: AdapterVersionOverrides,
+  adapterRegistry?: string,
 ): string | undefined {
   const explicit = resolveAgentCommand(driver, command);
   if (explicit) {
     return explicit;
   }
-  const managed = resolveManagedAdapterCommand(driver, adapterVersions);
+  const managed = resolveManagedAdapterCommand(driver, adapterVersions, adapterRegistry);
   if (managed) return managed;
   return preferLocal ? resolveLocalAgentCommand(driver) : undefined;
 }
@@ -46,13 +47,14 @@ export function resolveRuntimeAgentCommand(
  * this decomposition here prevents those identity-sensitive paths from drifting. */
 export function resolveConfiguredAgentCommand(
   agent: Pick<AgentConfig, "driver" | "command">,
-  transport?: Pick<TransportConfig, "preferLocalAgents" | "adapterVersions">,
+  transport?: Pick<TransportConfig, "preferLocalAgents" | "adapterVersions" | "adapterRegistry">,
 ): string | undefined {
   return resolveRuntimeAgentCommand(
     agent.driver,
     agent.command,
     transport?.preferLocalAgents !== false,
     transport?.adapterVersions,
+    transport?.adapterRegistry,
   );
 }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,6 +49,9 @@ export interface TransportConfig {
   /** Exact local overrides for xacpx-managed ACP adapter versions. Omitted entries
    * use the tested defaults compiled into this xacpx release. */
   adapterVersions?: AdapterVersionOverrides;
+  /** Registry used only for xacpx-managed ACP adapters. Defaults to the public
+   * npm registry instead of inheriting the machine's npm registry. */
+  adapterRegistry?: string;
   /**
    * Inactivity watchdog: abort a turn that produces NO agent activity (no streamed
    * output/tool/thought/usage event) for this many seconds, reclaiming its in-flight

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,5 @@
 import type { Locale } from "../i18n/resolve-locale";
+import type { AdapterVersionOverrides } from "../adapters/adapter-catalog";
 
 export type PermissionMode = "approve-all" | "approve-reads" | "deny-all";
 export type NonInteractivePermissions = "deny" | "fail";
@@ -45,6 +46,9 @@ export interface TransportConfig {
    * acpx's default resolution. A per-agent `command` override still takes precedence.
    */
   preferLocalAgents?: boolean;
+  /** Exact local overrides for xacpx-managed ACP adapter versions. Omitted entries
+   * use the tested defaults compiled into this xacpx release. */
+  adapterVersions?: AdapterVersionOverrides;
   /**
    * Inactivity watchdog: abort a turn that produces NO agent activity (no streamed
    * output/tool/thought/usage event) for this many seconds, reclaiming its in-flight

--- a/src/doctor/checks/smoke-check.ts
+++ b/src/doctor/checks/smoke-check.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from "../../config/load-config";
 import { resolveAcpxCommandMetadata, type AcpxCommandMetadata } from "../../config/resolve-acpx-command";
-import { resolveRuntimeAgentCommand } from "../../config/resolve-agent-command";
+import { resolveConfiguredAgentCommand } from "../../config/resolve-agent-command";
 import type { AppConfig } from "../../config/types";
 import { resolveBridgeEntryPath, resolveRuntimePaths, type RuntimePaths } from "../../main";
 import { spawnAcpxBridgeClient, type ManagedBridgeClient } from "../../transport/acpx-bridge/acpx-bridge-client";
@@ -263,11 +263,7 @@ function buildSession(options: {
     // Resolve the SAME way the runtime spawn paths do, so the smoke test validates the
     // real agent command (incl. a locally-preferred native CLI), not acpx's npx fallback.
     ...((): { agentCommand?: string } => {
-      const agentCommand = resolveRuntimeAgentCommand(
-        agentConfig.driver,
-        agentConfig.command,
-        options.config.transport.preferLocalAgents !== false,
-      );
+      const agentCommand = resolveConfiguredAgentCommand(agentConfig, options.config.transport);
       return agentCommand ? { agentCommand } : {};
     })(),
     workspace: options.workspace,

--- a/src/i18n/messages/en/cli.ts
+++ b/src/i18n/messages/en/cli.ts
@@ -18,6 +18,7 @@ export const cli: CliMessages = {
     "xacpx version - Show version",
     "xacpx agent|agents list|add|rm|templates - Manage local agents",
     "xacpx adapter list|check [name]|update (<name>|--all)|set <name> <version>|reset <name> - Manage ACP adapter versions",
+    "xacpx adapter registry [set <url>|reset] - Manage the ACP adapter npm registry",
     "xacpx workspace list|add [name] [--raw]|rm <name> - Manage local workspaces (alias: ws)",
     "xacpx later|lt list|cancel <id> - Manage local scheduled tasks",
     "xacpx mcp-stdio [--coordinator-session <session>] [--source-handle <handle>] [--workspace <name>] - Start MCP stdio server",
@@ -90,7 +91,11 @@ export const cli: CliMessages = {
   adapterSaved: (id, version) => `${id} adapter version set to ${version}.`,
   adapterReset: (id, version) => `${id} adapter override removed; effective version is ${version}.`,
   adapterFailed: (id, detail) => `Failed to update ${id} adapter: ${detail}`,
-  adapterRestartRequired: "Restart the xacpx daemon before using the new adapter version.",
+  adapterRestartRequired: "Restart the xacpx daemon before using the new adapter settings.",
+  adapterRegistryCurrent: (registry, source) => `Adapter registry: ${registry} (source=${source})`,
+  adapterRegistrySaved: (registry) => `Adapter registry set to ${registry}.`,
+  adapterRegistryReset: (registry) => `Adapter registry override removed; using ${registry}.`,
+  adapterInvalidRegistry: (detail) => `Invalid adapter registry: ${detail}`,
 
   // later commands
   laterIdEmpty: "Scheduled task ID cannot be empty.",

--- a/src/i18n/messages/en/cli.ts
+++ b/src/i18n/messages/en/cli.ts
@@ -17,6 +17,7 @@ export const cli: CliMessages = {
     "xacpx doctor - Run diagnostics",
     "xacpx version - Show version",
     "xacpx agent|agents list|add|rm|templates - Manage local agents",
+    "xacpx adapter list|check [name]|update (<name>|--all)|set <name> <version>|reset <name> - Manage ACP adapter versions",
     "xacpx workspace list|add [name] [--raw]|rm <name> - Manage local workspaces (alias: ws)",
     "xacpx later|lt list|cancel <id> - Manage local scheduled tasks",
     "xacpx mcp-stdio [--coordinator-session <session>] [--source-handle <handle>] [--workspace <name>] - Start MCP stdio server",
@@ -72,6 +73,24 @@ export const cli: CliMessages = {
   agentSaved: (name) => `Agent "${name}" saved`,
   agentNotFound: (name) => `Agent "${name}" not found.`,
   agentRemoved: (name) => `Agent "${name}" removed`,
+
+  // adapter commands
+  adapterListHeader: "Managed ACP adapters:",
+  adapterListRow: (id, effective, defaultVersion, source) =>
+    `${id}: effective=${effective} default=${defaultVersion} source=${source}`,
+  adapterSourceDefault: "xacpx-default",
+  adapterSourceConfigured: "configured",
+  adapterUnsupported: (id) => `Unsupported managed adapter "${id}". Available: codex, claude`,
+  adapterInvalidVersion: (version) => `Adapter version must be an exact semver value: ${version}`,
+  adapterVersionUnavailable: (id, version) => `${id} adapter version ${version} is not published by npm.`,
+  adapterLatestUnavailable: (id) => `Could not resolve the latest ${id} adapter version from npm.`,
+  adapterCheckRow: (id, effective, latest) => `${id}: effective=${effective} latest=${latest}`,
+  adapterAlreadyLatest: (id, version) => `${id} already uses the latest adapter version ${version}.`,
+  adapterVerifying: (id, version) => `Verifying ${id} adapter ${version} with ACP initialize...`,
+  adapterSaved: (id, version) => `${id} adapter version set to ${version}.`,
+  adapterReset: (id, version) => `${id} adapter override removed; effective version is ${version}.`,
+  adapterFailed: (id, detail) => `Failed to update ${id} adapter: ${detail}`,
+  adapterRestartRequired: "Restart the xacpx daemon before using the new adapter version.",
 
   // later commands
   laterIdEmpty: "Scheduled task ID cannot be empty.",

--- a/src/i18n/messages/en/recovery.ts
+++ b/src/i18n/messages/en/recovery.ts
@@ -1,6 +1,8 @@
 import type { RecoveryMessages } from "../../types";
 
 export const recovery: RecoveryMessages = {
+  adapterRegistryE404: (registry, officialRegistry) =>
+    `npm registry ${registry} returned E404 for the managed adapter. Run \`xacpx adapter registry set ${officialRegistry}\` and \`xacpx restart\`, or ask your registry administrator to proxy/allowlist the @agentclientprotocol scope.`,
   // renderTransportError — transient session
   transientSessionFailed: "The scheduled task's temporary session failed to start; this run was not executed.",
   transientSessionHint: "Temporary sessions are created automatically at run time — no manual action needed. To reschedule, use /lt.",

--- a/src/i18n/messages/zh/cli.ts
+++ b/src/i18n/messages/zh/cli.ts
@@ -18,6 +18,7 @@ export const cli: CliMessages = {
     "xacpx version - 查看版本",
     "xacpx agent|agents list|add|rm|templates - 管理本机 Agent",
     "xacpx adapter list|check [name]|update (<name>|--all)|set <name> <version>|reset <name> - 管理 ACP adapter 版本",
+    "xacpx adapter registry [set <url>|reset] - 管理 ACP adapter npm registry",
     "xacpx workspace list|add [name] [--raw]|rm <name> - 管理本机工作区（别名：ws）",
     "xacpx later|lt list|cancel <id> - 管理本机待执行定时任务",
     "xacpx mcp-stdio [--coordinator-session <session>] [--source-handle <handle>] [--workspace <name>] - 启动 MCP stdio 服务",
@@ -90,7 +91,11 @@ export const cli: CliMessages = {
   adapterSaved: (id, version) => `${id} adapter 版本已设置为 ${version}。`,
   adapterReset: (id, version) => `${id} adapter 本机覆盖已删除；当前生效版本为 ${version}。`,
   adapterFailed: (id, detail) => `${id} adapter 更新失败：${detail}`,
-  adapterRestartRequired: "请重启 xacpx daemon 后再使用新的 adapter 版本。",
+  adapterRestartRequired: "请重启 xacpx daemon 后再使用新的 adapter 配置。",
+  adapterRegistryCurrent: (registry, source) => `Adapter registry：${registry}（来源=${source}）`,
+  adapterRegistrySaved: (registry) => `Adapter registry 已设置为 ${registry}。`,
+  adapterRegistryReset: (registry) => `Adapter registry 本机覆盖已删除；当前使用 ${registry}。`,
+  adapterInvalidRegistry: (detail) => `Adapter registry 无效：${detail}`,
 
   // later commands
   laterIdEmpty: "定时任务 ID 不能为空。",

--- a/src/i18n/messages/zh/cli.ts
+++ b/src/i18n/messages/zh/cli.ts
@@ -17,6 +17,7 @@ export const cli: CliMessages = {
     "xacpx doctor - 运行诊断",
     "xacpx version - 查看版本",
     "xacpx agent|agents list|add|rm|templates - 管理本机 Agent",
+    "xacpx adapter list|check [name]|update (<name>|--all)|set <name> <version>|reset <name> - 管理 ACP adapter 版本",
     "xacpx workspace list|add [name] [--raw]|rm <name> - 管理本机工作区（别名：ws）",
     "xacpx later|lt list|cancel <id> - 管理本机待执行定时任务",
     "xacpx mcp-stdio [--coordinator-session <session>] [--source-handle <handle>] [--workspace <name>] - 启动 MCP stdio 服务",
@@ -72,6 +73,24 @@ export const cli: CliMessages = {
   agentSaved: (name) => `Agent「${name}」已保存`,
   agentNotFound: (name) => `没有找到 Agent「${name}」。`,
   agentRemoved: (name) => `Agent「${name}」已删除`,
+
+  // adapter commands
+  adapterListHeader: "受管 ACP adapter：",
+  adapterListRow: (id, effective, defaultVersion, source) =>
+    `${id}：生效=${effective} 默认=${defaultVersion} 来源=${source}`,
+  adapterSourceDefault: "xacpx 默认",
+  adapterSourceConfigured: "本机配置",
+  adapterUnsupported: (id) => `不支持受管 adapter「${id}」。可用：codex、claude`,
+  adapterInvalidVersion: (version) => `Adapter 版本必须是精确 semver：${version}`,
+  adapterVersionUnavailable: (id, version) => `npm 未发布 ${id} adapter 版本 ${version}。`,
+  adapterLatestUnavailable: (id) => `无法从 npm 获取 ${id} adapter 的最新版本。`,
+  adapterCheckRow: (id, effective, latest) => `${id}：生效=${effective} 最新=${latest}`,
+  adapterAlreadyLatest: (id, version) => `${id} 已使用最新 adapter 版本 ${version}。`,
+  adapterVerifying: (id, version) => `正在通过 ACP initialize 验证 ${id} adapter ${version}…`,
+  adapterSaved: (id, version) => `${id} adapter 版本已设置为 ${version}。`,
+  adapterReset: (id, version) => `${id} adapter 本机覆盖已删除；当前生效版本为 ${version}。`,
+  adapterFailed: (id, detail) => `${id} adapter 更新失败：${detail}`,
+  adapterRestartRequired: "请重启 xacpx daemon 后再使用新的 adapter 版本。",
 
   // later commands
   laterIdEmpty: "定时任务 ID 不能为空。",

--- a/src/i18n/messages/zh/recovery.ts
+++ b/src/i18n/messages/zh/recovery.ts
@@ -1,6 +1,8 @@
 import type { RecoveryMessages } from "../../types";
 
 export const recovery: RecoveryMessages = {
+  adapterRegistryE404: (registry, officialRegistry) =>
+    `npm registry ${registry} 返回了 managed adapter E404。请执行 \`xacpx adapter registry set ${officialRegistry}\` 和 \`xacpx restart\`，或让私源管理员代理/放行 @agentclientprotocol scope。`,
   // renderTransportError — transient session
   transientSessionFailed: "定时任务的临时会话启动失败，本次任务未能执行。",
   transientSessionHint: "临时会话由系统在执行时自动创建，无需手动操作；如需重排，请用 /lt 重新安排。",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -238,6 +238,7 @@ export interface NativeSessionMessages {
 }
 
 export interface RecoveryMessages {
+  adapterRegistryE404: (registry: string, officialRegistry: string) => string;
   // renderTransportError — transient session
   transientSessionFailed: string;
   transientSessionHint: string;

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -935,6 +935,10 @@ export interface CliMessages {
   adapterReset: (id: string, version: string) => string;
   adapterFailed: (id: string, detail: string) => string;
   adapterRestartRequired: string;
+  adapterRegistryCurrent: (registry: string, source: string) => string;
+  adapterRegistrySaved: (registry: string) => string;
+  adapterRegistryReset: (registry: string) => string;
+  adapterInvalidRegistry: (detail: string) => string;
 
   // later commands
   laterIdEmpty: string;

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -919,6 +919,23 @@ export interface CliMessages {
   agentNotFound: (name: string) => string;
   agentRemoved: (name: string) => string;
 
+  // adapter commands
+  adapterListHeader: string;
+  adapterListRow: (id: string, effective: string, defaultVersion: string, source: string) => string;
+  adapterSourceDefault: string;
+  adapterSourceConfigured: string;
+  adapterUnsupported: (id: string) => string;
+  adapterInvalidVersion: (version: string) => string;
+  adapterVersionUnavailable: (id: string, version: string) => string;
+  adapterLatestUnavailable: (id: string) => string;
+  adapterCheckRow: (id: string, effective: string, latest: string) => string;
+  adapterAlreadyLatest: (id: string, version: string) => string;
+  adapterVerifying: (id: string, version: string) => string;
+  adapterSaved: (id: string, version: string) => string;
+  adapterReset: (id: string, version: string) => string;
+  adapterFailed: (id: string, detail: string) => string;
+  adapterRestartRequired: string;
+
   // later commands
   laterIdEmpty: string;
   laterNotFound: (id: string) => string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { ConfigStore } from "./config/config-store";
 import { ensureConfigExists } from "./config/ensure-config";
 import { loadConfig } from "./config/load-config";
 import { resolveAcpxCommand } from "./config/resolve-acpx-command";
-import { resolveRuntimeAgentCommand } from "./config/resolve-agent-command";
+import { resolveConfiguredAgentCommand } from "./config/resolve-agent-command";
 import { ConsoleAgent } from "./console-agent";
 import type { AppConfig, LoggingLevel } from "./config/types";
 import { terminalEnabled, terminalIdleTimeoutSeconds, terminalShell, filesWriteEnabled, turnIdleTimeoutSeconds } from "./config/types";
@@ -497,7 +497,7 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
     return {
       alias: input.workerSession,
       agent: input.targetAgent,
-      agentCommand: resolveRuntimeAgentCommand(agentConfig.driver, agentConfig.command, config.transport.preferLocalAgents !== false),
+      agentCommand: resolveConfiguredAgentCommand(agentConfig, config.transport),
       workspace: input.workspace,
       transportSession: input.workerSession,
       cwd: input.cwd,

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -1,4 +1,9 @@
-import { resolveRuntimeAgentCommand } from "../config/resolve-agent-command";
+import {
+  isLegacyCodexCommand,
+  resolveAgentCommand,
+  resolveConfiguredAgentCommand,
+} from "../config/resolve-agent-command";
+import { preferCurrentManagedAdapterCommand } from "../adapters/adapter-catalog";
 import type { AppConfig, WechatReplyMode } from "../config/types";
 import { t } from "../i18n/index.js";
 import { AsyncMutex } from "../orchestration/async-mutex";
@@ -657,11 +662,22 @@ export class SessionService {
     // resolution (including per-session overrides via `session.reply_mode`) is unchanged.
     const channelId = getChannelIdFromChatKey(session.alias);
     const effectiveReplyMode = channelId === "relay" ? "stream" : undefined;
+    const currentAgentCommand = resolveConfiguredAgentCommand(agentConfig, this.config.transport);
+    const configuredAgentCommand = resolveAgentCommand(agentConfig.driver, agentConfig.command);
+    const recordedAgentCommand = agentConfig.driver === "codex" &&
+      session.transport_agent_command &&
+      isLegacyCodexCommand(session.transport_agent_command)
+      ? undefined
+      : session.transport_agent_command;
 
     return {
       alias: session.alias,
       agent: session.agent,
-      agentCommand: session.transport_agent_command ?? resolveRuntimeAgentCommand(agentConfig.driver, agentConfig.command, this.config.transport.preferLocalAgents !== false),
+      agentCommand: configuredAgentCommand ?? preferCurrentManagedAdapterCommand(
+        agentConfig.driver,
+        recordedAgentCommand,
+        currentAgentCommand,
+      ),
       // Session-level model wins; otherwise fall back to the agent config default.
       model: session.model ?? agentConfig.model,
       displayName: session.display_name,

--- a/src/transport/collect-reap-targets.ts
+++ b/src/transport/collect-reap-targets.ts
@@ -1,4 +1,4 @@
-import { resolveRuntimeAgentCommand } from "../config/resolve-agent-command";
+import { resolveConfiguredAgentCommand } from "../config/resolve-agent-command";
 import type { AppConfig } from "../config/types";
 import type { OrchestrationState } from "../orchestration/orchestration-types";
 import type { ResolvedSession } from "./types";
@@ -55,7 +55,7 @@ export function workerBindingReapTargets(
     if (!cwd) {
       continue;
     }
-    const agentCommand = resolveRuntimeAgentCommand(agentConfig.driver, agentConfig.command, config.transport.preferLocalAgents !== false);
+    const agentCommand = resolveConfiguredAgentCommand(agentConfig, config.transport);
     targets.push({
       agent: binding.targetAgent,
       ...(agentCommand ? { agentCommand } : {}),

--- a/tests/unit/adapters/adapter-catalog.test.ts
+++ b/tests/unit/adapters/adapter-catalog.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+
+import {
+  buildManagedAdapterCommand,
+  effectiveAdapterVersion,
+  isExactAdapterVersion,
+  isManagedAdapterCommand,
+} from "../../../src/adapters/adapter-catalog";
+
+test("managed adapters use tested exact defaults and accept local overrides", () => {
+  expect(effectiveAdapterVersion("codex", {})).toBe("1.1.4");
+  expect(effectiveAdapterVersion("claude", {})).toBe("0.59.0");
+  expect(effectiveAdapterVersion("codex", { codex: "1.1.2" })).toBe("1.1.2");
+  expect(buildManagedAdapterCommand("codex", "1.1.2")).toBe(
+    "npx -y @agentclientprotocol/codex-acp@1.1.2",
+  );
+});
+
+test("adapter versions are exact semver values, never ranges or package specs", () => {
+  expect(isExactAdapterVersion("1.1.4")).toBe(true);
+  expect(isExactAdapterVersion("1.2.0-beta.1")).toBe(true);
+  for (const value of [
+    "latest",
+    "^1.1.4",
+    "1.x",
+    "1.0.0-01",
+    "1.0.0-beta.01",
+    "github:user/repo",
+    "1.1.4; rm -rf /",
+  ]) {
+    expect(isExactAdapterVersion(value)).toBe(false);
+  }
+});
+
+test("recognizes only generated commands for managed adapter packages", () => {
+  expect(isManagedAdapterCommand("codex", "npx -y @agentclientprotocol/codex-acp@1.1.4")).toBe(true);
+  expect(isManagedAdapterCommand("codex", "npx -y @agentclientprotocol/codex-acp@^0.0.44")).toBe(true);
+  expect(isManagedAdapterCommand("codex", "custom-codex-acp")).toBe(false);
+  expect(isManagedAdapterCommand("claude", "npx -y @agentclientprotocol/codex-acp@1.1.4")).toBe(false);
+});

--- a/tests/unit/adapters/adapter-catalog.test.ts
+++ b/tests/unit/adapters/adapter-catalog.test.ts
@@ -12,7 +12,10 @@ test("managed adapters use tested exact defaults and accept local overrides", ()
   expect(effectiveAdapterVersion("claude", {})).toBe("0.59.0");
   expect(effectiveAdapterVersion("codex", { codex: "1.1.2" })).toBe("1.1.2");
   expect(buildManagedAdapterCommand("codex", "1.1.2")).toBe(
-    "npx -y @agentclientprotocol/codex-acp@1.1.2",
+    "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.2",
+  );
+  expect(buildManagedAdapterCommand("codex", "1.1.2", "https://npm.corp.example/repository/npm/")).toBe(
+    "npx -y --registry=https://npm.corp.example/repository/npm/ --@agentclientprotocol:registry=https://npm.corp.example/repository/npm/ @agentclientprotocol/codex-acp@1.1.2",
   );
 });
 
@@ -33,6 +36,10 @@ test("adapter versions are exact semver values, never ranges or package specs", 
 });
 
 test("recognizes only generated commands for managed adapter packages", () => {
+  expect(isManagedAdapterCommand(
+    "codex",
+    "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
+  )).toBe(true);
   expect(isManagedAdapterCommand("codex", "npx -y @agentclientprotocol/codex-acp@1.1.4")).toBe(true);
   expect(isManagedAdapterCommand("codex", "npx -y @agentclientprotocol/codex-acp@^0.0.44")).toBe(true);
   expect(isManagedAdapterCommand("codex", "custom-codex-acp")).toBe(false);

--- a/tests/unit/adapters/adapter-cli.test.ts
+++ b/tests/unit/adapters/adapter-cli.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test";
+
+import { handleAdapterCli, type AdapterCliDeps } from "../../../src/adapters/adapter-cli";
+
+function deps(overrides: Partial<AdapterCliDeps> = {}) {
+  const lines: string[] = [];
+  let saved: Record<string, string> | undefined;
+  const base: AdapterCliDeps = {
+    loadVersions: async () => ({}),
+    saveVersions: async (versions) => { saved = versions; },
+    getLatestVersion: async (id) => id === "codex" ? "1.1.4" : "0.59.0",
+    versionExists: async () => true,
+    verifyVersion: async () => {},
+    print: (line) => lines.push(line),
+  };
+  return {
+    deps: { ...base, ...overrides },
+    lines,
+    saved: () => saved,
+  };
+}
+
+test("list is local-only and shows default versus configured effective versions", async () => {
+  let networkCalls = 0;
+  const ctx = deps({
+    loadVersions: async () => ({ codex: "1.1.2" }),
+    getLatestVersion: async () => { networkCalls += 1; return "9.9.9"; },
+  });
+  expect(await handleAdapterCli(["list"], ctx.deps)).toBe(0);
+  expect(networkCalls).toBe(0);
+  expect(ctx.lines.join("\n")).toContain("codex");
+  expect(ctx.lines.join("\n")).toContain("1.1.2");
+  expect(ctx.lines.join("\n")).toContain("1.1.4");
+});
+
+test("set verifies a published exact version before persisting it", async () => {
+  const events: string[] = [];
+  const ctx = deps({
+    loadVersions: async () => ({ claude: "0.58.1" }),
+    versionExists: async (id, version) => { events.push(`exists:${id}:${version}`); return true; },
+    verifyVersion: async (id, version) => { events.push(`verify:${id}:${version}`); },
+  });
+  expect(await handleAdapterCli(["set", "codex", "1.1.2"], ctx.deps)).toBe(0);
+  expect(events).toEqual(["exists:codex:1.1.2", "verify:codex:1.1.2"]);
+  expect(ctx.saved()).toEqual({ claude: "0.58.1", codex: "1.1.2" });
+});
+
+test("failed verification never changes configured versions", async () => {
+  let saves = 0;
+  const ctx = deps({
+    saveVersions: async () => { saves += 1; },
+    verifyVersion: async () => { throw new Error("initialize failed"); },
+  });
+  expect(await handleAdapterCli(["set", "codex", "1.1.2"], ctx.deps)).toBe(1);
+  expect(saves).toBe(0);
+  expect(ctx.lines.join("\n")).toContain("initialize failed");
+});
+
+test("update --all verifies every latest version before one atomic save", async () => {
+  const events: string[] = [];
+  const ctx = deps({
+    getLatestVersion: async (id) => id === "codex" ? "1.1.5" : "0.60.0",
+    verifyVersion: async (id, version) => { events.push(`${id}:${version}`); },
+  });
+  expect(await handleAdapterCli(["update", "--all"], ctx.deps)).toBe(0);
+  expect(events).toEqual(["codex:1.1.5", "claude:0.60.0"]);
+  expect(ctx.saved()).toEqual({ codex: "1.1.5", claude: "0.60.0" });
+});
+
+test("update --all saves nothing when any candidate fails verification", async () => {
+  let saves = 0;
+  const ctx = deps({
+    getLatestVersion: async (id) => id === "codex" ? "1.1.5" : "0.60.0",
+    saveVersions: async () => { saves += 1; },
+    verifyVersion: async (id) => {
+      if (id === "claude") throw new Error("initialize failed");
+    },
+  });
+  expect(await handleAdapterCli(["update", "--all"], ctx.deps)).toBe(1);
+  expect(saves).toBe(0);
+  expect(ctx.lines.join("\n")).toContain("claude");
+});
+
+test("reset removes only the selected local override", async () => {
+  const ctx = deps({ loadVersions: async () => ({ codex: "1.1.2", claude: "0.58.1" }) });
+  expect(await handleAdapterCli(["reset", "codex"], ctx.deps)).toBe(0);
+  expect(ctx.saved()).toEqual({ claude: "0.58.1" });
+});

--- a/tests/unit/adapters/adapter-cli.test.ts
+++ b/tests/unit/adapters/adapter-cli.test.ts
@@ -8,6 +8,8 @@ function deps(overrides: Partial<AdapterCliDeps> = {}) {
   const base: AdapterCliDeps = {
     loadVersions: async () => ({}),
     saveVersions: async (versions) => { saved = versions; },
+    loadRegistry: async () => undefined,
+    saveRegistry: async () => {},
     getLatestVersion: async (id) => id === "codex" ? "1.1.4" : "0.59.0",
     versionExists: async () => true,
     verifyVersion: async () => {},
@@ -19,6 +21,52 @@ function deps(overrides: Partial<AdapterCliDeps> = {}) {
     saved: () => saved,
   };
 }
+
+test("registry shows the official npm default and can set or reset a local override", async () => {
+  const savedRegistries: Array<string | undefined> = [];
+  const ctx = deps({
+    loadRegistry: async () => undefined,
+    saveRegistry: async (registry) => { savedRegistries.push(registry); },
+  });
+
+  expect(await handleAdapterCli(["registry"], ctx.deps)).toBe(0);
+  expect(ctx.lines.join("\n")).toContain("https://registry.npmjs.org/");
+
+  expect(await handleAdapterCli(["registry", "set", "https://npm.corp.example/repository/npm"], ctx.deps)).toBe(0);
+  expect(savedRegistries).toEqual(["https://npm.corp.example/repository/npm/"]);
+
+  expect(await handleAdapterCli(["registry", "reset"], ctx.deps)).toBe(0);
+  expect(savedRegistries).toEqual(["https://npm.corp.example/repository/npm/", undefined]);
+});
+
+test("registry rejects unsafe URLs without changing config", async () => {
+  let saves = 0;
+  const ctx = deps({ saveRegistry: async () => { saves += 1; } });
+  for (const registry of [
+    "https://user:secret@npm.example/",
+    "https://npm.example/repository/;touch-pwned",
+  ]) {
+    expect(await handleAdapterCli(["registry", "set", registry], ctx.deps)).toBe(1);
+  }
+  expect(saves).toBe(0);
+  expect(ctx.lines.join("\n")).toContain("registry");
+});
+
+test("check queries npm through the configured adapter registry", async () => {
+  const queried: string[] = [];
+  const ctx = deps({
+    loadRegistry: async () => "https://npm.corp.example/repository/npm/",
+    getLatestVersion: async (id, registry) => {
+      queried.push(`${id}:${registry}`);
+      return id === "codex" ? "1.1.4" : "0.59.0";
+    },
+  });
+  expect(await handleAdapterCli(["check"], ctx.deps)).toBe(0);
+  expect(queried).toEqual([
+    "codex:https://npm.corp.example/repository/npm/",
+    "claude:https://npm.corp.example/repository/npm/",
+  ]);
+});
 
 test("list is local-only and shows default versus configured effective versions", async () => {
   let networkCalls = 0;
@@ -37,11 +85,15 @@ test("set verifies a published exact version before persisting it", async () => 
   const events: string[] = [];
   const ctx = deps({
     loadVersions: async () => ({ claude: "0.58.1" }),
-    versionExists: async (id, version) => { events.push(`exists:${id}:${version}`); return true; },
-    verifyVersion: async (id, version) => { events.push(`verify:${id}:${version}`); },
+    loadRegistry: async () => "https://npm.corp.example/",
+    versionExists: async (id, version, registry) => { events.push(`exists:${id}:${version}:${registry}`); return true; },
+    verifyVersion: async (id, version, registry) => { events.push(`verify:${id}:${version}:${registry}`); },
   });
   expect(await handleAdapterCli(["set", "codex", "1.1.2"], ctx.deps)).toBe(0);
-  expect(events).toEqual(["exists:codex:1.1.2", "verify:codex:1.1.2"]);
+  expect(events).toEqual([
+    "exists:codex:1.1.2:https://npm.corp.example/",
+    "verify:codex:1.1.2:https://npm.corp.example/",
+  ]);
   expect(ctx.saved()).toEqual({ claude: "0.58.1", codex: "1.1.2" });
 });
 

--- a/tests/unit/adapters/adapter-verifier.test.ts
+++ b/tests/unit/adapters/adapter-verifier.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+
+import { verifyAcpInitialize } from "../../../src/adapters/adapter-verifier";
+
+const SUCCESS_SCRIPT = String.raw`
+process.stdin.setEncoding("utf8");
+let text = "";
+process.stdin.on("data", chunk => {
+  text += chunk;
+  const line = text.split("\n")[0];
+  if (!line) return;
+  const request = JSON.parse(line);
+  setTimeout(() => {
+    process.stdout.write(JSON.stringify({jsonrpc:"2.0",id:request.id,result:{protocolVersion:1,agentCapabilities:{}}}) + "\n");
+  }, 30);
+});
+process.stdin.on("end", () => process.exit(0));
+`;
+
+test("accepts an adapter only after a successful ACP initialize response", async () => {
+  await expect(verifyAcpInitialize(process.execPath, ["-e", SUCCESS_SCRIPT], { timeoutMs: 2_000 }))
+    .resolves.toBeUndefined();
+});
+
+test("reports an ACP initialize error without persisting a bad adapter", async () => {
+  const script = String.raw`
+  process.stdin.resume();
+  process.stdin.once("data", () => process.stdout.write(JSON.stringify({
+    jsonrpc:"2.0",id:0,error:{code:-32603,message:"adapter boot failed"}
+  }) + "\n"));
+  `;
+  await expect(verifyAcpInitialize(process.execPath, ["-e", script], { timeoutMs: 2_000 }))
+    .rejects.toThrow("adapter boot failed");
+});
+
+test("times out and terminates an adapter that never initializes", async () => {
+  const script = "process.stdin.resume(); setInterval(() => {}, 1000)";
+  const startedAt = Date.now();
+  await expect(verifyAcpInitialize(process.execPath, ["-e", script], { timeoutMs: 30 }))
+    .rejects.toThrow("timed out after 30ms");
+  expect(Date.now() - startedAt).toBeLessThan(2_000);
+});

--- a/tests/unit/adapters/adapter-verifier.test.ts
+++ b/tests/unit/adapters/adapter-verifier.test.ts
@@ -40,3 +40,11 @@ test("times out and terminates an adapter that never initializes", async () => {
     .rejects.toThrow("timed out after 30ms");
   expect(Date.now() - startedAt).toBeLessThan(2_000);
 });
+
+test("npm E404 failures point users to the adapter registry setting", async () => {
+  await expect(verifyAcpInitialize(
+    process.execPath,
+    ["-e", "console.error('npm ERR! code E404'); process.exit(1)"],
+    { adapterRegistry: "https://npm.corp.example/" },
+  )).rejects.toThrow("xacpx adapter registry set https://registry.npmjs.org/");
+});

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1833,3 +1833,37 @@ test("runCli routes plugin command", async () => {
   expect(code).toBe(0);
   expect(lines).toEqual(["还没有安装插件。"]);
 });
+
+test("runCli routes adapter commands through injectable registry and probe seams", async () => {
+  setLocale("en");
+  const events: string[] = [];
+  const code = await runCli(["adapter", "set", "codex", "1.1.2"], {
+    print: (line) => events.push(line),
+    adapterCliDeps: {
+      loadVersions: async () => ({}),
+      saveVersions: async (versions) => { events.push(`saved:${JSON.stringify(versions)}`); },
+      getLatestVersion: async () => "1.1.4",
+      versionExists: async () => true,
+      verifyVersion: async (id, version) => { events.push(`verified:${id}@${version}`); },
+    },
+  });
+
+  expect(code).toBe(0);
+  expect(events).toContain("verified:codex@1.1.2");
+  expect(events).toContain('saved:{"codex":"1.1.2"}');
+});
+
+test("adapter set persists only transport.adapterVersions in the real config store", async () => {
+  await withTempHome(async (home) => {
+    const code = await runCli(["adapter", "set", "codex", "1.1.2"], {
+      print: () => {},
+      adapterCliDeps: {
+        versionExists: async () => true,
+        verifyVersion: async () => {},
+      },
+    });
+
+    expect(code).toBe(0);
+    expect((await readConfigJson(home)).transport.adapterVersions).toEqual({ codex: "1.1.2" });
+  });
+});

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1867,3 +1867,17 @@ test("adapter set persists only transport.adapterVersions in the real config sto
     expect((await readConfigJson(home)).transport.adapterVersions).toEqual({ codex: "1.1.2" });
   });
 });
+
+test("adapter registry CLI persists and resets only transport.adapterRegistry", async () => {
+  await withTempHome(async (home) => {
+    expect(await runCli([
+      "adapter", "registry", "set", "https://npm.corp.example/repository/npm",
+    ], { print: () => {} })).toBe(0);
+    expect((await readConfigJson(home)).transport.adapterRegistry).toBe(
+      "https://npm.corp.example/repository/npm/",
+    );
+
+    expect(await runCli(["adapter", "registry", "reset"], { print: () => {} })).toBe(0);
+    expect((await readConfigJson(home)).transport.adapterRegistry).toBeUndefined();
+  });
+});

--- a/tests/unit/commands/command-router-session.test.ts
+++ b/tests/unit/commands/command-router-session.test.ts
@@ -1076,7 +1076,7 @@ test("/ssn lists native sessions from the current session context", async () => 
   expect(reply.text).not.toContain("61456d60-b7e1-47e6-8641-72bbe8e552e7");
   expect(transport.listAgentSessions).toHaveBeenCalledWith({
     agent: "codex",
-    agentCommand: "npx -y @agentclientprotocol/codex-acp@1.1.4",
+    agentCommand: "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
     driver: "codex",
     cwd: "/tmp/project",
     filterCwd: "/tmp/project",
@@ -1171,7 +1171,7 @@ test("/ssn preserves transport method this binding when listing native sessions"
   expect(transport.client.calls).toEqual([
     {
       agent: "codex",
-      agentCommand: "npx -y @agentclientprotocol/codex-acp@1.1.4",
+      agentCommand: "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
       driver: "codex",
       cwd: "/tmp/project",
       filterCwd: "/tmp/project",
@@ -1360,7 +1360,7 @@ test("/ssn --all preserves all scope in next page commands", async () => {
   expect(reply.text).toContain("更多：/ssn codex --ws project --all --cursor cursor-2");
   expect(transport.listAgentSessions).toHaveBeenCalledWith({
     agent: "codex",
-    agentCommand: "npx -y @agentclientprotocol/codex-acp@1.1.4",
+    agentCommand: "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
     driver: "codex",
     cwd: "/tmp/project",
   });

--- a/tests/unit/commands/command-router-session.test.ts
+++ b/tests/unit/commands/command-router-session.test.ts
@@ -1076,6 +1076,7 @@ test("/ssn lists native sessions from the current session context", async () => 
   expect(reply.text).not.toContain("61456d60-b7e1-47e6-8641-72bbe8e552e7");
   expect(transport.listAgentSessions).toHaveBeenCalledWith({
     agent: "codex",
+    agentCommand: "npx -y @agentclientprotocol/codex-acp@1.1.4",
     driver: "codex",
     cwd: "/tmp/project",
     filterCwd: "/tmp/project",
@@ -1170,6 +1171,7 @@ test("/ssn preserves transport method this binding when listing native sessions"
   expect(transport.client.calls).toEqual([
     {
       agent: "codex",
+      agentCommand: "npx -y @agentclientprotocol/codex-acp@1.1.4",
       driver: "codex",
       cwd: "/tmp/project",
       filterCwd: "/tmp/project",
@@ -1358,6 +1360,7 @@ test("/ssn --all preserves all scope in next page commands", async () => {
   expect(reply.text).toContain("更多：/ssn codex --ws project --all --cursor cursor-2");
   expect(transport.listAgentSessions).toHaveBeenCalledWith({
     agent: "codex",
+    agentCommand: "npx -y @agentclientprotocol/codex-acp@1.1.4",
     driver: "codex",
     cwd: "/tmp/project",
   });

--- a/tests/unit/commands/golden/fixtures/attach-native-normal.json
+++ b/tests/unit/commands/golden/fixtures/attach-native-normal.json
@@ -13,7 +13,7 @@
     "ok": {
       "alias": "relay:demo",
       "agent": "codex",
-      "agentCommand": "npx -y @agentclientprotocol/codex-acp@1.1.4",
+      "agentCommand": "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
       "workspace": "backend",
       "transportSession": "backend:relay:demo",
       "cwd": "/tmp/backend",

--- a/tests/unit/commands/golden/fixtures/attach-native-normal.json
+++ b/tests/unit/commands/golden/fixtures/attach-native-normal.json
@@ -13,6 +13,7 @@
     "ok": {
       "alias": "relay:demo",
       "agent": "codex",
+      "agentCommand": "npx -y @agentclientprotocol/codex-acp@1.1.4",
       "workspace": "backend",
       "transportSession": "backend:relay:demo",
       "cwd": "/tmp/backend",

--- a/tests/unit/commands/golden/fixtures/create-normal.json
+++ b/tests/unit/commands/golden/fixtures/create-normal.json
@@ -14,7 +14,7 @@
     "ok": {
       "alias": "relay:demo",
       "agent": "codex",
-      "agentCommand": "npx -y @agentclientprotocol/codex-acp@1.1.4",
+      "agentCommand": "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
       "workspace": "backend",
       "transportSession": "backend:relay:demo",
       "cwd": "/tmp/backend",

--- a/tests/unit/commands/golden/fixtures/create-normal.json
+++ b/tests/unit/commands/golden/fixtures/create-normal.json
@@ -14,6 +14,7 @@
     "ok": {
       "alias": "relay:demo",
       "agent": "codex",
+      "agentCommand": "npx -y @agentclientprotocol/codex-acp@1.1.4",
       "workspace": "backend",
       "transportSession": "backend:relay:demo",
       "cwd": "/tmp/backend",

--- a/tests/unit/commands/golden/fixtures/create-refresh-fails.json
+++ b/tests/unit/commands/golden/fixtures/create-refresh-fails.json
@@ -15,6 +15,7 @@
     "ok": {
       "alias": "relay:demo",
       "agent": "codex",
+      "agentCommand": "npx -y @agentclientprotocol/codex-acp@1.1.4",
       "workspace": "backend",
       "transportSession": "backend:relay:demo",
       "cwd": "/tmp/backend",

--- a/tests/unit/commands/golden/fixtures/create-refresh-fails.json
+++ b/tests/unit/commands/golden/fixtures/create-refresh-fails.json
@@ -15,7 +15,7 @@
     "ok": {
       "alias": "relay:demo",
       "agent": "codex",
-      "agentCommand": "npx -y @agentclientprotocol/codex-acp@1.1.4",
+      "agentCommand": "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
       "workspace": "backend",
       "transportSession": "backend:relay:demo",
       "cwd": "/tmp/backend",

--- a/tests/unit/commands/handlers/session-recovery-handler.test.ts
+++ b/tests/unit/commands/handlers/session-recovery-handler.test.ts
@@ -128,3 +128,13 @@ test("runtime adapter E404 is actionable when a prompt cold-start fails", () => 
 
   expect(reply.text).toContain("xacpx adapter registry set https://registry.npmjs.org/");
 });
+
+test("a non-npm backend 404 is not misreported as an adapter registry failure", () => {
+  const error = new Error("model endpoint returned 404 Not Found");
+  expect(() => renderSessionCreationError(
+    session({
+      agentCommand: "npx -y --registry=https://npm.corp.example/ --@agentclientprotocol:registry=https://npm.corp.example/ @agentclientprotocol/codex-acp@1.1.4",
+    }),
+    error,
+  )).toThrow(error);
+});

--- a/tests/unit/commands/handlers/session-recovery-handler.test.ts
+++ b/tests/unit/commands/handlers/session-recovery-handler.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, beforeEach } from "bun:test";
 import {
+  renderSessionCreationError,
   renderSessionCreationVerificationError,
   renderTransportError,
   tryRecoverMissingSession,
@@ -103,4 +104,27 @@ test("renderSessionCreationVerificationError leaves a clean workspace name unquo
   expect(reply.text).toContain(
     t().recovery.sessionCreationAttachHint("review", "codex", "backend"),
   );
+});
+
+test("runtime adapter E404 points session creation to the registry CLI", () => {
+  const reply = renderSessionCreationError(
+    session({
+      agentCommand: "npx -y --registry=https://npm.corp.example/ --@agentclientprotocol:registry=https://npm.corp.example/ @agentclientprotocol/codex-acp@1.1.4",
+    }),
+    new Error("npm ERR! code E404\nnpm ERR! 404 Not Found"),
+  );
+
+  expect(reply.text).toContain("xacpx adapter registry set https://registry.npmjs.org/");
+  expect(reply.text).toContain("@agentclientprotocol");
+});
+
+test("runtime adapter E404 is actionable when a prompt cold-start fails", () => {
+  const reply = renderTransportError(
+    session({
+      agentCommand: "npx -y --registry=https://npm.corp.example/ --@agentclientprotocol:registry=https://npm.corp.example/ @agentclientprotocol/codex-acp@1.1.4",
+    }),
+    new Error("npm ERR! code E404"),
+  );
+
+  expect(reply.text).toContain("xacpx adapter registry set https://registry.npmjs.org/");
 });

--- a/tests/unit/config/config-store.test.ts
+++ b/tests/unit/config/config-store.test.ts
@@ -318,6 +318,40 @@ test("updateTransport deletes a key when its patch value is explicitly undefined
   await rm(dir, { recursive: true, force: true });
 });
 
+test("replaces managed adapter versions atomically without touching other transport keys", async () => {
+  const { dir, path } = await makeConfigFile({
+    transport: {
+      type: "acpx-bridge",
+      command: "custom-acpx",
+      adapterVersions: { codex: "1.0.0" },
+      custom: true,
+    },
+    agents: { codex: { driver: "codex" } },
+    workspaces: {},
+  });
+
+  const store = new ConfigStore(path);
+  const config = await store.replaceAdapterVersions({ codex: "1.1.2", claude: "0.58.1" });
+
+  expect(config.transport.adapterVersions).toEqual({ codex: "1.1.2", claude: "0.58.1" });
+  expect(await readRaw(path)).toMatchObject({
+    transport: {
+      type: "acpx-bridge",
+      command: "custom-acpx",
+      adapterVersions: { codex: "1.1.2", claude: "0.58.1" },
+      custom: true,
+    },
+  });
+
+  await store.replaceAdapterVersions({});
+  expect((await readRaw(path)).transport).toEqual({
+    type: "acpx-bridge",
+    command: "custom-acpx",
+    custom: true,
+  });
+  await rm(dir, { recursive: true, force: true });
+});
+
 test("updates channel reply mode while preserving channel ownerIds and unknown keys", async () => {
   const { dir, path } = await makeConfigFile({
     transport: { type: "acpx-cli" },

--- a/tests/unit/config/load-config.test.ts
+++ b/tests/unit/config/load-config.test.ts
@@ -187,6 +187,24 @@ test("leaves transport.preferLocalAgents undefined when omitted (defaults to pre
   await rm(dir, { recursive: true, force: true });
 });
 
+test("parses exact managed adapter version overrides", async () => {
+  const config = parseConfig({
+    transport: { adapterVersions: { codex: "1.1.2", claude: "0.58.1" } },
+    agents: {},
+    workspaces: {},
+  });
+  expect(config.transport.adapterVersions).toEqual({ codex: "1.1.2", claude: "0.58.1" });
+});
+
+test("rejects ranges and unknown managed adapter ids", async () => {
+  expect(() => parseConfig({
+    transport: { adapterVersions: { codex: "^1.1.2" } }, agents: {}, workspaces: {},
+  })).toThrow("transport.adapterVersions.codex must be an exact semver version");
+  expect(() => parseConfig({
+    transport: { adapterVersions: { other: "1.0.0" } }, agents: {}, workspaces: {},
+  })).toThrow("transport.adapterVersions contains unsupported adapter other");
+});
+
 test("rejects a negative transport.queueOwnerTtlSeconds", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-config-"));
   const path = join(dir, "config.json");

--- a/tests/unit/config/load-config.test.ts
+++ b/tests/unit/config/load-config.test.ts
@@ -196,6 +196,27 @@ test("parses exact managed adapter version overrides", async () => {
   expect(config.transport.adapterVersions).toEqual({ codex: "1.1.2", claude: "0.58.1" });
 });
 
+test("parses and normalizes a custom adapter registry", () => {
+  const config = parseConfig({
+    transport: { adapterRegistry: "https://npm.corp.example/repository/npm" },
+    agents: {},
+    workspaces: {},
+  });
+  expect(config.transport.adapterRegistry).toBe("https://npm.corp.example/repository/npm/");
+});
+
+test("rejects unsafe adapter registry URLs", () => {
+  for (const adapterRegistry of [
+    "file:///tmp/npm",
+    "https://user:secret@npm.example/",
+    "https://npm.example/repository?token=secret",
+  ]) {
+    expect(() => parseConfig({
+      transport: { adapterRegistry }, agents: {}, workspaces: {},
+    })).toThrow("transport.adapterRegistry");
+  }
+});
+
 test("rejects ranges and unknown managed adapter ids", async () => {
   expect(() => parseConfig({
     transport: { adapterVersions: { codex: "^1.1.2" } }, agents: {}, workspaces: {},

--- a/tests/unit/config/resolve-agent-command.test.ts
+++ b/tests/unit/config/resolve-agent-command.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "bun:test";
 
-import { resolveAgentCommand } from "../../../src/config/resolve-agent-command";
+import {
+  resolveAgentCommand,
+  resolveConfiguredAgentCommand,
+  resolveRuntimeAgentCommand,
+} from "../../../src/config/resolve-agent-command";
 
 test("drops the legacy codex shim command so acpx can use the built-in codex alias", () => {
   expect(resolveAgentCommand("codex", "./node_modules/.bin/codex-acp")).toBeUndefined();
@@ -21,4 +25,23 @@ test("drops a legacy absolute codex node script command", () => {
 
 test("keeps unrelated commands unchanged", () => {
   expect(resolveAgentCommand("claude", "custom-agent")).toBe("custom-agent");
+});
+
+test("runtime resolution pins managed adapters while preserving explicit commands", () => {
+  expect(resolveRuntimeAgentCommand("codex", undefined, true)).toBe(
+    "npx -y @agentclientprotocol/codex-acp@1.1.4",
+  );
+  expect(resolveRuntimeAgentCommand("claude", undefined, true, { claude: "0.58.1" })).toBe(
+    "npx -y @agentclientprotocol/claude-agent-acp@0.58.1",
+  );
+  expect(resolveRuntimeAgentCommand("codex", "my-codex-adapter", true, { codex: "1.0.0" })).toBe(
+    "my-codex-adapter",
+  );
+});
+
+test("config-shaped runtime resolution keeps agent and transport policy together", () => {
+  expect(resolveConfiguredAgentCommand(
+    { driver: "claude" },
+    { preferLocalAgents: false, adapterVersions: { claude: "0.58.1" } },
+  )).toBe("npx -y @agentclientprotocol/claude-agent-acp@0.58.1");
 });

--- a/tests/unit/config/resolve-agent-command.test.ts
+++ b/tests/unit/config/resolve-agent-command.test.ts
@@ -29,10 +29,10 @@ test("keeps unrelated commands unchanged", () => {
 
 test("runtime resolution pins managed adapters while preserving explicit commands", () => {
   expect(resolveRuntimeAgentCommand("codex", undefined, true)).toBe(
-    "npx -y @agentclientprotocol/codex-acp@1.1.4",
+    "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
   );
   expect(resolveRuntimeAgentCommand("claude", undefined, true, { claude: "0.58.1" })).toBe(
-    "npx -y @agentclientprotocol/claude-agent-acp@0.58.1",
+    "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/claude-agent-acp@0.58.1",
   );
   expect(resolveRuntimeAgentCommand("codex", "my-codex-adapter", true, { codex: "1.0.0" })).toBe(
     "my-codex-adapter",
@@ -42,6 +42,10 @@ test("runtime resolution pins managed adapters while preserving explicit command
 test("config-shaped runtime resolution keeps agent and transport policy together", () => {
   expect(resolveConfiguredAgentCommand(
     { driver: "claude" },
-    { preferLocalAgents: false, adapterVersions: { claude: "0.58.1" } },
-  )).toBe("npx -y @agentclientprotocol/claude-agent-acp@0.58.1");
+    {
+      preferLocalAgents: false,
+      adapterVersions: { claude: "0.58.1" },
+      adapterRegistry: "https://npm.corp.example/repository/npm/",
+    },
+  )).toBe("npx -y --registry=https://npm.corp.example/repository/npm/ --@agentclientprotocol:registry=https://npm.corp.example/repository/npm/ @agentclientprotocol/claude-agent-acp@0.58.1");
 });

--- a/tests/unit/sessions/session-service.test.ts
+++ b/tests/unit/sessions/session-service.test.ts
@@ -46,7 +46,7 @@ class MemoryStateStore implements Pick<StateStore, "save"> {
   }
 }
 
-test("creates a session from a known agent and workspace", async () => {
+test("creates a session with xacpx's pinned managed adapter", async () => {
   const store = new MemoryStateStore();
   const service = new SessionService(createConfig(), store, createEmptyState());
 
@@ -54,10 +54,10 @@ test("creates a session from a known agent and workspace", async () => {
 
   expect(session.transportSession).toBe("backend:api-fix");
   expect(session.cwd).toBe("/tmp/backend");
-  expect(session.agentCommand).toBeUndefined();
+  expect(session.agentCommand).toBe("npx -y @agentclientprotocol/codex-acp@1.1.4");
 });
 
-test("ignores a legacy raw codex command and falls back to the built-in codex alias", async () => {
+test("ignores a legacy raw codex command and falls back to xacpx's pinned adapter", async () => {
   const store = new MemoryStateStore();
   const config = createConfig();
   config.agents.codex = {
@@ -68,7 +68,61 @@ test("ignores a legacy raw codex command and falls back to the built-in codex al
 
   const session = await service.createSession("api-fix", "codex", "backend");
 
-  expect(session.agentCommand).toBeUndefined();
+  expect(session.agentCommand).toBe("npx -y @agentclientprotocol/codex-acp@1.1.4");
+});
+
+test("refreshes recorded generated adapter commands but preserves custom recorded commands", async () => {
+  const config = createConfig();
+  config.transport.adapterVersions = { codex: "1.1.2" };
+  const generatedState = createEmptyState();
+  generatedState.sessions.review = {
+    alias: "review",
+    agent: "codex",
+    workspace: "backend",
+    transport_session: "backend:review",
+    transport_agent_command: "npx -y @agentclientprotocol/codex-acp@^0.0.44",
+  };
+  const generated = new SessionService(config, new MemoryStateStore(), generatedState);
+  expect((await generated.getSession("review"))?.agentCommand).toBe(
+    "npx -y @agentclientprotocol/codex-acp@1.1.2",
+  );
+
+  generatedState.sessions.review!.transport_agent_command = "my-codex-wrapper --safe";
+  const custom = new SessionService(config, new MemoryStateStore(), generatedState);
+  expect((await custom.getSession("review"))?.agentCommand).toBe("my-codex-wrapper --safe");
+});
+
+test("refreshes a recorded legacy codex shim to the current managed pin", async () => {
+  const config = createConfig();
+  const state = createEmptyState();
+  state.sessions.review = {
+    alias: "review",
+    agent: "codex",
+    workspace: "backend",
+    transport_session: "backend:review",
+    transport_agent_command: "./node_modules/.bin/codex-acp",
+  };
+
+  const service = new SessionService(config, new MemoryStateStore(), state);
+  expect((await service.getSession("review"))?.agentCommand).toBe(
+    "npx -y @agentclientprotocol/codex-acp@1.1.4",
+  );
+});
+
+test("an explicit agents.<name>.command overrides a recorded session command", async () => {
+  const config = createConfig();
+  config.agents.codex = { driver: "codex", command: "configured-codex-wrapper" };
+  const state = createEmptyState();
+  state.sessions.review = {
+    alias: "review",
+    agent: "codex",
+    workspace: "backend",
+    transport_session: "backend:review",
+    transport_agent_command: "recorded-codex-wrapper",
+  };
+
+  const service = new SessionService(config, new MemoryStateStore(), state);
+  expect((await service.getSession("review"))?.agentCommand).toBe("configured-codex-wrapper");
 });
 
 test("attaches an existing transport session with a custom name", async () => {
@@ -753,7 +807,7 @@ test("recreating an alias with a different agent does not inherit transport agen
 
   const recreated = await service.createSession("foo", "claude", "backend");
 
-  expect(recreated.agentCommand).toBeUndefined();
+  expect(recreated.agentCommand).toBe("npx -y @agentclientprotocol/claude-agent-acp@0.59.0");
   expect(recreated.modeId).toBeUndefined();
   expect(recreated.replyMode).toBeUndefined();
   expect(state.sessions.foo?.transport_agent_command).toBeUndefined();
@@ -788,7 +842,7 @@ test("resolveSession does not reuse a cached transport agent command from a diff
   await service.setSessionTransportAgentCommand("foo", "npx @zed-industries/codex-acp@^0.9.5");
 
   const crossAgent = service.resolveSession("foo", "claude", "backend", "backend:foo");
-  expect(crossAgent.agentCommand).toBeUndefined();
+  expect(crossAgent.agentCommand).toBe("npx -y @agentclientprotocol/claude-agent-acp@0.59.0");
 
   const sameAgent = service.resolveSession("foo", "codex", "backend", "backend:foo");
   expect(sameAgent.agentCommand).toBe("npx @zed-industries/codex-acp@^0.9.5");

--- a/tests/unit/sessions/session-service.test.ts
+++ b/tests/unit/sessions/session-service.test.ts
@@ -54,7 +54,7 @@ test("creates a session with xacpx's pinned managed adapter", async () => {
 
   expect(session.transportSession).toBe("backend:api-fix");
   expect(session.cwd).toBe("/tmp/backend");
-  expect(session.agentCommand).toBe("npx -y @agentclientprotocol/codex-acp@1.1.4");
+  expect(session.agentCommand).toBe("npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4");
 });
 
 test("ignores a legacy raw codex command and falls back to xacpx's pinned adapter", async () => {
@@ -68,7 +68,7 @@ test("ignores a legacy raw codex command and falls back to xacpx's pinned adapte
 
   const session = await service.createSession("api-fix", "codex", "backend");
 
-  expect(session.agentCommand).toBe("npx -y @agentclientprotocol/codex-acp@1.1.4");
+  expect(session.agentCommand).toBe("npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4");
 });
 
 test("refreshes recorded generated adapter commands but preserves custom recorded commands", async () => {
@@ -84,7 +84,7 @@ test("refreshes recorded generated adapter commands but preserves custom recorde
   };
   const generated = new SessionService(config, new MemoryStateStore(), generatedState);
   expect((await generated.getSession("review"))?.agentCommand).toBe(
-    "npx -y @agentclientprotocol/codex-acp@1.1.2",
+    "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.2",
   );
 
   generatedState.sessions.review!.transport_agent_command = "my-codex-wrapper --safe";
@@ -105,7 +105,7 @@ test("refreshes a recorded legacy codex shim to the current managed pin", async 
 
   const service = new SessionService(config, new MemoryStateStore(), state);
   expect((await service.getSession("review"))?.agentCommand).toBe(
-    "npx -y @agentclientprotocol/codex-acp@1.1.4",
+    "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
   );
 });
 
@@ -807,7 +807,7 @@ test("recreating an alias with a different agent does not inherit transport agen
 
   const recreated = await service.createSession("foo", "claude", "backend");
 
-  expect(recreated.agentCommand).toBe("npx -y @agentclientprotocol/claude-agent-acp@0.59.0");
+  expect(recreated.agentCommand).toBe("npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/claude-agent-acp@0.59.0");
   expect(recreated.modeId).toBeUndefined();
   expect(recreated.replyMode).toBeUndefined();
   expect(state.sessions.foo?.transport_agent_command).toBeUndefined();
@@ -842,7 +842,7 @@ test("resolveSession does not reuse a cached transport agent command from a diff
   await service.setSessionTransportAgentCommand("foo", "npx @zed-industries/codex-acp@^0.9.5");
 
   const crossAgent = service.resolveSession("foo", "claude", "backend", "backend:foo");
-  expect(crossAgent.agentCommand).toBe("npx -y @agentclientprotocol/claude-agent-acp@0.59.0");
+  expect(crossAgent.agentCommand).toBe("npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/claude-agent-acp@0.59.0");
 
   const sameAgent = service.resolveSession("foo", "codex", "backend", "backend:foo");
   expect(sameAgent.agentCommand).toBe("npx @zed-industries/codex-acp@^0.9.5");

--- a/tests/unit/transport/collect-reap-targets.test.ts
+++ b/tests/unit/transport/collect-reap-targets.test.ts
@@ -44,7 +44,12 @@ test("builds reap targets from worker bindings, resolving cwd and agent command"
   const targets = workerBindingReapTargets(state.orchestration, createConfig());
 
   expect(targets).toEqual([
-    { agent: "codex", cwd: "/tmp/backend", transportSession: "backend:codex:wk" },
+    {
+      agent: "codex",
+      agentCommand: "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
+      cwd: "/tmp/backend",
+      transportSession: "backend:codex:wk",
+    },
     {
       agent: "opencode",
       agentCommand: "npx -y opencode-ai acp",
@@ -66,7 +71,12 @@ test("falls back to workspace cwd when the binding has no explicit cwd", () => {
   const targets = workerBindingReapTargets(state.orchestration, createConfig());
 
   expect(targets).toEqual([
-    { agent: "codex", cwd: "/tmp/backend", transportSession: "backend:codex:wk" },
+    {
+      agent: "codex",
+      agentCommand: "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
+      cwd: "/tmp/backend",
+      transportSession: "backend:codex:wk",
+    },
   ]);
 });
 
@@ -105,7 +115,12 @@ test("collectReapTargets combines logical sessions and worker bindings", () => {
   expect(targets).toEqual([
     { agent: "codex", cwd: "/tmp/a", transportSession: "wx:alice" },
     { agent: "opencode", agentCommand: "npx -y opencode-ai acp", cwd: "/tmp/b", transportSession: "wx:bob" },
-    { agent: "codex", cwd: "/tmp/backend", transportSession: "backend:codex:wk" },
+    {
+      agent: "codex",
+      agentCommand: "npx -y --registry=https://registry.npmjs.org/ --@agentclientprotocol:registry=https://registry.npmjs.org/ @agentclientprotocol/codex-acp@1.1.4",
+      cwd: "/tmp/backend",
+      transportSession: "backend:codex:wk",
+    },
   ]);
 });
 


### PR DESCRIPTION
## What changed

- add exact xacpx-owned defaults for Codex (`1.1.4`) and Claude (`0.59.0`) ACP adapters without adding either package as a dependency
- add `xacpx adapter list/check/update/set/reset` and persist exact overrides in `transport.adapterVersions`
- add `transport.adapterRegistry` plus `xacpx adapter registry [set <url>|reset]`
- default managed adapters to `https://registry.npmjs.org/`, overriding both a machine-wide registry and an existing `@agentclientprotocol:registry` mapping
- use the effective registry for latest queries, exact-version checks, verification downloads, and runtime `npx` launches
- verify candidates with a real ACP v1 `initialize` handshake before one atomic config write
- surface actionable E404 guidance during CLI checks, pre-save verification, session creation, and prompt cold starts; unrelated backend/API 404s remain untouched
- apply managed pins consistently to session, native-session, worker, doctor, and reap paths while keeping explicit `agents.<name>.command` highest priority

## Why

acpx's Codex fallback could resolve the old moving range `@agentclientprotocol/codex-acp@^0.0.44`, causing slow startup and `Pending response rejected since connection got disposed` failures. Some users also run npm behind a company registry that does not mirror the adapter packages, producing E404 during cold start.

xacpx should keep its install small while owning reproducible adapter versions. Managed adapters now use an adapter-only registry policy: public npm by default, or an explicitly configured company proxy.

## User impact

- managed Codex/Claude sessions use exact tested versions through npm exec/npx
- adapter downloads no longer inherit an unrelated company npm source
- `xacpx adapter registry` shows the effective source; `set` and `reset` change it locally
- company registries remain supported when they proxy/allowlist `@agentclientprotocol`; authentication stays in scoped `.npmrc`
- E404 failures tell users how to switch to public npm or ask an administrator to proxy the scope
- daemon startup never changes versions automatically; successful mutations instruct the user to restart

## Validation

- `npx tsc --noEmit`
- `bun run build`
- 30 focused adapter/config/runtime-E404/reap tests green, plus session/CLI/golden coverage
- real Codex `1.1.4` ACP `initialize` probe through the explicit public registry
- isolated npm experiment proved explicit generic + scoped flags override an unreachable `@agentclientprotocol:registry` in `.npmrc`
- Standards review: PASS, 0 findings
- Spec review: PASS, 0 findings after mutation-live positive and negative E404 checks

The repository-wide runner was exercised. Changed-area tests pass. On the current local host, timing-heavy `tests/unit/main.test.ts` repeatedly exceeded its fixed 5-second wall-clock limit under load without assertion differences; CI is the authoritative clean-host run for that unrelated file.
