### PR TITLE
fix(relay-web): load history when reselecting a session mid-turn

### DIFF
--- a/packages/relay-web/src/__tests__/chat-queue.test.ts
+++ b/packages/relay-web/src/__tests__/chat-queue.test.ts
@@ -187,6 +187,55 @@ it("reloads history immediately after reselecting a session during prompt RPC", 
   expect(chat.messages.map((message) => message.text)).toEqual(["queued prompt"]);
 });
 
+it("converges after the RPC settles when the reselect fetch raced the queueItemId stamp", async () => {
+  let resolveRpc!: (value: unknown) => void;
+  rpc.mockImplementationOnce(() => new Promise((resolve) => { resolveRpc = resolve; }));
+  const fetchMock = vi.fn()
+    // Reselect fetch races the RPC: the hub persisted the prompt row on enqueue, but
+    // markQueued hasn't stamped its queueItemId yet — the row arrives uncorrelated.
+    .mockResolvedValueOnce({
+      json: async () => ({
+        messages: [
+          { id: 1, instanceId: "i1", sessionAlias: "s", direction: "in", text: "queued prompt", createdAt: "t1" },
+        ],
+        hasMore: false,
+      }),
+    })
+    // The post-settle convergence reload returns the authoritative correlated row.
+    .mockResolvedValue({
+      json: async () => ({
+        messages: [
+          { id: 1, instanceId: "i1", sessionAlias: "s", direction: "in", text: "queued prompt", createdAt: "t1", queueItemId: "q1" },
+        ],
+        hasMore: false,
+      }),
+    });
+  globalThis.fetch = fetchMock as typeof fetch;
+  const chat = useChatStore();
+  chat.select("i1", "s");
+  const sending = chat.send("queued prompt");
+  chat.select("i1", "other");
+  chat.select("i1", "s");
+  await chat.loadHistory();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(chat.messages.map((message) => message.text)).toEqual(["queued prompt"]);
+
+  // The drain event can't correlate the uncorrelated row, so it pushes its own bubble —
+  // a transient duplicate that the convergence reload below must eliminate.
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "s", queueItemId: "q1", prompt: "queued prompt" } } as WebServerEvent);
+  expect(chat.messages.map((message) => message.text)).toEqual(["queued prompt", "queued prompt"]);
+
+  resolveRpc({ ok: true, queued: true, queueItemId: "q1" });
+  await sending;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // RPC settle triggered the deferred convergence reload with the authoritative row.
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(chat.messages.map((message) => [message.text, message.queueItemId])).toEqual([
+    ["queued prompt", "q1"],
+  ]);
+});
+
 it("cancelQueuedItem issues control.queue.cancel and optimistically drops the chip", async () => {
   rpc.mockResolvedValueOnce({ ok: true });
   const chat = useChatStore();

--- a/packages/relay-web/src/__tests__/chat-queue.test.ts
+++ b/packages/relay-web/src/__tests__/chat-queue.test.ts
@@ -156,7 +156,7 @@ it("defers history convergence until the queued RPC response establishes correla
   ]);
 });
 
