### PR TITLE
release: beta cut — Claude relay stack

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,13 +39,13 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.7",
+      "version": "0.3.3-beta.8",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0",
       },
       "peerDependencies": {
-        "xacpx": ">=0.17.0-beta.7",
+        "xacpx": ">=0.17.0-beta.10",
       },
       "optionalPeers": [
         "xacpx",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.22",
+      "version": "0.9.12-beta.25",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },
@@ -88,7 +88,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.14",
+      "version": "0.1.15",
     },
     "packages/relay-web": {
       "name": "@ganglion/xacpx-relay-web",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.9",
+  "version": "0.17.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.9",
+      "version": "0.17.0-beta.10",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -13141,14 +13141,14 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.7",
+      "version": "0.3.3-beta.8",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0"
       },
       "peerDependencies": {
-        "xacpx": ">=0.17.0-beta.7"
+        "xacpx": ">=0.17.0-beta.10"
       },
       "peerDependenciesMeta": {
         "xacpx": {
@@ -13183,7 +13183,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.24",
+      "version": "0.9.12-beta.25",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
@@ -13200,7 +13200,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT"
     },
     "packages/relay-web": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.9",
+  "version": "0.17.0-beta.10",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/channel-relay/README.md
+++ b/packages/channel-relay/README.md
@@ -3,7 +3,7 @@
 Connector channel plugin: dials out from a local xacpx instance to a
 self-hosted @ganglion/xacpx-relay hub over WebSocket.
 
-Requires xacpx >= 0.17.0-beta.7 (the first core exposing structured Git/worktree control operations).
+Requires xacpx >= 0.17.0-beta.10 (includes the Claude background subagent trace metadata used by Relay).
 
 Pairing: `xacpx channel add relay --url ws://<relay-host>:8788 --token <pairing-token>`.
 On first connect the pairing token is exchanged for a long-lived instance

--- a/packages/channel-relay/package.json
+++ b/packages/channel-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-relay",
-  "version": "0.3.3-beta.7",
+  "version": "0.3.3-beta.8",
   "description": "Relay hub connector channel plugin for xacpx.",
   "license": "MIT",
   "keywords": [
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "xacpx": ">=0.17.0-beta.7"
+    "xacpx": ">=0.17.0-beta.10"
   },
   "peerDependenciesMeta": {
     "xacpx": {

--- a/packages/channel-relay/src/index.ts
+++ b/packages/channel-relay/src/index.ts
@@ -9,7 +9,7 @@ export { relayCliProvider } from "./relay-provider.js";
 const plugin: XacpxPlugin = {
   apiVersion: 1,
   name: "@ganglion/xacpx-channel-relay",
-  minXacpxVersion: "0.17.0-beta.7",
+  minXacpxVersion: "0.17.0-beta.10",
   channels: [
     {
       type: "relay",

--- a/packages/relay-protocol/package.json
+++ b/packages/relay-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay-protocol",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Shared wire protocol types and codecs for the xacpx relay hub.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.24",
+  "version": "0.9.12-beta.25",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/tests/unit/packages/channel-relay/channel-relay-plugin.test.ts
+++ b/tests/unit/packages/channel-relay/channel-relay-plugin.test.ts
@@ -7,8 +7,8 @@ import { validatePluginCompatibility } from "../../../../src/plugins/compatibili
 test("relay connector requires the git-ops-capable xacpx core", () => {
   const pkg = JSON.parse(readFileSync("packages/channel-relay/package.json", "utf8"));
 
-  expect(plugin.minXacpxVersion).toBe("0.17.0-beta.7");
-  expect(pkg.peerDependencies.xacpx).toBe(">=0.17.0-beta.7");
+  expect(plugin.minXacpxVersion).toBe("0.17.0-beta.10");
+  expect(pkg.peerDependencies.xacpx).toBe(">=0.17.0-beta.10");
 
   expect(() => validatePluginCompatibility(plugin, {
     packageName: plugin.name,
@@ -16,7 +16,7 @@ test("relay connector requires the git-ops-capable xacpx core", () => {
   })).toThrow();
   expect(() => validatePluginCompatibility(plugin, {
     packageName: plugin.name,
-    currentXacpxVersion: "0.17.0-beta.7",
+    currentXacpxVersion: "0.17.0-beta.10",
   })).not.toThrow();
   expect(() => validatePluginCompatibility(plugin, {
     packageName: plugin.name,

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.9", () => {
+test("root package version is 0.17.0-beta.10", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.9");
+  expect(pkg.version).toBe("0.17.0-beta.10");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.9",
+  "version": "0.17.0-beta.10",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.9"
+    "@ganglion/xacpx": "^0.17.0-beta.10"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Packages

- @ganglion/xacpx 0.17.0-beta.10
- @ganglion/xacpx-relay-protocol 0.1.15
- @ganglion/xacpx-relay 0.9.12-beta.25
- @ganglion/xacpx-channel-relay 0.3.3-beta.8

## Why

Publishes the merged Claude provider settings and background subagent Relay fixes. Protocol is a stable patch so existing `^0.1.0` Relay consumers resolve the required DTO update.

## Validation

- npm test
- bun run verify:publish