### PR TITLE
feat(relay-web): unify provider subagent presentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,20 @@ There are two session concepts:
 
 Uses **Bun** for development scripts and builds. Dependencies are in `package.json`. The lockfile is `bun.lock`.
 
+## Agent skills
+
+### Issue tracker
+
+Issues and specs are tracked in GitHub Issues. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the canonical triage label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Use the single-context domain documentation layout. See `docs/agents/domain.md`.
+
 ## Maintaining AGENTS.md
 
 - Only write long-term stable constraints and navigation; volatile implementation details go to `docs/` or Code Wiki.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,11 @@
+# Domain docs
+
+Use the single-context layout:
+
+- Read root `CONTEXT.md` when it exists.
+- Read relevant decisions under `docs/adr/`.
+- Proceed silently when these files do not yet exist.
+- Use terminology defined by `CONTEXT.md`.
+- Surface conflicts with an existing ADR explicitly.
+
+Domain documents are created lazily when terminology or architectural decisions need to be recorded.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,7 @@
+# Issue tracker: GitHub
+
+Issues and specs live in the GitHub Issues of `gadzan/xacpx`. Use `gh` for creating, reading, commenting, labelling, and closing issues.
+
+- Publishing a spec means creating a GitHub issue.
+- PRs are not treated as a triage request surface.
+- Infer the repository from the current Git remote.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,9 @@
+# Triage labels
+
+| Role | GitHub label |
+| --- | --- |
+| `needs-triage` | `needs-triage` |
+| `needs-info` | `needs-info` |
+| `ready-for-agent` | `ready-for-agent` |
+| `ready-for-human` | `ready-for-human` |
+| `wontfix` | `wontfix` |

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -91,8 +91,13 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
 
 ## Subagent 执行轨迹
 
-- Claude ACP 的 `_meta.claudeCode.toolName="Agent"` 标准化为 `ToolUseEvent.isSubagent`；subagent 内部工具的
-  `parentToolUseId` 标准化为 `parentToolCallId`，经 channel-relay 和 `ToolStepDto` 原样进入 Relay Web。
+- Transport 在合并同一 `toolCallId` 的稀疏 ACP 更新后，按 resolved driver 将 provider 信号统一标准化为
+  `ToolUseEvent.isSubagent`：Claude 使用 `_meta.claudeCode.toolName="Agent"`，Qoder 使用
+  `_meta.qoder.toolName="Agent"`，Kimi 使用完整的 `prompt + subagent_type` Agent 输入，Codex 使用带线程与活动标识的
+  `_meta.codex.subagent`。识别规则按 driver 隔离，只有明确命中的委派工具才进入统一 subagent 卡片；普通 `Agent` 标题不会单独触发。
+- Claude subagent 内部工具的 `parentToolUseId` 继续标准化为 `parentToolCallId`，经 channel-relay 和 `ToolStepDto`
+  原样进入 Relay Web。Qoder、Kimi、Codex 当前 ACP 主流没有提供子工具父子关系，因此只展示统一父卡片和 adapter 已提供的结果，
+  不虚构执行时间线。
 - 异步 Agent 的 `async_launched` 只代表启动成功，父步骤保持 `running`；transport 装饰器在 ACP 结束后继续跟踪 Claude
   主 transcript，并递归增量读取 `<sessionId>/subagents/**/agent-*.jsonl`。后台任务真正完成、主 Agent 续写结束后才转为
   `success`；失败通知会把父 Agent 及仍在运行的子步骤收敛为 `error`。

