### PR TITLE
fix(relay-web): legible mermaid node labels in dark mode with author-pinned light fills

### DIFF
--- a/docs/superpowers/plans/2026-07-17-web-mermaid-label-contrast.md
+++ b/docs/superpowers/plans/2026-07-17-web-mermaid-label-contrast.md
@@ -1,0 +1,413 @@
+# Mermaid node-label dark-mode contrast fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In relay-web, make mermaid flowchart node labels legible in dark mode when the diagram author pins a light node fill, by overriding the label color only when its measured contrast is too low.
+
+**Architecture:** Add a pure WCAG-contrast math module, plus a live-DOM pass that walks each `g.node`, measures label-vs-fill contrast via `getComputedStyle`, and overrides the label color (black/white auto-pick) when contrast < 3.0. The pass runs inside `hydrateMermaidBlocks` right after the sanitized SVG is injected.
+
+**Tech Stack:** TypeScript, Vue/relay-web, Vitest (jsdom), mermaid 11.16.0, DOMPurify.
+
+## Global Constraints
+
+- Package: `packages/relay-web`. Tests run with **Vitest, not bun** (`npx vitest run` / `bun run --cwd packages/relay-web test`).
+- Threshold: override label color **only when contrast < 3.0** (WCAG graphical-object minimum). `>= 3.0` → leave untouched (zero regression).
+- Scope: **flowchart node labels only** — `g.node` `<text>` vs its shape fill. Do NOT touch edge labels, subgraph titles, sequence actors, gantt, pie.
+- Override color: black/white auto-pick (whichever contrasts more). Theme-agnostic — the same pass also fixes light-theme author-pinned dark fills; do not branch on theme.
+- The contrast pass reads **live computed styles**, so it must run after the SVG is in the document. jsdom's `getComputedStyle` resolves only **inline `style`** (not `<style>` classes / presentation attrs), so tests feed fills via inline `style.fill`; the real class/attribute path is covered by the one-off Chromium probe (see spec), not CI.
+- Spec: `docs/superpowers/specs/2026-07-17-web-mermaid-label-contrast-design.md`.
+
+---
+
+## File Structure
+
+- **Create** `packages/relay-web/src/lib/wcag-contrast.ts` — pure WCAG math + readable-color picker (no DOM).
+- **Create** `packages/relay-web/src/__tests__/wcag-contrast.test.ts` — unit tests for the math.
+- **Modify** `packages/relay-web/src/lib/render-mermaid.ts` — add + export `applyNodeLabelContrast(root)`; call it inside `hydrateMermaidBlocks` after `block.innerHTML = svg`.
+- **Create** `packages/relay-web/src/__tests__/node-label-contrast.test.ts` — jsdom logic test for `applyNodeLabelContrast` + integration test through `hydrateMermaidBlocks`.
+
+---
+
+## Task 1: Pure WCAG-contrast module
+
+**Files:**
+- Create: `packages/relay-web/src/lib/wcag-contrast.ts`
+- Test: `packages/relay-web/src/__tests__/wcag-contrast.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type RGB = [number, number, number]`
+  - `parseCssColor(value: string): RGB | null`
+  - `relativeLuminance(rgb: RGB): number`
+  - `contrastRatio(fg: RGB, bg: RGB): number`
+  - `pickReadableTextColor(bg: RGB): string` (returns `"rgb(0, 0, 0)"` or `"rgb(255, 255, 255)"`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/relay-web/src/__tests__/wcag-contrast.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+import {
+  parseCssColor,
+  relativeLuminance,
+  contrastRatio,
+  pickReadableTextColor,
+} from "../lib/wcag-contrast";
+
+test("parseCssColor parses rgb and rgba (drops alpha channel)", () => {
+  expect(parseCssColor("rgb(204, 204, 204)")).toEqual([204, 204, 204]);
+  expect(parseCssColor("rgba(1, 2, 3, 0.5)")).toEqual([1, 2, 3]);
+});
+
+test("parseCssColor returns null for none / fully transparent / garbage", () => {
+  expect(parseCssColor("none")).toBeNull();
+  expect(parseCssColor("rgba(0, 0, 0, 0)")).toBeNull();
+  expect(parseCssColor("")).toBeNull();
+});
+
+test("relativeLuminance: black is 0, white is 1", () => {
+  expect(relativeLuminance([0, 0, 0])).toBeCloseTo(0, 5);
+  expect(relativeLuminance([255, 255, 255])).toBeCloseTo(1, 5);
+});
+
+test("contrastRatio matches the probe-measured anchors", () => {
+  const text = parseCssColor("rgb(204, 204, 204)")!; // #ccc mermaid dark label
+  const lightFill = parseCssColor("rgb(224, 255, 255)")!; // #e0ffff pinned
+  const darkFill = parseCssColor("rgb(31, 32, 32)")!; // #1f2020 theme default
+  expect(contrastRatio(text, lightFill)).toBeCloseTo(1.52, 1);
+  expect(contrastRatio(text, darkFill)).toBeCloseTo(10.17, 1);
+});
+
+test("contrastRatio is symmetric and bounded at 21 for black/white", () => {
+  expect(contrastRatio([255, 255, 255], [0, 0, 0])).toBeCloseTo(21, 0);
+  expect(contrastRatio([0, 0, 0], [255, 255, 255])).toBeCloseTo(21, 0);
+});
+
+test("pickReadableTextColor: black on light fills, white on dark fills", () => {
+  expect(pickReadableTextColor([224, 255, 255])).toBe("rgb(0, 0, 0)");
+  expect(pickReadableTextColor([255, 255, 255])).toBe("rgb(0, 0, 0)");
+  expect(pickReadableTextColor([31, 32, 32])).toBe("rgb(255, 255, 255)");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/wcag-contrast.test.ts`
+Expected: FAIL — cannot resolve `../lib/wcag-contrast`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/relay-web/src/lib/wcag-contrast.ts`:
+
+```ts
+// WCAG relative-luminance / contrast math + a readable text-color picker.
+// Pure (no DOM) so it is unit-testable in isolation. Consumed by the mermaid
+// node-label contrast fix (render-mermaid.ts applyNodeLabelContrast).
+
+export type RGB = [number, number, number];
+
+/**
+ * Parse a CSS `rgb()/rgba()` computed-style string into an RGB triple.
+ * Returns null for `none`, fully transparent (alpha 0), or anything unparseable
+ * — i.e. "no usable background color".
+ */
+export function parseCssColor(value: string): RGB | null {
+  const m = value.match(/rgba?\(([^)]+)\)/i);
+  if (!m) return null;
+  const parts = m[1].split(",").map((p) => parseFloat(p.trim()));
+  if (parts.length < 3 || parts.slice(0, 3).some((n) => Number.isNaN(n))) return null;
+  const alpha = parts.length >= 4 ? parts[3] : 1;
+  if (alpha === 0) return null;
+  return [parts[0], parts[1], parts[2]];
+}
+
+function channelLuminance(c: number): number {
+  const s = c / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG 2.x relative luminance of an sRGB color (0..1). */
+export function relativeLuminance([r, g, b]: RGB): number {
+  return 0.2126 * channelLuminance(r) + 0.7152 * channelLuminance(g) + 0.0722 * channelLuminance(b);
+}
+
+/** WCAG contrast ratio between two colors (1..21). */
+export function contrastRatio(fg: RGB, bg: RGB): number {
+  const lf = relativeLuminance(fg);
+  const lb = relativeLuminance(bg);
+  const hi = Math.max(lf, lb);
+  const lo = Math.min(lf, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Pick black or white — whichever has the higher contrast against `bg`. */
+export function pickReadableTextColor(bg: RGB): string {
+  const black: RGB = [0, 0, 0];
+  const white: RGB = [255, 255, 255];
+  return contrastRatio(black, bg) >= contrastRatio(white, bg) ? "rgb(0, 0, 0)" : "rgb(255, 255, 255)";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/wcag-contrast.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/relay-web/src/lib/wcag-contrast.ts packages/relay-web/src/__tests__/wcag-contrast.test.ts
+git commit -m "feat(relay-web): add pure WCAG contrast math module"
+```
+
+---
+
+## Task 2: `applyNodeLabelContrast` DOM pass
+
+**Files:**
+- Modify: `packages/relay-web/src/lib/render-mermaid.ts` (add + export `applyNodeLabelContrast`)
+- Test: `packages/relay-web/src/__tests__/node-label-contrast.test.ts`
+
+**Interfaces:**
+- Consumes: `parseCssColor`, `contrastRatio`, `pickReadableTextColor` from `./wcag-contrast`.
+- Produces: `applyNodeLabelContrast(root: HTMLElement): void` (exported from `render-mermaid.ts`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/relay-web/src/__tests__/node-label-contrast.test.ts`:
+
+```ts
+import { afterEach, expect, test } from "vitest";
+import { applyNodeLabelContrast } from "../lib/render-mermaid";
+
+// Build a mermaid-like g.node. jsdom's getComputedStyle resolves only INLINE
+// style (not <style> classes / presentation attrs), so we feed fills via inline
+// style.fill — enough to exercise the decision + mutation logic. The real
+// class/attribute path is covered by the Chromium probe (see spec). The node
+// must be in-document for getComputedStyle to resolve.
+function nodeSvg(shapeFill: string, textFill: string): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML =
+    `<svg><g class="node">` +
+    `<rect style="fill: ${shapeFill}"></rect>` +
+    `<text style="fill: ${textFill}">Label</text>` +
+    `</g></svg>`;
+  document.body.appendChild(root);
+  return root;
+}
+function textFill(root: HTMLElement): string {
+  return (root.querySelector("text") as unknown as SVGElement).style.fill;
+}
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+test("overrides the label color on a light fill (contrast 1.52 < 3.0)", () => {
+  const root = nodeSvg("rgb(224, 255, 255)", "rgb(204, 204, 204)");
+  applyNodeLabelContrast(root);
+  expect(textFill(root)).toBe("rgb(0, 0, 0)");
+});
+
+test("leaves a readable label untouched (dark fill control, contrast 10.17)", () => {
+  const root = nodeSvg("rgb(31, 32, 32)", "rgb(204, 204, 204)");
+  applyNodeLabelContrast(root);
+  expect(textFill(root)).toBe("rgb(204, 204, 204)");
+});
+
+test("skips nodes whose shape has no resolvable fill (fill:none)", () => {
+  const root = nodeSvg("none", "rgb(204, 204, 204)");
+  applyNodeLabelContrast(root);
+  expect(textFill(root)).toBe("rgb(204, 204, 204)");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/node-label-contrast.test.ts`
+Expected: FAIL — `applyNodeLabelContrast` is not exported from `render-mermaid`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/relay-web/src/lib/render-mermaid.ts`, add this import at the top (next to the existing `DOMPurify` / `decodeMermaidSource` imports):
+
+```ts
+import { parseCssColor, contrastRatio, pickReadableTextColor } from "./wcag-contrast";
+```
+
+Then add, near the top of the module (after the imports, before `hydrateMermaidBlocks`):
+
+```ts
+// WCAG graphical-object minimum. Node labels below this against their fill are
+// illegible (e.g. mermaid dark's #ccc text on an author-pinned light fill ≈ 1.5).
+const MIN_LABEL_CONTRAST = 3.0;
+
+/**
+ * Fix illegible flowchart node labels in place. For each `g.node` under `root`,
+ * if its label <text> has < MIN_LABEL_CONTRAST against the node's shape fill,
+ * override the text color to black/white (whichever is more readable). No-op for
+ * labels that are already readable (zero regression) and for shapes with no
+ * resolvable fill (none/transparent — unknown background, left to the theme).
+ *
+ * Reads live computed styles, so it must run AFTER the SVG is in the document.
+ * Theme-agnostic: it also fixes light-theme author-pinned dark fills.
+ */
+export function applyNodeLabelContrast(root: HTMLElement): void {
+  const nodes = root.querySelectorAll<SVGGElement>("g.node");
+  nodes.forEach((node) => {
+    const shape = node.querySelector<SVGElement>("rect, polygon, path, circle, ellipse");
+    const text = node.querySelector<SVGElement>("text");
+    if (!shape || !text) return;
+    const fill = parseCssColor(getComputedStyle(shape).fill);
+    if (!fill) return; // none / transparent — unknown background, leave to theme
+    const color = parseCssColor(getComputedStyle(text).fill);
+    if (!color) return;
+    if (contrastRatio(color, fill) >= MIN_LABEL_CONTRAST) return;
+    text.style.fill = pickReadableTextColor(fill);
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/node-label-contrast.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/relay-web/src/lib/render-mermaid.ts packages/relay-web/src/__tests__/node-label-contrast.test.ts
+git commit -m "feat(relay-web): add node-label contrast pass for mermaid"
+```
+
+---
+
+## Task 3: Wire the pass into `hydrateMermaidBlocks`
+
+**Files:**
+- Modify: `packages/relay-web/src/lib/render-mermaid.ts` (call `applyNodeLabelContrast` inside the hydrate loop)
+- Test: `packages/relay-web/src/__tests__/node-label-contrast.test.ts` (add integration test)
+
+**Interfaces:**
+- Consumes: `applyNodeLabelContrast` (Task 2), `hydrateMermaidBlocks` + `__setMermaidLoaderForTest` (existing).
+- Produces: nothing new — behavior change only.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/relay-web/src/__tests__/node-label-contrast.test.ts`:
+
+```ts
+import {
+  hydrateMermaidBlocks,
+  __setMermaidLoaderForTest,
+} from "../lib/render-mermaid";
+import { encodeMermaidSource } from "../lib/mermaid-source";
+
+function mermaidBlock(src: string): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML = `<pre class="mermaid-block" data-mermaid="${encodeMermaidSource(src)}"><code>${src}</code></pre>`;
+  document.body.appendChild(root); // getComputedStyle needs it in-document
+  return root;
+}
+
+afterEach(() => __setMermaidLoaderForTest(null));
+
+test("hydrateMermaidBlocks fixes a low-contrast node label end to end", async () => {
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({
+      initialize: () => {},
+      render: async () => ({
+        svg:
+          `<svg><g class="node">` +
+          `<rect style="fill: rgb(224, 255, 255)"></rect>` +
+          `<text style="fill: rgb(204, 204, 204)">Hi</text>` +
+          `</g></svg>`,
+      }),
+    }),
+  );
+  const root = mermaidBlock("graph TD\n A-->B");
+  await hydrateMermaidBlocks(root, "dark");
+  const text = root.querySelector("pre.mermaid-block text") as unknown as SVGElement;
+  expect(text.style.fill).toBe("rgb(0, 0, 0)");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/node-label-contrast.test.ts`
+Expected: FAIL — the label stays `rgb(204, 204, 204)` because hydrate does not yet call the pass.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/relay-web/src/lib/render-mermaid.ts`, inside `hydrateMermaidBlocks`, find:
+
+```ts
+      if (shouldAbort?.()) return; // re-check after the await: DOM may have been torn down mid-render
+      block.innerHTML = svg;
+      block.setAttribute("data-mermaid-done", "1");
+      block.classList.add("mermaid-rendered");
+```
+
+Insert the contrast pass right after the innerHTML assignment:
+
+```ts
+      if (shouldAbort?.()) return; // re-check after the await: DOM may have been torn down mid-render
+      block.innerHTML = svg;
+      // svgCache holds the pre-fix SVG string, so re-apply on every injection (incl. cache hits).
+      // Cheap, idempotent DOM walk; no-op when contrast is already fine or fills don't resolve.
+      applyNodeLabelContrast(block);
+      block.setAttribute("data-mermaid-done", "1");
+      block.classList.add("mermaid-rendered");
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/node-label-contrast.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Run the existing mermaid render tests (no regression)**
+
+Run: `cd packages/relay-web && npx vitest run src/__tests__/render-mermaid.test.ts`
+Expected: PASS — existing hydrate tests unaffected (their SVGs have no `g.node`, or run detached where `getComputedStyle` yields no resolvable fill → the pass is a no-op).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/relay-web/src/lib/render-mermaid.ts packages/relay-web/src/__tests__/node-label-contrast.test.ts
+git commit -m "feat(relay-web): apply node-label contrast fix during mermaid hydrate"
+```
+
+---
+
+## Task 4: Full-suite verification + real-render confirmation
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole relay-web test suite + typecheck**
+
+Run: `cd packages/relay-web && npx vitest run && npx vue-tsc --noEmit`
+(`vue-tsc --noEmit` is exactly the typecheck half of this package's `build` script: `vue-tsc --noEmit && vite build`.)
+Expected: all tests PASS, no type errors.
+
+- [ ] **Step 2: Real-render confirmation via the Chromium probe (optional, not CI)**
+
+Rebuild the probe used during investigation (see spec "Probe reproduction") but read contrast **after** `applyNodeLabelContrast` runs, i.e. drive the real `hydrateMermaidBlocks` path. Expected result: the `style fill:#e0ffff` and `classDef fill:#e1f5fe` nodes now report the label `fill` as `rgb(0, 0, 0)` with contrast ≥ 10 (was ≈ 1.4–1.6); the control node is unchanged at 10.17. Capture a screenshot showing all node labels legible.
+
+If the probe harness is not readily available, this step may be skipped — the jsdom integration test (Task 3) plus the math unit tests (Task 1) are the automated gate; the probe is confirmatory only.
+
+- [ ] **Step 3: Final commit (if any verification tweaks were made)**
+
+```bash
+git add -A
+git commit -m "test(relay-web): verify mermaid node-label contrast fix"
+```
+
+(If nothing changed in this task, skip the commit.)
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** approach (post-render live-DOM pass) → Task 2/3; pure math module → Task 1; threshold < 3.0 → `MIN_LABEL_CONTRAST` (Task 2); scope `g.node` only → Task 2 selector; theme-agnostic → no theme branch in Task 2; override black/white auto-pick → `pickReadableTextColor` (Task 1); skip unresolvable fill → Task 2 early return; testing (math + jsdom logic + integration) → Task 1/2/3; probe not in CI → Task 4 Step 2. All covered.
+- **Type consistency:** `RGB`, `parseCssColor`, `contrastRatio`, `pickReadableTextColor`, `applyNodeLabelContrast` names/signatures identical across tasks.

--- a/docs/superpowers/specs/2026-07-17-web-mermaid-label-contrast-design.md
+++ b/docs/superpowers/specs/2026-07-17-web-mermaid-label-contrast-design.md
@@ -1,0 +1,129 @@
+# Mermaid node-label dark-mode contrast fix — design
+
+Date: 2026-07-17
+Scope: `packages/relay-web`
+
+## Problem
+
+In the relay-web chat, mermaid diagrams rendered in **dark mode** show node-label
+text that is washed out / illegible whenever the diagram author pins a **light**
+fill on a node (via `style X fill:#...` or `classDef ... fill:#...`).
+
+### Root cause (confirmed by real-Chromium probe)
+
+A headless-Chromium probe (cached `chromium_headless_shell-1228`, real
+mermaid 11.16.0, the **verbatim** `render-mermaid.ts` init/sanitize config —
+`theme:'dark'`, `htmlLabels:false`, `securityLevel:'strict'`, same DOMPurify
+`svg` profile) measured computed styles:
+
+| Case | text `fill` | shape fill | contrast |
+|---|---|---|---|
+| control (no pinned fill) | `rgb(204,204,204)` | `rgb(31,32,32)` | **10.17** ✅ |
+| `style fill:#e0ffff` / `#ffffff` | `rgb(204,204,204)` | near-white | **1.52 / 1.61** ❌ |
+| `classDef fill:#e1f5fe` | `rgb(204,204,204)` | `rgb(225,245,254)` | **1.43** ❌ |
+
+The label text color is **identical** (`#ccc`, mermaid dark theme's
+`nodeTextColor`) in every case — mermaid has **no** text↔fill contrast
+adaptation (upstream-inherent). When the author pins a light fill, `#ccc` lands
+on near-white ≈ 1.4–1.6:1.
+
+**Ruled out (not the cause):** theme detection is correct (`stores/theme.ts`
+maps dark→mermaid `"dark"` theme); DOMPurify keeps the `<style>` block, so theme
+variables are injected fine. The contrast conflict is the sole cause.
+
+There is currently **no** contrast post-processing in `render-mermaid.ts` — the
+previously-investigated fix was never merged.
+
+## Approach
+
+Post-render, on the **live DOM**, walk each flowchart node, compute the WCAG
+contrast between its label text and its shape fill, and override the text color
+**only when contrast < 3.0**. This is the only approach that handles per-node
+author-pinned fills (a global `themeVariables` text color cannot be right for
+both theme-default nodes and light-pinned nodes; CSS cannot compute per-node
+contrast).
+
+Must run on the **live DOM** because `getComputedStyle` must resolve mermaid's
+`<style>` classes + SVG presentation attributes — a detached SVG string does not
+resolve fills (this is also why jsdom cannot exercise a real render).
+
+### Integration point
+
+In `render-mermaid.ts` `hydrateMermaidBlocks`, immediately **after**
+`block.innerHTML = svg` and **before** setting `data-mermaid-done`, call
+`applyNodeLabelContrast(block)`. The `svgCache` stores the pre-fix sanitized SVG
+string, so the fixup runs on **every** injection (including cache hits) — it is a
+cheap, idempotent DOM walk.
+
+## Modules
+
+### `src/lib/wcag-contrast.ts` (new, pure — no DOM)
+
+The math, fully unit-testable:
+
+- `parseCssColor(str: string): [number, number, number] | null` — parse
+  `rgb()/rgba()` computed-style strings (returns null for unparseable / `none`).
+- `relativeLuminance(rgb: [number, number, number]): number` — WCAG sRGB luminance.
+- `contrastRatio(fg: [number,number,number], bg: [number,number,number]): number`.
+- `pickReadableTextColor(bg: [number,number,number]): string` — returns
+  `"rgb(0,0,0)"` or `"rgb(255,255,255)"`, whichever has the higher ratio against
+  `bg` (guarantees maximal contrast).
+
+### `applyNodeLabelContrast(root: HTMLElement): void`
+
+DOM walk. Lives in and is **exported from `render-mermaid.ts`** (next to the
+`hydrateMermaidBlocks` caller; imports the pure helpers from `wcag-contrast.ts`;
+the jsdom test imports it directly). For each `g.node` under `root`:
+
+1. Find the label `<text>` and the node shape (`rect, polygon, path, circle, ellipse`).
+2. `getComputedStyle` both; parse the shape fill and the text fill.
+3. If the shape fill is unparseable / `none` / fully transparent → **skip**
+   (cannot know the effective background; leave to theme — preserves zero regression).
+4. If `contrastRatio(textFill, shapeFill) >= 3.0` → **skip** (already readable).
+5. Else set `text.style.fill = pickReadableTextColor(shapeFill)` (inline style
+   overrides `<style>`/presentation attrs; `<tspan>` children inherit `fill`).
+
+## Key behaviors
+
+- **Threshold < 3.0** (WCAG graphical-object minimum): the control case (10.17)
+  is far above → **zero regression**; only clearly-broken labels are touched.
+- **Theme-agnostic**: because it picks black/white from the *measured* fill, the
+  same function also fixes light-theme author-pinned **dark** fills (dark-on-dark).
+  It runs regardless of theme; no theme branching.
+- **Override color**: black/white auto-pick (whichever contrasts more), for
+  guaranteed maximal contrast and simplicity.
+- **Scope**: flowchart **node labels only** (`g.node text`) — where `style` /
+  `classDef` pins land, which is 95%+ of real reports; text↔background pairing is
+  clean and reliable there.
+
+## Testing
+
+- **`wcag-contrast.test.ts` (vitest, pure math)**: known color-pair ratios
+  anchored to the probe's measured values (`#ccc` vs `#e0ffff` ≈ 1.52, `#ccc` vs
+  `#1f2020` ≈ 10.17), black/white pick correctness, boundary (== 3.0) and invalid
+  / `none` inputs.
+- **`applyNodeLabelContrast` jsdom logic test**: hand-build a `g.node` and feed
+  colors via **inline `style.fill`** (jsdom's `getComputedStyle` reads inline
+  style). Assert: light-fill node → text fill overridden to black; dark-fill
+  control → **untouched**; `fill:none` → skipped. This covers the decision + DOM
+  mutation logic without a browser.
+- **Real render**: the headless-Chromium probe already provided end-to-end
+  evidence (one-off). It is **not** wired into CI (needs a cached browser + local
+  http server, which CI lacks). Reproduction steps are recorded below.
+
+### Probe reproduction (manual, for the record)
+
+1. Bundle a probe entry that imports mermaid + DOMPurify, initializes with the
+   verbatim `render-mermaid.ts` config, renders a control diagram + a
+   `style fill:#e0ffff` diagram + a `classDef fill:#e1f5fe` diagram, injects the
+   sanitized SVG, then reads `getComputedStyle().fill` of each node's text and
+   shape and computes contrast.
+2. Serve the bundle over http (module scripts are CORS-blocked on `file://`).
+3. Drive the cached `chrome-headless-shell` via `playwright-core`
+   (`executablePath`), read `window.__PROBE__`, screenshot full page.
+
+## Out of scope (YAGNI)
+
+- Edge labels, subgraph titles, sequence-diagram actors, gantt, pie.
+- Configurable threshold.
+- Any change to the theme pipeline (it is correct).

--- a/packages/relay-web/src/__tests__/node-label-contrast.test.ts
+++ b/packages/relay-web/src/__tests__/node-label-contrast.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, expect, test } from "vitest";
+import { applyNodeLabelContrast } from "../lib/render-mermaid";
+
+// Build a mermaid-like g.node. jsdom's getComputedStyle resolves only INLINE
+// style (not <style> classes / presentation attrs), so we feed fills via inline
+// style.fill — enough to exercise the decision + mutation logic. The real
+// class/attribute path is covered by the Chromium probe (see spec). The node
+// must be in-document for getComputedStyle to resolve.
+function nodeSvg(shapeFill: string, textFill: string): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML =
+    `<svg><g class="node">` +
+    `<rect style="fill: ${shapeFill}"></rect>` +
+    `<text style="fill: ${textFill}">Label</text>` +
+    `</g></svg>`;
+  document.body.appendChild(root);
+  return root;
+}
+function textFill(root: HTMLElement): string {
+  return (root.querySelector("text") as unknown as SVGElement).style.fill;
+}
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+test("overrides the label color on a light fill (contrast 1.52 < 3.0)", () => {
+  const root = nodeSvg("rgb(224, 255, 255)", "rgb(204, 204, 204)");
+  applyNodeLabelContrast(root);
+  expect(textFill(root)).toBe("rgb(0, 0, 0)");
+});
+
+test("leaves a readable label untouched (dark fill control, contrast 10.17)", () => {
+  const root = nodeSvg("rgb(31, 32, 32)", "rgb(204, 204, 204)");
+  applyNodeLabelContrast(root);
+  expect(textFill(root)).toBe("rgb(204, 204, 204)");
+});
+
+test("skips nodes whose shape has no resolvable fill (fill:none)", () => {
+  const root = nodeSvg("none", "rgb(204, 204, 204)");
+  applyNodeLabelContrast(root);
+  expect(textFill(root)).toBe("rgb(204, 204, 204)");
+});

--- a/packages/relay-web/src/__tests__/node-label-contrast.test.ts
+++ b/packages/relay-web/src/__tests__/node-label-contrast.test.ts
@@ -59,6 +59,21 @@ test("skips nodes whose label color is unresolvable (text fill:none)", () => {
   expect(textFill(root)).toBe("none");
 });
 
+// Threshold boundary: white text on gray(148) ≈ 3.03 (>= 3.0) vs gray(149) ≈ 2.99
+// (< 3.0). These bracket MIN_LABEL_CONTRAST and pin both its value (a raise to 4.5
+// would recolor the 3.03 case) and its >= direction (equal stays untouched).
+test("leaves a label just at/above the 3.0 threshold untouched (gray 148 ≈ 3.03)", () => {
+  const root = nodeSvg("rgb(148, 148, 148)", "rgb(255, 255, 255)");
+  applyNodeLabelContrast(root);
+  expect(textFill(root)).toBe("rgb(255, 255, 255)");
+});
+
+test("recolors a label just below the 3.0 threshold (gray 149 ≈ 2.99)", () => {
+  const root = nodeSvg("rgb(149, 149, 149)", "rgb(255, 255, 255)");
+  applyNodeLabelContrast(root);
+  expect(textFill(root)).toBe("rgb(0, 0, 0)"); // black wins against a mid-gray fill
+});
+
 test("hydrateMermaidBlocks fixes a low-contrast node label end to end", async () => {
   __setMermaidLoaderForTest(() =>
     Promise.resolve({

--- a/packages/relay-web/src/__tests__/node-label-contrast.test.ts
+++ b/packages/relay-web/src/__tests__/node-label-contrast.test.ts
@@ -51,6 +51,14 @@ test("skips nodes whose shape has no resolvable fill (fill:none)", () => {
   expect(textFill(root)).toBe("rgb(204, 204, 204)");
 });
 
+test("skips nodes whose label color is unresolvable (text fill:none)", () => {
+  // Shape fill resolves (dark) so we reach the text-color check; the text fill
+  // does not, so the pass must leave the label untouched rather than recolor it.
+  const root = nodeSvg("rgb(31, 32, 32)", "none");
+  applyNodeLabelContrast(root);
+  expect(textFill(root)).toBe("none");
+});
+
 test("hydrateMermaidBlocks fixes a low-contrast node label end to end", async () => {
   __setMermaidLoaderForTest(() =>
     Promise.resolve({

--- a/packages/relay-web/src/__tests__/node-label-contrast.test.ts
+++ b/packages/relay-web/src/__tests__/node-label-contrast.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "vitest";
-import { applyNodeLabelContrast } from "../lib/render-mermaid";
+import { applyNodeLabelContrast, hydrateMermaidBlocks, __setMermaidLoaderForTest } from "../lib/render-mermaid";
+import { encodeMermaidSource } from "../lib/mermaid-source";
 
 // Build a mermaid-like g.node. jsdom's getComputedStyle resolves only INLINE
 // style (not <style> classes / presentation attrs), so we feed fills via inline
@@ -19,8 +20,17 @@ function nodeSvg(shapeFill: string, textFill: string): HTMLElement {
 function textFill(root: HTMLElement): string {
   return (root.querySelector("text") as unknown as SVGElement).style.fill;
 }
+
+function mermaidBlock(src: string): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML = `<pre class="mermaid-block" data-mermaid="${encodeMermaidSource(src)}"><code>${src}</code></pre>`;
+  document.body.appendChild(root); // getComputedStyle needs it in-document
+  return root;
+}
+
 afterEach(() => {
   document.body.innerHTML = "";
+  __setMermaidLoaderForTest(null);
 });
 
 test("overrides the label color on a light fill (contrast 1.52 < 3.0)", () => {
@@ -39,4 +49,23 @@ test("skips nodes whose shape has no resolvable fill (fill:none)", () => {
   const root = nodeSvg("none", "rgb(204, 204, 204)");
   applyNodeLabelContrast(root);
   expect(textFill(root)).toBe("rgb(204, 204, 204)");
+});
+
+test("hydrateMermaidBlocks fixes a low-contrast node label end to end", async () => {
+  __setMermaidLoaderForTest(() =>
+    Promise.resolve({
+      initialize: () => {},
+      render: async () => ({
+        svg:
+          `<svg><g class="node">` +
+          `<rect style="fill: rgb(224, 255, 255)"></rect>` +
+          `<text style="fill: rgb(204, 204, 204)">Hi</text>` +
+          `</g></svg>`,
+      }),
+    }),
+  );
+  const root = mermaidBlock("graph TD\n A-->B");
+  await hydrateMermaidBlocks(root, "dark");
+  const text = root.querySelector("pre.mermaid-block text") as unknown as SVGElement;
+  expect(text.style.fill).toBe("rgb(0, 0, 0)");
 });

--- a/packages/relay-web/src/__tests__/wcag-contrast.test.ts
+++ b/packages/relay-web/src/__tests__/wcag-contrast.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import {
+  parseCssColor,
+  relativeLuminance,
+  contrastRatio,
+  pickReadableTextColor,
+} from "../lib/wcag-contrast";
+
+test("parseCssColor parses rgb and rgba (drops alpha channel)", () => {
+  expect(parseCssColor("rgb(204, 204, 204)")).toEqual([204, 204, 204]);
+  expect(parseCssColor("rgba(1, 2, 3, 0.5)")).toEqual([1, 2, 3]);
+});
+
+test("parseCssColor returns null for none / fully transparent / garbage", () => {
+  expect(parseCssColor("none")).toBeNull();
+  expect(parseCssColor("rgba(0, 0, 0, 0)")).toBeNull();
+  expect(parseCssColor("")).toBeNull();
+});
+
+test("relativeLuminance: black is 0, white is 1", () => {
+  expect(relativeLuminance([0, 0, 0])).toBeCloseTo(0, 5);
+  expect(relativeLuminance([255, 255, 255])).toBeCloseTo(1, 5);
+});
+
+test("contrastRatio matches the probe-measured anchors", () => {
+  const text = parseCssColor("rgb(204, 204, 204)")!; // #ccc mermaid dark label
+  const lightFill = parseCssColor("rgb(224, 255, 255)")!; // #e0ffff pinned
+  const darkFill = parseCssColor("rgb(31, 32, 32)")!; // #1f2020 theme default
+  expect(contrastRatio(text, lightFill)).toBeCloseTo(1.52, 1);
+  expect(contrastRatio(text, darkFill)).toBeCloseTo(10.17, 1);
+});
+
+test("contrastRatio is symmetric and bounded at 21 for black/white", () => {
+  expect(contrastRatio([255, 255, 255], [0, 0, 0])).toBeCloseTo(21, 0);
+  expect(contrastRatio([0, 0, 0], [255, 255, 255])).toBeCloseTo(21, 0);
+});
+
+test("pickReadableTextColor: black on light fills, white on dark fills", () => {
+  expect(pickReadableTextColor([224, 255, 255])).toBe("rgb(0, 0, 0)");
+  expect(pickReadableTextColor([255, 255, 255])).toBe("rgb(0, 0, 0)");
+  expect(pickReadableTextColor([31, 32, 32])).toBe("rgb(255, 255, 255)");
+});

--- a/packages/relay-web/src/__tests__/wcag-contrast.test.ts
+++ b/packages/relay-web/src/__tests__/wcag-contrast.test.ts
@@ -6,15 +6,19 @@ import {
   pickReadableTextColor,
 } from "../lib/wcag-contrast";
 
-test("parseCssColor parses rgb and rgba (drops alpha channel)", () => {
+test("parseCssColor parses rgb and fully-opaque rgba", () => {
   expect(parseCssColor("rgb(204, 204, 204)")).toEqual([204, 204, 204]);
-  expect(parseCssColor("rgba(1, 2, 3, 0.5)")).toEqual([1, 2, 3]);
+  expect(parseCssColor("rgba(1, 2, 3, 1)")).toEqual([1, 2, 3]);
 });
 
-test("parseCssColor returns null for none / fully transparent / garbage", () => {
+test("parseCssColor returns null for anything not a usable opaque color", () => {
   expect(parseCssColor("none")).toBeNull();
-  expect(parseCssColor("rgba(0, 0, 0, 0)")).toBeNull();
   expect(parseCssColor("")).toBeNull();
+  expect(parseCssColor("rgba(0, 0, 0, 0)")).toBeNull(); // fully transparent
+  // Non-opaque alpha can't be composited without the effective background — skip it
+  // rather than measure the wrong (unblended) color and decide on it.
+  expect(parseCssColor("rgba(1, 2, 3, 0.5)")).toBeNull();
+  expect(parseCssColor("rgba(1, 2, 3, x)")).toBeNull(); // non-numeric alpha
 });
 
 test("relativeLuminance: black is 0, white is 1", () => {
@@ -28,6 +32,14 @@ test("contrastRatio matches the probe-measured anchors", () => {
   const darkFill = parseCssColor("rgb(31, 32, 32)")!; // #1f2020 theme default
   expect(contrastRatio(text, lightFill)).toBeCloseTo(1.52, 1);
   expect(contrastRatio(text, darkFill)).toBeCloseTo(10.17, 1);
+});
+
+test("contrastRatio straddles the 3.0 label threshold at gray 148/149 (boundary anchors)", () => {
+  // These grays bracket the MIN_LABEL_CONTRAST=3.0 decision in render-mermaid.ts:
+  // white-on-gray(148) ≈ 3.03 (>= 3.0, left untouched) and gray(149) ≈ 2.99 (< 3.0, recolored).
+  // Pins both the threshold value and the >= direction against accidental drift.
+  expect(contrastRatio([255, 255, 255], [148, 148, 148])).toBeGreaterThan(3.0);
+  expect(contrastRatio([255, 255, 255], [149, 149, 149])).toBeLessThan(3.0);
 });
 
 test("contrastRatio is symmetric and bounded at 21 for black/white", () => {

--- a/packages/relay-web/src/lib/render-mermaid.ts
+++ b/packages/relay-web/src/lib/render-mermaid.ts
@@ -10,8 +10,11 @@ export interface MermaidLike {
   render(id: string, text: string): Promise<{ svg: string }>;
 }
 
-// WCAG graphical-object minimum. Node labels below this against their fill are
-// illegible (e.g. mermaid dark's #ccc text on an author-pinned light fill ≈ 1.5).
+// Conservative "rescue" threshold — recolor only labels well below legibility, so
+// we don't second-guess mermaid's own borderline styling. This is deliberately NOT
+// WCAG AA text conformance (SC 1.4.3 would be 4.5:1); the 3.0–4.5 band is left
+// alone. The real failure mode this targets — #ccc text on an author-pinned light
+// fill — measures ≈ 1.5, far below 3.0, so this catches every actual case.
 const MIN_LABEL_CONTRAST = 3.0;
 
 let loaderOverride: null | (() => Promise<MermaidLike>) = null;

--- a/packages/relay-web/src/lib/render-mermaid.ts
+++ b/packages/relay-web/src/lib/render-mermaid.ts
@@ -1,5 +1,6 @@
 import DOMPurify from "dompurify";
 import { decodeMermaidSource } from "./mermaid-source";
+import { parseCssColor, contrastRatio, pickReadableTextColor } from "./wcag-contrast";
 
 export type MermaidTheme = "dark" | "light";
 
@@ -8,6 +9,10 @@ export interface MermaidLike {
   initialize(config: Record<string, unknown>): void;
   render(id: string, text: string): Promise<{ svg: string }>;
 }
+
+// WCAG graphical-object minimum. Node labels below this against their fill are
+// illegible (e.g. mermaid dark's #ccc text on an author-pinned light fill ≈ 1.5).
+const MIN_LABEL_CONTRAST = 3.0;
 
 let loaderOverride: null | (() => Promise<MermaidLike>) = null;
 let modPromise: Promise<MermaidLike> | null = null;
@@ -22,6 +27,31 @@ export function __setMermaidLoaderForTest(loader: null | (() => Promise<MermaidL
   initializedTheme = null;
   seq = 0;
   svgCache.clear();
+}
+
+/**
+ * Fix illegible flowchart node labels in place. For each `g.node` under `root`,
+ * if its label <text> has < MIN_LABEL_CONTRAST against the node's shape fill,
+ * override the text color to black/white (whichever is more readable). No-op for
+ * labels that are already readable (zero regression) and for shapes with no
+ * resolvable fill (none/transparent — unknown background, left to the theme).
+ *
+ * Reads live computed styles, so it must run AFTER the SVG is in the document.
+ * Theme-agnostic: it also fixes light-theme author-pinned dark fills.
+ */
+export function applyNodeLabelContrast(root: HTMLElement): void {
+  const nodes = root.querySelectorAll<SVGGElement>("g.node");
+  nodes.forEach((node) => {
+    const shape = node.querySelector<SVGElement>("rect, polygon, path, circle, ellipse");
+    const text = node.querySelector<SVGElement>("text");
+    if (!shape || !text) return;
+    const fill = parseCssColor(getComputedStyle(shape).fill);
+    if (!fill) return; // none / transparent — unknown background, leave to theme
+    const color = parseCssColor(getComputedStyle(text).fill);
+    if (!color) return;
+    if (contrastRatio(color, fill) >= MIN_LABEL_CONTRAST) return;
+    text.style.fill = pickReadableTextColor(fill);
+  });
 }
 
 function loadMermaid(): Promise<MermaidLike> {

--- a/packages/relay-web/src/lib/render-mermaid.ts
+++ b/packages/relay-web/src/lib/render-mermaid.ts
@@ -125,6 +125,9 @@ export async function hydrateMermaidBlocks(
       }
       if (shouldAbort?.()) return; // re-check after the await: DOM may have been torn down mid-render
       block.innerHTML = svg;
+      // svgCache holds the pre-fix SVG string, so re-apply on every injection (incl. cache hits).
+      // Cheap, idempotent DOM walk; no-op when contrast is already fine or fills don't resolve.
+      applyNodeLabelContrast(block);
       block.setAttribute("data-mermaid-done", "1");
       block.classList.add("mermaid-rendered");
     } catch {

--- a/packages/relay-web/src/lib/wcag-contrast.ts
+++ b/packages/relay-web/src/lib/wcag-contrast.ts
@@ -1,0 +1,46 @@
+// WCAG relative-luminance / contrast math + a readable text-color picker.
+// Pure (no DOM) so it is unit-testable in isolation. Consumed by the mermaid
+// node-label contrast fix (render-mermaid.ts applyNodeLabelContrast).
+
+export type RGB = [number, number, number];
+
+/**
+ * Parse a CSS `rgb()/rgba()` computed-style string into an RGB triple.
+ * Returns null for `none`, fully transparent (alpha 0), or anything unparseable
+ * — i.e. "no usable background color".
+ */
+export function parseCssColor(value: string): RGB | null {
+  const m = value.match(/rgba?\(([^)]+)\)/i);
+  if (!m) return null;
+  const parts = m[1].split(",").map((p) => parseFloat(p.trim()));
+  if (parts.length < 3 || parts.slice(0, 3).some((n) => Number.isNaN(n))) return null;
+  const alpha = parts.length >= 4 ? parts[3] : 1;
+  if (alpha === 0) return null;
+  return [parts[0], parts[1], parts[2]];
+}
+
+function channelLuminance(c: number): number {
+  const s = c / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG 2.x relative luminance of an sRGB color (0..1). */
+export function relativeLuminance([r, g, b]: RGB): number {
+  return 0.2126 * channelLuminance(r) + 0.7152 * channelLuminance(g) + 0.0722 * channelLuminance(b);
+}
+
+/** WCAG contrast ratio between two colors (1..21). */
+export function contrastRatio(fg: RGB, bg: RGB): number {
+  const lf = relativeLuminance(fg);
+  const lb = relativeLuminance(bg);
+  const hi = Math.max(lf, lb);
+  const lo = Math.min(lf, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Pick black or white — whichever has the higher contrast against `bg`. */
+export function pickReadableTextColor(bg: RGB): string {
+  const black: RGB = [0, 0, 0];
+  const white: RGB = [255, 255, 255];
+  return contrastRatio(black, bg) >= contrastRatio(white, bg) ? "rgb(0, 0, 0)" : "rgb(255, 255, 255)";
+}

--- a/packages/relay-web/src/lib/wcag-contrast.ts
+++ b/packages/relay-web/src/lib/wcag-contrast.ts
@@ -6,9 +6,11 @@ export type RGB = [number, number, number];
 
 /**
  * Parse a CSS `rgb()/rgba()` computed-style string into an RGB triple.
- * Returns null for `none`, fully transparent (alpha 0), or anything unparseable
- * — i.e. "no usable background color". A fractional alpha (e.g. `rgba(r,g,b,0.5)`)
- * is treated as opaque — no compositing is done; mermaid shape fills are opaque.
+ * Returns null for `none`, anything unparseable, and any non-opaque color — i.e.
+ * "no usable opaque background color". A partial or zero alpha (`rgba(r,g,b,a)`,
+ * a < 1, or a non-numeric alpha) can't be composited without the effective
+ * background, which we don't reliably have, so it is skipped rather than measured
+ * as its unblended color and decided on wrongly.
  */
 export function parseCssColor(value: string): RGB | null {
   const m = value.match(/rgba?\(([^)]+)\)/i);
@@ -16,7 +18,7 @@ export function parseCssColor(value: string): RGB | null {
   const parts = m[1].split(",").map((p) => parseFloat(p.trim()));
   if (parts.length < 3 || parts.slice(0, 3).some((n) => Number.isNaN(n))) return null;
   const alpha = parts.length >= 4 ? parts[3] : 1;
-  if (alpha === 0) return null;
+  if (!(alpha >= 1)) return null; // alpha < 1 (non-opaque) or NaN (non-numeric) → skip
   return [parts[0], parts[1], parts[2]];
 }
 

--- a/packages/relay-web/src/lib/wcag-contrast.ts
+++ b/packages/relay-web/src/lib/wcag-contrast.ts
@@ -7,7 +7,8 @@ export type RGB = [number, number, number];
 /**
  * Parse a CSS `rgb()/rgba()` computed-style string into an RGB triple.
  * Returns null for `none`, fully transparent (alpha 0), or anything unparseable
- * — i.e. "no usable background color".
+ * — i.e. "no usable background color". A fractional alpha (e.g. `rgba(r,g,b,0.5)`)
+ * is treated as opaque — no compositing is done; mermaid shape fills are opaque.
  */
 export function parseCssColor(value: string): RGB | null {
   const m = value.match(/rgba?\(([^)]+)\)/i);


### PR DESCRIPTION
## Problem
In dark mode, mermaid flowchart node labels are washed out / illegible when the diagram author pins a **light** node fill (`style X fill:#...` or `classDef ... fill:#...`). Mermaid's dark theme paints label text a fixed light gray (`#ccc`) and has **no** text↔fill contrast adaptation, so `#ccc` on a near-white pinned fill ≈ 1.4–1.6:1.

Confirmed by a headless-Chromium probe (real mermaid 11.16.0, verbatim `render-mermaid.ts` config): control node text/fill = 10.17 contrast (fine); `style fill:#e0ffff` = 1.52; `classDef fill:#e1f5fe` = 1.43. Theme detection and DOMPurify were ruled out — the contrast conflict is the sole cause.

## Fix
A pure WCAG-contrast module + a live-DOM pass in `hydrateMermaidBlocks`: after each render, for every `g.node`, if the label's measured contrast vs its shape fill is **< 3.0**, override the label color to black/white (whichever contrasts more). Otherwise leave it — zero regression on already-readable diagrams. Theme-agnostic (picks from the measured fill, so it also fixes light-theme dark-pinned fills). Skips when a fill/color can't be resolved.

## Files
- `src/lib/wcag-contrast.ts` (new) — pure `parseCssColor` / `relativeLuminance` / `contrastRatio` / `pickReadableTextColor`.
- `src/lib/render-mermaid.ts` — new exported `applyNodeLabelContrast(root)`, called right after the sanitized SVG is injected.
- Tests: `wcag-contrast.test.ts` (math, anchored to probe values) + `node-label-contrast.test.ts` (jsdom decision/mutation + end-to-end via the hydrate seam).

## Verification
- relay-web Vitest: **101 files / 789 tests pass**; `vue-tsc --noEmit` clean.
- Chromium probe on the **real** `applyNodeLabelContrast` over **real mermaid `<style>`-class fills**: control 10.17→10.17 (untouched), `style`-pinned 1.52/1.61→19.92/21, `classDef`-pinned 1.43→18.69 — all labels visually legible.

## Scope / limitations (intentional)
Flowchart node labels only. Not touched: edge labels, subgraph titles, sequence actors, gantt, pie. Multi-shape nodes (subroutine/double-circle) pair the label with the first shape — benign, since sibling shapes share the pinned fill and dividers are `fill:none` (skipped): the worst case is a missed fix, never a wrong recolor.

Spec: `docs/superpowers/specs/2026-07-17-web-mermaid-label-contrast-design.md`
Plan: `docs/superpowers/plans/2026-07-17-web-mermaid-label-contrast.md`