### PR TITLE
perf(relay-web): seed session first screen from a localStorage tail cache

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -189,6 +189,16 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
 - **`structured` 脱离深度响应式**（`stores/chat.ts` `rawStructured`）：历史行不可变、只会整行
   替换，`loadHistory`/`loadOlder`/`flushTurn` 对 `structured`（parts/toolSteps/diff 全文）做
   `markRaw`，避免 Vue 深代理化数百 KB 的对象树。
+- **localStorage 会话尾部缓存**（`src/lib/session-tail-cache.ts`，spec #205）：stale-while-revalidate。
+  `chat.select()` 同步用缓存的最近 ≤30 条持久化行播种首屏（`messages.length > 0` 抑制骨架屏），
+  `loadHistory()` 原样整页替换收敛（key 稳定无闪烁）；成功加载与 turn-finished 后防抖写回
+  （`debounce-flush`，切会话时 flush）。键 = `xacpx.chat.tail.v1.<username>.<instanceId>.<alias>`
+  + 索引键 `tail-index.v1`（LRU/TTL 记账）。三层淘汰：事件驱动（`archiveSession`/`removeSession`
+  → `drop`，`auth.logout` → `dropAll`）、对账（`loadSessions` 落地后 `reconcile` 掉该实例
+  非存活/已归档 alias——覆盖 Web 关闭期间其他端的归档删除）、兜底（单条 256KB / 全局 4MB LRU、
+  7 天 TTL、quota 溢出淘汰重试一次、旧版本键前缀懒清扫）。所有存储访问 try/catch（可能被禁用）。
+  缓存播种（≤30 行）→ 权威整页替换不经过 0→N，`MessageList` 的渐进挂载对该替换同样重新触发
+  （prev ≤ INITIAL_ROWS 且一次增长 ≥ REVEAL_BATCH 视为新 transcript）。
 
 hub 侧配套：tool step 全字段 32K 字符写入截断（见 docs/relay-module.md 的 `TOOL_DETAIL_CAP`）。
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -194,10 +194,13 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   `loadHistory()` 原样整页替换收敛（key 稳定无闪烁）；成功加载与 turn-finished 后防抖写回
   （`debounce-flush`，切会话时 flush）。键 = `xacpx.chat.tail.v1.<username>.<instanceId>.<alias>`
   + 索引键 `tail-index.v1`（LRU/TTL 记账）。三层淘汰：事件驱动（`archiveSession`/`removeSession`
-  → `drop`，`auth.logout` → `dropAll`）、对账（`loadSessions` 落地后 `reconcile` 掉该实例
+  → chat store `purgeTailCache`（drop + 取消待写回，防止防抖定时器复活刚清掉的条目），
+  `auth.logout` → `dropAll`）、对账（`loadSessions` 落地后 `reconcileTailCache` 掉该实例
   非存活/已归档 alias——覆盖 Web 关闭期间其他端的归档删除）、兜底（单条 256KB / 全局 4MB LRU、
   7 天 TTL、quota 溢出淘汰重试一次、旧版本键前缀懒清扫）。所有存储访问 try/catch（可能被禁用）。
-  缓存播种（≤30 行）→ 权威整页替换不经过 0→N，`MessageList` 的渐进挂载对该替换同样重新触发
+  仅含缓存播种行的 transcript 在 `loadHistory` 的 pending-prompt 守卫里视同为空
+  （`seededFromCache`，保持 #199 的重选中途拉取语义）；播种（≤30 行）→ 权威整页替换
+  不经过 0→N，`MessageList` 的渐进挂载对该替换同样重新触发
   （prev ≤ INITIAL_ROWS 且一次增长 ≥ REVEAL_BATCH 视为新 transcript）。
 
 hub 侧配套：tool step 全字段 32K 字符写入截断（见 docs/relay-module.md 的 `TOOL_DETAIL_CAP`）。

