### PR TITLE
fix(relay-web): render user messages as markdown to stop bubble overflow

### DIFF
--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -1,6 +1,12 @@
 import { mount } from "@vue/test-utils";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
+
+// MessageList imports AgentIcon at module evaluation time. Stub the raw SVG catalog so
+// this suite does not depend on Windows being able to open every optional @lobehub icon
+// file (some hosts return EPERM for openclaw-color.svg).
+vi.mock("../lib/agent-icons", () => ({ agentIconSvg: () => null }));
+
 import MessageList from "../components/MessageList.vue";
 import type { ChatMessage, LiveTurn } from "../stores/chat";
 import ToolCallPanel from "../components/ToolCallPanel.vue";
@@ -70,14 +76,20 @@ describe("MessageList", () => {
     expect(out.html()).toContain("<strong>bold</strong>");
   });
 
-  it("keeps user input as plain text (no markdown rendering)", () => {
+  it("renders user input as markdown, same as agent output", () => {
     const wrapper = mount(MessageList, {
-      props: { messages: [msg({ direction: "in", text: "**not bold**" })], liveTurn: null },
+      props: { messages: [msg({ direction: "in", text: "**bold input**" })], liveTurn: null },
     });
     const inEl = wrapper.find('[data-test="msg-in"]');
     expect(inEl.exists()).toBe(true);
-    expect(inEl.html()).not.toContain("<strong>");
-    expect(inEl.text()).toContain("**not bold**");
+    expect(inEl.html()).toContain("<strong>bold input</strong>");
+  });
+
+  it("does not render raw HTML from user input", () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [msg({ direction: "in", text: "<script>alert(1)</script>" })], liveTurn: null },
+    });
+    expect(wrapper.html()).not.toContain("<script>alert(1)</script>");
   });
 
   it("badges an inbound prompt from a fired scheduled task (live origin)", () => {

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -11,6 +11,7 @@ import MessageList from "../components/MessageList.vue";
 import type { ChatMessage, LiveTurn } from "../stores/chat";
 import ToolCallPanel from "../components/ToolCallPanel.vue";
 import ToolStepCard from "../components/ToolStepCard.vue";
+import CopyButton from "../components/CopyButton.vue";
 
 // StreamMarkdown (rendered for "out" messages) reads useThemeStore() to re-hydrate mermaid
 // diagrams on theme change, so every mount here needs an active Pinia instance.
@@ -85,11 +86,32 @@ describe("MessageList", () => {
     expect(inEl.html()).toContain("<strong>bold input</strong>");
   });
 
-  it("does not render raw HTML from user input", () => {
+  it("escapes raw HTML from user input instead of dropping it", () => {
     const wrapper = mount(MessageList, {
       props: { messages: [msg({ direction: "in", text: "<script>alert(1)</script>" })], liveTurn: null },
     });
-    expect(wrapper.html()).not.toContain("<script>alert(1)</script>");
+    const inEl = wrapper.find('[data-test="msg-in"]');
+    expect(inEl.text()).toContain("alert(1)");
+    expect(wrapper.find("script").exists()).toBe(false);
+  });
+
+  it("wraps user code fences and tables in scrollable containers", () => {
+    const text = "```js\nconst x = 1\n```\n\n| a | b |\n| --- | --- |\n| 1 | 2 |";
+    const wrapper = mount(MessageList, {
+      props: { messages: [msg({ direction: "in", text })], liveTurn: null },
+    });
+    const inEl = wrapper.find('[data-test="msg-in"]');
+    expect(inEl.find("pre").exists()).toBe(true);
+    expect(inEl.find(".md-table-wrap").exists()).toBe(true);
+  });
+
+  it("offers a copy button on user messages carrying the verbatim source text", () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [msg({ direction: "in", text: "**raw source**" })], liveTurn: null },
+    });
+    const copy = wrapper.findComponent(CopyButton);
+    expect(copy.exists()).toBe(true);
+    expect(copy.props("text")).toBe("**raw source**");
   });
 
   it("badges an inbound prompt from a fired scheduled task (live origin)", () => {

--- a/packages/relay-web/src/components/ConfirmDialog.vue
+++ b/packages/relay-web/src/components/ConfirmDialog.vue
@@ -30,7 +30,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKey));
           </div>
           <div class="min-w-0 flex-1 pt-0.5">
             <h2 class="text-[15px] font-semibold text-fg">{{ pending.title }}</h2>
