### PR TITLE
fix(relay-web): bind tail cache entries to session incarnation

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -226,9 +226,12 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   flush，写入 fire-and-forget）。存储 = DB `xacpx.chat-tail` / store `tails`，数组主键
   `[user, instanceId, alias]`（reconcile 用前缀 KeyRange，无需转义含点 alias），值含
   `rows`（≤30 条持久化行，剥离 client-only 字段）+ `lastAccess` + `bytes` + `incarnation`
-  （= `SessionDto.transportSession`；chat store 维护由 `loadSessions` 喂的 incarnation 注册表，
-  seed 读/写回都带上，`""` 为通配——**同名重建不复活旧尾部**：read 发现两侧都已知且不等即删条目
-  返 miss，reconcile 也会掉 alias 存活但 incarnation 变了的条目）。淘汰：事件驱动
+  （= `SessionDto.transportSession`；chat store 维护由 `loadSessions` 喂的 incarnation 注册表
+  （对账时同步剪掉死 alias 的注册项），seed 读/写回都带上，`""` 为通配——**同名重建不复活旧尾部**：
+  read 发现两侧都已知且不等即删条目返 miss；`""` 写回保留条目原有标签（刷新后首个 flush 抢跑
+  `loadSessions` 时不降级为通配），reconcile 会把存活会话的 live incarnation 盖到存 `""` 的条目上
+  （adoption），也会掉 alias 存活但 incarnation 变了的条目；选中中观察到同名重建时取消待写回并重拉
+  历史，防止把前任 transcript 打上新 incarnation 回写）。淘汰：事件驱动
   （`removeSession` → chat store `purgeTailCache`（drop + 取消待写回 + 清注册表项），`auth.logout` →
   `dropAll`；**睡眠不清缓存**——归档语义是可唤醒，缓存保留）、对账（`loadSessions` 落地后
   `reconcileTailCache` 掉该实例非存活 alias 或 incarnation 不匹配的条目，含睡眠中的都算存活——

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -225,11 +225,15 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   收敛（key 稳定无闪烁）。成功加载与 turn-finished 后防抖写回（`debounce-flush`，切会话时
   flush，写入 fire-and-forget）。存储 = DB `xacpx.chat-tail` / store `tails`，数组主键
   `[user, instanceId, alias]`（reconcile 用前缀 KeyRange，无需转义含点 alias），值含
-  `rows`（≤30 条持久化行，剥离 client-only 字段）+ `lastAccess` + `bytes`。淘汰：事件驱动
-  （`removeSession` → chat store `purgeTailCache`（drop + 取消待写回），`auth.logout` →
+  `rows`（≤30 条持久化行，剥离 client-only 字段）+ `lastAccess` + `bytes` + `incarnation`
+  （= `SessionDto.transportSession`；chat store 维护由 `loadSessions` 喂的 incarnation 注册表，
+  seed 读/写回都带上，`""` 为通配——**同名重建不复活旧尾部**：read 发现两侧都已知且不等即删条目
+  返 miss，reconcile 也会掉 alias 存活但 incarnation 变了的条目）。淘汰：事件驱动
+  （`removeSession` → chat store `purgeTailCache`（drop + 取消待写回 + 清注册表项），`auth.logout` →
   `dropAll`；**睡眠不清缓存**——归档语义是可唤醒，缓存保留）、对账（`loadSessions` 落地后
-  `reconcileTailCache` 掉该实例非存活 alias，含睡眠中的都算存活——覆盖 Web 关闭期间其他端的
-  删除）、兜底（全局 64MB 按 `lastAccess` LRU 淘汰、30 天 TTL 惰性过期；**无单条预算**——
+  `reconcileTailCache` 掉该实例非存活 alias 或 incarnation 不匹配的条目，含睡眠中的都算存活——
+  覆盖 Web 关闭期间其他端的删除/同名重建）、兜底（全局 64MB 按 `lastAccess` LRU 淘汰、30 天 TTL
+  惰性过期；**无单条预算**——
   重工具输出的大行也整会话缓存）。首次打开 DB 时懒清扫旧版 localStorage 键
   （`xacpx.chat.tail.*` / `xacpx.chat.tail-index.*`，不迁数据）。所有操作 try/catch +
   `indexedDB` 缺失兼容：read 返回 null、其余静默 no-op（缓存永不成为错误源）。

--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -195,6 +195,57 @@ test("a same-alias recreation from another client does not resurrect the old tai
   expect(chat.messages).toEqual([]);
 });
 
