### PR TITLE
fix(relay): make session rename immediate

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -171,8 +171,9 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   按 Enter 后 store 会立即乐观更新本地行，不等待 RPC 返回。pending 展示名会覆盖期间
   `sessions-changed` 触发的旧列表快照；同一会话的连续 rename 在 Web 侧按 FIFO 提交，失败时只回滚到
   最近确认值，迟到响应不能覆盖更新的名称。**空值清除**（回退显示 `alias`），不做唯一性约束。
-- Hub 仍为 rename 盖戳可信 `chatKey`，但它不进入 prompt/create/remove/archive/unarchive 共用的
-  同会话生命周期锁：展示名不改变会话身份，因此 agent 回合运行中也能立即持久化和跨 dashboard 同步。
+- Hub 仍为 rename 盖戳可信 `chatKey`。rename 不占同会话 turn 锁，因此 agent 回合运行中也能立即
+  持久化和跨 dashboard 同步；它仍占 lifecycle/metadata 锁，与 create/remove/archive/unarchive
+  保持互斥，避免跨会话 incarnation 写入。
 - 侧边栏与 `ChatPane` 头部均渲染 `displayName || alias`。微信 `/sessions`、`/use` 不受影响。
 
 ## 会话睡眠（原「归档」）与冷会话指示器

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -168,7 +168,11 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
 - 设置的是一个**纯展示名 `display_name`**（核心 `LogicalSession.display_name` → `SessionDto.displayName`）；
   它**不改会话身份**：`alias`、`/use` 句柄、transport 会话名都不变，仅 relay-web 展示。
 - 走 RPC `control.sessions.rename {alias, displayName}`（连接器 → `ControlService.setSessionDisplayName`）；
-  store `renameSession` 提交后乐观更新本地行。**空值清除**（回退显示 `alias`），不做唯一性约束。
+  按 Enter 后 store 会立即乐观更新本地行，不等待 RPC 返回。pending 展示名会覆盖期间
+  `sessions-changed` 触发的旧列表快照；同一会话的连续 rename 在 Web 侧按 FIFO 提交，失败时只回滚到
+  最近确认值，迟到响应不能覆盖更新的名称。**空值清除**（回退显示 `alias`），不做唯一性约束。
+- Hub 仍为 rename 盖戳可信 `chatKey`，但它不进入 prompt/create/remove/archive/unarchive 共用的
+  同会话生命周期锁：展示名不改变会话身份，因此 agent 回合运行中也能立即持久化和跨 dashboard 同步。
 - 侧边栏与 `ChatPane` 头部均渲染 `displayName || alias`。微信 `/sessions`、`/use` 不受影响。
 
 ## 会话睡眠（原「归档」）与冷会话指示器

--- a/docs/superpowers/plans/2026-07-30-issue-226-session-rename-immediate.md
+++ b/docs/superpowers/plans/2026-07-30-issue-226-session-rename-immediate.md
@@ -9,9 +9,11 @@ show the new name immediately and persist it without waiting for the turn to
 finish, while preserving lifecycle ordering, trusted chat scoping, error
 visibility, and cross-dashboard convergence.
 
-**Architecture:** Split cosmetic metadata from lifecycle serialization at the
-Hub boundary: `control.sessions.rename` remains chat-scoped but no longer takes
-the same keyed lock as prompt/create/remove/archive/unarchive. In Relay Web,
+**Architecture:** Split same-session turn and lifecycle serialization at the
+Hub boundary: `control.sessions.rename` remains chat-scoped and shares a
+lifecycle/metadata lock with create/remove/archive/unarchive, but it does not
+take the turn lock held by prompt/command-execute. Identity-changing lifecycle
+operations take both locks. In Relay Web,
 apply the display name before the RPC resolves and keep a per-session pending
 overlay across `sessions-changed` reloads. Serialize only Web rename mutations
 for the same session so consecutive attempts have deterministic confirmation
@@ -26,9 +28,9 @@ for Hub code, Vitest/jsdom for Relay Web.
 
 - `MSG.sessionsRename` stays in `CHAT_SCOPED_TYPES`; the Hub must continue to
   overwrite client-supplied `chatKey`, `senderId`, and `isOwner`.
-- Only cosmetic rename bypasses the keyed RPC lock. Prompt,
-  command-execute, create, remove, archive, and unarchive retain their current
-  same-session ordering.
+- Cosmetic rename bypasses only the turn lock. It stays serialized with create,
+  remove, archive, and unarchive; identity-changing lifecycle operations also
+  retain their ordering with prompt and command-execute.
 - Wire protocol, RPC names/payloads, Core persistence, `alias`,
   `transportSession`, and `/use` semantics do not change.
 - Preserve #212 behavior: connector errors are unwrapped, the existing error
@@ -43,8 +45,8 @@ for Hub code, Vitest/jsdom for Relay Web.
 
 ## File Structure
 
-- **Modify** `packages/relay/src/http/app.ts` — remove rename from the
-  lifecycle-lock classifier while retaining chat scoping.
+- **Modify** `packages/relay/src/http/app.ts` — split turn and lifecycle lock
+  classification while retaining chat scoping.
 - **Modify** `tests/unit/packages/relay/http-app.test.ts` — prove rename
   bypasses a pending prompt and lifecycle mutations still wait.
 - **Modify** `packages/relay-web/src/stores/instances.ts` — immediate local
@@ -59,7 +61,7 @@ for Hub code, Vitest/jsdom for Relay Web.
 
 ---
 
-## Task 1: Let cosmetic rename bypass the Hub lifecycle lock
+## Task 1: Let cosmetic rename bypass the Hub turn lock
 
 **Files:**
 
@@ -73,6 +75,8 @@ for Hub code, Vitest/jsdom for Relay Web.
   `gateway.sendRequest` and returns without waiting for that prompt.
 - A later lifecycle operation such as `control.sessions.remove` still waits
   for the prompt, proving the lock was narrowed rather than disabled.
+- Rename remains mutually exclusive with create/remove/archive/unarchive for
+  the same alias.
 - Rename still receives the server-stamped `chatKey`.
 
 - [ ] **Step 1: Add a controllable gateway seam to the test helper**
@@ -146,20 +150,13 @@ Expected before the fix:
 - rename-bypasses-prompt test fails because `renameForwarded` is not reached;
 - lifecycle counterexample and existing chatKey stamping tests remain valid.
 
-- [ ] **Step 5: Narrow `rpcSessionAlias()`**
+- [ ] **Step 5: Split turn and lifecycle lock classification**
 
-In `packages/relay/src/http/app.ts`, remove only:
-
-```ts
-type === MSG.sessionsRename
-```
-
-from the alias-returning lifecycle branch. Leave
-`MSG.sessionsRename` in `CHAT_SCOPED_TYPES`.
-
-Add a short comment near `rpcSessionAlias()` explaining that the function
-classifies RPCs needing lifecycle ordering, not every RPC that carries a
-session alias; cosmetic metadata writes intentionally bypass it.
+In `packages/relay/src/http/app.ts`, classify prompt/command-execute for the
+turn lock, rename for the lifecycle/metadata lock, and
+create/remove/archive/unarchive for both. Acquire lifecycle before turn so an
+identity mutation queued behind a running turn cannot be overtaken by a later
+rename. Leave `MSG.sessionsRename` in `CHAT_SCOPED_TYPES`.
 
 - [ ] **Step 6: Verify Hub behavior**
 
@@ -177,7 +174,7 @@ the remove counterexample remains blocked until release.
 
 ```bash
 git add packages/relay/src/http/app.ts tests/unit/packages/relay/http-app.test.ts
-git commit -m "fix(relay): let session rename bypass turn lifecycle lock"
+git commit -m "fix(relay): let session rename bypass turn lock"
 ```
 
 ---
@@ -375,8 +372,8 @@ In `docs/relay-web-module.md`'s session rename section, document:
 - pending names survive `sessions-changed` list reloads;
 - same-session Web rename attempts reconcile FIFO with confirmed-value
   rollback;
-- rename remains chat-scoped but intentionally bypasses the Hub lifecycle lock
-  because it does not change session identity.
+- rename remains chat-scoped, bypasses the Hub turn lock because it does not
+  change session identity, and remains serialized with lifecycle mutations.
 
 Do not describe alias/transport rename; those remain out of scope.
 

