### PR TITLE
release: 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.17.1] - 2026-07-27
+
+- Fix Claude profile reuse on Windows: `session-env` and `shell-snapshots` are now left profile-local because Claude may recreate them between turns. Durable Claude settings state remains linked into the managed profile.
+
 ## [terminal batch beta] - 2026-07-05
 
 A four-package beta shipping two terminal features together: **Windows support** and **content replay across reload**. Versions: `@ganglion/xacpx-relay-protocol` 0.1.11, `@ganglion/xacpx` (core) 0.17.0-beta.4, `@ganglion/xacpx-channel-relay` 0.3.3-beta.4, `@ganglion/xacpx-relay` (hub) 0.9.12-beta.19 — all on the npm `next` dist-tag. Update the core/daemon and the hub, restart both, then hard-reload the dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ganglion/xacpx",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.17.0", () => {
+test("root package version is 0.17.1", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.17.0");
+  expect(pkg.version).toBe("0.17.1");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.17.0"
+    "@ganglion/xacpx": "^0.17.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## 发布内容

- 将 @ganglion/xacpx 升级至 0.17.1。
- 同步发布兼容 shim weacpx 0.17.1，并将其核心依赖更新为 ^0.17.1。
- 记录 Claude Windows profile 在后续对话中复用失败的修复说明。

## 验证

- bun test tests/unit/packages/package-metadata.test.ts tests/unit/adapters/claude-settings-policy.test.ts（18 pass）
- npx tsc --noEmit
- 本机 bun run verify:publish 已完成核心、渠道和 relay protocol 构建；relay-web 的 Vite 阶段受已知 Windows EPERM 文件访问问题阻断，等待 CI 的完整 Linux 发布校验。