### PR TITLE
perf(relay-web): speed up switching to sessions with long histories

### DIFF
--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -150,6 +150,11 @@
 - `DIFF_CAP = 4000` 字符（diff oldText / newText 各自上限）。
 - `REASONING_CAP = 16000` 字符（在服务端侧对 reasoning chunk 累积截断）。
 - **工具步数上限 `MAX_TOOL_STEPS = 200`**（服务端 server.ts 中校验，超出步数的新步骤静默丢弃）。
+- **hub 侧 `TOOL_DETAIL_CAP = 32K 字符`（UTF-16 code units）**（server.ts `capToolStep` / `capSeededStructured`，纵深防御）：
+  递归截断 tool step 内所有超限字符串（title/error 以及 detail 的 diff、命令/搜索输出、read 预览、text、fields 等）。
+  tool-event 在 **broadcast 之前** 截断，保证 live 视图与持久化历史一致；`session-history` 回填的 `structured` 同样过闸。
+  规范的 connector 已经在上面 TEXT_CAP/DIFF_CAP 处截过，正常流量不受影响（字符串都在限内时原样返回，零拷贝）；
+  这道闸拦的是绕过规整的非规范/旧版 connector，避免超大 detail 撑爆持久化 `structured` 列、历史分页 payload 和浏览器扇出。
 - 按 `kind` 分派到具体 `ToolDetailDto` 变体（`diff / read / command / search / text / fields`），不向线路侧暴露任何原始 JSON。
 
 ### 服务端累积与持久化（packages/relay/src/server.ts）

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -170,6 +170,23 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   in-use 错误并浮现）。
 - **Workspaces 管理器**：列已配置 workspace，可删除（`control.workspaces.remove {name}`，占用时同样 in-use 拒绝）。
 
+## 切换会话的渲染性能
+
+长历史会话的切换开销主要在**组件创建**（每个文本 part 同步跑 markdown-it + DOMPurify），
+`content-visibility: auto` 只省 layout/paint。两道针对性优化：
+
+- **尾部优先渐进挂载**（`MessageList.vue`）：历史页落地（0→N）时先只挂载最新 30 行
+  （`INITIAL_ROWS`），随后 rAF 每帧向上补 30 行（`REVEAL_BATCH`）直到全量；`hiddenCount`
+  记录未挂载的最旧行数。展开是顶部 prepend：钉底时展开后重新钉底，用户已上滚则按
+  distance-from-bottom 不变式锚定视口。`hiddenCount > 0` 时顶部滚动**不**触发 `loadOlder`
+  （先本地展开）。turn-finished 收敛整页替换**不**重置 hiddenCount（key 稳定、组件复用）。
+  无 rAF 环境（jsdom 测试）同步全量挂载。
+- **`structured` 脱离深度响应式**（`stores/chat.ts` `rawStructured`）：历史行不可变、只会整行
+  替换，`loadHistory`/`loadOlder`/`flushTurn` 对 `structured`（parts/toolSteps/diff 全文）做
+  `markRaw`，避免 Vue 深代理化数百 KB 的对象树。
+
+hub 侧配套：tool step 全字段 32K 字符写入截断（见 docs/relay-module.md 的 `TOOL_DETAIL_CAP`）。
+
 ## 流式 Markdown 渲染
 
 - `src/lib/render-markdown.ts` —— `renderMarkdown(text, { streaming })` 把 markdown 渲染成**已净化**的 HTML：

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import MessageList from "../components/MessageList.vue";
 import type { ChatMessage, LiveTurn } from "../stores/chat";
@@ -328,4 +328,76 @@ it("renders live tool steps inline in the streaming bubble", () => {
   });
   expect(wrapper.findComponent(ToolStepCard).exists()).toBe(true);
   expect(wrapper.find('[data-test="msg-streaming"]').text()).toContain("thinking");
