### PR TITLE
release: cut core, channel, and relay betas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/channel-feishu": {
       "name": "@ganglion/xacpx-channel-feishu",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "~1.60.0",
       },
@@ -53,13 +53,13 @@
     },
     "packages/channel-yuanbao": {
       "name": "@ganglion/xacpx-channel-yuanbao",
-      "version": "0.5.0",
+      "version": "0.6.0-beta.0",
       "dependencies": {
         "protobufjs": "^7.5.6",
         "ws": "^8.20.0",
       },
       "peerDependencies": {
-        "xacpx": ">=0.9.0-0",
+        "xacpx": ">=0.17.0-beta.13",
       },
       "optionalPeers": [
         "xacpx",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.27",
+      "version": "0.9.12-beta.28",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.12",
+  "version": "0.17.0-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.12",
+      "version": "0.17.0-beta.13",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -13110,7 +13110,7 @@
     },
     "packages/channel-feishu": {
       "name": "@ganglion/xacpx-channel-feishu",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "~1.60.0"
@@ -13158,14 +13158,14 @@
     },
     "packages/channel-yuanbao": {
       "name": "@ganglion/xacpx-channel-yuanbao",
-      "version": "0.5.0",
+      "version": "0.6.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^7.5.6",
         "ws": "^8.20.0"
       },
       "peerDependencies": {
-        "xacpx": ">=0.9.0-0"
+        "xacpx": ">=0.17.0-beta.13"
       },
       "peerDependenciesMeta": {
         "xacpx": {
@@ -13183,7 +13183,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.27",
+      "version": "0.9.12-beta.28",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.12",
+  "version": "0.17.0-beta.13",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/channel-feishu/package.json
+++ b/packages/channel-feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-feishu",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "description": "Feishu channel plugin for xacpx.",
   "license": "MIT",
   "keywords": ["xacpx", "feishu", "channel", "plugin"],

--- a/packages/channel-yuanbao/package.json
+++ b/packages/channel-yuanbao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-yuanbao",
-  "version": "0.5.0",
+  "version": "0.6.0-beta.0",
   "description": "Tencent Yuanbao channel plugin for xacpx.",
   "license": "MIT",
   "keywords": ["xacpx", "yuanbao", "channel", "plugin"],
@@ -20,7 +20,7 @@
   },
   "files": ["dist", "README.md"],
   "peerDependencies": {
-    "xacpx": ">=0.9.0-0"
+    "xacpx": ">=0.17.0-beta.13"
   },
   "peerDependenciesMeta": {
     "xacpx": {

--- a/packages/channel-yuanbao/src/command-sync.ts
+++ b/packages/channel-yuanbao/src/command-sync.ts
@@ -2,7 +2,7 @@ import type { AppLogger } from "xacpx/plugin-api";
 import type { WsSyncCommand, WsSyncInformationData } from "./access/ws/types.js";
 
 // 与 packages/channel-yuanbao/package.json 的 version 一致；同步测试校验防漂移。
-export const PLUGIN_VERSION = "0.5.0";
+export const PLUGIN_VERSION = "0.6.0-beta.0";
 
 // 元宝协议 SyncInformationType.SYNC_INFORMATION_TYPE_COMMANDS。
 const SYNC_TYPE_COMMANDS = 1;

--- a/packages/channel-yuanbao/src/index.ts
+++ b/packages/channel-yuanbao/src/index.ts
@@ -9,7 +9,7 @@ export { yuanbaoCliProvider } from "./yuanbao-provider.js";
 const plugin: XacpxPlugin = {
   apiVersion: 1,
   name: "@ganglion/xacpx-channel-yuanbao",
-  minXacpxVersion: "0.8.0",
+  minXacpxVersion: "0.17.0-beta.13",
   channels: [
     {
       type: "yuanbao",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.27",
+  "version": "0.9.12-beta.28",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/tests/unit/packages/channel-yuanbao/yuanbao-plugin.test.ts
+++ b/tests/unit/packages/channel-yuanbao/yuanbao-plugin.test.ts
@@ -20,7 +20,7 @@ beforeAll(() => {
 });
 
 test("@ganglion/xacpx-channel-yuanbao exports a valid plugin definition", () => {
-  const validated = validateWeacpxPlugin(plugin, "@ganglion/xacpx-channel-yuanbao", { currentXacpxVersion: "0.8.0" });
+  const validated = validateWeacpxPlugin(plugin, "@ganglion/xacpx-channel-yuanbao", { currentXacpxVersion: "0.17.0-beta.13" });
 
   expect(validated.name).toBe("@ganglion/xacpx-channel-yuanbao");
   expect(validated.channels?.map((channel) => channel.type)).toEqual(["yuanbao"]);
@@ -29,7 +29,7 @@ test("@ganglion/xacpx-channel-yuanbao exports a valid plugin definition", () => 
 
 test("@ganglion/xacpx-channel-yuanbao declares compatibility metadata", () => {
   expect(plugin.apiVersion).toBe(1);
-  expect(plugin.minXacpxVersion).toBe("0.8.0");
+  expect(plugin.minXacpxVersion).toBe("0.17.0-beta.13");
 });
 
 test("yuanbao plugin factory creates the YuanbaoChannel runtime", () => {

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.12", () => {
+test("root package version is 0.17.0-beta.13", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.12");
+  expect(pkg.version).toBe("0.17.0-beta.13");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {
@@ -27,12 +27,13 @@ test("first-party channel plugins peer depend on xacpx", () => {
   const yuanbao = readJson("packages/channel-yuanbao/package.json");
 
   for (const pkg of [feishu, yuanbao]) {
-    expect(pkg.peerDependencies.xacpx).toBe(">=0.9.0-0");
     expect(pkg.peerDependencies.weacpx).toBeUndefined();
     expect(pkg.peerDependenciesMeta.xacpx.optional).toBe(true);
     expect(pkg.peerDependenciesMeta.weacpx).toBeUndefined();
     expect(pkg.publishConfig.access).toBe("public");
   }
+  expect(feishu.peerDependencies.xacpx).toBe(">=0.9.0-0");
+  expect(yuanbao.peerDependencies.xacpx).toBe(">=0.17.0-beta.13");
 });
 
 test("deprecated weacpx compat shim forwards plugin-api to xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.12",
+  "version": "0.17.0-beta.13",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.12"
+    "@ganglion/xacpx": "^0.17.0-beta.13"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Release scope

- `@ganglion/xacpx` → `0.17.0-beta.13`
- `weacpx` compatibility shim → `0.17.0-beta.13`
- `@ganglion/xacpx-channel-feishu` → `0.7.0-beta.0`
- `@ganglion/xacpx-channel-yuanbao` → `0.6.0-beta.0`
- `@ganglion/xacpx-relay` → `0.9.12-beta.28`

`@ganglion/xacpx-relay-protocol` and `@ganglion/xacpx-channel-relay` are intentionally unchanged because their package paths have no changes since their latest tags.

## Compatibility

Yuanbao now requires `xacpx >=0.17.0-beta.13` because it consumes the new runtime `SubagentNoticeTracker` plugin API export.

## Validation

- targeted package metadata/plugin tests: 19 passed
- `bun run verify:publish` passed, including all package builds and embedded Relay Web tarball verification
- `npm test` passed
- lockfile/package version consistency checked