### PR TITLE
fix(relay-web): de-proxy attachment rows before tail cache writes

### DIFF
--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -125,6 +125,32 @@ test("optimistic rows (no id) are never written to the cache", async () => {
   expect((await readEventually("alice", "i1", "s1"))!.map((r) => r.id)).toEqual([1]);
 });
 
+test("a history row with attachments is cached on switch-away (reactive proxy vs structured clone)", async () => {
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  // First visit pins an old snapshot [1] so a silent write failure is observable.
+  getMock.mockResolvedValue({ messages: [row(1)], hasMore: false });
+  await chat.loadHistory();
+  chat.select("i1", "other");
+  expect((await readEventually("alice", "i1", "s1"))!.map((r) => r.id)).toEqual([1]);
+  // Second visit: the tail now holds an attachment row. Read off the deeply
+  // reactive transcript it is a Vue Proxy, which IDB's structured clone rejects
+  // (DataCloneError) — the write must re-plain it, not silently fail and leave
+  // the cache frozen at [1] forever.
+  const withAttachment: MessageRecordDto = {
+    ...row(2, "here is a file"),
+    attachments: [{ id: "a1", filename: "shot.png", mimeType: "image/png", size: 123, kind: "image" }],
+  };
+  getMock.mockResolvedValue({ messages: [row(1), withAttachment], hasMore: false });
+  chat.select("i1", "s1");
+  await chat.loadHistory();
+  chat.select("i1", "other"); // flush the write-back
+  await vi.waitFor(async () => {
+    expect((await read("alice", "i1", "s1"))!.map((r) => r.id)).toEqual([1, 2]);
+  });
+  expect((await read("alice", "i1", "s1"))![1]!.attachments).toEqual(withAttachment.attachments);
+});
+
 test("loadHistory failure keeps showing the cached tail", async () => {
   await write("alice", "i1", "s1", [row(1), row(2)]);
   const chat = useChatStore();

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -1,3 +1,4 @@
+import { toRaw } from "vue";
 import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
 
 /** Stale-while-revalidate tail cache for session transcripts (spec #205).
@@ -179,7 +180,11 @@ function toCachedRow(row: MessageRecordDto): MessageRecordDto {
   };
   if (row.queueItemId !== undefined) out.queueItemId = row.queueItemId;
   if (row.structured !== undefined) out.structured = row.structured;
-  if (row.attachments !== undefined) out.attachments = row.attachments;
+  // The transcript is deeply reactive and only `structured` is markRaw'd, so
+  // `attachments` arrives as a Vue Proxy — IDB's structured clone rejects
+  // proxies (DataCloneError), silently killing every write for a session whose
+  // tail holds an attachment row. toRaw yields the underlying plain tree.
+  if (row.attachments !== undefined) out.attachments = toRaw(row.attachments);
   return out;
 }
 
@@ -272,7 +277,12 @@ export async function write(user: string, instanceId: string, alias: string, row
       retryTx.objectStore(STORE).put(record);
       await txDone(retryTx);
     }
-  } catch { /* cache is an optimization, never an error source */ }
+  } catch (err) {
+    // The cache is an optimization, never an error source — but a swallowed
+    // write failure freezes the entry at its last snapshot forever (a
+    // DataCloneError on a reactive row did exactly that), so leave a trace.
+    console.debug("[relay-web] tail-cache write failed", err);
+  }
 }
 
 /** Purge one session's cache — the remove hook (sleeping sessions KEEP their


### PR DESCRIPTION
## Summary
- Root cause of a session's tail cache being frozen at an old snapshot: the transcript is deeply reactive and only `structured` is markRaw'd, so `toCachedRow` copied `attachments` as a Vue Proxy. IndexedDB's structured clone rejects proxies (`DataCloneError`), `write()` swallowed it, so every cache write for a session whose last 30 rows contain an attachment row silently failed — while `read()`'s LRU touch kept refreshing `lastAccess` (matching the observed "lastAccess fresh, rows stale").
- Fix: `toRaw` the attachments in `toCachedRow` (future-proof against nested DTO fields, unlike a shallow spread).
- `write()`'s outer catch now logs swallowed failures via `console.debug("[relay-web] tail-cache write failed", err)` so a recurrence stays diagnosable.

## Test plan
- [x] New regression test: a history row with attachments flows through the reactive transcript and is cached on switch-away (red before the fix — cache stayed frozen at the old snapshot; green after)
- [x] `session-tail-cache.test.ts` + `chat-tail-cache.test.ts`: 40/40 pass (re-run after rebase onto latest main)
- [x] `vue-tsc --noEmit` clean