### PR TITLE
refactor(transport): generalize background follow-up naming

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -103,7 +103,9 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   driver 的原生主 transcript（Claude 在 `~/.claude/projects`，Qoder 为兼容 fork，布局相同，位于 `~/.qoder/projects`；
   仅这两个 driver 支持后台跟读），并递归增量读取 `<sessionId>/subagents/**/agent-*.jsonl`。结构化结果里显式的
   `status` 字段是权威判定，只有缺失时才回退到 launch 短语匹配。后台任务真正完成、主 Agent 续写结束后才转为
-  `success`；失败通知会把父 Agent 及仍在运行的子步骤收敛为 `error`。
+  `success`；失败通知会把父 Agent 及仍在运行的子步骤收敛为 `error`。实现入口是 provider-neutral 的
+  `src/transport/background-followup.ts` 与 `background-followup-transport.ts`；为兼容既有日志查询，遥测事件 key
+  暂时保留 `transport.claude_background_followup.*`。
 - `TurnParts.vue` 保留原始有序 parts，但展示时分为两条视觉通道：推理/工具按原相对顺序组成活动区，
   所有 text part 拼回一个连续 Markdown 文档，避免工具事件切断段落、列表或代码围栏；同时按
   `parentToolCallId` 把子工具归入对应 Agent，旧历史里没有父子字段的工具仍按普通卡片渲染。

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ import { runConsole } from "./run-console";
 import { spawnAcpxBridgeClient } from "./transport/acpx-bridge/acpx-bridge-client";
 import { AcpxBridgeTransport } from "./transport/acpx-bridge/acpx-bridge-transport";
 import { AcpxCliTransport } from "./transport/acpx-cli/acpx-cli-transport";
-import { createClaudeBackgroundFollowupTransport } from "./transport/claude-background-followup-transport";
+import { createBackgroundFollowupTransport } from "./transport/background-followup-transport";
 import type { ResolvedSession, SessionTransport } from "./transport/types";
 import { reapQueueOwners } from "./transport/queue-owner-reaper";
 import { collectReapTargets } from "./transport/collect-reap-targets";
@@ -287,7 +287,7 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
           ))
       : (deps.createCliTransport?.(acpxCommand) ??
           new AcpxCliTransport({ ...config.transport, command: acpxCommand }));
