### PR TITLE
fix(relay): persist session renames by stamping chatKey on the rename RPC

### DIFF
--- a/packages/relay-web/src/__tests__/instances-rename.test.ts
+++ b/packages/relay-web/src/__tests__/instances-rename.test.ts
@@ -31,4 +31,29 @@ describe("instances renameSession", () => {
     expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.rename", { alias: "backend", displayName: "" });
     expect(store.instances[0]!.sessions[0]!.displayName).toBeUndefined();
   });
+
+  it("rejects on an RPC error payload and keeps the previous displayName", async () => {
+    const store = useInstancesStore();
+    store.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      agents: [], workspaces: [], agentCatalog: [],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false, displayName: "old" }],
+    }] as never;
+    vi.spyOn(api, "rpc").mockResolvedValue({ error: { code: "invalid-payload", message: "boom" } } as never);
+    await expect(store.renameSession("i1", "backend", "New label")).rejects.toThrow("boom");
+    // The optimistic local update happens only after unwrap succeeds — a failed
+    // rename must not leave the sidebar showing a label the connector never saved.
+    expect(store.instances[0]!.sessions[0]!.displayName).toBe("old");
+  });
+
+  it("maps an unknown-type error to the connector-upgrade hint", async () => {
+    const store = useInstancesStore();
+    store.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      agents: [], workspaces: [], agentCatalog: [],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }],
+    }] as never;
+    vi.spyOn(api, "rpc").mockResolvedValue({ error: { code: "unknown-type", message: "unsupported rpc type: control.sessions.rename" } } as never);
+    await expect(store.renameSession("i1", "backend", "New label")).rejects.toThrow(/needs a newer connector/);
+  });
 });

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -9,6 +9,7 @@ import { useTerminalStore } from "../stores/terminal";
 import { killSessionTerminal } from "../lib/session-terminal";
 import { confirm } from "../lib/use-confirm";
 import { showActionToast } from "../lib/use-action-toast";
+import { pushToast } from "../lib/use-toasts";
 import { useSwipeActions } from "../lib/use-swipe-actions";
 import NewSessionDialog from "./NewSessionDialog.vue";
 import ManageInstanceDialog from "./ManageInstanceDialog.vue";