--- a/docs/superpowers/specs/2026-07-23-unified-subagent-presentation-spec.md
+++ b/docs/superpowers/specs/2026-07-23-unified-subagent-presentation-spec.md
@@ -1,0 +1,68 @@
+## Problem Statement
+
+Relay Web renders Claude delegated work as a dedicated subagent card, but equivalent delegation from Qoder, Kimi, and Codex appears as ordinary tool calls. Each ACP adapter emits a different provider-specific shape, and the current transport normalization only recognizes Claude metadata. Users therefore see inconsistent message presentation for the same intent and cannot reliably distinguish delegated work from ordinary tools.
+
+Captured production traces show that Qoder identifies its `Agent` tool in namespaced metadata, Kimi exposes a completed Agent call through merged semantic input, and Codex emits namespaced subagent thread/activity metadata. These signals are sufficient to classify the parent delegation consistently, but only Claude currently supplies parent links for child tool activity. The UI must not invent a trace that the adapter did not emit.
+
+## Solution
+
+Normalize provider-specific subagent signals at the transport boundary after sparse ACP tool updates have been merged. The normalized `ToolUseEvent` will mark delegated parent tools with `isSubagent`, preserve any real parent relationship, and retain the adapter's actual lifecycle status and output.
+
+Relay and Relay Web will remain provider-agnostic. Existing subagent DTO fields and the existing subagent card will render all recognized delegated work consistently. When an adapter does not expose child tool events, the card will show the delegated task and available result without fabricating timeline entries.
+
+## User Stories
+
+1. As a Relay Web user, I want Claude, Qoder, Kimi, and Codex delegations to use the same subagent card, so that identical actions look consistent across agents.
+2. As a Relay Web user, I want delegated work to be visually distinct from ordinary tools, so that I can scan a turn quickly.
+3. As a Qoder user, I want the namespaced Agent signal to be recognized, so that its delegation is not rendered as a generic thinking tool.
+4. As a Kimi user, I want its incrementally streamed Agent call to become a subagent card once the semantic input is available, so that sparse early frames do not prevent correct classification.
+5. As a Codex user, I want namespaced subagent activity to be recognized, so that a spawned Codex thread is presented as delegated work.
+6. As a Claude user, I want the existing nested subagent trace behavior to remain unchanged, so that this generalization does not regress the richest adapter integration.
+7. As a user of an adapter without child-tool events, I want the UI to avoid invented activity, so that the presentation remains truthful.
+8. As a user viewing historical or sparse tool events, I want ordinary tools without a positive subagent signal to keep their existing presentation, so that classification is fail-safe.
+9. As a custom-agent user, I want provider-specific recognition to be gated by the resolved driver, so that coincidental tool titles or input field names do not create false subagent cards.
+10. As a maintainer, I want provider-specific knowledge contained in transport normalization, so that Relay protocol and Vue components do not accumulate adapter branches.
+11. As a maintainer, I want captured adapter shapes covered by deterministic replay tests, so that adapter format drift is visible during development.
+12. As a maintainer, I want both direct CLI and bridge transports to use the same normalization path, so that deployment topology does not change presentation.
+13. As a maintainer, I want existing raw input, output, content, and status preserved, so that the unified card does not discard diagnostic information.
+14. As a maintainer, I want unknown or malformed provider metadata to remain an ordinary tool event, so that format drift fails open rather than misclassifying tools.
+
+## Implementation Decisions
+
+- Add a provider-aware subagent classification seam to the shared streaming tool-event normalization path.
+- Pass the resolved ACP driver into streaming normalization for both direct CLI and bridge execution paths; custom agent aliases use their resolved driver rather than their display name.
+- Classify Claude delegation from its existing namespaced Agent metadata and retain its existing parent-tool mapping and asynchronous lifecycle behavior.
+- Classify Qoder delegation only when the resolved driver is Qoder and its namespaced metadata positively identifies the Agent tool.
+- Classify Kimi delegation only when the resolved driver is Kimi and the merged tool state contains the semantic Agent input shape, including a non-empty prompt and subagent type. A generic title by itself is not sufficient.
+- Classify Codex delegation only when the resolved driver is Codex and namespaced Codex subagent metadata contains positive thread/activity identity.
+- Perform classification after sparse updates are merged so that Kimi can be recognized from its later rich frame and Qoder metadata survives its sparse terminal frame.
+- Generalize metadata typing and merging only as necessary to preserve the recognized provider namespaces; do not expose provider-specific metadata through Relay DTOs.
+- Continue emitting the existing normalized `isSubagent` and `parentToolCallId` contract. No provider branch is added to Relay Web.
+- Preserve the ACP tool status. A completed Codex launch activity is presented as a completed launch; it is not reinterpreted as proof that an unobserved child execution trace completed.
+- Preserve existing behavior for ordinary tools and adapters without a positive recognized signal.
+- Update the Relay Web module documentation before recording any new navigation in repository-level instructions. No new repository navigation entry is expected because the subsystem already has one.
+
+## Testing Decisions
+
+- The primary test seam is captured ACP event replay through the shared streaming parser, asserting the externally visible normalized `ToolUseEvent` rather than private classifier helpers.
+- Representative Claude, Qoder, Kimi, and Codex event sequences will be covered, including sparse terminal updates and incremental Kimi input.
+- Tests will assert positive classification, final status, useful title/summary preservation, and absence of fabricated parent links.
+- Negative tests will prove that Kimi-like titles without the driver-gated semantic input and malformed provider metadata remain ordinary tools.
+- Existing Relay protocol and Relay Web subagent-card tests serve as prior art and continue to verify that an `isSubagent` event is preserved and rendered by the common card.
+- Direct CLI and bridge call-site tests or type checks will verify that resolved driver identity reaches the shared parser in both paths.
+- Run the focused streaming parser tests during development, TypeScript checking regularly, and the complete unit test suite at the end.
+
+## Out of Scope
+
+- Synthesizing child-tool timelines when an ACP adapter does not emit child events or parent relationships.
+- Reading Qoder, Kimi, or Codex private transcript stores to reconstruct missing activity.
+- Changing ACP adapter packages or proposing a cross-vendor ACP standard.
+- Redesigning the existing subagent card, trace dialog, or Relay wire protocol.
+- Treating arbitrary tools named `Agent`, `Task`, or `spawn_agent` as subagents without a driver-gated positive signal.
+- Changing session-list filtering for native Codex subagent threads.
+
+## Further Notes
+
+- The captured traces used to define this behavior were recorded on 2026-07-22 from the configured Qoder, Kimi, and Codex adapters.
+- Qoder and Kimi expose a complete parent Agent tool result but no child-tool ownership links in the parent ACP stream.
+- Codex exposes a subagent thread identifier in the parent ACP stream, while the child result is stored in a separate rollout. This spec deliberately unifies presentation without coupling the transport to that private storage.

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -115,6 +115,7 @@ interface StreamingPromptRunnerOptions {
   now?: () => number;
   formatToolCalls?: boolean;
   toolEventMode?: ToolEventMode;
+  driver?: string;
   rawStream?: boolean;
   env?: NodeJS.ProcessEnv;
 }
