### PR TITLE
feat(relay-web): taller desktop composer with drag-to-resize height

### DIFF
--- a/packages/relay-web/src/__tests__/resize-panel.test.ts
+++ b/packages/relay-web/src/__tests__/resize-panel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { clampPanelWidth, createPanelResize } from "../lib/resize-panel";
+import { clampPanelWidth, createBottomPanelResize, createPanelResize } from "../lib/resize-panel";
 
 describe("clampPanelWidth", () => {
   it("clamps to the hard bounds and rounds", () => {
@@ -133,5 +133,86 @@ describe("createPanelResize (right panel)", () => {
     c.onPointerDown({ clientX: 300 });
     target.emit("pointermove", { clientX: 340 }); // 40px right → +40
     expect(width).toBe(288);
+  });
+});
+
+describe("createBottomPanelResize (composer)", () => {
+  it("grows when dragging the top edge upward, shrinks downward", () => {
+    let height = 120;
+    const target = makeTarget();
+    const c = createBottomPanelResize({
+      getHeight: () => height,
+      setHeight: (h) => { height = h; },
+      min: 60, max: 480,
+      isEnabled: () => true,
+      target,
+    });
+    c.onPointerDown({ clientY: 500 });
+    target.emit("pointermove", { clientY: 460 }); // moved 40px up → +40 height
+    expect(height).toBe(160);
+    target.emit("pointermove", { clientY: 520 }); // 20px below start → -20
+    expect(height).toBe(100);
+  });
+
+  it("clamps to bounds and to the viewport fraction", () => {
+    let height = 120;
+    const target = makeTarget();
+    const c = createBottomPanelResize({
+      getHeight: () => height,
+      setHeight: (h) => { height = h; },
+      min: 60, max: 480,
+      maxViewportFraction: 0.5,
+      viewportHeight: () => 600, // cap = 300 < max 480
+      isEnabled: () => true,
+      target,
+    });
+    c.onPointerDown({ clientY: 500 });
+    target.emit("pointermove", { clientY: 0 }); // +500 raw → capped at 300
+    expect(height).toBe(300);
+    target.emit("pointermove", { clientY: 900 }); // -400 raw → floor at 60
+    expect(height).toBe(60);
+  });
+
+  it("is a no-op and attaches nothing when disabled", () => {
+    let height = 120;
+    const target = makeTarget();
+    const c = createBottomPanelResize({
+      getHeight: () => height,
+      setHeight: (h) => { height = h; },
+      min: 60, max: 480,
+      isEnabled: () => false,
+      target,
+    });
+    c.onPointerDown({ clientY: 500 });
+    expect(target.count("pointermove")).toBe(0);
+    expect(height).toBe(120);
+  });
+
+  it("detaches listeners on release and on pointercancel", () => {
+    let height = 120;
+    const target = makeTarget();
+    const onDragStart = vi.fn();
+    const onDragEnd = vi.fn();
+    const c = createBottomPanelResize({
+      getHeight: () => height,
+      setHeight: (h) => { height = h; },
+      min: 60, max: 480,
+      isEnabled: () => true,
+      onDragStart, onDragEnd, target,
+    });
+    c.onPointerDown({ clientY: 500 });
+    expect(onDragStart).toHaveBeenCalledOnce();
+    target.emit("pointerup", {});
+    expect(onDragEnd).toHaveBeenCalledOnce();
+    expect(target.count("pointermove")).toBe(0);
+    expect(target.count("pointercancel")).toBe(0);
+    target.emit("pointermove", { clientY: 100 });
+    expect(height).toBe(120);
+    // Stolen pointer: pointercancel must clean up just like pointerup.
+    c.onPointerDown({ clientY: 500 });
+    target.emit("pointercancel", {});
+    expect(onDragEnd).toHaveBeenCalledTimes(2);
+    expect(target.count("pointermove")).toBe(0);
+    expect(target.count("pointerup")).toBe(0);
   });
 });

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -4,6 +4,7 @@ import { Brain, Check, ChevronDown, Gauge, Paperclip, Send, SlidersHorizontal, X
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
 import { createDebouncedFlush } from "../lib/debounce-flush";
+import { clampPanelWidth, createBottomPanelResize } from "../lib/resize-panel";
 import UsagePopover from "./UsagePopover.vue";
 import { useComposerStore } from "../stores/composer";
 import { useSessionControlsStore } from "../stores/session-controls";
@@ -76,6 +77,53 @@ function toggleEffortMenu() {
 const text = ref(loadDraft(props.draftKey ?? ""));
 const textarea = ref<HTMLTextAreaElement | null>(null);
 const fileInput = ref<HTMLInputElement | null>(null);
+
+// Desktop-only: drag the strip above the composer to resize the textarea height.
+// Mobile keeps the fixed rows="2" textarea, so `isDesktop` gates both the handle
+// and the inline height (an inline height would otherwise override rows on mobile).
+const HEIGHT_MIN = 60;
+const HEIGHT_MAX = 480;
+const HEIGHT_DEFAULT = 120;
+const HEIGHT_VIEWPORT_FRACTION = 0.5;
+// `matchMedia` is absent in some test/embedded runtimes; treat its absence as
+// "not desktop" so the resize handle and inline height simply don't engage.
+function queryDesktop(): boolean {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    && window.matchMedia("(min-width: 1024px)").matches;
+}
+const isDesktop = ref(queryDesktop());
+const composerHeight = ref(clampPanelWidth(
+  Number(localStorage.getItem("xacpx.composerHeight")) || HEIGHT_DEFAULT,
+  HEIGHT_MIN, HEIGHT_MAX,
+  typeof window !== "undefined" ? window.innerHeight : undefined, HEIGHT_VIEWPORT_FRACTION));
+const heightDragging = ref(false);
+watch(composerHeight, (v) => localStorage.setItem("xacpx.composerHeight", String(v)));
+
+const heightResize = createBottomPanelResize({
+  getHeight: () => composerHeight.value,
+  setHeight: (h) => { composerHeight.value = h; },
+  min: HEIGHT_MIN,
+  max: HEIGHT_MAX,
+  maxViewportFraction: HEIGHT_VIEWPORT_FRACTION,
+  isEnabled: () => isDesktop.value,
+  // Lock the cursor + suppress text selection for the whole document while
+  // dragging, so a fast drag that outruns the thin handle still feels solid.
+  onDragStart: () => {
+    heightDragging.value = true;
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+  },
+  onDragEnd: () => {
+    heightDragging.value = false;
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  },
+});
+
+let desktopMql: MediaQueryList | null = null;
+function onDesktopChange(e: MediaQueryListEvent | MediaQueryList) {
+  isDesktop.value = e.matches;
+}
 
 // Agent slash-command autocomplete: when the composer holds a single `/`-token, offer the
 // session's advertised commands. Selecting one inserts `/name `; it then sends as a normal
@@ -151,9 +199,17 @@ watch(
 function flushDraft(): void {
   draftPersist.flush();
 }
-onMounted(() => window.addEventListener("pagehide", flushDraft));
+onMounted(() => {
+  window.addEventListener("pagehide", flushDraft);
+  if (typeof window.matchMedia === "function") {
+    desktopMql = window.matchMedia("(min-width: 1024px)");
+    isDesktop.value = desktopMql.matches;
+    desktopMql.addEventListener("change", onDesktopChange);
+  }
+});
 onBeforeUnmount(() => {
   window.removeEventListener("pagehide", flushDraft);
+  desktopMql?.removeEventListener("change", onDesktopChange);
   flushDraft();
 });
 
@@ -238,6 +294,14 @@ function onInput() {
        iOS home indicator (like native input bars) instead of leaving an extra gap below it. -->
   <form class="relative border-t border-border px-0 pt-3 lg:pt-3" @submit.prevent="submit"
         @drop.prevent="onDrop" @dragover.prevent>
+    <!-- Resize handle: a thin grab strip above the composer card (desktop only).
+         touch-none keeps a touch on it from scrolling; it's hidden < lg anyway.
+         Pointer-only enhancement over the rows="2" fallback, so it's aria-hidden
+         (no keyboard/value semantics to honor); the title gives a hover hint. -->
+    <div data-test="composer-resize" aria-hidden="true" :title='$t("chat.resizeComposer")'
+         class="absolute inset-x-0 top-0 z-10 hidden h-2 cursor-row-resize touch-none select-none transition-colors lg:block"
+         :class="heightDragging ? 'bg-accent/50' : 'hover:bg-accent/30'"
+         @pointerdown.prevent="heightResize.onPointerDown" />
     <!-- hidden file picker -->
     <input ref="fileInput" type="file" multiple class="hidden" data-test="attach-input" @change="onFilesPicked" />
     <!-- COMPOSER — single elevated card: textarea on top, controls row below.
@@ -278,6 +342,7 @@ function onInput() {
            blocking) and Esc still cancels the in-flight turn. -->
       <textarea ref="textarea" v-model="text" rows="2"
                 class="w-full resize-none bg-transparent px-3.5 pt-2.5 pb-1 text-[16px] lg:text-[14px] leading-relaxed text-fg placeholder:text-fg-muted focus:outline-none"
+                :style="isDesktop ? { height: composerHeight + 'px' } : undefined"
                 :placeholder='busy ? $t("chat.working") : $t("chat.message")'
                 @input="onInput"
                 @keydown="onKeydown"

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -62,6 +62,7 @@ export default {
   palette: { placeholder: "Jump to a session…", noMatches: "no matches" },
   chat: {
     selectSession: "Select a session",
+    resizeComposer: "Drag to resize input height",
     browseFiles: "Browse files",
     viewChanges: "View changes",
     changed: "changed",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -60,6 +60,7 @@ export default {
   palette: { placeholder: "跳转到会话…", noMatches: "无匹配项" },
   chat: {
     selectSession: "选择一个会话",
+    resizeComposer: "拖动调整输入框高度",
     browseFiles: "浏览文件",
     viewChanges: "查看改动",
     changed: "处改动",

--- a/packages/relay-web/src/lib/resize-panel.ts
+++ b/packages/relay-web/src/lib/resize-panel.ts
@@ -47,6 +47,33 @@ export interface PanelResizeController {
   onPointerDown(e: PointerLike): void;
 }
 
+export interface VerticalPointerLike {
+  clientY: number;
+}
+
+export interface BottomPanelResizeOptions {
+  getHeight: () => number;
+  setHeight: (h: number) => void;
+  /** Hard lower bound (px). */
+  min: number;
+  /** Hard upper bound (px). */
+  max: number;
+  /** Optional extra cap as a fraction of viewport height (e.g. 0.5). */
+  maxViewportFraction?: number;
+  /** Defaults to `window.innerHeight`. */
+  viewportHeight?: () => number;
+  /** Only act when the static (desktop) layout is active. */
+  isEnabled: () => boolean;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
+  /** Event target for move/up listeners; defaults to `window`. */
+  target?: EventTargetLike;
+}
+
+export interface BottomPanelResizeController {
+  onPointerDown(e: VerticalPointerLike): void;
+}
+
 /**
  * Clamp a raw desired width to [min, hi], where hi is `max` further capped to
  * `floor(viewportWidth * fraction)` when a fraction is given. Rounds to whole
@@ -113,6 +140,58 @@ export function createPanelResize(opts: PanelResizeOptions): PanelResizeControll
     dragging = true;
     startX = e.clientX;
     startWidth = opts.getWidth();
+    target.addEventListener("pointermove", onMove);
+    target.addEventListener("pointerup", onUp);
+    target.addEventListener("pointercancel", onUp);
+    opts.onDragStart?.();
+  }
+
+  return { onPointerDown };
+}
+
+/**
+ * Vertical mirror of `createPanelResize` for a bottom-anchored panel dragged by
+ * its TOP edge: moving the pointer up grows the panel, moving it down shrinks
+ * it. Same clamping, gating, and listener lifecycle as the horizontal variant.
+ */
+export function createBottomPanelResize(opts: BottomPanelResizeOptions): BottomPanelResizeController {
+  const viewportHeight = opts.viewportHeight ?? (() => window.innerHeight);
+  const target: EventTargetLike = opts.target ?? (window as unknown as EventTargetLike);
+
+  let startY = 0;
+  let startHeight = 0;
+  let dragging = false;
+
+  function applyHeight(clientY: number): void {
+    const delta = startY - clientY;
+    const next = clampPanelWidth(
+      startHeight + delta,
+      opts.min,
+      opts.max,
+      viewportHeight(),
+      opts.maxViewportFraction,
+    );
+    opts.setHeight(next);
+  }
+
+  function onMove(e: VerticalPointerLike): void {
+    if (dragging) applyHeight(e.clientY);
+  }
+
+  function onUp(): void {
+    if (!dragging) return;
+    dragging = false;
+    target.removeEventListener("pointermove", onMove);
+    target.removeEventListener("pointerup", onUp);
+    target.removeEventListener("pointercancel", onUp);
+    opts.onDragEnd?.();
+  }
+
+  function onPointerDown(e: VerticalPointerLike): void {
+    if (!opts.isEnabled()) return;
+    dragging = true;
+    startY = e.clientY;
+    startHeight = opts.getHeight();
     target.addEventListener("pointermove", onMove);
     target.addEventListener("pointerup", onUp);
     target.addEventListener("pointercancel", onUp);


### PR DESCRIPTION
## Summary
- Raise the desktop chat composer default height to 120px (was ~2 rows) for more comfortable editing.
- Add a drag strip above the composer (desktop ≥1024px only) to resize the textarea height, clamped 60–480px and ≤50% of viewport height, persisted to `localStorage("xacpx.composerHeight")`.
- New `createBottomPanelResize` in `resize-panel.ts` — vertical mirror of the existing right-panel resize with the same clamp/listener lifecycle; mobile keeps `rows="2"` behavior untouched.

## Test plan
- [x] `vitest` relay-web suite: 946 tests pass (incl. 4 new vertical-resize cases)
- [x] `vue-tsc --noEmit` clean
- [ ] Manual: drag handle on desktop, verify mobile unchanged