### PR TITLE
fix(control): match Windows worktree paths

### DIFF
--- a/src/control/workspace-git.ts
+++ b/src/control/workspace-git.ts
@@ -83,22 +83,63 @@ export function worktreePathsEqual(
   platform: NodeJS.Platform = process.platform,
 ): boolean {
   if (platform === "win32") {
-    // Git for Windows may report C:/repo while fs.realpath returns C:\repo,
-    // and drive/path casing is not significant on Windows filesystems.
-    return win32.normalize(left).toLowerCase() === win32.normalize(right).toLowerCase();
+    return normalizeWindowsWorktreePath(left) === normalizeWindowsWorktreePath(right);
   }
   return left === right;
 }
 
+export function worktreePathIsWithin(
+  parent: string,
+  child: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const normalizedParent = platform === "win32" ? normalizeWindowsWorktreePath(parent) : parent;
+  const normalizedChild = platform === "win32" ? normalizeWindowsWorktreePath(child) : child;
+  if (normalizedParent === normalizedChild) return false;
+  const separator = platform === "win32" ? win32.sep : sep;
+  const parentPrefix = normalizedParent.endsWith(separator)
+    ? normalizedParent
+    : normalizedParent + separator;
+  return normalizedChild.startsWith(parentPrefix);
+}
+
+function normalizeWindowsWorktreePath(path: string): string {
+  // Git for Windows may report C:/repo while fs.realpath returns C:\repo.
+  // Extended-length paths are the same filesystem location with a device prefix.
+  let normalized = win32.normalize(path);
+  const folded = normalized.toLowerCase();
+  if (folded.startsWith("\\\\?\\unc\\")) {
+    normalized = `\\\\${normalized.slice(8)}`;
+  } else if (folded.startsWith("\\\\?\\")) {
+    normalized = normalized.slice(4);
+  }
+  normalized = win32.normalize(normalized);
+  const root = win32.parse(normalized).root;
+  while (normalized.length > root.length && normalized.endsWith(win32.sep)) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized.toLowerCase();
+}
+
+export interface WorkspaceGitOptions {
+  managedWorktreesRoot?: string;
+  platform?: NodeJS.Platform;
+  runGit?: (root: string, args: string[]) => Promise<string>;
+}
+
 export class WorkspaceGit {
   private readonly managedWorktreesRoot: string;
+  private readonly platform: NodeJS.Platform;
+  private readonly runGitOverride: WorkspaceGitOptions["runGit"];
   private readonly writeTails = new Map<string, Promise<void>>();
 
   constructor(
     private readonly listWorkspaces: () => GitWorkspaceRef[],
-    options: { managedWorktreesRoot?: string } = {},
+    options: WorkspaceGitOptions = {},
   ) {
     this.managedWorktreesRoot = options.managedWorktreesRoot ?? join(homedir(), ".xacpx", "worktrees");
+    this.platform = options.platform ?? process.platform;
+    this.runGitOverride = options.runGit;
   }
 
   private async rootFor(workspace: string): Promise<string> {
@@ -116,6 +157,7 @@ export class WorkspaceGit {
   }
 
   private async runRaw(root: string, args: string[]): Promise<string> {
+    if (this.runGitOverride) return await this.runGitOverride(root, args);
     const result = await execFileAsync("git", ["-C", root, ...args], {
       timeout: GIT_TIMEOUT_MS,
       killSignal: "SIGKILL",
@@ -306,7 +348,7 @@ export class WorkspaceGit {
         await mkdir(repoDir);
       }
       const realRepoDir = await realpath(repoDir);
-      if (!realRepoDir.startsWith(managedRoot + sep)) throw new Error("worktree-path-unsafe");
+      if (!worktreePathIsWithin(managedRoot, realRepoDir, this.platform)) throw new Error("worktree-path-unsafe");
       const target = join(realRepoDir, branchKey);
       try {
         await lstat(target);
@@ -321,7 +363,7 @@ export class WorkspaceGit {
         await this.run(root, ["worktree", "add", target, branch]);
       }
       const createdPath = await realpath(target);
-      if (!createdPath.startsWith(managedRoot + sep)) throw new Error("worktree-path-unsafe");
+      if (!worktreePathIsWithin(managedRoot, createdPath, this.platform)) throw new Error("worktree-path-unsafe");
       return { path: createdPath, branch, linked: true };
     });
   }
@@ -334,9 +376,9 @@ export class WorkspaceGit {
       const root = await this.rootFor(workspace);
       const managedRoot = await realpath(this.managedWorktreesRoot);
       const target = await realpath(path);
-      if (!target.startsWith(managedRoot + sep)) throw new Error("worktree-outside-managed-root");
+      if (!worktreePathIsWithin(managedRoot, target, this.platform)) throw new Error("worktree-outside-managed-root");
       const worktrees = await this.readWorktrees(root);
-      const worktree = worktrees.find((item) => item.path === target);
+      const worktree = worktrees.find((item) => worktreePathsEqual(item.path, target, this.platform));
       if (!worktree) throw new Error("worktree-not-found");
       if (worktree.current) throw new Error("cannot-remove-current-worktree");
       await this.run(root, ["worktree", "remove", target]);
@@ -447,7 +489,7 @@ export class WorkspaceGit {
       path: item.path,
       ...(item.branch ? { branch: item.branch } : {}),
       ...(item.detached ? { detached: true } : {}),
-      current: worktreePathsEqual(item.path, currentRoot),
+      current: worktreePathsEqual(item.path, currentRoot, this.platform),
       linked: index !== 0,
     }));
   }

--- a/src/control/workspace-git.ts
+++ b/src/control/workspace-git.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { lstat, mkdir, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, isAbsolute, join, resolve, sep } from "node:path";
+import { basename, isAbsolute, join, resolve, sep, win32 } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -75,6 +75,19 @@ function expandHome(path: string): string {
   if (path === "~") return homedir();
   if (path.startsWith(`~${sep}`) || path.startsWith("~/")) return resolve(homedir(), path.slice(2));
   return path;
+}
+
+export function worktreePathsEqual(
+  left: string,
+  right: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform === "win32") {
+    // Git for Windows may report C:/repo while fs.realpath returns C:\repo,
+    // and drive/path casing is not significant on Windows filesystems.
+    return win32.normalize(left).toLowerCase() === win32.normalize(right).toLowerCase();
+  }
+  return left === right;
 }
 
 export class WorkspaceGit {
@@ -434,7 +447,7 @@ export class WorkspaceGit {
       path: item.path,
       ...(item.branch ? { branch: item.branch } : {}),
       ...(item.detached ? { detached: true } : {}),
-      current: item.path === currentRoot,
+      current: worktreePathsEqual(item.path, currentRoot),
       linked: index !== 0,
     }));
   }

