### PR TITLE
fix(relay-web): keep narrative text continuous

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -102,8 +102,9 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
 - 异步 Agent 的 `async_launched` 只代表启动成功，父步骤保持 `running`；transport 装饰器在 ACP 结束后继续跟踪 Claude
   主 transcript，并递归增量读取 `<sessionId>/subagents/**/agent-*.jsonl`。后台任务真正完成、主 Agent 续写结束后才转为
   `success`；失败通知会把父 Agent 及仍在运行的子步骤收敛为 `error`。
-- `TurnParts.vue` 保留原始有序 parts，仅在展示层按 `parentToolCallId` 把子工具归入对应 Agent，旧历史里没有父子字段的工具
-  仍按普通卡片渲染。
+- `TurnParts.vue` 保留原始有序 parts，但展示时分为两条视觉通道：推理/工具按原相对顺序组成活动区，
+  所有 text part 拼回一个连续 Markdown 文档，避免工具事件切断段落、列表或代码围栏；同时按
+  `parentToolCallId` 把子工具归入对应 Agent，旧历史里没有父子字段的工具仍按普通卡片渲染。
 - `SubagentStepCard.vue` 以 `children.length > 0` 判定是否具备真实 trace（provider 无关，仅看数据是否到达）。
   有 trace：默认折叠、运行中轮播当前活动步骤，展开后显示紧凑时间线与 `traceCount`。无 trace：折叠行显示 `detail.output`
   尾行（回退到 prompt）、运行时长与“{ago} 前更新”心跳；展开显示委派 prompt 折叠行 + 输出块（运行中为定高、贴底滚动的

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -468,7 +468,8 @@ export interface LiveTurn {
 **`MessageList.vue` 渲染**（`packages/relay-web/src/components/MessageList.vue`）
 
 - 历史 `out` 消息正文始终展开，复制、时间及失败/停止状态保持可见；消息本身没有折叠开关。
-- `structured.parts` 由 `TurnParts` 按到达顺序渲染：文本直接显示，`ToolStepCard` 与 `ReasoningPanel` 默认折叠；实时 streaming 行遵循同一规则。
+- `structured.parts` 由 `TurnParts` 分成两条视觉通道：`ToolStepCard` 与 `ReasoningPanel`
+  按活动间的到达顺序组成默认折叠的活动区，所有文本拼成一个连续 Markdown 文档；实时 streaming 行遵循同一规则。
 - 旧历史没有 `parts` 时回退到聚合 `ToolCallPanel` + markdown/reasoning，其中工具面板与 reasoning 同样默认折叠。
 
 ## 消息附件（图片 / 文件上传）

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -157,9 +157,9 @@ export interface ToolStepDto {
   error?: string;
 }
 
-/** One entry in a turn's transcript, ordered as the agent produced it. Lets the web
- *  render text / reasoning / tool calls inline in arrival order instead of bucketing
- *  them into separate aggregated panels. */
+/** One entry in a turn's ordered wire transcript, retained for transport and
+ *  persistence. Presentation layers may derive separate activity and continuous
+ *  narrative lanes while preserving the relative order within each lane. */
 export type TurnPartDto =
   | { type: "text"; text: string }
   | { type: "reasoning"; text: string }

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -151,7 +151,7 @@ describe("MessageList", () => {
     const bubble = wrapper.find('[data-test="msg-streaming"]');
     expect(bubble.exists()).toBe(true);
     expect(bubble.html()).toContain("<strong>important</strong>");
-    expect(bubble.find(".caret").exists()).toBe(true);
+    expect(bubble.find(".stream-md.caret").exists()).toBe(true);
   });
 
   it("keeps live narrative continuous when activity arrives between text chunks", () => {
@@ -207,6 +207,22 @@ describe("MessageList", () => {
     const bubble = wrapper.find('[data-test="msg-streaming"]');
     expect(bubble.find('[data-test="reasoning-shimmer"]').exists()).toBe(true);
     expect(bubble.find('[data-test="turn-narrative"]').classes()).not.toContain("caret");
+  });
+
+  it("does not render an empty narrative lane for whitespace-only text", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [],
+        liveTurn: live([
+          { type: "reasoning", text: "checking" },
+          { type: "text", text: " \n" },
+        ]),
+      },
+    });
+
+    const bubble = wrapper.find('[data-test="msg-streaming"]');
+    expect(bubble.findComponent({ name: "ReasoningPanel" }).exists()).toBe(true);
+    expect(bubble.find('[data-test="turn-narrative"]').exists()).toBe(false);
   });
 
   it("marks failed output messages", () => {

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -153,6 +153,54 @@ describe("MessageList", () => {
     expect(bubble.html()).toContain("<strong>important</strong>");
   });
 
+  it("keeps live narrative continuous when activity arrives between text chunks", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [],
+        liveTurn: live([
+          { type: "text", text: "先检查这一层的 flex，" },
+          {
+            type: "tool",
+            step: {
+              toolCallId: "read-1",
+              toolName: "Read",
+              kind: "read",
+              status: "success",
+              title: "index.css",
+            },
+          },
+          { type: "reasoning", text: "确认 Android 的约束行为。" },
+          { type: "text", text: "再确认间接约束行高。" },
+        ]),
+      },
+    });
+
+    const bubble = wrapper.find('[data-test="msg-streaming"]');
+    expect(bubble.findAll(".stream-md")).toHaveLength(1);
+    expect(bubble.find(".stream-md").text()).toBe(
+      "先检查这一层的 flex，再确认间接约束行高。",
+    );
+    expect(bubble.find('[data-test="tool-step-header"]').exists()).toBe(true);
+    expect(bubble.findComponent({ name: "ReasoningPanel" }).exists()).toBe(true);
+  });
+
+  it("keeps the live indicator on the latest visible reasoning activity", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [],
+        liveTurn: live([
+          { type: "text", text: "partial answer" },
+          { type: "reasoning", text: "checking one more thing" },
+          { type: "reasoning", text: "   " },
+        ]),
+      },
+    });
+
+    const bubble = wrapper.find('[data-test="msg-streaming"]');
+    expect(bubble.find('[data-test="reasoning-shimmer"]').exists()).toBe(true);
+    expect(bubble.find(".stream-md").classes()).not.toContain("caret");
+  });
+
   it("marks failed output messages", () => {
     const wrapper = mount(MessageList, {
       props: { messages: [msg({ direction: "out", text: "boom", failed: true })], liveTurn: null },
@@ -224,26 +272,32 @@ it("renders legacy persisted tool steps (no parts) in a collapsed panel", () => 
   expect(wrapper.find('[data-test="tool-row"]').exists()).toBe(false);
 });
 
-it("renders persisted `parts` inline in arrival order (tool then text)", () => {
+it("replays persisted activity separately without breaking the narrative Markdown", () => {
   const wrapper = mount(MessageList, {
     props: {
       messages: [msg({
-        direction: "out", text: "all done", status: "done",
+        direction: "out", text: "**continuous prose**", status: "done",
         structured: {
           toolSteps: [{ toolCallId: "t1", toolName: "Bash", kind: "execute", status: "success", title: "ls" }],
           parts: [
+            { type: "text", text: "**continuous" },
             { type: "tool", step: { toolCallId: "t1", toolName: "Bash", kind: "execute", status: "success", title: "ls" } },
-            { type: "text", text: "all done" },
+            { type: "reasoning", text: "checking" },
+            { type: "text", text: " prose**" },
           ],
         },
       })],
       liveTurn: null,
     },
   });
-  // Inline cards, not the aggregated legacy panel.
+
+  const output = wrapper.find('[data-test="msg-out"]');
+  expect(output.find('[data-test="turn-activity"]').exists()).toBe(true);
+  expect(output.findAll(".stream-md")).toHaveLength(1);
+  expect(output.find(".stream-md").html()).toContain("<strong>continuous prose</strong>");
   expect(wrapper.findComponent(ToolStepCard).exists()).toBe(true);
   expect(wrapper.findComponent(ToolCallPanel).exists()).toBe(false);
-  expect(wrapper.find('[data-test="msg-out"]').text()).toContain("all done");
+  expect(wrapper.findComponent({ name: "ReasoningPanel" }).exists()).toBe(true);
 });
 
 it("shows a failed tool's error message in red when its card is expanded", async () => {

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -151,6 +151,7 @@ describe("MessageList", () => {
     const bubble = wrapper.find('[data-test="msg-streaming"]');
     expect(bubble.exists()).toBe(true);
     expect(bubble.html()).toContain("<strong>important</strong>");
+    expect(bubble.find(".caret").exists()).toBe(true);
   });
 
   it("keeps live narrative continuous when activity arrives between text chunks", () => {
@@ -205,7 +206,7 @@ describe("MessageList", () => {
 
     const bubble = wrapper.find('[data-test="msg-streaming"]');
     expect(bubble.find('[data-test="reasoning-shimmer"]').exists()).toBe(true);
-    expect(bubble.find(".stream-md").classes()).not.toContain("caret");
+    expect(bubble.find('[data-test="turn-narrative"]').classes()).not.toContain("caret");
   });
 
   it("marks failed output messages", () => {

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -154,6 +154,16 @@ describe("MessageList", () => {
     expect(bubble.find(".stream-md.caret").exists()).toBe(true);
   });
 
+  it("keeps a caret host when streaming Markdown ends with a horizontal rule", () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: live([{ type: "text", text: "---" }]) },
+    });
+
+    const narrative = wrapper.find(".stream-md.caret");
+    expect(narrative.exists()).toBe(true);
+    expect(narrative.find(":scope > hr:last-child").exists()).toBe(true);
+  });
+
   it("keeps live narrative continuous when activity arrives between text chunks", () => {
     const wrapper = mount(MessageList, {
       props: {

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -180,8 +180,14 @@ describe("MessageList", () => {
     expect(bubble.find(".stream-md").text()).toBe(
       "先检查这一层的 flex，再确认间接约束行高。",
     );
-    expect(bubble.find('[data-test="tool-step-header"]').exists()).toBe(true);
-    expect(bubble.findComponent({ name: "ReasoningPanel" }).exists()).toBe(true);
+    const toolHeader = bubble.find('[data-test="tool-step-header"]');
+    const reasoningPanel = bubble.findComponent({ name: "ReasoningPanel" });
+    expect(toolHeader.exists()).toBe(true);
+    expect(reasoningPanel.exists()).toBe(true);
+    expect(
+      toolHeader.element.compareDocumentPosition(reasoningPanel.element)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("keeps the live indicator on the latest visible reasoning activity", () => {
@@ -192,6 +198,7 @@ describe("MessageList", () => {
           { type: "text", text: "partial answer" },
           { type: "reasoning", text: "checking one more thing" },
           { type: "reasoning", text: "   " },
+          { type: "text", text: " \n" },
         ]),
       },
     });

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -306,8 +306,8 @@ watch(
             </div>
             <div data-test="msg-out" class="min-w-0 flex-1 space-y-2.5"
                  :class="m.failed ? 'rounded-lg ring-1 ring-danger/40' : ''">
-              <!-- Ordered transcript (text / reasoning / tools inline). Tool cards own
-                   their collapsed state; the surrounding agent message stays visible. -->
+              <!-- Structured transcript: activity cards stay grouped above one continuous
+                   Markdown narrative. Tool cards own their collapsed state. -->
               <div data-test="msg-content" class="space-y-2.5">
                 <TurnParts v-if="m.structured?.parts?.length" :parts="m.structured.parts" />
                 <!-- Legacy rows persisted before `parts`: aggregated fallback. -->

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -7,6 +7,8 @@ import { enhanceMermaidBlock } from "../lib/inline-mermaid";
 import MermaidViewer from "./MermaidViewer.vue";
 import { useThemeStore } from "../stores/theme";
 
+defineOptions({ inheritAttrs: false });
+
 const { t } = useI18n();
 
 const props = defineProps<{ text: string; streaming?: boolean }>();
@@ -180,7 +182,7 @@ onBeforeUnmount(() => {
 
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -- input is sanitized by renderMarkdown (DOMPurify) -->
-  <div ref="rootEl" class="stream-md text-sm" v-html="html" />
+  <div ref="rootEl" class="stream-md text-sm" v-bind="$attrs" v-html="html" />
   <MermaidViewer v-if="viewerSvg" :svg="viewerSvg" @close="viewerSvg = null" />
 </template>
 

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -7,19 +7,20 @@ import ToolStepCard from "./ToolStepCard.vue";
 import SubagentStepCard from "./SubagentStepCard.vue";
 import { hasToolStepAncestor, indexToolSteps } from "../lib/subagent-trace";
 
-// Renders a turn's transcript inline, in arrival order: text, reasoning (collapsed),
-// and tool calls interleaved exactly as the agent produced them — no Feishu-style
-// bucketing. When `streaming`, the final part shows the live affordance (caret/shimmer).
+// Preserve the wire transcript in `parts`, but present it as two visual lanes:
+// activity (reasoning/tools) followed by one continuous Markdown narrative. Tool
+// events must not split lists, code fences, or prose into separate Markdown roots.
 const props = defineProps<{ parts: TurnPartDto[]; streaming?: boolean }>();
 
+type ActivityPart = Exclude<TurnPartDto, { type: "text" }>;
 type RenderPart =
-  | { key: string; type: "part"; part: TurnPartDto }
+  | { key: string; type: "part"; part: ActivityPart }
   | { key: string; type: "subagent"; step: ToolStepDto; children: ToolStepDto[] };
 
 // ACP emits child tools as ordinary turn parts plus a parentToolCallId. Fold those
 // parts under their Agent task for display while preserving the wire/history shape.
 // If an old history row has only a child (no parent), it remains visible normally.
-const renderParts = computed<RenderPart[]>(() => {
+const renderActivities = computed<RenderPart[]>(() => {
   const parents = new Set(
     props.parts
       .filter((part): part is Extract<TurnPartDto, { type: "tool" }> => part.type === "tool" && part.step.isSubagent === true)
@@ -36,6 +37,8 @@ const renderParts = computed<RenderPart[]>(() => {
 
   const result: RenderPart[] = [];
   props.parts.forEach((part, index) => {
+    if (part.type === "text") return;
+    if (part.type === "reasoning" && !part.text.trim()) return;
     if (part.type === "tool" && hasToolStepAncestor(part.step, stepsById, (ancestorId) => parents.has(ancestorId))) return;
     if (part.type === "tool" && part.step.isSubagent) {
       result.push({
@@ -46,23 +49,45 @@ const renderParts = computed<RenderPart[]>(() => {
       });
       return;
     }
-    const key = part.type === "tool" ? `tool:${part.step.toolCallId}` : `${part.type}:${index}`;
+    const key = part.type === "tool" ? `tool:${part.step.toolCallId}` : `reasoning:${index}`;
     result.push({ key, type: "part", part });
   });
   return result;
 });
 
-const isLast = (i: number): boolean => props.streaming === true && i === renderParts.value.length - 1;
+const narrative = computed(() =>
+  props.parts
+    .filter((part): part is Extract<TurnPartDto, { type: "text" }> => part.type === "text")
+    .map((part) => part.text)
+    .join(""),
+);
+
+const latestVisiblePart = computed(() => {
+  for (let i = props.parts.length - 1; i >= 0; i -= 1) {
+    const part = props.parts[i];
+    if (part.type !== "reasoning" || part.text.trim()) return part;
+  }
+  return undefined;
+});
+const narrativeStreaming = computed(() =>
+  props.streaming === true && latestVisiblePart.value?.type === "text",
+);
+const isLastActivity = (i: number): boolean =>
+  props.streaming === true
+  && latestVisiblePart.value?.type === "reasoning"
+  && i === renderActivities.value.length - 1;
 </script>
 
 <template>
   <div class="space-y-2.5">
-    <template v-for="(item, i) in renderParts" :key="item.key">
-      <SubagentStepCard v-if="item.type === 'subagent'" :step="item.step" :children="item.children" />
-      <ReasoningPanel v-else-if="item.part.type === 'reasoning' && item.part.text.trim()" :reasoning="item.part.text" :streaming="isLast(i)" :default-open="false" />
-      <ToolStepCard v-else-if="item.part.type === 'tool'" :step="item.part.step" />
-      <StreamMarkdown v-else :text="item.part.text" :streaming="isLast(i)"
-                      class="text-[14px] leading-relaxed text-fg" :class="isLast(i) ? 'caret' : ''" />
-    </template>
+    <div v-if="renderActivities.length" data-test="turn-activity" class="space-y-2.5">
+      <template v-for="(item, i) in renderActivities" :key="item.key">
+        <SubagentStepCard v-if="item.type === 'subagent'" :step="item.step" :children="item.children" />
+        <ReasoningPanel v-else-if="item.part.type === 'reasoning'" :reasoning="item.part.text" :streaming="isLastActivity(i)" :default-open="false" />
+        <ToolStepCard v-else-if="item.part.type === 'tool'" :step="item.part.step" />
+      </template>
+    </div>
+    <StreamMarkdown v-if="narrative" :text="narrative" :streaming="narrativeStreaming"
+                    class="text-[14px] leading-relaxed text-fg" :class="narrativeStreaming ? 'caret' : ''" />
   </div>
 </template>

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -61,6 +61,7 @@ const narrative = computed(() =>
     .map((part) => part.text)
     .join(""),
 );
+const hasVisibleNarrative = computed(() => narrative.value.trim().length > 0);
 
 const latestVisiblePart = computed(() => {
   for (let i = props.parts.length - 1; i >= 0; i -= 1) {
@@ -87,9 +88,9 @@ const isLastActivity = (i: number): boolean =>
         <ToolStepCard v-else-if="item.part.type === 'tool'" :step="item.part.step" />
       </template>
     </div>
-    <div v-if="narrative" data-test="turn-narrative"
-         class="text-[14px] leading-relaxed text-fg" :class="narrativeStreaming ? 'caret' : ''">
-      <StreamMarkdown :text="narrative" :streaming="narrativeStreaming" />
-    </div>
+    <StreamMarkdown v-if="hasVisibleNarrative" data-test="turn-narrative"
+                    :text="narrative" :streaming="narrativeStreaming"
+                    class="text-[14px] leading-relaxed text-fg"
+                    :class="narrativeStreaming ? 'caret' : ''" />
   </div>
 </template>

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -65,7 +65,7 @@ const narrative = computed(() =>
 const latestVisiblePart = computed(() => {
   for (let i = props.parts.length - 1; i >= 0; i -= 1) {
     const part = props.parts[i];
-    if (part.type !== "reasoning" || part.text.trim()) return part;
+    if (part.type === "tool" || part.text.trim()) return part;
   }
   return undefined;
 });

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -87,7 +87,9 @@ const isLastActivity = (i: number): boolean =>
         <ToolStepCard v-else-if="item.part.type === 'tool'" :step="item.part.step" />
       </template>
     </div>
-    <StreamMarkdown v-if="narrative" :text="narrative" :streaming="narrativeStreaming"
-                    class="text-[14px] leading-relaxed text-fg" :class="narrativeStreaming ? 'caret' : ''" />
+    <div v-if="narrative" data-test="turn-narrative"
+         class="text-[14px] leading-relaxed text-fg" :class="narrativeStreaming ? 'caret' : ''">
+      <StreamMarkdown :text="narrative" :streaming="narrativeStreaming" />
+    </div>
   </div>
 </template>

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -31,8 +31,8 @@ export type TurnStatus = "working" | "streaming" | "done" | "cancelled" | "error
 /** Per-session context usage: window fill plus optional cost & token breakdown. */
 export type SessionUsage = { used: number; size: number; cost?: UsageCostDto; breakdown?: UsageBreakdownDto };
 
-/** One transcript entry, kept in arrival order so text / reasoning / tool calls
- *  render inline exactly as the agent produced them (mirrors the hub's persistence). */
+/** One transcript entry, kept in arrival order to mirror the hub's persistence.
+ *  Presentation may derive activity / narrative lanes without mutating wire order. */
 export type TurnPart = TurnPartDto;
 
 export interface LiveTurn {

--- a/packages/relay-web/src/style.css
+++ b/packages/relay-web/src/style.css
@@ -117,9 +117,14 @@ select:focus, select:focus-visible {
   animation: shimmer 2.4s linear infinite;
 }
 
-/* Streaming caret — accent blue. */
+/* Streaming caret — accent blue. Keep the :has() enhancement in a separate rule:
+   browsers that do not support it must still retain the basic caret declaration. */
 @keyframes blink { 0%,49% { opacity: 1; } 50%,100% { opacity: 0; } }
-.stream-md.caret > :last-child::after,
+.stream-md.caret > :last-child::after {
+  content: ''; display: inline-block; width: 2px; height: 1em;
+  background: rgb(var(--c-accent)); margin-left: 2px; vertical-align: text-bottom;
+  animation: blink 1s step-end infinite;
+}
 /* <hr> is a void element and cannot reliably host ::after; keep a visible fallback. */
 .stream-md.caret:has(> hr:last-child)::after {
   content: ''; display: inline-block; width: 2px; height: 1em;
@@ -139,7 +144,8 @@ select:focus, select:focus-visible {
 @media (prefers-reduced-motion: reduce) {
   .pulse-dot,
   .shimmer-text,
-  .stream-md.caret > :last-child::after,
+  .stream-md.caret > :last-child::after { animation: none !important; }
+
   .stream-md.caret:has(> hr:last-child)::after { animation: none !important; }
 }
 

--- a/packages/relay-web/src/style.css
+++ b/packages/relay-web/src/style.css
@@ -119,7 +119,9 @@ select:focus, select:focus-visible {
 
 /* Streaming caret — accent blue. */
 @keyframes blink { 0%,49% { opacity: 1; } 50%,100% { opacity: 0; } }
-.stream-md.caret > :last-child::after {
+.stream-md.caret > :last-child::after,
+/* <hr> is a void element and cannot reliably host ::after; keep a visible fallback. */
+.stream-md.caret:has(> hr:last-child)::after {
   content: ''; display: inline-block; width: 2px; height: 1em;
   background: rgb(var(--c-accent)); margin-left: 2px; vertical-align: text-bottom;
   animation: blink 1s step-end infinite;
@@ -135,7 +137,10 @@ select:focus, select:focus-visible {
 .no-scrollbar::-webkit-scrollbar { display: none; }
 
 @media (prefers-reduced-motion: reduce) {
-  .pulse-dot, .shimmer-text, .stream-md.caret > :last-child::after { animation: none !important; }
+  .pulse-dot,
+  .shimmer-text,
+  .stream-md.caret > :last-child::after,
+  .stream-md.caret:has(> hr:last-child)::after { animation: none !important; }
 }
 
 /* Transient flash when jumping to a line (content-search hit). The decoration is removed

--- a/packages/relay-web/src/style.css
+++ b/packages/relay-web/src/style.css
@@ -119,7 +119,7 @@ select:focus, select:focus-visible {
 
 /* Streaming caret — accent blue. */
 @keyframes blink { 0%,49% { opacity: 1; } 50%,100% { opacity: 0; } }
-.caret::after {
+.stream-md.caret > :last-child::after {
   content: ''; display: inline-block; width: 2px; height: 1em;
   background: rgb(var(--c-accent)); margin-left: 2px; vertical-align: text-bottom;
   animation: blink 1s step-end infinite;
@@ -135,7 +135,7 @@ select:focus, select:focus-visible {
 .no-scrollbar::-webkit-scrollbar { display: none; }
 
 @media (prefers-reduced-motion: reduce) {
-  .pulse-dot, .shimmer-text, .caret::after { animation: none !important; }
+  .pulse-dot, .shimmer-text, .stream-md.caret > :last-child::after { animation: none !important; }
 }
 
 /* Transient flash when jumping to a line (content-search hit). The decoration is removed


### PR DESCRIPTION
## Summary

- render reasoning and tool calls in a dedicated activity area
- concatenate all text parts into one Markdown document for both live turns and persisted history
- preserve raw ordered parts and existing subagent parent/child folding
- keep the streaming indicator on the latest visible narrative or reasoning activity
- ignore blank reasoning entries when deriving visible activity

## Root cause

`TurnParts` rendered text, reasoning, and tool parts strictly in arrival order. Whenever a tool or reasoning event arrived between text chunks, it created separate Markdown roots and inserted a card between prose fragments. Besides interrupting reading, this could break Markdown structures such as lists, emphasis, and code fences.

## User impact

Agent replies now remain a continuous readable document while execution activity stays visible in a separate area above it. Live rendering and history replay use the same presentation.

## Validation

- relay-web full suite: 107 files, 927 tests passed
- final focused suites: 49 tests passed (`messagelist` + `subagentstepcard`)
- `npm --prefix packages/relay-web run build`
- `git diff --check`
- independent standards and spec subagent reviews; one blank-reasoning edge case was found, fixed, and re-reviewed successfully
