### PR TITLE
fix(relay-web): preserve history when switching to a working session

### DIFF
--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -175,6 +175,43 @@ test("a delayed history response cannot overwrite a newly selected session", asy
   expect(store.messages.map((message) => message.text)).toEqual(["frontend history"]);
 });
 
+test("switching to a working session keeps history when its turn starts during the fetch", async () => {
+  let resolveHistory!: (response: Response) => void;
+  const historyResponse = new Promise<Response>((resolve) => { resolveHistory = resolve; });
+  const historyBody = {
+    messages: [
+      { id: 1, instanceId: "i1", sessionAlias: "working", direction: "out", text: "older history", createdAt: "t1" },
+      { id: 2, instanceId: "i1", sessionAlias: "working", direction: "in", text: "current task", createdAt: "t2" },
+    ],
+  };
+  let requests = 0;
+  vi.stubGlobal("fetch", vi.fn(() => (
+    ++requests === 1
+      ? historyResponse
+      : Promise.resolve(new Response(JSON.stringify(historyBody), { status: 200 }))
+  )));
+
+  const store = useChatStore();
+  store.select("i1", "working");
+  const historyLoad = store.loadHistory();
+
+  store.applyEvent({
+    kind: "control-event",
+    instanceId: "i1",
+    event: {
+      type: "turn-started",
+      chatKey: "relay:x",
+      sessionAlias: "working",
+      prompt: "current task",
+    },
+  });
+
+  resolveHistory(new Response(JSON.stringify(historyBody), { status: 200 }));
+  await historyLoad;
+
+  expect(store.messages.map((message) => message.text)).toEqual(["older history", "current task"]);
+});
+
 test("loadingHistory is raised while the initial history fetch is in flight", async () => {
   vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ messages: [] }), { status: 200 })));
   const store = useChatStore();

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -263,7 +263,13 @@ export const useChatStore = defineStore("chat", () => {
         `/api/instances/${id}/sessions/${alias}/messages?limit=${HISTORY_PAGE}`,
       );
       if (id !== instanceId.value || alias !== sessionAlias.value) return;
-      if (requestSequence !== historyRequestSequence || revision !== transcriptRevision) return;
+      if (requestSequence !== historyRequestSequence) return;
+      // A live event may mutate the selected transcript while this request is in
+      // flight (most notably turn-started when switching to a working session).
+      // The response can no longer replace local state safely, but abandoning it
+      // would leave the pane with only the live turn. Retry against the same
+      // selection so persisted history and the current turn converge.
+      if (revision !== transcriptRevision) return loadHistory();
       messages.value = rows;
       touchTranscript();
       hasMoreOlder.value = hasMore ?? false;


### PR DESCRIPTION
## Summary

- retry the selected session's history load when a live transcript mutation races the request
- keep rejecting responses superseded by a newer request or a different session selection
- add a regression test for `turn-started` arriving while session history is loading

## Root cause

Switching sessions clears the visible transcript and starts `loadHistory()`. If the selected working session emits `turn-started` before the request completes, the event increments the transcript revision. The returned history was then treated as stale and discarded permanently, leaving only the active task visible.

## User impact

Switching to a session whose agent is already working now shows its persisted history while continuing to display and update the live task.

## Validation

- `bun run --cwd packages/relay-web test src/__tests__/chat.test.ts` — 60 passed
- Relay Web typecheck passed
- Relay Web full suite — 103 files, 840 tests passed on the originating branch
- repository `npm test` passed
- Standards/Spec review passed with no findings