### PR TITLE
fix(relay-web): show queued prompts when they start

### DIFF
--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -84,7 +84,8 @@
 - **`queues`** — 交互式 `prompt`（`queueable: true`）遇忙时把提示词追加进 per-session FIFO
   队列并回 `{ ok: true, queued: true, queueItemId }`；定时轮次（非 `queueable`）遇忙则直接回
   `{ ok: false, errorMessage: "turn-already-running" }`，不入队。turn 结束时按 FIFO 依次
-  drain，每个队列头作为下一轮 turn 运行。
+  drain，每个队列头作为下一轮 turn 运行；其 `turn-started` 同时携带原 prompt 与
+  `queueItemId`，让 Relay Web 精确关联入队时的乐观消息和实际执行位置。
 - **`draining`** — 一轮结束到下一轮（drained head）重新注册 `inFlight` 之间的短暂交接窗口
   里，`submit` 把 `draining.has(key)` 也视为忙态，防止有提示词在这个缝隙里起并行 turn。
 

--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -85,7 +85,9 @@
 - **`GET /api/instances/:id/sessions/:alias/messages`**：按登录账号返回该会话的缓存历史。
 - **真实删除同步清历史**：`control.sessions.remove` 经 connector 成功确认后，Hub 删除对应
   `(instance_id, session_alias)` 的缓存消息；归档不删除，因此恢复归档会话仍能看到历史。
-- **prompt 回显历史**：`control.prompt` 经 RPC 代理时，把 prompt 文本 append 为一条 `in` 历史消息。
+- **prompt 回显历史**：`control.prompt` 经 RPC 代理时，把 prompt 文本 append 为一条 `in` 历史消息；
+  若返回 `queued + queueItemId`，Hub 在对应出队 `turn-started` 到达时把同一行移动到真实执行点，
+  因而刷新后的历史仍按“上一轮回复 → 出队 prompt”排列。
 - **command 回显历史（阶段四）**：`control.command.execute` 经 RPC 代理时，把输入文本 append 为 `in`、
   把返回 `output` append 为 `out`（与 `control.prompt` 的 `in` 回显并列），使 `/命令` 结果也能跨 reload 存活。
 - **`--web-root` 静态托管**：`createRelayRuntime({ webRoot })` → Hono `serveStatic` 托管 SPA

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -85,6 +85,9 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
 - **prompt RPC 超时被吞掉**：`control.prompt` 的 RPC 超时（HTTP 504 / `ApiError.code "timeout"`）视为**非致命**——
   回合结果仍会经 `/ws` 事件流（`turn-output`/`turn-finished`）抵达，因此长回合不会冒出多余的错误横幅，消息也不标记为失败。
   `/命令`（`control.command.execute`，纯请求/响应、无流式）超时**仍会浮现**。
+- **排队 prompt 的执行顺序**：入队响应的 `queueItemId` 会写到乐观消息；对应
+  `turn-started` 到达时，store 移动这条原消息到上一轮回复之后（保留附件且不重复）。若事件与 RPC
+  响应竞态，则仍以同一 id 合并；回合结束后 Hub 历史以相同顺序收敛。
 
 ## Subagent 执行轨迹
 