-            <p v-if="pending.message" class="mt-1 whitespace-pre-wrap text-[13px] leading-relaxed text-fg-muted">{{ pending.message }}</p>
+            <p v-if="pending.message" class="mt-1 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-fg-muted">{{ pending.message }}</p>
           </div>
         </div>
         <div class="mt-5 flex justify-end gap-2">

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -208,6 +208,11 @@ watch(
                 <StreamMarkdown v-if="m.text" :text="m.text" class="text-[14px] leading-relaxed text-fg" />
                 <MessageAttachments v-if="m.attachments?.length" :attachments="m.attachments" />
               </div>
+              <!-- Markdown rendering is lossy (headers, lists, fences reshape the text);
+                   copy hands back the verbatim source the user actually sent. -->
+              <div v-if="m.text" class="mt-0.5 flex items-center text-fg-muted">
+                <CopyButton :text="m.text" />
+              </div>
               <!-- Failed sends get a compact retry affordance on their own line below. -->
               <div v-if="m.failed" class="mt-1.5 flex items-center gap-2">
                 <span data-test="msg-failed" class="inline-flex items-center gap-1 text-[11px] font-medium text-danger">

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -203,9 +203,9 @@ watch(
                 <Clock :size="11" />{{ $t("chat.scheduled") }}
               </span>
               <div data-test="msg-in"
-                   class="rounded-2xl rounded-tr-md border px-3.5 py-2"
+                   class="min-w-0 max-w-full rounded-2xl rounded-tr-md border px-3.5 py-2"
                    :class="m.failed ? 'border-danger/30 bg-danger/5' : 'border-accent/15 bg-accent/10'">
-                <p class="whitespace-pre-wrap text-[14px] leading-relaxed text-fg">{{ m.text }}</p>
+                <StreamMarkdown v-if="m.text" :text="m.text" class="text-[14px] leading-relaxed text-fg" />
                 <MessageAttachments v-if="m.attachments?.length" :attachments="m.attachments" />
               </div>
               <!-- Failed sends get a compact retry affordance on their own line below. -->

--- a/packages/relay-web/src/components/ScheduledTaskRow.vue
+++ b/packages/relay-web/src/components/ScheduledTaskRow.vue
@@ -75,7 +75,7 @@ async function cancel(id: string) {
     </div>
     <!-- expanded details -->
     <div v-if="open" :data-test="`scheduled-detail-${task.id}`" class="space-y-1 border-t border-border px-2 py-1.5">
-      <p class="whitespace-pre-wrap text-[12.5px] text-fg">{{ task.message }}</p>
+      <p class="whitespace-pre-wrap break-words text-[12.5px] text-fg">{{ task.message }}</p>
       <p class="font-mono text-[10.5px] tabular-nums text-fg-muted">{{ fmtDateTime(task.executeAt) }}</p>
       <p v-if="task.status === 'failed' && task.lastError" :data-test="`scheduled-error-${task.id}`" class="rounded bg-danger/10 px-2 py-1 text-[11px] text-danger">{{ task.lastError }}</p>
     </div>

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -187,6 +187,11 @@ onBeforeUnmount(() => {
 <style>
 /* Tailwind's preflight strips element styling, so restore the markdown basics for
    v-html content. Non-scoped on purpose: scoped styles cannot reach v-html output. */
+.stream-md {
+  /* Long unbreakable runs (bare URLs, tokens, linkified <a>) must wrap instead of
+     drawing past the bubble; pre/table overflow is handled by their scroll containers. */
+  overflow-wrap: anywhere;
+}
 .stream-md > :first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- User prompts containing markdown (code fences, long lines, tables) broke the chat bubble layout because they were shown as raw pre-wrap text.
- Route user messages through the same `StreamMarkdown` (markdown-it + DOMPurify) pipeline as agent output; add `min-w-0 max-w-full` so code blocks/tables scroll inside the bubble instead of overflowing.
- Update MessageList tests: user input now renders as markdown, add an XSS guard test for user input, and stub `agent-icons` to avoid the known Windows EPERM on `openclaw-*.svg`.

## Test plan
- [x] `vitest run src/__tests__/messagelist.test.ts` — 27 tests pass
- [x] `vue-tsc --noEmit` — clean
- [ ] Manual check in relay dashboard: send a message with code fences / tables / long lines and confirm the bubble no longer overflows