@@ -108,7 +109,11 @@ function commitRename(id: string, alias: string) {
   if (renamingFor.value !== `${id}:${alias}`) return; // already cancelled
   const next = renameDraft.value.trim();
   renamingFor.value = null;
-  void store.renameSession(id, alias, next).catch(() => {});
+  // Surface failures (e.g. the store's "needs a newer connector" upgrade hint) as an
+  // error toast — the inline input is already gone, so silence would look like success.
+  void store.renameSession(id, alias, next).catch((e: unknown) => {
+    pushToast("error", "instance.sessionRenameFailed", { msg: e instanceof Error ? e.message : String(e) });
+  });
 }
 function cancelRename() {
   renamingFor.value = null;

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -298,6 +298,7 @@ export default {
     renameSave: "Save",
     renameSaving: "Saving…",
     renameFailed: "rename failed",
+    sessionRenameFailed: "Rename failed: {msg}",
   },
   agents: {
     title: "Agents",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -296,6 +296,7 @@ export default {
     renameSave: "保存",
     renameSaving: "保存中…",
     renameFailed: "重命名失败",
+    sessionRenameFailed: "重命名失败：{msg}",
   },
   agents: {
     title: "Agent",

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -267,7 +267,7 @@ export const useInstancesStore = defineStore("instances", () => {
   // update the local row so the sidebar reflects the new name without a reload. Empty → cleared.
   async function renameSession(instanceId: string, alias: string, displayName: string): Promise<void> {
     const trimmed = displayName.trim();
-    await api.rpc(instanceId, "control.sessions.rename", { alias, displayName: trimmed });
+    unwrap(await api.rpc(instanceId, "control.sessions.rename", { alias, displayName: trimmed }));
     const row = byId(instanceId)?.sessions.find((s) => s.alias === alias);
     if (row) row.displayName = trimmed || undefined;
   }

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -63,6 +63,9 @@ const CHAT_SCOPED_TYPES = new Set<string>([
   // Archive/unarchive resolve the alias within the caller's chat scope too; without
   // the stamp the connector calls getChannelIdFromChatKey(undefined) and throws.
   MSG.sessionsArchive, MSG.sessionsUnarchive,
+  // Rename resolves the alias within the caller's chat scope too; the connector's
+  // payload validator requires chatKey, so an unstamped rename fails as invalid-payload.
+  MSG.sessionsRename,
   // Model and effort get/set resolve the session within the caller's chat scope.
   MSG.sessionModelGet, MSG.sessionModelSet, MSG.sessionEffortGet, MSG.sessionEffortSet,
   // Terminal create carries sessionAlias; stamp chatKey/senderId/isOwner so the

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -107,7 +107,8 @@ function rpcSessionAlias(type: string, payload: unknown): string | undefined {
     type === MSG.sessionsCreate ||
     type === MSG.sessionsRemove ||
     type === MSG.sessionsArchive ||
-    type === MSG.sessionsUnarchive
+    type === MSG.sessionsUnarchive ||
+    type === MSG.sessionsRename
   ) {
     return typeof value.alias === "string" && value.alias ? value.alias : undefined;
   }

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -543,6 +543,7 @@ export class ControlService {
     const session = await this.resolveControlSession(chatKey, alias);
     if (!session) throw new Error("session not found");
     await this.deps.sessions.setDisplayName(session.alias, displayName);
+    this.deps.events.emit({ type: "sessions-changed" });
   }
 
   /** Resolve a chat-scoped display alias to its ResolvedSession, or null. */

--- a/tests/unit/control/control-service-display-name.test.ts
+++ b/tests/unit/control/control-service-display-name.test.ts
@@ -16,6 +16,7 @@ const session = {
 
 function makeDeps() {
   const calls: string[] = [];
+  const emitted: Array<{ type: string }> = [];
   const deps = {
     sessions: {
       resolveAliasForChat: async (_chatKey: string, alias: string) => `relay:internal-${alias}`,
@@ -24,23 +25,27 @@ function makeDeps() {
       listAllResolvedSessions: () => [session],
     },
     activeTurns: { isActiveAnywhere: () => false },
-    events: { emit: () => {} },
+    events: { emit: (event: { type: string }) => { emitted.push(event); } },
   };
-  return { deps, calls };
+  return { deps, calls, emitted };
 }
 
-test("setSessionDisplayName resolves the alias and persists the label", async () => {
-  const { deps, calls } = makeDeps();
+test("setSessionDisplayName resolves the alias, persists the label, and emits sessions-changed", async () => {
+  const { deps, calls, emitted } = makeDeps();
   const control = new ControlService(deps as never);
   await control.setSessionDisplayName("relay:acc", "backend", "My label");
   expect(calls).toEqual(["persist:relay:internal-backend:My label"]);
+  // relay-web only refreshes its session list on sessions-changed — without the
+  // emit the rename would not show up until an unrelated reload.
+  expect(emitted).toEqual([{ type: "sessions-changed" }]);
 });
 
-test("setSessionDisplayName throws when the session is not found", async () => {
-  const { deps } = makeDeps();
+test("setSessionDisplayName throws when the session is not found and emits nothing", async () => {
+  const { deps, emitted } = makeDeps();
   (deps.sessions as { getSession: unknown }).getSession = async () => null;
   const control = new ControlService(deps as never);
   await expect(control.setSessionDisplayName("relay:acc", "missing", "x")).rejects.toThrow("session not found");
+  expect(emitted).toEqual([]);
 });
 
 test("listSessions carries displayName in display form", async () => {

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -299,6 +299,28 @@ test("session archive/unarchive RPCs are chat-scoped (chatKey stamped, else the 
   }
 });
 
+test("session rename RPC is chat-scoped (chatKey stamped, client-forged chatKey overridden)", async () => {
+  const { app, instances, loginToken, login, rpcCalls } = await makeApp();
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const redeemed = instances.redeemPairingToken(token)!;
+
+  // Rename resolves the alias within the caller's chat scope, and the connector's
+  // payload validator requires chatKey — an unstamped rename fails as invalid-payload
+  // and the label silently never persists. The hub must stamp chatKey server-side,
+  // overriding whatever the client supplied (forged value here).
+  const res = await app.request(`/api/instances/${redeemed.instanceId}/rpc`, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.sessionsRename, payload: { chatKey: "forged", alias: "s", displayName: "New label" } }),
+  });
+  expect(res.status).toBe(200);
+  const stamped = rpcCalls[0]?.payload as { chatKey?: string };
+  expect(stamped.chatKey).toBe(`relay:${redeemed.accountId}`);
+});
+
 test("session effort RPCs are chat-scoped", async () => {
   const { app, instances, loginToken, login, rpcCalls } = await makeApp();
   const { cookie } = await login(loginToken);


### PR DESCRIPTION
## Summary
- Root cause: `MSG.sessionsRename` was missing from the hub's `CHAT_SCOPED_TYPES` (packages/relay/src/http/app.ts), so the rename RPC reached the connector without a stamped `chatKey`. The connector's payload validator requires `chatKey`, so every dashboard rename failed as `invalid-payload` and was never written to state.json — the new name vanished on page reload.
- The web store compounded it: `renameSession` didn't `unwrap()` the RPC result, so the instance-side error payload (200 + `{error}`) was silently swallowed and the optimistic row made the rename look successful. Now failures surface as a rejection.
- `ControlService.setSessionDisplayName` now emits `sessions-changed` after persisting, matching archive/remove, so other open dashboards refresh the renamed row live instead of waiting for a reload.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `bun test tests/unit/packages/channel-relay/control-bridge.test.ts tests/unit/control/control-service-display-name.test.ts` — 44 pass
- [x] `bun test tests/unit/packages/relay/http-app.test.ts tests/unit/packages/relay/web-dashboard-e2e.test.ts tests/unit/packages/relay/integration.test.ts` — 36 pass
- [x] `vitest run src/__tests__/instances-rename.test.ts` (relay-web) — 2 pass
- [ ] Manual: rebuild + restart hub and connector, rename a session in relay web, reload the page — the new label persists; a second browser picks it up without reload