### PR TITLE
fix(claude): keep runtime dirs profile-local

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -489,9 +489,11 @@ user settings `env` object. It then:
   `availableModels` through the managed adapter's `CLAUDE_MODEL_CONFIG` seam;
 - keeps project/local Claude settings enabled, so their normal precedence is preserved;
 - excludes user hooks, plugins, skills, MCP servers, and permissions;
-- gives the adapter a filtered settings profile while linking Claude's session-state
+- gives the adapter a filtered settings profile while linking Claude's durable session-state
   directories back to the original profile, so native list/resume and transcript persistence
-  continue to use the existing history;
+  continue to use the existing history; Claude-managed runtime directories such as
+  `session-env` and `shell-snapshots` remain local to the filtered profile because Claude
+  may recreate them during a turn;
 - never writes provider credentials to xacpx config/state, disk, or the bridge protocol.
 
 Normal first-party Claude OAuth and `ANTHROPIC_API_KEY`-only setups do not trigger the

--- a/src/adapters/claude-settings-policy.ts
+++ b/src/adapters/claude-settings-policy.ts
@@ -9,6 +9,11 @@ export type ClaudeSettingsPolicy = "provider-only" | "isolated" | "full-user";
 
 export const DEFAULT_CLAUDE_SETTINGS_POLICY: ClaudeSettingsPolicy = "provider-only";
 
+// Bump this when the filtered profile's on-disk layout changes. Reusing a
+// digest created by an older layout can leave real directories where the
+// current version requires links, and must not make every future prompt fail.
+const CLAUDE_SETTINGS_PROFILE_LAYOUT_VERSION = "persistent-state-links-v1";
+
 export function isClaudeSettingsPolicy(value: unknown): value is ClaudeSettingsPolicy {
   return value === "provider-only" || value === "isolated" || value === "full-user";
 }