@@ -536,6 +537,7 @@ export class BridgeRuntime {
         ? await this.runPromptCommand(spawnSpec.command, spawnSpec.args, onEvent, {
             formatToolCalls,
             toolEventMode,
+            driver: input.driver ?? input.agent,
             rawStream,
             env: this.spawnEnvironment(input),
           })
@@ -1015,6 +1017,7 @@ export async function runStreamingPrompt(
     const toolEventMode: ToolEventMode = options.toolEventMode ?? "text";
     const state = createStreamingPromptState(options.formatToolCalls ?? false, {
       mode: toolEventMode,
+      driver: options.driver,
       rawStream,
       ...(onEvent && (toolEventMode === "structured" || toolEventMode === "both")
         ? { onToolEvent: (toolEvent) => onEvent({ type: "prompt.tool_event", event: toolEvent }) }

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -378,6 +378,7 @@ export class AcpxCliTransport implements SessionTransport {
           options?.onCommands,
           rawStream,
           this.spawnEnvironment(session),
+          session.driver ?? session.agent,
         );
         const baseText = getPromptText(result);
         if (!reply) {
@@ -703,6 +704,7 @@ export class AcpxCliTransport implements SessionTransport {
     onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
     rawStream: boolean = false,
     env?: NodeJS.ProcessEnv,
+    driver?: string,
   ): Promise<{ result: CommandResult; overflowCount: number }> {
     const hooks = this.streamingHooks;
     const doSpawn = hooks.spawnPrompt
@@ -744,6 +746,7 @@ export class AcpxCliTransport implements SessionTransport {
 
       const state = createStreamingPromptState(formatToolCalls, {
         mode: toolEventMode,
+        driver,
         rawStream,
         ...(userOnToolEvent
           ? {

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -18,6 +18,8 @@ export interface StreamingPromptState {
   // reflects the full call (rich title + diff), not just the last sparse frame.
   toolCalls: Map<string, MergedToolUpdate>;
   toolEventMode: ToolEventMode;
+  /** Resolved ACP driver used for provider-gated event normalization. */
+  driver?: string;
   // Raw streaming (replyMode "stream"): the consumer renders one live bubble that
   // concatenates chunks verbatim, so we DON'T split on paragraph boundaries or trim.
   // Agent text accumulates raw in `buffer`; a short flush timer drains it as-is. This
@@ -55,6 +57,16 @@ interface StreamEvent {
       cost?: unknown;
       _meta?: {
         usage?: unknown;
+        qoder?: {
+          toolName?: string;
+        };
+        codex?: {
+          subagent?: {
+            threadId?: string;
+            path?: string;
+            activity?: string;
+          };
+        };
         claudeCode?: {
           toolName?: string;
           parentToolUseId?: string;
@@ -71,6 +83,7 @@ export type CreateStreamingPromptStateOptions =
   | ((event: ToolUseEvent) => void | Promise<void>)
   | {
       mode?: ToolEventMode;
+      driver?: string;
       rawStream?: boolean;
       onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
       onThought?: (chunk: string) => void | Promise<void>;
@@ -90,6 +103,7 @@ export function createStreamingPromptState(
   let onUsage: ((usage: PromptUsage) => void | Promise<void>) | undefined;
   let onCommands: ((commands: AgentCommand[]) => void | Promise<void>) | undefined;
   let rawStream = false;
+  let driver: string | undefined;
 
   if (options === undefined) {
     toolEventMode = "text";
@@ -105,6 +119,7 @@ export function createStreamingPromptState(
     onUsage = options.onUsage;
     onCommands = options.onCommands;
     rawStream = options.rawStream ?? false;
+    driver = options.driver?.trim().toLowerCase() || undefined;
     toolEventMode = resolveToolEventMode({
       toolEventMode: options.mode,
       onToolEvent,
@@ -120,6 +135,7 @@ export function createStreamingPromptState(
     emittedToolCallIds: new Set(),
     toolCalls: new Map(),
     toolEventMode,
+    driver,
     rawStream,
     onToolEvent,
     onThought,
@@ -187,7 +203,7 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
       const merged = update.toolCallId
         ? mergeToolCallUpdate(state, update.toolCallId, update)
         : update;
-      const toolEvent = buildToolUseEvent(merged);
+      const toolEvent = buildToolUseEvent(merged, state.driver);
       if (toolEvent) void state.onToolEvent(toolEvent);
     }
 
@@ -351,7 +367,10 @@ function mergeToolCallUpdate(
   return merged;
 }
 
-function buildToolUseEvent(update: NonNullable<StreamEvent["params"]>["update"]): ToolUseEvent | null {
+function buildToolUseEvent(
+  update: NonNullable<StreamEvent["params"]>["update"],
+  driver?: string,
+): ToolUseEvent | null {
   if (!update) return null;
   const toolCallId = update.toolCallId;
   if (!toolCallId) return null;
@@ -395,7 +414,10 @@ function buildToolUseEvent(update: NonNullable<StreamEvent["params"]>["update"])
   const locations = update.locations;
   const claudeMeta = update._meta?.claudeCode;
   const parentToolCallId = claudeMeta?.parentToolUseId?.trim();
-  const isSubagent = claudeMeta?.toolName === "Agent";
+  const isSubagent = claudeMeta?.toolName === "Agent"
+    || (driver === "qoder" && update._meta?.qoder?.toolName === "Agent")
+    || (driver === "kimi" && isKimiSubagentInput(rawInput))
+    || (driver === "codex" && isCodexSubagentMeta(update._meta?.codex?.subagent));
   return {
     toolCallId,
     ...(parentToolCallId ? { parentToolCallId } : {}),
@@ -409,6 +431,19 @@ function buildToolUseEvent(update: NonNullable<StreamEvent["params"]>["update"])
     ...(locations !== undefined ? { locations } : {}),
     status,
   };
+}
+
+function isKimiSubagentInput(rawInput: unknown): boolean {
+  return isRecord(rawInput)
+    && readFirstString(rawInput, ["prompt"]) !== undefined
+    && readFirstString(rawInput, ["subagent_type", "subagentType"]) !== undefined;
+}
+
+function isCodexSubagentMeta(meta: { threadId?: string; activity?: string } | undefined): boolean {
+  return typeof meta?.threadId === "string"
+    && meta.threadId.trim().length > 0
+    && typeof meta.activity === "string"
+    && meta.activity.trim().length > 0;
 }
 
 function summarizeToolInput(rawInput: unknown, title = ""): string | undefined {

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -411,7 +411,9 @@ function buildToolUseEvent(
   // dashboard spinner alive forever (notably for tools running inside an async
   // Agent). A concrete toolResponse is terminal even when the adapter omitted the
   // redundant status field.
-  const claudeToolResponse = update._meta?.claudeCode?.toolResponse;
+  const isClaudeDriver = driver === undefined || driver === "claude";
+  const claudeMeta = isClaudeDriver ? update._meta?.claudeCode : undefined;
+  const claudeToolResponse = claudeMeta?.toolResponse;
   const hasClaudeToolResponse = !isEmptyToolField(claudeToolResponse);
   const isAsyncAgentLaunch =
     update._meta?.claudeCode?.toolName === "Agent" &&
@@ -427,9 +429,8 @@ function buildToolUseEvent(
   const content = update.content;
   const rawOutput = update.rawOutput ?? claudeToolResponse;
   const locations = update.locations;
-  const claudeMeta = update._meta?.claudeCode;
   const parentToolCallId = claudeMeta?.parentToolUseId?.trim();
-  const isSubagent = ((driver === undefined || driver === "claude") && claudeMeta?.toolName === "Agent")
+  const isSubagent = (claudeMeta?.toolName === "Agent")
     || (driver === "qoder" && update._meta?.qoder?.toolName === "Agent")
     || (driver === "kimi" && isKimiSubagentInput(rawInput))
     || (driver === "codex" && isCodexSubagentMeta(update._meta?.codex?.subagent));

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -354,11 +354,26 @@ function mergeToolCallUpdate(
   }
   const nextMeta = update._meta;
   if (nextMeta) {
+    const previousMeta = merged._meta;
     merged._meta = {
-      ...merged._meta,
+      ...previousMeta,
       ...nextMeta,
-      ...(merged._meta?.claudeCode || nextMeta.claudeCode
-        ? { claudeCode: { ...merged._meta?.claudeCode, ...nextMeta.claudeCode } }
+      ...(previousMeta?.qoder || nextMeta.qoder
+        ? { qoder: { ...previousMeta?.qoder, ...nextMeta.qoder } }
+        : {}),
+      ...(previousMeta?.codex || nextMeta.codex
+        ? {
+            codex: {
+              ...previousMeta?.codex,
+              ...nextMeta.codex,
+              ...(previousMeta?.codex?.subagent || nextMeta.codex?.subagent
+                ? { subagent: { ...previousMeta?.codex?.subagent, ...nextMeta.codex?.subagent } }
+                : {}),
+            },
+          }
+        : {}),
+      ...(previousMeta?.claudeCode || nextMeta.claudeCode
+        ? { claudeCode: { ...previousMeta?.claudeCode, ...nextMeta.claudeCode } }
         : {}),
     };
   }
@@ -414,7 +429,7 @@ function buildToolUseEvent(
   const locations = update.locations;
   const claudeMeta = update._meta?.claudeCode;
   const parentToolCallId = claudeMeta?.parentToolUseId?.trim();
-  const isSubagent = claudeMeta?.toolName === "Agent"
+  const isSubagent = ((driver === undefined || driver === "claude") && claudeMeta?.toolName === "Agent")
     || (driver === "qoder" && update._meta?.qoder?.toolName === "Agent")
     || (driver === "kimi" && isKimiSubagentInput(rawInput))
     || (driver === "codex" && isCodexSubagentMeta(update._meta?.codex?.subagent));

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -445,3 +445,142 @@ test("Claude Agent and its nested tools preserve subagent hierarchy across spars
     status: "success",
   });
 });
+
+test("Qoder Agent metadata produces a subagent event across a sparse terminal update", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, {
+    driver: "qoder",
+    onToolEvent: (event) => events.push(event),
+  });
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+
+  send({
+    sessionUpdate: "tool_call",
+    toolCallId: "qoder-agent-1",
+    status: "pending",
+    kind: "think",
+    title: "Agent",
+    rawInput: {
+      description: "Pick a random number 1-100",
+      prompt: "Reply with one integer between 1 and 100.",
+      subagent_type: "general-purpose",
+    },
+    _meta: { qoder: { toolName: "Agent" } },
+  });
+  send({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "qoder-agent-1",
+    status: "completed",
+    rawOutput: "47",
+  });
+
+  expect(events.at(-1)).toEqual({
+    toolCallId: "qoder-agent-1",
+    isSubagent: true,
+    toolName: "Agent",
+    kind: "think",
+    summary: "general-purpose: Pick a random number 1-100",
+    rawInput: {
+      description: "Pick a random number 1-100",
+      prompt: "Reply with one integer between 1 and 100.",
+      subagent_type: "general-purpose",
+    },
+    rawOutput: "47",
+    status: "success",
+  });
+});
+
+test("Kimi recognizes delegated work only after its incremental Agent input is complete", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, {
+    driver: "kimi",
+    onToolEvent: (event) => events.push(event),
+  });
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+
+  send({
+    sessionUpdate: "tool_call",
+    toolCallId: "kimi-agent-1",
+    status: "pending",
+    kind: "other",
+    title: "Agent",
+  });
+  expect(events.at(-1)?.isSubagent).toBeUndefined();
+
+  send({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "kimi-agent-1",
+    status: "in_progress",
+    title: "Launching coder agent: Random number 1-100",
+    rawInput: {
+      prompt: "请随机说出 1 到 100 之间的一个整数。",
+      description: "Random number 1-100",
+      subagent_type: "coder",
+    },
+  });
+  send({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "kimi-agent-1",
+    status: "completed",
+    rawOutput: "73",
+  });
+
+  expect(events.at(-1)).toMatchObject({
+    toolCallId: "kimi-agent-1",
+    isSubagent: true,
+    toolName: "Launching coder agent: Random number 1-100",
+    summary: "coder: Random number 1-100",
+    rawOutput: "73",
+    status: "success",
+  });
+});
+
+test("Codex subagent activity metadata produces a completed subagent launch event", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, {
+    driver: "codex",
+    onToolEvent: (event) => events.push(event),
+  });
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: {
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "codex-agent-1",
+        status: "completed",
+        kind: "other",
+        title: "Start subagent random_number",
+        rawInput: {
+          agentThreadId: "thread-child-1",
+          agentPath: "/root/random_number",
+          activityKind: "started",
+        },
+        _meta: {
+          codex: {
+            subagent: {
+              threadId: "thread-child-1",
+              path: "/root/random_number",
+              activity: "started",
+            },
+          },
+        },
+      },
+    },
+  }));
+
+  expect(events).toEqual([{
+    toolCallId: "codex-agent-1",
+    isSubagent: true,
+    toolName: "Start subagent random_number",
+    kind: "other",
+    rawInput: {
+      agentThreadId: "thread-child-1",
+      agentPath: "/root/random_number",
+      activityKind: "started",
+    },
+    status: "success",
+  }]);
+});

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -473,6 +473,7 @@ test("Qoder Agent metadata produces a subagent event across a sparse terminal up
     toolCallId: "qoder-agent-1",
     status: "completed",
     rawOutput: "47",
+    _meta: { qoder: {} },
   });
 
   expect(events.at(-1)).toEqual({
@@ -537,7 +538,7 @@ test("Kimi recognizes delegated work only after its incremental Agent input is c
   });
 });
 
-test("Codex subagent activity metadata produces a completed subagent launch event", () => {
+test("Codex subagent metadata survives a sparse terminal namespace update", () => {
   const events: ToolUseEvent[] = [];
   const state = createStreamingPromptState(false, {
     driver: "codex",
@@ -550,7 +551,7 @@ test("Codex subagent activity metadata produces a completed subagent launch even
       update: {
         sessionUpdate: "tool_call",
         toolCallId: "codex-agent-1",
-        status: "completed",
+        status: "in_progress",
         kind: "other",
         title: "Start subagent random_number",
         rawInput: {
@@ -571,7 +572,19 @@ test("Codex subagent activity metadata produces a completed subagent launch even
     },
   }));
 
-  expect(events).toEqual([{
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: {
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "codex-agent-1",
+        status: "completed",
+        _meta: { codex: { subagent: { activity: "started" } } },
+      },
+    },
+  }));
+
+  expect(events.at(-1)).toEqual({
     toolCallId: "codex-agent-1",
     isSubagent: true,
     toolName: "Start subagent random_number",
@@ -582,5 +595,41 @@ test("Codex subagent activity metadata produces a completed subagent launch even
       activityKind: "started",
     },
     status: "success",
-  }]);
+  });
+});
+
+test("provider subagent signals are driver-gated and malformed metadata fails open", () => {
+  const parse = (driver: string, update: Record<string, unknown>): ToolUseEvent | undefined => {
+    const events: ToolUseEvent[] = [];
+    const state = createStreamingPromptState(false, {
+      driver,
+      onToolEvent: (event) => events.push(event),
+    });
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+    return events.at(-1);
+  };
+  const base = {
+    sessionUpdate: "tool_call",
+    toolCallId: "agent-1",
+    status: "completed",
+    kind: "other",
+    title: "Agent",
+  };
+
+  expect(parse("custom", { ...base, _meta: { claudeCode: { toolName: "Agent" } } })?.isSubagent).toBeUndefined();
+  expect(parse("custom", { ...base, _meta: { qoder: { toolName: "Agent" } } })?.isSubagent).toBeUndefined();
+  expect(parse("custom", {
+    ...base,
+    rawInput: { prompt: "delegate", subagent_type: "coder" },
+  })?.isSubagent).toBeUndefined();
+  expect(parse("custom", {
+    ...base,
+    _meta: { codex: { subagent: { threadId: "thread-1", activity: "started" } } },
+  })?.isSubagent).toBeUndefined();
+  expect(parse("qoder", { ...base, _meta: { qoder: { toolName: "" } } })?.isSubagent).toBeUndefined();
+  expect(parse("kimi", { ...base, rawInput: { prompt: "delegate" } })?.isSubagent).toBeUndefined();
+  expect(parse("codex", {
+    ...base,
+    _meta: { codex: { subagent: { activity: "started" } } },
+  })?.isSubagent).toBeUndefined();
 });

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -633,3 +633,38 @@ test("provider subagent signals are driver-gated and malformed metadata fails op
     _meta: { codex: { subagent: { activity: "started" } } },
   })?.isSubagent).toBeUndefined();
 });
+
+test("wrong-driver Claude metadata does not alter an ordinary tool event", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, {
+    driver: "custom",
+    onToolEvent: (event) => events.push(event),
+  });
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: {
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "ordinary-1",
+        status: "completed",
+        kind: "other",
+        title: "Agent",
+        _meta: {
+          claudeCode: {
+            toolName: "Agent",
+            parentToolUseId: "unrelated-parent",
+            toolResponse: { status: "async_launched", agentId: "unexpected" },
+          },
+        },
+      },
+    },
+  }));
+
+  expect(events).toEqual([{
+    toolCallId: "ordinary-1",
+    toolName: "Agent",
+    kind: "other",
+    status: "success",
+  }]);
+});


### PR DESCRIPTION
## Summary

- normalize Claude, Qoder, Kimi, and Codex delegation events into the existing Relay Web subagent card
- preserve provider metadata across sparse ACP updates and gate classification by the resolved driver
- keep full child timelines only when the adapter supplies parent-child ownership; do not fabricate missing traces
- document the provider signals and add the implementation spec

## Testing

- npm test
- bun test tests/unit/transport/streaming-prompt-tool-events.test.ts
- npx tsc --noEmit

## Review

- Standards review: no findings
- Spec review: no remaining findings after sparse-metadata and wrong-driver regression coverage