### PR TITLE
fix(relay-web): preserve text/tool interleaving at Markdown boundaries

### DIFF
--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -244,6 +244,37 @@ describe("MessageList", () => {
     ).toBeTruthy();
   });
 
+  it("keeps a leading tool before narrative when only whitespace preceded it", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [],
+        liveTurn: live([
+          { type: "text", text: " \n" },
+          {
+            type: "tool",
+            step: {
+              toolCallId: "read-1",
+              toolName: "Read",
+              kind: "read",
+              status: "success",
+              title: "index.css",
+            },
+          },
+          { type: "text", text: "after" },
+        ]),
+      },
+    });
+
+    const bubble = wrapper.find('[data-test="msg-streaming"]');
+    const tool = bubble.find('[data-test="tool-step-header"]');
+    const narrative = bubble.find(".stream-md");
+    expect(narrative.text()).toBe("after");
+    expect(
+      tool.element.compareDocumentPosition(narrative.element)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("keeps the live indicator on the latest visible reasoning activity", () => {
     const wrapper = mount(MessageList, {
       props: {

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -87,6 +87,17 @@ describe("deriveTurnPresentation", () => {
     ]);
   });
 
+  it("shows a leading tool before narrative when only whitespace preceded it", () => {
+    expect(visibleShape([
+      { type: "text", text: " \n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "after" },
+    ])).toEqual([
+      { type: "tool", id: "read-1" },
+      { type: "text", text: " \nafter" },
+    ]);
+  });
+
   it("folds child tools into their parent subagent activity", () => {
     const parent: ToolStepDto = {
       ...tool("agent-1"),

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -69,7 +69,7 @@ export function deriveTurnPresentation(parts: TurnPartDto[]): TurnPresentationIt
 
   const anchored = new Map<number, typeof activities>();
   for (const activity of activities) {
-    const anchor = activity.offset === 0
+    const anchor = narrative.slice(0, activity.offset).trim().length === 0
       ? 0
       : (boundaries.find((boundary) => boundary >= activity.offset) ?? narrative.length);
     const group = anchored.get(anchor) ?? [];


### PR DESCRIPTION
## Summary

- derive Relay Web turn presentation from the ordered wire transcript instead of bucketing all activity above all narrative
- keep text continuous while a paragraph, list, table, or fenced code block is still in progress
- place tool and reasoning activity at the end of that Markdown block, preserving text–activity–text interleaving at explicit block boundaries
- keep live turns and persisted history on the same presentation path, including subagent folding and streaming indicators

## Root cause

PR #221 concatenated every text part into one narrative lane and moved every tool/reasoning part into a separate activity lane. That protected Markdown continuity, but discarded the structural position of activity relative to narrative text.

The new presentation module records each activity's text offset and anchors it to the next safe top-level Markdown boundary. This avoids both failure modes: transport events no longer split an in-progress Markdown construct, and activity is no longer globally separated from narrative.

## User impact

Agent replies once again preserve meaningful text/tool interleaving. A tool event that arrives in the middle of a paragraph no longer tears the paragraph apart, while tools emitted between completed Markdown blocks remain visible in their original narrative position.

## Validation

- `bun run test --reporter=dot` — 108 test files, 949 tests passed
- `bun run build`
- `npx tsc --noEmit`
- `git diff --check`
