### PR TITLE
release: core 0.17.0-beta.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.8",
+  "version": "0.17.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.8",
+      "version": "0.17.0-beta.9",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.8",
+  "version": "0.17.0-beta.9",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/relay-web/src/components/FileViewer.vue
+++ b/packages/relay-web/src/components/FileViewer.vue
@@ -129,7 +129,7 @@ watch(content, (val) => {
   if (!editing.value || !props.path || !file.value) return;
   pendingEditDraft = { key: draftKey(props.sessionKey ?? "", props.path), text: val, disk: file.value.content };
   editDraftPersist.schedule();
-});
+}, { flush: "sync" });
 function flushEditDraft(): void {
   editDraftPersist.flush();
 }

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.8", () => {
+test("root package version is 0.17.0-beta.9", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.8");
+  expect(pkg.version).toBe("0.17.0-beta.9");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.8",
+  "version": "0.17.0-beta.9",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.8"
+    "@ganglion/xacpx": "^0.17.0-beta.9"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- release `@ganglion/xacpx` 0.17.0-beta.9
- include the Windows worktree-path fix from #179
- make file-draft persistence deterministic after a successful save

## Validation

- `npm test`
- `bun run verify:publish`