### PR TITLE
feat(channels): align subagent presentation across feishu/wechat/yuanbao

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -440,6 +440,31 @@ async start(input: ChannelStartInput): Promise<void> {
 
 ---
 
+### 5.2 Subagent notices for text channels (`formatSubagentNotice` / `SubagentNoticeTracker`)
+
+When a turn drives a subagent (an `Agent` / `Task` delegation), the transport marks the corresponding tool events with `isSubagent: true` (and, when the provider supplies it, `parentToolCallId`). Rich channels like the Feishu card or the web dashboard fold these into a nested trace. A text-only channel (WeChat, Yuanbao) can't render that, so `xacpx/plugin-api` exports two helpers that degrade the trace to one honest line per delegation:
+
+```ts
+import { SubagentNoticeTracker, formatSubagentNotice, type ToolUseEvent } from "xacpx/plugin-api";
+
+// Create ONE tracker per turn (not per event), then feed it every tool event.
+const notices = new SubagentNoticeTracker();
+
+const request = {
+  // ...
+  onToolEvent: (event: ToolUseEvent) => {
+    const line = notices.notice(event); // → "↳ [subagent] <task> (running)" or null
+    if (line) void sendLine(line);       // your channel's foreground-gated send
+  },
+};
+```
+
+- `SubagentNoticeTracker.notice(event)` returns a line **only** for `isSubagent` events, and **at most once per `toolCallId`** — the first sighting emits, every later frame (including the terminal one) is swallowed, so a `running → success` pair never doubles up. Ordinary tool calls always return `null` to avoid flooding a linear chat.
+- `formatSubagentNotice(event)` is the stateless formatter behind it (prefers `event.summary`, falls back to `toolName`, truncates long titles). Use it directly only if you need custom dedup.
+- The helpers never invent child activity they can't prove — they surface the delegation itself, nothing more.
+
+---
+
 ## 6. Outbound quota: `OutboundQuota`
 
 ```ts

--- a/docs/zh/plugin-development_zh.md
+++ b/docs/zh/plugin-development_zh.md
@@ -440,6 +440,31 @@ async start(input: ChannelStartInput): Promise<void> {
 
 ---
 
+### 5.2 文本频道的子代理提示（`formatSubagentNotice` / `SubagentNoticeTracker`）
+
+当一轮对话触发子代理（`Agent` / `Task` 委派）时，传输层会给对应的工具事件打上 `isSubagent: true`（若 provider 提供，还会带 `parentToolCallId`）。飞书卡片、Web 面板这类富频道会把它们折叠成嵌套轨迹；纯文本频道（微信、元宝）渲染不了，因此 `xacpx/plugin-api` 导出两个 helper，把轨迹降级为“每次委派一行”的诚实呈现：
+
+```ts
+import { SubagentNoticeTracker, formatSubagentNotice, type ToolUseEvent } from "xacpx/plugin-api";
+
+// 每一轮对话只建一个 tracker（不是每个事件建一个），把该轮的每个工具事件都喂给它。
+const notices = new SubagentNoticeTracker();
+
+const request = {
+  // ...
+  onToolEvent: (event: ToolUseEvent) => {
+    const line = notices.notice(event); // → "↳ [subagent] <task> (running)" 或 null
+    if (line) void sendLine(line);       // 你的频道自己的前台门控发送
+  },
+};
+```
+
+- `SubagentNoticeTracker.notice(event)` **只**对 `isSubagent` 事件返回一行，且**同一个 `toolCallId` 最多一行**——首次出现时输出，之后的所有帧（包括终止帧）都被吞掉，所以 `running → success` 不会重复出两行。普通工具调用一律返回 `null`，避免刷屏。
+- `formatSubagentNotice(event)` 是它背后的无状态格式化函数（优先取 `event.summary`，退回 `toolName`，超长标题会截断）。只有当你需要自定义去重时才直接用它。
+- 这两个 helper 绝不会编造无法证实的子步骤——它们只呈现委派本身。
+
+---
+
 ## 6. 出站配额：`OutboundQuota`
 
 ```ts

--- a/packages/channel-feishu/src/card/card-builder.ts
+++ b/packages/channel-feishu/src/card/card-builder.ts
@@ -267,20 +267,99 @@ const TOOL_KIND_ICON: Record<string, string> = {
   other: "\u{1F527}",
 };
 
+// Full-width space: ASCII leading spaces collapse in Feishu markdown, so
+// nesting depth is conveyed with an ideographic space that survives rendering.
+const INDENT_UNIT = "\u3000";
+
+function statusBadge(status: string): string {
+  return status === "running" ? "⏳" : status === "error" ? "❌" : "✅";
+}
+
+function stepSummarySuffix(step: ToolUseStep): string {
+  return step.summary ? `: ${truncateInline(step.summary, 80)}` : "";
+}
+
+function stepDurationSuffix(step: ToolUseStep): string {
+  return step.durationMs !== undefined ? ` _(${formatElapsedMs(step.durationMs)})_` : "";
+}
+
+/** Walk the parentToolCallId chain, cycle-safe, yielding ancestor ids present in the batch. */
+function* ancestorIds(step: ToolUseStep, byId: Map<string, ToolUseStep>): Generator<string> {
+  let parentId = step.parentToolCallId;
+  const seen = new Set<string>();
+  while (parentId && byId.has(parentId) && !seen.has(parentId)) {
+    yield parentId;
+    seen.add(parentId);
+    parentId = byId.get(parentId)?.parentToolCallId;
+  }
+}
+
+/** How many subagent ancestors a step has — its indentation level (0 = top level). */
+function subagentAncestorDepth(step: ToolUseStep, byId: Map<string, ToolUseStep>): number {
+  let depth = 0;
+  for (const id of ancestorIds(step, byId)) {
+    if (byId.get(id)?.isSubagent) depth += 1;
+  }
+  return depth;
+}
+
+function isDescendantOf(step: ToolUseStep, ancestorId: string, byId: Map<string, ToolUseStep>): boolean {
+  for (const id of ancestorIds(step, byId)) {
+    if (id === ancestorId) return true;
+  }
+  return false;
+}
+
+/**
+ * Fold the flat tool-step list into a subagent-aware, insertion-ordered
+ * display list: top-level steps (ordinary tools + top-level subagents) render
+ * at the root, and every subagent is immediately followed by its descendants.
+ * Mirrors the relay-web SubagentStepCard fold, adapted to a single markdown
+ * block. Provider-agnostic — reads only `isSubagent`/`parentToolCallId`.
+ */
 function buildToolUsePanel(steps: ToolUseStep[] | undefined): Record<string, unknown> | null {
   if (!steps || steps.length === 0) return null;
-  const visibleSteps = steps.slice(0, TOOL_PANEL_MAX_STEPS);
-  const lines = visibleSteps.map((step) => {
-    const icon = TOOL_KIND_ICON[step.kind] ?? TOOL_KIND_ICON.other;
-    const statusBadge =
-      step.status === "running" ? "⏳"
-      : step.status === "error" ? "❌"
-      : "✅";
-    const summary = step.summary ? `: ${truncateInline(step.summary, 80)}` : "";
-    const dur = step.durationMs !== undefined ? ` _(${formatElapsedMs(step.durationMs)})_` : "";
-    return `${statusBadge} ${icon} **${step.toolName}**${summary}${dur}`;
-  });
-  const omitted = steps.length - visibleSteps.length;
+  const byId = new Map(steps.map((step) => [step.toolCallId, step]));
+
+  const descendantCount = (parentId: string): number =>
+    steps.reduce((n, step) => (isDescendantOf(step, parentId, byId) ? n + 1 : n), 0);
+
+  // Display order: iterate top-level roots (no subagent ancestor); a subagent
+  // root is immediately trailed by all its descendants in insertion order, so
+  // nested steps never surface twice.
+  const displayOrder: ToolUseStep[] = [];
+  for (const step of steps) {
+    if (subagentAncestorDepth(step, byId) > 0) continue;
+    displayOrder.push(step);
+    if (step.isSubagent) {
+      for (const candidate of steps) {
+        if (candidate !== step && isDescendantOf(candidate, step.toolCallId, byId)) {
+          displayOrder.push(candidate);
+        }
+      }
+    }
+  }
+
+  const visible = displayOrder.slice(0, TOOL_PANEL_MAX_STEPS);
+  const lines: string[] = [];
+  for (const step of visible) {
+    const depth = subagentAncestorDepth(step, byId);
+    const indent = depth > 0 ? `${INDENT_UNIT.repeat(depth)}└ ` : "";
+    if (step.isSubagent) {
+      const children = descendantCount(step.toolCallId);
+      lines.push(`${indent}${statusBadge(step.status)} ${t().subagentHeader(step.toolName, children)}${stepSummarySuffix(step)}`);
+      // Truthful fallback: providers that report only the delegating call
+      // (Qoder/Kimi/Codex) leave the trace empty — never fabricate children.
+      if (children === 0) {
+        lines.push(`${INDENT_UNIT.repeat(depth + 1)}└ _${t().subagentNoActivity}_`);
+      }
+    } else {
+      const icon = TOOL_KIND_ICON[step.kind] ?? TOOL_KIND_ICON.other;
+      lines.push(`${indent}${statusBadge(step.status)} ${icon} **${step.toolName}**${stepSummarySuffix(step)}${stepDurationSuffix(step)}`);
+    }
+  }
+
+  const omitted = displayOrder.length - visible.length;
   if (omitted > 0) {
     lines.push(t().toolPanelOmitted(omitted));
   }
@@ -303,6 +382,7 @@ function buildToolUsePanel(steps: ToolUseStep[] | undefined): Record<string, unk
     ],
   };
 }
