### PR TITLE
release: sync v0.17.0 stable metadata to main

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/channel-feishu": {
       "name": "@ganglion/xacpx-channel-feishu",
-      "version": "0.7.0-beta.0",
+      "version": "0.7.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "~1.60.0",
       },
@@ -39,13 +39,13 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.9",
+      "version": "0.3.3",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0",
       },
       "peerDependencies": {
-        "xacpx": ">=0.17.0-beta.11",
+        "xacpx": ">=0.17.0",
       },
       "optionalPeers": [
         "xacpx",
@@ -53,13 +53,13 @@
     },
     "packages/channel-yuanbao": {
       "name": "@ganglion/xacpx-channel-yuanbao",
-      "version": "0.6.0-beta.0",
+      "version": "0.6.0",
       "dependencies": {
         "protobufjs": "^7.5.6",
         "ws": "^8.20.0",
       },
       "peerDependencies": {
-        "xacpx": ">=0.17.0-beta.13",
+        "xacpx": ">=0.17.0",
       },
       "optionalPeers": [
         "xacpx",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.28",
+      "version": "0.9.12",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/channel-feishu": {
       "name": "@ganglion/xacpx-channel-feishu",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "~1.60.0",
       },
@@ -53,13 +53,13 @@
     },
     "packages/channel-yuanbao": {
       "name": "@ganglion/xacpx-channel-yuanbao",
-      "version": "0.5.0",
+      "version": "0.6.0-beta.0",
       "dependencies": {
         "protobufjs": "^7.5.6",
         "ws": "^8.20.0",
       },
       "peerDependencies": {
-        "xacpx": ">=0.9.0-0",
+        "xacpx": ">=0.17.0-beta.13",
       },
       "optionalPeers": [
         "xacpx",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.27",
+      "version": "0.9.12-beta.28",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.13",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.13",
+      "version": "0.17.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -13110,7 +13110,7 @@
     },
     "packages/channel-feishu": {
       "name": "@ganglion/xacpx-channel-feishu",
-      "version": "0.7.0-beta.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "~1.60.0"
@@ -13141,14 +13141,14 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3-beta.9",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0"
       },
       "peerDependencies": {
-        "xacpx": ">=0.17.0-beta.11"
+        "xacpx": ">=0.17.0"
       },
       "peerDependenciesMeta": {
         "xacpx": {
@@ -13158,14 +13158,14 @@
     },
     "packages/channel-yuanbao": {
       "name": "@ganglion/xacpx-channel-yuanbao",
-      "version": "0.6.0-beta.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^7.5.6",
         "ws": "^8.20.0"
       },
       "peerDependencies": {
-        "xacpx": ">=0.17.0-beta.13"
+        "xacpx": ">=0.17.0"
       },
       "peerDependenciesMeta": {
         "xacpx": {
@@ -13183,7 +13183,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.28",
+      "version": "0.9.12",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.12",
+  "version": "0.17.0-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0-beta.12",
+      "version": "0.17.0-beta.13",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -13110,7 +13110,7 @@
     },
     "packages/channel-feishu": {
       "name": "@ganglion/xacpx-channel-feishu",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "~1.60.0"
@@ -13158,14 +13158,14 @@
     },
     "packages/channel-yuanbao": {
       "name": "@ganglion/xacpx-channel-yuanbao",
-      "version": "0.5.0",
+      "version": "0.6.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^7.5.6",
         "ws": "^8.20.0"
       },
       "peerDependencies": {
-        "xacpx": ">=0.9.0-0"
+        "xacpx": ">=0.17.0-beta.13"
       },
       "peerDependenciesMeta": {
         "xacpx": {
@@ -13183,7 +13183,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12-beta.27",
+      "version": "0.9.12-beta.28",
       "license": "MIT",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.12",
+  "version": "0.17.0-beta.13",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0-beta.13",
+  "version": "0.17.0",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/channel-feishu/package.json
+++ b/packages/channel-feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-feishu",
-  "version": "0.7.0-beta.0",
+  "version": "0.7.0",
   "description": "Feishu channel plugin for xacpx.",
   "license": "MIT",
   "keywords": ["xacpx", "feishu", "channel", "plugin"],

--- a/packages/channel-feishu/package.json
+++ b/packages/channel-feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-feishu",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "description": "Feishu channel plugin for xacpx.",
   "license": "MIT",
   "keywords": ["xacpx", "feishu", "channel", "plugin"],

--- a/packages/channel-relay/package.json
+++ b/packages/channel-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-relay",
-  "version": "0.3.3-beta.9",
+  "version": "0.3.3",
   "description": "Relay hub connector channel plugin for xacpx.",
   "license": "MIT",
   "keywords": [
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "xacpx": ">=0.17.0-beta.11"
+    "xacpx": ">=0.17.0"
   },
   "peerDependenciesMeta": {
     "xacpx": {

--- a/packages/channel-relay/src/index.ts
+++ b/packages/channel-relay/src/index.ts
@@ -9,7 +9,7 @@ export { relayCliProvider } from "./relay-provider.js";
 const plugin: XacpxPlugin = {
   apiVersion: 1,
   name: "@ganglion/xacpx-channel-relay",
-  minXacpxVersion: "0.17.0-beta.11",
+  minXacpxVersion: "0.17.0",
   channels: [
     {
       type: "relay",

--- a/packages/channel-yuanbao/package.json
+++ b/packages/channel-yuanbao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-yuanbao",
-  "version": "0.6.0-beta.0",
+  "version": "0.6.0",
   "description": "Tencent Yuanbao channel plugin for xacpx.",
   "license": "MIT",
   "keywords": ["xacpx", "yuanbao", "channel", "plugin"],
@@ -20,7 +20,7 @@
   },
   "files": ["dist", "README.md"],
   "peerDependencies": {
-    "xacpx": ">=0.17.0-beta.13"
+    "xacpx": ">=0.17.0"
   },
   "peerDependenciesMeta": {
     "xacpx": {

--- a/packages/channel-yuanbao/package.json
+++ b/packages/channel-yuanbao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-channel-yuanbao",
-  "version": "0.5.0",
+  "version": "0.6.0-beta.0",
   "description": "Tencent Yuanbao channel plugin for xacpx.",
   "license": "MIT",
   "keywords": ["xacpx", "yuanbao", "channel", "plugin"],
@@ -20,7 +20,7 @@
   },
   "files": ["dist", "README.md"],
   "peerDependencies": {
-    "xacpx": ">=0.9.0-0"
+    "xacpx": ">=0.17.0-beta.13"
   },
   "peerDependenciesMeta": {
     "xacpx": {

--- a/packages/channel-yuanbao/src/command-sync.ts
+++ b/packages/channel-yuanbao/src/command-sync.ts
@@ -2,7 +2,7 @@ import type { AppLogger } from "xacpx/plugin-api";
 import type { WsSyncCommand, WsSyncInformationData } from "./access/ws/types.js";
 
 // 与 packages/channel-yuanbao/package.json 的 version 一致；同步测试校验防漂移。
-export const PLUGIN_VERSION = "0.6.0-beta.0";
+export const PLUGIN_VERSION = "0.6.0";
 
 // 元宝协议 SyncInformationType.SYNC_INFORMATION_TYPE_COMMANDS。
 const SYNC_TYPE_COMMANDS = 1;

--- a/packages/channel-yuanbao/src/command-sync.ts
+++ b/packages/channel-yuanbao/src/command-sync.ts
@@ -2,7 +2,7 @@ import type { AppLogger } from "xacpx/plugin-api";
 import type { WsSyncCommand, WsSyncInformationData } from "./access/ws/types.js";
 
 // 与 packages/channel-yuanbao/package.json 的 version 一致；同步测试校验防漂移。
-export const PLUGIN_VERSION = "0.5.0";
+export const PLUGIN_VERSION = "0.6.0-beta.0";
 
 // 元宝协议 SyncInformationType.SYNC_INFORMATION_TYPE_COMMANDS。
 const SYNC_TYPE_COMMANDS = 1;

--- a/packages/channel-yuanbao/src/index.ts
+++ b/packages/channel-yuanbao/src/index.ts
@@ -9,7 +9,7 @@ export { yuanbaoCliProvider } from "./yuanbao-provider.js";
 const plugin: XacpxPlugin = {
   apiVersion: 1,
   name: "@ganglion/xacpx-channel-yuanbao",
-  minXacpxVersion: "0.8.0",
+  minXacpxVersion: "0.17.0-beta.13",
   channels: [
     {
       type: "yuanbao",

--- a/packages/channel-yuanbao/src/index.ts
+++ b/packages/channel-yuanbao/src/index.ts
@@ -9,7 +9,7 @@ export { yuanbaoCliProvider } from "./yuanbao-provider.js";
 const plugin: XacpxPlugin = {
   apiVersion: 1,
   name: "@ganglion/xacpx-channel-yuanbao",
-  minXacpxVersion: "0.17.0-beta.13",
+  minXacpxVersion: "0.17.0",
   channels: [
     {
       type: "yuanbao",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.28",
+  "version": "0.9.12",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.9.12-beta.27",
+  "version": "0.9.12-beta.28",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/tests/unit/packages/channel-relay/channel-relay-plugin.test.ts
+++ b/tests/unit/packages/channel-relay/channel-relay-plugin.test.ts
@@ -7,19 +7,19 @@ import { validatePluginCompatibility } from "../../../../src/plugins/compatibili
 test("relay connector requires the git-ops-capable xacpx core", () => {
   const pkg = JSON.parse(readFileSync("packages/channel-relay/package.json", "utf8"));
 
-  expect(plugin.minXacpxVersion).toBe("0.17.0-beta.11");
-  expect(pkg.peerDependencies.xacpx).toBe(">=0.17.0-beta.11");
+  expect(plugin.minXacpxVersion).toBe("0.17.0");
+  expect(pkg.peerDependencies.xacpx).toBe(">=0.17.0");
 
   expect(() => validatePluginCompatibility(plugin, {
     packageName: plugin.name,
-    currentXacpxVersion: "0.17.0-beta.6",
+    currentXacpxVersion: "0.16.0",
   })).toThrow();
   expect(() => validatePluginCompatibility(plugin, {
     packageName: plugin.name,
-    currentXacpxVersion: "0.17.0-beta.11",
+    currentXacpxVersion: "0.17.0",
   })).not.toThrow();
   expect(() => validatePluginCompatibility(plugin, {
     packageName: plugin.name,
-    currentXacpxVersion: "0.17.0",
+    currentXacpxVersion: "0.18.0",
   })).not.toThrow();
 });

--- a/tests/unit/packages/channel-yuanbao/yuanbao-plugin.test.ts
+++ b/tests/unit/packages/channel-yuanbao/yuanbao-plugin.test.ts
@@ -20,7 +20,7 @@ beforeAll(() => {
 });
 
 test("@ganglion/xacpx-channel-yuanbao exports a valid plugin definition", () => {
-  const validated = validateWeacpxPlugin(plugin, "@ganglion/xacpx-channel-yuanbao", { currentXacpxVersion: "0.8.0" });
+  const validated = validateWeacpxPlugin(plugin, "@ganglion/xacpx-channel-yuanbao", { currentXacpxVersion: "0.17.0-beta.13" });
 
   expect(validated.name).toBe("@ganglion/xacpx-channel-yuanbao");
   expect(validated.channels?.map((channel) => channel.type)).toEqual(["yuanbao"]);
@@ -29,7 +29,7 @@ test("@ganglion/xacpx-channel-yuanbao exports a valid plugin definition", () => 
 
 test("@ganglion/xacpx-channel-yuanbao declares compatibility metadata", () => {
   expect(plugin.apiVersion).toBe(1);
-  expect(plugin.minXacpxVersion).toBe("0.8.0");
+  expect(plugin.minXacpxVersion).toBe("0.17.0-beta.13");
 });
 
 test("yuanbao plugin factory creates the YuanbaoChannel runtime", () => {

--- a/tests/unit/packages/channel-yuanbao/yuanbao-plugin.test.ts
+++ b/tests/unit/packages/channel-yuanbao/yuanbao-plugin.test.ts
@@ -20,7 +20,7 @@ beforeAll(() => {
 });
 
 test("@ganglion/xacpx-channel-yuanbao exports a valid plugin definition", () => {
-  const validated = validateWeacpxPlugin(plugin, "@ganglion/xacpx-channel-yuanbao", { currentXacpxVersion: "0.17.0-beta.13" });
+  const validated = validateWeacpxPlugin(plugin, "@ganglion/xacpx-channel-yuanbao", { currentXacpxVersion: "0.17.0" });
 
   expect(validated.name).toBe("@ganglion/xacpx-channel-yuanbao");
   expect(validated.channels?.map((channel) => channel.type)).toEqual(["yuanbao"]);
@@ -29,7 +29,7 @@ test("@ganglion/xacpx-channel-yuanbao exports a valid plugin definition", () => 
 
 test("@ganglion/xacpx-channel-yuanbao declares compatibility metadata", () => {
   expect(plugin.apiVersion).toBe(1);
-  expect(plugin.minXacpxVersion).toBe("0.17.0-beta.13");
+  expect(plugin.minXacpxVersion).toBe("0.17.0");
 });
 
 test("yuanbao plugin factory creates the YuanbaoChannel runtime", () => {

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.12", () => {
+test("root package version is 0.17.0-beta.13", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.12");
+  expect(pkg.version).toBe("0.17.0-beta.13");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {
@@ -27,12 +27,13 @@ test("first-party channel plugins peer depend on xacpx", () => {
   const yuanbao = readJson("packages/channel-yuanbao/package.json");
 
   for (const pkg of [feishu, yuanbao]) {
-    expect(pkg.peerDependencies.xacpx).toBe(">=0.9.0-0");
     expect(pkg.peerDependencies.weacpx).toBeUndefined();
     expect(pkg.peerDependenciesMeta.xacpx.optional).toBe(true);
     expect(pkg.peerDependenciesMeta.weacpx).toBeUndefined();
     expect(pkg.publishConfig.access).toBe("public");
   }
+  expect(feishu.peerDependencies.xacpx).toBe(">=0.9.0-0");
+  expect(yuanbao.peerDependencies.xacpx).toBe(">=0.17.0-beta.13");
 });
 
 test("deprecated weacpx compat shim forwards plugin-api to xacpx", () => {

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0-beta.13", () => {
+test("root package version is 0.17.0", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0-beta.13");
+  expect(pkg.version).toBe("0.17.0");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {
@@ -33,7 +33,7 @@ test("first-party channel plugins peer depend on xacpx", () => {
     expect(pkg.publishConfig.access).toBe("public");
   }
   expect(feishu.peerDependencies.xacpx).toBe(">=0.9.0-0");
-  expect(yuanbao.peerDependencies.xacpx).toBe(">=0.17.0-beta.13");
+  expect(yuanbao.peerDependencies.xacpx).toBe(">=0.17.0");
 });
 
 test("deprecated weacpx compat shim forwards plugin-api to xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.13",
+  "version": "0.17.0",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.13"
+    "@ganglion/xacpx": "^0.17.0"
   },
   "publishConfig": {
     "access": "public"

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0-beta.12",
+  "version": "0.17.0-beta.13",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0-beta.12"
+    "@ganglion/xacpx": "^0.17.0-beta.13"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Merge the stable release commits from `release/beta-2026-07-24` back into `main`.

The branch HEAD (`8c3f6c06`) is exactly the `v0.17.0` tag used to publish the latest stable GitHub Release and `@ganglion/xacpx@0.17.0`. The branch advanced after PR #195 was merged, so the stable promotion commit never reached `main`; `main` therefore still reports beta package versions.

## Expected result

- preserve the Claude profile fix already merged on `main`
- restore stable package metadata and compatibility constants from the published `v0.17.0` release
- make `main` reflect the versions already published to npm

## Evidence

- branch HEAD: `8c3f6c0621ab3da156f8acf12a6b510344f1f48e`
- `v0.17.0` tag: `8c3f6c0621ab3da156f8acf12a6b510344f1f48e`
- current npm latest: `@ganglion/xacpx@0.17.0`
- GitHub Release published 2026-07-25