+const sessionsListOf = (transportSession: string) => async (_id: string, type: string) =>
+  type === "control.sessions.list"
+    ? { sessions: [{ alias: "s1", agent: "a", workspace: "w", transportSession, running: false, archived: false }] }
+    : { agents: [] };
+
+test("the debounced write-back carries the session's registered incarnation", async () => {
+  rpc.mockImplementation(sessionsListOf("t-A"));
+  await useInstancesStore().loadSessions("i1"); // registry: s1 → t-A
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
+  await chat.loadHistory();
+  chat.select("i1", "other"); // flush the pending write-back
+  expect(await readEventually("alice", "i1", "s1")).not.toBeNull();
+  // Stored tag must be t-A, not the wildcard: a mismatching read misses.
+  expect(await read("alice", "i1", "s1", "t-B")).toBeNull();
+});
+
+test("select() does not seed a cached tail whose incarnation predates the live session", async () => {
+  rpc.mockImplementation(sessionsListOf("t-new"));
+  await useInstancesStore().loadSessions("i1"); // registry: s1 → t-new
+  // Entry lands after reconcile ran (e.g. written by a tab with a stale registry).
+  await write("alice", "i1", "s1", [row(1, "pre-delete")], "t-old");
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  await new Promise((r) => setTimeout(r, 20));
+  expect(chat.messages).toEqual([]);
+});
+
+test("a recreation observed while selected cancels the pending write-back (no re-poisoning)", async () => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  try {
+    rpc.mockImplementation(sessionsListOf("t-old"));
+    await useInstancesStore().loadSessions("i1"); // registry: s1 → t-old
+    const chat = useChatStore();
+    chat.select("i1", "s1");
+    getMock.mockResolvedValue({ messages: [row(1, "pre-delete")], hasMore: false });
+    await chat.loadHistory(); // schedules the debounced write-back
+    // Other client deletes + recreates s1; the refetch stays pending so the only
+    // write that COULD land is the poisoned predecessor flush.
+    getMock.mockReturnValue(new Promise(() => {}));
+    rpc.mockImplementation(sessionsListOf("t-new"));
+    await useInstancesStore().loadSessions("i1"); // must cancel the pending flush
+    vi.advanceTimersByTime(500); // the cancelled timer must not fire
+  } finally {
+    vi.useRealTimers();
+  }
+  await new Promise((r) => setTimeout(r, 30));
+  expect(await read("alice", "i1", "s1")).toBeNull();
+});
+
 test("logout drops every cached transcript (all users) plus legacy localStorage keys", async () => {
   await write("alice", "i1", "s1", [row(1)]);
   await write("bob", "i2", "s9", [row(2)]);

--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -174,6 +174,27 @@ test("loadSessions reconciles the cache against alive aliases, keeping sleeping 
   expect(await read("alice", "i1", "sleeping")).not.toBeNull(); // slept elsewhere → kept
 });
 
+test("a same-alias recreation from another client does not resurrect the old tail", async () => {
+  // Old tail cached under incarnation t-old (e.g. before the browser was closed).
+  await write("alice", "i1", "s1", [row(1, "pre-delete")], "t-old");
+  rpc.mockImplementation(async (_id: string, type: string) => {
+    if (type === "control.sessions.list") {
+      return { sessions: [
+        // Same alias, new transport incarnation: deleted + recreated elsewhere.
+        { alias: "s1", agent: "a", workspace: "w", transportSession: "t-new", running: false, archived: false },
+      ] };
+    }
+    return { agents: [] };
+  });
+  await useInstancesStore().loadSessions("i1");
+  expect(await goneEventually("alice", "i1", "s1")).toBe(true); // old incarnation dropped
+  // Selecting the recreated session must not seed the deleted predecessor's rows.
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  await new Promise((r) => setTimeout(r, 20));
+  expect(chat.messages).toEqual([]);
+});
+
 test("logout drops every cached transcript (all users) plus legacy localStorage keys", async () => {
   await write("alice", "i1", "s1", [row(1)]);
   await write("bob", "i2", "s9", [row(2)]);

--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -246,6 +246,32 @@ test("a recreation observed while selected cancels the pending write-back (no re
   expect(await read("alice", "i1", "s1")).toBeNull();
 });
 
+test("first loadSessions after a wildcard seed cancels a live-turn flush (predecessor suspect)", async () => {
+  // Fresh page: registry empty, so the seed is a wildcard read of what may be a
+  // deleted predecessor's tail.
+  await write("alice", "i1", "s1", [row(1, "pre-delete")], "t-old");
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  await vi.waitFor(() => expect(chat.messages.map((m) => m.text)).toEqual(["pre-delete"]));
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  try {
+    getMock.mockReturnValue(new Promise(() => {})); // convergence refetches stay pending
+    // A live turn flushes onto the seeded transcript and schedules a write-back.
+    chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "s1", chunk: "live" } });
+    chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "s1", ok: true } });
+    // The FIRST loadSessions reveals the session was recreated (t-new).
+    rpc.mockImplementation(sessionsListOf("t-new"));
+    await useInstancesStore().loadSessions("i1"); // must cancel the suspect flush
+    vi.advanceTimersByTime(500);
+  } finally {
+    vi.useRealTimers();
+  }
+  await new Promise((r) => setTimeout(r, 30));
+  // reconcile dropped the t-old entry; the cancelled flush must not write the
+  // predecessor rows back under t-new.
+  expect(await read("alice", "i1", "s1")).toBeNull();
+});
+
 test("logout drops every cached transcript (all users) plus legacy localStorage keys", async () => {
   await write("alice", "i1", "s1", [row(1)]);
   await write("bob", "i2", "s9", [row(2)]);

--- a/packages/relay-web/src/__tests__/session-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/session-tail-cache.test.ts
@@ -137,7 +137,7 @@ describe("session-tail-cache", () => {
     await write("alice", "i1", "s2", [row(2)]);
     await write("alice", "i2", "s2", [row(3)]);
     await write("bob", "i1", "s2", [row(4)]);
-    await reconcile("alice", "i1", ["s1"]);
+    await reconcile("alice", "i1", [{ alias: "s1" }]);
     expect(await read("alice", "i1", "s1")).not.toBeNull();
     expect(await read("alice", "i1", "s2")).toBeNull(); // dead alias dropped
     expect(await read("alice", "i2", "s2")).not.toBeNull(); // other instance untouched
@@ -147,9 +147,38 @@ describe("session-tail-cache", () => {
   it("handles dotted aliases/instance ids without cross-matching in reconcile", async () => {
     await write("alice", "i.1", "a.b", [row(1)]);
     await write("alice", "i.1", "a.b.c", [row(2)]);
-    await reconcile("alice", "i.1", ["a.b"]);
+    await reconcile("alice", "i.1", [{ alias: "a.b" }]);
     expect(await read("alice", "i.1", "a.b")).not.toBeNull();
     expect(await read("alice", "i.1", "a.b.c")).toBeNull();
+  });
+
+  it("read misses (and deletes) when the stored incarnation mismatches", async () => {
+    await write("alice", "i1", "s1", [row(1)], "inc-A");
+    expect(await read("alice", "i1", "s1", "inc-B")).toBeNull();
+    // Entry was deleted — even a wildcard read stays a miss now.
+    expect(await read("alice", "i1", "s1")).toBeNull();
+  });
+
+  it("treats an unknown incarnation (\"\") as a wildcard in both directions", async () => {
+    await write("alice", "i1", "s1", [row(1)], "inc-A");
+    expect(await read("alice", "i1", "s1", "")).not.toBeNull(); // reader doesn't know yet
+    await write("alice", "i1", "s2", [row(2)]); // writer didn't know
+    expect(await read("alice", "i1", "s2", "inc-B")).not.toBeNull();
+    expect(await read("alice", "i1", "s1", "inc-A")).not.toBeNull(); // exact match hits
+  });
+
+  it("reconcile drops an alive alias whose incarnation changed (same-alias recreation)", async () => {
+    await write("alice", "i1", "s1", [row(1)], "inc-old");
+    await write("alice", "i1", "s2", [row(2)], "inc-keep");
+    await write("alice", "i1", "s3", [row(3)]); // stored incarnation unknown
+    await reconcile("alice", "i1", [
+      { alias: "s1", incarnation: "inc-new" },
+      { alias: "s2", incarnation: "inc-keep" },
+      { alias: "s3", incarnation: "inc-x" },
+    ]);
+    expect(await read("alice", "i1", "s1")).toBeNull(); // recreated → old tail dropped
+    expect(await read("alice", "i1", "s2")).not.toBeNull(); // same incarnation kept
+    expect(await read("alice", "i1", "s3")).not.toBeNull(); // unknown stored → kept
   });
 
   it("sweeps legacy localStorage keys once on first use", async () => {
@@ -170,7 +199,7 @@ describe("session-tail-cache", () => {
       await expect(write("alice", "i1", "s1", [row(1)])).resolves.toBeUndefined();
       await expect(drop("alice", "i1", "s1")).resolves.toBeUndefined();
       await expect(dropAll()).resolves.toBeUndefined();
-      await expect(reconcile("alice", "i1", ["s1"])).resolves.toBeUndefined();
+      await expect(reconcile("alice", "i1", [{ alias: "s1" }])).resolves.toBeUndefined();
     } finally {
       vi.unstubAllGlobals();
     }

--- a/packages/relay-web/src/__tests__/session-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/session-tail-cache.test.ts
@@ -181,6 +181,21 @@ describe("session-tail-cache", () => {
     expect(await read("alice", "i1", "s3")).not.toBeNull(); // unknown stored → kept
   });
 
+  it("a wildcard (\"\") write preserves the entry's previously stored incarnation", async () => {
+    await write("alice", "i1", "s1", [row(1)], "inc-A");
+    // e.g. the first flush after a page refresh, before loadSessions lands.
+    await write("alice", "i1", "s1", [row(2)], "");
+    expect((await read("alice", "i1", "s1", "inc-A"))!.map((r) => r.id)).toEqual([2]); // fresh rows, old tag
+    expect(await read("alice", "i1", "s1", "inc-B")).toBeNull(); // tag not downgraded to wildcard
+  });
+
+  it("reconcile stamps the live incarnation onto stored-\"\" entries (adoption)", async () => {
+    await write("alice", "i1", "s1", [row(1)]);
+    await reconcile("alice", "i1", [{ alias: "s1", incarnation: "inc-A" }]);
+    expect(await read("alice", "i1", "s1", "inc-A")).not.toBeNull();
+    expect(await read("alice", "i1", "s1", "inc-B")).toBeNull(); // adopted → recreation now detectable
+  });
+
   it("sweeps legacy localStorage keys once on first use", async () => {
     localStorage.setItem("xacpx.chat.tail.v1.alice.i1.s1", "[]");
     localStorage.setItem("xacpx.chat.tail-index.v1", "[]");

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -204,6 +204,17 @@ async function putAndEvict(db: IDBDatabase, record: TailRecord, now: number): Pr
   const tx = db.transaction(STORE, "readwrite");
   try {
     const store = tx.objectStore(STORE);
+    // A write-back that doesn't know the incarnation yet ("" — e.g. the first
+    // flush after a page refresh, racing loadSessions) must not downgrade the
+    // entry's stored identity to the wildcard: preserve the previous tag.
+    if (record.incarnation === "") {
+      const prev = await asPromise<TailRecord | undefined>(
+        store.get(keyOf(record.user, record.instanceId, record.alias)) as IDBRequest<TailRecord | undefined>,
+      );
+      if (typeof prev?.incarnation === "string" && prev.incarnation !== "") {
+        record = { ...record, incarnation: prev.incarnation };
+      }
+    }
     store.put(record);
     // One ascending-lastAccess pass: drop expired entries, then LRU-evict others
     // while the total exceeds the budget (the fresh write is never a victim).
@@ -290,7 +301,9 @@ export type AliveSession = { alias: string; incarnation?: string };
 /** Drop cached entries for an instance whose alias is not alive, or whose
  *  incarnation no longer matches the live session (same-alias recreation) —
  *  covers removals/recreations performed from other clients while the web was
- *  closed. Called as each instance's authoritative session list arrives. */
+ *  closed. Entries stored with an unknown ("") incarnation adopt the live one,
+ *  so a later recreation is detectable even if the session is never revisited.
+ *  Called as each instance's authoritative session list arrives. */
 export async function reconcile(user: string, instanceId: string, aliveSessions: Iterable<AliveSession>): Promise<void> {
   try {
     const alive = new Map<string, string>();
@@ -303,6 +316,7 @@ export async function reconcile(user: string, instanceId: string, aliveSessions:
     // instance's entries. The KEY cursor exposes alias + stored incarnation
     // (index key) and the primary key — no row payloads are materialized.
     const range = IDBKeyRange.bound([user, instanceId], [user, instanceId, []], false, true);
+    const adopt: Array<[IDBValidKey, string]> = [];
     await new Promise<void>((resolve, reject) => {
       const req = store.index("identity").openKeyCursor(range);
       req.onsuccess = () => {
@@ -311,10 +325,15 @@ export async function reconcile(user: string, instanceId: string, aliveSessions:
         const [, , alias, stored] = cursor.key as [string, string, string, string];
         const live = alive.get(alias);
         if (live === undefined || incarnationMismatch(stored, live)) store.delete(cursor.primaryKey);
+        else if (stored === "" && live !== "") adopt.push([cursor.primaryKey, live]);
         cursor.continue();
       };
       req.onerror = () => reject(req.error ?? new Error("cursor-failed"));
     });
+    for (const [pk, live] of adopt) {
+      const rec = await asPromise<TailRecord | undefined>(store.get(pk) as IDBRequest<TailRecord | undefined>);
+      if (rec) store.put({ ...rec, incarnation: live });
+    }
     await txDone(tx);
   } catch { /* best-effort */ }
 }

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -266,6 +266,8 @@ export async function write(user: string, instanceId: string, alias: string, row
       const clearTx = db.transaction(STORE, "readwrite");
       clearTx.objectStore(STORE).clear();
       await txDone(clearTx);
+      // The retry writes the caller's (possibly "") incarnation as-is: clear()
+      // just wiped any previous tag, and the next reconcile adopts the live one.
       const retryTx = db.transaction(STORE, "readwrite");
       retryTx.objectStore(STORE).put(record);
       await txDone(retryTx);

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -15,7 +15,10 @@ import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
 
 const DB_NAME = "xacpx.chat-tail";
 // v2: the [lastAccess, bytes] "lru" index replaced the plain lastAccess index.
-const DB_VERSION = 2;
+// v3: records carry the session incarnation (SessionDto.transportSession) plus
+// an "identity" index — a same-alias recreation must not resurrect the deleted
+// predecessor's tail.
+const DB_VERSION = 3;
 const STORE = "tails";
 
 export const TAIL_ROWS = 30;
@@ -31,7 +34,14 @@ type TailRecord = {
   rows: MessageRecordDto[];
   lastAccess: number;
   bytes: number;
+  /** Transport incarnation at write time; "" when unknown (matches anything).
+   *  Always a string so the identity index covers every record. */
+  incarnation: string;
 };
+
+/** Both sides known and different → the cached rows belong to a same-alias
+ *  predecessor session. Unknown ("") on either side matches anything. */
+const incarnationMismatch = (a: string, b: string): boolean => a !== "" && b !== "" && a !== b;
 
 const keyOf = (user: string, instanceId: string, alias: string): [string, string, string] =>
   [user, instanceId, alias];
@@ -68,6 +78,9 @@ function openDb(): Promise<IDBDatabase> {
       // Composite [lastAccess, bytes] index: a key-cursor walk yields both LRU
       // order and byte accounting without ever deserializing `rows`.
       store.createIndex("lru", ["lastAccess", "bytes"]);
+      // Identity index: reconcile checks alias liveness AND incarnation match
+      // via a key cursor — again without materializing any rows.
+      store.createIndex("identity", ["user", "instanceId", "alias", "incarnation"]);
     };
     let blocked = false;
     req.onsuccess = () => {
@@ -109,9 +122,10 @@ export async function resetTailCacheForTests(): Promise<void> {
   if (p) { try { (await p).close(); } catch { /* already broken */ } }
 }
 
-/** Read the cached tail for a session, or null on miss/expiry/corruption.
- *  A hit refreshes the entry's lastAccess (LRU touch). */
-export async function read(user: string, instanceId: string, alias: string): Promise<MessageRecordDto[] | null> {
+/** Read the cached tail for a session, or null on miss/expiry/corruption or an
+ *  incarnation mismatch (rows from a deleted same-alias predecessor). A hit
+ *  refreshes the entry's lastAccess (LRU touch). */
+export async function read(user: string, instanceId: string, alias: string, incarnation = ""): Promise<MessageRecordDto[] | null> {
   try {
     const db = await openDb();
     const key = keyOf(user, instanceId, alias);
@@ -123,10 +137,12 @@ export async function read(user: string, instanceId: string, alias: string): Pro
     );
     const now = Date.now();
     const rows = record?.rows;
-    // Expired or corrupted entries (non-array, empty, or non-object elements) are
-    // dropped here — the cache must never become an error source downstream.
+    // Expired, corrupted (non-array, empty, or non-object elements) or
+    // predecessor-incarnation entries are dropped here — the cache must never
+    // become an error source downstream.
     const valid = record !== undefined
       && now - record.lastAccess <= TTL_MS
+      && !incarnationMismatch(typeof record.incarnation === "string" ? record.incarnation : "", incarnation)
       && Array.isArray(rows) && rows.length > 0
       && !rows.some((r) => typeof r !== "object" || r === null);
     if (!valid) {
@@ -212,7 +228,7 @@ async function putAndEvict(db: IDBDatabase, record: TailRecord, now: number): Pr
 /** Cache the tail of `rows` for a session: the last ≤30 persisted rows
  *  (id !== undefined). Expired entries and LRU victims beyond the global
  *  budget are pruned in the same transaction. */
-export async function write(user: string, instanceId: string, alias: string, rows: MessageRecordDto[]): Promise<void> {
+export async function write(user: string, instanceId: string, alias: string, rows: MessageRecordDto[], incarnation = ""): Promise<void> {
   try {
     // Snapshot synchronously — the caller's `rows` may mutate while IDB awaits.
     const tail = rows.filter((r) => typeof r.id === "number").slice(-TAIL_ROWS).map(toCachedRow);
@@ -227,7 +243,7 @@ export async function write(user: string, instanceId: string, alias: string, row
     const now = Date.now();
     // Serialized length ≈ UTF-16 code units; ×2 approximates the storage bytes.
     const bytes = JSON.stringify(tail).length * 2;
-    const record: TailRecord = { user, instanceId, alias, rows: tail, lastAccess: now, bytes };
+    const record: TailRecord = { user, instanceId, alias, rows: tail, lastAccess: now, bytes, incarnation };
     try {
       await putAndEvict(db, record, now);
     } catch (err) {
@@ -269,23 +285,36 @@ export async function dropAll(): Promise<void> {
   } catch { /* best-effort */ }
 }
 
-/** Drop cached entries for an instance whose alias is not in `aliveAliases` —
- *  covers sessions removed from other clients while the web was closed.
- *  Called as each instance's authoritative session list arrives. */
-export async function reconcile(user: string, instanceId: string, aliveAliases: Iterable<string>): Promise<void> {
+export type AliveSession = { alias: string; incarnation?: string };
+
+/** Drop cached entries for an instance whose alias is not alive, or whose
+ *  incarnation no longer matches the live session (same-alias recreation) —
+ *  covers removals/recreations performed from other clients while the web was
+ *  closed. Called as each instance's authoritative session list arrives. */
+export async function reconcile(user: string, instanceId: string, aliveSessions: Iterable<AliveSession>): Promise<void> {
   try {
-    const alive = new Set(aliveAliases);
+    const alive = new Map<string, string>();
+    for (const s of aliveSessions) alive.set(s.alias, s.incarnation ?? "");
     const db = await openDb();
     const tx = db.transaction(STORE, "readwrite");
     const store = tx.objectStore(STORE);
-    // [user, instanceId] prefix range: an array upper bound sorts after every
-    // string alias, so this spans exactly the instance's entries.
+    // [user, instanceId] prefix range over the identity index: an array upper
+    // bound sorts after every string alias, so this spans exactly the
+    // instance's entries. The KEY cursor exposes alias + stored incarnation
+    // (index key) and the primary key — no row payloads are materialized.
     const range = IDBKeyRange.bound([user, instanceId], [user, instanceId, []], false, true);
-    const keys = await asPromise(store.getAllKeys(range));
-    for (const k of keys) {
-      const alias = (k as [string, string, string])[2];
-      if (!alive.has(alias)) store.delete(k);
-    }
+    await new Promise<void>((resolve, reject) => {
+      const req = store.index("identity").openKeyCursor(range);
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (!cursor) { resolve(); return; }
+        const [, , alias, stored] = cursor.key as [string, string, string, string];
+        const live = alive.get(alias);
+        if (live === undefined || incarnationMismatch(stored, live)) store.delete(cursor.primaryKey);
+        cursor.continue();
+      };
+      req.onerror = () => reject(req.error ?? new Error("cursor-failed"));
+    });
     await txDone(tx);
   } catch { /* best-effort */ }
 }

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -188,6 +188,13 @@ export const useChatStore = defineStore("chat", () => {
     return t;
   }
 
+  // Known transport incarnations (SessionDto.transportSession) per session, fed
+  // by each instance's authoritative session list (reconcileTailCache). Binds
+  // cache entries to the session's identity: a same-alias recreation must not
+  // resurrect the deleted predecessor's tail. "" = not yet known (matches any).
+  const sessionIncarnations = new Map<string, string>();
+  const incarnationOf = (id: string, alias: string): string => sessionIncarnations.get(bufKey(id, alias)) ?? "";
+
   // Stale-while-revalidate tail cache (#205): select() kicks off an async seed
   // from IndexedDB (pendingSeed below); authoritative rows (loadHistory) are
   // written back debounced so bursty turn-finished convergence doesn't hammer
@@ -196,7 +203,7 @@ export const useChatStore = defineStore("chat", () => {
   const cacheWrite = createDebouncedFlush(() => {
     const user = useAuthStore().account?.username;
     if (!user || !instanceId.value || !sessionAlias.value) return;
-    void tailCache.write(user, instanceId.value, sessionAlias.value, messages.value);
+    void tailCache.write(user, instanceId.value, sessionAlias.value, messages.value, incarnationOf(instanceId.value, sessionAlias.value));
   }, 500);
   // Best-effort: an IDB write started during unload may not commit (unlike the
   // old synchronous localStorage flush); loadHistory converges on the next visit.
@@ -219,16 +226,21 @@ export const useChatStore = defineStore("chat", () => {
    *  archive/remove would fire after the drop and resurrect the entry as a ghost. */
   function purgeTailCache(id: string, alias: string): void {
     if (instanceId.value === id && sessionAlias.value === alias) cacheWrite.cancel();
+    sessionIncarnations.delete(bufKey(id, alias));
     const user = useAuthStore().account?.username;
     if (user) void tailCache.drop(user, id, alias);
   }
 
   /** Reconcile an instance's cached tails against its authoritative alive
-   *  aliases (see purgeTailCache for why this lives on the chat store). */
-  function reconcileTailCache(id: string, aliveAliases: string[]): void {
-    if (instanceId.value === id && sessionAlias.value !== null && !aliveAliases.includes(sessionAlias.value)) cacheWrite.cancel();
+   *  sessions (alias + incarnation), refreshing the incarnation registry along
+   *  the way (see purgeTailCache for why this lives on the chat store). */
+  function reconcileTailCache(id: string, alive: tailCache.AliveSession[]): void {
+    for (const s of alive) {
+      if (s.incarnation) sessionIncarnations.set(bufKey(id, s.alias), s.incarnation);
+    }
+    if (instanceId.value === id && sessionAlias.value !== null && !alive.some((s) => s.alias === sessionAlias.value)) cacheWrite.cancel();
     const user = useAuthStore().account?.username;
-    if (user) void tailCache.reconcile(user, id, aliveAliases);
+    if (user) void tailCache.reconcile(user, id, alive);
   }
 
   /** Finalize a live turn: clear it (so `busy`/HUD release) and, if it streamed any
@@ -303,7 +315,7 @@ export const useChatStore = defineStore("chat", () => {
    *  while the read was in flight — those must never be clobbered by a seed. */
   async function seedFromCache(user: string, id: string, alias: string): Promise<void> {
     const revision = transcriptRevision;
-    const cached = await tailCache.read(user, id, alias);
+    const cached = await tailCache.read(user, id, alias, incarnationOf(id, alias));
     if (!cached || cached.length === 0) return;
     if (id !== instanceId.value || alias !== sessionAlias.value) return;
     if (messages.value.length > 0 || revision !== transcriptRevision) return;

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -232,13 +232,34 @@ export const useChatStore = defineStore("chat", () => {
   }
 
   /** Reconcile an instance's cached tails against its authoritative alive
-   *  sessions (alias + incarnation), refreshing the incarnation registry along
-   *  the way (see purgeTailCache for why this lives on the chat store). */
+   *  sessions (alias + incarnation), keeping the incarnation registry in sync
+   *  (see purgeTailCache for why this lives on the chat store). */
   function reconcileTailCache(id: string, alive: tailCache.AliveSession[]): void {
+    const aliveByAlias = new Map(alive.map((s) => [s.alias, s.incarnation ?? ""]));
+    if (instanceId.value === id && sessionAlias.value !== null) {
+      const incoming = aliveByAlias.get(sessionAlias.value);
+      if (incoming === undefined) {
+        cacheWrite.cancel();
+      } else {
+        // Same-alias recreation observed WHILE selected: the pane still shows the
+        // predecessor's transcript, so a pending debounced write-back would
+        // re-poison the cache under the NEW incarnation. Cancel it and refetch.
+        const prev = incarnationOf(id, sessionAlias.value);
+        if (prev !== "" && incoming !== "" && prev !== incoming) {
+          cacheWrite.cancel();
+          void loadHistory();
+        }
+      }
+    }
+    // Refresh the registry, pruning this instance's dead aliases so a stale
+    // incarnation cannot outlive its session.
+    const prefix = bufKey(id, "");
+    for (const key of sessionIncarnations.keys()) {
+      if (key.startsWith(prefix) && !aliveByAlias.has(key.slice(prefix.length))) sessionIncarnations.delete(key);
+    }
     for (const s of alive) {
       if (s.incarnation) sessionIncarnations.set(bufKey(id, s.alias), s.incarnation);
     }
-    if (instanceId.value === id && sessionAlias.value !== null && !alive.some((s) => s.alias === sessionAlias.value)) cacheWrite.cancel();
     const user = useAuthStore().account?.username;
     if (user) void tailCache.reconcile(user, id, alive);
   }

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -215,6 +215,12 @@ export const useChatStore = defineStore("chat", () => {
   // fetching over it clobbers nothing), cleared by the first authoritative replace
   // or any local push.
   let seededFromCache = false;
+  // True while ANY wildcard-seeded rows remain in the transcript (a live-turn
+  // flush appends but does not remove them; only an authoritative replace or a
+  // selection reset does). Unlike seededFromCache this survives flushTurn — it
+  // marks the transcript as a possible predecessor tail for the recreation
+  // guard in reconcileTailCache.
+  let seedRowsPresent = false;
   // The in-flight cache seed for the current selection (null when none was kicked
   // off) — loadHistory awaits it so its guards observe the seeded transcript
   // before deciding to fetch/skeleton.
@@ -244,10 +250,13 @@ export const useChatStore = defineStore("chat", () => {
         // Same-alias recreation observed WHILE selected: the pane still shows the
         // predecessor's transcript, so a pending debounced write-back would
         // re-poison the cache under the NEW incarnation. Cancel it and refetch.
+        // A still-unknown prev ("") counts as suspect while wildcard-seeded rows
+        // remain in the transcript — the seed may be the predecessor's tail.
         const prev = incarnationOf(id, sessionAlias.value);
-        if (prev !== "" && incoming !== "" && prev !== incoming) {
+        const recreated = prev !== "" && incoming !== "" && prev !== incoming;
+        if (recreated || (prev === "" && incoming !== "" && seedRowsPresent)) {
           cacheWrite.cancel();
-          void loadHistory();
+          if (recreated) void loadHistory().catch(() => {});
         }
       }
     }
@@ -321,6 +330,7 @@ export const useChatStore = defineStore("chat", () => {
     // page arrives; stable p${id} row keys make that replace flicker-free.
     const user = useAuthStore().account?.username;
     seededFromCache = false;
+    seedRowsPresent = false;
     pendingSeed = user ? seedFromCache(user, id, alias) : null;
     // Viewing a session clears its unread signal.
     const k = bufKey(id, alias);
@@ -343,6 +353,7 @@ export const useChatStore = defineStore("chat", () => {
     messages.value = cached.map(rawStructured);
     touchTranscript();
     seededFromCache = true;
+    seedRowsPresent = true;
   }
 
   /** Drop the active selection back to the empty "no session" state — used when the
@@ -350,6 +361,7 @@ export const useChatStore = defineStore("chat", () => {
   function clearSelection(): void {
     cacheWrite.flush();
     seededFromCache = false;
+    seedRowsPresent = false;
     pendingSeed = null;
     instanceId.value = null;
     sessionAlias.value = null;
@@ -413,6 +425,7 @@ export const useChatStore = defineStore("chat", () => {
       messages.value = rows.map(rawStructured);
       touchTranscript();
       seededFromCache = false;
+      seedRowsPresent = false;
       hasMoreOlder.value = hasMore ?? false;
       // Authoritative rows landed — refresh this session's cached tail (debounced).
       cacheWrite.schedule();

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -105,10 +105,11 @@ export const useInstancesStore = defineStore("instances", () => {
       if (agentsRes && !isErrorPayload(agentsRes) && Array.isArray(agentsRes.agents)) inst.agents = agentsRes.agents;
     }
     // Tail-cache reconciliation (spec #205): as each instance's authoritative session
-    // list arrives, drop cached transcripts for sessions no longer alive — covers
-    // removals performed from other clients while the web was closed. Sleeping
-    // (archived) sessions stay resumable and keep their cache.
-    useChatStore().reconcileTailCache(instanceId, sessions.map((s) => s.alias));
+    // list arrives, drop cached transcripts for sessions no longer alive or whose
+    // transport incarnation changed (same-alias recreation) — covers removals
+    // performed from other clients while the web was closed. Sleeping (archived)
+    // sessions stay resumable and keep their cache.
+    useChatStore().reconcileTailCache(instanceId, sessions.map((s) => ({ alias: s.alias, incarnation: s.transportSession })));
   }
 
   // Just the workspaces (for the file browser) — lighter than loadFormOptions, which


### PR DESCRIPTION
## Summary
- 同名重建不复活旧尾部：tail cache 记录新增 `incarnation` 字段（= `SessionDto.transportSession`），read 发现两侧已知且不等即删条目返 miss；reconcile 用新的 `identity` key-cursor 索引同时掉「alias 不存活」与「alias 存活但 incarnation 变了」的条目。
- chat store 维护由 `loadSessions` 喂的 incarnation 注册表（避免 chat↔instances 循环依赖），seed 读与防抖写回都带上；`""` 为通配（未知时行为不变）。
- `DB_VERSION` 升 3：升级时 drop+recreate store（缓存本就 disposable），保证索引布局一致。
- 已知局限：浏览器重开后、`loadSessions` 落地前的首次 select 仍以通配 seed（可能一闪旧尾部），reconcile 落地即删除不匹配条目，之后干净。

复现场景（用户报告）：A 浏览器缓存了 `xacpx-codex` 尾部 → B 端删除并同 workspace 同名重建 → A 重开切到该会话，会短暂看到删除前的记录。

## Test plan
- [x] `vue-tsc --noEmit`（relay-web）+ 根 `tsc --noEmit`
- [x] 新增单测：read incarnation 不匹配删条目、`""` 双向通配、reconcile 掉 incarnation 变更条目/保留未知条目
- [x] 新增集成测：另一端同名重建后 `loadSessions` → 旧尾部被删，select 不 seed 旧行
- [x] relay-web 全量 107 files / 920 tests 通过