--- a/tests/unit/control/workspace-git.test.ts
+++ b/tests/unit/control/workspace-git.test.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import { chmodSync, existsSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
-import { WorkspaceGit, worktreePathsEqual } from "../../../src/control/workspace-git";
+import { WorkspaceGit, worktreePathIsWithin, worktreePathsEqual } from "../../../src/control/workspace-git";
 
 const cleanups: string[] = [];
 
@@ -16,6 +16,15 @@ function temp(prefix: string): string {
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+async function runGitWithWindowsWorktreePaths(root: string, args: string[]): Promise<string> {
+  const output = execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (args.join("\0") !== ["worktree", "list", "--porcelain"].join("\0")) return output;
+  return output.replace(/^worktree (.+)$/gm, (_line, path: string) => `worktree ${path.replaceAll("/", "\\")}`);
 }
 
 function initRepo(): { repo: string; remote: string } {
@@ -50,6 +59,9 @@ describe("worktreePathsEqual", () => {
   test("matches Git and Node representations of the same Windows path", () => {
     expect(worktreePathsEqual("C:/Users/Alice/repo", "C:\\Users\\Alice\\repo", "win32")).toBe(true);
     expect(worktreePathsEqual("c:/users/alice/repo", "C:\\Users\\Alice\\repo", "win32")).toBe(true);
+    expect(worktreePathsEqual("C:/Users/Alice/repo/", "C:\\Users\\Alice\\repo", "win32")).toBe(true);
+    expect(worktreePathsEqual("\\\\?\\C:\\Users\\Alice\\repo", "C:\\Users\\Alice\\repo", "win32")).toBe(true);
+    expect(worktreePathsEqual("\\\\?\\UNC\\server\\share\\repo", "\\\\server\\share\\repo", "win32")).toBe(true);
   });
 
   test("keeps POSIX path comparison case-sensitive", () => {
@@ -57,7 +69,33 @@ describe("worktreePathsEqual", () => {
   });
 });
 
+describe("worktreePathIsWithin", () => {
+  test("matches Windows paths case-insensitively without accepting prefix siblings", () => {
+    expect(worktreePathIsWithin("C:/worktrees", "c:\\WORKTREES\\repo", "win32")).toBe(true);
+    expect(worktreePathIsWithin("C:/worktrees", "C:\\worktreesEVIL\\repo", "win32")).toBe(false);
+    expect(worktreePathIsWithin("C:/worktrees", "C:\\worktrees", "win32")).toBe(false);
+  });
+
+  test("keeps POSIX containment case-sensitive", () => {
+    expect(worktreePathIsWithin("/tmp/worktrees", "/tmp/worktrees/repo", "linux")).toBe(true);
+    expect(worktreePathIsWithin("/tmp/worktrees", "/tmp/Worktrees/repo", "linux")).toBe(false);
+  });
+});
+
 describe("WorkspaceGit status", () => {
+  test("matches Windows-shaped Git worktree output through the status wiring", async () => {
+    const { repo } = initRepo();
+    const service = new WorkspaceGit(
+      () => [{ name: "project", cwd: repo }],
+      { platform: "win32", runGit: runGitWithWindowsWorktreePaths },
+    );
+
+    const status = await service.status("project");
+
+    expect(worktreePathsEqual(status.worktree.root, realpathSync(repo), "win32")).toBe(true);
+    expect(status.worktrees).toContainEqual(expect.objectContaining({ current: true }));
+  });
+
   test("reports the symbolic branch in an unborn repository", async () => {
     const repo = temp("wsgit-empty-");
     git(repo, "init", "-q", "-b", "main");
@@ -287,6 +325,33 @@ describe("WorkspaceGit synchronization", () => {
 });
 
 describe("WorkspaceGit worktrees", () => {
+  test("removes a managed worktree when Git reports a Windows-shaped path", async () => {
+    const { repo } = initRepo();
+    const managedRoot = temp("wsgit-managed-");
+    const nativeService = new WorkspaceGit(
+      () => [{ name: "project", cwd: repo }],
+      { managedWorktreesRoot: managedRoot },
+    );
+    const created = await nativeService.createWorktree("project", {
+      branch: "feature/windows-rollback",
+      createBranch: true,
+      startPoint: "main",
+    });
+    const windowsService = new WorkspaceGit(
+      () => [{ name: "project", cwd: repo }],
+      {
+        managedWorktreesRoot: managedRoot,
+        platform: "win32",
+        runGit: runGitWithWindowsWorktreePaths,
+      },
+    );
+
+    await windowsService.removeManagedWorktree("project", created.path);
+
+    expect(existsSync(created.path)).toBe(false);
+    expect((await nativeService.status("project")).worktrees).toHaveLength(1);
+  });
+
   test("rejects a managed repo directory symlink before creating outside the root", async () => {
     const { repo } = initRepo();
     const managedRoot = temp("wsgit-managed-");

--- a/tests/unit/control/workspace-git.test.ts
+++ b/tests/unit/control/workspace-git.test.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import { chmodSync, existsSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
-import { WorkspaceGit } from "../../../src/control/workspace-git";
+import { WorkspaceGit, worktreePathsEqual } from "../../../src/control/workspace-git";
 
 const cleanups: string[] = [];
 
@@ -44,6 +44,17 @@ async function waitForFile(path: string): Promise<void> {
 
 afterEach(() => {
   for (const path of cleanups.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("worktreePathsEqual", () => {
+  test("matches Git and Node representations of the same Windows path", () => {
+    expect(worktreePathsEqual("C:/Users/Alice/repo", "C:\\Users\\Alice\\repo", "win32")).toBe(true);
+    expect(worktreePathsEqual("c:/users/alice/repo", "C:\\Users\\Alice\\repo", "win32")).toBe(true);
+  });
+
+  test("keeps POSIX path comparison case-sensitive", () => {
+    expect(worktreePathsEqual("/tmp/Repo", "/tmp/repo", "linux")).toBe(false);
+  });
 });
 
 describe("WorkspaceGit status", () => {


### PR DESCRIPTION
## Summary

- normalize Git and Node worktree paths before comparing them on Windows
- treat slash direction and path casing as insignificant only on Windows
- keep POSIX path comparison case-sensitive
- add regression coverage for Git-style and Node-style Windows paths

## Root cause

`git worktree list --porcelain` and `fs.realpath` can represent the same Windows directory differently, such as `C:/Users/Alice/repo` versus `C:\Users\Alice\repo`, with possible drive/path casing differences. The control service compared those strings with strict equality, failed to identify the current worktree, and returned `git-worktree-context-missing` through `control.git.status`.

## Impact

Relay Web Git status works for Windows-hosted xacpx instances instead of failing after the structured Git RPC reaches the connector.

## Validation

- `bun test tests/unit/control/workspace-git.test.ts` — 15 passed
- `bun test tests/unit/control/control-service-git.test.ts tests/unit/packages/channel-relay/control-bridge.test.ts` — 45 passed
- `npx tsc --noEmit`
- `git diff --check`