### PR TITLE
fix(relay): harden invite code edges from PR #234 review

### DIFF
--- a/docs/relay-deployment.md
+++ b/docs/relay-deployment.md
@@ -101,7 +101,7 @@ xacpx-relay add invite --label friend --ttl 3d --url https://relay.example.com -
 # 输出示例：
 #   invite code: mJ3…（仅打印一次）
 #   redeem link: https://relay.example.com/invite/mJ3…
-#   (share it now — single-use, not shown again; expires 2026-08-02 12:00)
+#   (share it now — single-use, not shown again; expires 2026-08-02 12:00 UTC)
 # 不传 --url 时打印 redeem path: /invite/<code>，自行拼到 hub 域名后即可。
 
 # ls 会追加 invites 段（短 id / 标签 / 过期时间 / 状态 unused|used|expired）
@@ -114,6 +114,7 @@ xacpx-relay rm invite <code-or-id> --db /var/lib/xacpx-relay/relay.db
 - 兑换页面**点击按钮才兑换**，不会因链接预览/爬虫抓取而烧掉邀请码。
 - 兑换端点与登录共用同一限流桶（按 IP，反代后方记得 `--trust-proxy`）。
 - 已用/过期的邀请码由每小时自动 GC 清理，`ls` 中的 used/expired 条目随之消失。
+- **注意**：邀请码明文出现在 URL 路径中，反向代理的 access log 会记录**未兑换**的邀请链接（兑换后即作废，无风险）。在意的话可缩短 `--ttl`，或在反代对 `/invite/` 路径关闭访问日志。
 
 ## 反向代理与限流（--trust-proxy）
 

