### PR TITLE
relay: beta fixes and relay-web UX polish

### DIFF
--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -174,6 +174,40 @@ test("a delayed history response cannot overwrite a newly selected session", asy
   expect(store.messages.map((message) => message.text)).toEqual(["frontend history"]);
 });
 
+test("loadingHistory is raised while the initial history fetch is in flight", async () => {
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ messages: [] }), { status: 200 })));
+  const store = useChatStore();
+  store.select("i1", "backend");
+  expect(store.loadingHistory).toBe(false); // select alone doesn't raise it
+  const load = store.loadHistory();
+  expect(store.loadingHistory).toBe(true);
+  await load;
+  expect(store.loadingHistory).toBe(false);
+});
+
+test("a stale history response cannot dismiss the skeleton a newer selection raised", async () => {
+  let resolveBackend!: (response: Response) => void;
+  const backendResponse = new Promise<Response>((resolve) => { resolveBackend = resolve; });
+  vi.stubGlobal("fetch", vi.fn((path: string) => {
+    if (path.includes("/sessions/backend/")) return backendResponse;
+    return Promise.resolve(new Response(JSON.stringify({ messages: [] }), { status: 200 }));
+  }));
+
+  const store = useChatStore();
+  store.select("i1", "backend");
+  const staleLoad = store.loadHistory();
+  expect(store.loadingHistory).toBe(true);
+  // Switching away drops the skeleton immediately (the new load raises it again).
+  store.select("i1", "frontend");
+  expect(store.loadingHistory).toBe(false);
+  await store.loadHistory();
+  expect(store.loadingHistory).toBe(false);
+  // The stale backend response landing late must not re-touch the flag.
+  resolveBackend(new Response(JSON.stringify({ messages: [] }), { status: 200 }));
+  await staleLoad;
+  expect(store.loadingHistory).toBe(false);
+});
+
 test("turn-finished invalidates an older history read and converges on the persisted final", async () => {
   let resolveStale!: (response: Response) => void;
   const staleResponse = new Promise<Response>((resolve) => { resolveStale = resolve; });

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -127,6 +127,36 @@ describe("MessageList", () => {
     const content = wrapper.find('[data-test="msg-content"]').element;
     expect(content.lastElementChild?.getAttribute("data-test")).toBe("msg-actions");
   });
+
+  it("shows a history skeleton while the initial page loads, then swaps in the transcript", async () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: null, loadingHistory: true },
+    });
+    const skeleton = wrapper.find('[data-test="history-skeleton"]');
+    expect(skeleton.exists()).toBe(true);
+    expect(skeleton.attributes("aria-hidden")).toBe("true");
+    expect(wrapper.find('[data-test="msg-out"]').exists()).toBe(false);
+
+    await wrapper.setProps({ messages: [msg({ direction: "out", text: "hi" })], loadingHistory: false });
+    expect(wrapper.find('[data-test="history-skeleton"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="msg-out"]').exists()).toBe(true);
+  });
+
+  it("keeps the skeleton hidden once messages exist, even if a reload is in flight", () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [msg({ direction: "in", text: "hey" })], liveTurn: null, loadingHistory: true },
+    });
+    expect(wrapper.find('[data-test="history-skeleton"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="msg-in"]').exists()).toBe(true);
+  });
+
+  it("prefers live streaming content over the skeleton", () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: live([{ type: "text", text: "working" }]), loadingHistory: true },
+    });
+    expect(wrapper.find('[data-test="history-skeleton"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="msg-streaming"]').exists()).toBe(true);
+  });
 });
 
 it("renders legacy persisted tool steps (no parts) after expanding a completed out message", async () => {

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -177,6 +177,7 @@ const verb = computed(() => {
                    :session-key="`${chat.instanceId}\0${chat.sessionAlias}`"
                    :scroll-to-scheduled="chat.scrollRequest"
                    :has-more-older="chat.hasMoreOlder" :loading-older="chat.loadingOlder"
+                   :loading-history="chat.loadingHistory"
                    @resend="chat.resend" @load-older="chat.loadOlder" />
       <!-- composer area. pb uses max(1rem, safe-area-inset-bottom) so the iOS home-indicator
            inset is applied ONCE here (the bottommost element) and never stacks on top of the

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref, useId, watch } from "vue";
+import { computed, nextTick, ref, useId, watch } from "vue";
 import type { ChatMessage, LiveTurn } from "../stores/chat";
 import StreamMarkdown from "./StreamMarkdown.vue";
 import ToolCallPanel from "./ToolCallPanel.vue";
@@ -11,7 +11,7 @@ import AgentIcon from "./AgentIcon.vue";
 import MessageAttachments from "./MessageAttachments.vue";
 import { fmtTime, fmtDateTime } from "../lib/format";
 
-const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; driver?: string | null; hasMoreOlder?: boolean; loadingOlder?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null }>();
+const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; driver?: string | null; hasMoreOlder?: boolean; loadingOlder?: boolean; loadingHistory?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null }>();
 const emit = defineEmits<{ resend: [message: ChatMessage]; loadOlder: [] }>();
 
 import type { ScheduledOriginDto } from "@ganglion/xacpx-relay-protocol";
@@ -47,6 +47,24 @@ function toggleMessage(m: ChatMessage, index: number): void {
 function messagePreview(m: ChatMessage): string {
   return m.text.trim().replace(/\s+/g, " ");
 }
+
+// Initial-history skeleton: fills the pane while the first page of a freshly selected
+// session loads. Only when the transcript is truly empty — a background reload (e.g.
+// turn-finished convergence) or an already-streaming turn never triggers it.
+const showSkeleton = computed(() =>
+  (props.loadingHistory ?? false)
+  && props.messages.length === 0
+  && !(props.liveTurn && props.liveTurn.parts.length > 0));
+
+// Alternates agent cards / user bubbles with varied widths so the placeholder reads as
+// a conversation, not a form. Rows pulse with a staggered delay (see --sk-delay).
+const SKELETON_ROWS = [
+  { kind: "agent", w: "64%", lines: 1 },
+  { kind: "user", w: "44%", lines: 1 },
+  { kind: "agent", w: "82%", lines: 1 },
+  { kind: "user", w: "58%", lines: 2 },
+  { kind: "agent", w: "38%", lines: 1 },
+] as const;
 
 // Stick-to-bottom: keep the newest content in view while the user is at the bottom,
 // but don't yank them down if they've scrolled up to read history. A "jump to latest"
@@ -165,7 +183,32 @@ watch(
 <template>
   <div class="relative flex-1 overflow-hidden">
     <div ref="scroller" data-test="msg-scroller" class="thin-scroll h-full overflow-y-auto px-3 py-4 lg:px-5 lg:py-5" @scroll="onScroll">
-      <div class="mx-auto max-w-3xl space-y-5">
+      <!-- Initial-history skeleton: bottom-anchored so the shimmering rows sit where the
+           transcript will land, then swap for the real content the instant rows arrive. -->
+      <div v-if="showSkeleton" data-test="history-skeleton" aria-hidden="true"
+           class="mx-auto flex min-h-full max-w-3xl flex-col justify-end gap-5">
+        <template v-for="(row, i) in SKELETON_ROWS" :key="i">
+          <!-- user bubble -->
+          <div v-if="row.kind === 'user'" class="flex justify-end" :style="{ '--sk-delay': `${i * 160}ms` }">
+            <div class="space-y-1.5 rounded-2xl rounded-tr-md border border-accent/10 bg-accent/5 px-3.5 py-2.5" :style="{ width: row.w }">
+              <div v-for="n in row.lines" :key="n" class="sk-bar h-3 rounded bg-accent/15"
+                   :style="{ width: n === row.lines ? '58%' : '100%' }" />
+            </div>
+          </div>
+          <!-- collapsed agent card -->
+          <div v-else class="flex gap-2.5" :style="{ '--sk-delay': `${i * 160}ms` }">
+            <div class="sk-bar mt-0.5 h-6 w-6 shrink-0 rounded-full bg-fg/10" />
+            <div class="min-w-0 flex-1 rounded-lg border border-border/60 bg-raised/25 px-2.5 py-2">
+              <div class="flex items-center gap-2">
+                <div class="sk-bar h-3 w-3 shrink-0 rounded bg-fg/10" />
+                <div class="sk-bar h-3 rounded bg-fg/10" :style="{ width: row.w }" />
+                <div class="sk-bar ml-auto h-2.5 w-9 shrink-0 rounded bg-fg/8" />
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+      <div v-else class="mx-auto max-w-3xl space-y-5">
         <!-- Older-history affordance: a spinner while a page loads, else a hint that more
              exists. Prepending older rows keeps the scroll position pinned (see watcher). -->
         <div v-if="loadingOlder" data-test="loading-older" class="flex justify-center py-1 text-[11px] text-fg-muted">
@@ -277,5 +320,19 @@ watch(
 .cv-row {
   content-visibility: auto;
   contain-intrinsic-size: auto 88px;
+}
+
+/* Skeleton shimmer: each row inherits --sk-delay from its root so the pulse cascades
+   top-to-bottom instead of breathing in unison. */
+.sk-bar {
+  animation: sk-pulse 1.8s ease-in-out infinite;
+  animation-delay: var(--sk-delay, 0ms);
+}
+@keyframes sk-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sk-bar { animation: none; }
 }
 </style>

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -154,6 +154,10 @@ export const useChatStore = defineStore("chat", () => {
   const HISTORY_PAGE = 100;
   const hasMoreOlder = ref(false);
   const loadingOlder = ref(false);
+  // True while the initial history page for a freshly selected session is in flight —
+  // drives the transcript skeleton. Background reloads (turn-finished convergence) set
+  // it too, but the skeleton only renders when the pane is empty, so those never flash.
+  const loadingHistory = ref(false);
   // An async history response may replace messages only if the user is still on
   // the same selection, it is the newest request, and no transcript mutation
   // happened while it was in flight.
@@ -211,6 +215,7 @@ export const useChatStore = defineStore("chat", () => {
     error.value = "";
     hasMoreOlder.value = false;
     loadingOlder.value = false;
+    loadingHistory.value = false;
     // Viewing a session clears its unread signal.
     const k = bufKey(id, alias);
     if (unread.value.has(k)) {
@@ -232,6 +237,7 @@ export const useChatStore = defineStore("chat", () => {
     error.value = "";
     hasMoreOlder.value = false;
     loadingOlder.value = false;
+    loadingHistory.value = false;
   }
 
   async function loadHistory(): Promise<void> {
@@ -240,14 +246,21 @@ export const useChatStore = defineStore("chat", () => {
     const alias = sessionAlias.value;
     const requestSequence = ++historyRequestSequence;
     const revision = transcriptRevision;
-    const { messages: rows, hasMore } = await api.get<{ messages: MessageRecordDto[]; hasMore?: boolean }>(
-      `/api/instances/${id}/sessions/${alias}/messages?limit=${HISTORY_PAGE}`,
-    );
-    if (id !== instanceId.value || alias !== sessionAlias.value) return;
-    if (requestSequence !== historyRequestSequence || revision !== transcriptRevision) return;
-    messages.value = rows;
-    touchTranscript();
-    hasMoreOlder.value = hasMore ?? false;
+    loadingHistory.value = true;
+    try {
+      const { messages: rows, hasMore } = await api.get<{ messages: MessageRecordDto[]; hasMore?: boolean }>(
+        `/api/instances/${id}/sessions/${alias}/messages?limit=${HISTORY_PAGE}`,
+      );
+      if (id !== instanceId.value || alias !== sessionAlias.value) return;
+      if (requestSequence !== historyRequestSequence || revision !== transcriptRevision) return;
+      messages.value = rows;
+      touchTranscript();
+      hasMoreOlder.value = hasMore ?? false;
+    } finally {
+      // Only the newest request owns the flag — a stale response must not dismiss
+      // the skeleton a newer selection just raised.
+      if (requestSequence === historyRequestSequence) loadingHistory.value = false;
+    }
   }
 
   /** Fetch the page of history immediately older than the oldest row we hold and PREPEND
@@ -527,5 +540,5 @@ export const useChatStore = defineStore("chat", () => {
     }
   }
 
-  return { instanceId, sessionAlias, messages, streaming, liveTurn, sessionPlan, sessionUsage, sessionCommands, liveToolSteps, busy, unread, sessionAttention, runningSince, sending, error, scrollRequest, requestScrollToScheduled, hasMoreOlder, loadingOlder, queues, sessionQueue, select, clearSelection, loadHistory, loadOlder, loadActiveTurns, seedActiveTurns, applyStateSnapshot, applyEvent, send, resend, cancel, cancelQueuedItem };
+  return { instanceId, sessionAlias, messages, streaming, liveTurn, sessionPlan, sessionUsage, sessionCommands, liveToolSteps, busy, unread, sessionAttention, runningSince, sending, error, scrollRequest, requestScrollToScheduled, hasMoreOlder, loadingOlder, loadingHistory, queues, sessionQueue, select, clearSelection, loadHistory, loadOlder, loadActiveTurns, seedActiveTurns, applyStateSnapshot, applyEvent, send, resend, cancel, cancelQueuedItem };
 });


### PR DESCRIPTION
## Summary
- **fix(relay):** keep recreated sessions free of old history
- **feat(relay-web):** collapse agent messages by default
- **feat(relay-web):** show a transcript skeleton while a freshly selected session's history loads — the pane is no longer blank during the fetch; the flag is stale-safe (a superseded response can't dismiss a newer selection's skeleton)
- **docs:** streamline AGENTS.md

## Test plan
- [x] relay-web unit tests (832 passed, incl. new store race + skeleton render tests)
- [x] `vue-tsc --noEmit` clean
- [ ] Manually switch between sessions in the dashboard and confirm the skeleton appears briefly instead of a blank pane
- [ ] Verify no skeleton flash on turn-finished background reloads or mid-stream