+});
+
+describe("progressive tail-first mounting", () => {
+  let rafQueue: FrameRequestCallback[];
+
+  beforeEach(() => {
+    rafQueue = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const many = (n: number): ChatMessage[] =>
+    Array.from({ length: n }, (_, i) => msg({ direction: "in", text: `m${i}`, id: i + 1 }));
+
+  async function flushFrames(wrapper: ReturnType<typeof mount>): Promise<void> {
+    while (rafQueue.length) {
+      for (const cb of rafQueue.splice(0)) cb(0);
+      await wrapper.vm.$nextTick();
+    }
+  }
+
+  it("mounts only the newest rows when a large history lands, then reveals the rest in batches", async () => {
+    const wrapper = mount(MessageList, { props: { messages: [], liveTurn: null, sessionKey: "a\0one" } });
+    await wrapper.setProps({ messages: many(80) });
+    // Only the tail is mounted immediately; older rows come in over later frames.
+    expect(wrapper.findAll(".cv-row").length).toBe(30);
+    expect(wrapper.text()).toContain("m79"); // newest row visible from frame one
+    await flushFrames(wrapper);
+    expect(wrapper.findAll(".cv-row").length).toBe(80);
+    expect(wrapper.text()).toContain("m0");
+  });
+
+  it("suppresses load-older while older rows are still revealing locally", async () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: null, hasMoreOlder: true, loadingOlder: false },
+    });
+    await wrapper.setProps({ messages: many(80) });
+    const scroller = wrapper.find('[data-test="msg-scroller"]');
+    const el = scroller.element as HTMLElement;
+    Object.defineProperty(el, "scrollHeight", { configurable: true, value: 5000 });
+    Object.defineProperty(el, "clientHeight", { configurable: true, value: 800 });
+    el.scrollTop = 10; // within TOP_THRESHOLD
+    await scroller.trigger("scroll");
+    // Rows are still mounting locally — nothing to fetch yet.
+    expect(wrapper.emitted("loadOlder")).toBeFalsy();
+    await flushFrames(wrapper);
+    // The reveal/settle passes re-pin the scroller to the bottom; scroll back near the top.
+    el.scrollTop = 10;
+    await scroller.trigger("scroll");
+    expect(wrapper.emitted("loadOlder")).toBeTruthy();
+  });
+
+  it("mounts everything synchronously when rAF is unavailable (jsdom fallback)", async () => {
+    vi.stubGlobal("requestAnimationFrame", undefined);
+    const wrapper = mount(MessageList, { props: { messages: [], liveTurn: null } });
+    await wrapper.setProps({ messages: many(80) });
+    expect(wrapper.findAll(".cv-row").length).toBe(80);
+  });
+
+  it("does not re-hide rows on an in-place history replace (turn-finished convergence)", async () => {
+    const wrapper = mount(MessageList, { props: { messages: [], liveTurn: null } });
+    await wrapper.setProps({ messages: many(80) });
+    await flushFrames(wrapper);
+    expect(wrapper.findAll(".cv-row").length).toBe(80);
+    // Same-session reload replaces the array with fresh row objects (stable keys).
+    await wrapper.setProps({ messages: many(81) });
+    expect(wrapper.findAll(".cv-row").length).toBe(81);
+  });
 });

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import type { ChatMessage, LiveTurn } from "../stores/chat";
 import StreamMarkdown from "./StreamMarkdown.vue";
 import ToolCallPanel from "./ToolCallPanel.vue";
@@ -52,6 +52,69 @@ const atBottom = ref(true);
 const THRESHOLD = 48; // px from bottom still counts as "at bottom"
 const TOP_THRESHOLD = 240; // px from top that triggers a "load older" page fetch
 
