### PR TITLE
fix(relay-web): persist session effort

### DIFF
--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -169,6 +169,12 @@ acpx 的既有 `set <key> <value>` 命令设置，返回 `{ ok, current }`。设
 transport 权威值并返回实际的 `{ current, applied }`；查询失败时仍保留原始 timeout。成功对账会记录
 `control.session.effort.timeout_reconciled` 诊断事件。同一逻辑会话的 model/effort 配置写入共用串行队列，
 避免旧操作最后落盘。
+成功设置或 timeout 对账得到的权威 effort 会写入逻辑 session state。后续
+`control.session.effort.get` 仍从 adapter 读取 `available`，但当持久化值仍在广告列表中时将其作为
+`current` 返回；每次 prompt 会先把仍受支持的持久化值写入 acpx 的 desired config，再启动
+queue owner，使新 ACP session 通过 acpx 的 reconnect replay 恢复该值。这样 adapter/queue owner
+随任务结束而重建时，Web 重载和实际 Agent 运行都不会回到 adapter 默认值；若 adapter 不再广告
+该值则采用当前受支持值，不阻断 prompt。
 串行队列出闸时，ControlService 会为最坏 90 秒的 set + readback 预留完整预算；剩余时间不足的
 请求在触碰 transport 前失败，避免排队重新吃掉 Hub 为状态变更保留的响应窗口。
 

--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -6,7 +6,8 @@
 `OrchestrationService` / `ConsoleAgent`（ChatAgent），自身无持久状态。每轮对话的
 并发闸门与执行体已从门面里拆出：并发生命周期（in-flight / 队列 / drain 三态）由
 `TurnQueue` 持有，单轮执行体由 `SessionTurnRunner` 承担，`ControlService.prompt` 只是把
-调用转交给 `TurnQueue.submit`。
+调用转交给 `TurnQueue.submit`；唯一的提交前协调是等待同一逻辑会话已登记的 model/effort
+配置操作完成，避免紧随配置变更的 prompt 使用旧值。该等待不持有或改变 turn 并发状态。
 
 ## 文件
 
@@ -14,7 +15,7 @@
   orchestration / prompt / executeCommand。导出类型：`ControlServiceDeps`、
   `ControlSessionInfo`、`ControlPromptInput`、`ControlPromptResult`、
   `ControlExecuteCommandInput`。`prompt` / `runScheduledTurn` / `cancelTurn` /
-  `cancelQueuedItem` 都转发给 `TurnQueue`。
+  `cancelQueuedItem` 都转发给 `TurnQueue`；`prompt` 在转发前等待同会话已登记的配置操作。
 - **`src/control/turn-queue.ts`** — `TurnQueue`：三态并发闸门
   （`inFlight` / `queues` / `draining`）。构造时注入 `{ runTurn, emitQueueUpdated,
   detectSessionsChanged }`。**无会话依赖**——回合结束后的 `sessions-changed` 检测经
@@ -174,7 +175,8 @@ transport 权威值并返回实际的 `{ current, applied }`；查询失败时�
 `current` 返回；每次 prompt 会先把仍受支持的持久化值写入 acpx 的 desired config，再启动
 queue owner，使新 ACP session 通过 acpx 的 reconnect replay 恢复该值。这样 adapter/queue owner
 随任务结束而重建时，Web 重载和实际 Agent 运行都不会回到 adapter 默认值；若 adapter 不再广告
-该值则采用当前受支持值，不阻断 prompt。
+该值则采用当前受支持值，不阻断 prompt。adapter 报告的 `current` 在 `available` 非空时也必须位于
+其中，否则 GET 与 timeout 对账都将其规范化为未设置，避免向 Web 返回或持久化不受支持的值。
 串行队列出闸时，ControlService 会为最坏 90 秒的 set + readback 预留完整预算；剩余时间不足的
 请求在触碰 transport 前失败，避免排队重新吃掉 Hub 为状态变更保留的响应窗口。
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -114,7 +114,9 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   才在其旁边显示独立的 effort chip。
 - effort 选项完全采用 adapter 返回的 `available`，不在 Web 中固定 `low/medium/high/xhigh`。
   选择后调用 `control.session.effort.set`，界面乐观更新；RPC 失败时回到失败落地时最新的权威值并显示
-  全局 toast，因此连续选择中较早成功、较新失败时不会回滚到较早选择之前的旧值。
+  全局 toast，因此连续选择中较早成功、较新失败时不会回滚到较早选择之前的旧值。成功值由 Core
+  按逻辑 session 持久化并在 adapter 重建后重放，所以刷新或重新进入页面仍显示并实际使用该值；
+  用户选择后立刻发送时，prompt 会等待同一会话正在进行的 effort 设置落地。
 - model 切换完成后会重新读取 effort，因为 adapter 可能按 model 广告不同的推理强度选项；仅当
   composer 仍指向发起切换的同一会话时应用刷新结果。
 - session/实例切换以独立 context revision 丢弃 model 与 effort 的迟到响应，避免旧会话结果污染

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -22,6 +22,7 @@ vi.mock("../api/client", () => ({
 }));
 
 import { useChatStore, loadPersistedSelection } from "../stores/chat";
+import { useSessionControlsStore } from "../stores/session-controls";
 import { ApiError } from "../api/client";
 import PromptInput from "../components/PromptInput.vue";
 
