### PR TITLE
feat(relay-web): add session effort control

### DIFF
--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -164,7 +164,10 @@ xacpx 不假定固定的配置 id：Codex adapter 常见的 `reasoning_effort`�
 acpx 的既有 `set <key> <value>` 命令设置，返回 `{ ok, current }`。设置值由 adapter 广告的
 `available` 驱动且在 transport 边界再次校验；具体可选值不在 xacpx 内硬编码。该路径同时支持
 `acpx-cli` 与 `acpx-bridge` transport，保留会话的 driver/settings policy/provider 环境，
-不修改或绕过上游 acpx。同一逻辑会话的 model/effort 配置写入共用串行队列，避免旧操作最后落盘。
+不修改或绕过上游 acpx。若 set 管理命令 timeout，ControlService 会通过 `getSessionEffort` 读取
+transport 权威值并返回实际的 `{ current, applied }`；查询失败时仍保留原始 timeout。成功对账会记录
+`control.session.effort.timeout_reconciled` 诊断事件。同一逻辑会话的 model/effort 配置写入共用串行队列，
+避免旧操作最后落盘。
 串行队列出闸时，ControlService 会为最坏 90 秒的 set + readback 预留完整预算；剩余时间不足的
 请求在触碰 transport 前失败，避免排队重新吃掉 Hub 为状态变更保留的响应窗口。
 

--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -162,8 +162,9 @@ xacpx 不假定固定的配置 id：Codex adapter 常见的 `reasoning_effort`�
 
 `control.session.effort.set { sessionAlias, effort }` 先读取同一记录确定真实 config id，再通过
 acpx 的既有 `set <key> <value>` 命令设置，返回 `{ ok, current }`。设置值由 adapter 广告的
-`available` 驱动；具体可选值不在 xacpx 内硬编码。该路径同时支持 `acpx-cli` 与
-`acpx-bridge` transport，不修改或绕过上游 acpx。
+`available` 驱动且在 transport 边界再次校验；具体可选值不在 xacpx 内硬编码。该路径同时支持
+`acpx-cli` 与 `acpx-bridge` transport，保留会话的 driver/settings policy/provider 环境，
+不修改或绕过上游 acpx。同一逻辑会话的 model/effort 配置写入共用串行队列，避免旧操作最后落盘。
 串行队列出闸时，ControlService 会为最坏 90 秒的 set + readback 预留完整预算；剩余时间不足的
 请求在触碰 transport 前失败，避免排队重新吃掉 Hub 为状态变更保留的响应窗口。
 

--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -152,6 +152,18 @@ RPC 错误返回，由 relay-web 浏览器诊断保留。同一逻辑会话的�
 仅在两者齐全时取更早值。绝对值保证传输耗时不会吃掉响应余量，相对 budget 限制跨机时钟偏差。
 旧 Hub 或部分字段缺失时，connector fail closed，将 deadline 设为接收时刻，使请求在触碰
 transport 前失败，而不是恢复到无期限排队。
+
+### 推理强度（effort）
+
+`control.session.effort.get` 从当前 transport session 的 acpx 记录读取 adapter 广告的
+`thought_level` 配置项，返回 `{ current, available }`；未广告该能力时 `available=[]`。
+xacpx 不假定固定的配置 id：Codex adapter 常见的 `reasoning_effort`、`effort`、
+`thought_level` 等名称均由记录中的 `category/id` 识别。
+
+`control.session.effort.set { sessionAlias, effort }` 先读取同一记录确定真实 config id，再通过
+acpx 的既有 `set <key> <value>` 命令设置，返回 `{ ok, current }`。设置值由 adapter 广告的
+`available` 驱动；具体可选值不在 xacpx 内硬编码。该路径同时支持 `acpx-cli` 与
+`acpx-bridge` transport，不修改或绕过上游 acpx。
 串行队列出闸时，ControlService 会为最坏 90 秒的 set + readback 预留完整预算；剩余时间不足的
 请求在触碰 transport 前失败，避免排队重新吃掉 Hub 为状态变更保留的响应窗口。
 

--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -15,6 +15,9 @@
   网关回退与服务端均复用之）；agent 冷启动慢 / 长 prompt 时可调大。Hub 会把均已扣除 15 秒
   响应余量的绝对 work deadline 与相对 work budget 附在下行 request envelope 上，使
   connector/core 在串行队列出闸时拒绝已来不及安全完成的状态变更；两字段任一缺失即 fail closed。
+- 会话级模型与推理强度分别通过 `control.session.model.get/set` 和
+  `control.session.effort.get/set` 暴露。Hub 会为这些 RPC 覆写可信的 `chatKey`；effort 的配置 id
+  与可选值由实例侧 adapter 广告，Hub/Web 不硬编码上游实现细节。
 - 安全：登录令牌（login token）以 sha256 哈希落盘（高熵随机令牌，无需 scrypt；scrypt 密码哈希已随密码登录一并移除）；所有 token/凭证哈希存储；登录限流按客户端 IP + 全局失败上限（有界，见阶段五）；
   凭证比较定时安全（`hashEquals`，见 src/auth.ts）；RPC 代理只放行
   control.* 且服务端覆写 chatKey(`relay:<accountId>`)/senderId/isOwner。

--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -17,7 +17,7 @@
   connector/core 在串行队列出闸时拒绝已来不及安全完成的状态变更；两字段任一缺失即 fail closed。
 - 会话级模型与推理强度分别通过 `control.session.model.get/set` 和
   `control.session.effort.get/set` 暴露。Hub 会为这些 RPC 覆写可信的 `chatKey`；effort 的配置 id
-  与可选值由实例侧 adapter 广告，Hub/Web 不硬编码上游实现细节。
+  与可选值由实例侧 adapter 广告，实例 transport 会拒绝未广告值，Hub/Web 不硬编码上游实现细节。
 - 安全：登录令牌（login token）以 sha256 哈希落盘（高熵随机令牌，无需 scrypt；scrypt 密码哈希已随密码登录一并移除）；所有 token/凭证哈希存储；登录限流按客户端 IP + 全局失败上限（有界，见阶段五）；
   凭证比较定时安全（`hashEquals`，见 src/auth.ts）；RPC 代理只放行
   control.* 且服务端覆写 chatKey(`relay:<accountId>`)/senderId/isOwner。

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -99,6 +99,16 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   `SubagentTraceDialog.vue`，按父子深度展示委派任务、嵌套 Agent 和每个子工具的完整详情。轮播尊重 `prefers-reduced-motion`，弹窗支持焦点圈定、
   Esc 和点击遮罩关闭。
 
+## Composer 的模型与 effort 控件
+
+- 会话切换时 `session-controls` store 并行读取 `control.session.model.get` 与
+  `control.session.effort.get`。模型 chip 保持原有行为；只有当前 adapter 广告了可选 effort 时，
+  才在其旁边显示独立的 effort chip。
+- effort 选项完全采用 adapter 返回的 `available`，不在 Web 中固定 `low/medium/high/xhigh`。
+  选择后调用 `control.session.effort.set`，界面乐观更新；RPC 失败时回到最后确认值并显示全局 toast。
+- session/实例切换以独立 context revision 丢弃 model 与 effort 的迟到响应，避免旧会话结果污染
+  当前 composer。没有广告 effort 的 agent 不显示控件，也不会触发设置请求。
+
 ## 阶段五加固（审计修复）
 
 - **API 客户端始终带 JSON content-type**：无 body 的 mutating 请求也发 `content-type: application/json`，

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -105,7 +105,8 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   `control.session.effort.get`。模型 chip 保持原有行为；只有当前 adapter 广告了可选 effort 时，
   才在其旁边显示独立的 effort chip。
 - effort 选项完全采用 adapter 返回的 `available`，不在 Web 中固定 `low/medium/high/xhigh`。
-  选择后调用 `control.session.effort.set`，界面乐观更新；RPC 失败时回到最后确认值并显示全局 toast。
+  选择后调用 `control.session.effort.set`，界面乐观更新；RPC 失败时回到失败落地时最新的权威值并显示
+  全局 toast，因此连续选择中较早成功、较新失败时不会回滚到较早选择之前的旧值。
 - model 切换完成后会重新读取 effort，因为 adapter 可能按 model 广告不同的推理强度选项；仅当
   composer 仍指向发起切换的同一会话时应用刷新结果。
 - session/实例切换以独立 context revision 丢弃 model 与 effort 的迟到响应，避免旧会话结果污染

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -106,6 +106,8 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   才在其旁边显示独立的 effort chip。
 - effort 选项完全采用 adapter 返回的 `available`，不在 Web 中固定 `low/medium/high/xhigh`。
   选择后调用 `control.session.effort.set`，界面乐观更新；RPC 失败时回到最后确认值并显示全局 toast。
+- model 切换完成后会重新读取 effort，因为 adapter 可能按 model 广告不同的推理强度选项；仅当
+  composer 仍指向发起切换的同一会话时应用刷新结果。
 - session/实例切换以独立 context revision 丢弃 model 与 effort 的迟到响应，避免旧会话结果污染
   当前 composer。没有广告 effort 的 agent 不显示控件，也不会触发设置请求。
 

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -69,6 +69,8 @@ export const CONTROL_RPC_TIMEOUT_MS = 60_000;
 //     status read (or two 45s bridge backstops). A 60s connector response timer
 //     would race that reconciliation without cancelling the underlying work;
 //     the Hub envelope budget instead prevents stale queued mutations from starting.
