### PR TITLE
feat(relay-web): sidebar session grouping by workspace or agent

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -174,6 +174,21 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   （`control.agents.create {name,driver}`）/删除（`control.agents.remove {name}`，正被会话占用时实例侧返回
   in-use 错误并浮现）。
 - **Workspaces 管理器**：列已配置 workspace，可删除（`control.workspaces.remove {name}`，占用时同样 in-use 拒绝）。
+- **General tab 的「侧栏分组」三选**（不分组 / 按工作区 / 按 Agent）：按实例记忆的**纯视图偏好**，见下节。
+
+## 侧栏会话分组（workspace / agent 二级分组）
+
+- 每个实例可独立选择侧栏分组模式：`instance`（平铺，默认）/ `workspace` / `agent`。偏好存
+  localStorage（`xacpx.sidebar.groupMode.<instanceId>`，helpers 在 `src/lib/sidebar-group-mode.ts`），
+  响应式镜像在 instances store（`groupModeFor`/`setGroupMode`），改动即时生效。
+- **组只由 session 派生**（不读 workspaces/agents 目录 → 无空组），按服务器首现顺序排列；组内 active
+  保持顺序、archived 沉底置灰。分组模式下**取消 10 行截断**（组折叠即长度控制，折叠为会话内状态、不持久化）。
+- **视觉**：实例=浅色卡片、组=更浅一层的底色块 + 极小缩进（tinted-zone，三种模式视觉同构）。组头 =
+  折叠箭头 + 类型图标（workspace→文件夹 / agent→品牌图标）+ 名称 + 计数；agent 分组下行内品牌图标去除。
+- **前缀去重**（仅展示层）：workspace 组内剥掉 `<组名>-` 前缀、agent 组内剥掉 `-<组名>` 后缀
+  （对应 `<workspace>-<agent>` 自动 alias），hover title 恒为全名；剥空则不剥。
+- **组头悬停 ＋**（触屏常显）打开 `NewSessionDialog` 并预填本组 workspace/agent
+  （`presetWorkspace`/`presetAgent` props，仍可改）；实例 footer 的 ＋ 不变。移动端零特化。
 
 ## 切换会话的渲染性能
 

--- a/packages/relay-web/src/__tests__/instancetree-grouping.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree-grouping.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import InstanceTree from "../components/InstanceTree.vue";
+import ManageInstanceDialog from "../components/ManageInstanceDialog.vue";
+import { useInstancesStore } from "../stores/instances";
+import { loadGroupMode } from "../lib/sidebar-group-mode";
+
+const sess = (alias: string, workspace: string, agent: string, archived = false) => ({
+  alias, agent, workspace, transportSession: `t-${alias}`, running: false, archived,
+});
+
+const instance = (sessions: unknown[]) => ({
+  id: "i1", name: "pc", online: true, lastSeenAt: null, sessions, sessionsLoaded: true,
+  agents: [{ name: "claude", driver: "claude" }, { name: "codex", driver: "codex" }], workspaces: [], agentCatalog: [],
+});
+
+const mountTree = () => mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+
+describe("InstanceTree grouped rendering", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+  afterEach(() => localStorage.clear());
+
+  it("renders workspace groups with header, count, and rows in server order", () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "workspace");
+    store.instances = [instance([sess("web-claude", "web", "claude"), sess("api-codex", "api", "codex"), sess("web-codex", "web", "codex")])] as never;
+    const w = mountTree();
+    const groups = w.findAll('[data-test="session-group"]');
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.find('[data-test="group-name"]').text()).toBe("web");
+    expect(groups[0]!.find('[data-test="group-count"]').text()).toBe("2");
+    expect(groups[1]!.find('[data-test="group-name"]').text()).toBe("api");
+    expect(groups[0]!.findAll('[data-test="session-row"]')).toHaveLength(2);
+  });
+
+  it("flat (default) mode renders no group zones", () => {
+    const store = useInstancesStore();
+    store.instances = [instance([sess("web-claude", "web", "claude")])] as never;
+    const w = mountTree();
+    expect(w.find('[data-test="session-group"]').exists()).toBe(false);
+    expect(w.findAll('[data-test="session-row"]')).toHaveLength(1);
+  });
+
+  it("dedups the group name out of the displayed alias but keeps the full name as title", () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "workspace");
+    store.instances = [instance([sess("web-claude", "web", "claude"), sess("standalone", "web", "codex")])] as never;
+    const w = mountTree();
+    const names = w.findAll('[data-test="session-name"]');
+    expect(names[0]!.text()).toBe("claude");
+    expect(names[0]!.attributes("title")).toBe("web-claude");
+    expect(names[1]!.text()).toBe("standalone"); // no prefix match → untouched
+  });
+
+  it("agent mode dedups the trailing agent name and drops the per-row agent icon", () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "agent");
+    store.instances = [instance([sess("web-claude", "web", "claude")])] as never;
+    const w = mountTree();
+    expect(w.find('[data-test="group-name"]').text()).toBe("claude");
+    expect(w.find('[data-test="session-name"]').text()).toBe("web");
+    // The row's AgentIcon is dropped in agent mode; the group header carries the brand icon.
+    expect(w.find('[data-test="session-row"]').findComponent({ name: "AgentIcon" }).exists()).toBe(false);
+  });
+
+  it("collapses and re-expands a group via its header (view-state only)", async () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "workspace");
+    store.instances = [instance([sess("web-claude", "web", "claude"), sess("api-codex", "api", "codex")])] as never;
+    const w = mountTree();
+    const header = w.findAll('[data-test="group-header"]')[0]!;
+    expect(header.attributes("aria-expanded")).toBe("true");
+    await header.trigger("click");
+    expect(header.attributes("aria-expanded")).toBe("false");
+    // v-show: the row stays in the DOM but is hidden.
+    const rows = w.findAll('[data-test="session-group"]')[0]!.find('[data-test="session-row"]');
+    expect(rows.element.closest("[style*='display: none']")).not.toBeNull();
+    await header.trigger("click");
+    expect(header.attributes("aria-expanded")).toBe("true");
+  });
+
+  it("does not cap grouped session lists (cap is flat-mode only)", () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "workspace");
+    const many = Array.from({ length: 13 }, (_, i) => sess(`s${i}`, "web", "claude"));
+    store.instances = [instance(many)] as never;
+    const w = mountTree();
+    expect(w.findAll('[data-test="session-row"]')).toHaveLength(13);
+    expect(w.find('[data-test="sessions-show-more"]').exists()).toBe(false);
+  });
+
+  it("sinks archived sessions to the bottom of their group, dimmed", () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "workspace");
+    store.instances = [instance([sess("web-old", "web", "claude", true), sess("web-live", "web", "claude")])] as never;
+    const w = mountTree();
+    const names = w.findAll('[data-test="session-name"]');
+    expect(names[0]!.text()).toBe("live");
+    expect(names[1]!.text()).toBe("old");
+    expect(names[1]!.classes()).toContain("text-fg-muted");
+  });
+
+  it("group ＋ opens the create dialog prefilled with the group's workspace", async () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "workspace");
+    store.instances = [instance([sess("web-claude", "web", "claude")])] as never;
+    const w = mountTree();
+    await w.find('[data-test="group-new-session"]').trigger("click");
+    const dialog = w.findComponent({ name: "NewSessionDialog" });
+    expect(dialog.exists()).toBe(true);
+    expect(dialog.props("presetWorkspace")).toBe("web");
+    expect(dialog.props("presetAgent")).toBeUndefined();
+  });
+
+  it("group ＋ prefills the agent in agent mode", async () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "agent");
+    store.instances = [instance([sess("web-claude", "web", "claude")])] as never;
+    const w = mountTree();
+    await w.find('[data-test="group-new-session"]').trigger("click");
+    const dialog = w.findComponent({ name: "NewSessionDialog" });
+    expect(dialog.props("presetAgent")).toBe("claude");
+    expect(dialog.props("presetWorkspace")).toBeUndefined();
+  });
+
+  it("dedups a user-set displayName too (the SHOWN name is what gets deduped)", () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "workspace");
+    store.instances = [instance([{ ...sess("some-alias", "web", "claude"), displayName: "web-notes" }])] as never;
+    const w = mountTree();
+    const name = w.find('[data-test="session-name"]');
+    expect(name.text()).toBe("notes");
+    expect(name.attributes("title")).toBe("web-notes"); // title = full shown name, not alias
+  });
+
+  it("isolates group collapse per mode (workspace collapse survives an agent-mode detour)", async () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "workspace");
+    store.instances = [instance([sess("web-claude", "web", "claude")])] as never;
+    const w = mountTree();
+    await w.find('[data-test="group-header"]').trigger("click");
+    expect(w.find('[data-test="group-header"]').attributes("aria-expanded")).toBe("false");
+    store.setGroupMode("i1", "agent");
+    await w.vm.$nextTick();
+    // Agent-mode groups start expanded — the workspace collapse doesn't leak across modes.
+    expect(w.find('[data-test="group-header"]').attributes("aria-expanded")).toBe("true");
+    store.setGroupMode("i1", "workspace");
+    await w.vm.$nextTick();
+    // Back in workspace mode the in-session collapse is remembered.
+    expect(w.find('[data-test="group-header"]').attributes("aria-expanded")).toBe("false");
+  });
+
+  it("re-renders live when the mode changes (store reactivity)", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([sess("web-claude", "web", "claude")])] as never;
+    const w = mountTree();
+    expect(w.find('[data-test="session-group"]').exists()).toBe(false);
+    store.setGroupMode("i1", "workspace");
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="session-group"]').exists()).toBe(true);
+  });
+});
+
+describe("ManageInstanceDialog group-mode control", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+  afterEach(() => localStorage.clear());
+
+  it("shows the three modes with the current one selected, and persists a change", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([])] as never;
+    const w = mount(ManageInstanceDialog, {
+      props: { instanceId: "i1", instanceName: "pc" },
+      global: { stubs: { WorkspacesManager: true, AgentsManager: true, Teleport: true } },
+    });
+    // onMounted loadFormOptions rejects (no api) → loading flips off; wait for it.
+    await new Promise((r) => setTimeout(r));
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="group-mode-instance"]').attributes("aria-checked")).toBe("true");
+    await w.find('[data-test="group-mode-workspace"]').trigger("click");
+    expect(w.find('[data-test="group-mode-workspace"]').attributes("aria-checked")).toBe("true");
+    expect(store.groupModeFor("i1")).toBe("workspace");
+    expect(loadGroupMode("i1")).toBe("workspace");
+    w.unmount();
+  });
+});