@@ -419,6 +420,32 @@ test("surfaces an error when send fails", async () => {
   await chat.send("hello");
   expect(chat.error).toBe("instance-offline");
   expect(chat.sending).toBe(false);
+});
+
+test("send waits for the selected effort to finish persisting", async () => {
+  let resolveEffort!: (value: unknown) => void;
+  rpc.mockReturnValueOnce(new Promise((resolve) => { resolveEffort = resolve; }));
+  rpc.mockResolvedValueOnce({ ok: true });
+  const controls = useSessionControlsStore();
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+
+  const setting = controls.setEffort("i1", "backend", "high");
+  const sending = chat.send("use the new effort");
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+  expect(rpc).toHaveBeenCalledTimes(1);
+  expect(rpc).toHaveBeenNthCalledWith(1, "i1", "control.session.effort.set", {
+    sessionAlias: "backend",
+    effort: "high",
+  });
+
+  resolveEffort({ current: "high", applied: true });
+  await setting;
+  await sending;
+  expect(rpc).toHaveBeenNthCalledWith(2, "i1", "control.prompt", {
+    sessionAlias: "backend",
+    text: "use the new effort",
+  });
 });
 
 test("a failed send flips the bubble to failed REACTIVELY (not only on the next push)", async () => {

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -268,6 +268,22 @@ describe("session-controls store", () => {
     log.mockRestore();
   });
 
+  it("waitForEffortSet waits for the active effort mutation in the same session", async () => {
+    const s = useSessionControlsStore();
+    let resolveSet!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveSet = resolve; }));
+    const setting = s.setEffort("i1", "backend", "high");
+    let settled = false;
+    const waiting = s.waitForEffortSet("i1", "backend")!.then(() => { settled = true; });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    resolveSet({ current: "high", applied: true });
+    await setting;
+    await waiting;
+    expect(settled).toBe(true);
+  });
+
   it("clears effort when a failed set reports an authoritative null current", async () => {
     rpc.mockResolvedValueOnce({ current: "medium", available: ["medium", "high"] });
     const s = useSessionControlsStore();

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, QueueItemDto, ScheduledOriginDto, SessionCommandsSnapshotDto, SessionUsageSnapshotDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
+import { useSessionControlsStore } from "./session-controls";
 
 // Remember which session was open so a page refresh returns to it (selection is not
 // part of the route). Paired with the active-turn snapshot, a refresh mid-turn lands
@@ -478,6 +479,8 @@ export const useChatStore = defineStore("chat", () => {
     if (!instanceId.value || !sessionAlias.value) return;
     const id = instanceId.value;
     const alias = sessionAlias.value;
+    const pendingEffortSet = useSessionControlsStore().waitForEffortSet(id, alias);
+    if (pendingEffortSet) await pendingEffortSet;
     const pendingKey = bufKey(id, alias);
     pendingPromptRequests.set(pendingKey, (pendingPromptRequests.get(pendingKey) ?? 0) + 1);
     error.value = "";

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -247,9 +247,13 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     }
   }
 
+  function waitForEffortSet(instanceId: string, alias: string): Promise<void> | undefined {
+    return pendingEffortSets.get(contextKey(instanceId, alias));
+  }
+
   return {
     modelCurrent, modelAvailable, modelLoading, reset, loadModel, setModel,
-    effortCurrent, effortAvailable, effortLoading, loadEffort, setEffort,
+    effortCurrent, effortAvailable, effortLoading, loadEffort, setEffort, waitForEffortSet,
   };
 });
 

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -98,6 +98,7 @@ interface BridgeSessionInput {
   cwd: string;
   name: string;
   model?: string;
+  effort?: string;
   mcpCoordinatorSession?: string;
   mcpSourceHandle?: string;
   replyMode?: "stream" | "final" | "verbose";
@@ -515,6 +516,9 @@ export class BridgeRuntime {
   }
 
   async prompt(input: BridgeSessionInput & { text: string }, onEvent?: (event: BridgePromptStreamEvent) => void): Promise<{ text: string }> {
+    if (input.effort?.trim()) {
+      await this.reapplySessionEffort(input, input.effort.trim());
+    }
     await this.launchMcpQueueOwnerIfNeeded(input);
     const structuredPrompt = await createStructuredPromptFile(input.text, input.media);
     const spawnSpec = resolveSpawnCommand(this.command, this.buildPromptArgs(input, [
@@ -720,13 +724,31 @@ export class BridgeRuntime {
     effort: string;
   }): Promise<Record<string, never>> {
     const record = await this.readRawSessionRecord(input, "get-session-effort", "json");
-    const advertised = requireAdvertisedSessionEffort(record, input.effort);
+    await this.applyAdvertisedSessionEffort(input, input.effort, record);
+    return {};
+  }
+
+  private async reapplySessionEffort(input: BridgeSessionInput, effort: string): Promise<void> {
+    const record = await this.readRawSessionRecord(input, "get-session-effort", "json");
+    const observed = parseSessionEffortRecord(record);
+    if (!observed?.available.includes(effort)) {
+      return;
+    }
+    await this.applyAdvertisedSessionEffort(input, effort, record);
+  }
+
+  private async applyAdvertisedSessionEffort(
+    input: BridgeSessionInput,
+    effort: string,
+    record: string,
+  ): Promise<void> {
+    const advertised = requireAdvertisedSessionEffort(record, effort);
     const spawnSpec = resolveSpawnCommand(this.command, this.buildSessionArgs(input, [
       "set",
       "-s",
       input.name,
       advertised.configId,
-      input.effort,
+      effort,
     ]));
     const result = await this.run(spawnSpec.command, spawnSpec.args, this.withSpawnEnvironment(input, {
       timeoutMs: this.managementCommandTimeoutMs(),
@@ -735,7 +757,6 @@ export class BridgeRuntime {
     if (result.code !== 0) {
       throw new Error(result.stderr || result.stdout || "set effort failed");
     }
-    return {};
   }
 
   async cancel(input: {

--- a/src/bridge/bridge-server.ts
+++ b/src/bridge/bridge-server.ts
@@ -218,6 +218,7 @@ export class BridgeServer {
           cwd: requireString(params, "cwd"),
           name: requireString(params, "name"),
           model: asOptionalString(params.model),
+          effort: asOptionalString(params.effort),
           mcpCoordinatorSession: asOptionalString(params.mcpCoordinatorSession),
           mcpSourceHandle: asOptionalString(params.mcpSourceHandle),
           text: requirePromptText(params, media),

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -47,6 +47,13 @@ const MODEL_SET_SETTLE_BUDGET_MS = 2 * (
   DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS + BRIDGE_REQUEST_TIMEOUT_GRACE_MS
 );
 
+function normalizeAdvertisedEffortCurrent(observed: { current?: string; available: string[] }): string | undefined {
+  if (observed.available.length === 0) return observed.current;
+  return observed.current && observed.available.includes(observed.current)
+    ? observed.current
+    : undefined;
+}
+
 export interface ModelSetRequestOptions {
   /** Connector-side deadline derived from the Hub request lifetime. */
   deadlineAt?: number;
@@ -451,15 +458,13 @@ export class ControlService {
       const session = await this.resolveControlSession(chatKey, alias);
       if (!session) return { available: [] };
       const observed = await getEffort(session);
+      const observedCurrent = normalizeAdvertisedEffortCurrent(observed);
       let current = session.effort && observed.available.includes(session.effort)
         ? session.effort
-        : observed.current;
+        : observedCurrent;
       if (session.effort && observed.available.length > 0 && !observed.available.includes(session.effort)) {
-        const reconciled = observed.current && observed.available.includes(observed.current)
-          ? observed.current
-          : undefined;
-        await this.deps.sessions.setSessionEffort(session.alias, reconciled);
-        current = reconciled;
+        await this.deps.sessions.setSessionEffort(session.alias, observedCurrent);
+        current = observedCurrent;
       }
       return {
         current,
@@ -491,7 +496,8 @@ export class ControlService {
           // Preserve the original timeout when authoritative reconciliation fails.
           throw error;
         }
-        await this.deps.sessions.setSessionEffort(session.alias, observed.current);
+        const observedCurrent = normalizeAdvertisedEffortCurrent(observed);
+        await this.deps.sessions.setSessionEffort(session.alias, observedCurrent);
         try {
           await this.deps.logger?.error(
             "control.session.effort.timeout_reconciled",
@@ -499,14 +505,14 @@ export class ControlService {
             {
               sessionAlias: session.alias,
               requestedEffort: effort,
-              observedEffort: observed.current ?? null,
+              observedEffort: observedCurrent ?? null,
               timeout: error instanceof Error ? error.message : String(error),
             },
           );
         } catch {
           // Logging is diagnostic only; reconciliation already succeeded.
         }
-        return { current: observed.current, applied: observed.current === effort };
+        return { current: observedCurrent, applied: observedCurrent === effort };
       }
       await this.deps.sessions.setSessionEffort(session.alias, effort);
       return { current: effort, applied: true };

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -451,16 +451,18 @@ export class ControlService {
       const session = await this.resolveControlSession(chatKey, alias);
       if (!session) return { available: [] };
       const observed = await getEffort(session);
+      let current = session.effort && observed.available.includes(session.effort)
+        ? session.effort
+        : observed.current;
       if (session.effort && observed.available.length > 0 && !observed.available.includes(session.effort)) {
         const reconciled = observed.current && observed.available.includes(observed.current)
           ? observed.current
           : undefined;
         await this.deps.sessions.setSessionEffort(session.alias, reconciled);
+        current = reconciled;
       }
       return {
-        current: session.effort && observed.available.includes(session.effort)
-          ? session.effort
-          : observed.current,
+        current,
         available: observed.available,
       };
     });

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -98,7 +98,7 @@ export interface ControlServiceDeps {
   agent: Pick<ChatAgent, "chat">;
   sessions: Pick<
     SessionService,
-    "listAllResolvedSessions" | "removeSession" | "useSession" | "resolveAliasForChat" | "getSession" | "setSessionModel" | "setDisplayName"
+    "listAllResolvedSessions" | "removeSession" | "useSession" | "resolveAliasForChat" | "getSession" | "setSessionModel" | "setSessionEffort" | "setDisplayName"
   >;
   // The active transport, for reading/switching a session's model and effort.
   // These controls are optional on the interface — absence is handled gracefully.
@@ -444,9 +444,26 @@ export class ControlService {
 
   /** Read the reasoning-effort values advertised by the session's adapter. */
   async getSessionEffort(chatKey: string, alias: string): Promise<{ current?: string; available: string[] }> {
-    const session = await this.resolveControlSession(chatKey, alias);
-    if (!session || !this.deps.transport.getSessionEffort) return { available: [] };
-    return await this.deps.transport.getSessionEffort(session);
+    const initialSession = await this.resolveControlSession(chatKey, alias);
+    const getEffort = this.deps.transport.getSessionEffort?.bind(this.deps.transport);
+    if (!initialSession || !getEffort) return { available: [] };
+    return await this.runSessionConfigSetExclusive(initialSession.alias, async () => {
+      const session = await this.resolveControlSession(chatKey, alias);
+      if (!session) return { available: [] };
+      const observed = await getEffort(session);
+      if (session.effort && observed.available.length > 0 && !observed.available.includes(session.effort)) {
+        const reconciled = observed.current && observed.available.includes(observed.current)
+          ? observed.current
+          : undefined;
+        await this.deps.sessions.setSessionEffort(session.alias, reconciled);
+      }
+      return {
+        current: session.effort && observed.available.includes(session.effort)
+          ? session.effort
+          : observed.current,
+        available: observed.available,
+      };
+    });
   }
 
   /** Set the adapter-advertised reasoning effort for a session. */
@@ -472,6 +489,7 @@ export class ControlService {
           // Preserve the original timeout when authoritative reconciliation fails.
           throw error;
         }
+        await this.deps.sessions.setSessionEffort(session.alias, observed.current);
         try {
           await this.deps.logger?.error(
             "control.session.effort.timeout_reconciled",
@@ -488,6 +506,7 @@ export class ControlService {
         }
         return { current: observed.current, applied: observed.current === effort };
       }
+      await this.deps.sessions.setSessionEffort(session.alias, effort);
       return { current: effort, applied: true };
     });
   }
@@ -698,6 +717,10 @@ export class ControlService {
   }
 
   async prompt(input: ControlPromptInput): Promise<ControlPromptResult> {
+    if (this.sessionConfigSetTails.size > 0) {
+      const internalAlias = await this.deps.sessions.resolveAliasForChat(input.chatKey, input.sessionAlias);
+      await this.sessionConfigSetTails.get(internalAlias)?.catch(() => {});
+    }
     return this.turnQueue.submit({
       chatKey: input.chatKey,
       sessionAlias: input.sessionAlias,

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -144,6 +144,7 @@ export class SessionService {
       // Carry the same-agent model so a recreated session is ensured under the
       // same model that gets persisted (keeps acpx and state in agreement).
       model: sameAgentExisting?.model,
+      effort: sameAgentExisting?.effort,
       created_at: existing?.created_at ?? new Date().toISOString(),
       last_used_at: new Date().toISOString(),
     });
@@ -724,6 +725,7 @@ export class SessionService {
       ),
       // Session-level model wins; otherwise fall back to the agent config default.
       model: session.model ?? agentConfig.model,
+      effort: session.effort,
       displayName: session.display_name,
       workspace: session.workspace,
       transportSession: session.transport_session,
@@ -753,6 +755,26 @@ export class SessionService {
         session.model = normalized;
       } else {
         delete session.model;
+      }
+
+      session.last_used_at = new Date(this.now()).toISOString();
+      await this.persist();
+    });
+  }
+
+  /** Persist (or clear) a session's reasoning-effort preference by internal alias. */
+  async setSessionEffort(alias: string, effort: string | undefined): Promise<void> {
+    await this.mutate(async () => {
+      const session = this.state.sessions[alias];
+      if (!session) {
+        throw new Error(`session "${alias}" does not exist`);
+      }
+
+      const normalized = effort?.trim();
+      if (normalized) {
+        session.effort = normalized;
+      } else {
+        delete session.effort;
       }
 
       session.last_used_at = new Date(this.now()).toISOString();
@@ -882,6 +904,7 @@ export class SessionService {
             : {}),
         mode_id: sameAgentExisting?.mode_id,
         model: sameAgentExisting?.model,
+        effort: sameAgentExisting?.effort,
         reply_mode: sameAgentExisting?.reply_mode,
         created_at: existingSession?.created_at ?? now,
         last_used_at: now,

--- a/src/state/state-store.ts
+++ b/src/state/state-store.ts
@@ -531,6 +531,7 @@ function isSessionRecord(value: unknown): value is AppState["sessions"][string] 
     isOptionalString(value.attached_at) &&
     isOptionalString(value.transport_agent_command) &&
     isOptionalString(value.mode_id) &&
+    isOptionalString(value.effort) &&
     (value.reply_mode === undefined || isReplyMode(value.reply_mode)) &&
     isString(value.created_at) &&
     isString(value.last_used_at)

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -33,6 +33,8 @@ export interface LogicalSession {
   mode_id?: string;
   /** Per-session LLM model override (e.g. `gpt-5.2[high]`); falls back to the agent config default. */
   model?: string;
+  /** Per-session reasoning-effort preference advertised by the active ACP adapter. */
+  effort?: string;
   /** Per-session cosmetic display label shown in the relay-web dashboard only.
    *  Never affects identity (`alias`), `/use`, or the transport session. Cleared → UI shows alias. */
   display_name?: string;

--- a/src/transport/acpx-bridge/acpx-bridge-transport.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-transport.ts
@@ -327,6 +327,7 @@ export class AcpxBridgeTransport implements SessionTransport {
       mcpSourceHandle: session.mcpSourceHandle,
       replyMode: session.effectiveReplyMode ?? session.replyMode ?? "verbose",
       ...(session.model?.trim() ? { model: session.model.trim() } : {}),
+      ...(session.effort?.trim() ? { effort: session.effort.trim() } : {}),
     };
   }
 }

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -347,6 +347,9 @@ export class AcpxCliTransport implements SessionTransport {
     replyContext?: ReplyQuotaContext,
     options?: PromptOptions,
   ): Promise<{ text: string }> {
+    if (session.effort?.trim()) {
+      await this.reapplySessionEffort(session, session.effort.trim());
+    }
     await this.launchMcpQueueOwnerIfNeeded(session);
     const structuredPrompt = await createStructuredPromptFile(text, options?.media);
     const args = this.buildPromptArgs(session, text, structuredPrompt?.filePath);
@@ -482,7 +485,21 @@ export class AcpxCliTransport implements SessionTransport {
   }
 
   async setSessionEffort(session: ResolvedSession, effort: string): Promise<void> {
-    const record = await this.run(this.buildArgs(session, [
+    const record = await this.readSessionEffortRecord(session);
+    await this.applyAdvertisedSessionEffort(session, effort, record);
+  }
+
+  private async reapplySessionEffort(session: ResolvedSession, effort: string): Promise<void> {
+    const record = await this.readSessionEffortRecord(session);
+    const observed = parseSessionEffortRecord(record);
+    if (!observed?.available.includes(effort)) {
+      return;
+    }
+    await this.applyAdvertisedSessionEffort(session, effort, record);
+  }
+
+  private async readSessionEffortRecord(session: ResolvedSession): Promise<string> {
+    return await this.run(this.buildArgs(session, [
       "sessions",
       "show",
       session.transportSession,
@@ -490,6 +507,13 @@ export class AcpxCliTransport implements SessionTransport {
       timeoutMs: this.managementCommandTimeoutMs,
       stage: "get-session-effort",
     }));
+  }
+
+  private async applyAdvertisedSessionEffort(
+    session: ResolvedSession,
+    effort: string,
+    record: string,
+  ): Promise<void> {
     const advertised = requireAdvertisedSessionEffort(record, effort);
     await this.run(this.buildArgs(session, [
       "set",

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -70,6 +70,8 @@ export interface ResolvedSession {
    * no `--model` is passed and acpx uses the agent adapter's default.
    */
   model?: string;
+  /** Persisted reasoning-effort preference to reapply when the adapter process is recreated. */
+  effort?: string;
   /** Cosmetic per-session display label (relay-web only). Mirrors LogicalSession.display_name;
    *  undefined when unset. Does not affect identity or transport. */
   displayName?: string;

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -672,6 +672,91 @@ test("prompt starts queue owner with orchestration MCP identity", async () => {
   }]);
 });
 
+test("prompt persists effort before launching the queue owner so reconnect replays it", async () => {
+  const events: string[] = [];
+  const effortRecord = JSON.stringify({
+    acpxRecordId: "acpx-record-1",
+    acpx: {
+      config_options: [{
+        id: "reasoning_effort",
+        category: "thought_level",
+        currentValue: "medium",
+        options: [{ value: "medium" }, { value: "high" }],
+      }],
+    },
+  });
+  const queueOwnerLauncher = {
+    launch: async () => {
+      events.push("launch");
+    },
+  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  const run = async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return { code: 0, stdout: effortRecord, stderr: "" };
+    }
+    if (args.includes("set")) {
+      events.push("set:high");
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    events.push("prompt");
+    return { code: 0, stdout: "worker response", stderr: "" };
+  };
+  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
+
+  await runtime.prompt({
+    agent: "codex",
+    cwd: "/repo",
+    name: "worker",
+    text: "hello",
+    effort: "high",
+    mcpCoordinatorSession: "backend:main",
+  });
+
+  expect(events).toEqual(["set:high", "launch", "prompt"]);
+});
+
+test("prompt continues when the persisted effort is no longer advertised", async () => {
+  const events: string[] = [];
+  const queueOwnerLauncher = {
+    launch: async () => {
+      events.push("launch");
+    },
+  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  const run = async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "high",
+              options: [{ value: "medium" }, { value: "high" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("set")) events.push("set");
+    else events.push("prompt");
+    return { code: 0, stdout: "worker response", stderr: "" };
+  };
+  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
+
+  await expect(runtime.prompt({
+    agent: "codex",
+    cwd: "/repo",
+    name: "worker",
+    text: "hello",
+    effort: "xhigh",
+    mcpCoordinatorSession: "backend:main",
+  })).resolves.toEqual({ text: "worker response" });
+  expect(events).toEqual(["launch", "prompt"]);
+});
+
 test("prompt forwards --ttl when queueOwnerTtlSeconds is configured", async () => {
   const calls: string[][] = [];
   const run = async (_command: string, args: string[]) => {

--- a/tests/unit/bridge/bridge-server.test.ts
+++ b/tests/unit/bridge/bridge-server.test.ts
@@ -76,6 +76,31 @@ test("handles tailSessionHistory over ndjson", async () => {
   }))).resolves.toBe('{"id":"tail-1","ok":true,"result":{"text":"ok:5"}}\n');
 });
 
+test("forwards persisted effort from bridge prompt params", async () => {
+  let captured: Record<string, unknown> | undefined;
+  const runtime = {
+    prompt: async (input: Record<string, unknown>) => {
+      captured = input;
+      return { text: "ok" };
+    },
+  } as unknown as BridgeRuntime;
+  const server = new BridgeServer(runtime);
+
+  await server.handleLine(JSON.stringify({
+    id: "prompt-effort",
+    method: "prompt",
+    params: {
+      agent: "codex",
+      cwd: "/repo",
+      name: "demo",
+      text: "hello",
+      effort: "high",
+    },
+  }));
+
+  expect(captured).toMatchObject({ effort: "high" });
+});
+
 test("forwards validated Claude settings policy metadata over ndjson", async () => {
   let captured: Record<string, unknown> | undefined;
   const runtime = {

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -306,6 +306,23 @@ test("a fresh web read reconciles a persisted effort the adapter no longer adver
   expect(calls).toEqual(["persist-effort:internal-backend:high"]);
 });
 
+test("a fresh web read does not return an adapter current outside its advertised efforts", async () => {
+  const { deps, calls } = makeDeps();
+  await deps.sessions.setSessionEffort("internal-backend", "xhigh");
+  calls.length = 0;
+  deps.transport.getSessionEffort = async () => ({
+    current: "xhigh",
+    available: ["low", "high"],
+  });
+  const control = new ControlService(deps as never);
+
+  await expect(control.getSessionEffort("relay:acc", "backend")).resolves.toEqual({
+    current: undefined,
+    available: ["low", "high"],
+  });
+  expect(calls).toEqual(["persist-effort:internal-backend:"]);
+});
+
 test("effort read reconciliation cannot race a newer user selection", async () => {
   const { deps, calls } = makeDeps();
   await deps.sessions.setSessionEffort("internal-backend", "xhigh");

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -14,11 +14,16 @@ const session = {
 function makeDeps() {
   const calls: string[] = [];
   const logs: Array<{ event: string; message: string; context?: Record<string, unknown> }> = [];
+  const resolvedSession: typeof session & { effort?: string } = { ...session };
   const deps = {
     sessions: {
       resolveAliasForChat: async (_chatKey: string, alias: string) => `internal-${alias}`,
-      getSession: async (internalAlias: string) => (internalAlias === "internal-backend" ? session : null),
+      getSession: async (internalAlias: string) => (internalAlias === "internal-backend" ? resolvedSession : null),
       setSessionModel: async (alias: string, id: string) => { calls.push(`persist:${alias}:${id}`); },
+      setSessionEffort: async (alias: string, effort: string | undefined) => {
+        calls.push(`persist-effort:${alias}:${effort ?? ""}`);
+        resolvedSession.effort = effort;
+      },
     },
     transport: {
       getSessionModel: async (s: typeof session) => ({ current: s.model, available: ["gpt-5.2[high]", "gpt-5.2[low]"] }),
@@ -254,7 +259,85 @@ test("setSessionEffort applies the selected value through the transport", async 
     current: "high",
     applied: true,
   });
-  expect(calls).toEqual(["effort:internal-backend:high"]);
+  expect(calls).toEqual(["effort:internal-backend:high", "persist-effort:internal-backend:high"]);
+});
+
+test("the selected effort survives an adapter task ending and a fresh web read", async () => {
+  const { deps } = makeDeps();
+  let adapterEffort = "medium";
+  deps.transport.setSessionEffort = async (_session: typeof session, effort: string) => {
+    adapterEffort = effort;
+  };
+  deps.transport.getSessionEffort = async () => ({
+    current: adapterEffort,
+    available: ["low", "medium", "high"],
+  });
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionEffort("relay:acc", "backend", "high")).resolves.toEqual({
+    current: "high",
+    applied: true,
+  });
+
+  // The adapter process that accepted the setting exits with the completed
+  // task. A newly opened Web page reads through a fresh adapter process.
+  adapterEffort = "medium";
+
+  await expect(control.getSessionEffort("relay:acc", "backend")).resolves.toEqual({
+    current: "high",
+    available: ["low", "medium", "high"],
+  });
+});
+
+test("a fresh web read reconciles a persisted effort the adapter no longer advertises", async () => {
+  const { deps, calls } = makeDeps();
+  await deps.sessions.setSessionEffort("internal-backend", "xhigh");
+  calls.length = 0;
+  deps.transport.getSessionEffort = async () => ({
+    current: "high",
+    available: ["low", "medium", "high"],
+  });
+  const control = new ControlService(deps as never);
+
+  await expect(control.getSessionEffort("relay:acc", "backend")).resolves.toEqual({
+    current: "high",
+    available: ["low", "medium", "high"],
+  });
+  expect(calls).toEqual(["persist-effort:internal-backend:high"]);
+});
+
+test("effort read reconciliation cannot race a newer user selection", async () => {
+  const { deps, calls } = makeDeps();
+  await deps.sessions.setSessionEffort("internal-backend", "xhigh");
+  calls.length = 0;
+  let markReadStarted!: () => void;
+  let releaseRead!: () => void;
+  const readStarted = new Promise<void>((resolve) => { markReadStarted = resolve; });
+  const readRelease = new Promise<void>((resolve) => { releaseRead = resolve; });
+  deps.transport.getSessionEffort = async () => {
+    markReadStarted();
+    await readRelease;
+    return { current: "high", available: ["low", "medium", "high"] };
+  };
+  const control = new ControlService(deps as never);
+
+  const read = control.getSessionEffort("relay:acc", "backend");
+  await readStarted;
+  const write = control.setSessionEffort("relay:acc", "backend", "low");
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+  expect(calls).toEqual([]);
+
+  releaseRead();
+  await expect(read).resolves.toEqual({
+    current: "high",
+    available: ["low", "medium", "high"],
+  });
+  await expect(write).resolves.toEqual({ current: "low", applied: true });
+  expect(calls).toEqual([
+    "persist-effort:internal-backend:high",
+    "effort:internal-backend:low",
+    "persist-effort:internal-backend:low",
+  ]);
 });
 
 test("setSessionEffort reconciles a timed-out write that acpx actually applied", async () => {
@@ -276,6 +359,7 @@ test("setSessionEffort reconciles a timed-out write that acpx actually applied",
   expect(calls).toEqual([
     "effort:internal-backend:high",
     "query-effort:internal-backend",
+    "persist-effort:internal-backend:high",
   ]);
   expect(logs).toEqual([{
     event: "control.session.effort.timeout_reconciled",
@@ -290,7 +374,7 @@ test("setSessionEffort reconciles a timed-out write that acpx actually applied",
 });
 
 test("setSessionEffort returns the authoritative effort when timeout readback observes another value", async () => {
-  const { deps } = makeDeps();
+  const { deps, calls } = makeDeps();
   deps.transport.setSessionEffort = async () => {
     throw new CommandTimeoutError(30_000, "acpx set effort", { stage: "set-session-effort" });
   };
@@ -304,6 +388,7 @@ test("setSessionEffort returns the authoritative effort when timeout readback ob
     current: "medium",
     applied: false,
   });
+  expect(calls).toEqual(["persist-effort:internal-backend:medium"]);
 });
 
 test("setSessionEffort preserves the original timeout when effort readback fails", async () => {
@@ -365,6 +450,8 @@ test("setSessionEffort serializes rapid mutations for the same session", async (
   await expect(second).resolves.toEqual({ current: "high", applied: true });
   expect(calls).toEqual([
     "effort:internal-backend:low",
+    "persist-effort:internal-backend:low",
     "effort:internal-backend:high",
+    "persist-effort:internal-backend:high",
   ]);
 });

--- a/tests/unit/control/control-service-model.test.ts
+++ b/tests/unit/control/control-service-model.test.ts
@@ -252,6 +252,34 @@ test("getSessionEffort returns the adapter-advertised values", async () => {
   });
 });
 
+test("getSessionEffort omits an unpersisted adapter current outside the advertised efforts", async () => {
+  const { deps } = makeDeps();
+  deps.transport.getSessionEffort = async () => ({
+    current: "xhigh",
+    available: ["low", "high"],
+  });
+  const control = new ControlService(deps as never);
+
+  await expect(control.getSessionEffort("relay:acc", "backend")).resolves.toEqual({
+    current: undefined,
+    available: ["low", "high"],
+  });
+});
+
+test("getSessionEffort normalizes a blank current when efforts are advertised", async () => {
+  const { deps } = makeDeps();
+  deps.transport.getSessionEffort = async () => ({
+    current: "",
+    available: ["low", "high"],
+  });
+  const control = new ControlService(deps as never);
+
+  await expect(control.getSessionEffort("relay:acc", "backend")).resolves.toEqual({
+    current: undefined,
+    available: ["low", "high"],
+  });
+});
+
 test("setSessionEffort applies the selected value through the transport", async () => {
   const { deps, calls } = makeDeps();
   const control = new ControlService(deps as never);
@@ -406,6 +434,24 @@ test("setSessionEffort returns the authoritative effort when timeout readback ob
     applied: false,
   });
   expect(calls).toEqual(["persist-effort:internal-backend:medium"]);
+});
+
+test("setSessionEffort omits an unsupported effort from timeout readback", async () => {
+  const { deps, calls } = makeDeps();
+  deps.transport.setSessionEffort = async () => {
+    throw new CommandTimeoutError(30_000, "acpx set effort", { stage: "set-session-effort" });
+  };
+  deps.transport.getSessionEffort = async () => ({
+    current: "xhigh",
+    available: ["low", "high"],
+  });
+  const control = new ControlService(deps as never);
+
+  await expect(control.setSessionEffort("relay:acc", "backend", "high")).resolves.toEqual({
+    current: undefined,
+    applied: false,
+  });
+  expect(calls).toEqual(["persist-effort:internal-backend:"]);
 });
 
 test("setSessionEffort preserves the original timeout when effort readback fails", async () => {

--- a/tests/unit/sessions/session-effort.test.ts
+++ b/tests/unit/sessions/session-effort.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+
+import type { AppConfig } from "../../../src/config/types";
+import { SessionService } from "../../../src/sessions/session-service";
+import type { StateStore } from "../../../src/state/state-store";
+import { createEmptyState, type AppState } from "../../../src/state/types";
+
+const config: AppConfig = {
+  transport: {
+    type: "acpx-cli",
+    command: "acpx",
+    permissionMode: "approve-all",
+    nonInteractivePermissions: "deny",
+  },
+  logging: { level: "info", maxSizeBytes: 1024, maxFiles: 2, retentionDays: 1 },
+  channel: { type: "weixin", replyMode: "stream" },
+  channels: [{ id: "weixin", type: "weixin", enabled: true }],
+  agents: {
+    codex: { driver: "codex" },
+    claude: { driver: "claude" },
+  },
+  workspaces: { backend: { cwd: "/tmp/backend" } },
+  orchestration: {
+    maxPendingAgentRequestsPerCoordinator: 3,
+    allowWorkerChainedRequests: false,
+    allowedAgentRequestTargets: [],
+    allowedAgentRequestRoles: [],
+  },
+};
+
+class MemoryStateStore implements Pick<StateStore, "save"> {
+  savedStates: AppState[] = [];
+
+  async save(state: AppState): Promise<void> {
+    this.savedStates.push(structuredClone(state));
+  }
+}
+
+test("a selected effort persists across SessionService reconstruction", async () => {
+  const store = new MemoryStateStore();
+  const first = new SessionService(config, store, createEmptyState());
+  await first.createSession("api-fix", "codex", "backend");
+  await first.setSessionEffort("api-fix", "high");
+
+  const restoredState = structuredClone(store.savedStates.at(-1)!);
+  const restored = new SessionService(config, new MemoryStateStore(), restoredState);
+
+  await expect(restored.getSession("api-fix")).resolves.toMatchObject({ effort: "high" });
+});
+
+test("session recreation carries effort only when the agent is unchanged", async () => {
+  const service = new SessionService(config, new MemoryStateStore(), createEmptyState());
+  await service.createSession("api-fix", "codex", "backend");
+  await service.setSessionEffort("api-fix", "high");
+
+  await service.createSession("api-fix", "codex", "backend");
+  await expect(service.getSession("api-fix")).resolves.toMatchObject({ effort: "high" });
+
+  await service.createSession("api-fix", "claude", "backend");
+  expect((await service.getSession("api-fix"))?.effort).toBeUndefined();
+});

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
@@ -131,11 +131,12 @@ test("includes orchestration MCP identity in bridge prompt params", async () => 
   const request = mock(async () => ({ text: "ok" }));
   const transport = new AcpxBridgeTransport({ request });
 
-  await transport.prompt(mcpSession, "hello");
+  await transport.prompt({ ...mcpSession, effort: "high" }, "hello");
 
   expect(request.mock.calls[0]?.[1]).toMatchObject({
     mcpCoordinatorSession: "backend:main",
     mcpSourceHandle: "backend:claude:backend:main",
+    effort: "high",
   });
 });
 

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -1395,6 +1395,97 @@ test("starts a queue owner with orchestration MCP before prompting an MCP-bound 
   }]);
 });
 
+test("persists effort before launching the queue owner so reconnect replays it", async () => {
+  const events: string[] = [];
+  const effortSession: ResolvedSession = {
+    ...session,
+    effort: "high",
+    mcpCoordinatorSession: "backend:main",
+  };
+  const effortRecord = JSON.stringify({
+    acpxRecordId: "acpx-record-1",
+    acpx: {
+      config_options: [{
+        id: "reasoning_effort",
+        category: "thought_level",
+        currentValue: "medium",
+        options: [{ value: "medium" }, { value: "high" }],
+      }],
+    },
+  });
+  const run = mock(async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return { code: 0, stdout: effortRecord, stderr: "" };
+    }
+    if (args.includes("set")) {
+      events.push("set:high");
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    events.push("prompt");
+    return { code: 0, stdout: "worker response", stderr: "" };
+  });
+  const queueOwnerLauncher = {
+    launch: async () => {
+      events.push("launch");
+    },
+  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    run,
+    undefined,
+    queueOwnerLauncher,
+  );
+
+  await transport.prompt(effortSession, "hello");
+
+  expect(events).toEqual(["set:high", "launch", "prompt"]);
+});
+
+test("does not block a prompt when the persisted effort is no longer advertised", async () => {
+  const events: string[] = [];
+  const staleSession: ResolvedSession = {
+    ...session,
+    effort: "xhigh",
+    mcpCoordinatorSession: "backend:main",
+  };
+  const run = mock(async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "high",
+              options: [{ value: "medium" }, { value: "high" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("set")) events.push("set");
+    else events.push("prompt");
+    return { code: 0, stdout: "worker response", stderr: "" };
+  });
+  const queueOwnerLauncher = {
+    launch: async () => {
+      events.push("launch");
+    },
+  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    run,
+    undefined,
+    queueOwnerLauncher,
+  );
+
+  await expect(transport.prompt(staleSession, "hello")).resolves.toEqual({ text: "worker response" });
+  expect(events).toEqual(["launch", "prompt"]);
+});
+
 // --- toolEventMode wiring tests ---
 
 function makeToolCallLine(toolCallId: string, title: string, kind = "read"): string {


### PR DESCRIPTION
## What changed

- persist the selected effort on the logical session and restore it after state reload
- keep adapter-advertised effort options authoritative while preferring the persisted selection for Web reads
- pass persisted effort through both CLI and bridge transports
- write the desired effort before queue-owner launch so acpx reconnect replay applies it to the fresh ACP session
- reconcile stale effort values when a model or adapter no longer advertises them without blocking prompts
- serialize effort reads/writes and wait for an in-flight effort selection before Web prompt submission

## Root cause

The Web control updated the active adapter process but xacpx did not persist the selected effort in logical session state. When that process ended, a fresh adapter reported its default and the Web page displayed that value. Replaying too early or too late around queue-owner recreation also left races where the next task could use the old/default effort.

## User impact

A selected effort now survives task completion, page reload/re-entry, adapter recreation, and an immediate send after changing the setting. If a later model/adapter no longer supports the saved value, xacpx adopts a supported current value instead of failing the prompt.

## Validation

- `npx tsc --noEmit`
- `bun run build`
- `npm test` (Core suite passed; final Relay Web rerun: 103 files passed, 839 passed / 2 skipped)
- targeted CLI/Bridge replay, stale-value, persistence, concurrent GET/SET, and Web SET-before-prompt tests
- Standards and Spec reviews by separate subagents; final reviews clean

No changes were made to the upstream `acpx` dependency.