+// Progressive tail-first mounting: switching to a session with a long history would
+// otherwise create every row's component tree (markdown-it parse + DOMPurify per text
+// part) in a single tick. Mount only the newest INITIAL_ROWS immediately, then reveal
+// the older rows in rAF batches — `content-visibility` already keeps them cheap to
+// paint, this keeps them cheap to CREATE. `hiddenCount` = oldest rows not yet mounted.
+const INITIAL_ROWS = 30;
+const REVEAL_BATCH = 30;
+const hiddenCount = ref(0);
+const visibleMessages = computed(() => (hiddenCount.value > 0 ? props.messages.slice(hiddenCount.value) : props.messages));
+let revealRaf = 0;
+
+function revealStep(): void {
+  revealRaf = 0;
+  if (hiddenCount.value <= 0) return;
+  // Revealing rows PREPENDS content: pin the viewport the same way load-older does —
+  // re-stick to the bottom when pinned there, else keep distance-from-bottom invariant.
+  const el = scroller.value;
+  const anchor = el && !atBottom.value ? el.scrollHeight - el.scrollTop : null;
+  hiddenCount.value = Math.max(0, hiddenCount.value - REVEAL_BATCH);
+  void nextTick(() => {
+    const e = scroller.value;
+    if (e) {
+      if (anchor !== null) e.scrollTop = e.scrollHeight - anchor;
+      else if (atBottom.value) e.scrollTop = e.scrollHeight;
+    }
+    if (hiddenCount.value > 0) revealRaf = requestAnimationFrame(revealStep);
+  });
+}
+
+function scheduleReveal(): void {
+  if (hiddenCount.value <= 0 || revealRaf) return;
+  // jsdom / engines without rAF: mount everything synchronously (tests see full lists).
+  if (typeof requestAnimationFrame !== "function") {
+    hiddenCount.value = 0;
+    return;
+  }
+  revealRaf = requestAnimationFrame(revealStep);
+}
+
+onBeforeUnmount(() => {
+  if (revealRaf) cancelAnimationFrame(revealRaf);
+  revealRaf = 0;
+  if (settleRaf) cancelAnimationFrame(settleRaf);
+  settleRaf = 0;
+});
+
+// Arm progressive mounting when a freshly selected session's rows land: only a jump
+// from empty to many rows re-arms it — an in-place replace (turn-finished history
+// convergence) keeps stable keys and reuses mounted components, so hiding rows again
+// would only cause churn. Session switches empty `messages` first (chat.select), so
+// the 0→N transition is a reliable "new transcript" signal.
+watch(
+  () => props.messages.length,
+  (now, prev) => {
+    if (prev === 0 && now > INITIAL_ROWS) {
+      hiddenCount.value = now - INITIAL_ROWS;
+      scheduleReveal();
+    } else if (hiddenCount.value > now) {
+      hiddenCount.value = Math.max(0, now - INITIAL_ROWS);
+    }
+  },
+);
+
 // Distance-from-bottom captured when a "load older" fetch starts, so we can restore the
 // exact scroll position after the older page is PREPENDED (prepend only grows the top, so
 // distance-from-bottom is content-invariant). Null when no prepend is pending.