@@ -126,6 +131,8 @@ function installSettingsProfile(
     .update("\0")
     .update(policy)
     .update("\0")
+    .update(CLAUDE_SETTINGS_PROFILE_LAYOUT_VERSION)
+    .update("\0")
     .update(serialized)
     .digest("hex")
     .slice(0, 20);
@@ -139,17 +146,20 @@ function installSettingsProfile(
   setEnvironmentValue(env, "CLAUDE_CONFIG_DIR", profileDir, platform);
 }
 
-const CLAUDE_SESSION_STATE_DIRS = [
+// Link only durable state that native list/resume and transcript discovery need.
+// Claude recreates session-env and shell-snapshots during a running turn. If
+// either is a junction, Claude can replace it with a real directory and poison
+// the next prompt's link validation. Those runtime-owned directories therefore
+// stay local to the filtered profile.
+const CLAUDE_PERSISTENT_SESSION_STATE_DIRS = [
   "projects",
   "file-history",
   "plans",
   "todos",
-  "session-env",
   "tasks",
   "teams",
   "sessions",
   "transcripts",
-  "shell-snapshots",
 ] as const;
 
 function linkClaudeSessionState(
@@ -157,7 +167,7 @@ function linkClaudeSessionState(
   profileDir: string,
   platform: NodeJS.Platform,
 ): void {
-  for (const name of CLAUDE_SESSION_STATE_DIRS) {
+  for (const name of CLAUDE_PERSISTENT_SESSION_STATE_DIRS) {
     const source = join(sourceConfigDir, name);
     // Create lazy state stores in the native profile before linking them. If
     // Claude created them under the filtered profile instead, that state would

--- a/tests/unit/adapters/claude-settings-policy.test.ts
+++ b/tests/unit/adapters/claude-settings-policy.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -125,6 +126,82 @@ test("different sanitized settings use immutable profile directories", () => {
 
   expect(profileDirs).toHaveLength(2);
   expect(profileDirs[0]).not.toBe(profileDirs[1]);
+});
+
+test("profile layout changes do not reuse incompatible legacy directories", () => {
+  const root = mkdtempSync(join(tmpdir(), "xacpx-claude-profile-layout-"));
+  const sourceConfigDir = join(root, "source");
+  const profileRoot = join(root, "profiles");
+  const serialized = "{}\n";
+  const legacyDigest = createHash("sha256")
+    .update(sourceConfigDir)
+    .update("\0")
+    .update("provider-only")
+    .update("\0")
+    .update(serialized)
+    .digest("hex")
+    .slice(0, 20);
+  const legacyProfileDir = join(profileRoot, legacyDigest);
+  mkdirSync(join(legacyProfileDir, "projects"), { recursive: true });
+  mkdirSync(sourceConfigDir, { recursive: true });
+  writeFileSync(join(sourceConfigDir, "settings.json"), JSON.stringify({
+    env: { ANTHROPIC_BASE_URL: "https://provider.example" },
+  }));
+
+  try {
+    const env = resolveClaudeSpawnEnvironment(
+      { driver: "claude" },
+      {
+        baseEnv: { CLAUDE_CONFIG_DIR: sourceConfigDir },
+        profileRoot,
+      },
+    );
+
+    expect(env?.CLAUDE_CONFIG_DIR).toBeDefined();
+    expect(env?.CLAUDE_CONFIG_DIR).not.toBe(legacyProfileDir);
+    writeFileSync(join(env!.CLAUDE_CONFIG_DIR!, "projects", "new.jsonl"), "new");
+    expect(readFileSync(join(sourceConfigDir, "projects", "new.jsonl"), "utf8")).toBe("new");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Claude-managed runtime directories can be recreated between prompts", () => {
+  const root = mkdtempSync(join(tmpdir(), "xacpx-claude-runtime-dirs-"));
+  const sourceConfigDir = join(root, "source");
+  const profileRoot = join(root, "profiles");
+  mkdirSync(sourceConfigDir, { recursive: true });
+  writeFileSync(join(sourceConfigDir, "settings.json"), JSON.stringify({
+    env: { ANTHROPIC_BASE_URL: "https://provider.example" },
+  }));
+
+  try {
+    const options = {
+      baseEnv: { CLAUDE_CONFIG_DIR: sourceConfigDir },
+      profileRoot,
+    };
+    const firstEnv = resolveClaudeSpawnEnvironment({ driver: "claude" }, options);
+    const profileDir = firstEnv?.CLAUDE_CONFIG_DIR;
+    expect(profileDir).toBeDefined();
+    expect(existsSync(join(profileDir!, "session-env"))).toBe(false);
+    expect(existsSync(join(profileDir!, "shell-snapshots"))).toBe(false);
+
+    mkdirSync(join(profileDir!, "session-env"), { recursive: true });
+    mkdirSync(join(profileDir!, "shell-snapshots"), { recursive: true });
+    writeFileSync(join(profileDir!, "session-env", "turn.env"), "session");
+    writeFileSync(join(profileDir!, "shell-snapshots", "turn.sh"), "snapshot");
+
+    const secondEnv = resolveClaudeSpawnEnvironment({ driver: "claude" }, options);
+    expect(secondEnv?.CLAUDE_CONFIG_DIR).toBe(profileDir);
+    expect(lstatSync(join(profileDir!, "session-env")).isSymbolicLink()).toBe(false);
+    expect(lstatSync(join(profileDir!, "shell-snapshots")).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(profileDir!, "session-env", "turn.env"), "utf8")).toBe("session");
+    expect(readFileSync(join(profileDir!, "shell-snapshots", "turn.sh"), "utf8")).toBe("snapshot");
+    expect(existsSync(join(sourceConfigDir, "session-env"))).toBe(false);
+    expect(existsSync(join(sourceConfigDir, "shell-snapshots"))).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("default provider-only stays inert for normal first-party Claude settings", () => {


### PR DESCRIPTION
## What changed

- keep Claude-managed `session-env` and `shell-snapshots` directories local to the filtered provider profile
- link only durable session state back to the native Claude profile
- version the filtered profile layout so incompatible legacy directories are not reused
- document the durable/runtime state boundary and add regression coverage for consecutive prompts

## Why

Claude can recreate `session-env` and `shell-snapshots` during a successful turn. When those paths were junctions, the first turn could replace them with ordinary directories. The next prompt then failed before reaching Claude because xacpx correctly rejected an existing state path that no longer pointed to the native profile.

## Impact

Provider-only Claude sessions can reuse the same filtered profile across later prompts even after Claude recreates its runtime-owned directories. Durable history and native list/resume state continue to use the original Claude profile.

## Validation

- `bun test tests/unit/adapters/claude-settings-policy.test.ts` — 14 passed
- related bridge, CLI transport, model, and queue-owner tests — 143 passed
- `npx tsc --noEmit`
- `bun run build`
- `git diff --check`
- local Windows two-pass profile verification confirmed persistent directories remain junctions while runtime directories remain ordinary profile-local directories