-it("retries a deferred history load after reselecting a session during prompt RPC", async () => {
+it("reloads history immediately after reselecting a session during prompt RPC", async () => {
   let resolveRpc!: (value: unknown) => void;
   rpc.mockImplementationOnce(() => new Promise((resolve) => { resolveRpc = resolve; }));
   const fetchMock = vi.fn().mockResolvedValue({
@@ -173,15 +173,17 @@ it("retries a deferred history load after reselecting a session during prompt RP
   const sending = chat.send("queued prompt");
   chat.select("i1", "other");
   chat.select("i1", "s");
+  // The reselected pane is empty — history must load right away rather than defer
+  // until the prompt RPC settles, or the pane would show only the live turn.
   await chat.loadHistory();
-  expect(chat.messages).toEqual([]);
-  expect(fetchMock).not.toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(chat.messages.map((message) => message.text)).toEqual(["queued prompt"]);
 
   resolveRpc({ ok: true, queued: true, queueItemId: "q1" });
   await sending;
   await new Promise((resolve) => setTimeout(resolve, 0));
 
-  expect(fetchMock).toHaveBeenCalledTimes(1);
+  // Settling the RPC must not duplicate the prompt row.
   expect(chat.messages.map((message) => message.text)).toEqual(["queued prompt"]);
 });
 

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -251,14 +251,20 @@ export const useChatStore = defineStore("chat", () => {
     const id = instanceId.value;
     const alias = sessionAlias.value;
     const historyKey = bufKey(id, alias);
-    // Defer only background convergence reloads: a non-empty transcript may hold an
-    // optimistic prompt row whose queueItemId correlation the pending RPC hasn't
-    // established yet, and replacing it would break the drain-event dedupe. A freshly
-    // selected pane is empty (select() cleared it), so fetching history there clobbers
-    // nothing — skipping it would leave only the live turn visible until the RPC settles.
-    if ((pendingPromptRequests.get(historyKey) ?? 0) > 0 && messages.value.length > 0) {
+    // While a prompt RPC is pending, history is not yet authoritative for that prompt:
+    // the hub persists the "in" row on enqueue, but its queueItemId is only stamped
+    // once the RPC response arrives (markQueued). Rows fetched inside that window lack
+    // the correlation id, so a later drain event can't match them and would push a
+    // duplicate bubble. Always schedule a convergence reload for after the RPC settles
+    // (send()'s finally) to pull the authoritative rows back. Beyond that, defer only
+    // background convergence reloads: a non-empty transcript may hold an optimistic
+    // prompt row whose queueItemId correlation the pending RPC hasn't established yet,
+    // and replacing it would break the drain-event dedupe. A freshly selected pane is
+    // empty (select() cleared it), so fetching history there clobbers nothing —
+    // skipping it would leave only the live turn visible until the RPC settles.
+    if ((pendingPromptRequests.get(historyKey) ?? 0) > 0) {
       deferredHistoryLoads.add(historyKey);
-      return;
+      if (messages.value.length > 0) return;
     }
     const requestSequence = ++historyRequestSequence;
     const revision = transcriptRevision;

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -251,7 +251,12 @@ export const useChatStore = defineStore("chat", () => {
     const id = instanceId.value;
     const alias = sessionAlias.value;
     const historyKey = bufKey(id, alias);
-    if ((pendingPromptRequests.get(historyKey) ?? 0) > 0) {
+    // Defer only background convergence reloads: a non-empty transcript may hold an
+    // optimistic prompt row whose queueItemId correlation the pending RPC hasn't
+    // established yet, and replacing it would break the drain-event dedupe. A freshly
+    // selected pane is empty (select() cleared it), so fetching history there clobbers
+    // nothing — skipping it would leave only the live turn visible until the RPC settles.
+    if ((pendingPromptRequests.get(historyKey) ?? 0) > 0 && messages.value.length > 0) {
       deferredHistoryLoads.add(historyKey);
       return;
     }


### PR DESCRIPTION
## Summary
- 修复：agent 工作中切换到其它会话再切回时，消息区只显示当前任务的实时输出，历史消息要等回合结束（或 RPC 超时）才出现。
- 根因：`loadHistory()` 的 pending-prompt 守卫在 `control.prompt` RPC 未 settle 期间无条件 defer 历史拉取，而 `select()` 已先清空 `messages`，导致切回后 pane 只剩 live turn。
- 修复：守卫仅在 transcript 非空（存在需保护乐观消息关联的后台收敛 reload）时才 defer；刚 select 的空白 pane 立即拉取历史并与实时流拼合。

## Test plan
- [x] `packages/relay-web` 全量 vitest（103 files / 842 tests）通过
- [x] `vue-tsc --noEmit` 通过
- [x] 更新 `chat-queue.test.ts`：重选会话后立即拉取历史，且 RPC settle 后不重复 prompt 行
- [ ] 手动验证：web 端在回合进行中切走再切回，历史 + 实时输出正常拼合