--- a/packages/relay-web/src/__tests__/sidebar-group-mode.test.ts
+++ b/packages/relay-web/src/__tests__/sidebar-group-mode.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { loadGroupMode, saveGroupMode, groupSessions, dedupedSessionName } from "../lib/sidebar-group-mode";
+
+const KEY = "xacpx.sidebar.groupMode.i1";
+
+describe("group mode persistence", () => {
+  afterEach(() => localStorage.clear());
+
+  it("defaults to instance (flat) when nothing is stored", () => {
+    expect(loadGroupMode("i1")).toBe("instance");
+  });
+
+  it("round-trips workspace/agent through localStorage per instance", () => {
+    saveGroupMode("i1", "workspace");
+    expect(loadGroupMode("i1")).toBe("workspace");
+    expect(loadGroupMode("other")).toBe("instance"); // isolated per instance
+    saveGroupMode("i1", "agent");
+    expect(loadGroupMode("i1")).toBe("agent");
+  });
+
+  it("removes the key when reset to instance", () => {
+    saveGroupMode("i1", "workspace");
+    saveGroupMode("i1", "instance");
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(loadGroupMode("i1")).toBe("instance");
+  });
+
+  it("ignores a corrupt stored value", () => {
+    localStorage.setItem(KEY, "banana");
+    expect(loadGroupMode("i1")).toBe("instance");
+  });
+});
+
+const s = (alias: string, workspace: string, agent: string, archived = false) => ({ alias, workspace, agent, archived });
+
+describe("groupSessions", () => {
+  it("groups by workspace in first-appearance order, derived from sessions only", () => {
+    const groups = groupSessions([s("a", "web", "claude"), s("b", "api", "codex"), s("c", "web", "codex")], "workspace");
+    expect(groups.map((g) => g.key)).toEqual(["web", "api"]);
+    expect(groups[0]!.sessions.map((x) => x.alias)).toEqual(["a", "c"]);
+    expect(groups[1]!.sessions.map((x) => x.alias)).toEqual(["b"]);
+  });
+
+  it("groups by agent", () => {
+    const groups = groupSessions([s("a", "web", "claude"), s("b", "api", "codex"), s("c", "web", "claude")], "agent");
+    expect(groups.map((g) => g.key)).toEqual(["claude", "codex"]);
+    expect(groups[0]!.sessions.map((x) => x.alias)).toEqual(["a", "c"]);
+  });
+
+  it("sinks archived sessions to the bottom of their group (stable)", () => {
+    const groups = groupSessions(
+      [s("arch1", "web", "claude", true), s("live1", "web", "claude"), s("arch2", "web", "codex", true), s("live2", "web", "codex")],
+      "workspace",
+    );
+    expect(groups[0]!.sessions.map((x) => x.alias)).toEqual(["live1", "live2", "arch1", "arch2"]);
+  });
+
+  it("returns no groups for no sessions", () => {
+    expect(groupSessions([], "workspace")).toEqual([]);
+  });
+});
+
+describe("dedupedSessionName", () => {
+  it("strips the leading '<workspace>-' inside a workspace group", () => {
+    expect(dedupedSessionName("web-claude", "web", "workspace")).toBe("claude");
+  });
+
+  it("strips the trailing '-<agent>' inside an agent group", () => {
+    expect(dedupedSessionName("web-claude", "claude", "agent")).toBe("web");
+  });
+
+  it("leaves non-matching names untouched", () => {
+    expect(dedupedSessionName("my-session", "web", "workspace")).toBe("my-session");
+    expect(dedupedSessionName("my-session", "claude", "agent")).toBe("my-session");
+  });
+
+  it("never dedups down to an empty name", () => {
+    expect(dedupedSessionName("web-", "web", "workspace")).toBe("web-");
+    expect(dedupedSessionName("-claude", "claude", "agent")).toBe("-claude");
+  });
+});

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { Archive, ChevronDown, ChevronRight, Link2, Loader2, MoreHorizontal, Pencil, Plus, Settings2, Trash2 } from "lucide-vue-next";
+import { Archive, ChevronDown, ChevronRight, Folder, Link2, Loader2, MoreHorizontal, Pencil, Plus, Settings2, Trash2 } from "lucide-vue-next";
 import { useInstancesStore } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