+
 
 function truncateInline(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max - 3)}...` : s;

--- a/packages/channel-feishu/src/card/card-builder.ts
+++ b/packages/channel-feishu/src/card/card-builder.ts
@@ -2,7 +2,7 @@ import type { PlanEntry, PromptUsage } from "xacpx/plugin-api";
 import { t } from "../i18n/index.js";
 import { en } from "../i18n/en.js";
 import { zh } from "../i18n/zh.js";
-import type { ToolUseStep } from "./tool-use-types.js";
+import type { ToolUseStatus, ToolUseStep } from "./tool-use-types.js";
 
 export const STREAMING_ELEMENT_ID = "streaming_content";
 export const REASONING_ELEMENT_ID = "reasoning_content";
@@ -271,7 +271,7 @@ const TOOL_KIND_ICON: Record<string, string> = {
 // nesting depth is conveyed with an ideographic space that survives rendering.
 const INDENT_UNIT = "\u3000";
 
-function statusBadge(status: string): string {
+function statusBadge(status: ToolUseStatus): string {
   return status === "running" ? "⏳" : status === "error" ? "❌" : "✅";
 }
 

--- a/packages/channel-feishu/src/card/tool-use-store.ts
+++ b/packages/channel-feishu/src/card/tool-use-store.ts
@@ -44,6 +44,11 @@ export class ToolUseStore {
         : event.status !== "running"
           ? { durationMs: 0 }
           : {}),
+      // Subagent classification comes from the transport and is fixed at
+      // start (like toolName/kind) — carry it through so the panel can fold
+      // the delegating parent and indent its children.
+      ...(event.isSubagent ? { isSubagent: true } : {}),
+      ...(event.parentToolCallId !== undefined ? { parentToolCallId: event.parentToolCallId } : {}),
     };
     this.stepsById.set(event.toolCallId, step);
     this.order.push(event.toolCallId);

--- a/packages/channel-feishu/src/card/tool-use-store.ts
+++ b/packages/channel-feishu/src/card/tool-use-store.ts
@@ -27,6 +27,14 @@ export class ToolUseStore {
       } else if (event.status !== "running" && existing.durationMs === undefined) {
         existing.durationMs = Math.max(0, this.now() - existing.startedAt);
       }
+      // Subagent classification can arrive AFTER the first frame: Kimi's opening
+      // tool_call ships a sparse rawInput (no subagent_type yet), and Codex fills
+      // its subagent _meta progressively, so the transport only sets
+      // isSubagent/parentToolCallId on a later merged update. Promote those
+      // positive signals when they appear; the transport never negates them, so
+      // we upgrade but never clear.
+      if (event.isSubagent) existing.isSubagent = true;
+      if (event.parentToolCallId !== undefined) existing.parentToolCallId = event.parentToolCallId;
       // Tool name and kind don't change post-start.
       this.revision += 1;
       return;
@@ -44,9 +52,8 @@ export class ToolUseStore {
         : event.status !== "running"
           ? { durationMs: 0 }
           : {}),
-      // Subagent classification comes from the transport and is fixed at
-      // start (like toolName/kind) — carry it through so the panel can fold
-      // the delegating parent and indent its children.
+      // Seed subagent classification when the first frame already carries it;
+      // later frames upgrade it in the existing-step branch above.
       ...(event.isSubagent ? { isSubagent: true } : {}),
       ...(event.parentToolCallId !== undefined ? { parentToolCallId: event.parentToolCallId } : {}),
     };

--- a/packages/channel-feishu/src/card/tool-use-types.ts
+++ b/packages/channel-feishu/src/card/tool-use-types.ts
@@ -12,4 +12,8 @@ export interface ToolUseStep {
   status: ToolUseStatus;
   startedAt: number;
   durationMs?: number;
+  /** Marks the delegating Agent/Task tool that owns a subagent trace. */
+  isSubagent?: boolean;
+  /** Links a child step to its subagent parent for fold/indent rendering. */
+  parentToolCallId?: string;
 }

--- a/packages/channel-feishu/src/i18n/en.ts
+++ b/packages/channel-feishu/src/i18n/en.ts
@@ -23,6 +23,9 @@ export const en: FeishuMessages = {
   reasoningHeaderElapsed: (elapsed) => `🧠 Thought for ${elapsed}`,
   toolPanelOmitted: (count) => `… ${count} more tool call${count === 1 ? "" : "s"} not shown`,
   toolPanelHeader: (count) => `🔧 Tool calls (${count})`,
+  subagentHeader: (toolName, childCount) =>
+    `🤖 **${toolName}** _(subagent · ${childCount} step${childCount === 1 ? "" : "s"})_`,
+  subagentNoActivity: "no recorded activity",
   planPanelHeader: (done, total) => `📋 Plan (${done}/${total})`,
   planPanelOmitted: (count) => `… ${count} more item${count === 1 ? "" : "s"} not shown`,
 

--- a/packages/channel-feishu/src/i18n/messages.ts
+++ b/packages/channel-feishu/src/i18n/messages.ts
@@ -47,6 +47,10 @@ export interface FeishuMessages {
   toolPanelOmitted: (count: number) => string;
   /** Collapsible panel header for the tool-use section. */
   toolPanelHeader: (count: number) => string;
+  /** Group header line for a delegating subagent step (with child count). */
+  subagentHeader: (toolName: string, childCount: number) => string;
+  /** Placeholder shown under a subagent that reported no child activity. */
+  subagentNoActivity: string;
   /** Collapsible panel header for the plan/todo section (done / total). */
   planPanelHeader: (done: number, total: number) => string;
   /** Text appended to the plan panel when entries are omitted. */

--- a/packages/channel-feishu/src/i18n/zh.ts
+++ b/packages/channel-feishu/src/i18n/zh.ts
@@ -38,6 +38,8 @@ export const zh: FeishuMessages = {
   reasoningHeaderElapsed: (elapsed) => `🧠 已思考 ${elapsed}`,
   toolPanelOmitted: (count) => `… 还有 ${count} 个工具调用未显示`,
   toolPanelHeader: (count) => `🔧 工具调用 (${count})`,
+  subagentHeader: (toolName, childCount) => `🤖 **${toolName}** _(子代理 · ${childCount} 步)_`,
+  subagentNoActivity: "无记录活动",
   planPanelHeader: (done, total) => `📋 任务清单 (${done}/${total})`,
   planPanelOmitted: (count) => `… 还有 ${count} 项未显示`,
 

--- a/packages/channel-yuanbao/src/channel.ts
+++ b/packages/channel-yuanbao/src/channel.ts
@@ -1,4 +1,4 @@
-import { createConversationExecutor, resolveTurnLane } from "xacpx/plugin-api";
+import { createConversationExecutor, resolveTurnLane, SubagentNoticeTracker } from "xacpx/plugin-api";
 import { t, setChannelLocale } from "./i18n/index.js";
 import type {
   ActiveTurnRegistry,
@@ -490,6 +490,7 @@ export class YuanbaoChannel implements MessageChannelRuntime {
         });
         try {
           heartbeat.start();
+          const subagentNotices = new SubagentNoticeTracker();
           const response = await this.agent.chat({
             accountId: account.accountId,
             conversationId: chatKey,
@@ -505,6 +506,14 @@ export class YuanbaoChannel implements MessageChannelRuntime {
               ...(input.chatType === "group" ? { groupId: target } : {}),
               isOwner: Boolean(raw.bot_owner_id && raw.from_account === raw.bot_owner_id),
               ...(boundAlias ? { boundSessionAlias: boundAlias } : {}),
+            },
+            // Text-only degradation: no card, so a delegation surfaces as one
+            // honest line. Ordinary tool calls stay hidden to avoid flooding
+            // the chat; the tracker dedups start/terminal per toolCallId.
+            onToolEvent: (event) => {
+              if (this.isAborted() || !inForeground()) return;
+              const line = subagentNotices.notice(event);
+              if (line) void queue.push(line);
             },
             reply: async (text) => {
               if (this.isAborted()) return;

--- a/src/channels/subagent-notice.ts
+++ b/src/channels/subagent-notice.ts
@@ -24,22 +24,19 @@ export function formatSubagentNotice(event: ToolUseEvent): string {
 
 /**
  * Per-turn accumulator that decides when a subagent event warrants a notice
- * line, deduping by toolCallId. A delegation emits once on first sighting and
- * once more on its terminal transition (success/error) — never on repeated
- * `running` updates. Non-subagent events yield nothing.
+ * line, deduping by toolCallId. Each delegation surfaces exactly once — on its
+ * first sighting, whatever status that is (a delegation first seen already
+ * terminal still gets its single line). Every later frame for the same id is
+ * swallowed, so a `running → success` pair never doubles up. Non-subagent
+ * events yield nothing.
  */
 export class SubagentNoticeTracker {
-  private readonly lastEmitted = new Map<string, ToolUseStatus>();
+  private readonly emitted = new Set<string>();
 
   notice(event: ToolUseEvent): string | null {
     if (!event.isSubagent) return null;
-    const previous = this.lastEmitted.get(event.toolCallId);
-    if (previous === event.status) return null;
-    // Emit on first sighting, or when a terminal state arrives after running.
-    if (previous === undefined || event.status !== "running") {
-      this.lastEmitted.set(event.toolCallId, event.status);
-      return formatSubagentNotice(event);
-    }
-    return null;
+    if (this.emitted.has(event.toolCallId)) return null;
+    this.emitted.add(event.toolCallId);
+    return formatSubagentNotice(event);
   }
 }

--- a/src/channels/subagent-notice.ts
+++ b/src/channels/subagent-notice.ts
@@ -1,0 +1,45 @@
+import type { ToolUseEvent, ToolUseStatus } from "./types.js";
+
+// Text-only channels (WeChat, Yuanbao) can't render the web/Feishu subagent
+// card, so they degrade to a single honest line per delegation. Only
+// `isSubagent` events surface — ordinary tool calls stay hidden to avoid
+// flooding a linear text chat. The line never claims child activity it can't
+// prove (see the unified-subagent-presentation spec).
+
+const NOTICE_MAX_TITLE = 120;
+
+function statusWord(status: ToolUseStatus): string {
+  return status === "running" ? "running" : status === "error" ? "failed" : "done";
+}
+
+function truncateTitle(text: string): string {
+  return text.length > NOTICE_MAX_TITLE ? `${text.slice(0, NOTICE_MAX_TITLE - 1)}…` : text;
+}
+
+/** Render a compact one-line notice for a subagent delegation event. */
+export function formatSubagentNotice(event: ToolUseEvent): string {
+  const title = (event.summary?.trim() || event.toolName || "subagent").trim();
+  return `↳ [subagent] ${truncateTitle(title)} (${statusWord(event.status)})`;
+}
+
+/**
+ * Per-turn accumulator that decides when a subagent event warrants a notice
+ * line, deduping by toolCallId. A delegation emits once on first sighting and
+ * once more on its terminal transition (success/error) — never on repeated
+ * `running` updates. Non-subagent events yield nothing.
+ */
+export class SubagentNoticeTracker {
+  private readonly lastEmitted = new Map<string, ToolUseStatus>();
+
+  notice(event: ToolUseEvent): string | null {
+    if (!event.isSubagent) return null;
+    const previous = this.lastEmitted.get(event.toolCallId);
+    if (previous === event.status) return null;
+    // Emit on first sighting, or when a terminal state arrives after running.
+    if (previous === undefined || event.status !== "running") {
+      this.lastEmitted.set(event.toolCallId, event.status);
+      return formatSubagentNotice(event);
+    }
+    return null;
+  }
+}

--- a/src/plugin-api.ts
+++ b/src/plugin-api.ts
@@ -16,6 +16,10 @@ export type {
   ToolUseKind,
   ToolUseStatus,
 } from "./channels/types.js";
+// Text-channel subagent degradation: a shared formatter + per-turn dedup
+// tracker so WeChat/Yuanbao surface delegations as one honest line each,
+// consuming the same normalized `isSubagent` contract the web card uses.
+export { formatSubagentNotice, SubagentNoticeTracker } from "./channels/subagent-notice.js";
 // Streaming side-channel payloads (context usage + advertised commands) so
 // channel plugins can render token/context footers and command hints. These
 // originate in the transport layer; surfaced here as the public plugin contract.

--- a/src/weixin/messaging/handle-weixin-message-turn.ts
+++ b/src/weixin/messaging/handle-weixin-message-turn.ts
@@ -28,6 +28,7 @@ import { markdownToPlainText, sendMessageWeixin } from "./send.js";
 import type { PendingFinalChunk } from "./quota-manager.js";
 import { handleSlashCommand } from "./slash-commands.js";
 import { normalizeMediaArray } from "../../channels/media-types.js";
+import { SubagentNoticeTracker } from "../../channels/subagent-notice.js";
 import { createNoopPerfTracer, type PerfTracer } from "../../perf/perf-tracer.js";
 import { t } from "../../i18n/index.js";
 
@@ -425,6 +426,10 @@ export async function handleWeixinMessageTurn(
   };
 
   const requestText = appendAttachmentNotes(bodyFromItemList(full.item_list), attachmentNotes);
+  // Text-only degradation: WeChat can't render the subagent card, so a
+  // delegation surfaces as one honest line via the existing reply path.
+  // Ordinary tool calls stay hidden; the tracker dedups per toolCallId.
+  const subagentNotices = new SubagentNoticeTracker();
   const request: Omit<ChatRequest, "reply"> = {
     accountId: deps.accountId,
     conversationId: buildWeixinChatKey(deps.accountId, full.from_user_id ?? ""),
@@ -444,6 +449,10 @@ export async function handleWeixinMessageTurn(
       // it, instead of re-reading current_session (which may have changed while
       // the prompt waited on the per-session lane).
       ...(deps.boundSessionAlias ? { boundSessionAlias: deps.boundSessionAlias } : {}),
+    },
+    onToolEvent: (event) => {
+      const line = subagentNotices.notice(event);
+      if (line) void sendReplySegment(line);
     },
     perfSpan,
   };

--- a/tests/unit/channels/subagent-notice.test.ts
+++ b/tests/unit/channels/subagent-notice.test.ts
@@ -32,17 +32,15 @@ test("tracker ignores non-subagent events", () => {
   expect(tracker.notice(event({}))).toBeNull();
 });
 
-test("tracker emits once on first sighting and once on terminal transition", () => {
+test("tracker emits exactly once per delegation, swallowing later frames", () => {
   const tracker = new SubagentNoticeTracker();
   const first = tracker.notice(event({ isSubagent: true, status: "running", summary: "job" }));
   expect(first).toBe("↳ [subagent] job (running)");
   // Repeated running updates are suppressed.
   expect(tracker.notice(event({ isSubagent: true, status: "running", summary: "job" }))).toBeNull();
-  // Terminal transition emits again.
-  const done = tracker.notice(event({ isSubagent: true, status: "success", summary: "job" }));
-  expect(done).toBe("↳ [subagent] job (done)");
-  // No duplicate for the same terminal status.
+  // The terminal transition must NOT produce a second line — one notice per delegation.
   expect(tracker.notice(event({ isSubagent: true, status: "success", summary: "job" }))).toBeNull();
+  expect(tracker.notice(event({ isSubagent: true, status: "error", summary: "job" }))).toBeNull();
 });
 
 test("tracker emits a single line when a delegation is first seen already terminal", () => {

--- a/tests/unit/channels/subagent-notice.test.ts
+++ b/tests/unit/channels/subagent-notice.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import { formatSubagentNotice, SubagentNoticeTracker } from "../../../src/channels/subagent-notice";
+import type { ToolUseEvent } from "../../../src/channels/types";
+
+function event(overrides: Partial<ToolUseEvent>): ToolUseEvent {
+  return {
+    toolCallId: "sa",
+    toolName: "Task",
+    kind: "other",
+    status: "running",
+    ...overrides,
+  };
+}
+
+test("formatSubagentNotice prefers summary, falls back to tool name", () => {
+  expect(formatSubagentNotice(event({ summary: "research the API", status: "running" }))).toBe(
+    "↳ [subagent] research the API (running)",
+  );
+  expect(formatSubagentNotice(event({ status: "success" }))).toBe("↳ [subagent] Task (done)");
+  expect(formatSubagentNotice(event({ status: "error" }))).toBe("↳ [subagent] Task (failed)");
+});
+
+test("formatSubagentNotice truncates an overlong title", () => {
+  const line = formatSubagentNotice(event({ summary: "x".repeat(200) }));
+  expect(line.endsWith("… (running)")).toBe(true);
+  expect(line.length).toBeLessThan(150);
+});
+
+test("tracker ignores non-subagent events", () => {
+  const tracker = new SubagentNoticeTracker();
+  expect(tracker.notice(event({ isSubagent: false }))).toBeNull();
+  expect(tracker.notice(event({}))).toBeNull();
+});
+
+test("tracker emits once on first sighting and once on terminal transition", () => {
+  const tracker = new SubagentNoticeTracker();
+  const first = tracker.notice(event({ isSubagent: true, status: "running", summary: "job" }));
+  expect(first).toBe("↳ [subagent] job (running)");
+  // Repeated running updates are suppressed.
+  expect(tracker.notice(event({ isSubagent: true, status: "running", summary: "job" }))).toBeNull();
+  // Terminal transition emits again.
+  const done = tracker.notice(event({ isSubagent: true, status: "success", summary: "job" }));
+  expect(done).toBe("↳ [subagent] job (done)");
+  // No duplicate for the same terminal status.
+  expect(tracker.notice(event({ isSubagent: true, status: "success", summary: "job" }))).toBeNull();
+});
+
+test("tracker emits a single line when a delegation is first seen already terminal", () => {
+  const tracker = new SubagentNoticeTracker();
+  const only = tracker.notice(event({ isSubagent: true, status: "success" }));
+  expect(only).toBe("↳ [subagent] Task (done)");
+  expect(tracker.notice(event({ isSubagent: true, status: "success" }))).toBeNull();
+});
+
+test("tracker keys by toolCallId so parallel delegations each emit", () => {
+  const tracker = new SubagentNoticeTracker();
+  expect(tracker.notice(event({ toolCallId: "a", isSubagent: true, summary: "A" }))).toBe("↳ [subagent] A (running)");
+  expect(tracker.notice(event({ toolCallId: "b", isSubagent: true, summary: "B" }))).toBe("↳ [subagent] B (running)");
+});

--- a/tests/unit/packages/channel-feishu/feishu-card-builder.test.ts
+++ b/tests/unit/packages/channel-feishu/feishu-card-builder.test.ts
@@ -390,3 +390,80 @@ test("buildCard reasoning header omits elapsed when reasoningElapsedMs is zero",
   expect(headerJson).toContain(t().reasoningHeader);
   expect(headerJson).not.toContain(t().reasoningHeaderElapsed(""));
 });
+
+// ---- subagent folding ----
+
+function toolPanelContent(card: ReturnType<typeof buildCard>): string {
+  const panel = (card.body as { elements: Array<Record<string, unknown>> }).elements[0];
+  const inner = (panel.elements as Array<{ content: string }>)[0];
+  return inner.content;
+}
+
+test("buildToolUsePanel folds subagent children under the delegating parent", () => {
+  const card = buildCard({
+    state: "streaming",
+    text: "working",
+    toolSteps: [
+      { toolCallId: "sa", toolName: "Task", kind: "other", status: "running", startedAt: 0, isSubagent: true, summary: "research the API" },
+      { toolCallId: "c1", toolName: "Read File", kind: "read", status: "success", startedAt: 1, durationMs: 20, parentToolCallId: "sa", summary: "api.ts" },
+      { toolCallId: "c2", toolName: "Bash", kind: "execute", status: "success", startedAt: 2, durationMs: 40, parentToolCallId: "sa", summary: "grep foo" },
+    ],
+  });
+  const content = toolPanelContent(card);
+  // Parent renders as a subagent header with the descendant count.
+  expect(content).toContain(t().subagentHeader("Task", 2));
+  expect(content).toContain("research the API");
+  // Children render indented (full-width space + tree marker) beneath.
+  expect(content).toContain("└ ");
+  expect(content).toContain("Read File");
+  expect(content).toContain("api.ts");
+  expect(content).toContain("Bash");
+  // Header counts every step (parent + 2 children).
+  const panel = (card.body as { elements: Array<Record<string, unknown>> }).elements[0];
+  expect(JSON.stringify(panel.header)).toContain(t().toolPanelHeader(3));
+});
+
+test("buildToolUsePanel shows a no-activity placeholder for a childless subagent", () => {
+  const card = buildCard({
+    state: "streaming",
+    text: "working",
+    toolSteps: [
+      { toolCallId: "sa", toolName: "Task", kind: "other", status: "success", startedAt: 0, isSubagent: true },
+    ],
+  });
+  const content = toolPanelContent(card);
+  expect(content).toContain(t().subagentHeader("Task", 0));
+  expect(content).toContain(t().subagentNoActivity);
+});
+
+test("buildToolUsePanel renders an orphan child (parent absent) as an ordinary top-level tool", () => {
+  const card = buildCard({
+    state: "streaming",
+    text: "working",
+    toolSteps: [
+      { toolCallId: "c1", toolName: "Read File", kind: "read", status: "success", startedAt: 0, parentToolCallId: "missing" },
+    ],
+  });
+  const content = toolPanelContent(card);
+  // No subagent ancestor is present → not indented, no tree marker.
+  expect(content).toContain("**Read File**");
+  expect(content).not.toContain("└ ");
+  expect(content).not.toContain(t().subagentNoActivity);
+});
+
+test("buildToolUsePanel keeps ordinary flat tools unchanged (no subagent markers)", () => {
+  const card = buildCard({
+    state: "streaming",
+    text: "working",
+    toolSteps: [
+      { toolCallId: "t1", toolName: "Read File", kind: "read", status: "success", startedAt: 0, durationMs: 30 },
+      { toolCallId: "t2", toolName: "Bash", kind: "execute", status: "running", startedAt: 1 },
+    ],
+  });
+  const content = toolPanelContent(card);
+  expect(content).toContain("**Read File**");
+  expect(content).toContain("**Bash**");
+  expect(content).not.toContain("└ ");
+  expect(content).not.toContain(t().subagentNoActivity);
+});
+

--- a/tests/unit/packages/channel-feishu/feishu-tool-use-store.test.ts
+++ b/tests/unit/packages/channel-feishu/feishu-tool-use-store.test.ts
@@ -67,3 +67,26 @@ test("later summary updates an earlier placeholder summary", () => {
   store.record(event({ toolCallId: "t1", summary: "foo.ts" }));
   expect(store.steps()[0].summary).toBe("foo.ts");
 });
+
+test("late-arriving subagent classification upgrades an existing step", () => {
+  // Kimi's opening tool_call ships a sparse rawInput, so the transport can't
+  // classify the delegation until a later merged frame — the step must promote
+  // isSubagent/parentToolCallId when they finally appear.
+  const store = new ToolUseStore(() => 0);
+  store.record(event({ toolCallId: "task-1", toolName: "Task", kind: "other" }));
+  expect(store.steps()[0].isSubagent).toBeUndefined();
+  store.record(
+    event({ toolCallId: "task-1", toolName: "Task", kind: "other", isSubagent: true, parentToolCallId: "root" }),
+  );
+  expect(store.steps()[0].isSubagent).toBe(true);
+  expect(store.steps()[0].parentToolCallId).toBe("root");
+});
+
+test("subagent classification is never cleared by a later sparse frame", () => {
+  const store = new ToolUseStore(() => 0);
+  store.record(event({ toolCallId: "task-1", isSubagent: true, parentToolCallId: "root" }));
+  // A terminal frame that omits the subagent fields must not regress them.
+  store.record(event({ toolCallId: "task-1", status: "success" }));
+  expect(store.steps()[0].isSubagent).toBe(true);
+  expect(store.steps()[0].parentToolCallId).toBe("root");
+});


### PR DESCRIPTION
## Summary
- Extends the unified subagent work (transport already normalizes `isSubagent`/`parentToolCallId`) to the chat channels so delegated work no longer collapses into ordinary tool calls — matching what the web dashboard already does.
- **Feishu (full alignment):** the tool-use card now folds each subagent parent into a `🤖` group header and indents its descendants beneath it; a childless delegation shows an honest "no recorded activity" placeholder.
- **WeChat + Yuanbao (text degradation):** a text channel can't render the card, so each delegation surfaces as one compact line (`↳ [subagent] <task> (running/done/failed)`), deduped per `toolCallId`. Ordinary tool calls stay hidden to avoid flooding the chat.
- Shared `formatSubagentNotice` + `SubagentNoticeTracker` in `src/channels/subagent-notice.ts`, exported via `plugin-api`.

## Design notes
- No transport or relay-protocol changes — channels stay provider-agnostic and read only the already-normalized contract.
- Never fabricates child activity: only Claude supplies real child parent-links today; Qoder/Kimi/Codex show the delegation without inventing sub-steps.
- Orphan children (parent absent from the batch) render as ordinary tools; existing flat tool lists are unchanged.

## Test plan
- [x] `npx tsc --noEmit`
- [x] Full `tests/unit` suite (exit 0)
- [x] New Feishu folding tests (parent+children indent, childless placeholder, orphan child, flat-list regression)
- [x] New `subagent-notice` tests (formatter, dedup, first-seen-terminal, parallel delegations)
- [ ] Manual Feishu card render check with a real delegation (requires live CardKit)