-  const transport = createClaudeBackgroundFollowupTransport(baseTransport, {
+  const transport = createBackgroundFollowupTransport(baseTransport, {
     logger,
     resolveDriver: (agent) => config.agents[agent]?.driver,
   });

--- a/src/transport/background-followup-transport.ts
+++ b/src/transport/background-followup-transport.ts
@@ -1,17 +1,21 @@
 import type { ToolUseEvent } from "../channels/types.js";
 import type { AppLogger } from "../logging/app-logger.js";
 import {
-  claudeAsyncAgentId,
-  followClaudeBackgroundTurn,
-  isClaudeAsyncAgentLaunch,
-  type ClaudeBackgroundFollowupOptions,
-  type ClaudeBackgroundFollowupResult,
-} from "./claude-background-followup.js";
+  asyncAgentId,
+  followBackgroundTurn as defaultFollowBackgroundTurn,
+  isAsyncAgentLaunch,
+  type BackgroundFollowupOptions,
+  type BackgroundFollowupResult,
+} from "./background-followup.js";
 import type { PromptOptions, SessionTransport } from "./types.js";
 
-type FollowBackgroundTurn = (options: ClaudeBackgroundFollowupOptions) => Promise<ClaudeBackgroundFollowupResult>;
+type FollowBackgroundTurn = (options: BackgroundFollowupOptions) => Promise<BackgroundFollowupResult>;
 
-export interface ClaudeBackgroundFollowupTransportOptions {
+// Preserve the established telemetry namespace so existing log queries and
+// alerts keep working while the public code surface moves to provider-neutral names.
+const LEGACY_LOG_EVENT_PREFIX = "transport.claude_background_followup";
+
+export interface BackgroundFollowupTransportOptions {
   logger: AppLogger;
   followBackgroundTurn?: FollowBackgroundTurn;
   resolveDriver?: (agent: string) => string | undefined;
@@ -21,11 +25,11 @@ export interface ClaudeBackgroundFollowupTransportOptions {
  * Claude Code-compatible drivers (claude, qoder). Command routing remains
  * driver-agnostic; optional transport capabilities stay intact because every
  * property except prompt is read directly from the delegate. */
-export function createClaudeBackgroundFollowupTransport(
+export function createBackgroundFollowupTransport(
   delegate: SessionTransport,
-  options: ClaudeBackgroundFollowupTransportOptions,
+  options: BackgroundFollowupTransportOptions,
 ): SessionTransport {
-  const followBackgroundTurn = options.followBackgroundTurn ?? followClaudeBackgroundTurn;
+  const runBackgroundFollowup = options.followBackgroundTurn ?? defaultFollowBackgroundTurn;
 
   const prompt: SessionTransport["prompt"] = async (session, text, reply, replyContext, promptOptions) => {
     const latestToolEvents = new Map<string, ToolUseEvent>();
@@ -38,9 +42,9 @@ export function createClaudeBackgroundFollowupTransport(
           latestToolEvents.set(event.toolCallId, event);
           if (event.status === "running") pendingToolEvents.set(event.toolCallId, event);
           else pendingToolEvents.delete(event.toolCallId);
-          if (event.isSubagent && isClaudeAsyncAgentLaunch(event)) {
+          if (event.isSubagent && isAsyncAgentLaunch(event)) {
             asyncToolCallIds.add(event.toolCallId);
-            const agentId = claudeAsyncAgentId(event);
+            const agentId = asyncAgentId(event);
             if (agentId) subagentIdsByToolCallId.set(event.toolCallId, agentId);
           }
           await downstreamToolEvent(event);
@@ -62,7 +66,7 @@ export function createClaudeBackgroundFollowupTransport(
         agentSessionId = await delegate.getAgentSessionId?.(session);
       } catch (error) {
         await options.logger.error(
-          "transport.claude_background_followup.session_id_failed",
+          `${LEGACY_LOG_EVENT_PREFIX}.session_id_failed`,
           "failed to resolve agent session id for background follow-up",
           { alias: session.alias, error: error instanceof Error ? error.message : String(error) },
         );
@@ -80,11 +84,11 @@ export function createClaudeBackgroundFollowupTransport(
     }
 
     await options.logger.info(
-      "transport.claude_background_followup.started",
+      `${LEGACY_LOG_EVENT_PREFIX}.started`,
       "following background-agent continuation",
       { alias: session.alias, agentSessionId, driver, taskCount: asyncToolCallIds.size },
     );
-    const followup = await followBackgroundTurn({
+    const followup = await runBackgroundFollowup({
       cwd: session.cwd,
       sessionId: agentSessionId,
       driver,
@@ -122,7 +126,7 @@ export function createClaudeBackgroundFollowupTransport(
       });
     }
     await options.logger.info(
-      `transport.claude_background_followup.${followup.status}`,
+      `${LEGACY_LOG_EVENT_PREFIX}.${followup.status}`,
       `background-agent follow-up ${followup.status}`,
       {
         alias: session.alias,

--- a/src/transport/background-followup.ts
+++ b/src/transport/background-followup.ts
@@ -11,7 +11,7 @@ const FINAL_SUBAGENT_DRAIN_MAX_POLLS = 4;
 const FINAL_SUBAGENT_DRAIN_STABLE_POLLS = 2;
 const ASYNC_AGENT_LAUNCH = /Async agent launched successfully|["']?status["']?\s*:\s*["']async_launched["']/i;
 
-export interface ClaudeBackgroundFollowupOptions {
+export interface BackgroundFollowupOptions {
   cwd: string;
   sessionId: string;
   /** ACP driver owning the transcript; qoder shares Claude Code's layout under ~/.qoder. */
@@ -19,7 +19,7 @@ export interface ClaudeBackgroundFollowupOptions {
   launchedToolCallIds: Iterable<string>;
   /** Latest ACP events already observed before the native transcript follower starts. */
   initialToolEvents?: Iterable<ToolUseEvent>;
-  /** Claude agent transcript id keyed by the Agent/Task tool call that launched it. */
+  /** Native agent transcript id keyed by the Agent/Task tool call that launched it. */
   subagentIdsByToolCallId?: Iterable<readonly [string, string]>;
   signal?: AbortSignal;
   homeDir?: string;
@@ -31,7 +31,7 @@ export interface ClaudeBackgroundFollowupOptions {
   onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
 }
 
-export interface ClaudeBackgroundFollowupResult {
+export interface BackgroundFollowupResult {
   status: "completed" | "timeout" | "unavailable";
   transcriptPath?: string;
   completedToolCallIds: string[];
@@ -53,10 +53,10 @@ interface JsonlCursor {
   partial: string;
 }
 
-/** Detect the successful tool result Claude Code returns when an Agent was
- * launched asynchronously. Kept at the transport boundary so callers do not
- * need to know Claude's private task ids or output-file layout. */
-export function isClaudeAsyncAgentLaunch(event: ToolUseEvent): boolean {
+/** Detect the successful tool result a compatible driver returns when an Agent
+ * is launched asynchronously. Kept at the transport boundary so callers do not
+ * need to know provider-private task ids or output-file layouts. */
+export function isAsyncAgentLaunch(event: ToolUseEvent): boolean {
   return isAsyncAgentLaunchOutput(event.rawOutput);
 }
 
@@ -84,7 +84,7 @@ function tryParseJsonObject(text: string): Record<string, unknown> | undefined {
   }
 }
 
-export function claudeAsyncAgentId(event: ToolUseEvent): string | undefined {
+export function asyncAgentId(event: ToolUseEvent): string | undefined {
   const fromObject = findStringField(event.rawOutput, new Set(["agentId", "agent_id"]));
   if (fromObject) return fromObject;
   return /\bagent(?:Id|_id)["']?\s*[:=]\s*["']?([A-Za-z0-9_-]+)/i.exec(textOfUnknown(event.rawOutput))?.[1];
@@ -94,7 +94,7 @@ export function claudeAsyncAgentId(event: ToolUseEvent): string | undefined {
  * project-folder encoding is tried first; a shallow fallback scan handles any
  * future/path-platform encoding drift. Qoder is a Claude Code-compatible fork
  * that keeps the identical layout under ~/.qoder. */
-export async function findClaudeTranscriptPath(input: {
+export async function findNativeTranscriptPath(input: {
   cwd: string;
   sessionId: string;
   homeDir?: string;
@@ -118,16 +118,16 @@ export async function findClaudeTranscriptPath(input: {
   return undefined;
 }
 
-/** Follow the out-of-band continuation Claude Code creates after an ACP prompt
- * launches async Agent tools and returns `end_turn`. Claude writes task
- * notifications and the resumed main-agent answer to its native JSONL even
- * though the ACP request is already closed. We replay only records after that
- * prompt's first end_turn and finish after every tracked task notified the main
- * agent and a subsequent main-agent end_turn was written. */
-export async function followClaudeBackgroundTurn(
-  options: ClaudeBackgroundFollowupOptions,
-): Promise<ClaudeBackgroundFollowupResult> {
-  const transcriptPath = options.transcriptPath ?? await findClaudeTranscriptPath(options);
+/** Follow the out-of-band continuation a compatible driver creates after an
+ * ACP prompt launches async Agent tools and returns `end_turn`. The driver
+ * writes task notifications and the resumed main-agent answer to its native
+ * JSONL even though the ACP request is already closed. We replay only records
+ * after that prompt's first end_turn and finish after every tracked task
+ * notified the main agent and a subsequent main-agent end_turn was written. */
+export async function followBackgroundTurn(
+  options: BackgroundFollowupOptions,
+): Promise<BackgroundFollowupResult> {
+  const transcriptPath = options.transcriptPath ?? await findNativeTranscriptPath(options);
   if (!transcriptPath) {
     return { status: "unavailable", completedToolCallIds: [], failedToolCallIds: [] };
   }
@@ -302,8 +302,8 @@ export async function followClaudeBackgroundTurn(
         ...(previous?.rawOutput !== undefined ? { rawOutput: previous.rawOutput } : output ? { rawOutput: output } : {}),
         status: readBoolean(block, "is_error") || previous?.status === "error" ? "error" : "success",
       };
-      if (event.isSubagent && isClaudeAsyncAgentLaunch(event)) {
-        const agentId = claudeAsyncAgentId(event);
+      if (event.isSubagent && isAsyncAgentLaunch(event)) {
+        const agentId = asyncAgentId(event);
         if (agentId) parentToolCallIdByAgentId.set(agentId, event.toolCallId);
       }
       await emitTool(event);

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -1,6 +1,6 @@
 import type { PlanEntry, ToolUseEvent, ToolUseKind, ToolUseStatus } from "../channels/types.js";
 import type { AgentCommand, PromptUsage, UsageBreakdown, UsageCost } from "./types.js";
-import { isAsyncAgentLaunchOutput } from "./claude-background-followup.js";
+import { isAsyncAgentLaunchOutput } from "./background-followup.js";
 import { resolveToolEventMode } from "./tool-event-mode.js";
 import type { ToolEventMode } from "./tool-event-mode.js";
 import { TOOL_KIND_EMOJI, DEFAULT_TOOL_EMOJI } from "./tool-kind-emoji.js";

--- a/tests/unit/commands/transport-invoker-background-followup.test.ts
+++ b/tests/unit/commands/transport-invoker-background-followup.test.ts
@@ -178,7 +178,7 @@ test("a failed top-level Claude Agent closes nested descendants as errors", asyn
   expect([...toolEvents].reverse().find((event) => event.toolCallId === "nested-read")?.status).toBe("error");
 });
 
-test("the Claude follow-up decorator preserves optional transport capabilities and binding", async () => {
+test("the background follow-up decorator preserves optional transport capabilities and binding", async () => {
   let disposed = false;
   const delegate = {
     marker: "delegate",

--- a/tests/unit/commands/transport-invoker-background-followup.test.ts
+++ b/tests/unit/commands/transport-invoker-background-followup.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "bun:test";
 import { TransportInvoker } from "../../../src/commands/transport-invoker";
 import { createNoopAppLogger } from "../../../src/logging/app-logger";
 import type { ToolUseEvent } from "../../../src/channels/types";
-import { createClaudeBackgroundFollowupTransport } from "../../../src/transport/claude-background-followup-transport";
+import { createBackgroundFollowupTransport } from "../../../src/transport/background-followup-transport";
 
 test("Claude async Agent continuation stays in the same turn and forwards the recovered final", async () => {
   const replies: string[] = [];
@@ -31,7 +31,7 @@ test("Claude async Agent continuation stays in the same turn and forwards the re
     getAgentSessionId: async () => "claude-session",
   };
   const logger = createNoopAppLogger();
-  const wrappedTransport = createClaudeBackgroundFollowupTransport(transport as never, {
+  const wrappedTransport = createBackgroundFollowupTransport(transport as never, {
     logger,
     followBackgroundTurn: async (options) => {
       followerCalled = true;
@@ -81,7 +81,7 @@ test("Claude async Agent continuation stays in the same turn and forwards the re
 test("a failed Claude Agent closes its still-running child tools as errors", async () => {
   const toolEvents: ToolUseEvent[] = [];
   const logger = createNoopAppLogger();
-  const transport = createClaudeBackgroundFollowupTransport({
+  const transport = createBackgroundFollowupTransport({
     prompt: async (_session: unknown, _text: string, _reply: unknown, _context: unknown, options: any) => {
       await options.onToolEvent({
         toolCallId: "agent-1",
@@ -136,7 +136,7 @@ test("a failed Claude Agent closes its still-running child tools as errors", asy
 test("a failed top-level Claude Agent closes nested descendants as errors", async () => {
   const toolEvents: ToolUseEvent[] = [];
   const logger = createNoopAppLogger();
-  const transport = createClaudeBackgroundFollowupTransport({
+  const transport = createBackgroundFollowupTransport({
     prompt: async (_session: unknown, _text: string, _reply: unknown, _context: unknown, options: any) => {
       for (const event of [
         { toolCallId: "agent-1", toolName: "Agent", kind: "think", isSubagent: true, rawOutput: { status: "async_launched", agentId: "abc" }, status: "running" },
@@ -188,7 +188,7 @@ test("the Claude follow-up decorator preserves optional transport capabilities a
       disposed = true;
     },
   };
-  const transport = createClaudeBackgroundFollowupTransport(delegate as never, {
+  const transport = createBackgroundFollowupTransport(delegate as never, {
     logger: createNoopAppLogger(),
   });
 
@@ -200,7 +200,7 @@ test("the Claude follow-up decorator preserves optional transport capabilities a
 test("a qoder session follows its background continuation with the qoder driver", async () => {
   const replies: string[] = [];
   let followedDriver: string | undefined;
-  const transport = createClaudeBackgroundFollowupTransport({
+  const transport = createBackgroundFollowupTransport({
     prompt: async (_session: unknown, _text: string, _reply: unknown, _context: unknown, options: any) => {
       await options.onToolEvent({
         toolCallId: "agent-1",
@@ -242,7 +242,7 @@ test("a qoder session follows its background continuation with the qoder driver"
 
 test("an unsupported driver never starts the background follow-up", async () => {
   let followerCalled = false;
-  const transport = createClaudeBackgroundFollowupTransport({
+  const transport = createBackgroundFollowupTransport({
     prompt: async (_session: unknown, _text: string, _reply: unknown, _context: unknown, options: any) => {
       await options.onToolEvent({
         toolCallId: "agent-1",
@@ -277,7 +277,7 @@ test("an unsupported driver never starts the background follow-up", async () => 
 
 test("a non-subagent tool whose output quotes the launch payload never starts the follow-up", async () => {
   let followerCalled = false;
-  const transport = createClaudeBackgroundFollowupTransport({
+  const transport = createBackgroundFollowupTransport({
     prompt: async (_session: unknown, _text: string, _reply: unknown, _context: unknown, options: any) => {
       await options.onToolEvent({
         toolCallId: "read-1",

--- a/tests/unit/transport/background-followup.test.ts
+++ b/tests/unit/transport/background-followup.test.ts
@@ -4,10 +4,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
-  findClaudeTranscriptPath,
-  followClaudeBackgroundTurn,
-  isClaudeAsyncAgentLaunch,
-} from "../../../src/transport/claude-background-followup";
+  findNativeTranscriptPath,
+  followBackgroundTurn,
+  isAsyncAgentLaunch,
+} from "../../../src/transport/background-followup";
 import type { ToolUseEvent } from "../../../src/channels/types";
 
 const TASK_A = "toolu_agent_a";
@@ -21,7 +21,7 @@ test("detects Claude's async Agent launch result", () => {
     rawOutput: [{ type: "text", text: "Async agent launched successfully. agentId: abc" }],
     status: "success",
   };
-  expect(isClaudeAsyncAgentLaunch(event)).toBe(true);
+  expect(isAsyncAgentLaunch(event)).toBe(true);
 });
 
 test("a completed sync Agent quoting the launch phrase is not an async launch", () => {
@@ -35,7 +35,7 @@ test("a completed sync Agent quoting the launch phrase is not an async launch", 
     },
     status: "success",
   };
-  expect(isClaudeAsyncAgentLaunch(event)).toBe(false);
+  expect(isAsyncAgentLaunch(event)).toBe(false);
 });
 
 test("a stringified sync result quoting the launch phrase is not an async launch", () => {
@@ -46,7 +46,7 @@ test("a stringified sync result quoting the launch phrase is not an async launch
     rawOutput: '{"status":"completed","content":"Async agent launched successfully"}',
     status: "success",
   };
-  expect(isClaudeAsyncAgentLaunch(event)).toBe(false);
+  expect(isAsyncAgentLaunch(event)).toBe(false);
 });
 
 test("resolves the default driver's transcript under ~/.claude/projects", async () => {
@@ -55,7 +55,7 @@ test("resolves the default driver's transcript under ~/.claude/projects", async 
   await mkdir(projectDir, { recursive: true });
   await writeFile(join(projectDir, "session-1.jsonl"), "", "utf8");
 
-  const found = await findClaudeTranscriptPath({
+  const found = await findNativeTranscriptPath({
     cwd: "/Users/me/demo",
     sessionId: "session-1",
     homeDir: home,
@@ -69,7 +69,7 @@ test("resolves the qoder driver's transcript under ~/.qoder/projects", async () 
   await mkdir(projectDir, { recursive: true });
   await writeFile(join(projectDir, "session-1.jsonl"), "", "utf8");
 
-  const found = await findClaudeTranscriptPath({
+  const found = await findNativeTranscriptPath({
     cwd: "/Users/me/demo",
     sessionId: "session-1",
     homeDir: home,
@@ -77,7 +77,7 @@ test("resolves the qoder driver's transcript under ~/.qoder/projects", async () 
   });
   expect(found).toBe(join(projectDir, "session-1.jsonl"));
 
-  const notFound = await findClaudeTranscriptPath({
+  const notFound = await findNativeTranscriptPath({
     cwd: "/Users/me/demo",
     sessionId: "session-1",
     homeDir: home,
@@ -106,7 +106,7 @@ test("recovers already-written background continuation after the ACP end_turn bo
 
   const texts: string[] = [];
   const tools: ToolUseEvent[] = [];
-  const result = await followClaudeBackgroundTurn({
+  const result = await followBackgroundTurn({
     cwd: "E:\\projects\\demo",
     sessionId: "session",
     launchedToolCallIds: [TASK_A, TASK_B],
@@ -141,7 +141,7 @@ test("waits for a partially-written ACP end_turn boundary before forwarding cont
   ].join("\n"), "utf8");
 
   const texts: string[] = [];
-  const following = followClaudeBackgroundTurn({
+  const following = followBackgroundTurn({
     cwd: dir,
     sessionId: "session",
     launchedToolCallIds: [TASK_A],
@@ -176,7 +176,7 @@ test("reports a failed background Agent from its task notification", async () =>
     assistant([{ type: "text", text: "任务失败，已说明原因。" }], "end_turn"),
   ].map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
 
-  const result = await followClaudeBackgroundTurn({
+  const result = await followBackgroundTurn({
     cwd: dir,
     sessionId: "session",
     launchedToolCallIds: [TASK_A],
@@ -206,7 +206,7 @@ test("recovers tool activity from the completed background subagent transcript",
   ].map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
 
   const tools: ToolUseEvent[] = [];
-  await followClaudeBackgroundTurn({
+  await followBackgroundTurn({
     cwd: dir,
     sessionId: "session",
     launchedToolCallIds: [TASK_A],
@@ -258,7 +258,7 @@ test("subagent transcript replay preserves richer terminal ACP tool events", asy
     durationMs: 12,
   };
   const tools: ToolUseEvent[] = [];
-  await followClaudeBackgroundTurn({
+  await followBackgroundTurn({
     cwd: dir,
     sessionId: "session",
     launchedToolCallIds: [TASK_A],
@@ -291,7 +291,7 @@ test("streams subagent tool activity written after the ACP request closes", asyn
   ].map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
 
   const tools: ToolUseEvent[] = [];
-  const following = followClaudeBackgroundTurn({
+  const following = followBackgroundTurn({
     cwd: dir,
     sessionId: "session",
     launchedToolCallIds: [TASK_A],
@@ -336,7 +336,7 @@ test("drains a subagent transcript that appears after the main turn becomes comp
   ].map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
 
   const tools: ToolUseEvent[] = [];
-  const result = await followClaudeBackgroundTurn({
+  const result = await followBackgroundTurn({
     cwd: dir,
     sessionId: "session",
     launchedToolCallIds: [TASK_A],
@@ -384,7 +384,7 @@ test("recovers nested Agent transcripts with their immediate parent tool call", 
   ].map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
 
   const tools: ToolUseEvent[] = [];
-  await followClaudeBackgroundTurn({
+  await followBackgroundTurn({
     cwd: dir,
     sessionId: "session",
     launchedToolCallIds: [TASK_A],
@@ -417,7 +417,7 @@ test("an aborted turn stops the background transcript follower", async () => {
   const controller = new AbortController();
   controller.abort();
 
-  await expect(followClaudeBackgroundTurn({
+  await expect(followBackgroundTurn({
     cwd: "E:\\projects\\demo",
     sessionId: "session",
     launchedToolCallIds: [TASK_A],


### PR DESCRIPTION
## Summary

- Rename the Claude-specific background follow-up files and public symbols to provider-neutral names now that the implementation supports both Claude and Qoder.
- Update runtime imports, streaming parser imports, and tests to use the generalized surface.
- Keep the existing `transport.claude_background_followup.*` telemetry namespace for compatibility with log queries and alerts, and document that intentional exception.

## Why

The implementation introduced for Claude now also follows Qoder's compatible native transcripts. The old `ClaudeBackgroundFollowup*` names incorrectly implied a single-provider responsibility and made the public transport boundary harder to understand.

This is a naming-only refactor; background continuation behavior is unchanged.

Closes #227

## Validation

- `npx tsc --noEmit`
- Focused background-followup and streaming tests: 44 passed
- `npm run test:unit`
- Relay Web: 107 test files passed, 935 tests passed, 2 skipped
- Old public-name/path scan returned no matches
- `git diff --check`