### PR TITLE
release: relay beta cut — @ganglion/xacpx-relay 0.9.12-beta.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13183,7 +13183,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.22",
+      "version": "0.9.12-beta.23",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.22",
+  "version": "0.9.12-beta.23",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Version-only bump of `@ganglion/xacpx-relay` to ship the updated **embedded relay-web dashboard** from #174 — legible mermaid node labels in dark mode with author-pinned light fills.

## What changed since 0.9.12-beta.22
Only the bundled `relay-web` (the mermaid contrast fix). No change to the hub src, `relay-protocol`, core, or `channel-relay`.

| package | from | to | dist-tag |
|---|---|---|---|
| `@ganglion/xacpx-relay` | 0.9.12-beta.22 | **0.9.12-beta.23** | next |

core / `relay-protocol` / `channel-relay` / `channel-feishu` / `channel-yuanbao` unchanged — not bumped.

## Verification
`bun run verify:publish` ✅ — builds all packages and asserts `relay-web/index.html` is bundled into `packages/relay/dist/relay-web` (so the hub ships the fixed dashboard). package-lock synced (relay version only).