### PR TITLE
release: relay beta cut — @ganglion/xacpx-relay 0.9.12-beta.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13183,7 +13183,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.23",
+      "version": "0.9.12-beta.24",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.23",
+  "version": "0.9.12-beta.24",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Version-only bump of `@ganglion/xacpx-relay` to ship the updated **embedded relay-web dashboard** from #176 — mermaid diagram **PNG download** + **source toggle**.

Only the bundled `relay-web` changed since 0.9.12-beta.23. No change to the hub src, `relay-protocol`, core, or `channel-relay`.

| package | from | to | dist-tag |
|---|---|---|---|
| `@ganglion/xacpx-relay` | 0.9.12-beta.23 | **0.9.12-beta.24** | next |

`bun run verify:publish` ✅ — asserts `relay-web/index.html` is bundled into `packages/relay/dist/relay-web`.