@@ -11,6 +11,7 @@ import { confirm } from "../lib/use-confirm";
 import { showActionToast } from "../lib/use-action-toast";
 import { pushToast } from "../lib/use-toasts";
 import { useSwipeActions } from "../lib/use-swipe-actions";
+import { groupSessions, dedupedSessionName, archivedLast } from "../lib/sidebar-group-mode";
 import NewSessionDialog from "./NewSessionDialog.vue";
 import ManageInstanceDialog from "./ManageInstanceDialog.vue";
 import AgentIcon from "./AgentIcon.vue";
@@ -33,7 +34,7 @@ function driverFor(inst: InstanceView, agentName: string): string | undefined {
   return inst.agents.find((a) => a.name === agentName)?.driver;
 }
 const emit = defineEmits<{ select: [instanceId: string, alias: string] }>();
-const dialogFor = ref<{ id: string; name: string } | null>(null);
+const dialogFor = ref<{ id: string; name: string; presetAgent?: string; presetWorkspace?: string } | null>(null);
 const manageFor = ref<{ id: string; name: string } | null>(null);
 
 // 1Hz clock so working-session elapsed badges tick.
@@ -71,12 +72,6 @@ function toggle(id: string) {
   if (isExpanded(id)) void store.loadSessions(id).catch(() => {});
 }
 
-// Archived sessions sink to the bottom of their instance group (stable: actives keep
-// server order, archived last) so the active work stays at the top of the list.
-function orderedSessions<T extends { archived?: boolean }>(sessions: T[]): T[] {
-  return [...sessions].sort((a, b) => Number(a.archived ?? false) - Number(b.archived ?? false));
-}
-
 // Long session lists get noisy fast — cap the rendered rows per instance and let the
 // user opt into the rest via "show N more" (mirrors the instance collapse/expand
 // pattern above, but keyed independently since either can toggle without the other).
@@ -89,8 +84,63 @@ function toggleSessions(id: string) {
   sessionsExpanded.value = next;
 }
 function visibleSessions(inst: InstanceView): InstanceView["sessions"] {
-  const all = orderedSessions(inst.sessions);
+  const all = archivedLast(inst.sessions);
   return sessionsExpanded.value.has(inst.id) ? all : all.slice(0, SESSION_CAP);
+}
+
+// ── Second-level grouping (workspace / agent) ───────────────────────────────
+// The per-instance mode lives in the store (localStorage-backed). Flat mode keeps
+// the SESSION_CAP truncation; grouped modes render every session — group collapse
+// is the length control there.
+function groupModeOf(inst: InstanceView) {
+  return store.groupModeFor(inst.id);
+}
+
+interface SidebarSection {
+  /** Group name (workspace or agent), or null for the flat (ungrouped) section. */
+  key: string | null;
+  sessions: InstanceView["sessions"];
+}
+function sectionsFor(inst: InstanceView): SidebarSection[] {
+  const mode = groupModeOf(inst);
+  if (mode === "instance") return [{ key: null, sessions: visibleSessions(inst) }];
+  return groupSessions(inst.sessions, mode);
+}
+
+// Group collapse is in-session view state only (not persisted), keyed by mode so
+// switching modes never carries stale collapse over.
+const collapsedGroups = ref<Set<string>>(new Set());
+function grpKey(inst: InstanceView, key: string): string {
+  return `${inst.id}:${groupModeOf(inst)}:${key}`;
+}
+function isGroupCollapsed(inst: InstanceView, key: string): boolean {
+  return collapsedGroups.value.has(grpKey(inst, key));
+}
+function toggleGroup(inst: InstanceView, key: string): void {
+  const k = grpKey(inst, key);
+  const next = new Set(collapsedGroups.value);
+  if (next.has(k)) next.delete(k);
+  else next.add(k);
+  collapsedGroups.value = next;
+  openSwipeFor.value = null;
+}
+
+// Display-only dedup of the `<workspace>-<agent>` auto-alias inside a group; the
+// row's hover title always carries the full name.
+function rowName(inst: InstanceView, s: { alias: string; displayName?: string }, sectionKey: string | null): string {
+  const name = s.displayName || s.alias;
+  const mode = groupModeOf(inst);
+  if (sectionKey === null || mode === "instance") return name;
+  return dedupedSessionName(name, sectionKey, mode);
+}
+
+// Group-header ＋: open the create dialog with the group's own value prefilled.
+function openGroupDialog(inst: InstanceView, key: string): void {
+  dialogFor.value = {
+    id: inst.id,
+    name: inst.name,
+    ...(groupModeOf(inst) === "workspace" ? { presetWorkspace: key } : { presetAgent: key }),
+  };
 }
 
 // Desktop overflow (⋯) menu open-state, keyed by `${instanceId}:${alias}`.