@@ -61,6 +124,9 @@ function onScroll(): void {
   const el = scroller.value;
   if (!el) return;
   atBottom.value = el.scrollHeight - el.scrollTop - el.clientHeight <= THRESHOLD;
+  // Near the top while older rows are still mounting locally → nothing to fetch yet;
+  // the reveal loop is already draining hiddenCount.
+  if (hiddenCount.value > 0) return;
   // Near the top with older history available → fetch the previous page. Capture the
   // anchor first; the prepend watcher below restores position once the rows arrive.
   if (el.scrollTop <= TOP_THRESHOLD && props.hasMoreOlder && !props.loadingOlder && pendingDistFromBottom === null) {
@@ -190,8 +256,11 @@ watch(
           <Loader2 :size="13" class="animate-spin motion-reduce:animate-none" />
         </div>
         <!-- Stable keys (persisted id, else an optimistic-row key) so a prepend doesn't
-             re-key/re-render every row — avoids markdown re-parse + scroll jank. -->
-        <template v-for="(m, i) in messages" :key="messageKey(m, i)">
+             re-key/re-render every row — avoids markdown re-parse + scroll jank.
+             `visibleMessages` mounts tail-first (progressive reveal, see hiddenCount);
+             the key index is translated back to the FULL-array index so optimistic-row
+             keys stay stable while older rows are still being revealed above. -->
+        <template v-for="(m, i) in visibleMessages" :key="messageKey(m, hiddenCount + i)">
           <!-- USER row -->
           <div v-if="m.direction === 'in'" class="cv-row flex justify-end"
                :data-scheduled-task="schedOf(m)?.taskId">

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { computed, ref } from "vue";
+import { computed, markRaw, ref } from "vue";
 import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, QueueItemDto, ScheduledOriginDto, SessionCommandsSnapshotDto, SessionUsageSnapshotDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 import { useSessionControlsStore } from "./session-controls";
@@ -73,6 +73,14 @@ export interface ChatMessage extends MessageRecordDto {
   // Present on an inbound prompt produced by a fired scheduled task — drives the
   // "⏰ Scheduled" badge so a turn that appears on its own has visible provenance.
   scheduled?: ScheduledOriginDto;
+}
+
+// History rows are immutable once loaded (updates arrive as whole-row replacements), so
+// deep-proxying their potentially huge `structured` payload (full tool diffs, command
+// output, ordered parts) is pure overhead — markRaw keeps it out of Vue's reactivity.
+function rawStructured<T extends MessageRecordDto>(row: T): T {
+  if (row.structured) row.structured = markRaw(row.structured);
+  return row;
 }
 
 export const useChatStore = defineStore("chat", () => {
@@ -195,7 +203,7 @@ export const useChatStore = defineStore("chat", () => {
     if (hasContent && selected) {
       const hasStructured = toolSteps.length > 0 || reasoning.length > 0;
       const structured = hasStructured
-        ? { toolSteps, ...(reasoning ? { reasoning } : {}), parts: t.parts }
+        ? markRaw({ toolSteps, ...(reasoning ? { reasoning } : {}), parts: t.parts })
         : undefined;
       messages.value.push({
         instanceId: instId,
@@ -270,7 +278,7 @@ export const useChatStore = defineStore("chat", () => {
       // would leave the pane with only the live turn. Retry against the same
       // selection so persisted history and the current turn converge.
       if (revision !== transcriptRevision) return loadHistory();
-      messages.value = rows;
+      messages.value = rows.map(rawStructured);
       touchTranscript();
       hasMoreOlder.value = hasMore ?? false;
     } finally {
@@ -297,7 +305,7 @@ export const useChatStore = defineStore("chat", () => {
       // The session may have changed while awaiting; only apply if still selected.
       if (id !== instanceId.value || alias !== sessionAlias.value) return;
       if (older.length > 0) {
-        messages.value = [...older, ...messages.value];
+        messages.value = [...older.map(rawStructured), ...messages.value];
         touchTranscript();
       }
       hasMoreOlder.value = hasMore ?? false;

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -25,6 +25,47 @@ const MAX_MESSAGES_PER_SESSION = 2000;
 const MAX_TOOL_STEPS = 200;
 const REASONING_CAP = 16000;
 const WEB_CLIENT_MAX_PAYLOAD_BYTES = 256 * 1024;
+// Per-string bound on tool-step / seeded-history content entering the turn buffer. Full
+// file diffs or command output can reach megabytes; everything buffered is broadcast,
+// snapshotted and persisted into the message's `structured` column, then served 100
+// rows per history page. Compliant connectors already cap at 8000/4000 chars
+// (tool-presentation.ts) — this is defence in depth against non-conforming connectors.
+// Counted in UTF-16 code units (string.length), not bytes.
+const TOOL_DETAIL_CAP = 32 * 1024;
+
+const capText = (s: string): string => (s.length > TOOL_DETAIL_CAP ? `${s.slice(0, TOOL_DETAIL_CAP)}…` : s);
+
+function hasOversizedString(value: unknown): boolean {
+  if (typeof value === "string") return value.length > TOOL_DETAIL_CAP;
+  if (Array.isArray(value)) return value.some(hasOversizedString);
+  if (value !== null && typeof value === "object") return Object.values(value).some(hasOversizedString);
+  return false;
+}
+
+function capDeep<T>(value: T): T {
+  if (typeof value === "string") return capText(value) as T;
+  if (Array.isArray(value)) return value.map(capDeep) as T;
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = capDeep(v);
+    return out as T;
+  }
+  return value;
+}
+
+/** Returns the step with every oversized string truncated — title, error, and all
+ *  detail variants (diff texts, command/search output, read preview, fields, …) —
+ *  or the original step when everything already fits (the common case: no copies
+ *  on the hot path). Deep-generic so future detail variants are covered by default. */
+export function capToolStep(step: ToolStepDto): ToolStepDto {
+  return hasOversizedString(step) ? capDeep(step) : step;
+}
+
+/** Same bound for a session-history seed's `structured` payload (toolSteps / parts /
+ *  reasoning), which enters the DB without passing through the turn buffer. */
+export function capSeededStructured<T>(structured: T): T {
+  return hasOversizedString(structured) ? capDeep(structured) : structured;
+}
 
 export interface RelayRuntime {
   db: SqlDriver;
@@ -166,7 +207,13 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             });
             return;
           }
-          const event = raw as ControlEventDto;
+          // Cap oversized tool steps BEFORE broadcast so the live view and the
+          // persisted history stay byte-identical, and an oversized event from a
+          // non-conforming connector isn't fanned out untruncated to every browser.
+          const event = ((): ControlEventDto => {
+            const e = raw as ControlEventDto;
+            return e.type === "tool-event" ? { ...e, step: capToolStep(e.step) } : e;
+          })();
           webGateway.broadcast(accountId, { kind: "control-event", instanceId, event });
           if (event.type === "turn-started") {
             turnBuffers.set(key(instanceId, event.sessionAlias), { text: "", steps: new Map(), reasoning: "", parts: [], startedAt: Date.now() });
@@ -194,6 +241,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
           } else if (event.type === "tool-event") {
             const a = turnBuffers.get(key(instanceId, event.sessionAlias));
             if (a && (a.steps.has(event.step.toolCallId) || a.steps.size < MAX_TOOL_STEPS)) {
+              // Already capped before broadcast above.
               a.steps.set(event.step.toolCallId, event.step);
               pushToolPart(a, event.step);
             }
@@ -233,7 +281,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             const existing = messages.listBySession(accountId, instanceId, event.sessionAlias, { limit: 1 });
             if (existing.messages.length === 0) {
               for (const row of event.messages) {
-                messages.append(instanceId, event.sessionAlias, row.direction, row.text, row.structured);
+                messages.append(instanceId, event.sessionAlias, row.direction, row.text, row.structured ? capSeededStructured(row.structured) : row.structured);
               }
             }
           }

--- a/tests/unit/packages/relay/cap-tool-step.test.ts
+++ b/tests/unit/packages/relay/cap-tool-step.test.ts
@@ -1,0 +1,81 @@
+// tests/unit/packages/relay/cap-tool-step.test.ts
+import { expect, test } from "bun:test";
+import type { ToolStepDto } from "../../../../packages/relay-protocol/src/index";
+import { capSeededStructured, capToolStep } from "../../../../packages/relay/src/server";
+
+const CAP = 32 * 1024;
+const big = "x".repeat(CAP + 100);
+
+function step(detail?: ToolStepDto["detail"]): ToolStepDto {
+  return { toolCallId: "t1", toolName: "Bash", kind: "execute", status: "success", title: "run", ...(detail ? { detail } : {}) };
+}
+
+test("returns the same object when there is no detail or everything fits", () => {
+  const noDetail = step();
+  expect(capToolStep(noDetail)).toBe(noDetail);
+  const small = step({ type: "diff", path: "a.ts", oldText: "old", newText: "new" });
+  expect(capToolStep(small)).toBe(small);
+});
+
+test("truncates oversized diff oldText/newText to the cap", () => {
+  const capped = capToolStep(step({ type: "diff", path: "a.ts", oldText: big, newText: big }));
+  const d = capped.detail as Extract<NonNullable<ToolStepDto["detail"]>, { type: "diff" }>;
+  expect(d.oldText.length).toBe(CAP + 1); // cap + ellipsis
+  expect(d.oldText.endsWith("…")).toBe(true);
+  expect(d.newText.length).toBe(CAP + 1);
+});
+
+test("truncates command output but keeps command and exitCode", () => {
+  const capped = capToolStep(step({ type: "command", command: "cat huge.log", output: big, exitCode: 0 }));
+  const d = capped.detail as Extract<NonNullable<ToolStepDto["detail"]>, { type: "command" }>;
+  expect(d.command).toBe("cat huge.log");
+  expect(d.exitCode).toBe(0);
+  expect(d.output!.length).toBe(CAP + 1);
+});
+
+test("truncates read preview, search output and text", () => {
+  const read = capToolStep(step({ type: "read", path: "a.ts", preview: big })).detail as { preview?: string };
+  expect(read.preview!.length).toBe(CAP + 1);
+  const search = capToolStep(step({ type: "search", query: "q", output: big })).detail as { output?: string };
+  expect(search.output!.length).toBe(CAP + 1);
+  const text = capToolStep(step({ type: "text", text: big })).detail as { text: string };
+  expect(text.text.length).toBe(CAP + 1);
+});
+
+test("truncates oversized fields values and output, leaving small fields intact", () => {
+  const capped = capToolStep(step({ type: "fields", fields: [{ label: "big", value: big }, { label: "small", value: "ok" }], output: big }));
+  const d = capped.detail as Extract<NonNullable<ToolStepDto["detail"]>, { type: "fields" }>;
+  expect(d.fields[0]!.value.length).toBe(CAP + 1);
+  expect(d.fields[1]!.value).toBe("ok");
+  expect(d.output!.length).toBe(CAP + 1);
+});
+
+test("does not mutate the original step when truncating", () => {
+  const original = step({ type: "command", command: "c", output: big });
+  const capped = capToolStep(original);
+  expect(capped).not.toBe(original);
+  expect((original.detail as { output?: string }).output!.length).toBe(big.length);
+});
+
+test("caps top-level step strings like title and error too", () => {
+  const capped = capToolStep({ ...step(), title: big, error: big });
+  expect(capped.title.length).toBe(CAP + 1);
+  expect(capped.error!.length).toBe(CAP + 1);
+});
+
+test("capSeededStructured caps nested strings in seeded history and is identity when small", () => {
+  const small = { toolSteps: [step({ type: "text", text: "ok" })] };
+  expect(capSeededStructured(small)).toBe(small);
+  const structured = {
+    toolSteps: [step({ type: "text", text: big })],
+    parts: [{ type: "tool", step: step({ type: "command", command: "c", output: big }) }],
+    reasoning: big,
+  };
+  const capped = capSeededStructured(structured);
+  expect(capped).not.toBe(structured);
+  expect((capped.toolSteps[0]!.detail as { text: string }).text.length).toBe(CAP + 1);
+  expect((capped.parts[0]!.step.detail as { output?: string }).output!.length).toBe(CAP + 1);
+  expect(capped.reasoning.length).toBe(CAP + 1);
+  // original untouched
+  expect(structured.reasoning.length).toBe(big.length);
+});


### PR DESCRIPTION
## Summary
- **MessageList.vue**: tail-first progressive mounting — on history load, mount only the newest 30 rows, then reveal older rows in rAF batches of 30 with distance-from-bottom scroll anchoring; top-scroll `loadOlder` is suppressed while local rows are still hidden; keys stay stable across turn-finished convergence
- **stores/chat.ts**: `markRaw` immutable `structured` payloads (parts/toolSteps/diffs) in `loadHistory`/`loadOlder`/`flushTurn` so Vue skips deep-proxying hundreds of KB of message trees
- **relay hub (server.ts)**: defence-in-depth `TOOL_DETAIL_CAP` (32K chars) — deep truncation of all oversized strings in tool steps, applied **before** broadcast (live view == persisted history) and to `session-history` seeded `structured`; zero-copy identity when everything fits

Root cause: session switch cost was dominated by synchronously creating ~100 row components (markdown-it + DOMPurify per text part) in a single tick — `content-visibility: auto` only saves layout/paint, not component creation.

Docs updated: `docs/relay-web-module.md` (new 切换会话的渲染性能 section), `docs/relay-module.md` (TOOL_DETAIL_CAP).

## Test plan
- [x] `bun run test:web` — 846 tests / 103 files pass (incl. 4 new progressive-mounting tests with stubbed rAF)
- [x] `npm run test:unit` — all pass (incl. new `cap-tool-step.test.ts`, 8 tests)
- [x] `npx tsc --noEmit` (root + relay), `npx vue-tsc --noEmit` (relay-web) clean
- [x] Subagent code review: no blockers; all 3 should-fix items addressed (cap before broadcast, session-history seed capped, cap covers all string fields)