### PR TITLE
fix(config): preserve files write gate

### DIFF
--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -228,11 +228,18 @@ export function parseConfig(
   const channel = raw.channel;
   const legacyWechat = raw.wechat;
   const orchestration = raw.orchestration;
+  const files = raw.files;
   if (logging !== undefined && !isRecord(logging)) {
     throw new Error("logging must be an object");
   }
   if (orchestration !== undefined && !isRecord(orchestration)) {
     throw new Error("orchestration must be an object");
+  }
+  if (files !== undefined && !isRecord(files)) {
+    throw new Error("files must be an object");
+  }
+  if (isRecord(files) && "writeEnabled" in files && typeof files.writeEnabled !== "boolean") {
+    throw new Error("files.writeEnabled must be boolean");
   }
   if (
     isRecord(logging) &&
@@ -413,6 +420,9 @@ export function parseConfig(
               : {}),
           },
         }
+      : {}),
+    ...(isRecord(files)
+      ? { files: { writeEnabled: files.writeEnabled === true } }
       : {}),
   };
 }

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -235,7 +235,7 @@ export function parseConfig(
   if (orchestration !== undefined && !isRecord(orchestration)) {
     throw new Error("orchestration must be an object");
   }
-  if (files !== undefined && !isRecord(files)) {
+  if (files !== undefined && (!isRecord(files) || Array.isArray(files))) {
     throw new Error("files must be an object");
   }
   if (isRecord(files) && "writeEnabled" in files && typeof files.writeEnabled !== "boolean") {

--- a/tests/unit/config/files-config.test.ts
+++ b/tests/unit/config/files-config.test.ts
@@ -35,6 +35,24 @@ test("loadConfig preserves files.writeEnabled for runtime Git mutations", async 
   }
 });
 
+test("loadConfig rejects files arrays", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "xacpx-files-config-"));
+  const path = join(dir, "config.json");
+
+  try {
+    await writeFile(path, JSON.stringify({
+      transport: {},
+      agents: {},
+      workspaces: {},
+      files: [],
+    }));
+
+    await expect(loadConfig(path)).rejects.toThrow("files must be an object");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("parseConfig rejects invalid files.writeEnabled values", () => {
   const raw = { transport: {}, agents: {}, workspaces: {} };
 

--- a/tests/unit/config/files-config.test.ts
+++ b/tests/unit/config/files-config.test.ts
@@ -1,4 +1,8 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, parseConfig } from "../../../src/config/load-config";
 import { filesWriteEnabled, type AppConfig } from "../../../src/config/types";
 
 const base = {} as AppConfig; // helper only touches `.files`
@@ -8,4 +12,34 @@ test("filesWriteEnabled defaults to false when unset", () => {
 test("filesWriteEnabled is true only when writeEnabled === true", () => {
   expect(filesWriteEnabled({ ...base, files: { writeEnabled: true } })).toBe(true);
   expect(filesWriteEnabled({ ...base, files: { writeEnabled: false } })).toBe(false);
+});
+
+test("loadConfig preserves files.writeEnabled for runtime Git mutations", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "xacpx-files-config-"));
+  const path = join(dir, "config.json");
+
+  try {
+    await writeFile(path, JSON.stringify({
+      transport: {},
+      agents: {},
+      workspaces: {},
+      files: { writeEnabled: true },
+    }));
+
+    const config = await loadConfig(path);
+
+    expect(config.files).toEqual({ writeEnabled: true });
+    expect(filesWriteEnabled(config)).toBe(true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseConfig rejects invalid files.writeEnabled values", () => {
+  const raw = { transport: {}, agents: {}, workspaces: {} };
+
+  expect(() => parseConfig({ ...raw, files: true })).toThrow("files must be an object");
+  expect(() => parseConfig({ ...raw, files: { writeEnabled: "true" } })).toThrow(
+    "files.writeEnabled must be boolean",
+  );
 });


### PR DESCRIPTION
## Summary

- preserve files.writeEnabled when loading JSON configuration
- reject invalid files and files.writeEnabled value types
- add regression coverage through the public loadConfig path

## Root cause

The config type and runtime gate supported files.writeEnabled, but parseConfig omitted files from the returned runtime configuration. The gate therefore always observed the default false value.

## Validation

- bun test tests/unit/config/files-config.test.ts
- bun test tests/unit/config tests/unit/control/control-service-git.test.ts (158 passed)
- npx tsc --noEmit
- bun run build
- focused runtime check against the configured local JSON returned enabled: true

## Full-suite note

npm test reaches an unrelated existing failure in tests/unit/bridge/bridge-runtime.test.ts: getAgentSessionId expects the JSON query to be the first recorded call, but receives a quiet query first. The same failure reproduces when that file is run alone; no task-related tests fail.