### PR TITLE
fix(relay-web): optimistically clear cold/sleeping indicators on send

### DIFF
--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -22,6 +22,7 @@ vi.mock("../api/client", () => ({
 }));
 
 import { useChatStore, loadPersistedSelection } from "../stores/chat";
+import { useInstancesStore } from "../stores/instances";
 import { useSessionControlsStore } from "../stores/session-controls";
 import { ApiError } from "../api/client";
 import PromptInput from "../components/PromptInput.vue";
@@ -822,4 +823,66 @@ test("whitespace between non-blank reasoning chunks is preserved", () => {
   ev({ type: "turn-thought", chatKey: "relay:a1", sessionAlias: "backend", chunk: "line2" });
   ev({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
   expect(store.messages.at(-1)!.structured?.reasoning).toBe("line1\n\nline2");
+});
+
+function seedColdSleepingRow(warm: boolean | undefined, archived: boolean) {
+  const instancesStore = useInstancesStore();
+  instancesStore.instances = [{
+    id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [],
+    sessions: [{ alias: "backend", agent: "codex", workspace: "/w", transportSession: "t", running: false, archived, ...(warm === undefined ? {} : { warm }) }],
+  }];
+  return instancesStore.instances[0]!.sessions[0]!;
+}
+
+test("send optimistically clears the cold and sleeping indicators (prompt wakes/warms the session)", async () => {
+  const row = seedColdSleepingRow(false, true);
+  rpc.mockResolvedValueOnce({ ok: true });
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  const sending = chat.send("wake up");
+  // Cleared BEFORE the RPC resolves — that's the optimistic part.
+  expect(row.warm).toBe(true);
+  expect(row.archived).toBe(false);
+  await sending;
+  expect(row.warm).toBe(true);
+  expect(row.archived).toBe(false);
+});
+
+test("a failed send restores the cold and sleeping indicators", async () => {
+  const row = seedColdSleepingRow(false, true);
+  rpc.mockRejectedValueOnce(new ApiError("instance-offline", 503));
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  await chat.send("wake up");
+  expect(row.warm).toBe(false);
+  expect(row.archived).toBe(true);
+});
+
+test("an ok:false prompt result restores the cold indicator", async () => {
+  const row = seedColdSleepingRow(false, false);
+  rpc.mockResolvedValueOnce({ ok: false, errorMessage: "boom" });
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  await chat.send("hi");
+  expect(row.warm).toBe(false);
+});
+
+test("a prompt RPC timeout keeps the indicators cleared (turn may still be running)", async () => {
+  const row = seedColdSleepingRow(false, true);
+  rpc.mockRejectedValueOnce(new ApiError("timeout", 504));
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  await chat.send("hi");
+  expect(row.warm).toBe(true);
+  expect(row.archived).toBe(false);
+});
+
+test("send leaves an unknown-warmth row untouched (warm stays undefined)", async () => {
+  const row = seedColdSleepingRow(undefined, false);
+  rpc.mockResolvedValueOnce({ ok: true });
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  await chat.send("hi");
+  expect(row.warm).toBeUndefined();
+  expect(row.archived).toBe(false);
 });

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -886,3 +886,21 @@ test("send leaves an unknown-warmth row untouched (warm stays undefined)", async
   expect(row.warm).toBeUndefined();
   expect(row.archived).toBe(false);
 });
+
+test("rollback after the row was replaced by a re-fetch is a no-op on the new row", async () => {
+  seedColdSleepingRow(false, true);
+  let rejectPrompt!: (e: unknown) => void;
+  rpc.mockReturnValueOnce(new Promise((_resolve, reject) => { rejectPrompt = reject; }));
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  const sending = chat.send("wake up");
+  // Mid-flight, a sessions-changed re-fetch replaces the whole array with server truth.
+  const instancesStore = useInstancesStore();
+  instancesStore.instances[0]!.sessions = [{ alias: "backend", agent: "codex", workspace: "/w", transportSession: "t", running: false, archived: false, warm: true }];
+  const freshRow = instancesStore.instances[0]!.sessions[0]!;
+  rejectPrompt(new ApiError("instance-offline", 503));
+  await sending;
+  // The rollback mutated only the detached old row; server truth stays untouched.
+  expect(freshRow.warm).toBe(true);
+  expect(freshRow.archived).toBe(false);
+});

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -665,22 +665,28 @@ export const useChatStore = defineStore("chat", () => {
     seededFromCache = false;
     // Sending a prompt wakes an archived session and warms a cold one server-side
     // (session-turn-runner clears both on prompt start), so flip the sidebar row's
-    // indicators now instead of leaving the cold/sleeping icon up until the
-    // sessions-changed push triggers a re-fetch. A failed send restores the prior
-    // values; if loadSessions replaced the row meanwhile, the rollback mutates a
-    // detached object and is a harmless no-op.
+    // indicators immediately. `archived` converges anyway via the sessions-changed
+    // push, but cold→warm has NO push (markWarm deliberately skips the event), so
+    // this optimistic clear is the ONLY way the cold icon disappears before the
+    // next unrelated re-fetch. A failed send restores the prior values; if
+    // loadSessions replaced the row meanwhile, the rollback mutates a detached
+    // object and is a harmless no-op.
     const sessionRow = useInstancesStore().byId(id)?.sessions.find((s) => s.alias === alias);
     const prevWarm = sessionRow?.warm;
-    const prevArchived = sessionRow?.archived;
+    const prevArchived = sessionRow?.archived === true;
     const clearedIndicators = sessionRow !== undefined && (sessionRow.warm === false || sessionRow.archived);
     if (sessionRow) {
       if (sessionRow.warm === false) sessionRow.warm = true;
       if (sessionRow.archived) sessionRow.archived = false;
     }
+    // Conservative on ok:false: the prompt RPC resolves only after the turn ends, so
+    // a failure may still have warmed the process (turn ran, agent errored). We can't
+    // tell that apart from "turn never started", so restore the cold icon — worst
+    // case it over-reports cold and the next send clears it again.
     const rollbackIndicators = (): void => {
       if (!sessionRow || !clearedIndicators) return;
       sessionRow.warm = prevWarm;
-      sessionRow.archived = prevArchived ?? false;
+      sessionRow.archived = prevArchived;
     };
     // `optimistic` above is the RAW object; the array element is a reactive proxy. Mutating the
     // raw ref (optimistic.failed = true) never trips Vue's set-trap, so the failed bubble would

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -5,6 +5,7 @@ import { api, ApiError } from "../api/client";
 import { createDebouncedFlush } from "../lib/debounce-flush";
 import * as tailCache from "../lib/session-tail-cache";
 import { useAuthStore } from "./auth";
+import { useInstancesStore } from "./instances";
 import { useSessionControlsStore } from "./session-controls";
 
 // Remember which session was open so a page refresh returns to it (selection is not
@@ -662,6 +663,25 @@ export const useChatStore = defineStore("chat", () => {
     messages.value.push(optimistic);
     touchTranscript();
     seededFromCache = false;
+    // Sending a prompt wakes an archived session and warms a cold one server-side
+    // (session-turn-runner clears both on prompt start), so flip the sidebar row's
+    // indicators now instead of leaving the cold/sleeping icon up until the
+    // sessions-changed push triggers a re-fetch. A failed send restores the prior
+    // values; if loadSessions replaced the row meanwhile, the rollback mutates a
+    // detached object and is a harmless no-op.
+    const sessionRow = useInstancesStore().byId(id)?.sessions.find((s) => s.alias === alias);
+    const prevWarm = sessionRow?.warm;
+    const prevArchived = sessionRow?.archived;
+    const clearedIndicators = sessionRow !== undefined && (sessionRow.warm === false || sessionRow.archived);
+    if (sessionRow) {
+      if (sessionRow.warm === false) sessionRow.warm = true;
+      if (sessionRow.archived) sessionRow.archived = false;
+    }
+    const rollbackIndicators = (): void => {
+      if (!sessionRow || !clearedIndicators) return;
+      sessionRow.warm = prevWarm;
+      sessionRow.archived = prevArchived ?? false;
+    };
     // `optimistic` above is the RAW object; the array element is a reactive proxy. Mutating the
     // raw ref (optimistic.failed = true) never trips Vue's set-trap, so the failed bubble would
     // only surface on the next list change (the next message). Mark failure through the proxy so
@@ -681,6 +701,7 @@ export const useChatStore = defineStore("chat", () => {
       if (res && res.ok === false) {
         error.value = res.errorMessage ?? "prompt-failed";
         entry.failed = true;
+        rollbackIndicators();
         touchTranscript();
       } else if (res?.queued && res.queueItemId) {
         entry.queueItemId = res.queueItemId;
@@ -699,6 +720,7 @@ export const useChatStore = defineStore("chat", () => {
       if (!isTimeout) {
         error.value = e instanceof ApiError ? e.code : "send-failed";
         entry.failed = true;
+        rollbackIndicators();
         touchTranscript();
       }
     } finally {


### PR DESCRIPTION
## Summary
- Sending a prompt wakes an archived (sleeping) session and warms a cold one server-side, but the sidebar's cold indicator (Unplug icon) and sleeping style only cleared after the `sessions-changed` push triggered a session re-fetch — leaving users wondering whether their message actually woke the session.
- `send()` in the chat store now optimistically flips the session row's `warm`/`archived` flags the moment the prompt is dispatched, mirroring the existing optimistic patterns (`cancel()`, `renameSession()`).
- A failed send (`ok:false` or a non-timeout RPC error) rolls the indicators back; a timeout keeps them cleared since the turn may still be running.

## Test plan
- [x] 5 new unit tests in `chat.test.ts`: optimistic clear before RPC resolves, rollback on rejection, rollback on `ok:false`, timeout keeps cleared, unknown warmth left untouched
- [x] Full relay-web suite passes (933 tests)
- [x] `vue-tsc --noEmit` clean