### PR TITLE
Fix Claude background session-id tracking

### DIFF
--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -569,7 +569,7 @@ export class BridgeRuntime {
       "sessions",
       "show",
       input.name,
-    ]));
+    ], { format: "json" }));
     const result = await this.run(spawnSpec.command, spawnSpec.args, this.withSpawnEnvironment(input, {
       timeoutMs: this.managementCommandTimeoutMs(),
       stage: "read-session-record",

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -584,7 +584,7 @@ export class AcpxCliTransport implements SessionTransport {
       "sessions",
       "show",
       session.transportSession,
-    ]), this.withSpawnEnvironment(session, {
+    ], "json"), this.withSpawnEnvironment(session, {
       timeoutMs: this.managementCommandTimeoutMs,
       stage: "read-session-record",
     }));
@@ -915,8 +915,8 @@ export class AcpxCliTransport implements SessionTransport {
     };
   }
 
-  private buildArgs(session: ResolvedSession, tail: string[]): string[] {
-    return sharedBuildSessionArgs(this.sessionInput(session), tail, { format: "quiet" });
+  private buildArgs(session: ResolvedSession, tail: string[], format: "quiet" | "json" = "quiet"): string[] {
+    return sharedBuildSessionArgs(this.sessionInput(session), tail, { format });
   }
 
   private buildAgentQueryArgs(query: AgentSessionListQuery, format: "json" | "quiet", tail: string[]): string[] {

--- a/src/transport/acpx-command-builder.ts
+++ b/src/transport/acpx-command-builder.ts
@@ -110,9 +110,13 @@ export function parseAcpxSessionRecordId(
     const acpxRecordId = typeof parsed.acpxRecordId === "string"
       ? parsed.acpxRecordId
       : typeof parsed.id === "string" ? parsed.id : undefined;
-    const agentSessionId = typeof parsed.acpSessionId === "string"
+    const providerSessionId = typeof parsed.agentSessionId === "string" && parsed.agentSessionId.length > 0
+      ? parsed.agentSessionId
+      : undefined;
+    const acpSessionId = typeof parsed.acpSessionId === "string" && parsed.acpSessionId.length > 0
       ? parsed.acpSessionId
-      : typeof parsed.agentSessionId === "string" ? parsed.agentSessionId : undefined;
+      : undefined;
+    const agentSessionId = providerSessionId ?? acpSessionId;
     if (acpxRecordId && /^[\w.:-]+$/.test(acpxRecordId) && acpxRecordId.length >= 8) {
       return { acpxRecordId, agentSessionId };
     }

--- a/src/transport/acpx-command-builder.ts
+++ b/src/transport/acpx-command-builder.ts
@@ -101,11 +101,18 @@ export function parseAcpxSessionRecordId(
   stdout: string,
 ): { acpxRecordId: string; agentSessionId?: string } | undefined {
   try {
-    const parsed = JSON.parse(stdout) as { acpxRecordId?: unknown; id?: unknown; agentSessionId?: unknown };
+    const parsed = JSON.parse(stdout) as {
+      acpxRecordId?: unknown;
+      id?: unknown;
+      acpSessionId?: unknown;
+      agentSessionId?: unknown;
+    };
     const acpxRecordId = typeof parsed.acpxRecordId === "string"
       ? parsed.acpxRecordId
       : typeof parsed.id === "string" ? parsed.id : undefined;
-    const agentSessionId = typeof parsed.agentSessionId === "string" ? parsed.agentSessionId : undefined;
+    const agentSessionId = typeof parsed.acpSessionId === "string"
+      ? parsed.acpSessionId
+      : typeof parsed.agentSessionId === "string" ? parsed.agentSessionId : undefined;
     if (acpxRecordId && /^[\w.:-]+$/.test(acpxRecordId) && acpxRecordId.length >= 8) {
       return { acpxRecordId, agentSessionId };
     }

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -1122,12 +1122,16 @@ test("bridge runtime retries native session listing without --filter-cwd when un
   expect(calls[1]).not.toContain("--filter-cwd");
 });
 
-test("getAgentSessionId returns the agentSessionId from sessions show", async () => {
-  const run = async (_command: string, _args: string[]) => ({
-    code: 0,
-    stdout: JSON.stringify({ acpxRecordId: "acpx-rec-1", agentSessionId: "agent-xyz" }),
-    stderr: "",
-  });
+test("getAgentSessionId requests JSON and returns acpx 0.12 acpSessionId", async () => {
+  const calls: string[][] = [];
+  const run = async (_command: string, args: string[]) => {
+    calls.push(args);
+    return {
+      code: 0,
+      stdout: JSON.stringify({ acpxRecordId: "acpx-rec-1", acpSessionId: "agent-xyz" }),
+      stderr: "",
+    };
+  };
   const runtime = new BridgeRuntime("acpx", run);
 
   const result = await runtime.getAgentSessionId({
@@ -1138,6 +1142,7 @@ test("getAgentSessionId returns the agentSessionId from sessions show", async ()
   });
 
   expect(result).toEqual({ agentSessionId: "agent-xyz" });
+  expect(calls[0]).toEqual(expect.arrayContaining(["--format", "json", "sessions", "show", "backend:review"]));
 });
 
 test("getAgentSessionId returns undefined agentSessionId when absent", async () => {

--- a/tests/unit/bridge/golden/fixtures/delete-session-bare-id.json
+++ b/tests/unit/bridge/golden/fixtures/delete-session-bare-id.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)",
+    "run(acpx --format json --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)",
     "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions close backend:demo @30000)"
   ],
   "outcome": {

--- a/tests/unit/bridge/golden/fixtures/delete-session-json-record.json
+++ b/tests/unit/bridge/golden/fixtures/delete-session-json-record.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)",
+    "run(acpx --format json --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)",
     "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions close backend:demo @30000)"
   ],
   "outcome": {

--- a/tests/unit/bridge/golden/fixtures/delete-session-malformed.json
+++ b/tests/unit/bridge/golden/fixtures/delete-session-malformed.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)"
+    "run(acpx --format json --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)"
   ],
   "outcome": {
     "threw": "failed to resolve acpx session record id"

--- a/tests/unit/bridge/golden/fixtures/record-id-only-fallback.json
+++ b/tests/unit/bridge/golden/fixtures/record-id-only-fallback.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "run(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)"
+    "run(acpx --format json --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)"
   ],
   "outcome": {
     "ok": {

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -2227,10 +2227,10 @@ test("onCommands: handler error rejects the prompt", async () => {
   ).rejects.toThrow("commands handler boom");
 });
 
-test("getAgentSessionId returns the agentSessionId from sessions show", async () => {
+test("getAgentSessionId requests JSON and returns acpx 0.12 acpSessionId", async () => {
   const run = mock(async () => ({
     code: 0,
-    stdout: JSON.stringify({ acpxRecordId: "acpx-rec-1", agentSessionId: "agent-xyz" }),
+    stdout: JSON.stringify({ acpxRecordId: "acpx-rec-1", acpSessionId: "agent-xyz" }),
     stderr: "",
   }));
   const runPty = mock(async () => ({ code: 0, stdout: "", stderr: "" }));
@@ -2241,7 +2241,7 @@ test("getAgentSessionId returns the agentSessionId from sessions show", async ()
   expect(id).toBe("agent-xyz");
   expect(run).toHaveBeenCalledWith(
     "acpx",
-    expect.arrayContaining(["sessions", "show", "backend:api-fix"]),
+    expect.arrayContaining(["--format", "json", "sessions", "show", "backend:api-fix"]),
     expect.objectContaining({ timeoutMs: 30_000 }),
   );
 });

--- a/tests/unit/transport/acpx-command-builder.test.ts
+++ b/tests/unit/transport/acpx-command-builder.test.ts
@@ -76,6 +76,8 @@ describe("isMissingAcpxSessionError", () => {
 });
 
 describe("parseAcpxSessionRecordId", () => {
+  test("acpx 0.12 json acpxRecordId + acpSessionId", () =>
+    expect(parseAcpxSessionRecordId('{"acpxRecordId":"abcd1234","acpSessionId":"z"}')).toEqual({ acpxRecordId: "abcd1234", agentSessionId: "z" }));
   test("json acpxRecordId + agentSessionId", () =>
     expect(parseAcpxSessionRecordId('{"acpxRecordId":"abcd1234","agentSessionId":"z"}')).toEqual({ acpxRecordId: "abcd1234", agentSessionId: "z" }));
   test("json id fallback", () =>

--- a/tests/unit/transport/acpx-command-builder.test.ts
+++ b/tests/unit/transport/acpx-command-builder.test.ts
@@ -80,6 +80,21 @@ describe("parseAcpxSessionRecordId", () => {
     expect(parseAcpxSessionRecordId('{"acpxRecordId":"abcd1234","acpSessionId":"z"}')).toEqual({ acpxRecordId: "abcd1234", agentSessionId: "z" }));
   test("json acpxRecordId + agentSessionId", () =>
     expect(parseAcpxSessionRecordId('{"acpxRecordId":"abcd1234","agentSessionId":"z"}')).toEqual({ acpxRecordId: "abcd1234", agentSessionId: "z" }));
+  test("prefers provider-native agentSessionId when both session ids are present", () =>
+    expect(parseAcpxSessionRecordId('{"acpxRecordId":"abcd1234","acpSessionId":"acp-session","agentSessionId":"native-session"}')).toEqual({
+      acpxRecordId: "abcd1234",
+      agentSessionId: "native-session",
+    }));
+  test("falls back to acpSessionId when agentSessionId is empty", () =>
+    expect(parseAcpxSessionRecordId('{"acpxRecordId":"abcd1234","acpSessionId":"acp-session","agentSessionId":""}')).toEqual({
+      acpxRecordId: "abcd1234",
+      agentSessionId: "acp-session",
+    }));
+  test("ignores an empty acpSessionId when agentSessionId is present", () =>
+    expect(parseAcpxSessionRecordId('{"acpxRecordId":"abcd1234","acpSessionId":"","agentSessionId":"native-session"}')).toEqual({
+      acpxRecordId: "abcd1234",
+      agentSessionId: "native-session",
+    }));
   test("json id fallback", () =>
     expect(parseAcpxSessionRecordId('{"id":"abcd1234"}')).toEqual({ acpxRecordId: "abcd1234", agentSessionId: undefined }));
   test("bare first line when JSON.parse throws", () =>

--- a/tests/unit/transport/golden/fixtures/cli/delete-session-bare-id.json
+++ b/tests/unit/transport/golden/fixtures/cli/delete-session-bare-id.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)",
+    "runCommand(acpx --format json --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)",
     "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions close backend:demo @30000)"
   ],
   "outcome": {}

--- a/tests/unit/transport/golden/fixtures/cli/delete-session-json-record.json
+++ b/tests/unit/transport/golden/fixtures/cli/delete-session-json-record.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)",
+    "runCommand(acpx --format json --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)",
     "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions close backend:demo @30000)"
   ],
   "outcome": {}

--- a/tests/unit/transport/golden/fixtures/cli/delete-session-malformed.json
+++ b/tests/unit/transport/golden/fixtures/cli/delete-session-malformed.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)"
+    "runCommand(acpx --format json --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)"
   ],
   "outcome": {
     "threw": "failed to resolve acpx session record id"

--- a/tests/unit/transport/golden/fixtures/cli/record-id-only-fallback.json
+++ b/tests/unit/transport/golden/fixtures/cli/record-id-only-fallback.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "runCommand(acpx --format quiet --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)"
+    "runCommand(acpx --format json --cwd /tmp/backend --approve-all --non-interactive-permissions deny codex sessions show backend:demo @30000)"
   ],
   "outcome": {
     "ok": "agent-from-id"


### PR DESCRIPTION
## Summary
- request JSON from `acpx sessions show` when resolving the session id used by Claude background continuation
- prefer a non-empty provider-native `agentSessionId`, with a non-empty `acpSessionId` fallback for existing acpx/Claude records
- cover both CLI and bridge transports, their golden command contracts, and ID conflict/empty-value precedence

## Root cause
The Claude background continuation follower needs a usable session id after the initial ACP request ends. Both transport paths queried `sessions show` with `--format quiet`, which returns only the local acpx record id. Some real Claude records expose the usable transcript id as `acpSessionId`, while newer records can also expose the provider-native `agentSessionId`. The old code therefore reached `session id unavailable` and stopped forwarding later subagent activity and the final response to Relay Web.

## Resolution
Both transport paths now read the JSON session record. The parser selects a non-empty provider-native `agentSessionId` first and falls back to a non-empty `acpSessionId`, preserving compatibility with the reported Windows session without overriding a more authoritative native ID.

## Validation
- red test reproduced the incorrect ID precedence before the review fix
- 249 focused transport/bridge tests passed
- `npx tsc --noEmit`
- `bun run build`
- `git diff --check origin/main...HEAD`
- built bridge resolved the session id from the reported real Windows record
- independent subagent review found no remaining merge blockers

## Known unrelated issue
The full local Windows unit run still stops on four existing path-separator assertions in `tests/unit/commands/command-router-config.test.ts`; the PR-specific suites and GitHub Actions are used as the merge gate.