+//   - sessionEffortSet: discovers the adapter's config id, then applies it; both
+//     management commands have their own 30s subprocess timeout.
 // For all of these the hub's own 120s request timeout is the real backstop.
 const CONNECTOR_TIMEOUT_EXEMPT_TYPES: ReadonlySet<string> = new Set([
   MSG.prompt,
@@ -76,6 +78,7 @@ const CONNECTOR_TIMEOUT_EXEMPT_TYPES: ReadonlySet<string> = new Set([
   MSG.sessionsNativeList,
   MSG.commandExecute,
   MSG.sessionModelSet,
+  MSG.sessionEffortSet,
 ]);
 
 export interface ControlBridgeOptions {
@@ -431,6 +434,19 @@ async function dispatchControlRequest(
       const result = deadlineAt === undefined
         ? await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId)
         : await control.setSessionModel(input.chatKey, input.sessionAlias, input.modelId, { deadlineAt });
+      return { ok: result.applied, current: result.current ?? null };
+    }
+    case MSG.sessionEffortGet: {
+      const input = parseControlPayload(MSG.sessionEffortGet, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionEffortGet}: malformed payload`);
+      if (!input.sessionAlias) return errorPayload("bad-request", "sessionAlias is required");
+      return await control.getSessionEffort(input.chatKey, input.sessionAlias);
+    }
+    case MSG.sessionEffortSet: {
+      const input = parseControlPayload(MSG.sessionEffortSet, payload);
+      if (!input) return errorPayload("invalid-payload", `${MSG.sessionEffortSet}: malformed payload`);
+      if (!input.sessionAlias || !input.effort) return errorPayload("bad-request", "sessionAlias and effort are required");
+      const result = await control.setSessionEffort(input.chatKey, input.sessionAlias, input.effort);
       return { ok: result.applied, current: result.current ?? null };
     }
     case MSG.terminalCreate: {

--- a/packages/relay-protocol/dist/index.js
+++ b/packages/relay-protocol/dist/index.js
@@ -95,6 +95,8 @@ var MSG = {
   upload: "control.upload",
   sessionModelGet: "control.session.model.get",
   sessionModelSet: "control.session.model.set",
+  sessionEffortGet: "control.session.effort.get",
+  sessionEffortSet: "control.session.effort.set",
   terminalCreate: "control.terminal.create",
   terminalAttach: "control.terminal.attach",
   terminalInput: "instance.terminal.input",
@@ -510,6 +512,14 @@ var validateSessionModelSet = (p) => {
   const o = fields(p);
   return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.modelId) ? o : null;
 };
+var validateSessionEffortGet = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? o : null;
+};
+var validateSessionEffortSet = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.effort) ? o : null;
+};
 var validateTerminalCreate = (p) => {
   const o = fields(p);
   return o && isStr(o.chatKey) && isStr(o.sessionAlias) && optNum(o.cols) && optNum(o.rows) ? o : null;
@@ -564,6 +574,8 @@ var CONTROL_PAYLOAD_VALIDATORS = {
   [MSG.gitWorktreeCreate]: validateGitWorktreeCreate,
   [MSG.sessionModelGet]: validateSessionModelGet,
   [MSG.sessionModelSet]: validateSessionModelSet,
+  [MSG.sessionEffortGet]: validateSessionEffortGet,
+  [MSG.sessionEffortSet]: validateSessionEffortSet,
   [MSG.terminalCreate]: validateTerminalCreate,
   [MSG.terminalAttach]: validateTerminalAttach,
   [MSG.upload]: validateUpload

--- a/packages/relay-protocol/dist/messages.d.ts
+++ b/packages/relay-protocol/dist/messages.d.ts
@@ -50,6 +50,8 @@ export declare const MSG: {
     readonly upload: "control.upload";
     readonly sessionModelGet: "control.session.model.get";
     readonly sessionModelSet: "control.session.model.set";
+    readonly sessionEffortGet: "control.session.effort.get";
+    readonly sessionEffortSet: "control.session.effort.set";
     readonly terminalCreate: "control.terminal.create";
     readonly terminalAttach: "control.terminal.attach";
     readonly terminalInput: "instance.terminal.input";
@@ -513,6 +515,23 @@ export interface SessionModelResult {
     /** The session's current model id, if known. */
     current?: string;
     /** Agent-advertised model ids the session can switch to (may be empty). */
+    available: string[];
+}
+export interface SessionEffortGetPayload {
+    chatKey: string;
+    sessionAlias: string;
+}
+export interface SessionEffortSetPayload {
+    chatKey: string;
+    sessionAlias: string;
+    effort: string;
+}
+export interface SessionEffortSetResult {
+    ok: boolean;
+    current?: string | null;
+}
+export interface SessionEffortResult {
+    current?: string;
     available: string[];
 }
 export interface TerminalCreatePayload {

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -54,6 +54,8 @@ export const MSG = {
   upload: "control.upload",
   sessionModelGet: "control.session.model.get",
   sessionModelSet: "control.session.model.set",
+  sessionEffortGet: "control.session.effort.get",
+  sessionEffortSet: "control.session.effort.set",
   terminalCreate: "control.terminal.create",
   terminalAttach: "control.terminal.attach",
   terminalInput: "instance.terminal.input",
@@ -497,6 +499,27 @@ export interface SessionModelResult {
   /** The session's current model id, if known. */
   current?: string;
   /** Agent-advertised model ids the session can switch to (may be empty). */
+  available: string[];
+}
+
+export interface SessionEffortGetPayload {
+  chatKey: string;
+  sessionAlias: string;
+}
+
+export interface SessionEffortSetPayload {
+  chatKey: string;
+  sessionAlias: string;
+  effort: string;
+}
+
+export interface SessionEffortSetResult {
+  ok: boolean;
+  current?: string | null;
+}
+
+export interface SessionEffortResult {
+  current?: string;
   available: string[];
 }
 

--- a/packages/relay-protocol/src/payload-validators.ts
+++ b/packages/relay-protocol/src/payload-validators.ts
@@ -40,6 +40,8 @@ import {
   type ScheduledListPayload,
   type SessionModelGetPayload,
   type SessionModelSetPayload,
+  type SessionEffortGetPayload,
+  type SessionEffortSetPayload,
   type SessionsArchivePayload,
   type SessionsCreatePayload,
   type SessionsListPayload,
@@ -252,6 +254,15 @@ const validateSessionModelSet: Validator<SessionModelSetPayload> = (p) => {
   const o = fields(p);
   return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.modelId) ? (o as unknown as SessionModelSetPayload) : null;
 };
+const validateSessionEffortGet: Validator<SessionEffortGetPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) ? (o as unknown as SessionEffortGetPayload) : null;
+};
+const validateSessionEffortSet: Validator<SessionEffortSetPayload> = (p) => {
+  const o = fields(p);
+  return o && isStr(o.chatKey) && isStr(o.sessionAlias) && isStr(o.effort)
+    ? (o as unknown as SessionEffortSetPayload) : null;
+};
 const validateTerminalCreate: Validator<TerminalCreatePayload> = (p) => {
   const o = fields(p);
   return o && isStr(o.chatKey) && isStr(o.sessionAlias) && optNum(o.cols) && optNum(o.rows)
@@ -282,6 +293,7 @@ export type ControlRpcType =
   | typeof MSG.fsRead | typeof MSG.fsDiff | typeof MSG.fsSearch | typeof MSG.fsCreate
   | typeof MSG.fsRename | typeof MSG.fsDelete | typeof MSG.fsCopy | typeof MSG.fsDownload
   | typeof MSG.fsWrite | typeof MSG.sessionModelGet | typeof MSG.sessionModelSet
+  | typeof MSG.sessionEffortGet | typeof MSG.sessionEffortSet
   | typeof MSG.gitStatus | typeof MSG.gitStage | typeof MSG.gitUnstage | typeof MSG.gitCommit
   | typeof MSG.gitFetch | typeof MSG.gitPull | typeof MSG.gitPush | typeof MSG.gitCheckout
   | typeof MSG.gitWorktreeCreate
@@ -332,6 +344,8 @@ export const CONTROL_PAYLOAD_VALIDATORS = {
   [MSG.gitWorktreeCreate]: validateGitWorktreeCreate,
   [MSG.sessionModelGet]: validateSessionModelGet,
   [MSG.sessionModelSet]: validateSessionModelSet,
+  [MSG.sessionEffortGet]: validateSessionEffortGet,
+  [MSG.sessionEffortSet]: validateSessionEffortSet,
   [MSG.terminalCreate]: validateTerminalCreate,
   [MSG.terminalAttach]: validateTerminalAttach,
   [MSG.upload]: validateUpload,

--- a/packages/relay-web/src/__tests__/promptinput-model.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput-model.test.ts
@@ -44,7 +44,7 @@ it("renders the model chip with the current model and lets you switch", async ()
   // ...but selecting still sends the RAW agent-advertised id, not the normalized label.
   await options[1].trigger("click");
   await flush();
-  expect(rpc).toHaveBeenLastCalledWith("i1", "control.session.model.set", { sessionAlias: "backend", modelId: "gpt-5.2[low]" });
+  expect(rpc).toHaveBeenCalledWith("i1", "control.session.model.set", { sessionAlias: "backend", modelId: "gpt-5.2[low]" });
 });
 
 it("hides the chip when there is no session", () => {
@@ -96,4 +96,38 @@ it("shows an effort chip only when the adapter advertises choices and switches e
     sessionAlias: "backend",
     effort: "high",
   });
+});
+
+it("refreshes adapter-advertised effort choices after switching models", async () => {
+  let effortReads = 0;
+  rpc.mockImplementation(async (_instanceId: string, type: string) => {
+    if (type === "control.session.model.get") {
+      return { current: "model-a", available: ["model-a", "model-b"] };
+    }
+    if (type === "control.session.model.set") return { ok: true, current: "model-b" };
+    if (type === "control.session.effort.get") {
+      effortReads += 1;
+      return effortReads === 1
+        ? { current: "medium", available: ["medium", "high"] }
+        : { current: "xhigh", available: ["high", "xhigh"] };
+    }
+    return {};
+  });
+  const w = mount(PromptInput, {
+    props: { instanceId: "i1", sessionAlias: "backend" },
+    global: { plugins: [pinia] },
+  });
+  await flush();
+  await w.vm.$nextTick();
+
+  await w.get('[data-test="model-chip"]').trigger("click");
+  await w.findAll('[data-test="model-option"]')[1].trigger("click");
+  await flush();
+  await w.vm.$nextTick();
+
+  expect(effortReads).toBe(2);
+  expect(w.get('[data-test="effort-chip"]').text()).toContain("xhigh");
+  await w.get('[data-test="effort-chip"]').trigger("click");
+  expect(w.findAll('[data-test="effort-option"]').map((option) => option.text()))
+    .toEqual(["high", "xhigh"]);
 });

--- a/packages/relay-web/src/__tests__/promptinput-model.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput-model.test.ts
@@ -67,3 +67,33 @@ it("shows a model-switch failure through the global toast instead of beside the 
   expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.modelSetFailed" });
   log.mockRestore();
 });
+
+it("shows an effort chip only when the adapter advertises choices and switches effort", async () => {
+  rpc.mockImplementation(async (_instanceId: string, type: string) => {
+    if (type === "control.session.model.get") return { current: "gpt-5.2", available: ["gpt-5.2"] };
+    if (type === "control.session.effort.get") {
+      return { current: "medium", available: ["low", "medium", "high"] };
+    }
+    if (type === "control.session.effort.set") return { ok: true, current: "high" };
+    return {};
+  });
+  const w = mount(PromptInput, {
+    props: { instanceId: "i1", sessionAlias: "backend" },
+    global: { plugins: [pinia] },
+  });
+  await flush();
+  await w.vm.$nextTick();
+
+  const chip = w.get('[data-test="effort-chip"]');
+  expect(chip.text()).toContain("medium");
+  await chip.trigger("click");
+  const options = w.findAll('[data-test="effort-option"]');
+  expect(options.map((option) => option.text())).toEqual(["low", "medium", "high"]);
+  await options[2].trigger("click");
+  await flush();
+
+  expect(rpc).toHaveBeenLastCalledWith("i1", "control.session.effort.set", {
+    sessionAlias: "backend",
+    effort: "high",
+  });
+});

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -238,4 +238,33 @@ describe("session-controls store", () => {
 
     expect(s.current).toBe("model-b");
   });
+
+  it("loadEffort fetches the adapter-advertised effort values", async () => {
+    rpc.mockResolvedValueOnce({ current: "medium", available: ["low", "medium", "high"] });
+    const s = useSessionControlsStore();
+
+    await s.loadEffort("i1", "backend");
+
+    expect(rpc).toHaveBeenCalledWith("i1", "control.session.effort.get", { sessionAlias: "backend" });
+    expect(s.effortCurrent).toBe("medium");
+    expect(s.effortAvailable).toEqual(["low", "medium", "high"]);
+  });
+
+  it("setEffort updates optimistically and rolls back on failure", async () => {
+    rpc.mockResolvedValueOnce({ current: "medium", available: ["medium", "high"] });
+    const s = useSessionControlsStore();
+    await s.loadEffort("i1", "backend");
+
+    let resolveSet!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveSet = resolve; }));
+    const pending = s.setEffort("i1", "backend", "high");
+    expect(s.effortCurrent).toBe("high");
+
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    resolveSet({ error: { code: "internal", message: "unsupported effort" } });
+    await expect(pending).resolves.toBe(false);
+    expect(s.effortCurrent).toBe("medium");
+    expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.effortSetFailed" });
+    log.mockRestore();
+  });
 });

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -22,8 +22,8 @@ describe("session-controls store", () => {
     const s = useSessionControlsStore();
     await s.loadModel("i1", "backend");
     expect(rpc).toHaveBeenCalledWith("i1", "control.session.model.get", { sessionAlias: "backend" });
-    expect(s.current).toBe("gpt-5.2[high]");
-    expect(s.available).toEqual(["gpt-5.2[high]", "gpt-5.2[low]"]);
+    expect(s.modelCurrent).toBe("gpt-5.2[high]");
+    expect(s.modelAvailable).toEqual(["gpt-5.2[high]", "gpt-5.2[low]"]);
   });
 
   it("loadModel coerces a malformed result to safe defaults (no array → [])", async () => {
@@ -32,15 +32,15 @@ describe("session-controls store", () => {
     rpc.mockResolvedValueOnce({});
     const s = useSessionControlsStore();
     await s.loadModel("i1", "backend");
-    expect(s.available).toEqual([]);
-    expect(s.current).toBeUndefined();
+    expect(s.modelAvailable).toEqual([]);
+    expect(s.modelCurrent).toBeUndefined();
   });
 
   it("loadModel resets on missing instance/alias without an rpc", async () => {
     const s = useSessionControlsStore();
     await s.loadModel(null, "backend");
     expect(rpc).not.toHaveBeenCalled();
-    expect(s.available).toEqual([]);
+    expect(s.modelAvailable).toEqual([]);
   });
 
   it("clears the previous session model while a new session is loading", async () => {
@@ -52,12 +52,12 @@ describe("session-controls store", () => {
     rpc.mockReturnValueOnce(new Promise((resolve) => { resolveLoad = resolve; }));
     const pendingLoad = s.loadModel("i1", "session-b");
 
-    expect(s.current).toBeUndefined();
-    expect(s.available).toEqual([]);
-    expect(s.loading).toBe(true);
+    expect(s.modelCurrent).toBeUndefined();
+    expect(s.modelAvailable).toEqual([]);
+    expect(s.modelLoading).toBe(true);
     resolveLoad({ current: "model-b", available: ["model-b"] });
     await pendingLoad;
-    expect(s.current).toBe("model-b");
+    expect(s.modelCurrent).toBe("model-b");
   });
 
   it("setModel updates current optimistically before the RPC resolves", async () => {
@@ -66,24 +66,24 @@ describe("session-controls store", () => {
     const s = useSessionControlsStore();
     const p = s.setModel("i1", "backend", "claude-opus-4-8");
     // The chip reflects the choice immediately — before the (slow) backend set resolves.
-    expect(s.current).toBe("claude-opus-4-8");
+    expect(s.modelCurrent).toBe("claude-opus-4-8");
     resolveRpc({ ok: true });
     expect(await p).toBe(true);
     expect(rpc).toHaveBeenCalledWith("i1", "control.session.model.set", { sessionAlias: "backend", modelId: "claude-opus-4-8" });
-    expect(s.current).toBe("claude-opus-4-8");
+    expect(s.modelCurrent).toBe("claude-opus-4-8");
   });
 
   it("setModel reverts current and reports a concise global toast on an instance-side error", async () => {
     rpc.mockResolvedValueOnce({ current: "gpt-5.2[high]", available: ["gpt-5.2[high]"] });
     const s = useSessionControlsStore();
     await s.loadModel("i1", "backend");
-    expect(s.current).toBe("gpt-5.2[high]");
+    expect(s.modelCurrent).toBe("gpt-5.2[high]");
     const detail = "acpx command timed out during set-model after 30s; stderr tail: adapter stalled";
     rpc.mockResolvedValueOnce({ error: { code: "internal", message: detail } });
     const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const ok = await s.setModel("i1", "backend", "bogus");
     expect(ok).toBe(false);
-    expect(s.current).toBe("gpt-5.2[high]"); // reverted, not left on "bogus"
+    expect(s.modelCurrent).toBe("gpt-5.2[high]"); // reverted, not left on "bogus"
     expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.modelSetFailed" });
     expect(useToasts().value[0]?.params).toBeUndefined();
     expect(log).toHaveBeenCalledWith("[relay-web] model switch failed", detail);
@@ -100,7 +100,7 @@ describe("session-controls store", () => {
     const ok = await s.setModel("i1", "backend", "claude-opus-4-8");
 
     expect(ok).toBe(false);
-    expect(s.current).toBe("provider/fallback-model");
+    expect(s.modelCurrent).toBe("provider/fallback-model");
     expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.modelSetFailed" });
     expect(log).toHaveBeenCalledWith(
       "[relay-web] model switch failed",
@@ -120,11 +120,11 @@ describe("session-controls store", () => {
 
     rpc.mockResolvedValueOnce({ current: "model-x", available: ["model-x"] });
     await s.loadModel("i1", "session-b");
-    expect(s.current).toBe("model-x");
+    expect(s.modelCurrent).toBe("model-x");
 
     resolveSet({ ok: true, current: "model-b" });
     await pendingSet;
-    expect(s.current).toBe("model-x");
+    expect(s.modelCurrent).toBe("model-x");
   });
 
   it("keeps the latest selection when model-set responses arrive out of order", async () => {
@@ -144,7 +144,7 @@ describe("session-controls store", () => {
     resolveB({ ok: true, current: "model-b" });
     await pendingB;
 
-    expect(s.current).toBe("model-c");
+    expect(s.modelCurrent).toBe("model-c");
   });
 
   it("returns to the last authoritative model when two rapid selections both fail", async () => {
@@ -165,7 +165,7 @@ describe("session-controls store", () => {
     resolveC({ error: { code: "internal", message: "model-c failed" } });
     await pendingC;
 
-    expect(s.current).toBe("model-a");
+    expect(s.modelCurrent).toBe("model-a");
     expect(useToasts().value).toHaveLength(1);
     log.mockRestore();
   });
@@ -175,15 +175,15 @@ describe("session-controls store", () => {
     rpc.mockReturnValueOnce(new Promise((resolve) => { resolveLoad = resolve; }));
     const s = useSessionControlsStore();
     const pendingLoad = s.loadModel("i1", "backend");
-    expect(s.loading).toBe(true);
+    expect(s.modelLoading).toBe(true);
 
     rpc.mockResolvedValueOnce({ ok: true, current: "model-b" });
     await s.setModel("i1", "backend", "model-b");
-    expect(s.loading).toBe(false);
+    expect(s.modelLoading).toBe(false);
 
     resolveLoad({ current: "model-a", available: ["model-a"] });
     await pendingLoad;
-    expect(s.current).toBe("model-b");
+    expect(s.modelCurrent).toBe("model-b");
   });
 
   it("does not toast a stale model-set failure from the previous session", async () => {
@@ -201,7 +201,7 @@ describe("session-controls store", () => {
     resolveSet({ error: { code: "internal", message: "late failure" } });
     await pendingSet;
 
-    expect(s.current).toBe("model-x");
+    expect(s.modelCurrent).toBe("model-x");
     expect(useToasts().value).toEqual([]);
     expect(log).not.toHaveBeenCalled();
     log.mockRestore();
@@ -236,7 +236,7 @@ describe("session-controls store", () => {
     await pendingSet;
     await pendingReload;
 
-    expect(s.current).toBe("model-b");
+    expect(s.modelCurrent).toBe("model-b");
   });
 
   it("loadEffort fetches the adapter-advertised effort values", async () => {

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -267,4 +267,40 @@ describe("session-controls store", () => {
     expect(useToasts().value[0]).toMatchObject({ tone: "error", key: "chat.effortSetFailed" });
     log.mockRestore();
   });
+
+  it("clears effort when a failed set reports an authoritative null current", async () => {
+    rpc.mockResolvedValueOnce({ current: "medium", available: ["medium", "high"] });
+    const s = useSessionControlsStore();
+    await s.loadEffort("i1", "backend");
+    rpc.mockResolvedValueOnce({ ok: false, current: null });
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(s.setEffort("i1", "backend", "high")).resolves.toBe(false);
+
+    expect(s.effortCurrent).toBeUndefined();
+    log.mockRestore();
+  });
+
+  it("keeps the last applied effort when a rapid newer selection fails", async () => {
+    rpc.mockResolvedValueOnce({ current: "medium", available: ["medium", "high", "xhigh"] });
+    const s = useSessionControlsStore();
+    await s.loadEffort("i1", "backend");
+
+    let resolveHigh!: (value: unknown) => void;
+    let resolveXhigh!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveHigh = resolve; }));
+    const pendingHigh = s.setEffort("i1", "backend", "high");
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveXhigh = resolve; }));
+    const pendingXhigh = s.setEffort("i1", "backend", "xhigh");
+
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    resolveHigh({ ok: true, current: "high" });
+    await expect(pendingHigh).resolves.toBe(true);
+    resolveXhigh({ error: { code: "internal", message: "xhigh failed" } });
+    await expect(pendingXhigh).resolves.toBe(false);
+
+    expect(s.effortCurrent).toBe("high");
+    expect(useToasts().value).toHaveLength(1);
+    log.mockRestore();
+  });
 });

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
-import { Brain, Check, ChevronDown, Gauge, Paperclip, Send, X } from "lucide-vue-next";
+import { Brain, Check, ChevronDown, Gauge, Paperclip, Send, SlidersHorizontal, X } from "lucide-vue-next";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
 import { createDebouncedFlush } from "../lib/debounce-flush";
@@ -38,14 +38,34 @@ function toggleUsage(e: MouseEvent) {
 
 // Load the session's model for the composer chip whenever the session changes.
 const modelMenuOpen = ref(false);
+const effortMenuOpen = ref(false);
 watch(
   () => [props.instanceId, props.sessionAlias] as const,
-  ([id, alias]) => { void controls.loadModel(id ?? null, alias ?? null); modelMenuOpen.value = false; },
+  ([id, alias]) => {
+    void controls.loadModel(id ?? null, alias ?? null);
+    void controls.loadEffort(id ?? null, alias ?? null);
+    modelMenuOpen.value = false;
+    effortMenuOpen.value = false;
+  },
   { immediate: true },
 );
 async function pickModel(id: string) {
   modelMenuOpen.value = false;
   if (props.instanceId && props.sessionAlias) await controls.setModel(props.instanceId, props.sessionAlias, id);
+}
+async function pickEffort(effort: string) {
+  effortMenuOpen.value = false;
+  if (props.instanceId && props.sessionAlias) {
+    await controls.setEffort(props.instanceId, props.sessionAlias, effort);
+  }
+}
+function toggleModelMenu() {
+  effortMenuOpen.value = false;
+  modelMenuOpen.value = !modelMenuOpen.value;
+}
+function toggleEffortMenu() {
+  modelMenuOpen.value = false;
+  effortMenuOpen.value = !effortMenuOpen.value;
 }
 const text = ref(loadDraft(props.draftKey ?? ""));
 const textarea = ref<HTMLTextAreaElement | null>(null);
@@ -262,7 +282,7 @@ function onInput() {
           <button type="button" data-test="model-chip"
                   class="flex items-center gap-1.5 px-1.5 py-1 rounded-md text-fg-muted hover:bg-raised transition-colors disabled:opacity-60"
                   :disabled="!controls.available.length"
-                  @click="modelMenuOpen = !modelMenuOpen">
+                  @click="toggleModelMenu">
             <Brain :size="14" class="text-accent" />
             <span class="font-mono text-[11.5px] font-medium text-fg">{{ controls.current ? formatModelLabel(controls.current) : $t("chat.model") }}</span>
             <ChevronDown v-if="controls.available.length" :size="13" />
@@ -279,6 +299,28 @@ function onInput() {
               </button>
             </li>
           </ul>
+          <div v-if="controls.effortAvailable.length" class="relative">
+            <button type="button" data-test="effort-chip"
+                    class="flex items-center gap-1.5 rounded-md px-1.5 py-1 text-fg-muted transition-colors hover:bg-raised"
+                    :title="$t('chat.effort')"
+                    @click="toggleEffortMenu">
+              <SlidersHorizontal :size="14" class="text-accent" />
+              <span class="font-mono text-[11.5px] font-medium text-fg">{{ controls.effortCurrent ?? $t("chat.effort") }}</span>
+              <ChevronDown :size="13" />
+            </button>
+            <ul v-if="effortMenuOpen" data-test="effort-menu"
+                class="absolute bottom-full left-0 z-10 mb-1 max-h-48 min-w-32 overflow-y-auto rounded-lg border border-border bg-raised shadow-lg">
+              <li v-for="effort in controls.effortAvailable" :key="effort">
+                <button type="button" data-test="effort-option"
+                        class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
+                        :class="effort === controls.effortCurrent ? 'bg-accent/10 text-accent' : 'hover:bg-fg/10 text-fg-muted'"
+                        @click="pickEffort(effort)">
+                  <span class="font-mono">{{ effort }}</span>
+                  <Check v-if="effort === controls.effortCurrent" :size="14" class="ml-auto" />
+                </button>
+              </li>
+            </ul>
+          </div>
           <!-- context-usage meter: click to open the cost / token-breakdown popover -->
           <button v-if="context" type="button" data-test="context-meter"
                   class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded pl-0.5 hover:opacity-80"

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -51,7 +51,13 @@ watch(
 );
 async function pickModel(id: string) {
   modelMenuOpen.value = false;
-  if (props.instanceId && props.sessionAlias) await controls.setModel(props.instanceId, props.sessionAlias, id);
+  const instanceId = props.instanceId;
+  const sessionAlias = props.sessionAlias;
+  if (!instanceId || !sessionAlias) return;
+  await controls.setModel(instanceId, sessionAlias, id);
+  if (props.instanceId === instanceId && props.sessionAlias === sessionAlias) {
+    await controls.loadEffort(instanceId, sessionAlias);
+  }
 }
 async function pickEffort(effort: string) {
   effortMenuOpen.value = false;
@@ -281,21 +287,21 @@ function onInput() {
         <div v-if="instanceId && sessionAlias" class="relative flex items-center gap-2">
           <button type="button" data-test="model-chip"
                   class="flex items-center gap-1.5 px-1.5 py-1 rounded-md text-fg-muted hover:bg-raised transition-colors disabled:opacity-60"
-                  :disabled="!controls.available.length"
+                  :disabled="!controls.modelAvailable.length"
                   @click="toggleModelMenu">
             <Brain :size="14" class="text-accent" />
-            <span class="font-mono text-[11.5px] font-medium text-fg">{{ controls.current ? formatModelLabel(controls.current) : $t("chat.model") }}</span>
-            <ChevronDown v-if="controls.available.length" :size="13" />
+            <span class="font-mono text-[11.5px] font-medium text-fg">{{ controls.modelCurrent ? formatModelLabel(controls.modelCurrent) : $t("chat.model") }}</span>
+            <ChevronDown v-if="controls.modelAvailable.length" :size="13" />
           </button>
-          <ul v-if="modelMenuOpen && controls.available.length" data-test="model-menu"
+          <ul v-if="modelMenuOpen && controls.modelAvailable.length" data-test="model-menu"
               class="absolute bottom-full left-0 z-10 mb-1 max-h-48 min-w-40 overflow-y-auto rounded-lg border border-border bg-raised shadow-lg">
-            <li v-for="m in controls.available" :key="m">
+            <li v-for="m in controls.modelAvailable" :key="m">
               <button type="button" data-test="model-option"
                       class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
-                      :class="m === controls.current ? 'bg-accent/10 text-accent' : 'hover:bg-fg/10 text-fg-muted'"
+                      :class="m === controls.modelCurrent ? 'bg-accent/10 text-accent' : 'hover:bg-fg/10 text-fg-muted'"
                       @click="pickModel(m)">
                 <span class="font-mono">{{ formatModelLabel(m) }}</span>
-                <Check v-if="m === controls.current" :size="14" class="ml-auto" />
+                <Check v-if="m === controls.modelCurrent" :size="14" class="ml-auto" />
               </button>
             </li>
           </ul>

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -78,6 +78,8 @@ export default {
     send: "Send",
     model: "model",
     modelSetFailed: "Failed to switch model. Try again.",
+    effort: "effort",
+    effortSetFailed: "Failed to switch effort. Try again.",
     working: "Agent is working… (Esc to stop)",
     message: "Message",
     mermaidError: "Diagram failed to render",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -76,6 +76,8 @@ export default {
     send: "发送",
     model: "模型",
     modelSetFailed: "切换模型失败，请重试。",
+    effort: "推理强度",
+    effortSetFailed: "切换推理强度失败，请重试。",
     working: "Agent 正在工作…（按 Esc 停止）",
     message: "消息",
     mermaidError: "图表渲染失败",

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -41,6 +41,16 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     const authoritative = authoritativeModels.get(context);
     return authoritative ? authoritative.current : fallback;
   }
+  function recordAuthoritativeEffort(context: string, revision: number, effort: string | undefined): void {
+    const existing = authoritativeEfforts.get(context);
+    if (!existing || revision >= existing.revision) {
+      authoritativeEfforts.set(context, { revision, current: effort });
+    }
+  }
+  function rollbackEffort(context: string, fallback: string | undefined): string | undefined {
+    const authoritative = authoritativeEfforts.get(context);
+    return authoritative ? authoritative.current : fallback;
+  }
 
   function clearModelState(): void {
     modelCurrent.value = undefined;
@@ -181,7 +191,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
       if (effortActiveContext !== context || effortRevision !== revision) return;
       if (isErrorPayload(effortResult)) { clearEffortState(); return; }
       effortCurrent.value = typeof effortResult.current === "string" ? effortResult.current : undefined;
-      authoritativeEfforts.set(context, { revision, current: effortCurrent.value });
+      recordAuthoritativeEffort(context, revision, effortCurrent.value);
       effortAvailable.value = Array.isArray(effortResult.available) ? effortResult.available : [];
     } catch {
       if (effortActiveContext === context && effortRevision === revision) clearEffortState();
@@ -206,19 +216,23 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
         });
         if (isErrorPayload(setResult) || setResult.ok === false) {
           if (effortActiveContext === context && effortRevision === revision) {
-            effortCurrent.value = typeof setResult === "object" && setResult !== null && "current" in setResult
-              && typeof setResult.current === "string" ? setResult.current : previous;
+            let observed = rollbackEffort(context, previous);
+            if (!isErrorPayload(setResult) && (setResult.current === null || typeof setResult.current === "string")) {
+              observed = setResult.current ?? undefined;
+              recordAuthoritativeEffort(context, revision, observed);
+            }
+            effortCurrent.value = observed;
             reportEffortSwitchFailure(isErrorPayload(setResult) ? setResult.error.message : `requested ${effort} was not applied`);
           }
           return false;
         }
         const observed = typeof setResult.current === "string" ? setResult.current : effort;
-        authoritativeEfforts.set(context, { revision, current: observed });
+        recordAuthoritativeEffort(context, revision, observed);
         if (effortActiveContext === context && effortRevision === revision) effortCurrent.value = observed;
         return true;
       } catch (error) {
         if (effortActiveContext === context && effortRevision === revision) {
-          effortCurrent.value = previous;
+          effortCurrent.value = rollbackEffort(context, previous);
           reportEffortSwitchFailure(error instanceof Error ? error.message : "set-failed");
         }
         return false;

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -177,12 +177,12 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
         await pendingSet;
         if (effortActiveContext !== context || effortRevision !== revision) return;
       }
-      const r = await api.rpc<SessionEffortResult>(instanceId, "control.session.effort.get", { sessionAlias: alias });
+      const effortResult = await api.rpc<SessionEffortResult>(instanceId, "control.session.effort.get", { sessionAlias: alias });
       if (effortActiveContext !== context || effortRevision !== revision) return;
-      if (isErrorPayload(r)) { clearEffortState(); return; }
-      effortCurrent.value = typeof r.current === "string" ? r.current : undefined;
+      if (isErrorPayload(effortResult)) { clearEffortState(); return; }
+      effortCurrent.value = typeof effortResult.current === "string" ? effortResult.current : undefined;
       authoritativeEfforts.set(context, { revision, current: effortCurrent.value });
-      effortAvailable.value = Array.isArray(r.available) ? r.available : [];
+      effortAvailable.value = Array.isArray(effortResult.available) ? effortResult.available : [];
     } catch {
       if (effortActiveContext === context && effortRevision === revision) clearEffortState();
     } finally {
@@ -200,19 +200,19 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     effortCurrent.value = effort;
     const operation = (async (): Promise<boolean> => {
       try {
-        const r = await api.rpc<SessionEffortSetResult>(instanceId, "control.session.effort.set", {
+        const setResult = await api.rpc<SessionEffortSetResult>(instanceId, "control.session.effort.set", {
           sessionAlias: alias,
           effort,
         });
-        if (isErrorPayload(r) || r.ok === false) {
+        if (isErrorPayload(setResult) || setResult.ok === false) {
           if (effortActiveContext === context && effortRevision === revision) {
-            effortCurrent.value = typeof r === "object" && r !== null && "current" in r
-              && typeof r.current === "string" ? r.current : previous;
-            reportEffortSwitchFailure(isErrorPayload(r) ? r.error.message : `requested ${effort} was not applied`);
+            effortCurrent.value = typeof setResult === "object" && setResult !== null && "current" in setResult
+              && typeof setResult.current === "string" ? setResult.current : previous;
+            reportEffortSwitchFailure(isErrorPayload(setResult) ? setResult.error.message : `requested ${effort} was not applied`);
           }
           return false;
         }
-        const observed = typeof r.current === "string" ? r.current : effort;
+        const observed = typeof setResult.current === "string" ? setResult.current : effort;
         authoritativeEfforts.set(context, { revision, current: observed });
         if (effortActiveContext === context && effortRevision === revision) effortCurrent.value = observed;
         return true;

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -10,12 +10,12 @@ import {
 import { api } from "../api/client";
 import { pushToast } from "../lib/use-toasts";
 
-/** Per-session model controls for the composer chip. The hub stamps chatKey for
+/** Per-session model and effort controls for the composer chips. The hub stamps chatKey for
  *  these chat-scoped RPCs, so the web only sends sessionAlias. */
 export const useSessionControlsStore = defineStore("session-controls", () => {
-  const current = ref<string | undefined>(undefined);
-  const available = ref<string[]>([]);
-  const loading = ref(false);
+  const modelCurrent = ref<string | undefined>(undefined);
+  const modelAvailable = ref<string[]>([]);
+  const modelLoading = ref(false);
   const effortCurrent = ref<string | undefined>(undefined);
   const effortAvailable = ref<string[]>([]);
   const effortLoading = ref(false);
@@ -43,8 +43,8 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   }
 
   function clearModelState(): void {
-    current.value = undefined;
-    available.value = [];
+    modelCurrent.value = undefined;
+    modelAvailable.value = [];
   }
 
   function clearEffortState(): void {
@@ -55,7 +55,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   function reset(): void {
     activeContext = null;
     requestRevision += 1;
-    loading.value = false;
+    modelLoading.value = false;
     clearModelState();
     effortActiveContext = null;
     effortRevision += 1;
@@ -69,7 +69,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     if (activeContext !== context) clearModelState();
     activeContext = context;
     const revision = ++requestRevision;
-    loading.value = true;
+    modelLoading.value = true;
     try {
       // A remount/session round-trip can request a fresh read while an earlier
       // selection for this same session is still being reconciled. Read only
@@ -83,15 +83,15 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
       const r = await api.rpc<SessionModelResult>(instanceId, "control.session.model.get", { sessionAlias: alias });
       if (!isCurrentRequest(context, revision)) return;
       if (isErrorPayload(r)) { clearModelState(); return; }
-      current.value = typeof r.current === "string" ? r.current : undefined;
-      recordAuthoritativeModel(context, revision, current.value);
+      modelCurrent.value = typeof r.current === "string" ? r.current : undefined;
+      recordAuthoritativeModel(context, revision, modelCurrent.value);
       // Never trust the wire to hand back an array — a malformed/partial result must
       // not blow up the composer's `available.length` reads (white-screens the input).
-      available.value = Array.isArray(r.available) ? r.available : [];
+      modelAvailable.value = Array.isArray(r.available) ? r.available : [];
     } catch {
       if (isCurrentRequest(context, revision)) clearModelState();
     } finally {
-      if (isCurrentRequest(context, revision)) loading.value = false;
+      if (isCurrentRequest(context, revision)) modelLoading.value = false;
     }
   }
 
@@ -102,18 +102,18 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     const context = contextKey(instanceId, alias);
     if (activeContext !== context) clearModelState();
     activeContext = context;
-    const prev = current.value;
+    const prev = modelCurrent.value;
     const revision = ++requestRevision;
     // This mutation supersedes any in-flight model load for the same UI store.
     // Its stale finally block is intentionally ignored, so clear the spinner now.
-    loading.value = false;
-    current.value = id;
+    modelLoading.value = false;
+    modelCurrent.value = id;
     const operation = (async (): Promise<boolean> => {
       try {
         const r = await api.rpc<SessionModelSetResult>(instanceId, "control.session.model.set", { sessionAlias: alias, modelId: id });
         if (isErrorPayload(r)) {
           if (isCurrentRequest(context, revision)) {
-            current.value = rollbackModel(context, prev);
+            modelCurrent.value = rollbackModel(context, prev);
             reportModelSwitchFailure(r.error.message);
           }
           return false;
@@ -124,7 +124,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
             : typeof r.current === "string" ? r.current : rollbackModel(context, prev);
           recordAuthoritativeModel(context, revision, observed);
           if (isCurrentRequest(context, revision)) {
-            current.value = observed;
+            modelCurrent.value = observed;
             reportModelSwitchFailure(
               `requested ${id}; authoritative model is ${r.current ?? "unknown"}`,
             );
@@ -136,12 +136,12 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
           : typeof r.current === "string" ? r.current : id;
         recordAuthoritativeModel(context, revision, observed);
         if (isCurrentRequest(context, revision)) {
-          current.value = observed;
+          modelCurrent.value = observed;
         }
         return true;
       } catch (e) {
         if (isCurrentRequest(context, revision)) {
-          current.value = rollbackModel(context, prev);
+          modelCurrent.value = rollbackModel(context, prev);
           reportModelSwitchFailure(e instanceof Error ? e.message : "set-failed");
         }
         return false;
@@ -234,7 +234,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   }
 
   return {
-    current, available, loading, reset, loadModel, setModel,
+    modelCurrent, modelAvailable, modelLoading, reset, loadModel, setModel,
     effortCurrent, effortAvailable, effortLoading, loadEffort, setEffort,
   };
 });

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -2,6 +2,8 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import {
   isErrorPayload,
+  type SessionEffortResult,
+  type SessionEffortSetResult,
   type SessionModelResult,
   type SessionModelSetResult,
 } from "@ganglion/xacpx-relay-protocol";
@@ -14,10 +16,17 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   const current = ref<string | undefined>(undefined);
   const available = ref<string[]>([]);
   const loading = ref(false);
+  const effortCurrent = ref<string | undefined>(undefined);
+  const effortAvailable = ref<string[]>([]);
+  const effortLoading = ref(false);
   let activeContext: string | null = null;
   let requestRevision = 0;
   const pendingModelSets = new Map<string, Promise<void>>();
   const authoritativeModels = new Map<string, { revision: number; current: string | undefined }>();
+  let effortActiveContext: string | null = null;
+  let effortRevision = 0;
+  const pendingEffortSets = new Map<string, Promise<void>>();
+  const authoritativeEfforts = new Map<string, { revision: number; current: string | undefined }>();
 
   const contextKey = (instanceId: string, alias: string): string => `${instanceId}\u0000${alias}`;
   const isCurrentRequest = (context: string, revision: number): boolean =>
@@ -38,11 +47,20 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     available.value = [];
   }
 
+  function clearEffortState(): void {
+    effortCurrent.value = undefined;
+    effortAvailable.value = [];
+  }
+
   function reset(): void {
     activeContext = null;
     requestRevision += 1;
     loading.value = false;
     clearModelState();
+    effortActiveContext = null;
+    effortRevision += 1;
+    effortLoading.value = false;
+    clearEffortState();
   }
 
   async function loadModel(instanceId: string | null, alias: string | null): Promise<void> {
@@ -140,7 +158,85 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     }
   }
 
-  return { current, available, loading, reset, loadModel, setModel };
+  async function loadEffort(instanceId: string | null, alias: string | null): Promise<void> {
+    if (!instanceId || !alias) {
+      effortActiveContext = null;
+      effortRevision += 1;
+      effortLoading.value = false;
+      clearEffortState();
+      return;
+    }
+    const context = contextKey(instanceId, alias);
+    if (effortActiveContext !== context) clearEffortState();
+    effortActiveContext = context;
+    const revision = ++effortRevision;
+    effortLoading.value = true;
+    try {
+      const pendingSet = pendingEffortSets.get(context);
+      if (pendingSet) {
+        await pendingSet;
+        if (effortActiveContext !== context || effortRevision !== revision) return;
+      }
+      const r = await api.rpc<SessionEffortResult>(instanceId, "control.session.effort.get", { sessionAlias: alias });
+      if (effortActiveContext !== context || effortRevision !== revision) return;
+      if (isErrorPayload(r)) { clearEffortState(); return; }
+      effortCurrent.value = typeof r.current === "string" ? r.current : undefined;
+      authoritativeEfforts.set(context, { revision, current: effortCurrent.value });
+      effortAvailable.value = Array.isArray(r.available) ? r.available : [];
+    } catch {
+      if (effortActiveContext === context && effortRevision === revision) clearEffortState();
+    } finally {
+      if (effortActiveContext === context && effortRevision === revision) effortLoading.value = false;
+    }
+  }
+
+  async function setEffort(instanceId: string, alias: string, effort: string): Promise<boolean> {
+    const context = contextKey(instanceId, alias);
+    if (effortActiveContext !== context) clearEffortState();
+    effortActiveContext = context;
+    const previous = authoritativeEfforts.get(context)?.current ?? effortCurrent.value;
+    const revision = ++effortRevision;
+    effortLoading.value = false;
+    effortCurrent.value = effort;
+    const operation = (async (): Promise<boolean> => {
+      try {
+        const r = await api.rpc<SessionEffortSetResult>(instanceId, "control.session.effort.set", {
+          sessionAlias: alias,
+          effort,
+        });
+        if (isErrorPayload(r) || r.ok === false) {
+          if (effortActiveContext === context && effortRevision === revision) {
+            effortCurrent.value = typeof r === "object" && r !== null && "current" in r
+              && typeof r.current === "string" ? r.current : previous;
+            reportEffortSwitchFailure(isErrorPayload(r) ? r.error.message : `requested ${effort} was not applied`);
+          }
+          return false;
+        }
+        const observed = typeof r.current === "string" ? r.current : effort;
+        authoritativeEfforts.set(context, { revision, current: observed });
+        if (effortActiveContext === context && effortRevision === revision) effortCurrent.value = observed;
+        return true;
+      } catch (error) {
+        if (effortActiveContext === context && effortRevision === revision) {
+          effortCurrent.value = previous;
+          reportEffortSwitchFailure(error instanceof Error ? error.message : "set-failed");
+        }
+        return false;
+      }
+    })();
+    const settled = operation.then(() => undefined, () => undefined);
+    pendingEffortSets.set(context, settled);
+    try {
+      return await operation;
+    } finally {
+      if (pendingEffortSets.get(context) === settled) pendingEffortSets.delete(context);
+    }
+  }
+
+  return {
+    current, available, loading, reset, loadModel, setModel,
+    effortCurrent, effortAvailable, effortLoading, loadEffort, setEffort,
+  };
 });
 
 function reportModelSwitchFailure(detail: string): void {
@@ -148,4 +244,9 @@ function reportModelSwitchFailure(detail: string): void {
   // available in browser diagnostics while the user sees the app's standard toast.
   console.error("[relay-web] model switch failed", detail);
   pushToast("error", "chat.modelSetFailed");
+}
+
+function reportEffortSwitchFailure(detail: string): void {
+  console.error("[relay-web] effort switch failed", detail);
+  pushToast("error", "chat.effortSetFailed");
 }

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -63,8 +63,8 @@ const CHAT_SCOPED_TYPES = new Set<string>([
   // Archive/unarchive resolve the alias within the caller's chat scope too; without
   // the stamp the connector calls getChannelIdFromChatKey(undefined) and throws.
   MSG.sessionsArchive, MSG.sessionsUnarchive,
-  // Model get/set resolve the session within the caller's chat scope.
-  MSG.sessionModelGet, MSG.sessionModelSet,
+  // Model and effort get/set resolve the session within the caller's chat scope.
+  MSG.sessionModelGet, MSG.sessionModelSet, MSG.sessionEffortGet, MSG.sessionEffortSet,
   // Terminal create carries sessionAlias; stamp chatKey/senderId/isOwner so the
   // connector can resolve the session within the caller's chat scope.
   MSG.terminalCreate,

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -45,7 +45,7 @@ import {
   DEFAULT_PERMISSION_MODE,
   DEFAULT_NON_INTERACTIVE,
 } from "../transport/acpx-command-builder";
-import { parseSessionEffortRecord } from "../transport/session-effort";
+import { parseSessionEffortRecord, requireAdvertisedSessionEffort } from "../transport/session-effort";
 
 type BridgePromptStreamEvent =
   | { type: "prompt.segment"; text: string }
@@ -696,6 +696,8 @@ export class BridgeRuntime {
   async getSessionEffort(input: {
     agent: string;
     agentCommand?: string;
+    driver?: string;
+    settingsPolicy?: ClaudeSettingsPolicy;
     cwd: string;
     name: string;
   }): Promise<SessionEffortState> {
@@ -709,13 +711,14 @@ export class BridgeRuntime {
   async setSessionEffort(input: {
     agent: string;
     agentCommand?: string;
+    driver?: string;
+    settingsPolicy?: ClaudeSettingsPolicy;
     cwd: string;
     name: string;
     effort: string;
   }): Promise<Record<string, never>> {
     const record = await this.readRawSessionRecord(input, "get-session-effort", "json");
-    const advertised = parseSessionEffortRecord(record);
-    if (!advertised) throw new Error("the active agent does not advertise a reasoning-effort option");
+    const advertised = requireAdvertisedSessionEffort(record, input.effort);
     const spawnSpec = resolveSpawnCommand(this.command, this.buildSessionArgs(input, [
       "set",
       "-s",
@@ -723,10 +726,10 @@ export class BridgeRuntime {
       advertised.configId,
       input.effort,
     ]));
-    const result = await this.run(spawnSpec.command, spawnSpec.args, {
+    const result = await this.run(spawnSpec.command, spawnSpec.args, this.withSpawnEnvironment(input, {
       timeoutMs: this.managementCommandTimeoutMs(),
       stage: "set-session-effort",
-    });
+    }));
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "set effort failed");
     }

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -34,6 +34,7 @@ import type {
   MissingOptionalDepErrorData,
 } from "../transport/acpx-bridge/acpx-bridge-protocol";
 import type { AgentSessionListResult, PromptMediaInput } from "../transport/types";
+import type { SessionEffortState } from "../transport/types";
 import type { ToolEventMode } from "../transport/tool-event-mode.js";
 import type { PlanEntry, ToolUseEvent } from "../channels/types.js";
 import {
@@ -44,6 +45,7 @@ import {
   DEFAULT_PERMISSION_MODE,
   DEFAULT_NON_INTERACTIVE,
 } from "../transport/acpx-command-builder";
+import { parseSessionEffortRecord } from "../transport/session-effort";
 
 type BridgePromptStreamEvent =
   | { type: "prompt.segment"; text: string }
@@ -141,7 +143,7 @@ interface BridgeRuntimeOptions {
   sessionInitTimeoutMs?: number;
   /**
    * Time bound for one-shot management commands (sessions show/close, cancel,
-   * set-mode, set model, status, history, list). A hung acpx here would
+   * set-mode, set model/effort, status, history, list). A hung acpx here would
    * otherwise wedge the session's serial bridge lane forever. Defaults to 30s.
    */
   managementCommandTimeoutMs?: number;
@@ -564,20 +566,28 @@ export class BridgeRuntime {
     });
   }
 
-  private async readSessionRecord(input: BridgeSessionInput): Promise<{ acpxRecordId: string; agentSessionId?: string }> {
+  private async readRawSessionRecord(
+    input: BridgeSessionInput,
+    stage: AcpxCommandStage = "read-session-record",
+    format: "quiet" | "json" = "quiet",
+  ): Promise<string> {
     const spawnSpec = resolveSpawnCommand(this.command, this.buildSessionArgs(input, [
       "sessions",
       "show",
       input.name,
-    ]));
+    ], { format }));
     const result = await this.run(spawnSpec.command, spawnSpec.args, this.withSpawnEnvironment(input, {
       timeoutMs: this.managementCommandTimeoutMs(),
-      stage: "read-session-record",
+      stage,
     }));
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "sessions show failed");
     }
-    const record = parseAcpxSessionRecordId(result.stdout);
+    return result.stdout;
+  }
+
+  private async readSessionRecord(input: BridgeSessionInput): Promise<{ acpxRecordId: string; agentSessionId?: string }> {
+    const record = parseAcpxSessionRecordId(await this.readRawSessionRecord(input));
     if (record) return record;
     throw new Error("failed to resolve acpx session record id");
   }
@@ -681,6 +691,46 @@ export class BridgeRuntime {
     } catch {
       return { available: [] };
     }
+  }
+
+  async getSessionEffort(input: {
+    agent: string;
+    agentCommand?: string;
+    cwd: string;
+    name: string;
+  }): Promise<SessionEffortState> {
+    const output = await this.readRawSessionRecord(input, "get-session-effort", "json");
+    const effort = parseSessionEffortRecord(output);
+    return effort
+      ? { current: effort.current, available: effort.available }
+      : { available: [] };
+  }
+
+  async setSessionEffort(input: {
+    agent: string;
+    agentCommand?: string;
+    cwd: string;
+    name: string;
+    effort: string;
+  }): Promise<Record<string, never>> {
+    const record = await this.readRawSessionRecord(input, "get-session-effort", "json");
+    const advertised = parseSessionEffortRecord(record);
+    if (!advertised) throw new Error("the active agent does not advertise a reasoning-effort option");
+    const spawnSpec = resolveSpawnCommand(this.command, this.buildSessionArgs(input, [
+      "set",
+      "-s",
+      input.name,
+      advertised.configId,
+      input.effort,
+    ]));
+    const result = await this.run(spawnSpec.command, spawnSpec.args, {
+      timeoutMs: this.managementCommandTimeoutMs(),
+      stage: "set-session-effort",
+    });
+    if (result.code !== 0) {
+      throw new Error(result.stderr || result.stdout || "set effort failed");
+    }
+    return {};
   }
 
   async cancel(input: {

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -306,6 +306,7 @@ export class BridgeServer {
       case "setSessionEffort":
         return await this.runtime.setSessionEffort({
           agent: requireString(params, "agent"),
+          ...agentExecutionSettings(params),
           agentCommand: asOptionalString(params.agentCommand),
           cwd: requireString(params, "cwd"),
           name: requireString(params, "name"),
@@ -314,6 +315,7 @@ export class BridgeServer {
       case "getSessionEffort":
         return await this.runtime.getSessionEffort({
           agent: requireString(params, "agent"),
+          ...agentExecutionSettings(params),
           agentCommand: asOptionalString(params.agentCommand),
           cwd: requireString(params, "cwd"),
           name: requireString(params, "name"),

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -37,6 +37,8 @@ const BRIDGE_METHODS = new Set<BridgeMethod>([
   "setMode",
   "setModel",
   "getSessionModel",
+  "setSessionEffort",
+  "getSessionEffort",
   "cancel",
   "removeSession",
   "deleteSession",
@@ -53,6 +55,8 @@ const SESSION_SCOPED_METHODS = new Set<BridgeMethod>([
   "setMode",
   "setModel",
   "getSessionModel",
+  "setSessionEffort",
+  "getSessionEffort",
   "cancel",
   "removeSession",
   "deleteSession",
@@ -295,6 +299,21 @@ export class BridgeServer {
         return await this.runtime.getSessionModel({
           agent: requireString(params, "agent"),
           ...agentExecutionSettings(params),
+          agentCommand: asOptionalString(params.agentCommand),
+          cwd: requireString(params, "cwd"),
+          name: requireString(params, "name"),
+        });
+      case "setSessionEffort":
+        return await this.runtime.setSessionEffort({
+          agent: requireString(params, "agent"),
+          agentCommand: asOptionalString(params.agentCommand),
+          cwd: requireString(params, "cwd"),
+          name: requireString(params, "name"),
+          effort: requireString(params, "effort"),
+        });
+      case "getSessionEffort":
+        return await this.runtime.getSessionEffort({
+          agent: requireString(params, "agent"),
           agentCommand: asOptionalString(params.agentCommand),
           cwd: requireString(params, "cwd"),
           name: requireString(params, "name"),

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -460,7 +460,34 @@ export class ControlService {
     const setEffort = this.deps.transport.setSessionEffort?.bind(this.deps.transport);
     if (!setEffort) throw new Error("the active transport does not support setting reasoning effort");
     return await this.runSessionConfigSetExclusive(session.alias, async () => {
-      await setEffort(session, effort);
+      try {
+        await setEffort(session, effort);
+      } catch (error) {
+        const getEffort = this.deps.transport.getSessionEffort?.bind(this.deps.transport);
+        if (!isCommandTimeoutError(error) || !getEffort) throw error;
+        let observed: { current?: string; available: string[] };
+        try {
+          observed = await getEffort(session);
+        } catch {
+          // Preserve the original timeout when authoritative reconciliation fails.
+          throw error;
+        }
+        try {
+          await this.deps.logger?.error(
+            "control.session.effort.timeout_reconciled",
+            "Effort switch timed out; adopted authoritative transport state",
+            {
+              sessionAlias: session.alias,
+              requestedEffort: effort,
+              observedEffort: observed.current ?? null,
+              timeout: error instanceof Error ? error.message : String(error),
+            },
+          );
+        } catch {
+          // Logging is diagnostic only; reconciliation already succeeded.
+        }
+        return { current: observed.current, applied: observed.current === effort };
+      }
       return { current: effort, applied: true };
     });
   }

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -206,7 +206,7 @@ export class ControlService {
   private readonly runner: SessionTurnRunner;
   private readonly turnQueue: TurnQueue;
   private readonly workspaceGit: WorkspaceGit;
-  private readonly modelSetTails = new Map<string, Promise<void>>();
+  private readonly sessionConfigSetTails = new Map<string, Promise<void>>();
   private readonly worktreeRegistrationTails = new Map<string, Promise<void>>();
 
   constructor(private readonly deps: ControlServiceDeps) {
@@ -398,7 +398,7 @@ export class ControlService {
     if (!session) throw new Error("session not found");
     const setModel = this.deps.transport.setModel?.bind(this.deps.transport);
     if (!setModel) throw new Error("the active transport does not support switching models");
-    return await this.runModelSetExclusive(session.alias, async () => {
+    return await this.runSessionConfigSetExclusive(session.alias, async () => {
       if (
         typeof options.deadlineAt === "number"
         && Number.isFinite(options.deadlineAt)
@@ -459,25 +459,27 @@ export class ControlService {
     if (!session) throw new Error("session not found");
     const setEffort = this.deps.transport.setSessionEffort?.bind(this.deps.transport);
     if (!setEffort) throw new Error("the active transport does not support setting reasoning effort");
-    await setEffort(session, effort);
-    return { current: effort, applied: true };
+    return await this.runSessionConfigSetExclusive(session.alias, async () => {
+      await setEffort(session, effort);
+      return { current: effort, applied: true };
+    });
   }
 
-  /** Serialize model mutations per logical session so stale reconciliation cannot win last. */
-  private async runModelSetExclusive<T>(sessionAlias: string, operation: () => Promise<T>): Promise<T> {
-    const previous = this.modelSetTails.get(sessionAlias) ?? Promise.resolve();
+  /** Serialize adapter configuration mutations per logical session so stale operations cannot win last. */
+  private async runSessionConfigSetExclusive<T>(sessionAlias: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.sessionConfigSetTails.get(sessionAlias) ?? Promise.resolve();
     let release!: () => void;
     const gate = new Promise<void>((resolve) => { release = resolve; });
     const tail = previous.catch(() => {}).then(() => gate);
-    this.modelSetTails.set(sessionAlias, tail);
+    this.sessionConfigSetTails.set(sessionAlias, tail);
 
     await previous.catch(() => {});
     try {
       return await operation();
     } finally {
       release();
-      if (this.modelSetTails.get(sessionAlias) === tail) {
-        this.modelSetTails.delete(sessionAlias);
+      if (this.sessionConfigSetTails.get(sessionAlias) === tail) {
+        this.sessionConfigSetTails.delete(sessionAlias);
       }
     }
   }

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -100,9 +100,9 @@ export interface ControlServiceDeps {
     SessionService,
     "listAllResolvedSessions" | "removeSession" | "useSession" | "resolveAliasForChat" | "getSession" | "setSessionModel" | "setDisplayName"
   >;
-  // The active transport, for reading/switching a session's model. setModel/
-  // getSessionModel are optional on the interface — absence is handled gracefully.
-  transport: Pick<SessionTransport, "setModel" | "getSessionModel">;
+  // The active transport, for reading/switching a session's model and effort.
+  // These controls are optional on the interface — absence is handled gracefully.
+  transport: Pick<SessionTransport, "setModel" | "getSessionModel" | "setSessionEffort" | "getSessionEffort">;
   // Full-lifecycle session creator (resolve → ensure acpx session → bind),
   // wired to CommandRouter.createSessionWithTransport in main.ts. Replaces the
   // logical-only sessions.createSession so control-created sessions are promptable.
@@ -440,6 +440,27 @@ export class ControlService {
       await this.deps.sessions.setSessionModel(session.alias, modelId);
       return { current: modelId, applied: true };
     });
+  }
+
+  /** Read the reasoning-effort values advertised by the session's adapter. */
+  async getSessionEffort(chatKey: string, alias: string): Promise<{ current?: string; available: string[] }> {
+    const session = await this.resolveControlSession(chatKey, alias);
+    if (!session || !this.deps.transport.getSessionEffort) return { available: [] };
+    return await this.deps.transport.getSessionEffort(session);
+  }
+
+  /** Set the adapter-advertised reasoning effort for a session. */
+  async setSessionEffort(
+    chatKey: string,
+    alias: string,
+    effort: string,
+  ): Promise<{ current?: string; applied: boolean }> {
+    const session = await this.resolveControlSession(chatKey, alias);
+    if (!session) throw new Error("session not found");
+    const setEffort = this.deps.transport.setSessionEffort?.bind(this.deps.transport);
+    if (!setEffort) throw new Error("the active transport does not support setting reasoning effort");
+    await setEffort(session, effort);
+    return { current: effort, applied: true };
   }
 
   /** Serialize model mutations per logical session so stale reconciliation cannot win last. */

--- a/src/transport/acpx-bridge/acpx-bridge-client.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-client.ts
@@ -84,6 +84,7 @@ export function bridgeRequestTimeoutMs(
       return 2 * sessionInitTimeoutMs + BRIDGE_REQUEST_TIMEOUT_GRACE_MS;
     case "deleteSession":
     case "freeWarmProcess":
+    case "setSessionEffort":
       // Two sequential management commands (sessions show + close/owner kill).
       return 2 * DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS + BRIDGE_REQUEST_TIMEOUT_GRACE_MS;
     default:

--- a/src/transport/acpx-bridge/acpx-bridge-protocol.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-protocol.ts
@@ -15,6 +15,8 @@ export type BridgeMethod =
   | "setMode"
   | "setModel"
   | "getSessionModel"
+  | "setSessionEffort"
+  | "getSessionEffort"
   | "cancel"
   | "removeSession"
   | "deleteSession"

--- a/src/transport/acpx-bridge/acpx-bridge-transport.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-transport.ts
@@ -8,6 +8,7 @@ import type {
   ReplyQuotaContext,
   ResolvedSession,
   SessionTransport,
+  SessionEffortState,
 } from "../types";
 import {
   buildOverflowSummary,
@@ -268,6 +269,14 @@ export class AcpxBridgeTransport implements SessionTransport {
 
   async getSessionModel(session: ResolvedSession): Promise<{ current?: string; available: string[] }> {
     return await this.client.request("getSessionModel", this.toParams(session));
+  }
+
+  async setSessionEffort(session: ResolvedSession, effort: string): Promise<void> {
+    await this.client.request("setSessionEffort", { ...this.toParams(session), effort });
+  }
+
+  async getSessionEffort(session: ResolvedSession): Promise<SessionEffortState> {
+    return await this.client.request("getSessionEffort", this.toParams(session));
   }
 
   async cancel(session: ResolvedSession): Promise<{ cancelled: boolean; message: string }> {

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -39,7 +39,7 @@ import { resolveToolEventMode, type ToolEventMode } from "../tool-event-mode.js"
 import { runAgentSessionList } from "../agent-session-list";
 import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../acpx-session-files";
-import { parseSessionEffortRecord } from "../session-effort";
+import { parseSessionEffortRecord, requireAdvertisedSessionEffort } from "../session-effort";
 import {
   CommandTimeoutError,
   DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
@@ -470,7 +470,10 @@ export class AcpxCliTransport implements SessionTransport {
       "sessions",
       "show",
       session.transportSession,
-    ], "json"), { timeoutMs: this.managementCommandTimeoutMs, stage: "get-session-effort" });
+    ], "json"), this.withSpawnEnvironment(session, {
+      timeoutMs: this.managementCommandTimeoutMs,
+      stage: "get-session-effort",
+    }));
     const effort = parseSessionEffortRecord(output);
     return effort
       ? { current: effort.current, available: effort.available }
@@ -482,16 +485,21 @@ export class AcpxCliTransport implements SessionTransport {
       "sessions",
       "show",
       session.transportSession,
-    ], "json"), { timeoutMs: this.managementCommandTimeoutMs, stage: "get-session-effort" });
-    const advertised = parseSessionEffortRecord(record);
-    if (!advertised) throw new Error("the active agent does not advertise a reasoning-effort option");
+    ], "json"), this.withSpawnEnvironment(session, {
+      timeoutMs: this.managementCommandTimeoutMs,
+      stage: "get-session-effort",
+    }));
+    const advertised = requireAdvertisedSessionEffort(record, effort);
     await this.run(this.buildArgs(session, [
       "set",
       "-s",
       session.transportSession,
       advertised.configId,
       effort,
-    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "set-session-effort" });
+    ]), this.withSpawnEnvironment(session, {
+      timeoutMs: this.managementCommandTimeoutMs,
+      stage: "set-session-effort",
+    }));
   }
 
   async cancel(session: ResolvedSession): Promise<{ cancelled: boolean; message: string }> {

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -21,6 +21,7 @@ import type {
   ReplyQuotaContext,
   ResolvedSession,
   SessionTransport,
+  SessionEffortState,
 } from "../types";
 import { getPromptText, normalizeCommandError } from "../prompt-output";
 import { isModelNotAdvertisedError } from "../model-not-advertised";
@@ -38,6 +39,7 @@ import { resolveToolEventMode, type ToolEventMode } from "../tool-event-mode.js"
 import { runAgentSessionList } from "../agent-session-list";
 import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../acpx-session-files";
+import { parseSessionEffortRecord } from "../session-effort";
 import {
   CommandTimeoutError,
   DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
@@ -59,7 +61,7 @@ interface AcpxCliTransportOptions {
   sessionInitTimeoutMs?: number;
   /**
    * Time bound for one-shot management commands (sessions show/close, cancel,
-   * set-mode, set model, status, history). A hung acpx here would otherwise
+   * set-mode, set model/effort, status, history). A hung acpx here would otherwise
    * wedge the session's serial request lane forever. Defaults to 30s.
    */
   managementCommandTimeoutMs?: number;
@@ -461,6 +463,35 @@ export class AcpxCliTransport implements SessionTransport {
     } catch {
       return { available: [] };
     }
+  }
+
+  async getSessionEffort(session: ResolvedSession): Promise<SessionEffortState> {
+    const output = await this.run(this.buildArgs(session, [
+      "sessions",
+      "show",
+      session.transportSession,
+    ], "json"), { timeoutMs: this.managementCommandTimeoutMs, stage: "get-session-effort" });
+    const effort = parseSessionEffortRecord(output);
+    return effort
+      ? { current: effort.current, available: effort.available }
+      : { available: [] };
+  }
+
+  async setSessionEffort(session: ResolvedSession, effort: string): Promise<void> {
+    const record = await this.run(this.buildArgs(session, [
+      "sessions",
+      "show",
+      session.transportSession,
+    ], "json"), { timeoutMs: this.managementCommandTimeoutMs, stage: "get-session-effort" });
+    const advertised = parseSessionEffortRecord(record);
+    if (!advertised) throw new Error("the active agent does not advertise a reasoning-effort option");
+    await this.run(this.buildArgs(session, [
+      "set",
+      "-s",
+      session.transportSession,
+      advertised.configId,
+      effort,
+    ]), { timeoutMs: this.managementCommandTimeoutMs, stage: "set-session-effort" });
   }
 
   async cancel(session: ResolvedSession): Promise<{ cancelled: boolean; message: string }> {
@@ -915,8 +946,8 @@ export class AcpxCliTransport implements SessionTransport {
     };
   }
 
-  private buildArgs(session: ResolvedSession, tail: string[]): string[] {
-    return sharedBuildSessionArgs(this.sessionInput(session), tail, { format: "quiet" });
+  private buildArgs(session: ResolvedSession, tail: string[], format: "json" | "quiet" = "quiet"): string[] {
+    return sharedBuildSessionArgs(this.sessionInput(session), tail, { format });
   }
 
   private buildAgentQueryArgs(query: AgentSessionListQuery, format: "json" | "quiet", tail: string[]): string[] {

--- a/src/transport/command-timeouts.ts
+++ b/src/transport/command-timeouts.ts
@@ -11,7 +11,7 @@
 
 /**
  * Default timeout for one-shot management commands (sessions show/close,
- * cancel, set-mode, set model, status, history). These normally finish in
+ * cancel, set-mode, set model/effort, status, history). These normally finish in
  * well under a second; 30s only trips when acpx itself is hung.
  */
 export const DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS = 30_000;
@@ -42,6 +42,8 @@ export type AcpxCommandStage =
   | "set-mode"
   | "set-model"
   | "get-session-model"
+  | "set-session-effort"
+  | "get-session-effort"
   | "cancel"
   | "remove-session";
 

--- a/src/transport/session-effort.ts
+++ b/src/transport/session-effort.ts
@@ -25,8 +25,7 @@ export function parseSessionEffortRecord(raw: string): EffortConfigOption | unde
     if (!isRecord(candidate) || typeof candidate.id !== "string") continue;
     if (candidate.category !== "thought_level" && !EFFORT_CONFIG_IDS.has(candidate.id)) continue;
     const available = Array.isArray(candidate.options)
-      ? candidate.options.flatMap((option) =>
-          isRecord(option) && typeof option.value === "string" ? [option.value] : [])
+      ? candidate.options.flatMap(effortOptionValues)
       : [];
     return {
       configId: candidate.id,
@@ -35,6 +34,12 @@ export function parseSessionEffortRecord(raw: string): EffortConfigOption | unde
     };
   }
   return undefined;
+}
+
+function effortOptionValues(option: unknown): string[] {
+  if (!isRecord(option)) return [];
+  if (typeof option.value === "string") return [option.value];
+  return Array.isArray(option.options) ? option.options.flatMap(effortOptionValues) : [];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/transport/session-effort.ts
+++ b/src/transport/session-effort.ts
@@ -1,0 +1,42 @@
+import type { SessionEffortState } from "./types";
+
+const EFFORT_CONFIG_IDS = new Set([
+  "reasoning_effort",
+  "effort",
+  "thought_level",
+  "thinking",
+]);
+
+type EffortConfigOption = SessionEffortState & { configId: string };
+
+/** Locate the reasoning-effort select advertised by an ACP adapter in an acpx record. */
+export function parseSessionEffortRecord(raw: string): EffortConfigOption | undefined {
+  let record: unknown;
+  try {
+    record = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(record) || !isRecord(record.acpx) || !Array.isArray(record.acpx.config_options)) {
+    return undefined;
+  }
+
+  for (const candidate of record.acpx.config_options) {
+    if (!isRecord(candidate) || typeof candidate.id !== "string") continue;
+    if (candidate.category !== "thought_level" && !EFFORT_CONFIG_IDS.has(candidate.id)) continue;
+    const available = Array.isArray(candidate.options)
+      ? candidate.options.flatMap((option) =>
+          isRecord(option) && typeof option.value === "string" ? [option.value] : [])
+      : [];
+    return {
+      configId: candidate.id,
+      current: typeof candidate.currentValue === "string" ? candidate.currentValue : undefined,
+      available,
+    };
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/transport/session-effort.ts
+++ b/src/transport/session-effort.ts
@@ -9,6 +9,17 @@ const EFFORT_CONFIG_IDS = new Set([
 
 type EffortConfigOption = SessionEffortState & { configId: string };
 
+export function requireAdvertisedSessionEffort(raw: string, value: string): EffortConfigOption {
+  const advertised = parseSessionEffortRecord(raw);
+  if (!advertised) {
+    throw new Error("the active agent does not advertise a reasoning-effort option");
+  }
+  if (!advertised.available.includes(value)) {
+    throw new Error(`reasoning effort "${value}" is not advertised by the active agent`);
+  }
+  return advertised;
+}
+
 /** Locate the reasoning-effort select advertised by an ACP adapter in an acpx record. */
 export function parseSessionEffortRecord(raw: string): EffortConfigOption | undefined {
   let record: unknown;

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -217,6 +217,10 @@ export interface SessionTransport {
   setModel?(session: ResolvedSession, modelId: string): Promise<void>;
   /** Read the current model and the agent-advertised available model ids. Optional. */
   getSessionModel?(session: ResolvedSession): Promise<{ current?: string; available: string[] }>;
+  /** Set the adapter-advertised reasoning effort for this session. Optional. */
+  setSessionEffort?(session: ResolvedSession, effort: string): Promise<void>;
+  /** Read the current and adapter-advertised reasoning-effort values. Optional. */
+  getSessionEffort?(session: ResolvedSession): Promise<SessionEffortState>;
   cancel(session: ResolvedSession): Promise<{ cancelled: boolean; message: string }>;
   hasSession(session: ResolvedSession): Promise<boolean>;
   listAgentSessions?(query: AgentSessionListQuery): Promise<AgentSessionListResult | undefined>;
@@ -248,4 +252,9 @@ export interface SessionTransport {
   getAgentSessionId?(session: ResolvedSession): Promise<string | undefined>;
   updatePermissionPolicy?(policy: PermissionPolicy): Promise<void>;
   dispose?(): Promise<void>;
+}
+
+export interface SessionEffortState {
+  current?: string;
+  available: string[];
 }

--- a/tests/unit/bridge/bridge-runtime-model.test.ts
+++ b/tests/unit/bridge/bridge-runtime-model.test.ts
@@ -81,3 +81,56 @@ test("getSessionModel returns empty available list on non-json output", async ()
   const result = await runtime.getSessionModel({ agent: "codex", cwd: "/repo", name: "s1" });
   expect(result.available).toEqual([]);
 });
+
+test("getSessionEffort reads the adapter-advertised effort option", async () => {
+  const run = async (_command: string, args: string[]) => {
+    expect(args).toContain("sessions");
+    expect(args).toContain("show");
+    return {
+      code: 0,
+      stdout: JSON.stringify({
+        acpx: {
+          config_options: [{
+            id: "reasoning_effort",
+            category: "thought_level",
+            currentValue: "high",
+            options: [{ value: "medium" }, { value: "high" }, { value: "xhigh" }],
+          }],
+        },
+      }),
+      stderr: "",
+    };
+  };
+  const runtime = new BridgeRuntime("acpx", run);
+
+  await expect(runtime.getSessionEffort({ agent: "codex", cwd: "/repo", name: "s1" }))
+    .resolves.toEqual({ current: "high", available: ["medium", "high", "xhigh"] });
+});
+
+test("setSessionEffort uses the adapter-advertised config id", async () => {
+  const calls: string[][] = [];
+  const run = async (_command: string, args: string[]) => {
+    calls.push(args);
+    if (args.includes("sessions")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpx: { config_options: [{
+            id: "effort",
+            category: "thought_level",
+            currentValue: "medium",
+            options: [{ value: "medium" }, { value: "high" }],
+          }] },
+        }),
+        stderr: "",
+      };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  const runtime = new BridgeRuntime("acpx", run);
+
+  await runtime.setSessionEffort({ agent: "codex", cwd: "/repo", name: "s1", effort: "high" });
+
+  const setArgs = calls.find((args) => args.includes("set"));
+  expect(setArgs?.slice(setArgs.indexOf("set"))).toEqual(["set", "-s", "s1", "effort", "high"]);
+});

--- a/tests/unit/bridge/bridge-runtime-model.test.ts
+++ b/tests/unit/bridge/bridge-runtime-model.test.ts
@@ -134,3 +134,74 @@ test("setSessionEffort uses the adapter-advertised config id", async () => {
   const setArgs = calls.find((args) => args.includes("set"));
   expect(setArgs?.slice(setArgs.indexOf("set"))).toEqual(["set", "-s", "s1", "effort", "high"]);
 });
+
+test("setSessionEffort rejects values not advertised by the adapter", async () => {
+  const calls: string[][] = [];
+  const run = async (_command: string, args: string[]) => {
+    calls.push(args);
+    return {
+      code: 0,
+      stdout: JSON.stringify({
+        acpx: { config_options: [{
+          id: "reasoning_effort",
+          category: "thought_level",
+          currentValue: "medium",
+          options: [{ value: "medium" }, { value: "high" }],
+        }] },
+      }),
+      stderr: "",
+    };
+  };
+  const runtime = new BridgeRuntime("acpx", run);
+
+  await expect(runtime.setSessionEffort({
+    agent: "codex",
+    cwd: "/repo",
+    name: "s1",
+    effort: "extreme",
+  })).rejects.toThrow('reasoning effort "extreme" is not advertised');
+  expect(calls.some((args) => args.includes("set"))).toBe(false);
+});
+
+test("effort get/set apply the bridged provider execution environment", async () => {
+  const environments: Array<NodeJS.ProcessEnv | undefined> = [];
+  const run = async (_command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
+    environments.push(options?.env);
+    return {
+      code: 0,
+      stdout: args.includes("sessions")
+        ? JSON.stringify({
+            acpx: { config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "medium",
+              options: [{ value: "medium" }, { value: "high" }],
+            }] },
+          })
+        : "",
+      stderr: "",
+    };
+  };
+  const runtime = new BridgeRuntime("acpx", run, undefined, {
+    resolveSpawnEnvironment: ({ driver, settingsPolicy }) => ({
+      RESOLVED_DRIVER: driver ?? "",
+      RESOLVED_POLICY: settingsPolicy ?? "",
+    }),
+  });
+  const input = {
+    agent: "claude-provider",
+    driver: "claude" as const,
+    settingsPolicy: "provider-only" as const,
+    cwd: "/repo",
+    name: "s1",
+  };
+
+  await runtime.getSessionEffort(input);
+  await runtime.setSessionEffort({ ...input, effort: "high" });
+
+  expect(environments).toEqual([
+    { RESOLVED_DRIVER: "claude", RESOLVED_POLICY: "provider-only" },
+    { RESOLVED_DRIVER: "claude", RESOLVED_POLICY: "provider-only" },
+    { RESOLVED_DRIVER: "claude", RESOLVED_POLICY: "provider-only" },
+  ]);
+});

--- a/tests/unit/bridge/bridge-server.test.ts
+++ b/tests/unit/bridge/bridge-server.test.ts
@@ -104,6 +104,43 @@ test("forwards validated Claude settings policy metadata over ndjson", async () 
   }));
 });
 
+test("forwards Claude execution settings for effort get/set", async () => {
+  const captured: Record<string, unknown>[] = [];
+  const runtime = {
+    getSessionEffort: async (input: Record<string, unknown>) => {
+      captured.push(input);
+      return { available: [] };
+    },
+    setSessionEffort: async (input: Record<string, unknown>) => {
+      captured.push(input);
+      return {};
+    },
+  } as unknown as BridgeRuntime;
+  const server = new BridgeServer(runtime);
+  const params = {
+    agent: "claude-provider",
+    driver: "claude",
+    settingsPolicy: "provider-only",
+    cwd: "/repo",
+    name: "demo",
+  };
+
+  await server.handleLine(JSON.stringify({ id: "effort-get", method: "getSessionEffort", params }));
+  await server.handleLine(JSON.stringify({
+    id: "effort-set",
+    method: "setSessionEffort",
+    params: { ...params, effort: "high" },
+  }));
+
+  expect(captured).toHaveLength(2);
+  for (const input of captured) {
+    expect(input).toEqual(expect.objectContaining({
+      driver: "claude",
+      settingsPolicy: "provider-only",
+    }));
+  }
+});
+
 test("reuses an existing session when ensure fails but status probe finds it", async () => {
   const calls: string[][] = [];
   const runtime = new BridgeRuntime("acpx", async (_command, args) => {

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -256,3 +256,32 @@ test("setSessionEffort applies the selected value through the transport", async 
   });
   expect(calls).toEqual(["effort:internal-backend:high"]);
 });
+
+test("setSessionEffort serializes rapid mutations for the same session", async () => {
+  const { deps, calls } = makeDeps();
+  let releaseFirst!: () => void;
+  let markFirstStarted!: () => void;
+  const firstStarted = new Promise<void>((resolve) => { markFirstStarted = resolve; });
+  deps.transport.setSessionEffort = async (s: typeof session, effort: string) => {
+    calls.push(`effort:${s.alias}:${effort}`);
+    if (effort === "low") {
+      markFirstStarted();
+      await new Promise<void>((resolve) => { releaseFirst = resolve; });
+    }
+  };
+  const control = new ControlService(deps as never);
+
+  const first = control.setSessionEffort("relay:acc", "backend", "low");
+  await firstStarted;
+  const second = control.setSessionEffort("relay:acc", "backend", "high");
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+
+  expect(calls).toEqual(["effort:internal-backend:low"]);
+  releaseFirst();
+  await expect(first).resolves.toEqual({ current: "low", applied: true });
+  await expect(second).resolves.toEqual({ current: "high", applied: true });
+  expect(calls).toEqual([
+    "effort:internal-backend:low",
+    "effort:internal-backend:high",
+  ]);
+});

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -257,6 +257,89 @@ test("setSessionEffort applies the selected value through the transport", async 
   expect(calls).toEqual(["effort:internal-backend:high"]);
 });
 
+test("setSessionEffort reconciles a timed-out write that acpx actually applied", async () => {
+  const { deps, calls, logs } = makeDeps();
+  deps.transport.setSessionEffort = async () => {
+    calls.push("effort:internal-backend:high");
+    throw new CommandTimeoutError(30_000, "acpx set effort", { stage: "set-session-effort" });
+  };
+  deps.transport.getSessionEffort = async () => {
+    calls.push("query-effort:internal-backend");
+    return { current: "high", available: ["low", "medium", "high"] };
+  };
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionEffort("relay:acc", "backend", "high")).resolves.toEqual({
+    current: "high",
+    applied: true,
+  });
+  expect(calls).toEqual([
+    "effort:internal-backend:high",
+    "query-effort:internal-backend",
+  ]);
+  expect(logs).toEqual([{
+    event: "control.session.effort.timeout_reconciled",
+    message: "Effort switch timed out; adopted authoritative transport state",
+    context: {
+      sessionAlias: "internal-backend",
+      requestedEffort: "high",
+      observedEffort: "high",
+      timeout: "acpx command timed out during set-session-effort after 30s: acpx set effort",
+    },
+  }]);
+});
+
+test("setSessionEffort returns the authoritative effort when timeout readback observes another value", async () => {
+  const { deps } = makeDeps();
+  deps.transport.setSessionEffort = async () => {
+    throw new CommandTimeoutError(30_000, "acpx set effort", { stage: "set-session-effort" });
+  };
+  deps.transport.getSessionEffort = async () => ({
+    current: "medium",
+    available: ["low", "medium", "high"],
+  });
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionEffort("relay:acc", "backend", "high")).resolves.toEqual({
+    current: "medium",
+    applied: false,
+  });
+});
+
+test("setSessionEffort preserves the original timeout when effort readback fails", async () => {
+  const { deps } = makeDeps();
+  const timeout = new CommandTimeoutError(30_000, "acpx set effort", { stage: "set-session-effort" });
+  deps.transport.setSessionEffort = async () => { throw timeout; };
+  deps.transport.getSessionEffort = async () => { throw new Error("readback failed"); };
+  const control = new ControlService(deps as never);
+
+  let caught: unknown;
+  try {
+    await control.setSessionEffort("relay:acc", "backend", "high");
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBe(timeout);
+});
+
+test("setSessionEffort reconciliation succeeds even when diagnostic logging fails", async () => {
+  const { deps } = makeDeps();
+  deps.transport.setSessionEffort = async () => {
+    throw new CommandTimeoutError(30_000, "acpx set effort", { stage: "set-session-effort" });
+  };
+  deps.transport.getSessionEffort = async () => ({
+    current: "high",
+    available: ["low", "medium", "high"],
+  });
+  deps.logger.error = async () => { throw new Error("logger unavailable"); };
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionEffort("relay:acc", "backend", "high")).resolves.toEqual({
+    current: "high",
+    applied: true,
+  });
+});
+
 test("setSessionEffort serializes rapid mutations for the same session", async () => {
   const { deps, calls } = makeDeps();
   let releaseFirst!: () => void;

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -23,6 +23,8 @@ function makeDeps() {
     transport: {
       getSessionModel: async (s: typeof session) => ({ current: s.model, available: ["gpt-5.2[high]", "gpt-5.2[low]"] }),
       setModel: async (s: typeof session, id: string) => { calls.push(`transport:${s.alias}:${id}`); },
+      getSessionEffort: async () => ({ current: "medium", available: ["low", "medium", "high"] }),
+      setSessionEffort: async (s: typeof session, effort: string) => { calls.push(`effort:${s.alias}:${effort}`); },
     },
     logger: {
       error: async (event: string, message: string, context?: Record<string, unknown>) => {
@@ -234,4 +236,23 @@ test("getSessionModel falls back to the resolved model when the transport can't 
   const control = new ControlService(deps as never);
   const r = await control.getSessionModel("relay:acc", "backend");
   expect(r).toEqual({ current: "gpt-5.2[high]", available: [] });
+});
+
+test("getSessionEffort returns the adapter-advertised values", async () => {
+  const { deps } = makeDeps();
+  const control = new ControlService(deps as never);
+  await expect(control.getSessionEffort("relay:acc", "backend")).resolves.toEqual({
+    current: "medium",
+    available: ["low", "medium", "high"],
+  });
+});
+
+test("setSessionEffort applies the selected value through the transport", async () => {
+  const { deps, calls } = makeDeps();
+  const control = new ControlService(deps as never);
+  await expect(control.setSessionEffort("relay:acc", "backend", "high")).resolves.toEqual({
+    current: "high",
+    applied: true,
+  });
+  expect(calls).toEqual(["effort:internal-backend:high"]);
 });

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -57,6 +57,8 @@ function makeFakeControl(overrides: Record<string, unknown> = {}) {
       return { cancelled: true };
     },
     executeCommand: async (input: unknown) => { record("executeCommand", input); return "output"; },
+    getSessionEffort: async () => ({ current: "medium", available: ["low", "medium", "high"] }),
+    setSessionEffort: async (_chatKey: string, _alias: string, effort: string) => ({ current: effort, applied: true }),
     listScheduledTasks: (chatKey: string) => [{
       id: "ab12", chat_key: chatKey, session_alias: "a",
       execute_at: "2026-06-14T10:00:00.000Z", message: "m", status: "pending", created_at: "2026-06-13T10:00:00.000Z",
@@ -155,6 +157,32 @@ test("session.model.set returns the authoritative reconciled model", async () =>
     sessionAlias: "a",
     modelId: "requested-model",
   }))).toEqual({ ok: false, current: "provider/fallback-model" });
+});
+
+test("session effort get/set dispatch through the structured control methods", async () => {
+  const calls: unknown[][] = [];
+  const { control } = makeFakeControl({
+    getSessionEffort: async (...args: unknown[]) => {
+      calls.push(["get", ...args]);
+      return { current: "medium", available: ["low", "medium", "high"] };
+    },
+    setSessionEffort: async (...args: unknown[]) => {
+      calls.push(["set", ...args]);
+      return { current: "high", applied: true };
+    },
+  });
+  const bridge = createControlBridge(control as never);
+
+  await expect(dispatch(bridge, req(MSG.sessionEffortGet, {
+    chatKey: "relay:acct", sessionAlias: "a",
+  }))).resolves.toEqual({ current: "medium", available: ["low", "medium", "high"] });
+  await expect(dispatch(bridge, req(MSG.sessionEffortSet, {
+    chatKey: "relay:acct", sessionAlias: "a", effort: "high",
+  }))).resolves.toEqual({ ok: true, current: "high" });
+  expect(calls).toEqual([
+    ["get", "relay:acct", "a"],
+    ["set", "relay:acct", "a", "high"],
+  ]);
 });
 
 test("session.model.set uses the earlier of the Hub deadline and connector work budget", async () => {
@@ -619,6 +647,7 @@ test("core-bounded / long RPC types are exempt from the connector timeout", asyn
     listNativeSessions: () => new Promise(() => {}),
     executeCommand: () => new Promise(() => {}),
     setSessionModel: () => new Promise(() => {}),
+    setSessionEffort: () => new Promise(() => {}),
   });
   const bridge = createControlBridge(control as never, seams);
 
@@ -629,6 +658,11 @@ test("core-bounded / long RPC types are exempt from the connector timeout", asyn
     chatKey: "relay:acct",
     sessionAlias: "a",
     modelId: "model-b",
+  }), () => {});
+  bridge(req(MSG.sessionEffortSet, {
+    chatKey: "relay:acct",
+    sessionAlias: "a",
+    effort: "high",
   }), () => {});
 
   // No timer armed for any exempt type.

--- a/tests/unit/packages/relay-protocol/payload-validators.test.ts
+++ b/tests/unit/packages/relay-protocol/payload-validators.test.ts
@@ -48,6 +48,18 @@ test("upload requires filename, content, mimeType strings", () => {
   expect(parseControlPayload(MSG.upload, { filename: "a", content: "b64" })).toBeNull();
 });
 
+test("session effort RPC payloads require a session alias and effort value", () => {
+  expect(parseControlPayload(MSG.sessionEffortGet, {
+    chatKey: "relay:a1", sessionAlias: "backend",
+  })).not.toBeNull();
+  expect(parseControlPayload(MSG.sessionEffortSet, {
+    chatKey: "relay:a1", sessionAlias: "backend", effort: "high",
+  })).not.toBeNull();
+  expect(parseControlPayload(MSG.sessionEffortSet, {
+    chatKey: "relay:a1", sessionAlias: "backend",
+  })).toBeNull();
+});
+
 test("Git RPC payloads accept only structured operations", () => {
   expect(parseControlPayload(MSG.gitStatus, { workspace: "project" })).not.toBeNull();
   expect(parseControlPayload(MSG.gitStage, { workspace: "project", paths: ["a.ts"] })).not.toBeNull();

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -299,6 +299,29 @@ test("session archive/unarchive RPCs are chat-scoped (chatKey stamped, else the 
   }
 });
 
+test("session effort RPCs are chat-scoped", async () => {
+  const { app, instances, loginToken, login, rpcCalls } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const redeemed = instances.redeemPairingToken(token)!;
+
+  for (const [type, payload] of [
+    [MSG.sessionEffortGet, { sessionAlias: "s" }],
+    [MSG.sessionEffortSet, { sessionAlias: "s", effort: "high" }],
+  ] as const) {
+    rpcCalls.length = 0;
+    const res = await app.request(`/api/instances/${redeemed.instanceId}/rpc`, {
+      method: "POST", headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ type, payload }),
+    });
+    expect(res.status).toBe(200);
+    expect((rpcCalls[0]?.payload as { chatKey?: string }).chatKey).toBe(`relay:${redeemed.accountId}`);
+  }
+});
+
 test("queue.cancel RPC is chat-scoped (chatKey stamped, else the connector's cancel is a no-op)", async () => {
   const { app, instances, loginToken, login, rpcCalls } = await makeApp();
   const { cookie } = await login(loginToken);

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-client.test.ts
@@ -448,6 +448,7 @@ describe("per-request timeout", () => {
     expect(bridgeRequestTimeoutMs("cancel")).toBe(45_000);
     expect(bridgeRequestTimeoutMs("hasSession")).toBe(45_000);
     expect(bridgeRequestTimeoutMs("setMode")).toBe(45_000);
+    expect(bridgeRequestTimeoutMs("setSessionEffort")).toBe(75_000);
   });
 
   test("a response arriving in time clears the armed timer", async () => {

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-model.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-model.test.ts
@@ -42,3 +42,20 @@ test("getSessionModel proxies and returns the result", async () => {
   expect(result).toEqual({ current: "gpt-5.2[high]", available: ["gpt-5.2[high]"] });
   expect(request.mock.calls[0][0]).toBe("getSessionModel");
 });
+
+test("getSessionEffort proxies and returns the result", async () => {
+  const request = mock(async () => ({ current: "high", available: ["medium", "high"] }));
+  const transport = new AcpxBridgeTransport({ request });
+  await expect(transport.getSessionEffort(session)).resolves.toEqual({
+    current: "high",
+    available: ["medium", "high"],
+  });
+  expect(request.mock.calls[0][0]).toBe("getSessionEffort");
+});
+
+test("setSessionEffort proxies the selected value", async () => {
+  const request = mock(async () => ({}));
+  const transport = new AcpxBridgeTransport({ request });
+  await transport.setSessionEffort(session, "xhigh");
+  expect(request).toHaveBeenCalledWith("setSessionEffort", expect.objectContaining({ effort: "xhigh" }));
+});

--- a/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
@@ -118,3 +118,66 @@ test("getSessionModel returns an empty available list when status output is not 
   const result = await transport.getSessionModel(modelSession);
   expect(result.available).toEqual([]);
 });
+
+test("getSessionEffort reads the adapter-advertised thought-level config option", async () => {
+  const record = JSON.stringify({
+    acpx: {
+      config_options: [
+        {
+          id: "reasoning_effort",
+          category: "thought_level",
+          currentValue: "medium",
+          options: [
+            { value: "low", name: "Low" },
+            { value: "medium", name: "Medium" },
+            { value: "high", name: "High" },
+          ],
+        },
+      ],
+    },
+  });
+  const run = mock(async () => ({ code: 0, stdout: record, stderr: "" }));
+  const transport = new AcpxCliTransport({ command: "acpx" }, run, okRunner());
+
+  await expect(transport.getSessionEffort(modelSession)).resolves.toEqual({
+    current: "medium",
+    available: ["low", "medium", "high"],
+  });
+  const args = run.mock.calls[0][1] as string[];
+  expect(args).toContain("sessions");
+  expect(args).toContain("show");
+  expect(args).toContain("backend:api-fix");
+  expect(args.slice(0, 2)).toEqual(["--format", "json"]);
+});
+
+test("setSessionEffort uses the config id advertised by the adapter", async () => {
+  const calls: string[][] = [];
+  const run = mock(async (_command: string, args: string[]) => {
+    calls.push(args);
+    if (args.includes("sessions")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpx: {
+            config_options: [{
+              id: "effort",
+              category: "thought_level",
+              currentValue: "medium",
+              options: [{ value: "medium" }, { value: "high" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const transport = new AcpxCliTransport({ command: "acpx" }, run, okRunner());
+
+  await transport.setSessionEffort(modelSession, "high");
+
+  const setArgs = calls.find((args) => args.includes("set"));
+  expect(setArgs?.slice(setArgs.indexOf("set"))).toEqual([
+    "set", "-s", "backend:api-fix", "effort", "high",
+  ]);
+});

--- a/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
@@ -150,6 +150,37 @@ test("getSessionEffort reads the adapter-advertised thought-level config option"
   expect(args.slice(0, 2)).toEqual(["--format", "json"]);
 });
 
+test("getSessionEffort flattens adapter-advertised grouped effort options", async () => {
+  const record = JSON.stringify({
+    acpx: {
+      config_options: [{
+        id: "reasoning_effort",
+        category: "thought_level",
+        currentValue: "high",
+        options: [
+          {
+            group: "standard",
+            name: "Standard",
+            options: [{ value: "low" }, { value: "medium" }, { value: "high" }],
+          },
+          {
+            group: "extended",
+            name: "Extended",
+            options: [{ value: "xhigh" }],
+          },
+        ],
+      }],
+    },
+  });
+  const run = mock(async () => ({ code: 0, stdout: record, stderr: "" }));
+  const transport = new AcpxCliTransport({ command: "acpx" }, run, okRunner());
+
+  await expect(transport.getSessionEffort(modelSession)).resolves.toEqual({
+    current: "high",
+    available: ["low", "medium", "high", "xhigh"],
+  });
+});
+
 test("setSessionEffort uses the config id advertised by the adapter", async () => {
   const calls: string[][] = [];
   const run = mock(async (_command: string, args: string[]) => {

--- a/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-model.test.ts
@@ -212,3 +212,73 @@ test("setSessionEffort uses the config id advertised by the adapter", async () =
     "set", "-s", "backend:api-fix", "effort", "high",
   ]);
 });
+
+test("setSessionEffort rejects values not advertised by the adapter", async () => {
+  const calls: string[][] = [];
+  const run = mock(async (_command: string, args: string[]) => {
+    calls.push(args);
+    return {
+      code: 0,
+      stdout: JSON.stringify({
+        acpx: { config_options: [{
+          id: "reasoning_effort",
+          category: "thought_level",
+          currentValue: "medium",
+          options: [{ value: "medium" }, { value: "high" }],
+        }] },
+      }),
+      stderr: "",
+    };
+  });
+  const transport = new AcpxCliTransport({ command: "acpx" }, run, okRunner());
+
+  await expect(transport.setSessionEffort(modelSession, "extreme")).rejects.toThrow(
+    'reasoning effort "extreme" is not advertised',
+  );
+  expect(calls.some((args) => args.includes("set"))).toBe(false);
+});
+
+test("effort get/set apply the session's resolved provider environment", async () => {
+  const options: Array<{ env?: NodeJS.ProcessEnv } | undefined> = [];
+  const run = mock(async (_command: string, args: string[], runOptions?: { env?: NodeJS.ProcessEnv }) => {
+    options.push(runOptions);
+    return {
+      code: 0,
+      stdout: args.includes("sessions")
+        ? JSON.stringify({
+            acpx: { config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "medium",
+              options: [{ value: "medium" }, { value: "high" }],
+            }] },
+          })
+        : "",
+      stderr: "",
+    };
+  });
+  const transport = new AcpxCliTransport({
+    command: "acpx",
+    resolveSpawnEnvironment: ({ driver, settingsPolicy }) => ({
+      RESOLVED_DRIVER: driver ?? "",
+      RESOLVED_POLICY: settingsPolicy ?? "",
+    }),
+  }, run, okRunner());
+  const providerSession = {
+    ...modelSession,
+    agent: "claude-provider",
+    driver: "claude" as const,
+    settingsPolicy: "provider-only" as const,
+  };
+
+  await transport.getSessionEffort(providerSession);
+  await transport.setSessionEffort(providerSession, "high");
+
+  expect(options).toHaveLength(3);
+  for (const runOptions of options) {
+    expect(runOptions?.env).toEqual({
+      RESOLVED_DRIVER: "claude",
+      RESOLVED_POLICY: "provider-only",
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- discover adapter-advertised effort options through existing acpx session records
- add effort get/set across transport, control, Relay protocol, and connector layers
- add a Relay Web effort selector that only appears when the adapter advertises choices
- support both flat and grouped ACP option shapes without modifying upstream acpx

## Testing
- focused core and Relay tests: 155 passed
- Relay Web Vitest: 19 passed
- npx tsc --noEmit
- git diff --check origin/main...HEAD
- full npm test passed before rebasing onto current origin/main (Relay Web: 102 files, 812 tests)