--- a/packages/relay-protocol/dist/index.js
+++ b/packages/relay-protocol/dist/index.js
@@ -264,7 +264,7 @@ function validControlEvent(e) {
     case "scheduled-changed":
       return typeof c.chatKey === "string";
     case "turn-started":
-      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string";
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && optStr(c.prompt) && optStr(c.queueItemId);
     case "turn-thought":
       return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
     case "plan":

--- a/packages/relay-protocol/dist/web-dtos.d.ts
+++ b/packages/relay-protocol/dist/web-dtos.d.ts
@@ -23,6 +23,9 @@ export interface MessageRecordDto {
     direction: MessageDirection;
     text: string;
     createdAt: string;
+    /** Present while an inbound Web prompt is queued, so a history reload can still
+     *  associate it with the later drain event. Cleared when execution starts. */
+    queueItemId?: string;
     /** Present on completed `out` turns (`toolSteps`/`reasoning`/`parts`), and on an
      *  `in` row produced by a fired scheduled task (`scheduled`, so the badge + "View"
      *  jump survive a history reload). `parts` is the ordered transcript; `toolSteps`/

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -197,8 +197,8 @@ export interface QueueItemDto {
 /** Wire mirror of src/control ControlEvent (tool-event carries the NORMALIZED step). */
 export type ControlEventDto =
   | { type: "turn-output"; chatKey: string; sessionAlias: string; chunk: string }
-  // `prompt`/`scheduled` are set only for turns started by a fired scheduled task,
-  // so the hub can persist the inbound prompt and the web can badge it.
+  // `prompt` is set for scheduled turns and drained queued prompts. `queueItemId`
+  // associates the latter with the message originally persisted at enqueue time.
   | { type: "turn-started"; chatKey: string; sessionAlias: string; prompt?: string; scheduled?: ScheduledOriginDto; queueItemId?: string }
   | { type: "tool-event"; chatKey: string; sessionAlias: string; step: ToolStepDto }
   | { type: "turn-thought"; chatKey: string; sessionAlias: string; chunk: string }

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -249,7 +249,8 @@ export function validControlEvent(e: unknown): boolean {
     case "scheduled-changed":
       return typeof c.chatKey === "string";
     case "turn-started":
-      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string";
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string"
+        && optStr(c.prompt) && optStr(c.queueItemId);
     case "turn-thought":
       return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
     case "plan":

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -28,6 +28,9 @@ export interface MessageRecordDto {
   direction: MessageDirection;
   text: string;
   createdAt: string;
+  /** Present while an inbound Web prompt is queued, so a history reload can still
+   *  associate it with the later drain event. Cleared when execution starts. */
+  queueItemId?: string;
   /** Present on completed `out` turns (`toolSteps`/`reasoning`/`parts`), and on an
    *  `in` row produced by a fired scheduled task (`scheduled`, so the badge + "View"
    *  jump survive a history reload). `parts` is the ordered transcript; `toolSteps`/

--- a/packages/relay-web/src/__tests__/chat-queue.test.ts
+++ b/packages/relay-web/src/__tests__/chat-queue.test.ts
@@ -48,6 +48,43 @@ it("sending while busy still issues control.prompt and pushes the optimistic bub
   expect(rpc).toHaveBeenCalledWith("i1", "control.prompt", { sessionAlias: "s", text: "queued msg" });
 });
 
+it("moves a drained queued prompt after the previous reply without duplicating it", async () => {
+  rpc.mockResolvedValueOnce({ ok: true, queued: true, queueItemId: "q1" });
+  const chat = useChatStore();
+  chat.select("i1", "s");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s" } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s", chunk: "first reply" } } as WebServerEvent);
+
+  await chat.send("queued prompt");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s", ok: true } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s", queueItemId: "q1", prompt: "queued prompt" } } as WebServerEvent);
+
+  expect(chat.messages.map((message) => [message.direction, message.text])).toEqual([
+    ["out", "first reply"],
+    ["in", "queued prompt"],
+  ]);
+});
+
+it("reconciles when the drain event arrives before the queued RPC response", async () => {
+  let resolveRpc!: (value: unknown) => void;
+  rpc.mockImplementationOnce(() => new Promise((resolve) => { resolveRpc = resolve; }));
+  const chat = useChatStore();
+  chat.select("i1", "s");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s" } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s", chunk: "first reply" } } as WebServerEvent);
+
+  const sending = chat.send("queued prompt");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s", ok: true } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s", queueItemId: "q1", prompt: "queued prompt" } } as WebServerEvent);
+  resolveRpc({ ok: true, queued: true, queueItemId: "q1" });
+  await sending;
+
+  expect(chat.messages.map((message) => [message.direction, message.text])).toEqual([
+    ["out", "first reply"],
+    ["in", "queued prompt"],
+  ]);
+});
+
 it("cancelQueuedItem issues control.queue.cancel and optimistically drops the chip", async () => {
   rpc.mockResolvedValueOnce({ ok: true });
   const chat = useChatStore();

--- a/packages/relay-web/src/__tests__/chat-queue.test.ts
+++ b/packages/relay-web/src/__tests__/chat-queue.test.ts
@@ -119,14 +119,15 @@ it("keeps queue correlation across the previous turn history reload", async () =
   ]);
 });
 
-it("does not let history overwrite a prompt before its queued RPC response", async () => {
+it("defers history convergence until the queued RPC response establishes correlation", async () => {
   let resolveRpc!: (value: unknown) => void;
   rpc.mockImplementationOnce(() => new Promise((resolve) => { resolveRpc = resolve; }));
   const fetchMock = vi.fn().mockResolvedValue({
     json: async () => ({
       messages: [
-        { id: 1, instanceId: "i1", sessionAlias: "s", direction: "in", text: "queued prompt", createdAt: "t1" },
-        { id: 2, instanceId: "i1", sessionAlias: "s", direction: "out", text: "first reply", createdAt: "t2" },
+        { id: 1, instanceId: "i1", sessionAlias: "s", direction: "out", text: "first reply", createdAt: "t1" },
+        { id: 2, instanceId: "i1", sessionAlias: "s", direction: "in", text: "queued prompt", createdAt: "t2" },
+        { id: 3, instanceId: "i1", sessionAlias: "s", direction: "out", text: "second reply", createdAt: "t3" },
       ],
       hasMore: false,
     }),
@@ -142,15 +143,46 @@ it("does not let history overwrite a prompt before its queued RPC response", asy
   chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s", queueItemId: "q1", prompt: "queued prompt" } } as WebServerEvent);
   chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s", chunk: "second reply" } } as WebServerEvent);
   chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s", ok: true } } as WebServerEvent);
+  expect(fetchMock).not.toHaveBeenCalled();
   resolveRpc({ ok: true, queued: true, queueItemId: "q1" });
   await sending;
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
-  expect(fetchMock).not.toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
   expect(chat.messages.map((message) => [message.direction, message.text])).toEqual([
     ["out", "first reply"],
     ["in", "queued prompt"],
     ["out", "second reply"],
   ]);
+});
+
+it("retries a deferred history load after reselecting a session during prompt RPC", async () => {
+  let resolveRpc!: (value: unknown) => void;
+  rpc.mockImplementationOnce(() => new Promise((resolve) => { resolveRpc = resolve; }));
+  const fetchMock = vi.fn().mockResolvedValue({
+    json: async () => ({
+      messages: [
+        { id: 1, instanceId: "i1", sessionAlias: "s", direction: "in", text: "queued prompt", createdAt: "t1", queueItemId: "q1" },
+      ],
+      hasMore: false,
+    }),
+  });
+  globalThis.fetch = fetchMock as typeof fetch;
+  const chat = useChatStore();
+  chat.select("i1", "s");
+  const sending = chat.send("queued prompt");
+  chat.select("i1", "other");
+  chat.select("i1", "s");
+  await chat.loadHistory();
+  expect(chat.messages).toEqual([]);
+  expect(fetchMock).not.toHaveBeenCalled();
+
+  resolveRpc({ ok: true, queued: true, queueItemId: "q1" });
+  await sending;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(chat.messages.map((message) => message.text)).toEqual(["queued prompt"]);
 });
 
 it("cancelQueuedItem issues control.queue.cancel and optimistically drops the chip", async () => {

--- a/packages/relay-web/src/__tests__/chat-queue.test.ts
+++ b/packages/relay-web/src/__tests__/chat-queue.test.ts
@@ -119,6 +119,40 @@ it("keeps queue correlation across the previous turn history reload", async () =
   ]);
 });
 
+it("does not let history overwrite a prompt before its queued RPC response", async () => {
+  let resolveRpc!: (value: unknown) => void;
+  rpc.mockImplementationOnce(() => new Promise((resolve) => { resolveRpc = resolve; }));
+  const fetchMock = vi.fn().mockResolvedValue({
+    json: async () => ({
+      messages: [
+        { id: 1, instanceId: "i1", sessionAlias: "s", direction: "in", text: "queued prompt", createdAt: "t1" },
+        { id: 2, instanceId: "i1", sessionAlias: "s", direction: "out", text: "first reply", createdAt: "t2" },
+      ],
+      hasMore: false,
+    }),
+  });
+  globalThis.fetch = fetchMock as typeof fetch;
+  const chat = useChatStore();
+  chat.select("i1", "s");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s" } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s", chunk: "first reply" } } as WebServerEvent);
+
+  const sending = chat.send("queued prompt");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s", ok: true } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s", queueItemId: "q1", prompt: "queued prompt" } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s", chunk: "second reply" } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s", ok: true } } as WebServerEvent);
+  resolveRpc({ ok: true, queued: true, queueItemId: "q1" });
+  await sending;
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(chat.messages.map((message) => [message.direction, message.text])).toEqual([
+    ["out", "first reply"],
+    ["in", "queued prompt"],
+    ["out", "second reply"],
+  ]);
+});
+
 it("cancelQueuedItem issues control.queue.cancel and optimistically drops the chip", async () => {
   rpc.mockResolvedValueOnce({ ok: true });
   const chat = useChatStore();

--- a/packages/relay-web/src/__tests__/chat-queue.test.ts
+++ b/packages/relay-web/src/__tests__/chat-queue.test.ts
@@ -1,8 +1,9 @@
 // packages/relay-web/src/__tests__/chat-queue.test.ts
 import { setActivePinia, createPinia } from "pinia";
-import { beforeEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 const rpc = vi.fn();
+const originalFetch = globalThis.fetch;
 vi.mock("../api/client", () => ({
   ApiError: class ApiError extends Error {
     constructor(public code: string, public status: number) {
@@ -25,6 +26,8 @@ beforeEach(() => {
   setActivePinia(createPinia());
   rpc.mockReset();
 });
+
+afterEach(() => { globalThis.fetch = originalFetch; });
 
 it("queue-updated replaces the per-session queue list", () => {
   const chat = useChatStore();
@@ -76,8 +79,39 @@ it("reconciles when the drain event arrives before the queued RPC response", asy
   const sending = chat.send("queued prompt");
   chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s", ok: true } } as WebServerEvent);
   chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s", queueItemId: "q1", prompt: "queued prompt" } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s", chunk: "second reply" } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s", ok: true } } as WebServerEvent);
   resolveRpc({ ok: true, queued: true, queueItemId: "q1" });
   await sending;
+
+  expect(chat.messages.map((message) => [message.direction, message.text])).toEqual([
+    ["out", "first reply"],
+    ["in", "queued prompt"],
+    ["out", "second reply"],
+  ]);
+});
+
+it("keeps queue correlation across the previous turn history reload", async () => {
+  rpc.mockResolvedValueOnce({ ok: true, queued: true, queueItemId: "q1" });
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    json: async () => ({
+      messages: [
+        { id: 1, instanceId: "i1", sessionAlias: "s", direction: "in", text: "queued prompt", createdAt: "t1", queueItemId: "q1" },
+        { id: 2, instanceId: "i1", sessionAlias: "s", direction: "out", text: "first reply", createdAt: "t2" },
+      ],
+      hasMore: false,
+    }),
+  }) as typeof fetch;
+  const chat = useChatStore();
+  chat.select("i1", "s");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s" } } as WebServerEvent);
+  await chat.send("queued prompt");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s", chunk: "first reply" } } as WebServerEvent);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s", ok: true } } as WebServerEvent);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(chat.messages[0]?.id).toBe(1);
+
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s", queueItemId: "q1", prompt: "queued prompt" } } as WebServerEvent);
 
   expect(chat.messages.map((message) => [message.direction, message.text])).toEqual([
     ["out", "first reply"],

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -145,6 +145,7 @@ export const useChatStore = defineStore("chat", () => {
   // still has no queueItemId. Keep that session on its optimistic transcript until
   // the response establishes correlation; a later finish reloads authoritative rows.
   const pendingPromptRequests = new Map<string, number>();
+  const deferredHistoryLoads = new Set<string>();
   const error = ref("");
   // "View" on a fired scheduled task asks MessageList to scroll to that run. Nonce-keyed
   // so repeat clicks on the same task re-trigger the jump (a plain id wouldn't change).
@@ -242,7 +243,11 @@ export const useChatStore = defineStore("chat", () => {
     if (!instanceId.value || !sessionAlias.value) return;
     const id = instanceId.value;
     const alias = sessionAlias.value;
-    if ((pendingPromptRequests.get(bufKey(id, alias)) ?? 0) > 0) return;
+    const historyKey = bufKey(id, alias);
+    if ((pendingPromptRequests.get(historyKey) ?? 0) > 0) {
+      deferredHistoryLoads.add(historyKey);
+      return;
+    }
     const requestSequence = ++historyRequestSequence;
     const revision = transcriptRevision;
     const { messages: rows, hasMore } = await api.get<{ messages: MessageRecordDto[]; hasMore?: boolean }>(
@@ -518,7 +523,11 @@ export const useChatStore = defineStore("chat", () => {
     } finally {
       const remaining = (pendingPromptRequests.get(pendingKey) ?? 1) - 1;
       if (remaining > 0) pendingPromptRequests.set(pendingKey, remaining);
-      else pendingPromptRequests.delete(pendingKey);
+      else {
+        pendingPromptRequests.delete(pendingKey);
+        const shouldReload = deferredHistoryLoads.delete(pendingKey);
+        if (shouldReload && selectedKey.value === pendingKey) void loadHistory().catch(() => {});
+      }
       sending.value = false;
     }
   }

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -141,6 +141,10 @@ export const useChatStore = defineStore("chat", () => {
   const busy = computed(() => liveTurn.value !== null);
 
   const sending = ref(false);
+  // A turn-finished event may trigger history convergence while a queued prompt RPC
+  // still has no queueItemId. Keep that session on its optimistic transcript until
+  // the response establishes correlation; a later finish reloads authoritative rows.
+  const pendingPromptRequests = new Map<string, number>();
   const error = ref("");
   // "View" on a fired scheduled task asks MessageList to scroll to that run. Nonce-keyed
   // so repeat clicks on the same task re-trigger the jump (a plain id wouldn't change).
@@ -238,6 +242,7 @@ export const useChatStore = defineStore("chat", () => {
     if (!instanceId.value || !sessionAlias.value) return;
     const id = instanceId.value;
     const alias = sessionAlias.value;
+    if ((pendingPromptRequests.get(bufKey(id, alias)) ?? 0) > 0) return;
     const requestSequence = ++historyRequestSequence;
     const revision = transcriptRevision;
     const { messages: rows, hasMore } = await api.get<{ messages: MessageRecordDto[]; hasMore?: boolean }>(
@@ -453,11 +458,15 @@ export const useChatStore = defineStore("chat", () => {
 
   async function send(text: string, attachments: PromptAttachmentRef[] = []): Promise<void> {
     if (!instanceId.value || !sessionAlias.value) return;
+    const id = instanceId.value;
+    const alias = sessionAlias.value;
+    const pendingKey = bufKey(id, alias);
+    pendingPromptRequests.set(pendingKey, (pendingPromptRequests.get(pendingKey) ?? 0) + 1);
     error.value = "";
     sending.value = true;
     const optimistic: ChatMessage = {
-      instanceId: instanceId.value,
-      sessionAlias: sessionAlias.value,
+      instanceId: id,
+      sessionAlias: alias,
       direction: "in",
       text,
       createdAt: new Date().toISOString(),
@@ -478,8 +487,8 @@ export const useChatStore = defineStore("chat", () => {
       // not handled here; the console forwards control-channel `/` text to the agent
       // verbatim (see command-router passthrough). Only WeChat/Feishu, which lack a
       // GUI, still rely on xacpx command handling.
-      const res = await api.rpc<{ ok?: boolean; errorMessage?: string; queued?: boolean; queueItemId?: string }>(instanceId.value, "control.prompt", {
-        sessionAlias: sessionAlias.value,
+      const res = await api.rpc<{ ok?: boolean; errorMessage?: string; queued?: boolean; queueItemId?: string }>(id, "control.prompt", {
+        sessionAlias: alias,
         text,
         ...(attachments.length > 0 ? { media: attachments } : {}),
       });
@@ -507,6 +516,9 @@ export const useChatStore = defineStore("chat", () => {
         touchTranscript();
       }
     } finally {
+      const remaining = (pendingPromptRequests.get(pendingKey) ?? 1) - 1;
+      if (remaining > 0) pendingPromptRequests.set(pendingKey, remaining);
+      else pendingPromptRequests.delete(pendingKey);
       sending.value = false;
     }
   }

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -69,8 +69,6 @@ const reasoningOf = (parts: TurnPart[]): string => parts.filter((p) => p.type ==
 export interface ChatMessage extends MessageRecordDto {
   failed?: boolean;
   status?: TurnStatus;
-  /** Client-only correlation for an optimistic prompt accepted into the queue. */
-  queueItemId?: string;
   // Present on an inbound prompt produced by a fired scheduled task — drives the
   // "⏰ Scheduled" badge so a turn that appears on its own has visible provenance.
   scheduled?: ScheduledOriginDto;
@@ -490,17 +488,14 @@ export const useChatStore = defineStore("chat", () => {
         entry.failed = true;
         touchTranscript();
       } else if (res?.queued && res.queueItemId) {
-        const eventBubbleIndex = messages.value.findIndex(
-          (message) => message !== entry && message.queueItemId === res.queueItemId,
-        );
         entry.queueItemId = res.queueItemId;
-        if (eventBubbleIndex >= 0) {
+        if (messages.value.some((message) => message !== entry && message.queueItemId === res.queueItemId)) {
           // The drain event won the race with the RPC response. Keep the original
-          // optimistic row (including attachments) at the event's position.
-          messages.value.splice(eventBubbleIndex, 1);
+          // optimistic row (including attachments) at the event bubble's position.
           const entryIndex = messages.value.indexOf(entry);
           if (entryIndex >= 0) messages.value.splice(entryIndex, 1);
-          messages.value.push(entry);
+          const eventBubbleIndex = messages.value.findIndex((message) => message.queueItemId === res.queueItemId);
+          if (eventBubbleIndex >= 0) messages.value.splice(eventBubbleIndex, 1, entry);
         }
         touchTranscript();
       }

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -69,6 +69,8 @@ const reasoningOf = (parts: TurnPart[]): string => parts.filter((p) => p.type ==
 export interface ChatMessage extends MessageRecordDto {
   failed?: boolean;
   status?: TurnStatus;
+  /** Client-only correlation for an optimistic prompt accepted into the queue. */
+  queueItemId?: string;
   // Present on an inbound prompt produced by a fired scheduled task — drives the
   // "⏰ Scheduled" badge so a turn that appears on its own has visible provenance.
   scheduled?: ScheduledOriginDto;
@@ -370,11 +372,27 @@ export const useChatStore = defineStore("chat", () => {
       const k = bufKey(event.instanceId, e.sessionAlias);
       finishedTurns.delete(k); // a fresh turn supersedes any prior finish on this key
       ensureTurn(k);
-      // A scheduled-origin turn has no optimistic user bubble (no one typed it), so
-      // surface its prompt as an inbound message — with the schedule badge — when this
-      // session is the one being viewed. History persists the same "in" row server-side.
+      // Scheduled turns have no optimistic bubble; drained queue turns use queueItemId
+      // to move their existing bubble. Other clients can add the carried prompt here.
       const selected = event.instanceId === instanceId.value && e.sessionAlias === sessionAlias.value;
-      if (e.prompt && selected) {
+      if (e.queueItemId && selected) {
+        const queuedIndex = messages.value.findIndex((message) => message.queueItemId === e.queueItemId);
+        if (queuedIndex >= 0) {
+          const [queued] = messages.value.splice(queuedIndex, 1);
+          messages.value.push(queued!);
+          touchTranscript();
+        } else if (e.prompt) {
+          messages.value.push({
+            instanceId: event.instanceId,
+            sessionAlias: e.sessionAlias,
+            direction: "in",
+            text: e.prompt,
+            createdAt: new Date().toISOString(),
+            queueItemId: e.queueItemId,
+          });
+          touchTranscript();
+        }
+      } else if (e.prompt && selected) {
         messages.value.push({
           instanceId: event.instanceId,
           sessionAlias: e.sessionAlias,
@@ -462,7 +480,7 @@ export const useChatStore = defineStore("chat", () => {
       // not handled here; the console forwards control-channel `/` text to the agent
       // verbatim (see command-router passthrough). Only WeChat/Feishu, which lack a
       // GUI, still rely on xacpx command handling.
-      const res = await api.rpc<{ ok?: boolean; errorMessage?: string }>(instanceId.value, "control.prompt", {
+      const res = await api.rpc<{ ok?: boolean; errorMessage?: string; queued?: boolean; queueItemId?: string }>(instanceId.value, "control.prompt", {
         sessionAlias: sessionAlias.value,
         text,
         ...(attachments.length > 0 ? { media: attachments } : {}),
@@ -470,6 +488,20 @@ export const useChatStore = defineStore("chat", () => {
       if (res && res.ok === false) {
         error.value = res.errorMessage ?? "prompt-failed";
         entry.failed = true;
+        touchTranscript();
+      } else if (res?.queued && res.queueItemId) {
+        const eventBubbleIndex = messages.value.findIndex(
+          (message) => message !== entry && message.queueItemId === res.queueItemId,
+        );
+        entry.queueItemId = res.queueItemId;
+        if (eventBubbleIndex >= 0) {
+          // The drain event won the race with the RPC response. Keep the original
+          // optimistic row (including attachments) at the event's position.
+          messages.value.splice(eventBubbleIndex, 1);
+          const entryIndex = messages.value.indexOf(entry);
+          if (entryIndex >= 0) messages.value.splice(entryIndex, 1);
+          messages.value.push(entry);
+        }
         touchTranscript();
       }
     } catch (e) {

--- a/packages/relay/src/db.ts
+++ b/packages/relay/src/db.ts
@@ -115,7 +115,8 @@ export function initSchema(db: SqlDriver): void {
       text TEXT NOT NULL,
       created_at TEXT NOT NULL,
       structured TEXT,
-      attachments TEXT
+      attachments TEXT,
+      queue_item_id TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_messages_session ON messages (instance_id, session_alias, id);
   `);
@@ -124,5 +125,8 @@ export function initSchema(db: SqlDriver): void {
   const messageCols = db.all<{ name: string }>("PRAGMA table_info(messages)");
   if (!messageCols.some((c) => c.name === "attachments")) {
     db.exec("ALTER TABLE messages ADD COLUMN attachments TEXT");
+  }
+  if (!messageCols.some((c) => c.name === "queue_item_id")) {
+    db.exec("ALTER TABLE messages ADD COLUMN queue_item_id TEXT");
   }
 }

--- a/packages/relay/src/db.ts
+++ b/packages/relay/src/db.ts
@@ -116,7 +116,8 @@ export function initSchema(db: SqlDriver): void {
       created_at TEXT NOT NULL,
       structured TEXT,
       attachments TEXT,
-      queue_item_id TEXT
+      queue_item_id TEXT,
+      queue_fallback INTEGER NOT NULL DEFAULT 0
     );
     CREATE INDEX IF NOT EXISTS idx_messages_session ON messages (instance_id, session_alias, id);
   `);
@@ -128,5 +129,8 @@ export function initSchema(db: SqlDriver): void {
   }
   if (!messageCols.some((c) => c.name === "queue_item_id")) {
     db.exec("ALTER TABLE messages ADD COLUMN queue_item_id TEXT");
+  }
+  if (!messageCols.some((c) => c.name === "queue_fallback")) {
+    db.exec("ALTER TABLE messages ADD COLUMN queue_fallback INTEGER NOT NULL DEFAULT 0");
   }
 }

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -419,12 +419,11 @@ export function createApp(deps: AppDeps): Hono<Vars> {
         && (result as { queued?: unknown }).queued === true
         && typeof (result as { queueItemId?: unknown }).queueItemId === "string") {
         const p = payload as { sessionAlias: string };
-        deps.messages.markQueued(
-          persistedPromptId,
-          instance.id,
-          p.sessionAlias,
-          (result as { queueItemId: string }).queueItemId,
-        );
+        deps.messages.markQueued(persistedPromptId, {
+          instanceId: instance.id,
+          sessionAlias: p.sessionAlias,
+          queueItemId: (result as { queueItemId: string }).queueItemId,
+        });
       }
       // A real delete has two histories: the connector-owned acpx record and the
       // Hub-owned Web transcript. Purge the latter only after the connector confirms

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -360,6 +360,7 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       };
     }
     let releaseSessionRpcLock: (() => void) | undefined;
+    let persistedPromptId: number | undefined;
     try {
       // Shape-validate the RPCs the hub persists BEFORE forwarding, so a malformed frame
       // can't poison history ahead of the connector's own boundary check. Error body carries
@@ -409,10 +410,22 @@ export function createApp(deps: AppDeps): Hono<Vars> {
               ...(previewUrl ? { previewUrl } : {}),
             };
           });
-          deps.messages.append(instance.id, p.sessionAlias, "in", p.text, undefined, attachments);
+          persistedPromptId = deps.messages.append(instance.id, p.sessionAlias, "in", p.text, undefined, attachments);
         }
       }
       const result = await deps.gateway.sendRequest(instance.id, body.type, payload);
+      if (body.type === MSG.prompt && persistedPromptId !== undefined
+        && typeof result === "object" && result !== null
+        && (result as { queued?: unknown }).queued === true
+        && typeof (result as { queueItemId?: unknown }).queueItemId === "string") {
+        const p = payload as { sessionAlias: string };
+        deps.messages.markQueued(
+          persistedPromptId,
+          instance.id,
+          p.sessionAlias,
+          (result as { queueItemId: string }).queueItemId,
+        );
+      }
       // A real delete has two histories: the connector-owned acpx record and the
       // Hub-owned Web transcript. Purge the latter only after the connector confirms
       // success; archive intentionally keeps both histories.

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -60,7 +60,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   // `parts` records text / reasoning / tool events in arrival order so the web can
   // replay history inline (same model the live view builds). `steps`/`reasoning`/`text`
   // remain for the flat fallback + the persisted `text` column.
-  interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reasoning: string; parts: TurnPartDto[]; startedAt: number }
+  interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reasoning: string; parts: TurnPartDto[]; startedAt: number; queueItemId?: string }
   const turnBuffers = new Map<string, TurnAccumulator>();
   const key = (instanceId: string, alias: string) => `${instanceId}\0${alias}`;
   // Latest context-usage meter per (instance, session). Unlike turnBuffers this is
@@ -169,11 +169,24 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
           const event = raw as ControlEventDto;
           webGateway.broadcast(accountId, { kind: "control-event", instanceId, event });
           if (event.type === "turn-started") {
-            turnBuffers.set(key(instanceId, event.sessionAlias), { text: "", steps: new Map(), reasoning: "", parts: [], startedAt: Date.now() });
-            // A scheduled-origin turn carries its prompt here (a normal web turn persists
-            // its inbound message via the prompt RPC instead). Persist it so the fired
-            // task's prompt shows in history, not just the agent's out-of-context reply.
-            if (event.prompt) messages.append(instanceId, event.sessionAlias, "in", event.prompt, event.scheduled ? { scheduled: event.scheduled } : undefined);
+            turnBuffers.set(key(instanceId, event.sessionAlias), {
+              text: "", steps: new Map(), reasoning: "", parts: [], startedAt: Date.now(),
+              ...(event.queueItemId ? { queueItemId: event.queueItemId } : {}),
+            });
+            if (event.queueItemId) {
+              // A Web prompt was persisted at enqueue time; move that same row to its
+              // actual execution point. Other origins have no HTTP row, so fall back to
+              // the prompt carried by the event and reconcile if the HTTP response raced.
+              const promoted = messages.promoteQueued(instanceId, event.sessionAlias, event.queueItemId);
+              if (!promoted && event.prompt) {
+                const fallbackId = messages.append(instanceId, event.sessionAlias, "in", event.prompt);
+                messages.recordQueuedFallback(instanceId, event.sessionAlias, event.queueItemId, fallbackId);
+              }
+            } else if (event.prompt) {
+              // Scheduled turns have no enqueue-time HTTP request; persist their prompt
+              // directly when execution starts.
+              messages.append(instanceId, event.sessionAlias, "in", event.prompt, event.scheduled ? { scheduled: event.scheduled } : undefined);
+            }
           } else if (event.type === "turn-output") {
             // Only append to an existing buffer; never lazily resurrect one. A buffer
             // is created solely by turn-started, so a stray streaming event arriving
@@ -195,6 +208,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             const a = turnBuffers.get(k);
             turnBuffers.delete(k);
             if (!a) return;
+            if (a.queueItemId) messages.forgetQueuedFallback(instanceId, event.sessionAlias, a.queueItemId);
             const steps = [...a.steps.values()];
             // Treat whitespace-only reasoning as absent: it would otherwise persist as an
             // empty `structured.reasoning` and render as a blank reasoning panel in history.

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -60,7 +60,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   // `parts` records text / reasoning / tool events in arrival order so the web can
   // replay history inline (same model the live view builds). `steps`/`reasoning`/`text`
   // remain for the flat fallback + the persisted `text` column.
-  interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reasoning: string; parts: TurnPartDto[]; startedAt: number; queueItemId?: string }
+  interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reasoning: string; parts: TurnPartDto[]; startedAt: number }
   const turnBuffers = new Map<string, TurnAccumulator>();
   const key = (instanceId: string, alias: string) => `${instanceId}\0${alias}`;
   // Latest context-usage meter per (instance, session). Unlike turnBuffers this is
@@ -169,18 +169,15 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
           const event = raw as ControlEventDto;
           webGateway.broadcast(accountId, { kind: "control-event", instanceId, event });
           if (event.type === "turn-started") {
-            turnBuffers.set(key(instanceId, event.sessionAlias), {
-              text: "", steps: new Map(), reasoning: "", parts: [], startedAt: Date.now(),
-              ...(event.queueItemId ? { queueItemId: event.queueItemId } : {}),
-            });
+            turnBuffers.set(key(instanceId, event.sessionAlias), { text: "", steps: new Map(), reasoning: "", parts: [], startedAt: Date.now() });
             if (event.queueItemId) {
               // A Web prompt was persisted at enqueue time; move that same row to its
               // actual execution point. Other origins have no HTTP row, so fall back to
               // the prompt carried by the event and reconcile if the HTTP response raced.
-              const promoted = messages.promoteQueued(instanceId, event.sessionAlias, event.queueItemId);
+              const correlation = { instanceId, sessionAlias: event.sessionAlias, queueItemId: event.queueItemId };
+              const promoted = messages.promoteQueued(correlation);
               if (!promoted && event.prompt) {
-                const fallbackId = messages.append(instanceId, event.sessionAlias, "in", event.prompt);
-                messages.recordQueuedFallback(instanceId, event.sessionAlias, event.queueItemId, fallbackId);
+                messages.appendQueuedFallback(correlation, event.prompt);
               }
             } else if (event.prompt) {
               // Scheduled turns have no enqueue-time HTTP request; persist their prompt
@@ -208,7 +205,6 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             const a = turnBuffers.get(k);
             turnBuffers.delete(k);
             if (!a) return;
-            if (a.queueItemId) messages.forgetQueuedFallback(instanceId, event.sessionAlias, a.queueItemId);
             const steps = [...a.steps.values()];
             // Treat whitespace-only reasoning as absent: it would otherwise persist as an
             // empty `structured.reasoning` and render as a blank reasoning panel in history.

--- a/packages/relay/src/stores/messages.ts
+++ b/packages/relay/src/stores/messages.ts
@@ -22,7 +22,16 @@ export interface MessagePage {
 }
 
 export class MessageStore {
+  /** Queue starts can race the HTTP response that supplies the queue id. A fallback
+   *  row keeps non-Web queue origins visible; the original persisted row replaces it
+   *  if the matching HTTP response arrives afterwards. */
+  private readonly startedQueueFallbacks = new Map<string, number | null>();
+
   constructor(private readonly db: SqlDriver, private readonly now: () => Date = () => new Date()) {}
+
+  private queueKey(instanceId: string, sessionAlias: string, queueItemId: string): string {
+    return `${instanceId}\0${sessionAlias}\0${queueItemId}`;
+  }
 
   append(
     instanceId: string,
@@ -31,7 +40,7 @@ export class MessageStore {
     text: string,
     structured?: StructuredTurn,
     attachments?: AttachmentMetadata[],
-  ): void {
+  ): number {
     this.db.run(
       "INSERT INTO messages (instance_id, session_alias, direction, text, created_at, structured, attachments) VALUES (?,?,?,?,?,?,?)",
       [
@@ -44,6 +53,49 @@ export class MessageStore {
         attachments && attachments.length > 0 ? JSON.stringify(attachments) : null,
       ],
     );
+    return this.db.get<{ id: number }>("SELECT last_insert_rowid() AS id")!.id;
+  }
+
+  /** Associate an already-persisted Web prompt with the connector's queue id. */
+  markQueued(rowId: number, instanceId: string, sessionAlias: string, queueItemId: string): void {
+    this.db.run(
+      "UPDATE messages SET queue_item_id = ? WHERE id = ? AND instance_id = ? AND session_alias = ?",
+      [queueItemId, rowId, instanceId, sessionAlias],
+    );
+    const k = this.queueKey(instanceId, sessionAlias, queueItemId);
+    if (!this.startedQueueFallbacks.has(k)) return;
+    const fallbackId = this.startedQueueFallbacks.get(k);
+    if (fallbackId !== null && fallbackId !== undefined) {
+      this.db.run("DELETE FROM messages WHERE id = ?", [fallbackId]);
+    }
+    this.promoteQueued(instanceId, sessionAlias, queueItemId);
+  }
+
+  /** Move a queued inbound row to the current end of the transcript when execution
+   *  starts. Updating the integer key preserves the existing cursor contract. */
+  promoteQueued(instanceId: string, sessionAlias: string, queueItemId: string): boolean {
+    const row = this.db.get<{ id: number }>(
+      "SELECT id FROM messages WHERE instance_id = ? AND session_alias = ? AND queue_item_id = ?",
+      [instanceId, sessionAlias, queueItemId],
+    );
+    const k = this.queueKey(instanceId, sessionAlias, queueItemId);
+    if (!row) {
+      this.startedQueueFallbacks.set(k, null);
+      return false;
+    }
+    const nextId = this.db.get<{ id: number }>("SELECT COALESCE(MAX(id), 0) + 1 AS id FROM messages")!.id;
+    this.db.run("UPDATE messages SET id = ?, queue_item_id = NULL WHERE id = ?", [nextId, row.id]);
+    this.startedQueueFallbacks.delete(k);
+    return true;
+  }
+
+  recordQueuedFallback(instanceId: string, sessionAlias: string, queueItemId: string, rowId: number): void {
+    const k = this.queueKey(instanceId, sessionAlias, queueItemId);
+    if (this.startedQueueFallbacks.has(k)) this.startedQueueFallbacks.set(k, rowId);
+  }
+
+  forgetQueuedFallback(instanceId: string, sessionAlias: string, queueItemId: string): void {
+    this.startedQueueFallbacks.delete(this.queueKey(instanceId, sessionAlias, queueItemId));
   }
 
   /**

--- a/packages/relay/src/stores/messages.ts
+++ b/packages/relay/src/stores/messages.ts
@@ -13,6 +13,7 @@ interface MessageRow {
   created_at: string;
   structured: string | null;
   attachments: string | null;
+  queue_item_id: string | null;
 }
 
 export interface MessagePage {
@@ -21,17 +22,14 @@ export interface MessagePage {
   hasMore: boolean;
 }
 
+export interface QueueCorrelation {
+  instanceId: string;
+  sessionAlias: string;
+  queueItemId: string;
+}
+
 export class MessageStore {
-  /** Queue starts can race the HTTP response that supplies the queue id. A fallback
-   *  row keeps non-Web queue origins visible; the original persisted row replaces it
-   *  if the matching HTTP response arrives afterwards. */
-  private readonly startedQueueFallbacks = new Map<string, number | null>();
-
   constructor(private readonly db: SqlDriver, private readonly now: () => Date = () => new Date()) {}
-
-  private queueKey(instanceId: string, sessionAlias: string, queueItemId: string): string {
-    return `${instanceId}\0${sessionAlias}\0${queueItemId}`;
-  }
 
   append(
     instanceId: string,
@@ -57,45 +55,43 @@ export class MessageStore {
   }
 
   /** Associate an already-persisted Web prompt with the connector's queue id. */
-  markQueued(rowId: number, instanceId: string, sessionAlias: string, queueItemId: string): void {
+  markQueued(rowId: number, correlation: QueueCorrelation): void {
     this.db.run(
       "UPDATE messages SET queue_item_id = ? WHERE id = ? AND instance_id = ? AND session_alias = ?",
-      [queueItemId, rowId, instanceId, sessionAlias],
+      [correlation.queueItemId, rowId, correlation.instanceId, correlation.sessionAlias],
     );
-    const k = this.queueKey(instanceId, sessionAlias, queueItemId);
-    if (!this.startedQueueFallbacks.has(k)) return;
-    const fallbackId = this.startedQueueFallbacks.get(k);
-    if (fallbackId !== null && fallbackId !== undefined) {
-      this.db.run("DELETE FROM messages WHERE id = ?", [fallbackId]);
-    }
-    this.promoteQueued(instanceId, sessionAlias, queueItemId);
+    const fallback = this.db.get<{ id: number }>(
+      "SELECT id FROM messages WHERE instance_id = ? AND session_alias = ? AND queue_item_id = ? AND queue_fallback = 1",
+      [correlation.instanceId, correlation.sessionAlias, correlation.queueItemId],
+    );
+    if (!fallback) return;
+    // The drain event arrived before the RPC response. Replace its lightweight row
+    // at the SAME sequence id, preserving execution order even if the turn already
+    // emitted and persisted its reply before this response arrived.
+    this.db.run("DELETE FROM messages WHERE id = ?", [fallback.id]);
+    this.db.run("UPDATE messages SET id = ?, queue_item_id = NULL WHERE id = ?", [fallback.id, rowId]);
   }
 
   /** Move a queued inbound row to the current end of the transcript when execution
    *  starts. Updating the integer key preserves the existing cursor contract. */
-  promoteQueued(instanceId: string, sessionAlias: string, queueItemId: string): boolean {
+  promoteQueued(correlation: QueueCorrelation): boolean {
     const row = this.db.get<{ id: number }>(
-      "SELECT id FROM messages WHERE instance_id = ? AND session_alias = ? AND queue_item_id = ?",
-      [instanceId, sessionAlias, queueItemId],
+      "SELECT id FROM messages WHERE instance_id = ? AND session_alias = ? AND queue_item_id = ? AND queue_fallback = 0",
+      [correlation.instanceId, correlation.sessionAlias, correlation.queueItemId],
     );
-    const k = this.queueKey(instanceId, sessionAlias, queueItemId);
-    if (!row) {
-      this.startedQueueFallbacks.set(k, null);
-      return false;
-    }
+    if (!row) return false;
     const nextId = this.db.get<{ id: number }>("SELECT COALESCE(MAX(id), 0) + 1 AS id FROM messages")!.id;
     this.db.run("UPDATE messages SET id = ?, queue_item_id = NULL WHERE id = ?", [nextId, row.id]);
-    this.startedQueueFallbacks.delete(k);
     return true;
   }
 
-  recordQueuedFallback(instanceId: string, sessionAlias: string, queueItemId: string, rowId: number): void {
-    const k = this.queueKey(instanceId, sessionAlias, queueItemId);
-    if (this.startedQueueFallbacks.has(k)) this.startedQueueFallbacks.set(k, rowId);
-  }
-
-  forgetQueuedFallback(instanceId: string, sessionAlias: string, queueItemId: string): void {
-    this.startedQueueFallbacks.delete(this.queueKey(instanceId, sessionAlias, queueItemId));
+  appendQueuedFallback(correlation: QueueCorrelation, text: string): number {
+    const rowId = this.append(correlation.instanceId, correlation.sessionAlias, "in", text);
+    this.db.run(
+      "UPDATE messages SET queue_item_id = ?, queue_fallback = 1 WHERE id = ?",
+      [correlation.queueItemId, rowId],
+    );
+    return rowId;
   }
 
   /**
@@ -114,7 +110,7 @@ export class MessageStore {
     const before = opts.before ?? null;
     // Fetch one extra row to detect whether older history remains, then drop it.
     const rows = this.db.all<MessageRow>(
-      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments
+      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments, m.queue_item_id
        FROM messages m JOIN instances i ON i.id = m.instance_id
        WHERE i.account_id = ? AND m.instance_id = ? AND m.session_alias = ?
          AND (? IS NULL OR m.id < ?)
@@ -132,6 +128,7 @@ export class MessageStore {
         direction: r.direction,
         text: r.text,
         createdAt: r.created_at,
+        ...(r.queue_item_id ? { queueItemId: r.queue_item_id } : {}),
         ...(r.structured ? { structured: JSON.parse(r.structured) as StructuredTurn } : {}),
         ...(r.attachments ? { attachments: JSON.parse(r.attachments) as AttachmentMetadata[] } : {}),
       })),

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -587,7 +587,7 @@ export class BridgeRuntime {
   }
 
   private async readSessionRecord(input: BridgeSessionInput): Promise<{ acpxRecordId: string; agentSessionId?: string }> {
-    const record = parseAcpxSessionRecordId(await this.readRawSessionRecord(input));
+    const record = parseAcpxSessionRecordId(await this.readRawSessionRecord(input, "read-session-record", "json"));
     if (record) return record;
     throw new Error("failed to resolve acpx session record id");
   }

--- a/src/control/control-event-bus.ts
+++ b/src/control/control-event-bus.ts
@@ -20,8 +20,8 @@ export type ControlEvent =
   | { type: "turn-output"; chatKey: string; sessionAlias: string; chunk: string }
   // `prompt`/`scheduled` are populated only for turns started by a fired scheduled
   // task (relay channel), or a turn drained from the queue, letting the hub persist
-  // the inbound prompt and the web badge it. `queueItemId` is set when this turn was
-  // drained from the queue (Task 2), so the web can reconcile the queue chip.
+  // the inbound prompt and the web badge it. A drained turn carries `queueItemId` so
+  // the web can move its original optimistic bubble to the actual execution point.
   | { type: "turn-started"; chatKey: string; sessionAlias: string; prompt?: string; scheduled?: ScheduledOrigin; queueItemId?: string }
   // Full ordered snapshot (replace-latest) of the pending prompt queue for a session,
   // emitted on every enqueue/drain/cancel.

--- a/src/control/turn-queue.ts
+++ b/src/control/turn-queue.ts
@@ -287,9 +287,9 @@ export class TurnQueue {
       this.emitQueueUpdated(chatKey, sessionAlias);
       // Fire-and-forget: the drained turn drives its own settled lifecycle. It bypasses the
       // busy gate (drained: true), re-registers inFlight and clears `draining` at its top — all
-      // synchronously before the first await — so there is no parallel-turn window. Pass
-      // queueItemId ONLY, never prompt: the hub already persisted the inbound at enqueue, so
-      // re-emitting prompt would double-persist and duplicate the bubble.
+      // synchronously before the first await — so there is no parallel-turn window. The
+      // prompt and queueItemId let web clients associate the optimistic enqueue-time bubble
+      // with this execution-time event without guessing by message text.
       void this.submit({
         chatKey,
         sessionAlias,
@@ -300,7 +300,7 @@ export class TurnQueue {
         ...(next.isOwner !== undefined ? { isOwner: next.isOwner } : {}),
         ...(next.accountId !== undefined ? { accountId: next.accountId } : {}),
         ...(next.media !== undefined ? { media: next.media } : {}),
-        turnStarted: { queueItemId: next.id },
+        turnStarted: { prompt: next.text, queueItemId: next.id },
       });
     } else {
       // The queue emptied during the drain hand-off (e.g. a cancel removed the only queued

--- a/tests/unit/control/control-service-queue.test.ts
+++ b/tests/unit/control/control-service-queue.test.ts
@@ -109,10 +109,10 @@ test("queued prompts drain FIFO after the running turn finishes, each as its own
   nextChat();
   await tick(); // finish turn 1 → drain "second"
   const started = events.filter((e) => e.type === "turn-started") as TurnStarted[];
-  // Drained turn carries queueItemId but NOT prompt (persistence already happened at
-  // enqueue in the hub; re-emitting prompt would double-persist).
+  // Drained turns identify the original queued prompt so web clients can move their
+  // optimistic bubble to the point where the prompt actually starts executing.
   expect(started.at(-1)!.queueItemId).toBeDefined();
-  expect(started.at(-1)!.prompt).toBeUndefined();
+  expect(started.at(-1)!.prompt).toBe("second");
   // queue now shows only "third"
   const q = (events.filter((e) => e.type === "queue-updated") as QueueUpdated[]).at(-1)!;
   expect(q.items.map((i) => i.textPreview)).toEqual(["third"]);

--- a/tests/unit/control/golden/fixtures/aborted-queue-sessions-window.json
+++ b/tests/unit/control/golden/fixtures/aborted-queue-sessions-window.json
@@ -100,6 +100,7 @@
       "type": "turn-started",
       "chatKey": "c",
       "sessionAlias": "s",
+      "prompt": "second",
       "queueItemId": "<id-1>"
     }
   },
@@ -136,6 +137,7 @@
       "type": "turn-started",
       "chatKey": "c",
       "sessionAlias": "s",
+      "prompt": "third",
       "queueItemId": "<id-2>"
     }
   },

--- a/tests/unit/control/golden/fixtures/busy-second-enqueues.json
+++ b/tests/unit/control/golden/fixtures/busy-second-enqueues.json
@@ -64,6 +64,7 @@
       "type": "turn-started",
       "chatKey": "c",
       "sessionAlias": "s",
+      "prompt": "second",
       "queueItemId": "<id-1>"
     }
   }

--- a/tests/unit/control/golden/fixtures/drain-window-enqueue.json
+++ b/tests/unit/control/golden/fixtures/drain-window-enqueue.json
@@ -99,6 +99,7 @@
       "type": "turn-started",
       "chatKey": "c",
       "sessionAlias": "s",
+      "prompt": "second",
       "queueItemId": "<id-1>"
     }
   }

--- a/tests/unit/control/golden/fixtures/fifo-drain.json
+++ b/tests/unit/control/golden/fixtures/fifo-drain.json
@@ -99,6 +99,7 @@
       "type": "turn-started",
       "chatKey": "c",
       "sessionAlias": "s",
+      "prompt": "second",
       "queueItemId": "<id-1>"
     }
   },
@@ -135,6 +136,7 @@
       "type": "turn-started",
       "chatKey": "c",
       "sessionAlias": "s",
+      "prompt": "third",
       "queueItemId": "<id-2>"
     }
   },

--- a/tests/unit/control/golden/fixtures/same-tick-one-wins.json
+++ b/tests/unit/control/golden/fixtures/same-tick-one-wins.json
@@ -72,6 +72,7 @@
       "type": "turn-started",
       "chatKey": "c",
       "sessionAlias": "s",
+      "prompt": "B",
       "queueItemId": "<id-1>"
     }
   },

--- a/tests/unit/control/golden/fixtures/stranded-tail.json
+++ b/tests/unit/control/golden/fixtures/stranded-tail.json
@@ -108,6 +108,7 @@
       "type": "turn-started",
       "chatKey": "c",
       "sessionAlias": "s",
+      "prompt": "third",
       "queueItemId": "<id-2>"
     }
   },

--- a/tests/unit/packages/relay-protocol/web-dtos.test.ts
+++ b/tests/unit/packages/relay-protocol/web-dtos.test.ts
@@ -94,6 +94,8 @@ function roundtrip(event: any) {
 
 test("accepts the new turn-status control events", () => {
   expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s" } })).not.toBeNull();
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s", prompt: "queued", queueItemId: "q1" } })).not.toBeNull();
+  expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s", queueItemId: 1 } })).toBeNull();
   expect(roundtrip({ kind: "control-event", instanceId: "i1", event: { type: "turn-thought", chatKey: "c", sessionAlias: "s", chunk: "x" } })).not.toBeNull();
   expect(roundtrip({
     kind: "control-event", instanceId: "i1",

--- a/tests/unit/packages/relay/http/messages-endpoint.test.ts
+++ b/tests/unit/packages/relay/http/messages-endpoint.test.ts
@@ -46,6 +46,63 @@ test("rpc prompt echoes the user message into history", async () => {
   runtime.close();
 });
 
+test("a queued prompt is persisted where it drains, after the previous turn reply", async () => {
+  const { runtime, cookie } = await loggedIn();
+  const accountId = runtime.accounts.findByUsername("admin")!.id;
+  const fire = (event: unknown) => runtime.gateway["deps"].onEvent!("i1", accountId, {
+    protocolVersion: 1, kind: "event", type: MSG.instanceEvent, payload: { event },
+  });
+  fire({ type: "turn-started", chatKey: `relay:${accountId}`, sessionAlias: "backend" });
+  (runtime.gateway as unknown as { sendRequest: () => Promise<unknown> }).sendRequest = async () => {
+    fire({ type: "turn-output", chatKey: `relay:${accountId}`, sessionAlias: "backend", chunk: "first reply" });
+    fire({ type: "turn-finished", chatKey: `relay:${accountId}`, sessionAlias: "backend", ok: true });
+    return { ok: true, queued: true, queueItemId: "q1" };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "queued prompt" } }),
+  });
+  fire({ type: "turn-started", chatKey: `relay:${accountId}`, sessionAlias: "backend", queueItemId: "q1", prompt: "queued prompt" });
+  fire({ type: "turn-output", chatKey: `relay:${accountId}`, sessionAlias: "backend", chunk: "second reply" });
+  fire({ type: "turn-finished", chatKey: `relay:${accountId}`, sessionAlias: "backend", ok: true });
+
+  const cached = runtime.messages.listBySession(accountId, "i1", "backend");
+  expect(cached.messages.map((message) => [message.direction, message.text])).toEqual([
+    ["out", "first reply"],
+    ["in", "queued prompt"],
+    ["out", "second reply"],
+  ]);
+  runtime.close();
+});
+
+test("queued history reconciles when turn-started races ahead of the prompt response", async () => {
+  const { runtime, cookie } = await loggedIn();
+  const accountId = runtime.accounts.findByUsername("admin")!.id;
+  const fire = (event: unknown) => runtime.gateway["deps"].onEvent!("i1", accountId, {
+    protocolVersion: 1, kind: "event", type: MSG.instanceEvent, payload: { event },
+  });
+  fire({ type: "turn-started", chatKey: `relay:${accountId}`, sessionAlias: "backend" });
+  (runtime.gateway as unknown as { sendRequest: () => Promise<unknown> }).sendRequest = async () => {
+    fire({ type: "turn-output", chatKey: `relay:${accountId}`, sessionAlias: "backend", chunk: "first reply" });
+    fire({ type: "turn-finished", chatKey: `relay:${accountId}`, sessionAlias: "backend", ok: true });
+    fire({ type: "turn-started", chatKey: `relay:${accountId}`, sessionAlias: "backend", queueItemId: "q1", prompt: "queued prompt" });
+    return { ok: true, queued: true, queueItemId: "q1" };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "queued prompt" } }),
+  });
+
+  const cached = runtime.messages.listBySession(accountId, "i1", "backend");
+  expect(cached.messages.map((message) => [message.direction, message.text])).toEqual([
+    ["out", "first reply"],
+    ["in", "queued prompt"],
+  ]);
+  runtime.close();
+});
+
 test("delete then same-alias create returns an empty Web history", async () => {
   const { runtime, cookie } = await loggedIn();
   (runtime.gateway as unknown as { sendRequest: () => Promise<unknown> }).sendRequest = async () => ({ ok: true });

--- a/tests/unit/packages/relay/http/messages-endpoint.test.ts
+++ b/tests/unit/packages/relay/http/messages-endpoint.test.ts
@@ -87,6 +87,8 @@ test("queued history reconciles when turn-started races ahead of the prompt resp
     fire({ type: "turn-output", chatKey: `relay:${accountId}`, sessionAlias: "backend", chunk: "first reply" });
     fire({ type: "turn-finished", chatKey: `relay:${accountId}`, sessionAlias: "backend", ok: true });
     fire({ type: "turn-started", chatKey: `relay:${accountId}`, sessionAlias: "backend", queueItemId: "q1", prompt: "queued prompt" });
+    fire({ type: "turn-output", chatKey: `relay:${accountId}`, sessionAlias: "backend", chunk: "second reply" });
+    fire({ type: "turn-finished", chatKey: `relay:${accountId}`, sessionAlias: "backend", ok: true });
     return { ok: true, queued: true, queueItemId: "q1" };
   };
 
@@ -99,6 +101,7 @@ test("queued history reconciles when turn-started races ahead of the prompt resp
   expect(cached.messages.map((message) => [message.direction, message.text])).toEqual([
     ["out", "first reply"],
     ["in", "queued prompt"],
+    ["out", "second reply"],
   ]);
   runtime.close();
 });


### PR DESCRIPTION
## Summary

- correlate queued Web prompts with their drain event using queueItemId
- move the original optimistic bubble after the previous agent reply without duplication
- reorder the persisted Hub message row at drain time so refreshed history matches execution order
- carry drained prompt text for other connected Web clients and handle RPC/event races
- restore the existing bridge session-record JSON lookup so the repository test job passes

## Tests

- npm test
- npx tsc --noEmit
- targeted control, relay protocol, Relay Hub, and Relay Web queue tests

No changes are made to the upstream acpx dependency.