--- a/docs/superpowers/specs/2026-07-28-relay-web-session-tail-cache-spec.md
+++ b/docs/superpowers/specs/2026-07-28-relay-web-session-tail-cache-spec.md
@@ -1,0 +1,63 @@
+# Relay Web: localStorage Session Tail Cache for Instant First Screen
+
+## Problem Statement
+
+Switching sessions in Relay Web always starts from a blank transcript: `chat.select()` clears `messages`, then `loadHistory()` fetches `GET /api/instances/:id/sessions/:alias/messages?limit=100` and the user watches a 5-row skeleton until the network round-trip completes. The progressive tail-first mount from #201 made *rendering* long histories cheap, but the *waiting* is now dominated by fetch latency — every switch, every page reload, even for a session viewed seconds ago, because the store keeps no per-session message state (`messages` is a single flat ref for the selected session only).
+
+The first screen only needs the transcript tail (MessageList mounts the last `INITIAL_ROWS = 30` rows first). That tail is small, immutable (persisted rows with stable monotonic `id`s are never edited), and already survives wholesale replacement without flicker thanks to stable `p${id}` keys — ideal conditions for stale-while-revalidate.
+
+localStorage is long-lived but sessions are not: sessions get archived and removed (sometimes from other clients while the web is closed), and accounts can change on a shared browser. A cache without a deliberate eviction story becomes a garbage pile that can show ghost data for dead sessions.
+
+## Solution
+
+A client-only stale-while-revalidate tail cache. On session switch, synchronously seed `messages` from a localStorage entry holding the last ≤30 persisted rows of that session, rendering the first screen instantly (no skeleton). The existing `loadHistory()` runs unchanged and replaces the transcript wholesale when the authoritative page arrives; stable row ids make the replace an in-place patch. Cache entries are written back after every successful authoritative load and (debounced) after each finished turn.
+
+Validity is enforced by construction (key = schema version + username + instanceId + sessionAlias) and by a three-layer eviction scheme: event-driven purge (archive / remove / logout), reconciliation against authoritative session lists as they arrive, and budget/TTL fallbacks (global LRU byte budget + max age) for anything events can't reach — e.g. sessions deleted from WeChat while the dashboard was closed.
+
+No server or protocol changes; this is entirely `packages/relay-web`.
+
+## User Stories
+
+1. As a user switching between sessions, I want the previously seen transcript tail to appear instantly, so that switching feels immediate instead of showing a skeleton.
+2. As a user reloading the dashboard, I want my selected session's tail to render before the network responds, so that cold starts feel warm.
+3. As a user, I want the transcript to converge to the latest server rows right after the cached tail appears, so that I never act on stale history for long.
+4. As a user who archives or deletes a session, I want its cache purged, so that ghost transcripts of dead sessions never reappear.
+5. As a user on a shared machine, I want logout to clear all cached transcripts, so that the next login cannot read my history from localStorage.
+6. As a user with many sessions over weeks, I want the cache to stay within a fixed byte budget and expire idle entries, so that localStorage never fills up or overflows quota.
+7. As a maintainer, I want the cache module isolated behind a small interface, so that the chat store changes stay minimal and testable.
+
+## Implementation Decisions
+
+- **New module `packages/relay-web/src/lib/session-tail-cache.ts`** exposing `read(user, instanceId, alias)`, `write(user, instanceId, alias, rows)`, `drop(user, instanceId, alias)`, `dropAll()`, `reconcile(user, instanceId, aliveAliases)`. All storage access wrapped in try/catch per repo convention (storage may be blocked).
+- **Keys**: per-entry `xacpx.chat.tail.v1.<username>.<instanceId>.<alias>` plus one index key `xacpx.chat.tail-index.v1` recording `{ key, lastAccess, bytes }` for LRU/TTL bookkeeping — per-entry keys keep reads/writes proportional to one session, never the whole cache. `username` (the only client-side identity; auth is a server cookie) partitions accounts by construction. Schema changes bump the `.v1` suffix; old keys are swept lazily by prefix.
+- **Entry contents**: the last ≤30 rows (`INITIAL_ROWS`) with `id !== undefined` (optimistic rows excluded), stripped to pure `MessageRecordDto` fields (no client-only `failed`/`status`). `structured` is kept intact — dropping it would flash text-only rows and then jump when tool cards arrive. If an entry exceeds the per-entry budget (256 KB serialized), trim oldest rows instead of stripping fields; if a single row exceeds it, skip caching that session.
+- **Budgets**: global 4 MB across entries; evict least-recently-accessed entries beyond budget on write. On `QuotaExceededError`, evict LRU and retry once, then give up silently (cache is an optimization, never an error source).
+- **Seeding (`chat.select()`)**: after the existing reset, synchronously `read()`; on hit, set `messages` from cached rows via the existing `rawStructured` (markRaw) path. `messages.length > 0` already suppresses the skeleton. No dimming/"cached" badge — convergence is near-immediate and in-place.
+- **Convergence**: `loadHistory()` is unchanged — full replace on arrival, existing staleness guards (`historyRequestSequence`, `transcriptRevision`) still apply. One addition: a cache-seeded transcript grows from ≤30 to up-to-100 rows on replace without a `0 → >30` transition, so the #201 progressive-mount arming must also trigger on that replace (mount the new older rows tail-first) to avoid paying a 70-component synchronous mount.
+- **Write-back**: after each successful `loadHistory()` (tail slice of authoritative rows) and after `flushTurn` on `turn-finished`, debounced via the existing `lib/debounce-flush.ts` so bursty turns don't hammer `JSON.stringify`.
+- **Event-driven purge**: `instances.archiveSession` / `removeSession` call `drop()`; `auth.logout()` calls `dropAll()` (today logout clears nothing in storage — this is the first cleanup hook).
+- **Reconciliation**: whenever `loadSessions(instanceId)` lands (sessions load lazily per instance, incl. on `sessions-changed` events), call `reconcile()` with that instance's live unarchived aliases and drop the rest. This covers archive/remove performed from other clients while the web was closed, per instance, as truth arrives.
+- **Fallbacks**: TTL 7 days since `lastAccess` (checked lazily on read/write), so entries for instances the user never expands again still die.
+- **`loadHistory()` failure**: keep showing the cached tail (better than blank) — the existing error toast already signals the failure; retry paths are unchanged.
+
+## Testing Decisions
+
+- Cache module unit tests (Vitest): read/write round-trip, per-entry trim, LRU eviction under the global budget, TTL expiry, quota-exceeded retry-then-give-up, `reconcile` dropping dead/archived aliases, version-prefix sweep, blocked-storage no-throw.
+- Chat store tests: `select()` seeds from cache and suppresses the skeleton; authoritative replace converges and re-arms progressive mount; optimistic rows never cached; write-back happens after `loadHistory` and `turn-finished` (debounced); cross-account key isolation.
+- Store integration tests: archive/remove purge, logout `dropAll`, `sessions-changed` reconciliation.
+- Full gates: `bun run test:web`, `npm run test:unit`, `npx tsc --noEmit`, `vue-tsc --noEmit` in relay-web.
+- Manual: switch between two long sessions and reload the page with DevTools network throttled — tail appears instantly, then converges; archive a session from WeChat while the web is closed and confirm its cache dies on next reconcile.
+
+## Out of Scope
+
+- Proactively caching non-selected sessions or full transcripts (only the selected session's tail, written on load/turn boundaries).
+- Caching plans, usage, queues, agent commands, or live-turn state — transcript rows only.
+- Encrypting cached history at rest (logout purge + per-username keys are the mitigation).
+- Service-worker/offline support and cross-tab cache coordination beyond localStorage's natural sharing.
+- Server or protocol changes (none required).
+
+## Further Notes
+
+- Builds on #201 (progressive tail-first mount, `markRaw` structured, stable `p${id}` row keys) — those mechanics are what make wholesale replace of a cache-seeded transcript flicker-free.
+- Worst-case row weight is bounded by connector caps (`TEXT_CAP` 8K / `DIFF_CAP` 4K per string, ≤200 steps) with the hub's 32 K-per-string deep cap as backstop; the 256 KB per-entry budget assumes typical rows are far smaller and heavy outliers just shorten the cached tail.
+- There is no `__APP_VERSION__` build constant in relay-web; versioning stays with the `.v1` key-suffix convention already used by sessionStorage caches (`xacpx.center-tabs.v1` etc.).

--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -131,3 +131,75 @@ test("logout drops every cached transcript", async () => {
   await useAuthStore().logout();
   expect(Object.keys(localStorage).filter((k) => k.startsWith("xacpx.chat.tail"))).toEqual([]);
 });
+
+test("reselecting a session mid-prompt still fetches history over a cache seed (#199)", async () => {
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
+  await chat.loadHistory();
+  // The prompt RPC stays pending for the whole turn (non-queued prompt).
+  rpc.mockReturnValue(new Promise(() => {}));
+  void chat.send("hello");
+  chat.select("i1", "other"); // switch away (flushes s1's tail into the cache)
+  chat.select("i1", "s1"); // reselect: transcript is seeded from the cache
+  expect(chat.messages.map((m) => m.id)).toEqual([1]);
+  // The pending-prompt guard must treat the cache-seeded transcript as empty and
+  // fetch anyway — otherwise the just-sent (already persisted) prompt row stays
+  // invisible until the RPC settles.
+  getMock.mockResolvedValue({ messages: [row(1), row(2, "hello")], hasMore: false });
+  await chat.loadHistory();
+  expect(chat.messages.map((m) => m.id)).toEqual([1, 2]);
+  chat.clearSelection(); // flush the pending write-back so no timer leaks into later tests
+});
+
+test("an optimistic send clears the seeded state so a mid-prompt reload defers again", async () => {
+  write("alice", "i1", "s1", [row(1)]);
+  const chat = useChatStore();
+  chat.select("i1", "s1"); // seeded
+  rpc.mockReturnValue(new Promise(() => {}));
+  void chat.send("hello"); // pushes an optimistic row → transcript no longer seed-only
+  getMock.mockResolvedValue({ messages: [row(1), row(2, "hello")], hasMore: false });
+  await chat.loadHistory();
+  // Guard defers: the optimistic row (pending queueItemId correlation) is protected.
+  expect(chat.messages.map((m) => m.text)).toEqual(["m1", "hello"]);
+});
+
+test("write-back fires on the debounce timer without a session switch", async () => {
+  vi.useFakeTimers();
+  try {
+    const chat = useChatStore();
+    chat.select("i1", "s1");
+    getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
+    await chat.loadHistory();
+    expect(read("alice", "i1", "s1")).toBeNull(); // still debounced
+    vi.advanceTimersByTime(500);
+    expect(read("alice", "i1", "s1")!.map((r) => r.id)).toEqual([1]);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("pagehide flushes a pending write-back", async () => {
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
+  await chat.loadHistory();
+  window.dispatchEvent(new Event("pagehide"));
+  expect(read("alice", "i1", "s1")!.map((r) => r.id)).toEqual([1]);
+});
+
+test("archiving cancels a pending write-back so it cannot resurrect the purged entry", async () => {
+  vi.useFakeTimers();
+  try {
+    const chat = useChatStore();
+    chat.select("i1", "s1");
+    getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
+    await chat.loadHistory(); // schedules the debounced write-back
+    rpc.mockResolvedValue({ sessions: [], agents: [] });
+    await useInstancesStore().archiveSession("i1", "s1"); // purge + cancel
+    vi.advanceTimersByTime(500); // the cancelled timer must not fire
+    expect(read("alice", "i1", "s1")).toBeNull();
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -1,0 +1,133 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, expect, test, vi } from "vitest";
+import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
+import { read, resetSweepForTests, write } from "../lib/session-tail-cache";
+
+const getMock = vi.fn();
+const rpc = vi.fn();
+const post = vi.fn(async (..._args: unknown[]) => ({}));
+vi.mock("../api/client", () => ({
+  ApiError: class ApiError extends Error {
+    constructor(public code: string, public status: number) {
+      super(code);
+    }
+  },
+  api: {
+    get: (path: string) => getMock(path),
+    rpc: (instanceId: string, type: string, payload?: unknown) => rpc(instanceId, type, payload),
+    post: (path: string, body?: unknown) => post(path, body),
+  },
+}));
+
+import { useAuthStore } from "../stores/auth";
+import { useChatStore } from "../stores/chat";
+import { useInstancesStore } from "../stores/instances";
+
+const row = (id: number, text = `m${id}`): MessageRecordDto => ({
+  id, instanceId: "i1", sessionAlias: "s1", direction: "out", text, createdAt: "2026-07-28T00:00:00.000Z",
+});
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  localStorage.clear();
+  resetSweepForTests();
+  getMock.mockReset();
+  rpc.mockReset();
+  post.mockClear();
+  useAuthStore().account = { username: "alice" };
+});
+
+test("select() seeds the transcript synchronously from the cached tail (no skeleton)", () => {
+  write("alice", "i1", "s1", [row(1), row(2)]);
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  // Synchronous — no network round-trip involved.
+  expect(chat.messages.map((m) => m.id)).toEqual([1, 2]);
+  expect(chat.loadingHistory).toBe(false);
+});
+
+test("select() leaves the transcript empty on cache miss or when logged out", () => {
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  expect(chat.messages).toEqual([]);
+  write("alice", "i1", "s2", [row(1)]);
+  useAuthStore().account = null;
+  chat.select("i1", "s2");
+  expect(chat.messages).toEqual([]);
+});
+
+test("authoritative loadHistory replaces the seeded tail and writes back on the next switch", async () => {
+  write("alice", "i1", "s1", [row(1, "stale")]);
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  expect(chat.messages.map((m) => m.id)).toEqual([1]);
+
+  const fresh = Array.from({ length: 50 }, (_, i) => row(i + 1, `fresh${i + 1}`));
+  getMock.mockResolvedValue({ messages: fresh, hasMore: false });
+  await chat.loadHistory();
+  expect(chat.messages.length).toBe(50); // full replace, stale row converged
+
+  // The write-back is debounced; switching sessions flushes it for the outgoing session.
+  chat.select("i1", "other");
+  const cached = read("alice", "i1", "s1")!;
+  expect(cached.length).toBe(30); // tail only
+  expect(cached.at(-1)).toMatchObject({ id: 50, text: "fresh50" });
+});
+
+test("optimistic rows (no id) are never written to the cache", async () => {
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
+  await chat.loadHistory();
+  // A streamed turn flushes an optimistic out-row without an id.
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s1", chunk: "live" } });
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s1", ok: true } });
+  chat.select("i1", "other"); // flush pending write-back
+  expect(read("alice", "i1", "s1")!.map((r) => r.id)).toEqual([1]);
+});
+
+test("loadHistory failure keeps showing the cached tail", async () => {
+  write("alice", "i1", "s1", [row(1), row(2)]);
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  getMock.mockRejectedValue(new Error("network"));
+  await expect(chat.loadHistory()).rejects.toThrow();
+  expect(chat.messages.map((m) => m.id)).toEqual([1, 2]);
+});
+
+test("archiveSession and removeSession purge the session's cache", async () => {
+  write("alice", "i1", "s1", [row(1)]);
+  write("alice", "i1", "s2", [row(2)]);
+  rpc.mockResolvedValue({ sessions: [], agents: [] });
+  const instances = useInstancesStore();
+  await instances.archiveSession("i1", "s1");
+  expect(read("alice", "i1", "s1")).toBeNull();
+  await instances.removeSession("i1", "s2");
+  expect(read("alice", "i1", "s2")).toBeNull();
+});
+
+test("loadSessions reconciles the cache against alive unarchived aliases", async () => {
+  write("alice", "i1", "alive", [row(1)]);
+  write("alice", "i1", "archived", [row(2)]);
+  write("alice", "i1", "gone", [row(3)]);
+  rpc.mockImplementation(async (_id: string, type: string) => {
+    if (type === "control.sessions.list") {
+      return { sessions: [
+        { alias: "alive", agent: "a", workspace: "w", transportSession: "t", running: false, archived: false },
+        { alias: "archived", agent: "a", workspace: "w", transportSession: "t", running: false, archived: true },
+      ] };
+    }
+    return { agents: [] };
+  });
+  await useInstancesStore().loadSessions("i1");
+  expect(read("alice", "i1", "alive")).not.toBeNull();
+  expect(read("alice", "i1", "archived")).toBeNull(); // archived elsewhere → dropped
+  expect(read("alice", "i1", "gone")).toBeNull(); // removed elsewhere → dropped
+});
+
+test("logout drops every cached transcript", async () => {
+  write("alice", "i1", "s1", [row(1)]);
+  write("bob", "i2", "s9", [row(2)]);
+  await useAuthStore().logout();
+  expect(Object.keys(localStorage).filter((k) => k.startsWith("xacpx.chat.tail"))).toEqual([]);
+});

--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -160,8 +160,10 @@ test("an optimistic send clears the seeded state so a mid-prompt reload defers a
   void chat.send("hello"); // pushes an optimistic row → transcript no longer seed-only
   getMock.mockResolvedValue({ messages: [row(1), row(2, "hello")], hasMore: false });
   await chat.loadHistory();
-  // Guard defers: the optimistic row (pending queueItemId correlation) is protected.
-  expect(chat.messages.map((m) => m.text)).toEqual(["m1", "hello"]);
+  // Guard defers: the optimistic row (id undefined until the RPC settles) is
+  // protected. Asserting on ids distinguishes defer ([1, undefined]) from a
+  // full-page replace ([1, 2]) — texts would be identical either way.
+  expect(chat.messages.map((m) => m.id)).toEqual([1, undefined]);
 });
 
 test("write-back fires on the debounce timer without a session switch", async () => {

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -434,4 +434,17 @@ describe("progressive tail-first mounting", () => {
     await wrapper.setProps({ messages: many(81) });
     expect(wrapper.findAll(".cv-row").length).toBe(81);
   });
+
+  // Spec #205: a cache-seeded transcript (≤30 stale rows) is replaced by the full
+  // authoritative page without passing through 0 — the arming must still trigger so
+  // the ~70 prepended older rows mount in rAF batches, not one synchronous tick.
+  it("re-arms progressive mounting when a cache-seeded tail is replaced by the full page", async () => {
+    const wrapper = mount(MessageList, { props: { messages: [], liveTurn: null } });
+    await wrapper.setProps({ messages: many(20) }); // cached tail seed (< INITIAL_ROWS)
+    expect(wrapper.findAll(".cv-row").length).toBe(20);
+    await wrapper.setProps({ messages: many(100) }); // authoritative replace
+    expect(wrapper.findAll(".cv-row").length).toBe(30); // only the tail mounts immediately
+    await flushFrames(wrapper);
+    expect(wrapper.findAll(".cv-row").length).toBe(100);
+  });
 });

--- a/packages/relay-web/src/__tests__/session-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/session-tail-cache.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
+import { drop, dropAll, read, reconcile, resetSweepForTests, TAIL_ROWS, write } from "../lib/session-tail-cache";
+
+const row = (id: number, text = `m${id}`): MessageRecordDto => ({
+  id, instanceId: "i1", sessionAlias: "s1", direction: "out", text, createdAt: "2026-07-28T00:00:00.000Z",
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  resetSweepForTests();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("session-tail-cache", () => {
+  it("round-trips the tail and strips client-only fields + optimistic rows", () => {
+    const rows = [
+      { ...row(1), failed: true, status: "error" } as MessageRecordDto,
+      row(2),
+      // optimistic row (no id) must never be cached
+      { instanceId: "i1", sessionAlias: "s1", direction: "in", text: "pending", createdAt: "x" } as MessageRecordDto,
+    ];
+    write("alice", "i1", "s1", rows);
+    const back = read("alice", "i1", "s1")!;
+    expect(back.map((r) => r.id)).toEqual([1, 2]);
+    expect(back[0]).not.toHaveProperty("failed");
+    expect(back[0]).not.toHaveProperty("status");
+    expect(back[0]).toMatchObject({ text: "m1", direction: "out" });
+  });
+
+  it("keeps only the newest TAIL_ROWS rows", () => {
+    write("alice", "i1", "s1", Array.from({ length: 100 }, (_, i) => row(i + 1)));
+    const back = read("alice", "i1", "s1")!;
+    expect(back.length).toBe(TAIL_ROWS);
+    expect(back[0]!.id).toBe(100 - TAIL_ROWS + 1);
+    expect(back.at(-1)!.id).toBe(100);
+  });
+
+  it("keeps structured payloads intact", () => {
+    const r = { ...row(1), structured: { toolSteps: [{ toolCallId: "t", toolName: "R", kind: "read", status: "success", title: "x" }] } } as MessageRecordDto;
+    write("alice", "i1", "s1", [r]);
+    expect(read("alice", "i1", "s1")![0]!.structured?.toolSteps?.[0]).toMatchObject({ toolCallId: "t" });
+  });
+
+  it("misses across accounts, instances and aliases (key isolation)", () => {
+    write("alice", "i1", "s1", [row(1)]);
+    expect(read("bob", "i1", "s1")).toBeNull();
+    expect(read("alice", "i2", "s1")).toBeNull();
+    expect(read("alice", "i1", "s2")).toBeNull();
+  });
+
+  it("trims oldest rows to fit the per-entry budget", () => {
+    const fat = (id: number): MessageRecordDto => row(id, "x".repeat(30_000)); // ~60 KB serialized each
+    write("alice", "i1", "s1", Array.from({ length: 10 }, (_, i) => fat(i + 1)));
+    const back = read("alice", "i1", "s1")!;
+    expect(back.length).toBeLessThan(10);
+    expect(back.at(-1)!.id).toBe(10); // newest survives; oldest trimmed
+  });
+
+  it("skips caching when a single row exceeds the per-entry budget", () => {
+    write("alice", "i1", "s1", [row(1, "x".repeat(200_000))]);
+    expect(read("alice", "i1", "s1")).toBeNull();
+  });
+
+  it("evicts least-recently-accessed entries beyond the global budget", () => {
+    // ~200 KB (bytes) per entry; 25 entries ≈ 5 MB > the 4 MB budget.
+    const fat = (alias: string, id: number): void => write("alice", "i1", alias, [row(id, "x".repeat(100_000))]);
+    for (let i = 0; i < 25; i += 1) fat(`s${i}`, i + 1);
+    expect(read("alice", "i1", "s0")).toBeNull(); // earliest written → evicted
+    expect(read("alice", "i1", "s24")).not.toBeNull(); // newest survives
+  });
+
+  it("expires entries older than the TTL", () => {
+    const t0 = Date.now();
+    const now = vi.spyOn(Date, "now").mockReturnValue(t0);
+    write("alice", "i1", "s1", [row(1)]);
+    now.mockReturnValue(t0 + 8 * 24 * 60 * 60 * 1000); // 8 days later
+    expect(read("alice", "i1", "s1")).toBeNull();
+  });
+
+  it("a read refreshes lastAccess (LRU touch)", () => {
+    const t0 = Date.now();
+    const now = vi.spyOn(Date, "now").mockReturnValue(t0);
+    write("alice", "i1", "s1", [row(1)]);
+    now.mockReturnValue(t0 + 6 * 24 * 60 * 60 * 1000); // day 6: touch
+    expect(read("alice", "i1", "s1")).not.toBeNull();
+    now.mockReturnValue(t0 + 12 * 24 * 60 * 60 * 1000); // day 12: 6 days since touch
+    expect(read("alice", "i1", "s1")).not.toBeNull();
+  });
+
+  it("retries once after a quota error by evicting the LRU entry", () => {
+    write("alice", "i1", "old", [row(1)]);
+    const original = Storage.prototype.setItem;
+    let threw = false;
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (this: Storage, key: string, value: string) {
+      if (!threw && key.includes(".s1")) { threw = true; throw new DOMException("quota", "QuotaExceededError"); }
+      original.call(this, key, value);
+    });
+    write("alice", "i1", "s1", [row(2)]);
+    expect(threw).toBe(true);
+    expect(read("alice", "i1", "s1")!.map((r) => r.id)).toEqual([2]);
+    expect(read("alice", "i1", "old")).toBeNull(); // the eviction victim
+  });
+
+  it("gives up silently when the quota retry also fails", () => {
+    const original = Storage.prototype.setItem;
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (this: Storage, key: string, value: string) {
+      if (key.startsWith("xacpx.chat.tail.v1.")) throw new DOMException("quota", "QuotaExceededError");
+      original.call(this, key, value);
+    });
+    expect(() => write("alice", "i1", "s1", [row(1)])).not.toThrow();
+    vi.restoreAllMocks();
+    expect(read("alice", "i1", "s1")).toBeNull();
+  });
+
+  it("drop purges one session; dropAll purges everything", () => {
+    write("alice", "i1", "s1", [row(1)]);
+    write("alice", "i1", "s2", [row(2)]);
+    drop("alice", "i1", "s1");
+    expect(read("alice", "i1", "s1")).toBeNull();
+    expect(read("alice", "i1", "s2")).not.toBeNull();
+    dropAll();
+    expect(read("alice", "i1", "s2")).toBeNull();
+    expect(Object.keys(localStorage).filter((k) => k.startsWith("xacpx.chat.tail"))).toEqual([]);
+  });
+
+  it("reconcile drops entries whose alias is not alive, scoped to the instance + user", () => {
+    write("alice", "i1", "s1", [row(1)]);
+    write("alice", "i1", "s2", [row(2)]);
+    write("alice", "i2", "s2", [row(3)]);
+    write("bob", "i1", "s2", [row(4)]);
+    reconcile("alice", "i1", ["s1"]);
+    expect(read("alice", "i1", "s1")).not.toBeNull();
+    expect(read("alice", "i1", "s2")).toBeNull(); // dead alias dropped
+    expect(read("alice", "i2", "s2")).not.toBeNull(); // other instance untouched
+    expect(read("bob", "i1", "s2")).not.toBeNull(); // other account untouched
+  });
+
+  it("handles dotted aliases/instance ids without cross-matching in reconcile", () => {
+    write("alice", "i.1", "a.b", [row(1)]);
+    write("alice", "i.1", "a.b.c", [row(2)]);
+    reconcile("alice", "i.1", ["a.b"]);
+    expect(read("alice", "i.1", "a.b")).not.toBeNull();
+    expect(read("alice", "i.1", "a.b.c")).toBeNull();
+  });
+
+  it("sweeps old-version keys lazily by prefix", () => {
+    localStorage.setItem("xacpx.chat.tail.v0.alice.i1.s1", "[]");
+    localStorage.setItem("xacpx.chat.tail-index.v0", "[]");
+    resetSweepForTests();
+    read("alice", "i1", "s1");
+    expect(localStorage.getItem("xacpx.chat.tail.v0.alice.i1.s1")).toBeNull();
+    expect(localStorage.getItem("xacpx.chat.tail-index.v0")).toBeNull();
+  });
+
+  it("never throws when storage is blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => { throw new Error("blocked"); });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => { throw new Error("blocked"); });
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => { throw new Error("blocked"); });
+    vi.spyOn(Storage.prototype, "key").mockImplementation(() => { throw new Error("blocked"); });
+    expect(read("alice", "i1", "s1")).toBeNull();
+    expect(() => write("alice", "i1", "s1", [row(1)])).not.toThrow();
+    expect(() => drop("alice", "i1", "s1")).not.toThrow();
+    expect(() => dropAll()).not.toThrow();
+    expect(() => reconcile("alice", "i1", ["s1"])).not.toThrow();
+  });
+});

--- a/packages/relay-web/src/__tests__/session-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/session-tail-cache.test.ts
@@ -117,6 +117,13 @@ describe("session-tail-cache", () => {
     expect(localStorage.getItem(entryKey)).toBeNull();
   });
 
+  it("drops a corrupted entry (non-object elements) instead of returning it", () => {
+    write("alice", "i1", "s1", [row(1)]);
+    localStorage.setItem("xacpx.chat.tail.v1.alice.i1.s1", "[null]");
+    expect(read("alice", "i1", "s1")).toBeNull();
+    expect(localStorage.getItem("xacpx.chat.tail.v1.alice.i1.s1")).toBeNull();
+  });
+
   it("drop purges one session; dropAll purges everything", () => {
     write("alice", "i1", "s1", [row(1)]);
     write("alice", "i1", "s2", [row(2)]);

--- a/packages/relay-web/src/__tests__/session-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/session-tail-cache.test.ts
@@ -102,15 +102,19 @@ describe("session-tail-cache", () => {
     expect(read("alice", "i1", "old")).toBeNull(); // the eviction victim
   });
 
-  it("gives up silently when the quota retry also fails", () => {
+  it("gives up silently when the quota retry also fails, without orphaning the stale entry", () => {
+    write("alice", "i1", "s1", [row(1, "old")]);
+    const entryKey = Object.keys(localStorage).find((k) => k.startsWith("xacpx.chat.tail.v1.") && k.endsWith(".s1"))!;
     const original = Storage.prototype.setItem;
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (this: Storage, key: string, value: string) {
       if (key.startsWith("xacpx.chat.tail.v1.")) throw new DOMException("quota", "QuotaExceededError");
       original.call(this, key, value);
     });
-    expect(() => write("alice", "i1", "s1", [row(1)])).not.toThrow();
+    expect(() => write("alice", "i1", "s1", [row(2, "new")])).not.toThrow();
     vi.restoreAllMocks();
     expect(read("alice", "i1", "s1")).toBeNull();
+    // The previous stored value must not linger as an index-less orphan holding quota.
+    expect(localStorage.getItem(entryKey)).toBeNull();
   });
 
   it("drop purges one session; dropAll purges everything", () => {

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -98,15 +98,20 @@ onBeforeUnmount(() => {
   settleRaf = 0;
 });
 
-// Arm progressive mounting when a freshly selected session's rows land: only a jump
-// from empty to many rows re-arms it — an in-place replace (turn-finished history
-// convergence) keeps stable keys and reuses mounted components, so hiding rows again
-// would only cause churn. Session switches empty `messages` first (chat.select), so
-// the 0→N transition is a reliable "new transcript" signal.
+// Arm progressive mounting when a freshly selected session's rows land. Two shapes:
+// the 0→many jump (select empties `messages` first, then history lands), and the
+// cache-seeded replace (≤INITIAL_ROWS stale rows from the tail cache swap to the full
+// authoritative page without passing through 0 — spec #205). The seeded rows are the
+// newest of the page, so stable keys keep them mounted; only the PREPENDED older rows
+// hide and reveal in rAF batches. The prev-length + big-jump guard keeps ordinary
+// in-place convergence (turn-finished reload, small append bursts) and load-older
+// prepends (prev is already ≥ a full page there) from churning mounted components.
 watch(
   () => props.messages.length,
   (now, prev) => {
-    if (prev === 0 && now > INITIAL_ROWS) {
+    const freshJump = prev === 0 && now > INITIAL_ROWS;
+    const cacheSeededReplace = prev > 0 && prev <= INITIAL_ROWS && now - prev >= REVEAL_BATCH;
+    if (freshJump || cacheSeededReplace) {
       hiddenCount.value = now - INITIAL_ROWS;
       scheduleReveal();
     } else if (hiddenCount.value > now) {

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -1,0 +1,234 @@
+import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
+
+/** Stale-while-revalidate tail cache for session transcripts (spec #205).
+ *
+ *  Stores the last ≤30 persisted rows of a session in localStorage so
+ *  `chat.select()` can seed the first screen synchronously while the
+ *  authoritative history fetch is in flight. Validity comes from the key
+ *  (schema version + username + instance + alias) plus three eviction layers:
+ *  event-driven purge (archive/remove/logout), reconciliation against live
+ *  session lists, and LRU/TTL budget fallbacks. Every storage access is
+ *  wrapped in try/catch — storage may be blocked, and the cache must never
+ *  become an error source. */
+
+const VERSION = "v1";
+// Any-version prefixes, used by dropAll() and the lazy old-version sweep.
+const BASE_ENTRY_PREFIX = "xacpx.chat.tail.";
+const BASE_INDEX_PREFIX = "xacpx.chat.tail-index.";
+const ENTRY_PREFIX = `${BASE_ENTRY_PREFIX}${VERSION}.`;
+const INDEX_KEY = `${BASE_INDEX_PREFIX}${VERSION}`;
+
+export const TAIL_ROWS = 30;
+const ENTRY_BUDGET_BYTES = 256 * 1024;
+const GLOBAL_BUDGET_BYTES = 4 * 1024 * 1024;
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type IndexRecord = { key: string; lastAccess: number; bytes: number };
+
+// Key segments must never contain "." so reconcile() can prefix-match
+// (user, instanceId) unambiguously even when aliases contain dots.
+const esc = (s: string): string => encodeURIComponent(s).replace(/\./g, "%2E");
+const entryKey = (user: string, instanceId: string, alias: string): string =>
+  `${ENTRY_PREFIX}${esc(user)}.${esc(instanceId)}.${esc(alias)}`;
+
+function loadIndex(): IndexRecord[] {
+  try {
+    const raw = localStorage.getItem(INDEX_KEY);
+    if (!raw) return [];
+    const v = JSON.parse(raw) as unknown;
+    if (!Array.isArray(v)) return [];
+    return v.filter((r): r is IndexRecord =>
+      typeof r === "object" && r !== null &&
+      typeof (r as IndexRecord).key === "string" &&
+      typeof (r as IndexRecord).lastAccess === "number" &&
+      typeof (r as IndexRecord).bytes === "number");
+  } catch { return []; }
+}
+
+function saveIndex(index: IndexRecord[]): void {
+  try {
+    if (index.length === 0) localStorage.removeItem(INDEX_KEY);
+    else localStorage.setItem(INDEX_KEY, JSON.stringify(index));
+  } catch { /* storage may be blocked */ }
+}
+
+function removeEntry(index: IndexRecord[], key: string): IndexRecord[] {
+  try { localStorage.removeItem(key); } catch { /* storage may be blocked */ }
+  return index.filter((r) => r.key !== key);
+}
+
+/** Drop entries whose lastAccess is older than the TTL. Runs lazily on read/write
+ *  so idle entries for instances the user never expands again still die. */
+function pruneExpired(index: IndexRecord[], now: number): IndexRecord[] {
+  let next = index;
+  for (const r of index) {
+    if (now - r.lastAccess > TTL_MS) next = removeEntry(next, r.key);
+  }
+  return next;
+}
+
+// Old-version keys (e.g. a future v2 rollout leaving v1 behind, or vice versa on
+// rollback) are swept once per page load — cheap, and keeps quota for live data.
+let sweptOldVersions = false;
+function sweepOldVersions(): void {
+  if (sweptOldVersions) return;
+  sweptOldVersions = true;
+  try {
+    const stale: string[] = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      const oldEntry = key.startsWith(BASE_ENTRY_PREFIX) && !key.startsWith(ENTRY_PREFIX);
+      const oldIndex = key.startsWith(BASE_INDEX_PREFIX) && key !== INDEX_KEY;
+      if (oldEntry || oldIndex) stale.push(key);
+    }
+    for (const key of stale) localStorage.removeItem(key);
+  } catch { /* storage may be blocked */ }
+}
+
+/** Test hook: reset the once-per-load sweep latch. */
+export function resetSweepForTests(): void { sweptOldVersions = false; }
+
+/** Synchronously read the cached tail for a session, or null on miss/expiry.
+ *  A hit refreshes the entry's lastAccess (LRU touch). */
+export function read(user: string, instanceId: string, alias: string): MessageRecordDto[] | null {
+  sweepOldVersions();
+  try {
+    const key = entryKey(user, instanceId, alias);
+    const now = Date.now();
+    let index = pruneExpired(loadIndex(), now);
+    const record = index.find((r) => r.key === key);
+    if (!record) {
+      // No index record — remove any orphaned entry so it can't linger untracked.
+      index = removeEntry(index, key);
+      saveIndex(index);
+      return null;
+    }
+    const raw = localStorage.getItem(key);
+    if (!raw) {
+      saveIndex(index.filter((r) => r.key !== key));
+      return null;
+    }
+    const rows = JSON.parse(raw) as unknown;
+    if (!Array.isArray(rows) || rows.length === 0) {
+      saveIndex(removeEntry(index, key));
+      return null;
+    }
+    record.lastAccess = now;
+    saveIndex(index);
+    return rows as MessageRecordDto[];
+  } catch { return null; }
+}
+
+/** Strip a row to pure persisted DTO fields — client-only flags (`failed`,
+ *  `status`) must not resurrect on a cache hit. */
+function toCachedRow(row: MessageRecordDto): MessageRecordDto {
+  const out: MessageRecordDto = {
+    id: row.id,
+    instanceId: row.instanceId,
+    sessionAlias: row.sessionAlias,
+    direction: row.direction,
+    text: row.text,
+    createdAt: row.createdAt,
+  };
+  if (row.queueItemId !== undefined) out.queueItemId = row.queueItemId;
+  if (row.structured !== undefined) out.structured = row.structured;
+  if (row.attachments !== undefined) out.attachments = row.attachments;
+  return out;
+}
+
+/** Cache the tail of `rows` for a session. Keeps the last ≤30 persisted rows
+ *  (id !== undefined), trims oldest rows to fit the per-entry budget, evicts
+ *  LRU entries beyond the global budget, and retries once on quota errors. */
+export function write(user: string, instanceId: string, alias: string, rows: MessageRecordDto[]): void {
+  sweepOldVersions();
+  try {
+    const key = entryKey(user, instanceId, alias);
+    const now = Date.now();
+    let index = pruneExpired(loadIndex(), now);
+
+    let tail = rows.filter((r) => typeof r.id === "number").slice(-TAIL_ROWS).map(toCachedRow);
+    if (tail.length === 0) {
+      saveIndex(removeEntry(index, key));
+      return;
+    }
+    let serialized = JSON.stringify(tail);
+    // Serialized length ≈ UTF-16 code units; ×2 approximates the storage bytes.
+    while (serialized.length * 2 > ENTRY_BUDGET_BYTES && tail.length > 1) {
+      tail = tail.slice(1);
+      serialized = JSON.stringify(tail);
+    }
+    if (serialized.length * 2 > ENTRY_BUDGET_BYTES) {
+      // A single row exceeding the budget: skip caching this session.
+      saveIndex(removeEntry(index, key));
+      return;
+    }
+    const bytes = serialized.length * 2;
+
+    // Evict least-recently-accessed OTHER entries until the new entry fits the
+    // global budget (the fresh write is never a victim of its own eviction).
+    const evictLru = (): boolean => {
+      const victims = index.filter((r) => r.key !== key).sort((a, b) => a.lastAccess - b.lastAccess);
+      if (victims.length === 0) return false;
+      index = removeEntry(index, victims[0].key);
+      return true;
+    };
+    const totalOthers = (): number => index.filter((r) => r.key !== key).reduce((sum, r) => sum + r.bytes, 0);
+    while (totalOthers() + bytes > GLOBAL_BUDGET_BYTES) {
+      if (!evictLru()) break;
+    }
+
+    const store = (): void => localStorage.setItem(key, serialized);
+    try {
+      store();
+    } catch {
+      // Quota exceeded: evict the LRU entry and retry once, then give up.
+      if (!evictLru()) { saveIndex(index.filter((r) => r.key !== key)); return; }
+      try { store(); } catch {
+        saveIndex(index.filter((r) => r.key !== key));
+        return;
+      }
+    }
+    const existing = index.find((r) => r.key === key);
+    if (existing) { existing.lastAccess = now; existing.bytes = bytes; }
+    else index.push({ key, lastAccess: now, bytes });
+    saveIndex(index);
+  } catch { /* cache is an optimization, never an error source */ }
+}
+
+/** Purge one session's cache — archive/remove hooks. */
+export function drop(user: string, instanceId: string, alias: string): void {
+  try {
+    const key = entryKey(user, instanceId, alias);
+    saveIndex(removeEntry(loadIndex(), key));
+  } catch { /* storage may be blocked */ }
+}
+
+/** Purge every cached transcript (any schema version) — the logout hook. */
+export function dropAll(): void {
+  try {
+    const stale: string[] = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      if (key.startsWith(BASE_ENTRY_PREFIX) || key.startsWith(BASE_INDEX_PREFIX)) stale.push(key);
+    }
+    for (const key of stale) localStorage.removeItem(key);
+  } catch { /* storage may be blocked */ }
+}
+
+/** Drop cached entries for an instance whose alias is not in `aliveAliases` —
+ *  covers sessions archived/removed from other clients while the web was closed.
+ *  Called as each instance's authoritative session list arrives. */
+export function reconcile(user: string, instanceId: string, aliveAliases: Iterable<string>): void {
+  try {
+    const prefix = `${ENTRY_PREFIX}${esc(user)}.${esc(instanceId)}.`;
+    const alive = new Set<string>();
+    for (const alias of aliveAliases) alive.add(`${prefix}${esc(alias)}`);
+    let index = loadIndex();
+    for (const r of [...index]) {
+      if (r.key.startsWith(prefix) && !alive.has(r.key)) index = removeEntry(index, r.key);
+    }
+    saveIndex(index);
+  } catch { /* storage may be blocked */ }
+}

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -110,7 +110,9 @@ export function read(user: string, instanceId: string, alias: string): MessageRe
       return null;
     }
     const rows = JSON.parse(raw) as unknown;
-    if (!Array.isArray(rows) || rows.length === 0) {
+    // A corrupted entry (non-array, empty, or non-object elements) must be
+    // dropped here — the cache must never become an error source downstream.
+    if (!Array.isArray(rows) || rows.length === 0 || rows.some((r) => typeof r !== "object" || r === null)) {
       saveIndex(removeEntry(index, key));
       return null;
     }

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -182,10 +182,13 @@ export function write(user: string, instanceId: string, alias: string, rows: Mes
     try {
       store();
     } catch {
-      // Quota exceeded: evict the LRU entry and retry once, then give up.
-      if (!evictLru()) { saveIndex(index.filter((r) => r.key !== key)); return; }
+      // Quota exceeded: evict the LRU entry and retry once, then give up. Giving up
+      // must also remove any PREVIOUS stored value under this key (the failed setItem
+      // left it in place): an index-less orphan would hold quota — the very resource
+      // exhausted here — invisibly to LRU/TTL/reconcile.
+      if (!evictLru()) { saveIndex(removeEntry(index, key)); return; }
       try { store(); } catch {
-        saveIndex(index.filter((r) => r.key !== key));
+        saveIndex(removeEntry(index, key));
         return;
       }
     }

--- a/packages/relay-web/src/stores/auth.ts
+++ b/packages/relay-web/src/stores/auth.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 import { ApiError, api } from "../api/client";
+import { dropAll as dropAllTailCaches } from "../lib/session-tail-cache";
 
 export interface Account {
   username: string;
@@ -35,6 +36,9 @@ export const useAuthStore = defineStore("auth", () => {
   async function logout(): Promise<void> {
     await api.post("/api/logout").catch(() => {});
     account.value = null;
+    // Shared-machine hygiene: the next login must not be able to read cached
+    // transcripts from localStorage (spec #205 user story 5).
+    dropAllTailCaches();
   }
 
   return { account, error, login, fetchMe, logout };

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -2,6 +2,9 @@ import { defineStore } from "pinia";
 import { computed, markRaw, ref } from "vue";
 import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, QueueItemDto, ScheduledOriginDto, SessionCommandsSnapshotDto, SessionUsageSnapshotDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
+import { createDebouncedFlush } from "../lib/debounce-flush";
+import * as tailCache from "../lib/session-tail-cache";
+import { useAuthStore } from "./auth";
 import { useSessionControlsStore } from "./session-controls";
 
 // Remember which session was open so a page refresh returns to it (selection is not
@@ -185,6 +188,18 @@ export const useChatStore = defineStore("chat", () => {
     return t;
   }
 
+  // Stale-while-revalidate tail cache (#205): select() seeds the first screen from
+  // localStorage synchronously; authoritative rows (loadHistory) are written back
+  // debounced so bursty turn-finished convergence doesn't hammer JSON.stringify.
+  // The writer reads selection/messages at FLUSH time, so a flush always persists
+  // what is actually displayed for the session it is keyed to.
+  const cacheWrite = createDebouncedFlush(() => {
+    const user = useAuthStore().account?.username;
+    if (!user || !instanceId.value || !sessionAlias.value) return;
+    tailCache.write(user, instanceId.value, sessionAlias.value, messages.value);
+  }, 500);
+  if (typeof window !== "undefined") window.addEventListener("pagehide", () => cacheWrite.flush());
+
   /** Finalize a live turn: clear it (so `busy`/HUD release) and, if it streamed any
    *  content into the selected session, flush it into a persisted-shaped message.
    *  Used by both turn-finished and the optimistic local cancel. Idempotent — a
@@ -216,10 +231,14 @@ export const useChatStore = defineStore("chat", () => {
         ...(structured ? { structured } : {}),
       });
       touchTranscript();
+      cacheWrite.schedule();
     }
   }
 
   function select(id: string, alias: string): void {
+    // Persist the outgoing session's tail before the transcript resets, so a quick
+    // back-and-forth switch still finds the freshest rows in the cache.
+    cacheWrite.flush();
     instanceId.value = id;
     sessionAlias.value = alias;
     persistSelection(id, alias);
@@ -230,6 +249,18 @@ export const useChatStore = defineStore("chat", () => {
     hasMoreOlder.value = false;
     loadingOlder.value = false;
     loadingHistory.value = false;
+    // Stale-while-revalidate: synchronously seed the transcript from the cached tail
+    // so the first screen renders instantly (no skeleton — messages.length > 0
+    // suppresses it). loadHistory() replaces this wholesale when the authoritative
+    // page arrives; stable p${id} row keys make that replace flicker-free.
+    const user = useAuthStore().account?.username;
+    if (user) {
+      const cached = tailCache.read(user, id, alias);
+      if (cached && cached.length > 0) {
+        messages.value = cached.map(rawStructured);
+        touchTranscript();
+      }
+    }
     // Viewing a session clears its unread signal.
     const k = bufKey(id, alias);
     if (unread.value.has(k)) {
@@ -242,6 +273,7 @@ export const useChatStore = defineStore("chat", () => {
   /** Drop the active selection back to the empty "no session" state — used when the
    *  selected session is deleted out from under the view. */
   function clearSelection(): void {
+    cacheWrite.flush();
     instanceId.value = null;
     sessionAlias.value = null;
     clearPersistedSelection();
@@ -292,6 +324,8 @@ export const useChatStore = defineStore("chat", () => {
       messages.value = rows.map(rawStructured);
       touchTranscript();
       hasMoreOlder.value = hasMore ?? false;
+      // Authoritative rows landed — refresh this session's cached tail (debounced).
+      cacheWrite.schedule();
     } finally {
       // Only the newest request owns the flag — a stale response must not dismiss
       // the skeleton a newer selection just raised.

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -200,6 +200,31 @@ export const useChatStore = defineStore("chat", () => {
   }, 500);
   if (typeof window !== "undefined") window.addEventListener("pagehide", () => cacheWrite.flush());
 
+  // True while `messages` holds ONLY rows seeded from the tail cache — i.e. no
+  // optimistic/live rows a wholesale history replace could clobber. loadHistory's
+  // pending-prompt guard treats such a transcript as empty (the #199 semantics:
+  // fetching over it clobbers nothing), cleared by the first authoritative replace
+  // or any local push.
+  let seededFromCache = false;
+
+  /** Purge one session's cached tail. Routed through the chat store (not called on
+   *  the cache module directly) so a purge also cancels a pending debounced
+   *  write-back targeting that session — otherwise a write scheduled just before an
+   *  archive/remove would fire after the drop and resurrect the entry as a ghost. */
+  function purgeTailCache(id: string, alias: string): void {
+    if (instanceId.value === id && sessionAlias.value === alias) cacheWrite.cancel();
+    const user = useAuthStore().account?.username;
+    if (user) tailCache.drop(user, id, alias);
+  }
+
+  /** Reconcile an instance's cached tails against its authoritative alive unarchived
+   *  aliases (see purgeTailCache for why this lives on the chat store). */
+  function reconcileTailCache(id: string, aliveAliases: string[]): void {
+    if (instanceId.value === id && sessionAlias.value !== null && !aliveAliases.includes(sessionAlias.value)) cacheWrite.cancel();
+    const user = useAuthStore().account?.username;
+    if (user) tailCache.reconcile(user, id, aliveAliases);
+  }
+
   /** Finalize a live turn: clear it (so `busy`/HUD release) and, if it streamed any
    *  content into the selected session, flush it into a persisted-shaped message.
    *  Used by both turn-finished and the optimistic local cancel. Idempotent — a
@@ -231,6 +256,7 @@ export const useChatStore = defineStore("chat", () => {
         ...(structured ? { structured } : {}),
       });
       touchTranscript();
+      seededFromCache = false;
       cacheWrite.schedule();
     }
   }
@@ -254,11 +280,13 @@ export const useChatStore = defineStore("chat", () => {
     // suppresses it). loadHistory() replaces this wholesale when the authoritative
     // page arrives; stable p${id} row keys make that replace flicker-free.
     const user = useAuthStore().account?.username;
+    seededFromCache = false;
     if (user) {
       const cached = tailCache.read(user, id, alias);
       if (cached && cached.length > 0) {
         messages.value = cached.map(rawStructured);
         touchTranscript();
+        seededFromCache = true;
       }
     }
     // Viewing a session clears its unread signal.
@@ -274,6 +302,7 @@ export const useChatStore = defineStore("chat", () => {
    *  selected session is deleted out from under the view. */
   function clearSelection(): void {
     cacheWrite.flush();
+    seededFromCache = false;
     instanceId.value = null;
     sessionAlias.value = null;
     clearPersistedSelection();
@@ -300,11 +329,13 @@ export const useChatStore = defineStore("chat", () => {
     // background convergence reloads: a non-empty transcript may hold an optimistic
     // prompt row whose queueItemId correlation the pending RPC hasn't established yet,
     // and replacing it would break the drain-event dedupe. A freshly selected pane is
-    // empty (select() cleared it), so fetching history there clobbers nothing —
-    // skipping it would leave only the live turn visible until the RPC settles.
+    // empty or holds only cache-seeded persisted rows (select() cleared it, then may
+    // have seeded the tail cache — spec #205), so fetching history there clobbers
+    // nothing — skipping it would leave the stale tail + live turn (without the just
+    // sent prompt) visible until the RPC settles.
     if ((pendingPromptRequests.get(historyKey) ?? 0) > 0) {
       deferredHistoryLoads.add(historyKey);
-      if (messages.value.length > 0) return;
+      if (messages.value.length > 0 && !seededFromCache) return;
     }
     const requestSequence = ++historyRequestSequence;
     const revision = transcriptRevision;
@@ -323,6 +354,7 @@ export const useChatStore = defineStore("chat", () => {
       if (revision !== transcriptRevision) return loadHistory();
       messages.value = rows.map(rawStructured);
       touchTranscript();
+      seededFromCache = false;
       hasMoreOlder.value = hasMore ?? false;
       // Authoritative rows landed — refresh this session's cached tail (debounced).
       cacheWrite.schedule();
@@ -472,6 +504,7 @@ export const useChatStore = defineStore("chat", () => {
             queueItemId: e.queueItemId,
           });
           touchTranscript();
+          seededFromCache = false;
         }
       } else if (e.prompt && selected) {
         messages.value.push({
@@ -483,6 +516,7 @@ export const useChatStore = defineStore("chat", () => {
           ...(e.scheduled ? { scheduled: e.scheduled } : {}),
         });
         touchTranscript();
+        seededFromCache = false;
       }
     } else if (e.type === "turn-output") {
       const t = ensureTurn(bufKey(event.instanceId, e.sessionAlias));
@@ -556,6 +590,7 @@ export const useChatStore = defineStore("chat", () => {
     };
     messages.value.push(optimistic);
     touchTranscript();
+    seededFromCache = false;
     // `optimistic` above is the RAW object; the array element is a reactive proxy. Mutating the
     // raw ref (optimistic.failed = true) never trips Vue's set-trap, so the failed bubble would
     // only surface on the next list change (the next message). Mark failure through the proxy so
@@ -650,5 +685,5 @@ export const useChatStore = defineStore("chat", () => {
     }
   }
 
-  return { instanceId, sessionAlias, messages, streaming, liveTurn, sessionPlan, sessionUsage, sessionCommands, liveToolSteps, busy, unread, sessionAttention, runningSince, sending, error, scrollRequest, requestScrollToScheduled, hasMoreOlder, loadingOlder, loadingHistory, queues, sessionQueue, select, clearSelection, loadHistory, loadOlder, loadActiveTurns, seedActiveTurns, applyStateSnapshot, applyEvent, send, resend, cancel, cancelQueuedItem };
+  return { instanceId, sessionAlias, messages, streaming, liveTurn, sessionPlan, sessionUsage, sessionCommands, liveToolSteps, busy, unread, sessionAttention, runningSince, sending, error, scrollRequest, requestScrollToScheduled, hasMoreOlder, loadingOlder, loadingHistory, queues, sessionQueue, select, clearSelection, loadHistory, loadOlder, loadActiveTurns, seedActiveTurns, applyStateSnapshot, applyEvent, send, resend, cancel, cancelQueuedItem, purgeTailCache, reconcileTailCache };
 });

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -2,8 +2,7 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import { isErrorPayload, type AgentCatalogEntryDto, type AgentDto, type NativeSessionDto, type SessionDto, type SessionModelResult, type WebServerEvent, type WorkspaceDto } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
-import * as tailCache from "../lib/session-tail-cache";
-import { useAuthStore } from "./auth";
+import { useChatStore } from "./chat";
 
 // An instance-side RPC error comes back as a 200 with an `{error:{code,message}}`
 // payload (the gateway resolves, it does not reject), so api.rpc won't throw.
@@ -92,8 +91,7 @@ export const useInstancesStore = defineStore("instances", () => {
     // Tail-cache reconciliation (spec #205): as each instance's authoritative session
     // list arrives, drop cached transcripts for sessions no longer alive/unarchived —
     // covers archive/remove performed from other clients while the web was closed.
-    const user = useAuthStore().account?.username;
-    if (user) tailCache.reconcile(user, instanceId, sessions.filter((s) => !s.archived).map((s) => s.alias));
+    useChatStore().reconcileTailCache(instanceId, sessions.filter((s) => !s.archived).map((s) => s.alias));
   }
 
   // Just the workspaces (for the file browser) — lighter than loadFormOptions, which
@@ -257,21 +255,17 @@ export const useInstancesStore = defineStore("instances", () => {
 
   async function removeSession(instanceId: string, alias: string): Promise<void> {
     await api.rpc(instanceId, "control.sessions.remove", { alias });
-    dropTailCache(instanceId, alias);
+    // Event-driven tail-cache purge (spec #205): a session archived/removed here must
+    // never resurface as a ghost transcript from localStorage. Routed through the chat
+    // store so a pending debounced write-back targeting it is cancelled too.
+    useChatStore().purgeTailCache(instanceId, alias);
     await loadSessions(instanceId);
   }
 
   async function archiveSession(instanceId: string, alias: string): Promise<void> {
     await api.rpc(instanceId, "control.sessions.archive", { alias });
-    dropTailCache(instanceId, alias);
+    useChatStore().purgeTailCache(instanceId, alias);
     await loadSessions(instanceId);
-  }
-
-  // Event-driven tail-cache purge (spec #205): a session archived/removed here must
-  // never resurface as a ghost transcript from localStorage.
-  function dropTailCache(instanceId: string, alias: string): void {
-    const user = useAuthStore().account?.username;
-    if (user) tailCache.drop(user, instanceId, alias);
   }
 
   async function unarchiveSession(instanceId: string, alias: string): Promise<void> {

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -2,6 +2,8 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import { isErrorPayload, type AgentCatalogEntryDto, type AgentDto, type NativeSessionDto, type SessionDto, type SessionModelResult, type WebServerEvent, type WorkspaceDto } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
+import * as tailCache from "../lib/session-tail-cache";
+import { useAuthStore } from "./auth";
 
 // An instance-side RPC error comes back as a 200 with an `{error:{code,message}}`
 // payload (the gateway resolves, it does not reject), so api.rpc won't throw.
@@ -87,6 +89,11 @@ export const useInstancesStore = defineStore("instances", () => {
       inst.sessionsLoaded = true;
       if (agentsRes && !isErrorPayload(agentsRes) && Array.isArray(agentsRes.agents)) inst.agents = agentsRes.agents;
     }
+    // Tail-cache reconciliation (spec #205): as each instance's authoritative session
+    // list arrives, drop cached transcripts for sessions no longer alive/unarchived —
+    // covers archive/remove performed from other clients while the web was closed.
+    const user = useAuthStore().account?.username;
+    if (user) tailCache.reconcile(user, instanceId, sessions.filter((s) => !s.archived).map((s) => s.alias));
   }
 
   // Just the workspaces (for the file browser) — lighter than loadFormOptions, which
@@ -250,12 +257,21 @@ export const useInstancesStore = defineStore("instances", () => {
 
   async function removeSession(instanceId: string, alias: string): Promise<void> {
     await api.rpc(instanceId, "control.sessions.remove", { alias });
+    dropTailCache(instanceId, alias);
     await loadSessions(instanceId);
   }
 
   async function archiveSession(instanceId: string, alias: string): Promise<void> {
     await api.rpc(instanceId, "control.sessions.archive", { alias });
+    dropTailCache(instanceId, alias);
     await loadSessions(instanceId);
+  }
+
+  // Event-driven tail-cache purge (spec #205): a session archived/removed here must
+  // never resurface as a ghost transcript from localStorage.
+  function dropTailCache(instanceId: string, alias: string): void {
+    const user = useAuthStore().account?.username;
+    if (user) tailCache.drop(user, instanceId, alias);
   }
 
   async function unarchiveSession(instanceId: string, alias: string): Promise<void> {


### PR DESCRIPTION
Closes #205

## Summary
- New `packages/relay-web/src/lib/session-tail-cache.ts`: stale-while-revalidate tail cache keyed `xacpx.chat.tail.v1.<username>.<instanceId>.<alias>` with an index key for LRU/TTL bookkeeping — 256KB per-entry / 4MB global LRU budgets, 7-day TTL, quota retry-once, lazy old-version key sweep, all storage access try/catch.
- `chat.select()` synchronously seeds the transcript from the cached last ≤30 persisted rows (skeleton suppressed); `loadHistory()` converges wholesale in place (stable `p${id}` keys keep it flicker-free). Write-back is debounced after successful loads and turn-finished flushes, flushed on session switch / pagehide.
- Three-layer eviction: `archiveSession`/`removeSession` → `drop`, `auth.logout()` → `dropAll`, and `loadSessions` landing → `reconcile` against that instance's alive unarchived aliases (covers archive/remove from other clients while the web was closed).
- `MessageList` progressive tail-first mount re-arms on the cache-seeded (≤30) → authoritative full-page replace, so the ~70 prepended older rows still mount in rAF batches.

## Test plan
- [x] `bun run test:web` — 883 tests, 105 files pass (30 new: cache module unit tests, chat/instances/auth integration, MessageList re-arm)
- [x] `npx tsc --noEmit` and `npx vue-tsc --noEmit` (relay-web) clean
- [ ] Manual: throttle network, switch between two long sessions / reload — tail appears instantly then converges; archive a session elsewhere and confirm its cache dies on next reconcile