### PR TITLE
feat(relay-web): migrate session tail cache to IndexedDB

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     },
     "packages/channel-relay": {
       "name": "@ganglion/xacpx-channel-relay",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@ganglion/xacpx-relay-protocol": "^0.1.0",
         "ws": "^8.20.0",
@@ -75,7 +75,7 @@
     },
     "packages/relay": {
       "name": "@ganglion/xacpx-relay",
-      "version": "0.9.12",
+      "version": "0.9.15",
       "bin": {
         "xacpx-relay": "./dist/cli.js",
       },
@@ -88,7 +88,7 @@
     },
     "packages/relay-protocol": {
       "name": "@ganglion/xacpx-relay-protocol",
-      "version": "0.1.16",
+      "version": "0.1.17",
     },
     "packages/relay-web": {
       "name": "@ganglion/xacpx-relay-web",
@@ -131,6 +131,7 @@
         "@vitejs/plugin-vue": "^5.1.0",
         "@vue/test-utils": "^2.4.6",
         "autoprefixer": "^10.4.0",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^25.0.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^3.4.0",
@@ -1161,6 +1162,8 @@
     "express": ["express@5.2.1", "https://registry.npmmirror.com/express/-/express-5.2.1.tgz", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.3.2", "https://registry.npmmirror.com/express-rate-limit/-/express-rate-limit-8.3.2.tgz", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -172,7 +172,8 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   RPC `control.sessions.archive`、`SessionDto.archived` 字段与代码标识符全部不变。`⋯` 菜单项与
   滑动动作块图标换为 `Moon`，并带原生 `title` tooltip（`instance.sleepTooltip`）说明「睡眠会立即
   关闭会话进程，历史保留，发消息即唤醒」；移动端靠睡眠后的 toast（`instance.sessionArchivedToast`）
-  传达同一信息。微信端术语统一是独立 follow-up。
+  传达同一信息。微信端术语统一是独立 follow-up。**睡眠不再清本地 tail 缓存**（睡眠会话切回
+  仍可秒开首屏；仅删除会话与 logout 清缓存，见下文「IndexedDB 会话尾部缓存」）。
 - **冷会话指示器**：`SessionDto` 可选字段 `warm?: boolean`（实例侧 `SessionWarmthTracker` 60s 轮询
   queue-owner lock pid，温度翻转时推 `sessions-changed`，见 [docs/control-module.md](control-module.md)）。
   仅「醒着且 `warm === false`」的会话行显示 `Unplug` 小图标（`data-test="cold-indicator"`，
@@ -217,15 +218,21 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
 - **`structured` 脱离深度响应式**（`stores/chat.ts` `rawStructured`）：历史行不可变、只会整行
   替换，`loadHistory`/`loadOlder`/`flushTurn` 对 `structured`（parts/toolSteps/diff 全文）做
   `markRaw`，避免 Vue 深代理化数百 KB 的对象树。
-- **localStorage 会话尾部缓存**（`src/lib/session-tail-cache.ts`，spec #205）：stale-while-revalidate。
-  `chat.select()` 同步用缓存的最近 ≤30 条持久化行播种首屏（`messages.length > 0` 抑制骨架屏），
-  `loadHistory()` 原样整页替换收敛（key 稳定无闪烁）；成功加载与 turn-finished 后防抖写回
-  （`debounce-flush`，切会话时 flush）。键 = `xacpx.chat.tail.v1.<username>.<instanceId>.<alias>`
-  + 索引键 `tail-index.v1`（LRU/TTL 记账）。三层淘汰：事件驱动（`archiveSession`/`removeSession`
-  → chat store `purgeTailCache`（drop + 取消待写回，防止防抖定时器复活刚清掉的条目），
-  `auth.logout` → `dropAll`）、对账（`loadSessions` 落地后 `reconcileTailCache` 掉该实例
-  非存活/已归档 alias——覆盖 Web 关闭期间其他端的归档删除）、兜底（单条 256KB / 全局 4MB LRU、
-  7 天 TTL、quota 溢出淘汰重试一次、旧版本键前缀懒清扫）。所有存储访问 try/catch（可能被禁用）。
+- **IndexedDB 会话尾部缓存**（`src/lib/session-tail-cache.ts`，spec #205，后迁 IndexedDB）：
+  stale-while-revalidate。`chat.select()` 发起异步种子读（chat store 的 `pendingSeed`；落地守卫
+  = 选中未变 + transcript 仍为空 + revision 未变），`loadHistory()` 入口先 `await pendingSeed`
+  （毫秒级）再决定骨架屏——缓存命中时 `messages.length > 0` 照旧抑制骨架屏；之后权威整页替换
+  收敛（key 稳定无闪烁）。成功加载与 turn-finished 后防抖写回（`debounce-flush`，切会话时
+  flush，写入 fire-and-forget）。存储 = DB `xacpx.chat-tail` / store `tails`，数组主键
+  `[user, instanceId, alias]`（reconcile 用前缀 KeyRange，无需转义含点 alias），值含
+  `rows`（≤30 条持久化行，剥离 client-only 字段）+ `lastAccess` + `bytes`。淘汰：事件驱动
+  （`removeSession` → chat store `purgeTailCache`（drop + 取消待写回），`auth.logout` →
+  `dropAll`；**睡眠不清缓存**——归档语义是可唤醒，缓存保留）、对账（`loadSessions` 落地后
+  `reconcileTailCache` 掉该实例非存活 alias，含睡眠中的都算存活——覆盖 Web 关闭期间其他端的
+  删除）、兜底（全局 64MB 按 `lastAccess` LRU 淘汰、30 天 TTL 惰性过期；**无单条预算**——
+  重工具输出的大行也整会话缓存）。首次打开 DB 时懒清扫旧版 localStorage 键
+  （`xacpx.chat.tail.*` / `xacpx.chat.tail-index.*`，不迁数据）。所有操作 try/catch +
+  `indexedDB` 缺失兼容：read 返回 null、其余静默 no-op（缓存永不成为错误源）。
   仅含缓存播种行的 transcript 在 `loadHistory` 的 pending-prompt 守卫里视同为空
   （`seededFromCache`，保持 #199 的重选中途拉取语义）；播种（≤30 行）→ 权威整页替换
   不经过 0→N，`MessageList` 的渐进挂载对该替换同样重新触发

--- a/packages/relay-web/package.json
+++ b/packages/relay-web/package.json
@@ -48,6 +48,7 @@
     "@vitejs/plugin-vue": "^5.1.0",
     "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.0",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^25.0.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",

--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -66,6 +66,23 @@ test("select() seeds the transcript from the cached tail before any fetch (no sk
   expect(chat.loadingHistory).toBe(false);
 });
 
+test("a cache hit keeps the seeded tail visible during a slow fetch (skeleton suppressed)", async () => {
+  await write("alice", "i1", "s1", [row(1), row(2)]);
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  let resolveFetch!: (v: { messages: MessageRecordDto[]; hasMore: boolean }) => void;
+  getMock.mockReturnValue(new Promise((r) => { resolveFetch = r; }));
+  const load = chat.loadHistory();
+  // The skeleton renders only when `loadingHistory && messages.length === 0` —
+  // the awaited seed must land before loadingHistory is raised.
+  await vi.waitFor(() => expect(chat.loadingHistory).toBe(true));
+  expect(chat.messages.map((m) => m.id)).toEqual([1, 2]);
+  resolveFetch({ messages: [row(1), row(2), row(3)], hasMore: false });
+  await load;
+  expect(chat.messages.map((m) => m.id)).toEqual([1, 2, 3]);
+  chat.clearSelection(); // flush/cancel pending write-back so no timer leaks
+});
+
 test("select() leaves the transcript empty on cache miss or when logged out", async () => {
   const chat = useChatStore();
   chat.select("i1", "s1");

--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -1,7 +1,8 @@
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, expect, test, vi } from "vitest";
+import { IDBFactory } from "fake-indexeddb";
 import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
-import { read, resetSweepForTests, write } from "../lib/session-tail-cache";
+import { read, resetTailCacheForTests, write } from "../lib/session-tail-cache";
 
 const getMock = vi.fn();
 const rpc = vi.fn();
@@ -27,40 +28,61 @@ const row = (id: number, text = `m${id}`): MessageRecordDto => ({
   id, instanceId: "i1", sessionAlias: "s1", direction: "out", text, createdAt: "2026-07-28T00:00:00.000Z",
 });
 
-beforeEach(() => {
+/** The cache write-back is fire-and-forget; poll until the entry appears. */
+async function readEventually(user: string, instanceId: string, alias: string): Promise<MessageRecordDto[] | null> {
+  for (let i = 0; i < 100; i += 1) {
+    const rows = await read(user, instanceId, alias);
+    if (rows) return rows;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return null;
+}
+
+/** Purges are fire-and-forget too; poll until the entry is gone. */
+async function goneEventually(user: string, instanceId: string, alias: string): Promise<boolean> {
+  for (let i = 0; i < 100; i += 1) {
+    if ((await read(user, instanceId, alias)) === null) return true;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return false;
+}
+
+beforeEach(async () => {
   setActivePinia(createPinia());
+  await resetTailCacheForTests();
+  (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
   localStorage.clear();
-  resetSweepForTests();
   getMock.mockReset();
   rpc.mockReset();
   post.mockClear();
   useAuthStore().account = { username: "alice" };
 });
 
-test("select() seeds the transcript synchronously from the cached tail (no skeleton)", () => {
-  write("alice", "i1", "s1", [row(1), row(2)]);
+test("select() seeds the transcript from the cached tail before any fetch (no skeleton)", async () => {
+  await write("alice", "i1", "s1", [row(1), row(2)]);
   const chat = useChatStore();
   chat.select("i1", "s1");
-  // Synchronous — no network round-trip involved.
-  expect(chat.messages.map((m) => m.id)).toEqual([1, 2]);
+  await vi.waitFor(() => expect(chat.messages.map((m) => m.id)).toEqual([1, 2]));
   expect(chat.loadingHistory).toBe(false);
 });
 
-test("select() leaves the transcript empty on cache miss or when logged out", () => {
+test("select() leaves the transcript empty on cache miss or when logged out", async () => {
   const chat = useChatStore();
   chat.select("i1", "s1");
+  await new Promise((r) => setTimeout(r, 20));
   expect(chat.messages).toEqual([]);
-  write("alice", "i1", "s2", [row(1)]);
+  await write("alice", "i1", "s2", [row(1)]);
   useAuthStore().account = null;
   chat.select("i1", "s2");
+  await new Promise((r) => setTimeout(r, 20));
   expect(chat.messages).toEqual([]);
 });
 
 test("authoritative loadHistory replaces the seeded tail and writes back on the next switch", async () => {
-  write("alice", "i1", "s1", [row(1, "stale")]);
+  await write("alice", "i1", "s1", [row(1, "stale")]);
   const chat = useChatStore();
   chat.select("i1", "s1");
-  expect(chat.messages.map((m) => m.id)).toEqual([1]);
+  await vi.waitFor(() => expect(chat.messages.map((m) => m.id)).toEqual([1]));
 
   const fresh = Array.from({ length: 50 }, (_, i) => row(i + 1, `fresh${i + 1}`));
   getMock.mockResolvedValue({ messages: fresh, hasMore: false });
@@ -69,7 +91,7 @@ test("authoritative loadHistory replaces the seeded tail and writes back on the 
 
   // The write-back is debounced; switching sessions flushes it for the outgoing session.
   chat.select("i1", "other");
-  const cached = read("alice", "i1", "s1")!;
+  const cached = (await readEventually("alice", "i1", "s1"))!;
   expect(cached.length).toBe(30); // tail only
   expect(cached.at(-1)).toMatchObject({ id: 50, text: "fresh50" });
 });
@@ -83,53 +105,66 @@ test("optimistic rows (no id) are never written to the cache", async () => {
   chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s1", chunk: "live" } });
   chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s1", ok: true } });
   chat.select("i1", "other"); // flush pending write-back
-  expect(read("alice", "i1", "s1")!.map((r) => r.id)).toEqual([1]);
+  expect((await readEventually("alice", "i1", "s1"))!.map((r) => r.id)).toEqual([1]);
 });
 
 test("loadHistory failure keeps showing the cached tail", async () => {
-  write("alice", "i1", "s1", [row(1), row(2)]);
+  await write("alice", "i1", "s1", [row(1), row(2)]);
   const chat = useChatStore();
   chat.select("i1", "s1");
+  await vi.waitFor(() => expect(chat.messages.map((m) => m.id)).toEqual([1, 2]));
   getMock.mockRejectedValue(new Error("network"));
   await expect(chat.loadHistory()).rejects.toThrow();
   expect(chat.messages.map((m) => m.id)).toEqual([1, 2]);
 });
 
-test("archiveSession and removeSession purge the session's cache", async () => {
-  write("alice", "i1", "s1", [row(1)]);
-  write("alice", "i1", "s2", [row(2)]);
-  rpc.mockResolvedValue({ sessions: [], agents: [] });
+test("removeSession purges the cache; archiveSession (sleep) keeps it", async () => {
+  await write("alice", "i1", "s1", [row(1)]);
+  await write("alice", "i1", "s2", [row(2)]);
+  rpc.mockImplementation(async (_id: string, type: string) => {
+    if (type === "control.sessions.list") {
+      return { sessions: [
+        { alias: "s1", agent: "a", workspace: "w", transportSession: "t", running: false, archived: true },
+      ] };
+    }
+    return { agents: [], sessions: [] };
+  });
   const instances = useInstancesStore();
+  // Sleeping a session must NOT drop its cache — waking it should paint instantly.
   await instances.archiveSession("i1", "s1");
-  expect(read("alice", "i1", "s1")).toBeNull();
+  await new Promise((r) => setTimeout(r, 20));
+  expect(await read("alice", "i1", "s1")).not.toBeNull();
   await instances.removeSession("i1", "s2");
-  expect(read("alice", "i1", "s2")).toBeNull();
+  expect(await goneEventually("alice", "i1", "s2")).toBe(true);
 });
 
-test("loadSessions reconciles the cache against alive unarchived aliases", async () => {
-  write("alice", "i1", "alive", [row(1)]);
-  write("alice", "i1", "archived", [row(2)]);
-  write("alice", "i1", "gone", [row(3)]);
+test("loadSessions reconciles the cache against alive aliases, keeping sleeping sessions", async () => {
+  await write("alice", "i1", "alive", [row(1)]);
+  await write("alice", "i1", "sleeping", [row(2)]);
+  await write("alice", "i1", "gone", [row(3)]);
   rpc.mockImplementation(async (_id: string, type: string) => {
     if (type === "control.sessions.list") {
       return { sessions: [
         { alias: "alive", agent: "a", workspace: "w", transportSession: "t", running: false, archived: false },
-        { alias: "archived", agent: "a", workspace: "w", transportSession: "t", running: false, archived: true },
+        { alias: "sleeping", agent: "a", workspace: "w", transportSession: "t", running: false, archived: true },
       ] };
     }
     return { agents: [] };
   });
   await useInstancesStore().loadSessions("i1");
-  expect(read("alice", "i1", "alive")).not.toBeNull();
-  expect(read("alice", "i1", "archived")).toBeNull(); // archived elsewhere → dropped
-  expect(read("alice", "i1", "gone")).toBeNull(); // removed elsewhere → dropped
+  expect(await goneEventually("alice", "i1", "gone")).toBe(true); // removed elsewhere → dropped
+  expect(await read("alice", "i1", "alive")).not.toBeNull();
+  expect(await read("alice", "i1", "sleeping")).not.toBeNull(); // slept elsewhere → kept
 });
 
-test("logout drops every cached transcript", async () => {
-  write("alice", "i1", "s1", [row(1)]);
-  write("bob", "i2", "s9", [row(2)]);
+test("logout drops every cached transcript (all users) plus legacy localStorage keys", async () => {
+  await write("alice", "i1", "s1", [row(1)]);
+  await write("bob", "i2", "s9", [row(2)]);
+  localStorage.setItem("xacpx.chat.tail.v1.alice.i1.s1", "[]");
   await useAuthStore().logout();
-  expect(Object.keys(localStorage).filter((k) => k.startsWith("xacpx.chat.tail"))).toEqual([]);
+  expect(await read("alice", "i1", "s1")).toBeNull();
+  expect(await read("bob", "i2", "s9")).toBeNull();
+  expect(localStorage.getItem("xacpx.chat.tail.v1.alice.i1.s1")).toBeNull();
 });
 
 test("reselecting a session mid-prompt still fetches history over a cache seed (#199)", async () => {
@@ -141,8 +176,9 @@ test("reselecting a session mid-prompt still fetches history over a cache seed (
   rpc.mockReturnValue(new Promise(() => {}));
   void chat.send("hello");
   chat.select("i1", "other"); // switch away (flushes s1's tail into the cache)
+  await readEventually("alice", "i1", "s1"); // write-back is async — wait for it
   chat.select("i1", "s1"); // reselect: transcript is seeded from the cache
-  expect(chat.messages.map((m) => m.id)).toEqual([1]);
+  await vi.waitFor(() => expect(chat.messages.map((m) => m.id)).toEqual([1]));
   // The pending-prompt guard must treat the cache-seeded transcript as empty and
   // fetch anyway — otherwise the just-sent (already persisted) prompt row stays
   // invisible until the RPC settles.
@@ -153,9 +189,10 @@ test("reselecting a session mid-prompt still fetches history over a cache seed (
 });
 
 test("an optimistic send clears the seeded state so a mid-prompt reload defers again", async () => {
-  write("alice", "i1", "s1", [row(1)]);
+  await write("alice", "i1", "s1", [row(1)]);
   const chat = useChatStore();
-  chat.select("i1", "s1"); // seeded
+  chat.select("i1", "s1");
+  await vi.waitFor(() => expect(chat.messages.map((m) => m.id)).toEqual([1])); // seeded
   rpc.mockReturnValue(new Promise(() => {}));
   void chat.send("hello"); // pushes an optimistic row → transcript no longer seed-only
   getMock.mockResolvedValue({ messages: [row(1), row(2, "hello")], hasMore: false });
@@ -167,18 +204,19 @@ test("an optimistic send clears the seeded state so a mid-prompt reload defers a
 });
 
 test("write-back fires on the debounce timer without a session switch", async () => {
-  vi.useFakeTimers();
+  // Fake only the debounce's timer — fake-indexeddb's scheduling must stay real.
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
   try {
     const chat = useChatStore();
     chat.select("i1", "s1");
     getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
     await chat.loadHistory();
-    expect(read("alice", "i1", "s1")).toBeNull(); // still debounced
+    expect(await read("alice", "i1", "s1")).toBeNull(); // still debounced
     vi.advanceTimersByTime(500);
-    expect(read("alice", "i1", "s1")!.map((r) => r.id)).toEqual([1]);
   } finally {
     vi.useRealTimers();
   }
+  expect((await readEventually("alice", "i1", "s1"))!.map((r) => r.id)).toEqual([1]);
 });
 
 test("pagehide flushes a pending write-back", async () => {
@@ -187,21 +225,22 @@ test("pagehide flushes a pending write-back", async () => {
   getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
   await chat.loadHistory();
   window.dispatchEvent(new Event("pagehide"));
-  expect(read("alice", "i1", "s1")!.map((r) => r.id)).toEqual([1]);
+  expect((await readEventually("alice", "i1", "s1"))!.map((r) => r.id)).toEqual([1]);
 });
 
-test("archiving cancels a pending write-back so it cannot resurrect the purged entry", async () => {
-  vi.useFakeTimers();
+test("removing cancels a pending write-back so it cannot resurrect the purged entry", async () => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
   try {
     const chat = useChatStore();
     chat.select("i1", "s1");
     getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
     await chat.loadHistory(); // schedules the debounced write-back
     rpc.mockResolvedValue({ sessions: [], agents: [] });
-    await useInstancesStore().archiveSession("i1", "s1"); // purge + cancel
+    await useInstancesStore().removeSession("i1", "s1"); // purge + cancel
     vi.advanceTimersByTime(500); // the cancelled timer must not fire
-    expect(read("alice", "i1", "s1")).toBeNull();
   } finally {
     vi.useRealTimers();
   }
+  await new Promise((r) => setTimeout(r, 20));
+  expect(await read("alice", "i1", "s1")).toBeNull();
 });

--- a/packages/relay-web/src/__tests__/session-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/session-tail-cache.test.ts
@@ -1,178 +1,178 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IDBFactory } from "fake-indexeddb";
 import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
-import { drop, dropAll, read, reconcile, resetSweepForTests, TAIL_ROWS, write } from "../lib/session-tail-cache";
+import { drop, dropAll, read, reconcile, resetTailCacheForTests, TAIL_ROWS, write } from "../lib/session-tail-cache";
 
 const row = (id: number, text = `m${id}`): MessageRecordDto => ({
   id, instanceId: "i1", sessionAlias: "s1", direction: "out", text, createdAt: "2026-07-28T00:00:00.000Z",
 });
 
-beforeEach(() => {
+const DAY = 24 * 60 * 60 * 1000;
+
+beforeEach(async () => {
+  await resetTailCacheForTests();
+  // Fresh factory per test — no cross-test IndexedDB state.
+  (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
   localStorage.clear();
-  resetSweepForTests();
 });
 afterEach(() => vi.restoreAllMocks());
 
 describe("session-tail-cache", () => {
-  it("round-trips the tail and strips client-only fields + optimistic rows", () => {
+  it("round-trips the tail and strips client-only fields + optimistic rows", async () => {
     const rows = [
       { ...row(1), failed: true, status: "error" } as MessageRecordDto,
       row(2),
       // optimistic row (no id) must never be cached
       { instanceId: "i1", sessionAlias: "s1", direction: "in", text: "pending", createdAt: "x" } as MessageRecordDto,
     ];
-    write("alice", "i1", "s1", rows);
-    const back = read("alice", "i1", "s1")!;
+    await write("alice", "i1", "s1", rows);
+    const back = (await read("alice", "i1", "s1"))!;
     expect(back.map((r) => r.id)).toEqual([1, 2]);
     expect(back[0]).not.toHaveProperty("failed");
     expect(back[0]).not.toHaveProperty("status");
     expect(back[0]).toMatchObject({ text: "m1", direction: "out" });
   });
 
-  it("keeps only the newest TAIL_ROWS rows", () => {
-    write("alice", "i1", "s1", Array.from({ length: 100 }, (_, i) => row(i + 1)));
-    const back = read("alice", "i1", "s1")!;
+  it("keeps only the newest TAIL_ROWS rows", async () => {
+    await write("alice", "i1", "s1", Array.from({ length: 100 }, (_, i) => row(i + 1)));
+    const back = (await read("alice", "i1", "s1"))!;
     expect(back.length).toBe(TAIL_ROWS);
     expect(back[0]!.id).toBe(100 - TAIL_ROWS + 1);
     expect(back.at(-1)!.id).toBe(100);
   });
 
-  it("keeps structured payloads intact", () => {
+  it("keeps structured payloads intact", async () => {
     const r = { ...row(1), structured: { toolSteps: [{ toolCallId: "t", toolName: "R", kind: "read", status: "success", title: "x" }] } } as MessageRecordDto;
-    write("alice", "i1", "s1", [r]);
-    expect(read("alice", "i1", "s1")![0]!.structured?.toolSteps?.[0]).toMatchObject({ toolCallId: "t" });
+    await write("alice", "i1", "s1", [r]);
+    expect((await read("alice", "i1", "s1"))![0]!.structured?.toolSteps?.[0]).toMatchObject({ toolCallId: "t" });
   });
 
-  it("misses across accounts, instances and aliases (key isolation)", () => {
-    write("alice", "i1", "s1", [row(1)]);
-    expect(read("bob", "i1", "s1")).toBeNull();
-    expect(read("alice", "i2", "s1")).toBeNull();
-    expect(read("alice", "i1", "s2")).toBeNull();
+  it("misses across accounts, instances and aliases (key isolation)", async () => {
+    await write("alice", "i1", "s1", [row(1)]);
+    expect(await read("bob", "i1", "s1")).toBeNull();
+    expect(await read("alice", "i2", "s1")).toBeNull();
+    expect(await read("alice", "i1", "s2")).toBeNull();
   });
 
-  it("trims oldest rows to fit the per-entry budget", () => {
-    const fat = (id: number): MessageRecordDto => row(id, "x".repeat(30_000)); // ~60 KB serialized each
-    write("alice", "i1", "s1", Array.from({ length: 10 }, (_, i) => fat(i + 1)));
-    const back = read("alice", "i1", "s1")!;
-    expect(back.length).toBeLessThan(10);
-    expect(back.at(-1)!.id).toBe(10); // newest survives; oldest trimmed
+  it("caches oversized rows whole — no per-entry budget (regression: 640KB tool turns lost their cache)", async () => {
+    const fat = (id: number): MessageRecordDto => row(id, "x".repeat(400_000)); // ~800KB per row
+    await write("alice", "i1", "s1", Array.from({ length: 5 }, (_, i) => fat(i + 1)));
+    const back = (await read("alice", "i1", "s1"))!;
+    expect(back.length).toBe(5);
+    expect(back[0]!.text.length).toBe(400_000);
   });
 
-  it("skips caching when a single row exceeds the per-entry budget", () => {
-    write("alice", "i1", "s1", [row(1, "x".repeat(200_000))]);
-    expect(read("alice", "i1", "s1")).toBeNull();
+  it("evicts least-recently-accessed entries beyond the global budget", async () => {
+    // ~32MB (bytes estimate) per entry; 3 entries ≈ 96MB > the 64MB budget.
+    const fat = (alias: string, id: number): Promise<void> =>
+      write("alice", "i1", alias, [row(id, "x".repeat(16_000_000))]);
+    const t0 = Date.now();
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(t0);
+    await fat("s0", 1);
+    now.mockReturnValue(t0 + 1000);
+    await fat("s1", 2);
+    now.mockReturnValue(t0 + 2000);
+    await fat("s2", 3);
+    expect(await read("alice", "i1", "s0")).toBeNull(); // least recent → evicted
+    expect(await read("alice", "i1", "s2")).not.toBeNull(); // newest survives
   });
 
-  it("evicts least-recently-accessed entries beyond the global budget", () => {
-    // ~200 KB (bytes) per entry; 25 entries ≈ 5 MB > the 4 MB budget.
-    const fat = (alias: string, id: number): void => write("alice", "i1", alias, [row(id, "x".repeat(100_000))]);
-    for (let i = 0; i < 25; i += 1) fat(`s${i}`, i + 1);
-    expect(read("alice", "i1", "s0")).toBeNull(); // earliest written → evicted
-    expect(read("alice", "i1", "s24")).not.toBeNull(); // newest survives
-  });
-
-  it("expires entries older than the TTL", () => {
+  it("expires entries older than the TTL", async () => {
     const t0 = Date.now();
     const now = vi.spyOn(Date, "now").mockReturnValue(t0);
-    write("alice", "i1", "s1", [row(1)]);
-    now.mockReturnValue(t0 + 8 * 24 * 60 * 60 * 1000); // 8 days later
-    expect(read("alice", "i1", "s1")).toBeNull();
+    await write("alice", "i1", "s1", [row(1)]);
+    now.mockReturnValue(t0 + 31 * DAY);
+    expect(await read("alice", "i1", "s1")).toBeNull();
   });
 
-  it("a read refreshes lastAccess (LRU touch)", () => {
+  it("a read refreshes lastAccess (LRU touch)", async () => {
     const t0 = Date.now();
     const now = vi.spyOn(Date, "now").mockReturnValue(t0);
-    write("alice", "i1", "s1", [row(1)]);
-    now.mockReturnValue(t0 + 6 * 24 * 60 * 60 * 1000); // day 6: touch
-    expect(read("alice", "i1", "s1")).not.toBeNull();
-    now.mockReturnValue(t0 + 12 * 24 * 60 * 60 * 1000); // day 12: 6 days since touch
-    expect(read("alice", "i1", "s1")).not.toBeNull();
+    await write("alice", "i1", "s1", [row(1)]);
+    now.mockReturnValue(t0 + 20 * DAY); // day 20: touch
+    expect(await read("alice", "i1", "s1")).not.toBeNull();
+    now.mockReturnValue(t0 + 45 * DAY); // day 45: 25 days since touch
+    expect(await read("alice", "i1", "s1")).not.toBeNull();
   });
 
-  it("retries once after a quota error by evicting the LRU entry", () => {
-    write("alice", "i1", "old", [row(1)]);
-    const original = Storage.prototype.setItem;
-    let threw = false;
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (this: Storage, key: string, value: string) {
-      if (!threw && key.includes(".s1")) { threw = true; throw new DOMException("quota", "QuotaExceededError"); }
-      original.call(this, key, value);
+  it("drops a corrupted entry (non-object elements) instead of returning it", async () => {
+    await write("alice", "i1", "s1", [row(1)]);
+    // Corrupt the stored record through a second raw connection.
+    await new Promise<void>((resolve, reject) => {
+      const open = indexedDB.open("xacpx.chat-tail");
+      open.onerror = () => reject(open.error);
+      open.onsuccess = () => {
+        const db = open.result;
+        const tx = db.transaction("tails", "readwrite");
+        tx.objectStore("tails").put({ user: "alice", instanceId: "i1", alias: "s1", rows: [null], lastAccess: Date.now(), bytes: 8 });
+        tx.oncomplete = () => { db.close(); resolve(); };
+        tx.onerror = () => reject(tx.error);
+      };
     });
-    write("alice", "i1", "s1", [row(2)]);
-    expect(threw).toBe(true);
-    expect(read("alice", "i1", "s1")!.map((r) => r.id)).toEqual([2]);
-    expect(read("alice", "i1", "old")).toBeNull(); // the eviction victim
+    expect(await read("alice", "i1", "s1")).toBeNull();
+    expect(await read("alice", "i1", "s1")).toBeNull(); // stays gone (entry deleted)
   });
 
-  it("gives up silently when the quota retry also fails, without orphaning the stale entry", () => {
-    write("alice", "i1", "s1", [row(1, "old")]);
-    const entryKey = Object.keys(localStorage).find((k) => k.startsWith("xacpx.chat.tail.v1.") && k.endsWith(".s1"))!;
-    const original = Storage.prototype.setItem;
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (this: Storage, key: string, value: string) {
-      if (key.startsWith("xacpx.chat.tail.v1.")) throw new DOMException("quota", "QuotaExceededError");
-      original.call(this, key, value);
-    });
-    expect(() => write("alice", "i1", "s1", [row(2, "new")])).not.toThrow();
-    vi.restoreAllMocks();
-    expect(read("alice", "i1", "s1")).toBeNull();
-    // The previous stored value must not linger as an index-less orphan holding quota.
-    expect(localStorage.getItem(entryKey)).toBeNull();
+  it("drop purges one session; dropAll purges everything", async () => {
+    await write("alice", "i1", "s1", [row(1)]);
+    await write("alice", "i1", "s2", [row(2)]);
+    await drop("alice", "i1", "s1");
+    expect(await read("alice", "i1", "s1")).toBeNull();
+    expect(await read("alice", "i1", "s2")).not.toBeNull();
+    await dropAll();
+    expect(await read("alice", "i1", "s2")).toBeNull();
   });
 
-  it("drops a corrupted entry (non-object elements) instead of returning it", () => {
-    write("alice", "i1", "s1", [row(1)]);
-    localStorage.setItem("xacpx.chat.tail.v1.alice.i1.s1", "[null]");
-    expect(read("alice", "i1", "s1")).toBeNull();
+  it("dropAll also clears legacy localStorage entries", async () => {
+    localStorage.setItem("xacpx.chat.tail.v1.alice.i1.s1", "[]");
+    localStorage.setItem("xacpx.chat.tail-index.v1", "[]");
+    await dropAll();
     expect(localStorage.getItem("xacpx.chat.tail.v1.alice.i1.s1")).toBeNull();
+    expect(localStorage.getItem("xacpx.chat.tail-index.v1")).toBeNull();
   });
 
-  it("drop purges one session; dropAll purges everything", () => {
-    write("alice", "i1", "s1", [row(1)]);
-    write("alice", "i1", "s2", [row(2)]);
-    drop("alice", "i1", "s1");
-    expect(read("alice", "i1", "s1")).toBeNull();
-    expect(read("alice", "i1", "s2")).not.toBeNull();
-    dropAll();
-    expect(read("alice", "i1", "s2")).toBeNull();
-    expect(Object.keys(localStorage).filter((k) => k.startsWith("xacpx.chat.tail"))).toEqual([]);
+  it("reconcile drops entries whose alias is not alive, scoped to the instance + user", async () => {
+    await write("alice", "i1", "s1", [row(1)]);
+    await write("alice", "i1", "s2", [row(2)]);
+    await write("alice", "i2", "s2", [row(3)]);
+    await write("bob", "i1", "s2", [row(4)]);
+    await reconcile("alice", "i1", ["s1"]);
+    expect(await read("alice", "i1", "s1")).not.toBeNull();
+    expect(await read("alice", "i1", "s2")).toBeNull(); // dead alias dropped
+    expect(await read("alice", "i2", "s2")).not.toBeNull(); // other instance untouched
+    expect(await read("bob", "i1", "s2")).not.toBeNull(); // other account untouched
   });
 
-  it("reconcile drops entries whose alias is not alive, scoped to the instance + user", () => {
-    write("alice", "i1", "s1", [row(1)]);
-    write("alice", "i1", "s2", [row(2)]);
-    write("alice", "i2", "s2", [row(3)]);
-    write("bob", "i1", "s2", [row(4)]);
-    reconcile("alice", "i1", ["s1"]);
-    expect(read("alice", "i1", "s1")).not.toBeNull();
-    expect(read("alice", "i1", "s2")).toBeNull(); // dead alias dropped
-    expect(read("alice", "i2", "s2")).not.toBeNull(); // other instance untouched
-    expect(read("bob", "i1", "s2")).not.toBeNull(); // other account untouched
+  it("handles dotted aliases/instance ids without cross-matching in reconcile", async () => {
+    await write("alice", "i.1", "a.b", [row(1)]);
+    await write("alice", "i.1", "a.b.c", [row(2)]);
+    await reconcile("alice", "i.1", ["a.b"]);
+    expect(await read("alice", "i.1", "a.b")).not.toBeNull();
+    expect(await read("alice", "i.1", "a.b.c")).toBeNull();
   });
 
-  it("handles dotted aliases/instance ids without cross-matching in reconcile", () => {
-    write("alice", "i.1", "a.b", [row(1)]);
-    write("alice", "i.1", "a.b.c", [row(2)]);
-    reconcile("alice", "i.1", ["a.b"]);
-    expect(read("alice", "i.1", "a.b")).not.toBeNull();
-    expect(read("alice", "i.1", "a.b.c")).toBeNull();
+  it("sweeps legacy localStorage keys once on first use", async () => {
+    localStorage.setItem("xacpx.chat.tail.v1.alice.i1.s1", "[]");
+    localStorage.setItem("xacpx.chat.tail-index.v1", "[]");
+    localStorage.setItem("xacpx.unrelated", "keep");
+    await read("alice", "i1", "s1");
+    expect(localStorage.getItem("xacpx.chat.tail.v1.alice.i1.s1")).toBeNull();
+    expect(localStorage.getItem("xacpx.chat.tail-index.v1")).toBeNull();
+    expect(localStorage.getItem("xacpx.unrelated")).toBe("keep");
   });
 
-  it("sweeps old-version keys lazily by prefix", () => {
-    localStorage.setItem("xacpx.chat.tail.v0.alice.i1.s1", "[]");
-    localStorage.setItem("xacpx.chat.tail-index.v0", "[]");
-    resetSweepForTests();
-    read("alice", "i1", "s1");
-    expect(localStorage.getItem("xacpx.chat.tail.v0.alice.i1.s1")).toBeNull();
-    expect(localStorage.getItem("xacpx.chat.tail-index.v0")).toBeNull();
-  });
-
-  it("never throws when storage is blocked", () => {
-    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => { throw new Error("blocked"); });
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => { throw new Error("blocked"); });
-    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => { throw new Error("blocked"); });
-    vi.spyOn(Storage.prototype, "key").mockImplementation(() => { throw new Error("blocked"); });
-    expect(read("alice", "i1", "s1")).toBeNull();
-    expect(() => write("alice", "i1", "s1", [row(1)])).not.toThrow();
-    expect(() => drop("alice", "i1", "s1")).not.toThrow();
-    expect(() => dropAll()).not.toThrow();
-    expect(() => reconcile("alice", "i1", ["s1"])).not.toThrow();
+  it("never throws when IndexedDB is unavailable", async () => {
+    await resetTailCacheForTests();
+    vi.stubGlobal("indexedDB", undefined);
+    try {
+      expect(await read("alice", "i1", "s1")).toBeNull();
+      await expect(write("alice", "i1", "s1", [row(1)])).resolves.toBeUndefined();
+      await expect(drop("alice", "i1", "s1")).resolves.toBeUndefined();
+      await expect(dropAll()).resolves.toBeUndefined();
+      await expect(reconcile("alice", "i1", ["s1"])).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/packages/relay-web/src/__tests__/setup.ts
+++ b/packages/relay-web/src/__tests__/setup.ts
@@ -1,3 +1,6 @@
+// jsdom does not implement IndexedDB; the session tail cache depends on it.
+// `fake-indexeddb/auto` installs indexedDB/IDBKeyRange/etc. as globals.
+import "fake-indexeddb/auto";
 import { config } from "@vue/test-utils";
 import { i18n } from "../i18n";
 

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -62,12 +62,21 @@ function openDb(): Promise<IDBDatabase> {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE)) {
         const store = db.createObjectStore(STORE, { keyPath: ["user", "instanceId", "alias"] });
-        store.createIndex("lastAccess", "lastAccess");
+        // Composite [lastAccess, bytes] index: a key-cursor walk yields both LRU
+        // order and byte accounting without ever deserializing `rows`.
+        store.createIndex("lru", ["lastAccess", "bytes"]);
       }
     };
-    req.onsuccess = () => { sweepLegacyLocalStorage(); resolve(req.result); };
+    let blocked = false;
+    req.onsuccess = () => {
+      // A blocked open can still succeed later; the promise already rejected,
+      // so close the orphan connection (a leak would block future upgrades).
+      if (blocked) { req.result.close(); return; }
+      sweepLegacyLocalStorage();
+      resolve(req.result);
+    };
     req.onerror = () => reject(req.error ?? new Error("open-failed"));
-    req.onblocked = () => reject(new Error("open-blocked"));
+    req.onblocked = () => { blocked = true; reject(new Error("open-blocked")); };
   });
   // A failed open must not be cached forever — a later call may succeed (e.g.
   // transient blocked state); the rejection itself is handled by each caller.
@@ -103,10 +112,13 @@ export async function resetTailCacheForTests(): Promise<void> {
 export async function read(user: string, instanceId: string, alias: string): Promise<MessageRecordDto[] | null> {
   try {
     const db = await openDb();
-    const tx = db.transaction(STORE, "readwrite");
-    const store = tx.objectStore(STORE);
     const key = keyOf(user, instanceId, alias);
-    const record = await asPromise<TailRecord | undefined>(store.get(key) as IDBRequest<TailRecord | undefined>);
+    // Readonly get still serializes after any earlier overlapping readwrite tx
+    // (IDB starts transactions in creation order), so a flush-write immediately
+    // before a seed-read is always observed.
+    const record = await asPromise<TailRecord | undefined>(
+      db.transaction(STORE, "readonly").objectStore(STORE).get(key) as IDBRequest<TailRecord | undefined>,
+    );
     const now = Date.now();
     const rows = record?.rows;
     // Expired or corrupted entries (non-array, empty, or non-object elements) are
@@ -116,12 +128,22 @@ export async function read(user: string, instanceId: string, alias: string): Pro
       && Array.isArray(rows) && rows.length > 0
       && !rows.some((r) => typeof r !== "object" || r === null);
     if (!valid) {
-      if (record) store.delete(key);
-      await txDone(tx);
+      if (record) {
+        try {
+          const tx = db.transaction(STORE, "readwrite");
+          tx.objectStore(STORE).delete(key);
+          await txDone(tx);
+        } catch { /* best-effort cleanup */ }
+      }
       return null;
     }
-    store.put({ ...record, lastAccess: now });
-    await txDone(tx);
+    // LRU touch in its own transaction: under real quota pressure the put can
+    // fail, and that must not nullify a hit whose rows are already in hand.
+    try {
+      const tx = db.transaction(STORE, "readwrite");
+      tx.objectStore(STORE).put({ ...record, lastAccess: now });
+      await txDone(tx);
+    } catch { /* touch is best-effort */ }
     return rows as MessageRecordDto[];
   } catch { return null; }
 }
@@ -143,6 +165,41 @@ function toCachedRow(row: MessageRecordDto): MessageRecordDto {
   return out;
 }
 
+type LruEntry = { pk: [string, string, string]; lastAccess: number; bytes: number };
+/** Walk the [lastAccess, bytes] index with a KEY cursor — LRU order + byte
+ *  accounting without materializing a single `rows` payload. */
+const lruEntries = (index: IDBIndex): Promise<LruEntry[]> =>
+  new Promise((resolve, reject) => {
+    const entries: LruEntry[] = [];
+    const req = index.openKeyCursor();
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (!cursor) { resolve(entries); return; }
+      const [lastAccess, bytes] = cursor.key as [number, number];
+      entries.push({ pk: cursor.primaryKey as [string, string, string], lastAccess, bytes });
+      cursor.continue();
+    };
+    req.onerror = () => reject(req.error ?? new Error("cursor-failed"));
+  });
+
+async function putAndEvict(db: IDBDatabase, record: TailRecord, now: number): Promise<void> {
+  const tx = db.transaction(STORE, "readwrite");
+  const store = tx.objectStore(STORE);
+  store.put(record);
+  // One ascending-lastAccess pass: drop expired entries, then LRU-evict others
+  // while the total exceeds the budget (the fresh write is never a victim).
+  const entries = await lruEntries(store.index("lru"));
+  let total = entries.reduce((sum, e) => sum + (e.bytes || 0), 0);
+  for (const e of entries) {
+    if (e.pk[0] === record.user && e.pk[1] === record.instanceId && e.pk[2] === record.alias) continue;
+    if (now - e.lastAccess > TTL_MS || total > GLOBAL_BUDGET_BYTES) {
+      store.delete(e.pk);
+      total -= e.bytes || 0;
+    }
+  }
+  await txDone(tx);
+}
+
 /** Cache the tail of `rows` for a session: the last ≤30 persisted rows
  *  (id !== undefined). Expired entries and LRU victims beyond the global
  *  budget are pruned in the same transaction. */
@@ -152,29 +209,31 @@ export async function write(user: string, instanceId: string, alias: string, row
     const tail = rows.filter((r) => typeof r.id === "number").slice(-TAIL_ROWS).map(toCachedRow);
     const key = keyOf(user, instanceId, alias);
     const db = await openDb();
-    const tx = db.transaction(STORE, "readwrite");
-    const store = tx.objectStore(STORE);
     if (tail.length === 0) {
-      store.delete(key);
+      const tx = db.transaction(STORE, "readwrite");
+      tx.objectStore(STORE).delete(key);
       await txDone(tx);
       return;
     }
     const now = Date.now();
     // Serialized length ≈ UTF-16 code units; ×2 approximates the storage bytes.
     const bytes = JSON.stringify(tail).length * 2;
-    store.put({ user, instanceId, alias, rows: tail, lastAccess: now, bytes } satisfies TailRecord);
-    // One ascending-lastAccess pass: drop expired entries, then LRU-evict others
-    // while the total exceeds the budget (the fresh write is never a victim).
-    const all = await asPromise(store.index("lastAccess").getAll() as IDBRequest<TailRecord[]>);
-    let total = all.reduce((sum, r) => sum + (r.bytes || 0), 0);
-    for (const r of all) {
-      if (r.user === user && r.instanceId === instanceId && r.alias === alias) continue;
-      if (now - r.lastAccess > TTL_MS || total > GLOBAL_BUDGET_BYTES) {
-        store.delete(keyOf(r.user, r.instanceId, r.alias));
-        total -= r.bytes || 0;
-      }
+    const record: TailRecord = { user, instanceId, alias, rows: tail, lastAccess: now, bytes };
+    try {
+      await putAndEvict(db, record, now);
+    } catch (err) {
+      // Real quota exhausted below the 64MB logical budget (private browsing,
+      // storage-pressured device): the cache is disposable, so drop everything
+      // and retry the fresh write once — keeping the current session's tail is
+      // the best possible outcome there.
+      if ((err as DOMException | null)?.name !== "QuotaExceededError") throw err;
+      const clearTx = db.transaction(STORE, "readwrite");
+      clearTx.objectStore(STORE).clear();
+      await txDone(clearTx);
+      const retryTx = db.transaction(STORE, "readwrite");
+      retryTx.objectStore(STORE).put(record);
+      await txDone(retryTx);
     }
-    await txDone(tx);
   } catch { /* cache is an optimization, never an error source */ }
 }
 

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -2,122 +2,126 @@ import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
 
 /** Stale-while-revalidate tail cache for session transcripts (spec #205).
  *
- *  Stores the last ≤30 persisted rows of a session in localStorage so
- *  `chat.select()` can seed the first screen synchronously while the
- *  authoritative history fetch is in flight. Validity comes from the key
- *  (schema version + username + instance + alias) plus three eviction layers:
- *  event-driven purge (archive/remove/logout), reconciliation against live
- *  session lists, and LRU/TTL budget fallbacks. Every storage access is
- *  wrapped in try/catch — storage may be blocked, and the cache must never
- *  become an error source. */
+ *  Stores the last ≤30 persisted rows of a session in IndexedDB so
+ *  `chat.select()` can seed the first screen while the authoritative history
+ *  fetch is in flight. IndexedDB's quota (hundreds of MB) fits full structured
+ *  rows — no per-entry byte budget or row degradation is needed (a 640KB tool
+ *  turn overflowed the old localStorage budget and silently lost its cache).
+ *  Validity comes from the [user, instanceId, alias] key plus three eviction
+ *  layers: event-driven purge (remove/logout), reconciliation against live
+ *  session lists, and LRU/TTL budget fallbacks. Every access is wrapped in
+ *  try/catch — IndexedDB may be unavailable or blocked, and the cache must
+ *  never become an error source. */
 
-const VERSION = "v1";
-// Any-version prefixes, used by dropAll() and the lazy old-version sweep.
-const BASE_ENTRY_PREFIX = "xacpx.chat.tail.";
-const BASE_INDEX_PREFIX = "xacpx.chat.tail-index.";
-const ENTRY_PREFIX = `${BASE_ENTRY_PREFIX}${VERSION}.`;
-const INDEX_KEY = `${BASE_INDEX_PREFIX}${VERSION}`;
+const DB_NAME = "xacpx.chat-tail";
+const DB_VERSION = 1;
+const STORE = "tails";
 
 export const TAIL_ROWS = 30;
-const ENTRY_BUDGET_BYTES = 256 * 1024;
-const GLOBAL_BUDGET_BYTES = 4 * 1024 * 1024;
-const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const GLOBAL_BUDGET_BYTES = 64 * 1024 * 1024;
+// Aligned with the hub's historyRetentionDays default (30): rows older than the
+// retention window are gone server-side anyway.
+const TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
-type IndexRecord = { key: string; lastAccess: number; bytes: number };
+type TailRecord = {
+  user: string;
+  instanceId: string;
+  alias: string;
+  rows: MessageRecordDto[];
+  lastAccess: number;
+  bytes: number;
+};
 
-// Key segments must never contain "." so reconcile() can prefix-match
-// (user, instanceId) unambiguously even when aliases contain dots.
-const esc = (s: string): string => encodeURIComponent(s).replace(/\./g, "%2E");
-const entryKey = (user: string, instanceId: string, alias: string): string =>
-  `${ENTRY_PREFIX}${esc(user)}.${esc(instanceId)}.${esc(alias)}`;
+const keyOf = (user: string, instanceId: string, alias: string): [string, string, string] =>
+  [user, instanceId, alias];
 
-function loadIndex(): IndexRecord[] {
-  try {
-    const raw = localStorage.getItem(INDEX_KEY);
-    if (!raw) return [];
-    const v = JSON.parse(raw) as unknown;
-    if (!Array.isArray(v)) return [];
-    return v.filter((r): r is IndexRecord =>
-      typeof r === "object" && r !== null &&
-      typeof (r as IndexRecord).key === "string" &&
-      typeof (r as IndexRecord).lastAccess === "number" &&
-      typeof (r as IndexRecord).bytes === "number");
-  } catch { return []; }
-}
-
-function saveIndex(index: IndexRecord[]): void {
-  try {
-    if (index.length === 0) localStorage.removeItem(INDEX_KEY);
-    else localStorage.setItem(INDEX_KEY, JSON.stringify(index));
-  } catch { /* storage may be blocked */ }
-}
-
-function removeEntry(index: IndexRecord[], key: string): IndexRecord[] {
-  try { localStorage.removeItem(key); } catch { /* storage may be blocked */ }
-  return index.filter((r) => r.key !== key);
-}
-
-/** Drop entries whose lastAccess is older than the TTL. Runs lazily on read/write
- *  so idle entries for instances the user never expands again still die. */
-function pruneExpired(index: IndexRecord[], now: number): IndexRecord[] {
-  let next = index;
-  for (const r of index) {
-    if (now - r.lastAccess > TTL_MS) next = removeEntry(next, r.key);
-  }
-  return next;
-}
-
-// Old-version keys (e.g. a future v2 rollout leaving v1 behind, or vice versa on
-// rollback) are swept once per page load — cheap, and keeps quota for live data.
-let sweptOldVersions = false;
-function sweepOldVersions(): void {
-  if (sweptOldVersions) return;
-  sweptOldVersions = true;
+// Legacy localStorage entries (the pre-IndexedDB v1 cache) are swept once per
+// page load — the cache is disposable, so old data is dropped, not migrated.
+const LEGACY_PREFIXES = ["xacpx.chat.tail.", "xacpx.chat.tail-index."];
+let sweptLegacy = false;
+function sweepLegacyLocalStorage(): void {
+  if (sweptLegacy) return;
+  sweptLegacy = true;
   try {
     const stale: string[] = [];
     for (let i = 0; i < localStorage.length; i += 1) {
       const key = localStorage.key(i);
-      if (!key) continue;
-      const oldEntry = key.startsWith(BASE_ENTRY_PREFIX) && !key.startsWith(ENTRY_PREFIX);
-      const oldIndex = key.startsWith(BASE_INDEX_PREFIX) && key !== INDEX_KEY;
-      if (oldEntry || oldIndex) stale.push(key);
+      if (key && LEGACY_PREFIXES.some((p) => key.startsWith(p))) stale.push(key);
     }
     for (const key of stale) localStorage.removeItem(key);
   } catch { /* storage may be blocked */ }
 }
 
-/** Test hook: reset the once-per-load sweep latch. */
-export function resetSweepForTests(): void { sweptOldVersions = false; }
+let dbPromise: Promise<IDBDatabase> | null = null;
+function openDb(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+  const opened = new Promise<IDBDatabase>((resolve, reject) => {
+    if (typeof indexedDB === "undefined") { reject(new Error("indexeddb-unavailable")); return; }
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        const store = db.createObjectStore(STORE, { keyPath: ["user", "instanceId", "alias"] });
+        store.createIndex("lastAccess", "lastAccess");
+      }
+    };
+    req.onsuccess = () => { sweepLegacyLocalStorage(); resolve(req.result); };
+    req.onerror = () => reject(req.error ?? new Error("open-failed"));
+    req.onblocked = () => reject(new Error("open-blocked"));
+  });
+  // A failed open must not be cached forever — a later call may succeed (e.g.
+  // transient blocked state); the rejection itself is handled by each caller.
+  dbPromise = opened;
+  opened.catch(() => { if (dbPromise === opened) dbPromise = null; });
+  return opened;
+}
 
-/** Synchronously read the cached tail for a session, or null on miss/expiry.
+const asPromise = <T>(req: IDBRequest<T>): Promise<T> =>
+  new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("request-failed"));
+  });
+
+const txDone = (tx: IDBTransaction): Promise<void> =>
+  new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onabort = () => reject(tx.error ?? new Error("tx-aborted"));
+    tx.onerror = () => reject(tx.error ?? new Error("tx-failed"));
+  });
+
+/** Test hook: drop the cached connection (and the legacy-sweep latch) so each
+ *  test can start against a fresh fake IndexedDB factory. */
+export async function resetTailCacheForTests(): Promise<void> {
+  sweptLegacy = false;
+  const p = dbPromise;
+  dbPromise = null;
+  if (p) { try { (await p).close(); } catch { /* already broken */ } }
+}
+
+/** Read the cached tail for a session, or null on miss/expiry/corruption.
  *  A hit refreshes the entry's lastAccess (LRU touch). */
-export function read(user: string, instanceId: string, alias: string): MessageRecordDto[] | null {
-  sweepOldVersions();
+export async function read(user: string, instanceId: string, alias: string): Promise<MessageRecordDto[] | null> {
   try {
-    const key = entryKey(user, instanceId, alias);
+    const db = await openDb();
+    const tx = db.transaction(STORE, "readwrite");
+    const store = tx.objectStore(STORE);
+    const key = keyOf(user, instanceId, alias);
+    const record = await asPromise<TailRecord | undefined>(store.get(key) as IDBRequest<TailRecord | undefined>);
     const now = Date.now();
-    let index = pruneExpired(loadIndex(), now);
-    const record = index.find((r) => r.key === key);
-    if (!record) {
-      // No index record — remove any orphaned entry so it can't linger untracked.
-      index = removeEntry(index, key);
-      saveIndex(index);
-      return null;
-    }
-    const raw = localStorage.getItem(key);
-    if (!raw) {
-      saveIndex(index.filter((r) => r.key !== key));
-      return null;
-    }
-    const rows = JSON.parse(raw) as unknown;
-    // A corrupted entry (non-array, empty, or non-object elements) must be
+    const rows = record?.rows;
+    // Expired or corrupted entries (non-array, empty, or non-object elements) are
     // dropped here — the cache must never become an error source downstream.
-    if (!Array.isArray(rows) || rows.length === 0 || rows.some((r) => typeof r !== "object" || r === null)) {
-      saveIndex(removeEntry(index, key));
+    const valid = record !== undefined
+      && now - record.lastAccess <= TTL_MS
+      && Array.isArray(rows) && rows.length > 0
+      && !rows.some((r) => typeof r !== "object" || r === null);
+    if (!valid) {
+      if (record) store.delete(key);
+      await txDone(tx);
       return null;
     }
-    record.lastAccess = now;
-    saveIndex(index);
+    store.put({ ...record, lastAccess: now });
+    await txDone(tx);
     return rows as MessageRecordDto[];
   } catch { return null; }
 }
@@ -139,101 +143,81 @@ function toCachedRow(row: MessageRecordDto): MessageRecordDto {
   return out;
 }
 
-/** Cache the tail of `rows` for a session. Keeps the last ≤30 persisted rows
- *  (id !== undefined), trims oldest rows to fit the per-entry budget, evicts
- *  LRU entries beyond the global budget, and retries once on quota errors. */
-export function write(user: string, instanceId: string, alias: string, rows: MessageRecordDto[]): void {
-  sweepOldVersions();
+/** Cache the tail of `rows` for a session: the last ≤30 persisted rows
+ *  (id !== undefined). Expired entries and LRU victims beyond the global
+ *  budget are pruned in the same transaction. */
+export async function write(user: string, instanceId: string, alias: string, rows: MessageRecordDto[]): Promise<void> {
   try {
-    const key = entryKey(user, instanceId, alias);
-    const now = Date.now();
-    let index = pruneExpired(loadIndex(), now);
-
-    let tail = rows.filter((r) => typeof r.id === "number").slice(-TAIL_ROWS).map(toCachedRow);
+    // Snapshot synchronously — the caller's `rows` may mutate while IDB awaits.
+    const tail = rows.filter((r) => typeof r.id === "number").slice(-TAIL_ROWS).map(toCachedRow);
+    const key = keyOf(user, instanceId, alias);
+    const db = await openDb();
+    const tx = db.transaction(STORE, "readwrite");
+    const store = tx.objectStore(STORE);
     if (tail.length === 0) {
-      saveIndex(removeEntry(index, key));
+      store.delete(key);
+      await txDone(tx);
       return;
     }
-    let serialized = JSON.stringify(tail);
+    const now = Date.now();
     // Serialized length ≈ UTF-16 code units; ×2 approximates the storage bytes.
-    while (serialized.length * 2 > ENTRY_BUDGET_BYTES && tail.length > 1) {
-      tail = tail.slice(1);
-      serialized = JSON.stringify(tail);
-    }
-    if (serialized.length * 2 > ENTRY_BUDGET_BYTES) {
-      // A single row exceeding the budget: skip caching this session.
-      saveIndex(removeEntry(index, key));
-      return;
-    }
-    const bytes = serialized.length * 2;
-
-    // Evict least-recently-accessed OTHER entries until the new entry fits the
-    // global budget (the fresh write is never a victim of its own eviction).
-    const evictLru = (): boolean => {
-      const victims = index.filter((r) => r.key !== key).sort((a, b) => a.lastAccess - b.lastAccess);
-      if (victims.length === 0) return false;
-      index = removeEntry(index, victims[0].key);
-      return true;
-    };
-    const totalOthers = (): number => index.filter((r) => r.key !== key).reduce((sum, r) => sum + r.bytes, 0);
-    while (totalOthers() + bytes > GLOBAL_BUDGET_BYTES) {
-      if (!evictLru()) break;
-    }
-
-    const store = (): void => localStorage.setItem(key, serialized);
-    try {
-      store();
-    } catch {
-      // Quota exceeded: evict the LRU entry and retry once, then give up. Giving up
-      // must also remove any PREVIOUS stored value under this key (the failed setItem
-      // left it in place): an index-less orphan would hold quota — the very resource
-      // exhausted here — invisibly to LRU/TTL/reconcile.
-      if (!evictLru()) { saveIndex(removeEntry(index, key)); return; }
-      try { store(); } catch {
-        saveIndex(removeEntry(index, key));
-        return;
+    const bytes = JSON.stringify(tail).length * 2;
+    store.put({ user, instanceId, alias, rows: tail, lastAccess: now, bytes } satisfies TailRecord);
+    // One ascending-lastAccess pass: drop expired entries, then LRU-evict others
+    // while the total exceeds the budget (the fresh write is never a victim).
+    const all = await asPromise(store.index("lastAccess").getAll() as IDBRequest<TailRecord[]>);
+    let total = all.reduce((sum, r) => sum + (r.bytes || 0), 0);
+    for (const r of all) {
+      if (r.user === user && r.instanceId === instanceId && r.alias === alias) continue;
+      if (now - r.lastAccess > TTL_MS || total > GLOBAL_BUDGET_BYTES) {
+        store.delete(keyOf(r.user, r.instanceId, r.alias));
+        total -= r.bytes || 0;
       }
     }
-    const existing = index.find((r) => r.key === key);
-    if (existing) { existing.lastAccess = now; existing.bytes = bytes; }
-    else index.push({ key, lastAccess: now, bytes });
-    saveIndex(index);
+    await txDone(tx);
   } catch { /* cache is an optimization, never an error source */ }
 }
 
-/** Purge one session's cache — archive/remove hooks. */
-export function drop(user: string, instanceId: string, alias: string): void {
+/** Purge one session's cache — the remove hook (sleeping sessions KEEP their
+ *  cache: they stay resumable and should still paint instantly). */
+export async function drop(user: string, instanceId: string, alias: string): Promise<void> {
   try {
-    const key = entryKey(user, instanceId, alias);
-    saveIndex(removeEntry(loadIndex(), key));
-  } catch { /* storage may be blocked */ }
+    const db = await openDb();
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).delete(keyOf(user, instanceId, alias));
+    await txDone(tx);
+  } catch { /* best-effort */ }
 }
 
-/** Purge every cached transcript (any schema version) — the logout hook. */
-export function dropAll(): void {
+/** Purge every cached transcript (plus legacy localStorage keys) — the logout hook. */
+export async function dropAll(): Promise<void> {
+  sweptLegacy = false;
+  sweepLegacyLocalStorage();
   try {
-    const stale: string[] = [];
-    for (let i = 0; i < localStorage.length; i += 1) {
-      const key = localStorage.key(i);
-      if (!key) continue;
-      if (key.startsWith(BASE_ENTRY_PREFIX) || key.startsWith(BASE_INDEX_PREFIX)) stale.push(key);
-    }
-    for (const key of stale) localStorage.removeItem(key);
-  } catch { /* storage may be blocked */ }
+    const db = await openDb();
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).clear();
+    await txDone(tx);
+  } catch { /* best-effort */ }
 }
 
 /** Drop cached entries for an instance whose alias is not in `aliveAliases` —
- *  covers sessions archived/removed from other clients while the web was closed.
+ *  covers sessions removed from other clients while the web was closed.
  *  Called as each instance's authoritative session list arrives. */
-export function reconcile(user: string, instanceId: string, aliveAliases: Iterable<string>): void {
+export async function reconcile(user: string, instanceId: string, aliveAliases: Iterable<string>): Promise<void> {
   try {
-    const prefix = `${ENTRY_PREFIX}${esc(user)}.${esc(instanceId)}.`;
-    const alive = new Set<string>();
-    for (const alias of aliveAliases) alive.add(`${prefix}${esc(alias)}`);
-    let index = loadIndex();
-    for (const r of [...index]) {
-      if (r.key.startsWith(prefix) && !alive.has(r.key)) index = removeEntry(index, r.key);
+    const alive = new Set(aliveAliases);
+    const db = await openDb();
+    const tx = db.transaction(STORE, "readwrite");
+    const store = tx.objectStore(STORE);
+    // [user, instanceId] prefix range: an array upper bound sorts after every
+    // string alias, so this spans exactly the instance's entries.
+    const range = IDBKeyRange.bound([user, instanceId], [user, instanceId, []], false, true);
+    const keys = await asPromise(store.getAllKeys(range));
+    for (const k of keys) {
+      const alias = (k as [string, string, string])[2];
+      if (!alive.has(alias)) store.delete(k);
     }
-    saveIndex(index);
-  } catch { /* storage may be blocked */ }
+    await txDone(tx);
+  } catch { /* best-effort */ }
 }

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -14,7 +14,8 @@ import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
  *  never become an error source. */
 
 const DB_NAME = "xacpx.chat-tail";
-const DB_VERSION = 1;
+// v2: the [lastAccess, bytes] "lru" index replaced the plain lastAccess index.
+const DB_VERSION = 2;
 const STORE = "tails";
 
 export const TAIL_ROWS = 30;
@@ -60,12 +61,13 @@ function openDb(): Promise<IDBDatabase> {
     const req = indexedDB.open(DB_NAME, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
-      if (!db.objectStoreNames.contains(STORE)) {
-        const store = db.createObjectStore(STORE, { keyPath: ["user", "instanceId", "alias"] });
-        // Composite [lastAccess, bytes] index: a key-cursor walk yields both LRU
-        // order and byte accounting without ever deserializing `rows`.
-        store.createIndex("lru", ["lastAccess", "bytes"]);
-      }
+      // The cache is disposable: any schema change drops and recreates the
+      // store, guaranteeing the current index layout regardless of prior version.
+      if (db.objectStoreNames.contains(STORE)) db.deleteObjectStore(STORE);
+      const store = db.createObjectStore(STORE, { keyPath: ["user", "instanceId", "alias"] });
+      // Composite [lastAccess, bytes] index: a key-cursor walk yields both LRU
+      // order and byte accounting without ever deserializing `rows`.
+      store.createIndex("lru", ["lastAccess", "bytes"]);
     };
     let blocked = false;
     req.onsuccess = () => {
@@ -184,20 +186,27 @@ const lruEntries = (index: IDBIndex): Promise<LruEntry[]> =>
 
 async function putAndEvict(db: IDBDatabase, record: TailRecord, now: number): Promise<void> {
   const tx = db.transaction(STORE, "readwrite");
-  const store = tx.objectStore(STORE);
-  store.put(record);
-  // One ascending-lastAccess pass: drop expired entries, then LRU-evict others
-  // while the total exceeds the budget (the fresh write is never a victim).
-  const entries = await lruEntries(store.index("lru"));
-  let total = entries.reduce((sum, e) => sum + (e.bytes || 0), 0);
-  for (const e of entries) {
-    if (e.pk[0] === record.user && e.pk[1] === record.instanceId && e.pk[2] === record.alias) continue;
-    if (now - e.lastAccess > TTL_MS || total > GLOBAL_BUDGET_BYTES) {
-      store.delete(e.pk);
-      total -= e.bytes || 0;
+  try {
+    const store = tx.objectStore(STORE);
+    store.put(record);
+    // One ascending-lastAccess pass: drop expired entries, then LRU-evict others
+    // while the total exceeds the budget (the fresh write is never a victim).
+    const entries = await lruEntries(store.index("lru"));
+    let total = entries.reduce((sum, e) => sum + (e.bytes || 0), 0);
+    for (const e of entries) {
+      if (e.pk[0] === record.user && e.pk[1] === record.instanceId && e.pk[2] === record.alias) continue;
+      if (now - e.lastAccess > TTL_MS || total > GLOBAL_BUDGET_BYTES) {
+        store.delete(e.pk);
+        total -= e.bytes || 0;
+      }
     }
+    await txDone(tx);
+  } catch (err) {
+    // A quota failure on the put request aborts the tx, surfacing to the pending
+    // cursor as AbortError — tx.error still holds the original QuotaExceededError
+    // that write()'s fallback keys on.
+    throw tx.error ?? err;
   }
-  await txDone(tx);
 }
 
 /** Cache the tail of `rows` for a session: the last ≤30 persisted rows

--- a/packages/relay-web/src/stores/auth.ts
+++ b/packages/relay-web/src/stores/auth.ts
@@ -37,8 +37,8 @@ export const useAuthStore = defineStore("auth", () => {
     await api.post("/api/logout").catch(() => {});
     account.value = null;
     // Shared-machine hygiene: the next login must not be able to read cached
-    // transcripts from localStorage (spec #205 user story 5).
-    dropAllTailCaches();
+    // transcripts from IndexedDB (spec #205 user story 5).
+    await dropAllTailCaches();
   }
 
   return { account, error, login, fetchMe, logout };

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -188,16 +188,18 @@ export const useChatStore = defineStore("chat", () => {
     return t;
   }
 
-  // Stale-while-revalidate tail cache (#205): select() seeds the first screen from
-  // localStorage synchronously; authoritative rows (loadHistory) are written back
-  // debounced so bursty turn-finished convergence doesn't hammer JSON.stringify.
-  // The writer reads selection/messages at FLUSH time, so a flush always persists
-  // what is actually displayed for the session it is keyed to.
+  // Stale-while-revalidate tail cache (#205): select() kicks off an async seed
+  // from IndexedDB (pendingSeed below); authoritative rows (loadHistory) are
+  // written back debounced so bursty turn-finished convergence doesn't hammer
+  // serialization. The writer reads selection/messages at FLUSH time, so a flush
+  // always persists what is actually displayed for the session it is keyed to.
   const cacheWrite = createDebouncedFlush(() => {
     const user = useAuthStore().account?.username;
     if (!user || !instanceId.value || !sessionAlias.value) return;
     void tailCache.write(user, instanceId.value, sessionAlias.value, messages.value);
   }, 500);
+  // Best-effort: an IDB write started during unload may not commit (unlike the
+  // old synchronous localStorage flush); loadHistory converges on the next visit.
   if (typeof window !== "undefined") window.addEventListener("pagehide", () => cacheWrite.flush());
 
   // True while `messages` holds ONLY rows seeded from the tail cache — i.e. no
@@ -315,6 +317,7 @@ export const useChatStore = defineStore("chat", () => {
   function clearSelection(): void {
     cacheWrite.flush();
     seededFromCache = false;
+    pendingSeed = null;
     instanceId.value = null;
     sessionAlias.value = null;
     clearPersistedSelection();
@@ -331,8 +334,13 @@ export const useChatStore = defineStore("chat", () => {
     if (!instanceId.value || !sessionAlias.value) return;
     // Let a cache seed kicked off by select() land first (ms-scale IndexedDB read):
     // the guards below must observe the seeded transcript, and a hit keeps the
-    // skeleton suppressed during the fetch. No seed → stay synchronous.
-    if (pendingSeed) await pendingSeed;
+    // skeleton suppressed during the fetch. No seed → stay synchronous. A select()
+    // during the await replaces pendingSeed — loop until the awaited seed is the
+    // current one, then clear it (consumed).
+    for (let seed = pendingSeed; seed; seed = pendingSeed) {
+      await seed;
+      if (pendingSeed === seed) { pendingSeed = null; break; }
+    }
     if (!instanceId.value || !sessionAlias.value) return;
     const id = instanceId.value;
     const alias = sessionAlias.value;

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -196,7 +196,7 @@ export const useChatStore = defineStore("chat", () => {
   const cacheWrite = createDebouncedFlush(() => {
     const user = useAuthStore().account?.username;
     if (!user || !instanceId.value || !sessionAlias.value) return;
-    tailCache.write(user, instanceId.value, sessionAlias.value, messages.value);
+    void tailCache.write(user, instanceId.value, sessionAlias.value, messages.value);
   }, 500);
   if (typeof window !== "undefined") window.addEventListener("pagehide", () => cacheWrite.flush());
 
@@ -206,6 +206,10 @@ export const useChatStore = defineStore("chat", () => {
   // fetching over it clobbers nothing), cleared by the first authoritative replace
   // or any local push.
   let seededFromCache = false;
+  // The in-flight cache seed for the current selection (null when none was kicked
+  // off) — loadHistory awaits it so its guards observe the seeded transcript
+  // before deciding to fetch/skeleton.
+  let pendingSeed: Promise<void> | null = null;
 
   /** Purge one session's cached tail. Routed through the chat store (not called on
    *  the cache module directly) so a purge also cancels a pending debounced
@@ -214,15 +218,15 @@ export const useChatStore = defineStore("chat", () => {
   function purgeTailCache(id: string, alias: string): void {
     if (instanceId.value === id && sessionAlias.value === alias) cacheWrite.cancel();
     const user = useAuthStore().account?.username;
-    if (user) tailCache.drop(user, id, alias);
+    if (user) void tailCache.drop(user, id, alias);
   }
 
-  /** Reconcile an instance's cached tails against its authoritative alive unarchived
+  /** Reconcile an instance's cached tails against its authoritative alive
    *  aliases (see purgeTailCache for why this lives on the chat store). */
   function reconcileTailCache(id: string, aliveAliases: string[]): void {
     if (instanceId.value === id && sessionAlias.value !== null && !aliveAliases.includes(sessionAlias.value)) cacheWrite.cancel();
     const user = useAuthStore().account?.username;
-    if (user) tailCache.reconcile(user, id, aliveAliases);
+    if (user) void tailCache.reconcile(user, id, aliveAliases);
   }
 
   /** Finalize a live turn: clear it (so `busy`/HUD release) and, if it streamed any
@@ -275,20 +279,14 @@ export const useChatStore = defineStore("chat", () => {
     hasMoreOlder.value = false;
     loadingOlder.value = false;
     loadingHistory.value = false;
-    // Stale-while-revalidate: synchronously seed the transcript from the cached tail
-    // so the first screen renders instantly (no skeleton — messages.length > 0
-    // suppresses it). loadHistory() replaces this wholesale when the authoritative
+    // Stale-while-revalidate: seed the transcript from the cached tail so the first
+    // screen renders near-instantly (an IndexedDB read is ms-scale; loadHistory
+    // awaits pendingSeed before its guards/fetch so a hit still suppresses the
+    // skeleton). loadHistory() replaces the seed wholesale when the authoritative
     // page arrives; stable p${id} row keys make that replace flicker-free.
     const user = useAuthStore().account?.username;
     seededFromCache = false;
-    if (user) {
-      const cached = tailCache.read(user, id, alias);
-      if (cached && cached.length > 0) {
-        messages.value = cached.map(rawStructured);
-        touchTranscript();
-        seededFromCache = true;
-      }
-    }
+    pendingSeed = user ? seedFromCache(user, id, alias) : null;
     // Viewing a session clears its unread signal.
     const k = bufKey(id, alias);
     if (unread.value.has(k)) {
@@ -296,6 +294,20 @@ export const useChatStore = defineStore("chat", () => {
       next.delete(k);
       unread.value = next;
     }
+  }
+
+  /** Apply the cached tail for a freshly selected session, unless the selection
+   *  changed or the transcript gained rows (live turn / authoritative history)
+   *  while the read was in flight — those must never be clobbered by a seed. */
+  async function seedFromCache(user: string, id: string, alias: string): Promise<void> {
+    const revision = transcriptRevision;
+    const cached = await tailCache.read(user, id, alias);
+    if (!cached || cached.length === 0) return;
+    if (id !== instanceId.value || alias !== sessionAlias.value) return;
+    if (messages.value.length > 0 || revision !== transcriptRevision) return;
+    messages.value = cached.map(rawStructured);
+    touchTranscript();
+    seededFromCache = true;
   }
 
   /** Drop the active selection back to the empty "no session" state — used when the
@@ -316,6 +328,11 @@ export const useChatStore = defineStore("chat", () => {
   }
 
   async function loadHistory(): Promise<void> {
+    if (!instanceId.value || !sessionAlias.value) return;
+    // Let a cache seed kicked off by select() land first (ms-scale IndexedDB read):
+    // the guards below must observe the seeded transcript, and a hit keeps the
+    // skeleton suppressed during the fetch. No seed → stay synchronous.
+    if (pendingSeed) await pendingSeed;
     if (!instanceId.value || !sessionAlias.value) return;
     const id = instanceId.value;
     const alias = sessionAlias.value;

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -105,9 +105,10 @@ export const useInstancesStore = defineStore("instances", () => {
       if (agentsRes && !isErrorPayload(agentsRes) && Array.isArray(agentsRes.agents)) inst.agents = agentsRes.agents;
     }
     // Tail-cache reconciliation (spec #205): as each instance's authoritative session
-    // list arrives, drop cached transcripts for sessions no longer alive/unarchived —
-    // covers archive/remove performed from other clients while the web was closed.
-    useChatStore().reconcileTailCache(instanceId, sessions.filter((s) => !s.archived).map((s) => s.alias));
+    // list arrives, drop cached transcripts for sessions no longer alive — covers
+    // removals performed from other clients while the web was closed. Sleeping
+    // (archived) sessions stay resumable and keep their cache.
+    useChatStore().reconcileTailCache(instanceId, sessions.map((s) => s.alias));
   }
 
   // Just the workspaces (for the file browser) — lighter than loadFormOptions, which
@@ -271,8 +272,8 @@ export const useInstancesStore = defineStore("instances", () => {
 
   async function removeSession(instanceId: string, alias: string): Promise<void> {
     await api.rpc(instanceId, "control.sessions.remove", { alias });
-    // Event-driven tail-cache purge (spec #205): a session archived/removed here must
-    // never resurface as a ghost transcript from localStorage. Routed through the chat
+    // Event-driven tail-cache purge (spec #205): a removed session must never
+    // resurface as a ghost transcript from the cache. Routed through the chat
     // store so a pending debounced write-back targeting it is cancelled too.
     useChatStore().purgeTailCache(instanceId, alias);
     await loadSessions(instanceId);
@@ -280,7 +281,8 @@ export const useInstancesStore = defineStore("instances", () => {
 
   async function archiveSession(instanceId: string, alias: string): Promise<void> {
     await api.rpc(instanceId, "control.sessions.archive", { alias });
-    useChatStore().purgeTailCache(instanceId, alias);
+    // No cache purge: a sleeping session stays resumable, and its cached tail
+    // lets waking it paint instantly.
     await loadSessions(instanceId);
   }
 


### PR DESCRIPTION
## Summary
- Root cause fix for "heavy sessions still show ~2s skeleton on revisit": the localStorage tail cache skipped the whole session when the final row serialized >256KB (real-world data: lastRowBytes 436KB vs 256KB budget). The IndexedDB store has **no per-row budget** — heavy tool-output rows are cached whole.
- New store: DB `xacpx.chat-tail` / object store `tails`, composite key `[user, instanceId, alias]` (prefix KeyRange for reconcile, dotted aliases need no escaping), `lastAccess` index. 64MB global LRU + 30-day TTL (aligned with hub `historyRetentionDays` default). Legacy `xacpx.chat.tail.*` localStorage keys are lazily swept on first DB open (cache is disposable — no data migration).
- Seeding is now async: `chat.select()` kicks off `pendingSeed`; `loadHistory()` awaits it (ms-scale) before deciding on the skeleton, so cache hits still paint instantly. Logged-out path stays fully synchronous.
- **Sleeping sessions keep their cache**: `archiveSession` no longer purges, reconcile treats archived aliases as alive — waking a slept session paints instantly. `removeSession` and `logout` still purge.
- Never-throw contract: all cache ops try/catch; missing `indexedDB` → read null / silent no-op.
- Tests: `fake-indexeddb` in jsdom setup; tail-cache suites rewritten (28 tests incl. oversized-row regression, LRU/TTL, corrupted-entry, legacy sweep, IDB-unavailable).

## Test plan
- [x] `bun run --cwd packages/relay-web test` — 107 files / 915 tests pass
- [x] root `npx tsc --noEmit`
- [x] `bun run build:relay` (dashboard bundled into hub dist)
- [ ] Manual: heavy session revisit paints instantly; sleeping session revisit instant; delete/logout clear entries; legacy localStorage keys swept