@@ -237,8 +287,12 @@ const rowSwipes = computed(() => {
 
 <template>
   <nav class="thin-scroll flex h-full flex-1 flex-col space-y-1.5 overflow-y-auto px-2 pb-2 pt-1.5">
-    <!-- One instance group: header row + indented session rows + per-instance footer. -->
-    <div v-for="inst in store.instances" :key="inst.id" :class="inst.online ? '' : 'opacity-60'">
+    <!-- One instance card: header row + session area (flat or grouped) + footer.
+         The card background is the level-1 zone of the tinted-zone hierarchy; group
+         zones inside are one step lighter (visually isomorphic across all modes). -->
+    <div v-for="inst in store.instances" :key="inst.id" data-test="instance-card"
+         class="rounded-lg border border-border bg-surface/60 p-[3px]"
+         :class="inst.online ? '' : 'opacity-60'">
       <!-- Instance header: chevron + online/offline dot + name + session count. -->
       <button
         class="group flex h-7 w-full items-center gap-1.5 rounded-md px-1.5 transition-colors hover:bg-raised"
@@ -253,106 +307,134 @@ const rowSwipes = computed(() => {
         <span v-else class="text-[10px] font-medium text-fg-muted">{{ $t("instance.offline") }}</span>
       </button>
 
-      <!-- Indented session rows under an accent-able left rule. -->
-      <div v-show="isExpanded(inst.id)" class="ml-2.5 mt-px space-y-px border-l border-border pl-2.5">
-        <div
-          v-for="s in visibleSessions(inst)"
-          :key="s.alias"
-          data-test="session-row"
-          class="group relative rounded-md"
-        >
-          <!-- Clip layer: bounds ONLY the swipe track so the off-screen action blocks
-               stay hidden until revealed. The row itself is NOT clipped, so the ⋯
-               dropdown (rendered below as a row child) can overflow past the row. -->
-          <div class="overflow-hidden rounded-md">
-          <!-- Swipe track: full-width row content followed by the off-screen action
-               blocks. Swiping right→left translates the track left to reveal them. -->
-          <div
-            data-test="swipe-track"
-            class="flex touch-pan-y ease-out"
-            :class="draggingKey === `${inst.id}:${s.alias}` ? '' : 'transition-transform duration-200'"
-            :style="{ transform: rowTransform(inst.id, s) }"
-            v-on="inst.online ? rowSwipes[`${inst.id}:${s.alias}`] ?? {} : {}"
-          >
-            <!-- Foreground row content (spans the full row width). -->
-            <div class="relative flex w-full shrink-0 items-center rounded-md transition-colors"
-                 :class="isSelected(inst.id, s.alias) ? 'bg-accent/10' : 'hover:bg-raised'">
-              <!-- Selected row: left accent bar. -->
-              <span v-if="isSelected(inst.id, s.alias)" class="absolute bottom-1 left-0 top-1 w-[3px] rounded-full bg-accent" />
-              <button
-                class="flex min-w-0 flex-1 items-center gap-2 py-2 pl-2.5 pr-1.5 text-left"
-                @click="onRowTap(inst.id, s.alias)"
-              >
-                <Loader2 v-if="s.creating" data-test="session-creating" :size="12" class="shrink-0 animate-spin motion-reduce:animate-none text-accent" />
-                <span v-else-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'working'" data-test="attention-dot" data-attention="working"
-                      class="pulse-dot h-2 w-2 shrink-0 rounded-full bg-run-bright" />
-                <span v-else-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'unread'" data-test="attention-dot" data-attention="unread"
-                      class="h-2 w-2 shrink-0 rounded-full bg-info" />
-                <span v-else-if="!s.archived && s.running" data-test="attention-dot" data-attention="running" class="h-2 w-2 shrink-0 rounded-full bg-run" />
-                <!-- Agent brand glyph (driver icon) BEFORE the name, in place of a text badge —
-                     saves horizontal space; the agent name stays available on hover. -->
-                <AgentIcon :driver="driverFor(inst, s.agent)" :title="s.agent" :size="14"
-                           :class="s.archived ? 'opacity-60' : ''" />
-                <input v-if="renamingFor === `${inst.id}:${s.alias}`" data-test="rename-input"
-                       v-model="renameDraft" :maxlength="60" :placeholder="$t('instance.sessionRenamePlaceholder')"
-                       class="min-w-0 flex-1 rounded border border-accent bg-bg px-1 py-px text-[13px] text-fg outline-none"
-                       @click.stop @keydown.enter.prevent="commitRename(inst.id, s.alias)"
-                       @keydown.escape.prevent="cancelRename" @blur="commitRename(inst.id, s.alias)"
-                       v-focus />
-                <span v-else data-test="session-name" class="min-w-0 truncate text-[12.5px] font-medium"
-                      :class="s.archived ? 'text-fg-muted' : (isSelected(inst.id, s.alias) ? 'font-semibold text-accent' : 'text-fg')">{{ s.displayName || s.alias }}</span>
-                <!-- Archived state is shown visually by the dimmed name (no text badge), but that
-                     greying carries no signal for screen readers — keep a visually-hidden label so
-                     archived status is still announced. -->
-                <span v-if="s.archived" data-test="archived-label" class="sr-only">{{ $t("instance.sessionArchivedLabel") }}</span>
-                <!-- Native (agent-side / resumed) sessions get a small link glyph instead of a text
-                     badge to keep the row uncluttered. -->
-                <Link2 v-if="s.native" data-test="native-badge" :size="12"
-                       :aria-label="$t('instance.sessionNativeBadgeTitle')" :title="$t('instance.sessionNativeBadgeTitle')"
-                       class="shrink-0 text-info" :class="s.archived ? 'opacity-60' : ''" />
-                <span v-if="!s.archived && elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
-                      class="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-run">{{ elapsedLabel(inst.id, s.alias) }}</span>
-              </button>
-              <!-- Row actions: desktop overflow (⋯) menu → archive / delete. Hidden when the instance is offline. -->
-              <div v-if="inst.online" data-test="session-actions" class="relative mr-1 shrink-0">
-                <button data-test="session-menu" :aria-label="$t('common.more')"
-                        class="grid h-5 w-5 place-items-center rounded text-fg-muted hover:bg-raised hover:text-fg opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
-                        @click.stop="openSwipeFor = null; openMenuFor = openMenuFor === `${inst.id}:${s.alias}` ? null : `${inst.id}:${s.alias}`"><MoreHorizontal :size="13" /></button>
+      <!-- Session area: flat rows, or tinted group zones (workspace/agent mode).
+           Instead of a border-l indent rail, hierarchy reads from background tint +
+           a very small indent — grouped rows keep almost the full row width. -->
+      <div v-show="isExpanded(inst.id)" class="mt-px space-y-1 px-0.5 pb-0.5">
+        <div v-for="grp in sectionsFor(inst)" :key="grp.key ?? '~flat'"
+             :class="grp.key !== null ? 'rounded-md bg-fg/[0.035] p-0.5' : 'space-y-px'"
+             :data-test="grp.key !== null ? 'session-group' : undefined">
+          <!-- Group header: chevron + kind icon + name + count; hover ＋ creates in-group. -->
+          <div v-if="grp.key !== null" class="group/hdr flex items-center gap-0.5">
+            <button data-test="group-header" :aria-expanded="!isGroupCollapsed(inst, grp.key)"
+                    class="flex h-6 min-w-0 flex-1 items-center gap-1.5 rounded px-1.5 text-left transition-colors hover:bg-fg/5"
+                    @click="toggleGroup(inst, grp.key)">
+              <ChevronDown v-if="!isGroupCollapsed(inst, grp.key)" :size="11" class="shrink-0 text-fg-muted" />
+              <ChevronRight v-else :size="11" class="shrink-0 text-fg-muted" />
+              <Folder v-if="groupModeOf(inst) === 'workspace'" :size="12" class="shrink-0 text-fg-muted" />
+              <AgentIcon v-else :driver="driverFor(inst, grp.key)" :title="grp.key" :size="13" />
+              <span data-test="group-name" class="min-w-0 truncate text-[11.5px] font-semibold text-fg-muted">{{ grp.key }}</span>
+              <span data-test="group-count" class="shrink-0 font-mono text-[10px] tabular-nums text-fg-muted">{{ grp.sessions.length }}</span>
+            </button>
+            <button data-test="group-new-session" :title="$t('instance.groupNewSession', { name: grp.key })" :aria-label="$t('instance.groupNewSession', { name: grp.key })"
+                    class="grid h-5 w-5 shrink-0 place-items-center rounded text-accent transition-colors hover:bg-accent/10 opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover/hdr:opacity-100"
+                    @click.stop="openGroupDialog(inst, grp.key)"><Plus :size="12" /></button>
+          </div>
+          <div v-show="grp.key === null || !isGroupCollapsed(inst, grp.key)" class="space-y-px" :class="grp.key !== null ? 'pl-2' : ''">
+            <div
+              v-for="s in grp.sessions"
+              :key="s.alias"
+              data-test="session-row"
+              class="group relative rounded-md"
+            >
+            <!-- Clip layer: bounds ONLY the swipe track so the off-screen action blocks
+                 stay hidden until revealed. The row itself is NOT clipped, so the ⋯
+                 dropdown (rendered below as a row child) can overflow past the row. -->
+            <div class="overflow-hidden rounded-md">
+            <!-- Swipe track: full-width row content followed by the off-screen action
+                 blocks. Swiping right→left translates the track left to reveal them. -->
+            <div
+              data-test="swipe-track"
+              class="flex touch-pan-y ease-out"
+              :class="draggingKey === `${inst.id}:${s.alias}` ? '' : 'transition-transform duration-200'"
+              :style="{ transform: rowTransform(inst.id, s) }"
+              v-on="inst.online ? rowSwipes[`${inst.id}:${s.alias}`] ?? {} : {}"
+            >
+              <!-- Foreground row content (spans the full row width). -->
+              <div class="relative flex w-full shrink-0 items-center rounded-md transition-colors"
+                   :class="isSelected(inst.id, s.alias) ? 'bg-accent/10' : 'hover:bg-raised'">
+                <!-- Selected row: left accent bar. -->
+                <span v-if="isSelected(inst.id, s.alias)" class="absolute bottom-1 left-0 top-1 w-[3px] rounded-full bg-accent" />
+                <button
+                  class="flex min-w-0 flex-1 items-center gap-2 py-2 pl-2.5 pr-1.5 text-left"
+                  @click="onRowTap(inst.id, s.alias)"
+                >
+                  <Loader2 v-if="s.creating" data-test="session-creating" :size="12" class="shrink-0 animate-spin motion-reduce:animate-none text-accent" />
+                  <span v-else-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'working'" data-test="attention-dot" data-attention="working"
+                        class="pulse-dot h-2 w-2 shrink-0 rounded-full bg-run-bright" />
+                  <span v-else-if="!s.archived && chat.sessionAttention(inst.id, s.alias) === 'unread'" data-test="attention-dot" data-attention="unread"
+                        class="h-2 w-2 shrink-0 rounded-full bg-info" />
+                  <span v-else-if="!s.archived && s.running" data-test="attention-dot" data-attention="running" class="h-2 w-2 shrink-0 rounded-full bg-run" />
+                  <!-- Agent brand glyph (driver icon) BEFORE the name, in place of a text badge —
+                       saves horizontal space; the agent name stays available on hover. Redundant
+                       inside an agent-mode group (the group header already carries it) → dropped. -->
+                  <AgentIcon v-if="groupModeOf(inst) !== 'agent'" :driver="driverFor(inst, s.agent)" :title="s.agent" :size="14"
+                             :class="s.archived ? 'opacity-60' : ''" />
+                  <input v-if="renamingFor === `${inst.id}:${s.alias}`" data-test="rename-input"
+                         v-model="renameDraft" :maxlength="60" :placeholder="$t('instance.sessionRenamePlaceholder')"
+                         class="min-w-0 flex-1 rounded border border-accent bg-bg px-1 py-px text-[13px] text-fg outline-none"
+                         @click.stop @keydown.enter.prevent="commitRename(inst.id, s.alias)"
+                         @keydown.escape.prevent="cancelRename" @blur="commitRename(inst.id, s.alias)"
+                         v-focus />
+                  <span v-else data-test="session-name" class="min-w-0 truncate text-[12.5px] font-medium"
+                        :title="s.displayName || s.alias"
+                        :class="s.archived ? 'text-fg-muted' : (isSelected(inst.id, s.alias) ? 'font-semibold text-accent' : 'text-fg')">{{ rowName(inst, s, grp.key) }}</span>
+                  <!-- Archived state is shown visually by the dimmed name (no text badge), but that
+                       greying carries no signal for screen readers — keep a visually-hidden label so
+                       archived status is still announced. -->
+                  <span v-if="s.archived" data-test="archived-label" class="sr-only">{{ $t("instance.sessionArchivedLabel") }}</span>
+                  <!-- Native (agent-side / resumed) sessions get a small link glyph instead of a text
+                       badge to keep the row uncluttered. -->
+                  <Link2 v-if="s.native" data-test="native-badge" :size="12"
+                         :aria-label="$t('instance.sessionNativeBadgeTitle')" :title="$t('instance.sessionNativeBadgeTitle')"
+                         class="shrink-0 text-info" :class="s.archived ? 'opacity-60' : ''" />
+                  <span v-if="!s.archived && elapsedLabel(inst.id, s.alias)" data-test="session-elapsed"
+                        class="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-run">{{ elapsedLabel(inst.id, s.alias) }}</span>
+                </button>
+                <!-- Row actions: desktop overflow (⋯) menu → archive / delete. Hidden when the instance is offline. -->
+                <div v-if="inst.online" data-test="session-actions" class="relative mr-1 shrink-0">
+                  <button data-test="session-menu" :aria-label="$t('common.more')"
+                          class="grid h-5 w-5 place-items-center rounded text-fg-muted hover:bg-raised hover:text-fg opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
+                          @click.stop="openSwipeFor = null; openMenuFor = openMenuFor === `${inst.id}:${s.alias}` ? null : `${inst.id}:${s.alias}`"><MoreHorizontal :size="13" /></button>
+                </div>
               </div>
+              <!-- Swipe-revealed action blocks (touch). Sit just past the right edge; the
+                   `@click.stop` prevents the row tap from also firing. -->
+              <template v-if="inst.online">
+                <button v-if="!s.archived" data-test="swipe-archive" :aria-label="$t('instance.archiveSession')" :title="$t('instance.archiveSession')"
+                        class="flex w-14 shrink-0 items-center justify-center bg-warn text-white transition-colors hover:bg-warn/90"
+                        @click.stop="onArchive(inst.id, s.alias)"><Archive :size="16" /></button>
+                <button data-test="swipe-delete" :aria-label="$t('common.delete')" :title="$t('common.delete')"
+                        class="flex w-14 shrink-0 items-center justify-center bg-danger text-white transition-colors hover:bg-danger/90"
+                        @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="16" /></button>
+              </template>
             </div>
-            <!-- Swipe-revealed action blocks (touch). Sit just past the right edge; the
-                 `@click.stop` prevents the row tap from also firing. -->
-            <template v-if="inst.online">
-              <button v-if="!s.archived" data-test="swipe-archive" :aria-label="$t('instance.archiveSession')" :title="$t('instance.archiveSession')"
-                      class="flex w-14 shrink-0 items-center justify-center bg-warn text-white transition-colors hover:bg-warn/90"
-                      @click.stop="onArchive(inst.id, s.alias)"><Archive :size="16" /></button>
-              <button data-test="swipe-delete" :aria-label="$t('common.delete')" :title="$t('common.delete')"
-                      class="flex w-14 shrink-0 items-center justify-center bg-danger text-white transition-colors hover:bg-danger/90"
-                      @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="16" /></button>
-            </template>
-          </div>
-          </div>
-          <!-- ⋯ dropdown: a child of the ROW (not the clip layer), so it overflows the
-               row downward instead of being clipped to the row's height.
-               `@mousedown.stop`: the document-level mousedown listener nulls openMenuFor,
-               which would unmount this menu in the microtask BEFORE the item's click
-               fires (mousedown → Vue flush → mouseup → click on a detached node), so
-               archive/delete silently no-op. Stopping mousedown keeps the menu mounted. -->
-          <div v-if="inst.online && openMenuFor === `${inst.id}:${s.alias}`" @mousedown.stop
-               class="absolute right-1 top-full z-30 mt-0.5 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
-            <button data-test="action-rename" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="startRename(inst.id, s)"><Pencil :size="12" />{{ $t("instance.renameSession") }}</button>
-            <button v-if="!s.archived" data-test="action-archive" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="onArchive(inst.id, s.alias)"><Archive :size="12" />{{ $t("instance.archiveSession") }}</button>
-            <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
+            </div>
+            <!-- ⋯ dropdown: a child of the ROW (not the clip layer), so it overflows the
+                 row downward instead of being clipped to the row's height.
+                 `@mousedown.stop`: the document-level mousedown listener nulls openMenuFor,
+                 which would unmount this menu in the microtask BEFORE the item's click
+                 fires (mousedown → Vue flush → mouseup → click on a detached node), so
+                 archive/delete silently no-op. Stopping mousedown keeps the menu mounted. -->
+            <div v-if="inst.online && openMenuFor === `${inst.id}:${s.alias}`" @mousedown.stop
+                 class="absolute right-1 top-full z-30 mt-0.5 w-32 rounded-md border border-border bg-surface py-1 shadow-lg">
+              <button data-test="action-rename" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="startRename(inst.id, s)"><Pencil :size="12" />{{ $t("instance.renameSession") }}</button>
+              <button v-if="!s.archived" data-test="action-archive" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-fg hover:bg-raised" @click.stop="onArchive(inst.id, s.alias)"><Archive :size="12" />{{ $t("instance.archiveSession") }}</button>
+              <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
+            </div>
+            </div>
           </div>
         </div>
 
-        <button v-if="orderedSessions(inst.sessions).length > SESSION_CAP && !sessionsExpanded.has(inst.id)"
+        <!-- The row cap only applies in flat mode — grouped modes render everything
+             and rely on per-group collapse to keep the list short. -->
+        <button v-if="groupModeOf(inst) === 'instance' && inst.sessions.length > SESSION_CAP && !sessionsExpanded.has(inst.id)"
                 data-test="sessions-show-more"
                 class="w-full py-1 pl-2.5 text-left text-[11px] font-medium text-fg-muted hover:text-fg"
                 @click.stop="toggleSessions(inst.id)">
-          {{ $t("instance.showMoreSessions", { n: orderedSessions(inst.sessions).length - SESSION_CAP }) }}
+          {{ $t("instance.showMoreSessions", { n: inst.sessions.length - SESSION_CAP }) }}
         </button>
-        <button v-else-if="orderedSessions(inst.sessions).length > SESSION_CAP"
+        <button v-else-if="groupModeOf(inst) === 'instance' && inst.sessions.length > SESSION_CAP"
                 data-test="sessions-collapse"
                 class="w-full py-1 pl-2.5 text-left text-[11px] font-medium text-fg-muted hover:text-fg"
                 @click.stop="toggleSessions(inst.id)">
@@ -377,6 +459,7 @@ const rowSwipes = computed(() => {
     </div>
 
     <NewSessionDialog v-if="dialogFor" :instance-id="dialogFor.id" :instance-name="dialogFor.name"
+                      :preset-agent="dialogFor.presetAgent" :preset-workspace="dialogFor.presetWorkspace"
                       @close="dialogFor = null" @created="onSessionCreated" />
     <ManageInstanceDialog v-if="manageFor" :instance-id="manageFor.id" :instance-name="manageFor.name"
                           @close="manageFor = null" />

--- a/packages/relay-web/src/components/ManageInstanceDialog.vue
+++ b/packages/relay-web/src/components/ManageInstanceDialog.vue
@@ -14,6 +14,13 @@ const { t } = useI18n();
 
 const coreVersion = computed(() => store.byId(props.instanceId)?.coreVersion ?? null);
 
+// Sidebar grouping mode for THIS instance (view preference, localStorage-backed).
+const GROUP_MODES = ["instance", "workspace", "agent"] as const;
+const groupMode = computed(() => store.groupModeFor(props.instanceId));
+function pickGroupMode(mode: (typeof GROUP_MODES)[number]): void {
+  store.setGroupMode(props.instanceId, mode);
+}
+
 const loading = ref(true);
 type Tab = "general" | "workspaces" | "agents";
 const TABS = ["general", "workspaces", "agents"] as const;
@@ -108,6 +115,19 @@ onMounted(async () => {
                 <button data-test="rename-save" class="shrink-0 rounded bg-accent px-3 py-1.5 text-sm text-white hover:bg-accent-hover disabled:opacity-50"
                         :disabled="renaming || !name.trim()" @click="saveName">{{ renaming ? $t("instance.renameSaving") : $t("instance.renameSave") }}</button>
               </div>
+            </section>
+            <section class="space-y-2">
+              <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("instance.groupModeLabel") }}</h3>
+              <div class="flex gap-1" role="radiogroup" :aria-label="$t('instance.groupModeLabel')">
+                <button v-for="m in GROUP_MODES" :key="m" type="button" role="radio"
+                        :aria-checked="groupMode === m" :data-test="`group-mode-${m}`"
+                        class="flex-1 rounded px-2 py-1.5 text-xs"
+                        :class="groupMode === m ? 'bg-accent text-white' : 'bg-bg border border-border text-fg-muted hover:bg-fg/5'"
+                        @click="pickGroupMode(m)">
+                  {{ m === 'instance' ? $t('instance.groupModeInstance') : m === 'workspace' ? $t('instance.groupModeWorkspace') : $t('instance.groupModeAgent') }}
+                </button>
+              </div>
+              <p class="text-xs text-fg-muted">{{ $t("instance.groupModeHint") }}</p>
             </section>
             <section class="space-y-1">
               <h3 class="text-sm font-semibold uppercase text-fg-muted">{{ $t("instance.versionLabel") }}</h3>

--- a/packages/relay-web/src/components/NewSessionDialog.vue
+++ b/packages/relay-web/src/components/NewSessionDialog.vue
@@ -9,7 +9,10 @@ import { genAlias, uniqueName, workspaceNameFromPath } from "../lib/session-form
 import { fmtDateTime } from "../lib/format";
 import SelectMenu, { type SelectGroup } from "./SelectMenu.vue";
 
-const props = defineProps<{ instanceId: string; instanceName: string }>();
+// presetAgent / presetWorkspace: seed the pickers (group-header ＋ in the grouped
+// sidebar prefills its own group). Still changeable — they only override the default
+// first-option selection.
+const props = defineProps<{ instanceId: string; instanceName: string; presetAgent?: string; presetWorkspace?: string }>();
 const emit = defineEmits<{ created: [alias: string]; close: [] }>();
 
 const { t } = useI18n();
@@ -109,9 +112,19 @@ onMounted(async () => {
   } finally {
     loading.value = false;
   }
-  // default selections
-  agentValue.value = inst.value?.agents[0]?.name ?? inst.value?.agentCatalog.find((c) => c.installed !== "unknown")?.driver ?? "";
-  workspaceSel.value = inst.value?.workspaces[0]?.name ?? "";
+  // default selections — a preset (from the grouped sidebar's group ＋) wins when it
+  // still exists in the loaded options; otherwise fall back to the first option.
+  const agents = inst.value?.agents ?? [];
+  agentValue.value =
+    (props.presetAgent && agents.some((a) => a.name === props.presetAgent) ? props.presetAgent : undefined)
+    ?? agents[0]?.name
+    ?? inst.value?.agentCatalog.find((c) => c.installed !== "unknown")?.driver
+    ?? "";
+  const workspaces = inst.value?.workspaces ?? [];
+  workspaceSel.value =
+    (props.presetWorkspace && workspaces.some((w) => w.name === props.presetWorkspace) ? props.presetWorkspace : undefined)
+    ?? workspaces[0]?.name
+    ?? "";
 });
 
 // configured agent NAMEs (to know if a chosen value needs agent auto-create)

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -299,6 +299,12 @@ export default {
     renameSaving: "Saving…",
     renameFailed: "rename failed",
     sessionRenameFailed: "Rename failed: {msg}",
+    groupModeLabel: "Sidebar grouping",
+    groupModeHint: "How this instance's sessions are grouped in the sidebar.",
+    groupModeInstance: "None (flat)",
+    groupModeWorkspace: "By workspace",
+    groupModeAgent: "By agent",
+    groupNewSession: "New session in {name}",
   },
   agents: {
     title: "Agents",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -297,6 +297,12 @@ export default {
     renameSaving: "保存中…",
     renameFailed: "重命名失败",
     sessionRenameFailed: "重命名失败：{msg}",
+    groupModeLabel: "侧栏分组",
+    groupModeHint: "该实例的会话在侧栏中的分组方式。",
+    groupModeInstance: "不分组（平铺）",
+    groupModeWorkspace: "按工作区",
+    groupModeAgent: "按 Agent",
+    groupNewSession: "在 {name} 中新建会话",
   },
   agents: {
     title: "Agent",

--- a/packages/relay-web/src/lib/sidebar-group-mode.ts
+++ b/packages/relay-web/src/lib/sidebar-group-mode.ts
@@ -1,0 +1,80 @@
+// Sidebar grouping: per-instance view preference (flat instance list vs second-level
+// grouping by workspace or agent) plus the pure grouping/dedup helpers the tree renders
+// from. Preference is a pure view concern → persisted in localStorage, never the server.
+
+export type SidebarGroupMode = "instance" | "workspace" | "agent";
+
+const KEY_PREFIX = "xacpx.sidebar.groupMode.";
+
+const MODES: readonly SidebarGroupMode[] = ["instance", "workspace", "agent"];
+
+export function loadGroupMode(instanceId: string): SidebarGroupMode {
+  try {
+    const raw = localStorage.getItem(KEY_PREFIX + instanceId);
+    if (raw && (MODES as readonly string[]).includes(raw)) return raw as SidebarGroupMode;
+  } catch {
+    // localStorage unavailable (private mode) → fall through to default
+  }
+  return "instance";
+}
+
+export function saveGroupMode(instanceId: string, mode: SidebarGroupMode): void {
+  try {
+    if (mode === "instance") localStorage.removeItem(KEY_PREFIX + instanceId);
+    else localStorage.setItem(KEY_PREFIX + instanceId, mode);
+  } catch {
+    // best-effort: the in-memory mode still applies for this page's lifetime
+  }
+}
+
+export interface SessionGroup<T> {
+  /** The workspace or agent name this group collects. */
+  key: string;
+  sessions: T[];
+}
+
+/**
+ * Archived sessions sink below active ones (stable: both halves keep their
+ * incoming order) — shared by the flat list and every group.
+ */
+export function archivedLast<T extends { archived?: boolean }>(sessions: T[]): T[] {
+  return [...sessions].sort((a, b) => Number(a.archived ?? false) - Number(b.archived ?? false));
+}
+
+/**
+ * Derive second-level groups from the sessions themselves (never from the
+ * workspaces/agents catalogs — no empty groups, and the catalogs may not be
+ * loaded when sessions arrive). Groups appear in first-appearance (server)
+ * order; within a group actives keep server order and archived sink last.
+ */
+export function groupSessions<T extends { workspace: string; agent: string; archived?: boolean }>(
+  sessions: T[],
+  mode: "workspace" | "agent",
+): Array<SessionGroup<T>> {
+  const byKey = new Map<string, T[]>();
+  for (const s of sessions) {
+    const key = mode === "workspace" ? s.workspace : s.agent;
+    const bucket = byKey.get(key);
+    if (bucket) bucket.push(s);
+    else byKey.set(key, [s]);
+  }
+  return [...byKey.entries()].map(([key, list]) => ({ key, sessions: archivedLast(list) }));
+}
+
+/**
+ * Display-layer dedup of the auto-alias pattern `<workspace>-<agent>`: inside a
+ * workspace group drop the leading "<group>-", inside an agent group drop the
+ * trailing "-<group>". Only when a non-empty remainder is left; the real alias
+ * is untouched (hover title always shows the full name).
+ */
+export function dedupedSessionName(name: string, groupKey: string, mode: "workspace" | "agent"): string {
+  if (mode === "workspace" && name.startsWith(`${groupKey}-`)) {
+    const rest = name.slice(groupKey.length + 1);
+    if (rest) return rest;
+  }
+  if (mode === "agent" && name.endsWith(`-${groupKey}`)) {
+    const rest = name.slice(0, name.length - groupKey.length - 1);
+    if (rest) return rest;
+  }
+  return name;
+}

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -3,6 +3,7 @@ import { ref } from "vue";
 import { isErrorPayload, type AgentCatalogEntryDto, type AgentDto, type NativeSessionDto, type SessionDto, type SessionModelResult, type WebServerEvent, type WorkspaceDto } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 import { useChatStore } from "./chat";
+import { loadGroupMode, saveGroupMode, type SidebarGroupMode } from "../lib/sidebar-group-mode";
 
 // An instance-side RPC error comes back as a 200 with an `{error:{code,message}}`
 // payload (the gateway resolves, it does not reject), so api.rpc won't throw.
@@ -53,6 +54,21 @@ export interface InstanceView {
 
 export const useInstancesStore = defineStore("instances", () => {
   const instances = ref<InstanceView[]>([]);
+
+  // Per-instance sidebar grouping mode (flat / by-workspace / by-agent). Reactive
+  // mirror of the localStorage preference so the sidebar re-renders the moment the
+  // manage dialog changes it. Reads are pure (no render-phase writes): until the
+  // first setGroupMode we fall through to localStorage directly.
+  const groupModes = ref<Record<string, SidebarGroupMode>>({});
+
+  function groupModeFor(instanceId: string): SidebarGroupMode {
+    return groupModes.value[instanceId] ?? loadGroupMode(instanceId);
+  }
+
+  function setGroupMode(instanceId: string, mode: SidebarGroupMode): void {
+    groupModes.value[instanceId] = mode;
+    saveGroupMode(instanceId, mode);
+  }
 
   async function loadInstances(): Promise<void> {
     const { instances: rows } = await api.get<{ instances: Array<Omit<InstanceView, "sessions" | "sessionsLoaded" | "agents" | "workspaces" | "agentCatalog">> }>("/api/instances");
@@ -313,5 +329,5 @@ export const useInstancesStore = defineStore("instances", () => {
     return instances.value.find((i) => i.id === id);
   }
 
-  return { instances, loadInstances, loadSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, beginSessionCreation, cancelSessionCreation, listNativeSessions, listModelSuggestions, removeSession, archiveSession, unarchiveSession, renameSession, renameInstance, applyEvent, byId };
+  return { instances, groupModes, groupModeFor, setGroupMode, loadInstances, loadSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, beginSessionCreation, cancelSessionCreation, listNativeSessions, listModelSuggestions, removeSession, archiveSession, unarchiveSession, renameSession, renameInstance, applyEvent, byId };
 });


### PR DESCRIPTION
## Summary
- Per-instance switchable sidebar grouping mode (flat / by-workspace / by-agent), persisted in localStorage (`xacpx.sidebar.groupMode.<instanceId>`), controlled from a new 3-way selector in ManageInstanceDialog's General tab, reactive via the instances store.
- Grouped rendering in InstanceTree: instance card + tinted group zones with tiny indent (visually isomorphic across modes), group headers (chevron + folder/brand icon + name + count), display-only alias dedup with full name on hover, agent-mode rows drop the per-row brand icon, no 10-row cap in grouped modes (group collapse is the length control, in-session state only).
- Group-header hover ＋ (always visible on touch) opens NewSessionDialog prefilled with the group's workspace/agent via new `presetWorkspace`/`presetAgent` props (still changeable).
- Groups derive from sessions only (no empty groups); archived sessions sink to the group bottom, dimmed. Zero mobile specialization.

Closes #216

## Test plan
- [x] 23 new unit tests (`sidebar-group-mode.test.ts`, `instancetree-grouping.test.ts`): persistence round-trip/corrupt-value fallback, grouping order, archived sink, dedup edge cases, no-cap, group collapse + per-mode isolation, displayName dedup semantics, preset prop wiring, ManageInstanceDialog control persistence
- [x] Full relay-web suite: 107 files / 914 tests pass
- [x] `vue-tsc --noEmit` clean