--- a/packages/relay/src/cli.ts
+++ b/packages/relay/src/cli.ts
@@ -69,6 +69,8 @@ function hasFlag(args: string[], name: string): boolean {
 /**
  * Parses an invite TTL like "30m", "12h", "7d" into milliseconds.
  * Returns null for malformed input; undefined input yields the 7-day default.
+ * Capped at 10 years — beyond that Date arithmetic overflows the ECMAScript
+ * time range and toISOString() throws instead of printing usage.
  */
 export function parseTtlMs(raw: string | undefined): number | null {
   if (raw === undefined) return 7 * 24 * 60 * 60 * 1000;
@@ -77,7 +79,9 @@ export function parseTtlMs(raw: string | undefined): number | null {
   const n = Number(match[1]);
   if (n <= 0) return null;
   const unit = match[2] === "m" ? 60_000 : match[2] === "h" ? 3_600_000 : 86_400_000;
-  return n * unit;
+  const ms = n * unit;
+  const maxMs = 10 * 365 * 86_400_000;
+  return ms > maxMs ? null : ms;
 }
 
 export interface StartOptions {
@@ -161,7 +165,14 @@ export async function runRelayCli(args: string[], io: RelayCliIo): Promise<numbe
   // add invite [--label <l>] [--ttl <n>{m|h|d}] [--url <base>] --db <path>
   if (args[0] === "add" && args[1] === "invite") {
     const label = flag(args, "--label");
-    const ttlMs = parseTtlMs(flag(args, "--ttl"));
+    const ttlRaw = flag(args, "--ttl");
+    // A bare --ttl with a missing/flag-like value must error, not silently
+    // fall back to the 7-day default — the lifetime is security-relevant.
+    if (hasFlag(args, "--ttl") && ttlRaw === undefined) {
+      io.print(USAGE);
+      return 1;
+    }
+    const ttlMs = parseTtlMs(ttlRaw);
     if (ttlMs === null) {
       io.print(USAGE);
       return 1;
@@ -176,7 +187,7 @@ export async function runRelayCli(args: string[], io: RelayCliIo): Promise<numbe
       } else {
         io.print(`redeem path: /invite/${code}   (append to your hub URL)`);
       }
-      io.print(`(share it now — single-use, not shown again; expires ${expiresAt.slice(0, 16).replace("T", " ")})`);
+      io.print(`(share it now — single-use, not shown again; expires ${expiresAt.slice(0, 16).replace("T", " ")} UTC)`);
       return 0;
     } finally {
       runtime.close();
@@ -205,7 +216,7 @@ export async function runRelayCli(args: string[], io: RelayCliIo): Promise<numbe
         const nowMs = Date.now();
         io.print("");
         io.print("invites");
-        io.print("id        label                 expires               status");
+        io.print("id        label                 expires (UTC)         status");
         io.print("--------  --------------------  --------------------  -------");
         for (const inv of invites) {
           const shortId = inv.id.slice(0, 8);

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -255,7 +255,7 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       return c.json({ error: "too-many-attempts" }, 429);
     }
 
-    const r = deps.accounts.redeemInviteCode(body.code ?? "");
+    const r = deps.accounts.redeemInviteCode(typeof body.code === "string" ? body.code : "");
     if (!r) {
       recordFailure(ip, nowMs);
       deps.logger?.info("relay.invite.rejected", "invite redeem rejected", { reason: "invalid-code", ip });
@@ -267,7 +267,10 @@ export function createApp(deps: AppDeps): Hono<Vars> {
   });
 
   app.use("/api/*", async (c, next) => {
-    if (c.req.path === "/api/login") return next();
+    // Belt-and-braces exemptions mirroring the pre-gate registrations above;
+    // registration order alone already keeps these public, but if the gate is
+    // ever hoisted the exemption keeps behavior identical.
+    if (c.req.path === "/api/login" || c.req.path === "/api/invites/redeem") return next();
     const token = getCookie(c, SESSION_COOKIE);
     const account = token ? deps.accounts.getSessionAccount(token) : null;
     if (!account) return c.json({ error: "unauthorized" }, 401);

--- a/packages/relay/src/maintenance.ts
+++ b/packages/relay/src/maintenance.ts
@@ -21,7 +21,7 @@ export interface MaintenanceSummary {
   inviteCodesDeleted: number;
 }
 
-/** Runs one maintenance pass: prune old/excess messages, GC expired sessions/pairing tokens. */
+/** Runs one maintenance pass: prune old/excess messages, GC expired sessions/pairing tokens/invite codes. */
 export function runMaintenance(stores: MaintenanceStores, opts: MaintenanceOptions): MaintenanceSummary {
   const now = (opts.now ?? (() => new Date()))();
   const messagesDeleted = stores.messages.prune({

--- a/packages/relay/src/stores/accounts.ts
+++ b/packages/relay/src/stores/accounts.ts
@@ -291,7 +291,7 @@ export class AccountStore {
     this.db.exec("BEGIN");
     try {
       this.db.run(
-        "UPDATE invite_codes SET used_at = ?, used_account_id = ? WHERE code_hash = ?",
+        "UPDATE invite_codes SET used_at = ?, used_account_id = ? WHERE code_hash = ? AND used_at IS NULL",
         [nowIso, accountId, codeHash],
       );
       this.db.run(

--- a/tests/unit/packages/relay/cli.test.ts
+++ b/tests/unit/packages/relay/cli.test.ts
@@ -267,6 +267,27 @@ test("parseTtlMs: default 7d, m/h/d units, malformed → null", () => {
   expect(parseTtlMs("7w")).toBeNull();
 });
 
+test("parseTtlMs: capped at 10 years — overflow returns null instead of a Date RangeError", () => {
+  expect(parseTtlMs("3650d")).toBe(3650 * 86_400_000);
+  expect(parseTtlMs("3651d")).toBeNull();
+  expect(parseTtlMs("999999999999d")).toBeNull();
+});
+
+test("add invite with --ttl missing its value prints usage instead of silently defaulting", async () => {
+  const dbPath = makeTmpDb();
+  const io = makeIo();
+  const code = await runRelayCli(["add", "invite", "--ttl", "--label", "x", "--db", dbPath], io);
+  expect(code).toBe(1);
+  expect(io.lines.join("\n")).toContain("Usage");
+
+  const rt = await createRelayRuntime(dbPath);
+  try {
+    expect(rt.accounts.listInviteCodes().length).toBe(0);
+  } finally {
+    rt.close();
+  }
+});
+
 test("ls shows invite section with status transitions unused → used", async () => {
   const dbPath = makeTmpDb();
   const addIo = makeIo();

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -780,6 +780,27 @@ test("invite redeem without JSON content-type → 415", async () => {
   expect(res.status).toBe(415);
 });
 
+test("invite redeem with an expired code → 401 invalid-code (same as unknown)", async () => {
+  const { app, accounts } = await makeApp();
+  const { code } = accounts.issueInviteCode(undefined, 0);
+  const res = await app.request("/api/invites/redeem", {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ code }),
+  });
+  expect(res.status).toBe(401);
+  expect((await res.json() as { error: string }).error).toBe("invalid-code");
+});
+
+test("invite redeem with a non-string code → 401, not 500", async () => {
+  const { app } = await makeApp();
+  for (const code of [123, { a: 1 }, null, ["x"]]) {
+    const res = await app.request("/api/invites/redeem", {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ code }),
+    });
+    expect(res.status).toBe(401);
+    expect((await res.json() as { error: string }).error).toBe("invalid-code");
+  }
+});
+
 test("invite redeem shares the login rate-limit bucket", async () => {
   const { app } = await makeApp();
   const badRedeem = () => app.request("/api/invites/redeem", {


### PR DESCRIPTION
## Summary
Follow-up to #234 addressing subagent review findings (approve-with-nits):
- **TTL overflow**: `parseTtlMs` now capped at 10 years — huge values print usage instead of crashing with `Invalid time value`; bare `--ttl` (missing value) errors instead of silently defaulting to 7d.
- **Non-string redeem body**: `{"code": 123}` now returns 401 `invalid-code` instead of an uncaught TypeError → 500.
- **Defense-in-depth**: redeem `UPDATE` gains `AND used_at IS NULL`; auth gate path-exempts `/api/invites/redeem` for symmetry with `/api/login` (registration order alone already kept it public).
- **Clarity**: CLI expiry output marked UTC (`add invite` + `ls` header), stale maintenance doc comment updated, deployment doc notes that proxy access logs record unredeemed invite links.

## Test plan
- [x] `bun test tests/unit/packages/relay/` — 257 pass (4 new tests: TTL overflow, bare --ttl, non-string code, expired-code HTTP path)
- [x] `npx tsc --noEmit` clean