### PR TITLE
release: beta cut — core 0.17.0-beta.7, relay stack, protocol 0.1.14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,13 +39,13 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.5",
+      "version": "0.3.3-beta.7",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0",
       },
       "peerDependencies": {
-        "xacpx": ">=0.17.0-beta.6",
+        "xacpx": ">=0.17.0-beta.7",
       },
       "optionalPeers": [
         "xacpx",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.20",
+      "version": "0.9.12-beta.22",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },
@@ -88,7 +88,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.12",
+      "version": "0.1.14",
     },
     "packages/relay-web": {
       "name": "@ganglion/xacpx-relay-web",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.6",
+  "version": "0.17.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.6",
+      "version": "0.17.0-beta.7",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -34,7 +34,7 @@
         "typescript": "^6.0.2"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.12"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -13141,14 +13141,14 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.6",
+      "version": "0.3.3-beta.7",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0"
       },
       "peerDependencies": {
-        "xacpx": ">=0.17.0-beta.6"
+        "xacpx": ">=0.17.0-beta.7"
       },
       "peerDependenciesMeta": {
         "xacpx": {
@@ -13183,7 +13183,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.21",
+      "version": "0.9.12-beta.22",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -13200,7 +13200,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT"
     },
     "packages/relay-web": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.6",
+  "version": "0.17.0-beta.7",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/channel-relay/README.md
+++ b/packages/channel-relay/README.md
@@ -3,7 +3,7 @@
 Connector channel plugin: dials out from a local xacpx instance to a
 self-hosted @ganglion/xacpx-relay hub over WebSocket.
 
-Requires xacpx >= 0.17.0-beta.6 (the first deadline-aware control core).
+Requires xacpx >= 0.17.0-beta.7 (the first core exposing structured Git/worktree control operations).
 
 Pairing: `xacpx channel add relay --url ws://<relay-host>:8788 --token <pairing-token>`.
 On first connect the pairing token is exchanged for a long-lived instance

--- a/packages/channel-relay/package.json
+++ b/packages/channel-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-relay",
-  "version": "0.3.3-beta.6",
+  "version": "0.3.3-beta.7",
   "description": "Relay hub connector channel plugin for xacpx.",
   "license": "MIT",
   "keywords": [
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "xacpx": ">=0.17.0-beta.6"
+    "xacpx": ">=0.17.0-beta.7"
   },
   "peerDependenciesMeta": {
     "xacpx": {

--- a/packages/channel-relay/src/index.ts
+++ b/packages/channel-relay/src/index.ts
@@ -9,7 +9,7 @@ export { relayCliProvider } from "./relay-provider.js";
 const plugin: XacpxPlugin = {
   apiVersion: 1,
   name: "@ganglion/xacpx-channel-relay",
-  minXacpxVersion: "0.17.0-beta.6",
+  minXacpxVersion: "0.17.0-beta.7",
   channels: [
     {
       type: "relay",

--- a/packages/relay-protocol/package.json
+++ b/packages/relay-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay-protocol",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Shared wire protocol types and codecs for the xacpx relay hub.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.21",
+  "version": "0.9.12-beta.22",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/tests/unit/packages/channel-relay/channel-relay-plugin.test.ts
+++ b/tests/unit/packages/channel-relay/channel-relay-plugin.test.ts
@@ -4,19 +4,19 @@ import { readFileSync } from "node:fs";
 import plugin from "../../../../packages/channel-relay/src/index";
 import { validatePluginCompatibility } from "../../../../src/plugins/compatibility";
 
-test("relay connector requires the first deadline-aware xacpx core", () => {
+test("relay connector requires the git-ops-capable xacpx core", () => {
   const pkg = JSON.parse(readFileSync("packages/channel-relay/package.json", "utf8"));
 
-  expect(plugin.minXacpxVersion).toBe("0.17.0-beta.6");
-  expect(pkg.peerDependencies.xacpx).toBe(">=0.17.0-beta.6");
+  expect(plugin.minXacpxVersion).toBe("0.17.0-beta.7");
+  expect(pkg.peerDependencies.xacpx).toBe(">=0.17.0-beta.7");
 
-  expect(() => validatePluginCompatibility(plugin, {
-    packageName: plugin.name,
-    currentXacpxVersion: "0.17.0-beta.5",
-  })).toThrow();
   expect(() => validatePluginCompatibility(plugin, {
     packageName: plugin.name,
     currentXacpxVersion: "0.17.0-beta.6",
+  })).toThrow();
+  expect(() => validatePluginCompatibility(plugin, {
+    packageName: plugin.name,
+    currentXacpxVersion: "0.17.0-beta.7",
   })).not.toThrow();
   expect(() => validatePluginCompatibility(plugin, {
     packageName: plugin.name,

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.6", () => {
+test("root package version is 0.17.0-beta.7", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.6");
+  expect(pkg.version).toBe("0.17.0-beta.7");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.6",
+  "version": "0.17.0-beta.7",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.6"
+    "@ganglion/xacpx": "^0.17.0-beta.7"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Beta cut covering everything merged since `v0.17.0-beta.6`.

## Changes since last beta
- **#170 `feat(relay-web): add structured Git operations`** — one feature spanning the whole stack: core `ControlService` + new `workspace-git.ts` → `relay-protocol` git messages/validators → `channel-relay` control-bridge dispatch → `relay-web` Files/Git panels.
- **#171 `fix(config): derive agent install hints from acpx's own registry`** — core only (`agent-catalog`/`agent-templates`/`agent-registry`).

## Version bumps
| package | from | to | dist-tag |
|---|---|---|---|
| `@ganglion/xacpx` | 0.17.0-beta.6 | **0.17.0-beta.7** | next |
| `@ganglion/xacpx-relay-protocol` | 0.1.13 | **0.1.14** | latest |
| `@ganglion/xacpx-relay` | 0.9.12-beta.21 | **0.9.12-beta.22** | next |
| `@ganglion/xacpx-channel-relay` | 0.3.3-beta.6 | **0.3.3-beta.7** | next |

`channel-feishu` (0.6.0) / `channel-yuanbao` (0.5.0) unchanged since their last release — not bumped.

## Coupling handled
- `channel-relay` control-bridge now calls core's new `workspaceGitStatus`/`gitStage`/`gitCommit`/`gitPush`/`gitCreateWorktree`… → **peerDep `xacpx` raised `>=0.17.0-beta.6` → `>=0.17.0-beta.7`**.
- Synced `weacpx-compat` shim (version + `^dep`), `package-metadata.test.ts` version assertion, `package-lock.json`, `bun.lock`.
- `relay` re-published to ship the updated embedded `relay-web` dashboard (Files/Git panels).

## Release order (after merge, tag-triggered CI)
1. `v0.17.0-beta.7` (core)
2. `relay-protocol-v0.1.14`
3. `relay-v0.9.12-beta.22` + `channel-relay-v0.3.3-beta.7`

## Verification
- `bun run verify:publish` ✅ (builds all packages, asserts relay-web bundled into relay dist, relay-protocol runtime exports OK).
- `bun run test` green under `TZ=UTC` (as CI runs). Local-only non-failures confirmed environmental: TZ-sensitive session render test passes under UTC; `agent-catalog` acpx-registry drift guard was a stale local `node_modules` (acpx 0.11.0 vs locked 0.12.0, resynced); `main.test.ts` orchestration tests pass with adequate per-test timeout (slow locally, they spawn real processes).