--- a/docs/superpowers/plans/2026-07-30-issue-226-session-rename-immediate.md
+++ b/docs/superpowers/plans/2026-07-30-issue-226-session-rename-immediate.md
@@ -1,0 +1,460 @@
+# Issue #226 Session Rename Immediate Update — Implementation Plan
+
+> **For agentic workers:** execute the plan task-by-task. Keep the two production
+> changes in separate commits so the Hub ordering fix and Web optimistic-state
+> hardening can be reviewed and reverted independently.
+
+**Goal:** When a Relay Web user renames a session during an active agent turn,
+show the new name immediately and persist it without waiting for the turn to
+finish, while preserving lifecycle ordering, trusted chat scoping, error
+visibility, and cross-dashboard convergence.
+
+**Architecture:** Split cosmetic metadata from lifecycle serialization at the
+Hub boundary: `control.sessions.rename` remains chat-scoped but no longer takes
+the same keyed lock as prompt/create/remove/archive/unarchive. In Relay Web,
+apply the display name before the RPC resolves and keep a per-session pending
+overlay across `sessions-changed` reloads. Serialize only Web rename mutations
+for the same session so consecutive attempts have deterministic confirmation
+and rollback semantics.
+
+**Tech Stack:** TypeScript, Hono Relay Hub, Vue 3 + Pinia Relay Web, Bun tests
+for Hub code, Vitest/jsdom for Relay Web.
+
+**Research:** `docs/superpowers/specs/2026-07-30-issue-226-session-rename-latency-research.md`
+
+## Global Constraints
+
+- `MSG.sessionsRename` stays in `CHAT_SCOPED_TYPES`; the Hub must continue to
+  overwrite client-supplied `chatKey`, `senderId`, and `isOwner`.
+- Only cosmetic rename bypasses the keyed RPC lock. Prompt,
+  command-execute, create, remove, archive, and unarchive retain their current
+  same-session ordering.
+- Wire protocol, RPC names/payloads, Core persistence, `alias`,
+  `transportSession`, and `/use` semantics do not change.
+- Preserve #212 behavior: connector errors are unwrapped, the existing error
+  toast remains visible, and successful persistence emits
+  `sessions-changed`.
+- A stale failure must never overwrite a newer rename. A server refresh must
+  not overwrite the latest rename while its RPC is pending.
+- Relay Web tests run with Vitest, not `bun test`. Smoke tests are out of scope
+  because they require real acpx and WeChat infrastructure.
+- Preserve the unrelated untracked
+  `docs/superpowers/specs/2026-07-27-relay-web-message-fork-design.md`.
+
+## File Structure
+
+- **Modify** `packages/relay/src/http/app.ts` — remove rename from the
+  lifecycle-lock classifier while retaining chat scoping.
+- **Modify** `tests/unit/packages/relay/http-app.test.ts` — prove rename
+  bypasses a pending prompt and lifecycle mutations still wait.
+- **Modify** `packages/relay-web/src/stores/instances.ts` — immediate local
+  update, per-session rename queue, pending overlay during session reloads,
+  confirmed-value rollback.
+- **Modify** `packages/relay-web/src/__tests__/instances-rename.test.ts` —
+  deferred-RPC, reload-overlay, and consecutive-rename coverage.
+- **Modify** `packages/relay-web/src/__tests__/instancetree-rename.test.ts` —
+  assert the visible row changes before the RPC resolves.
+- **Modify** `docs/relay-web-module.md` — document immediate optimistic rename,
+  pending reconciliation, and the Hub lock exception.
+
+---
+
+## Task 1: Let cosmetic rename bypass the Hub lifecycle lock
+
+**Files:**
+
+- Modify: `packages/relay/src/http/app.ts`
+- Test: `tests/unit/packages/relay/http-app.test.ts`
+
+**Contract:**
+
+- `control.prompt` for `(instance, alias)` may remain pending.
+- A later `control.sessions.rename` for the same key reaches
+  `gateway.sendRequest` and returns without waiting for that prompt.
+- A later lifecycle operation such as `control.sessions.remove` still waits
+  for the prompt, proving the lock was narrowed rather than disabled.
+- Rename still receives the server-stamped `chatKey`.
+
+- [ ] **Step 1: Add a controllable gateway seam to the test helper**
+
+Extend `makeApp(opts)` in `http-app.test.ts` with an optional
+`sendRequest` function. Keep `rpcCalls` recording in the helper wrapper so
+existing tests retain the same observations:
+
+```ts
+async function makeApp(opts: {
+  trustProxy?: boolean;
+  now?: () => Date;
+  sendRequest?: (instanceId: string, type: string, payload: unknown) => Promise<unknown>;
+} = {}) {
+  // ...
+  const gateway = {
+    isOnline: (id: string) => id !== "offline-id",
+    sendRequest: async (instanceId: string, type: string, payload: unknown) => {
+      rpcCalls.push({ instanceId, type, payload });
+      return await (opts.sendRequest?.(instanceId, type, payload)
+        ?? Promise.resolve({ sessions: [] }));
+    },
+  };
+  // ...
+}
+```
+
+Add a small local `deferred<T>()` helper returning
+`{ promise, resolve, reject }`; do not use real sleeps.
+
+- [ ] **Step 2: Write the failing concurrency regression test**
+
+Add a test that:
+
+1. Logs in and redeems an instance as existing HTTP tests do.
+2. Starts a `MSG.prompt` request for alias `backend`.
+3. Holds only that gateway call on a deferred Promise and waits for a
+   `promptStarted` signal.
+4. Starts `MSG.sessionsRename` for the same alias.
+5. Races a `renameForwarded` deferred (resolved by the fake gateway) against a
+   short bounded test sentinel and expects `renameForwarded` to win. This keeps
+   the current buggy implementation red without leaving the test hung on a
+   never-resolving Promise.
+6. Awaits the rename HTTP response and asserts status 200 plus stamped
+   `chatKey`.
+7. Releases and awaits the prompt request so the test leaves no pending work.
+
+The test must fail on the current code because rename waits inside
+`acquireSessionRpcLock`.
+
+- [ ] **Step 3: Add the lifecycle-lock counterexample**
+
+Using the same deferred-prompt shape, start `MSG.sessionsRemove` for the same
+alias. Assert its gateway signal has not fired while the prompt is pending;
+after releasing the prompt, assert remove is forwarded and completes.
+
+Use a deterministic observation seam (recorded call/signal driven by the fake
+gateway), not a long wall-clock timeout. A single event-loop yield is allowed
+only to let Hono begin processing the second request.
+
+- [ ] **Step 4: Run the new tests and confirm the intended red state**
+
+Run:
+
+```bash
+bun test tests/unit/packages/relay/http-app.test.ts
+```
+
+Expected before the fix:
+
+- rename-bypasses-prompt test fails because `renameForwarded` is not reached;
+- lifecycle counterexample and existing chatKey stamping tests remain valid.
+
+- [ ] **Step 5: Narrow `rpcSessionAlias()`**
+
+In `packages/relay/src/http/app.ts`, remove only:
+
+```ts
+type === MSG.sessionsRename
+```
+
+from the alias-returning lifecycle branch. Leave
+`MSG.sessionsRename` in `CHAT_SCOPED_TYPES`.
+
+Add a short comment near `rpcSessionAlias()` explaining that the function
+classifies RPCs needing lifecycle ordering, not every RPC that carries a
+session alias; cosmetic metadata writes intentionally bypass it.
+
+- [ ] **Step 6: Verify Hub behavior**
+
+Run:
+
+```bash
+bun test tests/unit/packages/relay/http-app.test.ts
+bun test tests/unit/packages/relay/gateway.test.ts tests/unit/packages/relay/integration.test.ts
+```
+
+Expected: all pass; the new rename test completes before prompt release, while
+the remove counterexample remains blocked until release.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/relay/src/http/app.ts tests/unit/packages/relay/http-app.test.ts
+git commit -m "fix(relay): let session rename bypass turn lifecycle lock"
+```
+
+---
+
+## Task 2: Make Relay Web rename genuinely optimistic and race-safe
+
+**Files:**
+
+- Modify: `packages/relay-web/src/stores/instances.ts`
+- Test: `packages/relay-web/src/__tests__/instances-rename.test.ts`
+- Test: `packages/relay-web/src/__tests__/instancetree-rename.test.ts`
+
+**Store invariants:**
+
+1. Calling `renameSession` mutates the visible row synchronously before its RPC
+   settles.
+2. `loadSessions` overlays the newest pending display name onto an
+   authoritative list response.
+3. Same-session rename RPCs execute FIFO even if users submit again quickly.
+4. Each success advances the last confirmed value.
+5. The latest failure rolls back to the last confirmed value; a stale
+   success/failure never replaces a newer optimistic value.
+6. Different instance/session keys remain independent.
+
+- [ ] **Step 1: Add deferred-RPC tests for immediate update**
+
+Replace the misleading current “optimistically sets” test with a Promise that
+does not resolve immediately:
+
+1. Seed `displayName: "old"`.
+2. Call `store.renameSession(..., "New label")` without awaiting it.
+3. Immediately assert the row is `"New label"` and the correct RPC was sent.
+4. Resolve the RPC and await the returned Promise.
+
+Keep the existing whitespace trim and empty-clears assertions.
+
+- [ ] **Step 2: Add pending-overlay and rollback tests**
+
+Add store tests for:
+
+- `loadSessions()` returns server value `"old"` while rename is pending; the
+  visible row remains `"New label"`.
+- A single RPC error rejects and restores `"old"`.
+- `unknown-type` still produces the connector-upgrade hint and restores the
+  previous label.
+
+Seed a non-empty `agents` list, or route the mock by RPC type, so
+`loadSessions`' optional agent prefetch cannot make call-order assertions
+fragile.
+
+- [ ] **Step 3: Add consecutive-rename tests**
+
+Use two deferred RPC results for the same key:
+
+- Submit A, then submit B before A resolves. The row must immediately show B,
+  while only A has reached `api.rpc`.
+- A succeeds, then B is sent and fails: the row rolls back to confirmed A.
+- A fails, then B succeeds: A's failure never removes optimistic B, and the
+  final row is B.
+
+Also add a small independence test showing a pending rename for
+`i1/backend` does not delay `i1/frontend` (or `i2/backend`).
+
+- [ ] **Step 4: Add the component-level visible regression**
+
+In `instancetree-rename.test.ts`, use the real store method with a deferred
+`api.rpc` instead of spying `renameSession` to immediate resolution:
+
+1. Open Rename, set the input, press Enter.
+2. Await Vue DOM flushing only—not the RPC.
+3. Assert the input is gone and `[data-test="session-name"]` contains the new
+   value while the RPC is still unresolved.
+4. Resolve the RPC and cleanly await pending promises.
+
+Keep the existing Escape and Enter+blur double-commit tests.
+
+- [ ] **Step 5: Run tests and confirm the intended red state**
+
+Run:
+
+```bash
+bun run --cwd packages/relay-web test -- \
+  src/__tests__/instances-rename.test.ts \
+  src/__tests__/instancetree-rename.test.ts
+```
+
+Expected before the store fix: immediate-update and pending-overlay cases fail.
+
+- [ ] **Step 6: Implement per-session pending state**
+
+Inside `useInstancesStore`, add private store-local state keyed by a collision-
+safe value such as `JSON.stringify([instanceId, alias])`:
+
+```ts
+interface PendingSessionRename {
+  latestRevision: number;
+  desiredDisplayName?: string;
+  confirmedDisplayName?: string;
+}
+
+const pendingSessionRenames = new Map<string, PendingSessionRename>();
+const sessionRenameTails = new Map<string, Promise<void>>();
+let sessionRenameRevision = 0;
+```
+
+Do not expose these as protocol DTO fields or persist them to local storage.
+
+- [ ] **Step 7: Overlay pending names in `loadSessions()`**
+
+Before assigning the server array to `inst.sessions`, map each row. When a
+pending entry exists, first copy the server row's `displayName` into
+`pending.confirmedDisplayName`, then overlay the local desired value:
+
+```ts
+const pending = pendingSessionRenames.get(renameKey(instanceId, session.alias));
+if (!pending) return session;
+pending.confirmedDisplayName = session.displayName;
+return { ...session, displayName: pending.desiredDisplayName };
+```
+
+Use the overlaid rows for display only. Tail-cache reconciliation must continue
+to use alias and `transportSession`; rename state must not affect incarnation
+logic. Updating `confirmedDisplayName` is important: if another dashboard
+changes the name while this client has a pending rename that later fails,
+rollback must use the newest server value rather than the value captured before
+the request began.
+
+- [ ] **Step 8: Implement immediate update plus FIFO mutation handling**
+
+Refactor `renameSession` so its synchronous prefix:
+
+1. trims the requested name and converts empty to `undefined`;
+2. finds the current row;
+3. creates or updates the pending state, preserving its confirmed value across
+   consecutive attempts;
+4. increments `latestRevision`;
+5. immediately updates the live row;
+6. chains the RPC behind the previous same-key rename tail.
+
+When one queued operation runs:
+
+- on success, update the pending state's confirmed value to that operation's
+  value; clear pending state only if it is still the latest revision;
+- on failure, if it is the latest revision, clear pending state and restore the
+  last confirmed value on the current live row; if a newer revision exists,
+  leave its optimistic value untouched;
+- always rethrow the operation's error so `InstanceTree` keeps showing the
+  existing error toast;
+- clean `sessionRenameTails` only if the completing Promise is still the map's
+  current tail;
+- use both fulfillment and rejection cleanup handlers so cleanup itself does
+  not create an unhandled rejected Promise.
+
+Same-key FIFO is a Web consistency mechanism only; it must not reintroduce
+prompt/rename coupling. Different keys get different tails.
+
+- [ ] **Step 9: Verify focused Web tests**
+
+Run:
+
+```bash
+bun run --cwd packages/relay-web test -- \
+  src/__tests__/instances-rename.test.ts \
+  src/__tests__/instancetree-rename.test.ts \
+  src/__tests__/chatpane-displayname.test.ts \
+  src/__tests__/commandpalette.test.ts
+```
+
+Expected: all pass, including deferred update, overlay, rollback, and
+consecutive rename cases.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add \
+  packages/relay-web/src/stores/instances.ts \
+  packages/relay-web/src/__tests__/instances-rename.test.ts \
+  packages/relay-web/src/__tests__/instancetree-rename.test.ts
+git commit -m "fix(relay-web): update session names optimistically"
+```
+
+---
+
+## Task 3: Update documentation and run cross-layer validation
+
+**Files:**
+
+- Modify: `docs/relay-web-module.md`
+
+- [ ] **Step 1: Update the rename behavior documentation**
+
+In `docs/relay-web-module.md`'s session rename section, document:
+
+- the row changes immediately on Enter;
+- pending names survive `sessions-changed` list reloads;
+- same-session Web rename attempts reconcile FIFO with confirmed-value
+  rollback;
+- rename remains chat-scoped but intentionally bypasses the Hub lifecycle lock
+  because it does not change session identity.
+
+Do not describe alias/transport rename; those remain out of scope.
+
+- [ ] **Step 2: Run formatting and static checks**
+
+Run:
+
+```bash
+git diff --check
+npx tsc --noEmit
+bun run --cwd packages/relay-web build
+```
+
+Expected: no whitespace errors, TypeScript errors, or Vue build errors.
+
+- [ ] **Step 3: Run focused cross-layer tests**
+
+Run:
+
+```bash
+bun test \
+  tests/unit/packages/relay/http-app.test.ts \
+  tests/unit/packages/relay/gateway.test.ts \
+  tests/unit/packages/relay/integration.test.ts \
+  tests/unit/packages/channel-relay/control-bridge.test.ts \
+  tests/unit/control/control-service-display-name.test.ts
+
+bun run --cwd packages/relay-web test -- \
+  src/__tests__/instances-rename.test.ts \
+  src/__tests__/instancetree-rename.test.ts \
+  src/__tests__/chatpane-displayname.test.ts \
+  src/__tests__/commandpalette.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Run the repository unit suite**
+
+Run:
+
+```bash
+npm test
+```
+
+Expected: typecheck and all `tests/unit/**/*.test.ts` pass. Do not run
+`npm run test:smoke`.
+
+- [ ] **Step 5: Manual acceptance in Relay Web**
+
+With a locally built Relay stack:
+
+1. Start a turn that runs long enough to keep the working indicator visible.
+2. Rename that same session and press Enter.
+3. Confirm the sidebar and ChatPane header change immediately.
+4. Confirm the turn continues uninterrupted.
+5. Refresh before the turn finishes and confirm the persisted new name remains.
+6. Open a second dashboard and confirm it receives the name via
+   `sessions-changed`.
+7. Rename twice quickly; confirm the last successful value wins.
+8. Simulate connector failure/offline and confirm the name rolls back with an
+   error toast.
+
+- [ ] **Step 6: Commit documentation**
+
+```bash
+git add docs/relay-web-module.md
+git commit -m "docs(relay-web): document immediate session rename semantics"
+```
+
+## Done When
+
+- Rename is forwarded and persisted while an agent turn for the same session is
+  still active.
+- The new label appears immediately on Enter without waiting for network
+  completion.
+- Refresh/list reconciliation cannot replace a pending optimistic label with
+  stale server data.
+- Consecutive rename success/failure order is deterministic.
+- `CHAT_SCOPED_TYPES`, error unwrap/toast, `sessions-changed`, and lifecycle
+  locking remain intact.
+- Focused tests, `npx tsc --noEmit`, Relay Web build, and `npm test` pass.

--- a/docs/superpowers/specs/2026-07-30-issue-226-session-rename-latency-research.md
+++ b/docs/superpowers/specs/2026-07-30-issue-226-session-rename-latency-research.md
@@ -25,8 +25,8 @@ Issue #226 是确定性的同会话 RPC 串行阻塞，不是 Vue 渲染或
    issue：“Enter 后看起来没成功，agent 执行结束后才显示新名称”。
    来源：[issue #226 正文](https://github.com/gadzan/xacpx/issues/226)。
 
-最小根因修复是：**保留 rename 的 chat scope 盖戳，但把
-`MSG.sessionsRename` 从 Hub 的 `rpcSessionAlias()` 串行集合中移除。**
+最小根因修复是：**保留 rename 的 chat scope 盖戳，把同会话的 turn 与 lifecycle/metadata
+串行拆开；rename 只绕过 prompt 持有的 turn 锁，并继续与 create/remove/archive/unarchive 互斥。**
 建议同时把 Web 改成真正的乐观更新，并实现带请求代次/当前值检查的失败回滚；前者解决服务端阻塞，
 后者提供即时反馈和稳健的错误体验。
 
@@ -70,9 +70,9 @@ Core 的展示名写入也已有自身的一致性边界：
   请求未完成时执行。
   来源：[bridge scheduler 并发测试](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/tests/unit/bridge/bridge-request-scheduler.test.ts#L46-L73)。
 
-据此推断，展示名无需 Hub 的“整回合”锁；移出该锁不会使 alias/transport 身份在 turn 中途变化，
-逻辑状态写入仍由 Core mutex 串行。这个判断不应外推到 create/remove/archive/unarchive：
-它们改变会话生命周期，仍应保留现有排序。
+据此推断，展示名无需 Hub 的“整回合”turn 锁；绕过该锁不会使 alias/transport 身份在 turn 中途变化，
+逻辑状态写入仍由 Core mutex 串行。rename 仍应通过独立 lifecycle/metadata 锁与
+create/remove/archive/unarchive 互斥，避免在会话销毁或重建期间写入错误 incarnation。
 
 ## 回归来源
 
@@ -90,23 +90,25 @@ Hub 的 keyed RPC lock 由提交
   `chatKey`；这必须保留。当前注释也说明 connector payload validator 需要该字段。
   来源：[chat-scoped 集合](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay/src/http/app.ts#L52-L74)、
   [chatKey stamping 测试](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/tests/unit/packages/relay/http-app.test.ts#L302-L322)。
-- 不必要地把 `MSG.sessionsRename` 也加入 `rpcSessionAlias()` 的生命周期锁集合，从而引入
-  issue #226。
+- 不必要地让 `MSG.sessionsRename` 与 prompt 共用同一把覆盖整回合的锁，从而引入 issue #226；
+  它与身份生命周期操作之间的互斥仍需保留。
   来源：[提交 diff](https://github.com/gadzan/xacpx/commit/08d5204286575a693f3e40881d86e31e4834fdeb)。
 
 因此修复不能简单回退整个 #212；应只解耦“chat scope stamping”和“同会话 RPC locking”。
 
 ## 建议修复
 
-### 1. 必需：解除 Hub 对 rename 的整回合串行
+### 1. 必需：解除 Hub 对 rename 的整回合串行，同时保留生命周期互斥
 
-在 `packages/relay/src/http/app.ts` 的 `rpcSessionAlias()` 中移除
-`type === MSG.sessionsRename`；不要从 `CHAT_SCOPED_TYPES` 移除它。
+在 `packages/relay/src/http/app.ts` 中拆分 turn 与 lifecycle/metadata 两把 keyed lock：
+prompt/command-execute 取得 turn，rename 取得 lifecycle/metadata，
+create/remove/archive/unarchive 先取得 lifecycle/metadata 再取得 turn。不要从
+`CHAT_SCOPED_TYPES` 移除 rename。
 
 预期时序变为：
 
-1. prompt 继续持有同会话的 lifecycle RPC lock；
-2. rename 不申请该锁，立刻经 gateway 下发；
+1. prompt 继续持有同会话的 turn lock；
+2. rename 只申请未被 prompt 占用的 lifecycle/metadata lock，立刻经 gateway 下发；
 3. Core 在共享 state mutex 内写入 `display_name`；
 4. `sessions-changed` 上行，所有打开的 dashboard 重拉权威列表；
 5. rename RPC 返回成功。

--- a/docs/superpowers/specs/2026-07-30-issue-226-session-rename-latency-research.md
+++ b/docs/superpowers/specs/2026-07-30-issue-226-session-rename-latency-research.md
@@ -1,0 +1,200 @@
+# Issue #226：运行中会话重命名延迟调研
+
+**日期：** 2026-07-30
+**状态：** 调研完成，未修改实现
+**范围：** [GitHub issue #226](https://github.com/gadzan/xacpx/issues/226)、Relay Web → Relay Hub → channel-relay → Core 的重命名链路、相关设计与测试
+
+## 结论
+
+Issue #226 是确定性的同会话 RPC 串行阻塞，不是 Vue 渲染或
+`sessions-changed` 丢失：
+
+1. Relay Web 在 Enter 后立即退出输入态，但 `renameSession()` 要先等待
+   `control.sessions.rename` RPC 完成，成功后才写本地 `row.displayName`。所以现有注释和测试虽然称它为
+   “optimistic”，实际不是“请求发出即更新”。
+   来源：[InstanceTree 提交逻辑](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay-web/src/components/InstanceTree.vue#L149-L167)、
+   [instances store 重命名逻辑](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay-web/src/stores/instances.ts#L295-L302)。
+2. Relay Hub 把 `control.prompt` 与 `control.sessions.rename` 都映射到相同的
+   `${instanceId}\0${sessionAlias}` 锁键；请求获得锁后一直持有到
+   `gateway.sendRequest()` 返回。长 prompt 的响应要等 agent 回合结束，因此同一 alias 的 rename 只能排在它后面。
+   来源：[受锁 RPC 的 alias 归类](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay/src/http/app.ts#L101-L116)、
+   [锁实现](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay/src/http/app.ts#L118-L139)、
+   [请求取得锁并等待网关响应](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay/src/http/app.ts#L392-L420)、
+   [finally 释放锁](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay/src/http/app.ts#L443-L451)。
+3. Prompt 完成后，rename 才被下发、持久化并返回；Web 随后更新本地行。因此现象精确吻合
+   issue：“Enter 后看起来没成功，agent 执行结束后才显示新名称”。
+   来源：[issue #226 正文](https://github.com/gadzan/xacpx/issues/226)。
+
+最小根因修复是：**保留 rename 的 chat scope 盖戳，但把
+`MSG.sessionsRename` 从 Hub 的 `rpcSessionAlias()` 串行集合中移除。**
+建议同时把 Web 改成真正的乐观更新，并实现带请求代次/当前值检查的失败回滚；前者解决服务端阻塞，
+后者提供即时反馈和稳健的错误体验。
+
+## 复现序列
+
+1. 在 Relay Web 选中会话 `S`，发送一个会持续执行的 prompt。
+2. 该 prompt 的 HTTP RPC 在 Hub 取得 `(instanceId, S)` keyed lock，并等待 agent 回合完成。
+3. Agent 仍执行时，从 `S` 的菜单进入 Rename，输入新名称并按 Enter。
+4. 输入框立即消失，但 store 发出的 rename HTTP RPC 卡在同一个 keyed lock，尚未到达 connector。
+5. Sidebar 继续从 `row.displayName || alias` 渲染旧值；用户也没有 pending 状态，容易重复提交。
+6. Agent 回合完成，prompt RPC 释放锁；rename 才下发、持久化、触发
+   `sessions-changed` 并返回。此时 Sidebar 才显示新名称。
+
+来源：[issue #226 现象](https://github.com/gadzan/xacpx/issues/226)、
+[Enter 提交后立即退出输入态](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay-web/src/components/InstanceTree.vue#L158-L166)、
+[Hub 取得并持有同会话锁](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay/src/http/app.ts#L392-L420)。
+
+## 现有语义与为什么 rename 可以绕过 turn 锁
+
+会话重命名只设置可选的展示标签，`alias`、`transportSession`、`/use` 身份都不变；设计文档明确将
+“重命名底层 alias / transport session”列为范围外。因此它不改变当前回合的路由身份。
+来源：[display-name 设计的 Goal / Decisions](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/docs/superpowers/specs/2026-06-29-relay-web-session-display-name-design.md#L6-L24)、
+[Out of scope](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/docs/superpowers/specs/2026-06-29-relay-web-session-display-name-design.md#L99-L105)。
+
+Connector 对多个下行 request 本身支持异步并发：收到 request 后调用 `onRequest`，不等待前一个
+request 完成；control bridge 也以 fire-and-forget 方式启动
+`dispatchControlRequest()`。
+来源：[RelayClient request 分派](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/channel-relay/src/relay-client.ts#L246-L279)、
+[control bridge 异步 dispatch](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/channel-relay/src/control-bridge.ts#L130-L143)。
+
+Core 的展示名写入也已有自身的一致性边界：
+
+- `ControlService.setSessionDisplayName()` 解析 scoped alias，调用 session service 持久化，成功后发
+  `sessions-changed`。
+  来源：[ControlService](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/src/control/control-service.ts#L547-L553)。
+- `SessionService.setDisplayName()` 只修改 `display_name` 与 `last_used_at`，并通过共享
+  `stateMutex` 的 `mutate()` 持久化。
+  来源：[setDisplayName](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/src/sessions/session-service.ts#L785-L803)、
+  [mutate 使用共享 mutex](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/src/sessions/session-service.ts#L849-L857)。
+- 仓库的 bridge scheduler 已明确建立先例：同一 session 的 control 请求可以在 normal
+  请求未完成时执行。
+  来源：[bridge scheduler 并发测试](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/tests/unit/bridge/bridge-request-scheduler.test.ts#L46-L73)。
+
+据此推断，展示名无需 Hub 的“整回合”锁；移出该锁不会使 alias/transport 身份在 turn 中途变化，
+逻辑状态写入仍由 Core mutex 串行。这个判断不应外推到 create/remove/archive/unarchive：
+它们改变会话生命周期，仍应保留现有排序。
+
+## 回归来源
+
+Hub 的 keyed RPC lock 由提交
+[`feb4999d` / PR #187](https://github.com/gadzan/xacpx/commit/feb4999d732ec76d8f209e7f650bed46f9e99d76)
+引入；该提交同时处理“删除后同名重建不得恢复旧历史”和删除成功后清 Hub transcript。
+从提交 diff 看，lock 与 prompt、command、create/remove/archive/unarchive 一起进入 HTTP RPC
+代理。这里关于 lock 保护生命周期/历史顺序的目的，是基于同一提交上下文的推断。
+
+随后提交
+[`08d5204` / PR #212](https://github.com/gadzan/xacpx/commit/08d5204286575a693f3e40881d86e31e4834fdeb)
+修复 rename 没有 `chatKey`、错误被 Web 吞掉、其他 dashboard 不会实时刷新的问题。该提交同时做了两件不同性质的事：
+
+- 正确地把 `MSG.sessionsRename` 加入 `CHAT_SCOPED_TYPES`，让 Hub 覆写可信
+  `chatKey`；这必须保留。当前注释也说明 connector payload validator 需要该字段。
+  来源：[chat-scoped 集合](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay/src/http/app.ts#L52-L74)、
+  [chatKey stamping 测试](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/tests/unit/packages/relay/http-app.test.ts#L302-L322)。
+- 不必要地把 `MSG.sessionsRename` 也加入 `rpcSessionAlias()` 的生命周期锁集合，从而引入
+  issue #226。
+  来源：[提交 diff](https://github.com/gadzan/xacpx/commit/08d5204286575a693f3e40881d86e31e4834fdeb)。
+
+因此修复不能简单回退整个 #212；应只解耦“chat scope stamping”和“同会话 RPC locking”。
+
+## 建议修复
+
+### 1. 必需：解除 Hub 对 rename 的整回合串行
+
+在 `packages/relay/src/http/app.ts` 的 `rpcSessionAlias()` 中移除
+`type === MSG.sessionsRename`；不要从 `CHAT_SCOPED_TYPES` 移除它。
+
+预期时序变为：
+
+1. prompt 继续持有同会话的 lifecycle RPC lock；
+2. rename 不申请该锁，立刻经 gateway 下发；
+3. Core 在共享 state mutex 内写入 `display_name`；
+4. `sessions-changed` 上行，所有打开的 dashboard 重拉权威列表；
+5. rename RPC 返回成功。
+
+### 2. 建议：Web 做真正的乐观更新，并带条件回滚
+
+当前 store 是“RPC 成功后更新”，不是乐观更新。建议：
+
+1. 保存旧 `displayName`；
+2. 调用 RPC 前立即把本地行设置为 trimmed 新值；
+3. RPC 失败时，仅在该行仍对应本次尝试时回滚旧值并继续抛错；
+4. 用 `(instanceId, alias)` 的 mutation revision / request token 防止较早失败覆盖较新的成功重命名。
+
+仅做这一步而不解除 Hub lock 不足以修复根因：
+
+- 持久化仍要等 agent 回合结束；
+- 期间任意 `sessions-changed` 会触发 `loadSessions()`，它直接以服务端数组替换
+  `inst.sessions`，可能用旧权威值覆盖乐观标签；
+  来源：[sessions-changed 重拉](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay-web/src/stores/instances.ts#L313-L329)、
+  [loadSessions 整体替换](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay-web/src/stores/instances.ts#L87-L112)。
+- 用户连续重命名时，乱序成功/失败可能把较新的标签回滚成旧值。
+
+如果实现真正 optimism，`loadSessions()` 还应合并仍 pending 的 rename overlay，直到对应请求成功并由
+权威列表确认，或请求失败并条件回滚。
+
+## 拒绝的替代方案
+
+### 只做前端乐观更新
+
+拒绝作为完整修复。它会让单个浏览器暂时显示新值，但 rename 仍未到达 Core；agent 回合结束前的
+会话列表重拉还可能用旧值覆盖本地值，其他 dashboard 也看不到已持久化的新名称。
+
+### 把本地更新继续放在 RPC 成功后，只加 loading 状态
+
+拒绝。Loading 能降低重复提交概率，但仍保留不必要的整回合延迟，未修复根因。
+
+### 从 `CHAT_SCOPED_TYPES` 删除 rename
+
+拒绝。#212 已证明 connector 的 rename payload 需要 Hub 盖戳的可信 `chatKey`；删除会使 rename
+重新变成 `invalid-payload` 或解析到错误 scope。
+
+### 让所有会话管理 RPC 都绕过 keyed lock
+
+拒绝。Create/remove/archive/unarchive 改变会话生命周期；本调研只证明纯展示元数据 rename
+不需要 turn 锁，没有证据支持扩大到生命周期操作。
+
+### 回退整个 #212
+
+拒绝。#212 同时修复了 chat scope、RPC error unwrap、错误 toast 与跨 dashboard 的
+`sessions-changed`；问题只在它把 rename 偶合到 lifecycle lock。
+
+## 测试缺口与建议用例
+
+现有覆盖验证了：
+
+- Enter 会调用 store，Escape 取消，Enter + blur 不会重复提交；
+  来源：[InstanceTree rename 测试](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay-web/src/__tests__/instancetree-rename.test.ts#L23-L71)。
+- RPC 立即 resolve 后本地值正确，RPC error 后旧值保留；
+  来源：[instances rename 测试](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/packages/relay-web/src/__tests__/instances-rename.test.ts#L9-L57)。
+- Core 持久化成功后会发 `sessions-changed`。
+  来源：[ControlService display-name 测试](https://github.com/gadzan/xacpx/blob/6248fe2e9df5db855f28306acc3d365a0889874d/tests/unit/control/control-service-display-name.test.ts#L33-L56)。
+
+这些测试都没有构造“同 alias 的 prompt 尚未 resolve”或“rename RPC 尚未 resolve”，所以无法发现
+#226。建议增加：
+
+1. **Hub 并发回归测试（关键）：** 用 deferred gateway 挂起 `control.prompt`，随后向同一
+   instance + alias 发 `control.sessions.rename`；断言 rename 已到达 gateway 且能在 prompt
+   release 前返回。再用 remove/archive 等生命周期操作做反例，断言它们仍等待。
+2. **Web 真 optimism 测试：** deferred rename RPC 未完成时，立即断言 sidebar/store 已显示新值。
+3. **失败条件回滚：** 单次失败恢复旧值并显示既有错误 toast。
+4. **连续 rename 乱序：** A 后 B，A 迟到失败不得回滚 B。
+5. **pending overlay 对账：** rename 未完成期间触发 `loadSessions()` 返回旧标签，不得覆盖仍 pending
+   的本地值；成功后的权威新标签应清除 overlay。
+
+## 本次验证
+
+调研期间运行了现有相关测试；它们全部通过，也印证了上述并发覆盖缺口：
+
+- `bun run --cwd packages/relay-web test -- src/__tests__/instances-rename.test.ts src/__tests__/instancetree-rename.test.ts`
+  — 2 个文件、8 个测试通过。
+- `bun test tests/unit/packages/relay/http-app.test.ts tests/unit/control/control-service-display-name.test.ts`
+  — 2 个文件、37 个测试通过。
+
+未运行 smoke tests；本次未修改实现。
+
+## 非目标
+
+- 不改 alias、transport session 或 `/use` 语义。
+- 不让 create/remove/archive/unarchive 绕过生命周期锁。
+- 不以静默吞错换取“即时感”；#212 增加的 error unwrap、upgrade hint、toast 和
+  `sessions-changed` 都应保留。

--- a/packages/relay-web/src/__tests__/instances-rename.test.ts
+++ b/packages/relay-web/src/__tests__/instances-rename.test.ts
@@ -61,6 +61,44 @@ describe("instances renameSession", () => {
     expect(visibleWhilePending).toBe("New label");
   });
 
+  it("does not let a list started before a single successful rename restore the old name", async () => {
+    const store = useInstancesStore();
+    store.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      agents: [{ name: "claude", driver: "claude" }], workspaces: [], agentCatalog: [],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "old" }],
+    }] as never;
+    const staleListResult = deferred<unknown>();
+    const confirmingListResult = deferred<unknown>();
+    const renameResult = deferred<unknown>();
+    let listCalls = 0;
+    vi.spyOn(api, "rpc").mockImplementation((_instanceId, type) => {
+      if (type === "control.sessions.rename") return renameResult.promise as never;
+      if (type === "control.sessions.list") {
+        listCalls += 1;
+        return (listCalls === 1 ? staleListResult.promise : confirmingListResult.promise) as never;
+      }
+      throw new Error(`unexpected rpc: ${type}`);
+    });
+
+    const staleReload = store.loadSessions("i1");
+    const renaming = store.renameSession("i1", "backend", "A");
+    renameResult.resolve({ ok: true });
+    await Promise.resolve();
+
+    staleListResult.resolve({
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "old" }],
+    });
+    await staleReload;
+    expect(store.instances[0]!.sessions[0]!.displayName).toBe("A");
+
+    confirmingListResult.resolve({
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "A" }],
+    });
+    await renaming;
+    expect(store.instances[0]!.sessions[0]!.displayName).toBe("A");
+  });
+
   it("serializes consecutive renames and rolls a failed latest rename back to the last confirmed value", async () => {
     const store = useInstancesStore();
     store.instances = [{

--- a/packages/relay-web/src/__tests__/instances-rename.test.ts
+++ b/packages/relay-web/src/__tests__/instances-rename.test.ts
@@ -3,20 +3,190 @@ import { setActivePinia, createPinia } from "pinia";
 import { useInstancesStore } from "../stores/instances";
 import { api } from "../api/client";
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("instances renameSession", () => {
   beforeEach(() => setActivePinia(createPinia()));
 
-  it("calls control.sessions.rename and optimistically sets displayName", async () => {
+  it("shows the new displayName before control.sessions.rename resolves", async () => {
     const store = useInstancesStore();
     store.instances = [{
       id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
       agents: [], workspaces: [], agentCatalog: [],
-      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false, displayName: "old" }],
     }] as never;
-    const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ ok: true } as never);
-    await store.renameSession("i1", "backend", "  My label  ");
+    const result = deferred<unknown>();
+    const rpc = vi.spyOn(api, "rpc").mockReturnValue(result.promise as never);
+    const renaming = store.renameSession("i1", "backend", "  My label  ");
+
     expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.rename", { alias: "backend", displayName: "My label" });
     expect(store.instances[0]!.sessions[0]!.displayName).toBe("My label");
+
+    result.resolve({ ok: true });
+    await renaming;
+  });
+
+  it("keeps a pending displayName when the authoritative session list is still stale", async () => {
+    const store = useInstancesStore();
+    store.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      agents: [{ name: "claude", driver: "claude" }], workspaces: [], agentCatalog: [],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "old" }],
+    }] as never;
+    const renameResult = deferred<unknown>();
+    vi.spyOn(api, "rpc").mockImplementation((_instanceId, type) => {
+      if (type === "control.sessions.rename") return renameResult.promise as never;
+      if (type === "control.sessions.list") {
+        return Promise.resolve({
+          sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "old" }],
+        }) as never;
+      }
+      throw new Error(`unexpected rpc: ${type}`);
+    });
+
+    const renaming = store.renameSession("i1", "backend", "New label");
+    await store.loadSessions("i1");
+    const visibleWhilePending = store.instances[0]!.sessions[0]!.displayName;
+
+    renameResult.resolve({ ok: true });
+    await renaming;
+    expect(visibleWhilePending).toBe("New label");
+  });
+
+  it("serializes consecutive renames and rolls a failed latest rename back to the last confirmed value", async () => {
+    const store = useInstancesStore();
+    store.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      agents: [], workspaces: [], agentCatalog: [],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "old" }],
+    }] as never;
+    const firstResult = deferred<unknown>();
+    const secondResult = deferred<unknown>();
+    let renameCalls = 0;
+    vi.spyOn(api, "rpc").mockImplementation((_instanceId, type) => {
+      if (type !== "control.sessions.rename") throw new Error(`unexpected rpc: ${type}`);
+      renameCalls += 1;
+      return (renameCalls === 1 ? firstResult.promise : secondResult.promise) as never;
+    });
+
+    const firstRename = store.renameSession("i1", "backend", "A");
+    const secondRename = store.renameSession("i1", "backend", "B");
+    const secondOutcome = secondRename.catch((error: unknown) => error);
+    const callsBeforeFirstSettled = renameCalls;
+    expect(store.instances[0]!.sessions[0]!.displayName).toBe("B");
+
+    firstResult.resolve({ ok: true });
+    await firstRename;
+    await Promise.resolve();
+    expect(renameCalls).toBe(2);
+    secondResult.reject(new Error("B failed"));
+    expect(await secondOutcome).toBeInstanceOf(Error);
+
+    expect(callsBeforeFirstSettled).toBe(1);
+    expect(store.instances[0]!.sessions[0]!.displayName).toBe("A");
+  });
+
+  it("does not let a stale session-list response downgrade a newer confirmed rename", async () => {
+    const store = useInstancesStore();
+    store.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      agents: [{ name: "claude", driver: "claude" }], workspaces: [], agentCatalog: [],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "old" }],
+    }] as never;
+    const firstResult = deferred<unknown>();
+    const secondResult = deferred<unknown>();
+    const listResult = deferred<unknown>();
+    let renameCalls = 0;
+    vi.spyOn(api, "rpc").mockImplementation((_instanceId, type) => {
+      if (type === "control.sessions.list") return listResult.promise as never;
+      if (type !== "control.sessions.rename") throw new Error(`unexpected rpc: ${type}`);
+      renameCalls += 1;
+      return (renameCalls === 1 ? firstResult.promise : secondResult.promise) as never;
+    });
+
+    const firstRename = store.renameSession("i1", "backend", "A");
+    const secondOutcome = store.renameSession("i1", "backend", "B").catch((error: unknown) => error);
+    const staleReload = store.loadSessions("i1");
+
+    firstResult.resolve({ ok: true });
+    await firstRename;
+    await Promise.resolve();
+    listResult.resolve({
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "old" }],
+    });
+    await staleReload;
+    secondResult.reject(new Error("B failed"));
+    expect(await secondOutcome).toBeInstanceOf(Error);
+
+    expect(store.instances[0]!.sessions[0]!.displayName).toBe("A");
+  });
+
+  it("keeps a newer optimistic rename when an earlier queued rename fails", async () => {
+    const store = useInstancesStore();
+    store.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      agents: [], workspaces: [], agentCatalog: [],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "old" }],
+    }] as never;
+    const firstResult = deferred<unknown>();
+    const secondResult = deferred<unknown>();
+    let renameCalls = 0;
+    vi.spyOn(api, "rpc").mockImplementation(() => {
+      renameCalls += 1;
+      return (renameCalls === 1 ? firstResult.promise : secondResult.promise) as never;
+    });
+
+    const firstOutcome = store.renameSession("i1", "backend", "A").catch((error: unknown) => error);
+    const secondRename = store.renameSession("i1", "backend", "B");
+    expect(store.instances[0]!.sessions[0]!.displayName).toBe("B");
+    expect(renameCalls).toBe(1);
+
+    firstResult.reject(new Error("A failed"));
+    expect(await firstOutcome).toBeInstanceOf(Error);
+    await Promise.resolve();
+    expect(renameCalls).toBe(2);
+    secondResult.resolve({ ok: true });
+    await secondRename;
+
+    expect(store.instances[0]!.sessions[0]!.displayName).toBe("B");
+  });
+
+  it("does not serialize renames for different sessions", async () => {
+    const store = useInstancesStore();
+    store.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      agents: [], workspaces: [], agentCatalog: [],
+      sessions: [
+        { alias: "backend", agent: "claude", workspace: "home", transportSession: "t1", running: true, archived: false, displayName: "old-backend" },
+        { alias: "frontend", agent: "claude", workspace: "home", transportSession: "t2", running: true, archived: false, displayName: "old-frontend" },
+      ],
+    }] as never;
+    const backendResult = deferred<unknown>();
+    const frontendResult = deferred<unknown>();
+    const seenAliases: string[] = [];
+    vi.spyOn(api, "rpc").mockImplementation((_instanceId, type, payload) => {
+      if (type !== "control.sessions.rename") throw new Error(`unexpected rpc: ${type}`);
+      const alias = (payload as { alias: string }).alias;
+      seenAliases.push(alias);
+      return (alias === "backend" ? backendResult.promise : frontendResult.promise) as never;
+    });
+
+    const backendRename = store.renameSession("i1", "backend", "Backend A");
+    const frontendRename = store.renameSession("i1", "frontend", "Frontend A");
+    expect(seenAliases).toEqual(["backend", "frontend"]);
+
+    backendResult.resolve({ ok: true });
+    frontendResult.resolve({ ok: true });
+    await Promise.all([backendRename, frontendRename]);
+    expect(store.instances[0]!.sessions.map((session) => session.displayName)).toEqual(["Backend A", "Frontend A"]);
   });
 
   it("clears displayName when given an empty value", async () => {
@@ -41,9 +211,26 @@ describe("instances renameSession", () => {
     }] as never;
     vi.spyOn(api, "rpc").mockResolvedValue({ error: { code: "invalid-payload", message: "boom" } } as never);
     await expect(store.renameSession("i1", "backend", "New label")).rejects.toThrow("boom");
-    // The optimistic local update happens only after unwrap succeeds — a failed
-    // rename must not leave the sidebar showing a label the connector never saved.
+    // A failed optimistic rename must restore the last confirmed label.
     expect(store.instances[0]!.sessions[0]!.displayName).toBe("old");
+  });
+
+  it("preserves the original rename error when the session row disappears in flight", async () => {
+    const store = useInstancesStore();
+    store.instances = [{
+      id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
+      agents: [], workspaces: [], agentCatalog: [],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false, displayName: "old" }],
+    }] as never;
+    const result = deferred<unknown>();
+    vi.spyOn(api, "rpc").mockReturnValue(result.promise as never);
+    const renaming = store.renameSession("i1", "backend", "");
+
+    store.instances[0]!.sessions = [];
+    result.reject(new Error("instance-offline"));
+
+    await expect(renaming).rejects.toThrow("instance-offline");
+    expect(store.instances[0]!.sessions).toEqual([]);
   });
 
   it("maps an unknown-type error to the connector-upgrade hint", async () => {
@@ -51,9 +238,10 @@ describe("instances renameSession", () => {
     store.instances = [{
       id: "i1", name: "pc", online: true, lastSeenAt: null, sessionsLoaded: true,
       agents: [], workspaces: [], agentCatalog: [],
-      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }],
+      sessions: [{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false, displayName: "old" }],
     }] as never;
     vi.spyOn(api, "rpc").mockResolvedValue({ error: { code: "unknown-type", message: "unsupported rpc type: control.sessions.rename" } } as never);
     await expect(store.renameSession("i1", "backend", "New label")).rejects.toThrow(/needs a newer connector/);
+    expect(store.instances[0]!.sessions[0]!.displayName).toBe("old");
   });
 });

--- a/packages/relay-web/src/__tests__/instancetree-rename.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree-rename.test.ts
@@ -1,13 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import InstanceTree from "../components/InstanceTree.vue";
 import { useInstancesStore } from "../stores/instances";
+import { api } from "../api/client";
 
 const instance = (sessions: unknown[] = []) => ({
   id: "i1", name: "pc", online: true, lastSeenAt: null, sessions, sessionsLoaded: true,
   agents: [], workspaces: [], agentCatalog: [],
 });
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
 
 describe("InstanceTree rename", () => {
   beforeEach(() => setActivePinia(createPinia()));
@@ -35,6 +44,26 @@ describe("InstanceTree rename", () => {
     await input.trigger("keydown.enter");
 
     expect(rename).toHaveBeenCalledWith("i1", "backend", "API hotfix");
+  });
+
+  it("shows the committed name while the rename RPC is still pending", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: true, archived: false, displayName: "old" }])] as never;
+    const result = deferred<unknown>();
+    vi.spyOn(api, "rpc").mockReturnValue(result.promise as never);
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+
+    await w.find('[data-test="session-menu"]').trigger("click");
+    await w.find('[data-test="action-rename"]').trigger("click");
+    const input = w.find('[data-test="rename-input"]');
+    await input.setValue("API hotfix");
+    await input.trigger("keydown.enter");
+
+    expect(w.find('[data-test="rename-input"]').exists()).toBe(false);
+    expect(w.find('[data-test="session-name"]').text()).toBe("API hotfix");
+
+    result.resolve({ ok: true });
+    await flushPromises();
   });
 
   it("cancels on Escape without calling renameSession", async () => {

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -54,6 +54,18 @@ export interface InstanceView {
 
 export const useInstancesStore = defineStore("instances", () => {
   const instances = ref<InstanceView[]>([]);
+  const pendingSessionRenames = new Map<string, {
+    latestRevision: number;
+    confirmedRevision: number;
+    desiredDisplayName?: string;
+    confirmedDisplayName?: string;
+  }>();
+  const sessionRenameTails = new Map<string, Promise<void>>();
+  let sessionRenameRevision = 0;
+
+  function sessionRenameKey(instanceId: string, alias: string): string {
+    return JSON.stringify([instanceId, alias]);
+  }
 
   // Per-instance sidebar grouping mode (flat / by-workspace / by-agent). Reactive
   // mirror of the localStorage preference so the sidebar re-renders the moment the
@@ -85,6 +97,12 @@ export const useInstancesStore = defineStore("instances", () => {
   }
 
   async function loadSessions(instanceId: string): Promise<void> {
+    // A list request can start before a rename succeeds and return afterwards.
+    // Snapshot confirmation revisions so that stale response cannot downgrade a
+    // newer value confirmed while the request was in flight.
+    const confirmedRevisionsAtRequest = new Map(
+      [...pendingSessionRenames].map(([key, pending]) => [key, pending.confirmedRevision]),
+    );
     // Pull the configured agents alongside the session list (once) so the sidebar and chat
     // can map each session's agent NAME → driver for the brand icon. Agents otherwise only
     // load when a create/manage dialog opens (loadFormOptions), so in the normal
@@ -100,7 +118,15 @@ export const useInstancesStore = defineStore("instances", () => {
     ]);
     const inst = byId(instanceId);
     if (inst) {
-      inst.sessions = sessions;
+      inst.sessions = sessions.map((session) => {
+        const key = sessionRenameKey(instanceId, session.alias);
+        const pending = pendingSessionRenames.get(key);
+        if (!pending) return session;
+        if (confirmedRevisionsAtRequest.get(key) === pending.confirmedRevision) {
+          pending.confirmedDisplayName = session.displayName;
+        }
+        return { ...session, displayName: pending.desiredDisplayName };
+      });
       inst.sessionsLoaded = true;
       if (agentsRes && !isErrorPayload(agentsRes) && Array.isArray(agentsRes.agents)) inst.agents = agentsRes.agents;
     }
@@ -292,13 +318,62 @@ export const useInstancesStore = defineStore("instances", () => {
     await loadSessions(instanceId);
   }
 
-  // The display label lives in core session state; set it via control RPC, then optimistically
-  // update the local row so the sidebar reflects the new name without a reload. Empty → cleared.
+  // The display label lives in core session state. Update the local row before the
+  // RPC settles so Enter has immediate visual feedback; a failed request restores
+  // the previous value only when this optimistic value is still current.
   async function renameSession(instanceId: string, alias: string, displayName: string): Promise<void> {
     const trimmed = displayName.trim();
-    unwrap(await api.rpc(instanceId, "control.sessions.rename", { alias, displayName: trimmed }));
     const row = byId(instanceId)?.sessions.find((s) => s.alias === alias);
-    if (row) row.displayName = trimmed || undefined;
+    const previousDisplayName = row?.displayName;
+    const nextDisplayName = trimmed || undefined;
+    const key = sessionRenameKey(instanceId, alias);
+    const revision = ++sessionRenameRevision;
+    const existingPending = pendingSessionRenames.get(key);
+    if (existingPending) {
+      existingPending.latestRevision = revision;
+      existingPending.desiredDisplayName = nextDisplayName;
+    } else {
+      pendingSessionRenames.set(key, {
+        latestRevision: revision,
+        confirmedRevision: 0,
+        desiredDisplayName: nextDisplayName,
+        confirmedDisplayName: previousDisplayName,
+      });
+    }
+    if (row) row.displayName = nextDisplayName;
+
+    const execute = async (): Promise<void> => {
+      try {
+        unwrap(await api.rpc(instanceId, "control.sessions.rename", { alias, displayName: trimmed }));
+        const pending = pendingSessionRenames.get(key);
+        if (!pending) return;
+        pending.confirmedDisplayName = nextDisplayName;
+        pending.confirmedRevision = revision;
+        if (pending.latestRevision === revision) pendingSessionRenames.delete(key);
+      } catch (error) {
+        const pending = pendingSessionRenames.get(key);
+        if (pending?.latestRevision === revision) {
+          pendingSessionRenames.delete(key);
+          const current = byId(instanceId)?.sessions.find((s) => s.alias === alias);
+          if (current && current.displayName === nextDisplayName) current.displayName = pending.confirmedDisplayName;
+        }
+        throw error;
+      }
+    };
+
+    // Preserve request order for repeated renames of one session, while keeping
+    // different sessions independent. The first request starts synchronously so
+    // existing callers still observe the RPC in the same turn.
+    const previousTail = sessionRenameTails.get(key);
+    const operation = previousTail
+      ? previousTail.catch(() => {}).then(execute)
+      : execute();
+    sessionRenameTails.set(key, operation);
+    const cleanup = () => {
+      if (sessionRenameTails.get(key) === operation) sessionRenameTails.delete(key);
+    };
+    void operation.then(cleanup, cleanup);
+    await operation;
   }
 
   // The instance name lives solely in the relay DB (not on the connector), so this

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -122,8 +122,13 @@ export const useInstancesStore = defineStore("instances", () => {
         const key = sessionRenameKey(instanceId, session.alias);
         const pending = pendingSessionRenames.get(key);
         if (!pending) return session;
-        if (confirmedRevisionsAtRequest.get(key) === pending.confirmedRevision) {
-          pending.confirmedDisplayName = session.displayName;
+        if (
+          confirmedRevisionsAtRequest.get(key) === pending.confirmedRevision
+          && pending.latestRevision === pending.confirmedRevision
+          && session.displayName === pending.confirmedDisplayName
+        ) {
+          pendingSessionRenames.delete(key);
+          return session;
         }
         return { ...session, displayName: pending.desiredDisplayName };
       });
@@ -349,7 +354,12 @@ export const useInstancesStore = defineStore("instances", () => {
         if (!pending) return;
         pending.confirmedDisplayName = nextDisplayName;
         pending.confirmedRevision = revision;
-        if (pending.latestRevision === revision) pendingSessionRenames.delete(key);
+        if (pending.latestRevision === revision) {
+          // Keep the optimistic overlay until a list request started after this
+          // successful write confirms the same value. This prevents a list that
+          // was already in flight from repainting the old display name.
+          await loadSessions(instanceId).catch(() => {});
+        }
       } catch (error) {
         const pending = pendingSessionRenames.get(key);
         if (pending?.latestRevision === revision) {

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -98,6 +98,10 @@ function boundField<T extends string | undefined>(v: T): T {
   return (typeof v === "string" ? v.slice(0, MAX_ATTACHMENT_FIELD_LEN) : v) as T;
 }
 
+// Classify RPCs that must preserve same-session lifecycle ordering. This is
+// intentionally narrower than "every RPC carrying an alias": cosmetic metadata
+// writes such as sessionsRename do not change session identity and must remain
+// responsive while a prompt holds the lifecycle lock.
 function rpcSessionAlias(type: string, payload: unknown): string | undefined {
   const value = payload as { alias?: unknown; sessionAlias?: unknown };
   if (type === MSG.prompt || type === MSG.commandExecute) {
@@ -107,8 +111,7 @@ function rpcSessionAlias(type: string, payload: unknown): string | undefined {
     type === MSG.sessionsCreate ||
     type === MSG.sessionsRemove ||
     type === MSG.sessionsArchive ||
-    type === MSG.sessionsUnarchive ||
-    type === MSG.sessionsRename
+    type === MSG.sessionsUnarchive
   ) {
     return typeof value.alias === "string" && value.alias ? value.alias : undefined;
   }

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -98,14 +98,26 @@ function boundField<T extends string | undefined>(v: T): T {
   return (typeof v === "string" ? v.slice(0, MAX_ATTACHMENT_FIELD_LEN) : v) as T;
 }
 
-// Classify RPCs that must preserve same-session lifecycle ordering. This is
-// intentionally narrower than "every RPC carrying an alias": cosmetic metadata
-// writes such as sessionsRename do not change session identity and must remain
-// responsive while a prompt holds the lifecycle lock.
-function rpcSessionAlias(type: string, payload: unknown): string | undefined {
+type SessionRpcLocks = {
+  alias: string;
+  lifecycle: boolean;
+  turn: boolean;
+};
+
+// Prompts serialize with other turns but not cosmetic metadata writes. Rename
+// serializes with identity-changing lifecycle operations but not turns. Lifecycle
+// operations take both locks so they cannot race either category.
+function rpcSessionLocks(type: string, payload: unknown): SessionRpcLocks | undefined {
   const value = payload as { alias?: unknown; sessionAlias?: unknown };
   if (type === MSG.prompt || type === MSG.commandExecute) {
-    return typeof value.sessionAlias === "string" && value.sessionAlias ? value.sessionAlias : undefined;
+    return typeof value.sessionAlias === "string" && value.sessionAlias
+      ? { alias: value.sessionAlias, lifecycle: false, turn: true }
+      : undefined;
+  }
+  if (type === MSG.sessionsRename) {
+    return typeof value.alias === "string" && value.alias
+      ? { alias: value.alias, lifecycle: true, turn: false }
+      : undefined;
   }
   if (
     type === MSG.sessionsCreate ||
@@ -113,7 +125,9 @@ function rpcSessionAlias(type: string, payload: unknown): string | undefined {
     type === MSG.sessionsArchive ||
     type === MSG.sessionsUnarchive
   ) {
-    return typeof value.alias === "string" && value.alias ? value.alias : undefined;
+    return typeof value.alias === "string" && value.alias
+      ? { alias: value.alias, lifecycle: true, turn: true }
+      : undefined;
   }
   return undefined;
 }
@@ -147,7 +161,8 @@ export function createApp(deps: AppDeps): Hono<Vars> {
   const pairingTtlMs = deps.pairingTtlMs ?? 10 * 60 * 1000;
   const trustProxy = deps.trustProxy ?? false;
   const now = deps.now ?? (() => new Date());
-  const acquireSessionRpcLock = createKeyedRpcLock();
+  const acquireSessionLifecycleRpcLock = createKeyedRpcLock();
+  const acquireSessionTurnRpcLock = createKeyedRpcLock();
 
   // Per-IP failure tracking
   const loginFailures = new Map<string, { count: number; windowStart: number }>();
@@ -366,7 +381,7 @@ export function createApp(deps: AppDeps): Hono<Vars> {
         isOwner: true,
       };
     }
-    let releaseSessionRpcLock: (() => void) | undefined;
+    const releaseSessionRpcLocks: Array<() => void> = [];
     let persistedPromptId: number | undefined;
     try {
       // Shape-validate the RPCs the hub persists BEFORE forwarding, so a malformed frame
@@ -392,9 +407,17 @@ export function createApp(deps: AppDeps): Hono<Vars> {
         const approxBytes = up.content ? Math.floor((up.content.length * 3) / 4) : 0;
         if (approxBytes > 10 * 1024 * 1024) return c.json({ error: "file-too-large" }, 413);
       }
-      const sessionAlias = rpcSessionAlias(body.type, payload);
-      if (sessionAlias) {
-        releaseSessionRpcLock = await acquireSessionRpcLock(`${instance.id}\0${sessionAlias}`);
+      const sessionLocks = rpcSessionLocks(body.type, payload);
+      if (sessionLocks) {
+        const key = `${instance.id}\0${sessionLocks.alias}`;
+        // Lifecycle first: if a destructive operation is queued behind a running
+        // turn, later renames queue behind that operation instead of overtaking it.
+        if (sessionLocks.lifecycle) {
+          releaseSessionRpcLocks.push(await acquireSessionLifecycleRpcLock(key));
+        }
+        if (sessionLocks.turn) {
+          releaseSessionRpcLocks.push(await acquireSessionTurnRpcLock(key));
+        }
       }
       // Persist the inbound user message BEFORE awaiting the turn: sendRequest
       // resolves only after the agent's turn-finished event has already
@@ -450,7 +473,9 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       if (message === "timeout") return c.json({ error: message }, 504);
       return c.json({ error: message }, 500);
     } finally {
-      releaseSessionRpcLock?.();
+      for (let i = releaseSessionRpcLocks.length - 1; i >= 0; i--) {
+        releaseSessionRpcLocks[i]?.();
+      }
     }
   });
 

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -14,6 +14,16 @@ import type { RelayLogger } from "../../../../packages/relay/src/logging";
 
 type LogEntry = [string, string, Record<string, unknown> | undefined];
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function makeFakeLogger(): { logger: RelayLogger; logs: LogEntry[] } {
   const logs: LogEntry[] = [];
   const logger: RelayLogger = {
@@ -24,7 +34,11 @@ function makeFakeLogger(): { logger: RelayLogger; logs: LogEntry[] } {
   return { logger, logs };
 }
 
-async function makeApp(opts: { trustProxy?: boolean; now?: () => Date } = {}) {
+async function makeApp(opts: {
+  trustProxy?: boolean;
+  now?: () => Date;
+  sendRequest?: (instanceId: string, type: string, payload: unknown) => Promise<unknown>;
+} = {}) {
   const db = await createSqlDriver(":memory:");
   initSchema(db);
   const accounts = new AccountStore(db);
@@ -36,7 +50,7 @@ async function makeApp(opts: { trustProxy?: boolean; now?: () => Date } = {}) {
     isOnline: (id: string) => id !== "offline-id",
     sendRequest: async (instanceId: string, type: string, payload: unknown) => {
       rpcCalls.push({ instanceId, type, payload });
-      return { sessions: [] };
+      return await (opts.sendRequest?.(instanceId, type, payload) ?? Promise.resolve({ sessions: [] }));
     },
   };
   const messages = new MessageStore(db);
@@ -319,6 +333,101 @@ test("session rename RPC is chat-scoped (chatKey stamped, client-forged chatKey 
   expect(res.status).toBe(200);
   const stamped = rpcCalls[0]?.payload as { chatKey?: string };
   expect(stamped.chatKey).toBe(`relay:${redeemed.accountId}`);
+});
+
+test("session rename is forwarded while a prompt for the same session is still running", async () => {
+  const promptStarted = deferred<void>();
+  const promptRelease = deferred<unknown>();
+  const renameForwarded = deferred<void>();
+  const { app, instances, loginToken, login, rpcCalls } = await makeApp({
+    sendRequest: async (_instanceId, type) => {
+      if (type === MSG.prompt) {
+        promptStarted.resolve(undefined);
+        return await promptRelease.promise;
+      }
+      if (type === MSG.sessionsRename) {
+        renameForwarded.resolve(undefined);
+        return { ok: true };
+      }
+      return {};
+    },
+  });
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const redeemed = instances.redeemPairingToken(token)!;
+  const rpcPath = `/api/instances/${redeemed.instanceId}/rpc`;
+
+  const promptResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "long task" } }),
+  });
+  await promptStarted.promise;
+
+  const renameResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.sessionsRename, payload: { alias: "backend", displayName: "New label" } }),
+  });
+  const forwardedBeforePromptFinished = await Promise.race([
+    renameForwarded.promise.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+  ]);
+
+  promptRelease.resolve({ ok: true });
+  expect((await promptResponse).status).toBe(200);
+  expect((await renameResponse).status).toBe(200);
+  expect(forwardedBeforePromptFinished).toBe(true);
+  const renameCall = rpcCalls.find((call) => call.type === MSG.sessionsRename);
+  expect((renameCall?.payload as { chatKey?: string }).chatKey).toBe(`relay:${redeemed.accountId}`);
+});
+
+test("session removal still waits for a prompt on the same session", async () => {
+  const promptStarted = deferred<void>();
+  const promptRelease = deferred<unknown>();
+  const removeForwarded = deferred<void>();
+  const { app, instances, loginToken, login } = await makeApp({
+    sendRequest: async (_instanceId, type) => {
+      if (type === MSG.prompt) {
+        promptStarted.resolve(undefined);
+        return await promptRelease.promise;
+      }
+      if (type === MSG.sessionsRemove) {
+        removeForwarded.resolve(undefined);
+        return { ok: true };
+      }
+      return {};
+    },
+  });
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const redeemed = instances.redeemPairingToken(token)!;
+  const rpcPath = `/api/instances/${redeemed.instanceId}/rpc`;
+
+  const promptResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "long task" } }),
+  });
+  await promptStarted.promise;
+
+  const removeResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.sessionsRemove, payload: { alias: "backend" } }),
+  });
+  const forwardedBeforePromptFinished = await Promise.race([
+    removeForwarded.promise.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+  ]);
+
+  expect(forwardedBeforePromptFinished).toBe(false);
+  promptRelease.resolve({ ok: true });
+  expect((await promptResponse).status).toBe(200);
+  expect((await removeResponse).status).toBe(200);
+  await expect(removeForwarded.promise).resolves.toBeUndefined();
 });
 
 test("session effort RPCs are chat-scoped", async () => {

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -430,6 +430,53 @@ test("session removal still waits for a prompt on the same session", async () =>
   await expect(removeForwarded.promise).resolves.toBeUndefined();
 });
 
+test("session rename waits for a lifecycle operation on the same session", async () => {
+  const removeStarted = deferred<void>();
+  const removeRelease = deferred<unknown>();
+  const renameForwarded = deferred<void>();
+  const { app, instances, loginToken, login } = await makeApp({
+    sendRequest: async (_instanceId, type) => {
+      if (type === MSG.sessionsRemove) {
+        removeStarted.resolve(undefined);
+        return await removeRelease.promise;
+      }
+      if (type === MSG.sessionsRename) {
+        renameForwarded.resolve(undefined);
+        return { ok: true };
+      }
+      return {};
+    },
+  });
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const redeemed = instances.redeemPairingToken(token)!;
+  const rpcPath = `/api/instances/${redeemed.instanceId}/rpc`;
+
+  const removeResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.sessionsRemove, payload: { alias: "backend" } }),
+  });
+  await removeStarted.promise;
+
+  const renameResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.sessionsRename, payload: { alias: "backend", displayName: "New label" } }),
+  });
+  const forwardedBeforeRemoveFinished = await Promise.race([
+    renameForwarded.promise.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+  ]);
+
+  expect(forwardedBeforeRemoveFinished).toBe(false);
+  removeRelease.resolve({ ok: true });
+  expect((await removeResponse).status).toBe(200);
+  expect((await renameResponse).status).toBe(200);
+  await expect(renameForwarded.promise).resolves.toBeUndefined();
+});
+
 test("session effort RPCs are chat-scoped", async () => {
   const { app, instances, loginToken, login, rpcCalls } = await makeApp();
   const { cookie } = await login(loginToken);


### PR DESCRIPTION
## 背景

修复 #226：Relay Web 中会话重命名会被同一会话正在运行的 prompt 阻塞，用户按 Enter 后必须等待 agent 回合结束才能看到新名称。

根因有两层：Hub 让纯展示元数据写入 `sessions.rename` 与 turn 共用同一把锁；Web 又只在 RPC 成功后更新本地行。

## 改动

- 将 Hub 的同会话锁拆成 turn 与 lifecycle/metadata 两个维度
- `sessions.rename` 不占 turn 锁，因此可在 prompt 运行中立即执行；它仍与 create/remove/archive/unarchive 互斥
- 生命周期操作按 lifecycle → turn 顺序取锁，避免排队中的 remove/archive 被后来的 rename 越过
- 继续覆盖客户端提供的 `chatKey`
- Relay Web 在提交重命名时立即乐观更新展示名
- pending 名称覆盖期间到达的旧 session-list 快照；成功后由一次新的权威列表确认清除保护
- 同一会话的连续重命名按 FIFO 提交，并通过 revision/confirmed value 避免迟到响应错误回滚
- 增加 Hub 并发回归、store 状态机和组件可见性测试
- 更新 Relay Web 模块文档，并附调研与实施计划

## 用户影响

即使 agent 正在执行长任务，按 Enter 后侧边栏会立即显示新的会话名称；RPC 最终失败时会安全回滚到最近已确认的名称。迟到的旧列表不会覆盖已成功的单次重命名，会话销毁或重建期间也不会与 rename 发生无序竞态。

## 验证

- `npm test`（完整测试套件，退出码 0；Relay Web 107 个文件、949 项测试通过）
- `bun test tests/unit/packages/relay/http-app.test.ts tests/unit/packages/channel-relay/control-bridge.test.ts tests/unit/control/control-service-display-name.test.ts`（81 项通过）
- `bun run --cwd packages/relay-web test -- src/__tests__/instances-rename.test.ts src/__tests__/instancetree-rename.test.ts src/__tests__/chatpane-displayname.test.ts src/__tests__/commandpalette.test.ts`（25 项通过）
- `npx tsc --noEmit`
- `bun run --cwd packages/relay-web build`
- `git diff --check`

Fixes #226