### PR TITLE
feat(relay-web): move plan panel into side whitespace on wide panes

### DIFF
--- a/docs/relay-deployment.md
+++ b/docs/relay-deployment.md
@@ -101,7 +101,7 @@ xacpx-relay add invite --label friend --ttl 3d --url https://relay.example.com -
 # 输出示例：
 #   invite code: mJ3…（仅打印一次）
 #   redeem link: https://relay.example.com/invite/mJ3…
-#   (share it now — single-use, not shown again; expires 2026-08-02 12:00)
+#   (share it now — single-use, not shown again; expires 2026-08-02 12:00 UTC)
 # 不传 --url 时打印 redeem path: /invite/<code>，自行拼到 hub 域名后即可。
 
 # ls 会追加 invites 段（短 id / 标签 / 过期时间 / 状态 unused|used|expired）
@@ -114,6 +114,7 @@ xacpx-relay rm invite <code-or-id> --db /var/lib/xacpx-relay/relay.db
 - 兑换页面**点击按钮才兑换**，不会因链接预览/爬虫抓取而烧掉邀请码。
 - 兑换端点与登录共用同一限流桶（按 IP，反代后方记得 `--trust-proxy`）。
 - 已用/过期的邀请码由每小时自动 GC 清理，`ls` 中的 used/expired 条目随之消失。
+- **注意**：邀请码明文出现在 URL 路径中，反向代理的 access log 会记录**未兑换**的邀请链接（兑换后即作废，无风险）。在意的话可缩短 `--ttl`，或在反代对 `/invite/` 路径关闭访问日志。
 
 ## 反向代理与限流（--trust-proxy）
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -285,6 +285,14 @@ DOMPurify（svg profile）净化，并按 `theme+源码` 缓存；`StreamMarkdow
     所以抽屉开合 `leftOpen`/`rightOpen` 仅在移动端可见、桌面无副作用——无需 JS 断点检测。
   - 半透明 backdrop 点击关闭；选中会话自动关左抽屉直达对话；抽屉头部有 `✕` 关闭按钮（`lg:hidden`）。
 - 中栏聊天始终占据剩余宽度；登录页/设置页（`max-w-2xl mx-auto`）本身是流式宽度，移动端无需额外处理。
+- **宽屏 Plan 侧列**（issue #231）：中栏足够宽时,`PlanPanel` 从 composer 区移到消息历史右侧的
+  `w-72` 全高列（`ChatPane.vue` 的 `data-test="plan-side-col"`,右栏左边）。判定不是视口断点而是
+  **ResizeObserver 实测 ChatPane 根宽**（左栏折叠/右栏拖拽都会改变可用宽）,阈值带迟滞
+  （`src/lib/plan-placement.ts`:进入 ≥ 768+288+32+32=1120px,退出 < 1088px,防滚动条/拖窗抖动）;
+  无 ResizeObserver 的环境（jsdom/嵌入式）恒回落 composer 区原位。侧列形态用
+  `PlanPanel` 的 `variant="side"`:放开 `max-h-48`,header 钉住、列表在列高内滚动。
+  常量与模板 class 是双份事实（`CHAT_CONTENT_MAX`↔`max-w-3xl`、`PLAN_SIDE_WIDTH`↔`w-72`),改一处须同步另一处。
+  两插槽 `v-if` 切换会重建组件,`expanded` 重置为 `active ?? true`——有意为之,切换低频可接受。
 
 ## 文件地图
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -289,7 +289,8 @@ DOMPurify（svg profile）净化，并按 `theme+源码` 缓存；`StreamMarkdow
   `w-72` 全高列（`ChatPane.vue` 的 `data-test="plan-side-col"`,右栏左边）。判定不是视口断点而是
   **ResizeObserver 实测 ChatPane 根宽**（左栏折叠/右栏拖拽都会改变可用宽）,阈值带迟滞
   （`src/lib/plan-placement.ts`:进入 ≥ 768+288+32+32=1120px,退出 < 1088px,防滚动条/拖窗抖动）;
-  无 ResizeObserver 的环境（jsdom/嵌入式）恒回落 composer 区原位。侧列形态用
+  宽度 ≤ 0（无 ResizeObserver 的 jsdom/嵌入式环境,或 ChatPane 被 `v-show` 藏在其他 tab 后）时**保持上次判定**——
+  无 RO 时初始即 inline 故恒回落原位,宽屏下切 tab 再切回也不会销毁重建侧列面板。侧列形态用
   `PlanPanel` 的 `variant="side"`:放开 `max-h-48`,header 钉住、列表在列高内滚动。
   常量与模板 class 是双份事实（`CHAT_CONTENT_MAX`↔`max-w-3xl`、`PLAN_SIDE_WIDTH`↔`w-72`),改一处须同步另一处。
   两插槽 `v-if` 切换会重建组件,`expanded` 重置为 `active ?? true`——有意为之,切换低频可接受。

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -293,7 +293,7 @@ DOMPurify（svg profile）净化，并按 `theme+源码` 缓存；`StreamMarkdow
   无 RO 时初始即 inline 故恒回落原位,宽屏下切 tab 再切回也不会销毁重建侧列面板。侧列形态用
   `PlanPanel` 的 `variant="side"`:放开 `max-h-48`,header 钉住、列表在列高内滚动。
   常量与模板 class 是双份事实（`CHAT_CONTENT_MAX`↔`max-w-3xl`、`PLAN_SIDE_WIDTH`↔`w-72`),改一处须同步另一处。
-  两插槽 `v-if` 切换会重建组件,`expanded` 重置为 `active ?? true`——有意为之,切换低频可接受。
+  两插槽 `v-if` 切换会重建 PlanPanel,但 `expanded` 折叠状态由 ChatPane 用 `v-model:expanded` 持有,跨切换保留。
 
 ## 文件地图
 

--- a/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
@@ -1,0 +1,114 @@
+import { setActivePinia, createPinia } from "pinia";
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+vi.mock("../api/client", () => ({
+  ApiError: class extends Error { constructor(public code: string, public status: number) { super(code); } },
+  api: { get: vi.fn(), rpc: vi.fn() },
+}));
+
+import ChatPane from "../components/ChatPane.vue";
+import { useChatStore } from "../stores/chat";
+import { useInstancesStore } from "../stores/instances";
+
+// jsdom has no scrollIntoView; the plan panel calls it on update.
+(window.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+
+beforeEach(() => setActivePinia(createPinia()));
+afterEach(() => vi.unstubAllGlobals());
+
+// Minimal ResizeObserver stand-in: captures the callback so tests drive widths by hand.
+let roCallback: ((entries: { contentRect: { width: number } }[]) => void) | null = null;
+const roDisconnect = vi.fn();
+class FakeRO {
+  constructor(cb: (entries: { contentRect: { width: number } }[]) => void) { roCallback = cb; }
+  observe() {}
+  disconnect() { roDisconnect(); }
+}
+
+function seedInstance(sessions: unknown[] = [{ alias: "backend", agent: "codex", workspace: "gaia" }]) {
+  const instances = useInstancesStore();
+  instances.instances.push({
+    id: "i1", name: "prod-box", online: true, lastSeenAt: null,
+    sessions, agents: [], workspaces: [], agentCatalog: [],
+  } as never);
+}
+
+function seedPlan(chat: ReturnType<typeof useChatStore>) {
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: {
+    type: "plan", sessionAlias: "backend",
+    entries: [{ content: "a", status: "completed" }, { content: "b", status: "in_progress" }],
+  } } as never);
+}
+
+async function resize(w: ReturnType<typeof mount>, width: number) {
+  roCallback?.([{ contentRect: { width } }]);
+  await w.vm.$nextTick();
+}
+
+it("keeps the plan panel in the composer when ResizeObserver is unavailable (jsdom fallback)", async () => {
+  seedInstance();
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  seedPlan(chat);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  expect(w.find('[data-test="plan-side-col"]').exists()).toBe(false);
+  expect(w.find('[data-test="composer-area"] [data-test="plan-panel"]').exists()).toBe(true);
+});
+
+it("moves the plan panel to the side column on wide panes and back on narrow ones", async () => {
+  vi.stubGlobal("ResizeObserver", FakeRO);
+  seedInstance();
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  seedPlan(chat);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  // Wide pane → side column hosts the panel, composer copy disappears.
+  await resize(w, 1400);
+  const side = w.find('[data-test="plan-side-col"]');
+  expect(side.exists()).toBe(true);
+  expect(side.find('[data-test="plan-panel"]').exists()).toBe(true);
+  expect(w.find('[data-test="composer-area"] [data-test="plan-panel"]').exists()).toBe(false);
+  // Narrow pane → back to the composer area.
+  await resize(w, 800);
+  expect(w.find('[data-test="plan-side-col"]').exists()).toBe(false);
+  expect(w.find('[data-test="composer-area"] [data-test="plan-panel"]').exists()).toBe(true);
+});
+
+it("renders no side column on a wide pane when the session has no plan", async () => {
+  vi.stubGlobal("ResizeObserver", FakeRO);
+  seedInstance();
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  await resize(w, 1400);
+  expect(w.find('[data-test="plan-side-col"]').exists()).toBe(false);
+});
+
+it("renders no side column while the session is still booting", async () => {
+  vi.stubGlobal("ResizeObserver", FakeRO);
+  seedInstance([{ alias: "backend", agent: "codex", workspace: "gaia", transportSession: "", running: false, archived: false, creating: true, creatingSince: Date.now() }]);
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  seedPlan(chat);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  await resize(w, 1400);
+  expect(w.find('[data-test="session-booting"]').exists()).toBe(true);
+  expect(w.find('[data-test="plan-side-col"]').exists()).toBe(false);
+});
+
+it("disconnects the observer on unmount", async () => {
+  vi.stubGlobal("ResizeObserver", FakeRO);
+  roDisconnect.mockClear();
+  seedInstance();
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  w.unmount();
+  expect(roDisconnect).toHaveBeenCalled();
+});

--- a/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
@@ -15,9 +15,11 @@ import { useInstancesStore } from "../stores/instances";
 (window.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
 
 beforeEach(() => setActivePinia(createPinia()));
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => { vi.unstubAllGlobals(); roCallback = null; });
 
 // Minimal ResizeObserver stand-in: captures the callback so tests drive widths by hand.
+// Unlike a real RO it does NOT auto-report the initial size on observe() — every width
+// change must come from an explicit resize() call.
 let roCallback: ((entries: { contentRect: { width: number } }[]) => void) | null = null;
 const roDisconnect = vi.fn();
 class FakeRO {

--- a/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
@@ -79,6 +79,27 @@ it("moves the plan panel to the side column on wide panes and back on narrow one
   expect(w.find('[data-test="composer-area"] [data-test="plan-panel"]').exists()).toBe(true);
 });
 
+it("preserves the manual expand/collapse state across the placement switch", async () => {
+  vi.stubGlobal("ResizeObserver", FakeRO);
+  seedInstance();
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  seedPlan(chat);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  // Inline + not busy → starts collapsed; expand it by hand.
+  const toggle = w.find('[data-test="composer-area"] [data-test="plan-toggle"]');
+  expect(toggle.attributes("aria-expanded")).toBe("false");
+  await toggle.trigger("click");
+  expect(w.find('[data-test="composer-area"] [data-test="plan-toggle"]').attributes("aria-expanded")).toBe("true");
+  // Cross into the side column: the remounted panel keeps the expanded state.
+  await resize(w, 1400);
+  expect(w.find('[data-test="plan-side-col"] [data-test="plan-toggle"]').attributes("aria-expanded")).toBe("true");
+  // And back to inline again.
+  await resize(w, 800);
+  expect(w.find('[data-test="composer-area"] [data-test="plan-toggle"]').attributes("aria-expanded")).toBe("true");
+});
+
 it("renders no side column on a wide pane when the session has no plan", async () => {
   vi.stubGlobal("ResizeObserver", FakeRO);
   seedInstance();

--- a/packages/relay-web/src/__tests__/plan-placement.test.ts
+++ b/packages/relay-web/src/__tests__/plan-placement.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import {
+  computePlanPlacement,
+  CHAT_CONTENT_MAX,
+  PLAN_SIDE_WIDTH,
+  PLAN_SIDE_GAP,
+  PLAN_SIDE_HYSTERESIS,
+} from "../lib/plan-placement";
+
+const BASE = CHAT_CONTENT_MAX + PLAN_SIDE_WIDTH + PLAN_SIDE_GAP; // 1088
+const ENTER = BASE + PLAN_SIDE_HYSTERESIS; // 1120
+
+describe("computePlanPlacement", () => {
+  it("switches to side on wide panes", () => {
+    expect(computePlanPlacement(1400, "inline")).toBe("side");
+    expect(computePlanPlacement(ENTER, "inline")).toBe("side");
+  });
+
+  it("falls back to inline on narrow panes", () => {
+    expect(computePlanPlacement(800, "side")).toBe("inline");
+    expect(computePlanPlacement(BASE - 1, "side")).toBe("inline");
+  });
+
+  it("keeps the previous placement inside the hysteresis band", () => {
+    const inBand = BASE + PLAN_SIDE_HYSTERESIS / 2; // 1104
+    expect(computePlanPlacement(inBand, "side")).toBe("side");
+    expect(computePlanPlacement(inBand, "inline")).toBe("inline");
+    expect(computePlanPlacement(BASE, "side")).toBe("side");
+    expect(computePlanPlacement(BASE, "inline")).toBe("inline");
+    expect(computePlanPlacement(ENTER - 1, "inline")).toBe("inline");
+  });
+
+  it("treats unmeasured widths as inline (no ResizeObserver fallback)", () => {
+    expect(computePlanPlacement(0, "side")).toBe("inline");
+    expect(computePlanPlacement(-5, "side")).toBe("inline");
+  });
+});

--- a/packages/relay-web/src/__tests__/plan-placement.test.ts
+++ b/packages/relay-web/src/__tests__/plan-placement.test.ts
@@ -30,8 +30,11 @@ describe("computePlanPlacement", () => {
     expect(computePlanPlacement(ENTER - 1, "inline")).toBe("inline");
   });
 
-  it("treats unmeasured widths as inline (no ResizeObserver fallback)", () => {
-    expect(computePlanPlacement(0, "side")).toBe("inline");
-    expect(computePlanPlacement(-5, "side")).toBe("inline");
+  it("keeps the previous placement for unmeasured or hidden panes", () => {
+    // No RO (jsdom) → width stays 0 and the initial "inline" never changes;
+    // a hidden pane (display:none tab switch) must not flip an active "side".
+    expect(computePlanPlacement(0, "inline")).toBe("inline");
+    expect(computePlanPlacement(0, "side")).toBe("side");
+    expect(computePlanPlacement(-5, "side")).toBe("side");
   });
 });

--- a/packages/relay-web/src/__tests__/planpanel.test.ts
+++ b/packages/relay-web/src/__tests__/planpanel.test.ts
@@ -44,6 +44,24 @@ describe("PlanPanel", () => {
     expect(classes).toContain("max-h-48");
     expect(classes).toContain("overflow-y-auto");
   });
+  it("drops the height cap and flexes in the side variant", () => {
+    const w = mount(PlanPanel, { props: { variant: "side", entries: [
+      { content: "a", status: "in_progress" },
+    ] } });
+    const classes = w.find("#plan-list").classes();
+    expect(classes).not.toContain("max-h-48");
+    expect(classes).toContain("flex-1");
+    expect(classes).toContain("overflow-y-auto");
+    expect(w.find('[data-test="plan-panel"]').classes()).toContain("max-h-full");
+  });
+  it("still toggles in the side variant", async () => {
+    const w = mount(PlanPanel, { props: { variant: "side", entries: [
+      { content: "a", status: "in_progress" },
+    ] } });
+    expect(w.find('[data-test="plan-toggle"]').attributes("aria-expanded")).toBe("true");
+    await w.find('[data-test="plan-toggle"]').trigger("click");
+    expect(w.find('[data-test="plan-toggle"]').attributes("aria-expanded")).toBe("false");
+  });
   it("scrolls the active task into view on an entries update", async () => {
     const calls: unknown[] = [];
     (window.HTMLElement.prototype as unknown as { scrollIntoView: (a?: unknown) => void })

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -5,6 +5,8 @@ import { useInstancesStore } from "../stores/instances";
 import { useFilesStore } from "../stores/files";
 import { useComposerStore } from "../stores/composer";
 import { useVirtualKeyboardInset } from "../lib/use-virtual-keyboard";
+import { useElementWidth } from "../lib/use-element-width";
+import { computePlanPlacement, type PlanPlacement } from "../lib/plan-placement";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import MessageList from "./MessageList.vue";
 import PromptInput from "./PromptInput.vue";
@@ -21,6 +23,15 @@ const composer = useComposerStore();
 // While the soft keyboard is open it already covers the iOS home indicator, so the
 // composer's safe-area bottom padding is just a gap — drop it then (see the template).
 const keyboardInset = useVirtualKeyboardInset();
+
+// Wide-pane plan placement (issue #231): the pane root spans the middle column
+// (absolute inset-0), so its width is the placement input. Observing the root —
+// not the message area — avoids a feedback loop when the side column appears.
+const paneEl = ref<HTMLElement | null>(null);
+const paneWidth = useElementWidth(paneEl);
+const planPlacement = ref<PlanPlacement>("inline");
+watch(paneWidth, (w) => { planPlacement.value = computePlanPlacement(w, planPlacement.value); });
+const planSide = computed(() => planPlacement.value === "side" && (chat.sessionPlan?.length ?? 0) > 0);
 
 function onSend(text: string, media: PromptAttachmentRef[] = []) {
   void chat.send(text, media);
@@ -109,7 +120,7 @@ const verb = computed(() => {
 </script>
 
 <template>
-  <div class="flex h-full flex-1 flex-col">
+  <div ref="paneEl" class="flex h-full flex-1 flex-col">
     <div v-if="!chat.sessionAlias" class="flex flex-1 items-center justify-center text-fg-muted">
       {{ $t("chat.selectSession") }}
     </div>
@@ -173,12 +184,25 @@ const verb = computed(() => {
         </template>
       </div>
       <template v-else>
-      <MessageList :messages="chat.messages" :live-turn="chat.liveTurn" :driver="currentDriver"
+      <!-- min-h-0 keeps the column height chain intact (flex min-height:auto would let a
+           long transcript blow past the pane); the row's default align-stretch is what
+           gives MessageList (and the side column) their full height. -->
+      <div class="flex min-h-0 flex-1" data-test="chat-body">
+      <MessageList class="min-w-0" :messages="chat.messages" :live-turn="chat.liveTurn" :driver="currentDriver"
                    :session-key="`${chat.instanceId}\0${chat.sessionAlias}`"
                    :scroll-to-scheduled="chat.scrollRequest"
                    :has-more-older="chat.hasMoreOlder" :loading-older="chat.loadingOlder"
                    :loading-history="chat.loadingHistory"
                    @resend="chat.resend" @load-older="chat.loadOlder" />
+      <!-- Wide panes only: the plan panel moves into the message history's right-hand
+           whitespace. The column itself never scrolls — scrolling stays inside the
+           panel's list so the active-entry tracking keeps working. -->
+      <aside v-if="planSide" data-test="plan-side-col"
+             class="flex w-72 shrink-0 flex-col py-3 pr-3 lg:py-5 lg:pr-5"
+             :aria-label="$t('plan.title')">
+        <PlanPanel variant="side" :entries="chat.sessionPlan!" :active="chat.busy" />
+      </aside>
+      </div>
       <!-- composer area. pb uses max(1rem, safe-area-inset-bottom) so the iOS home-indicator
            inset is applied ONCE here (the bottommost element) and never stacks on top of the
            composer's own padding — env() is 0 off-PWA, so desktop stays at 1rem. -->
@@ -198,7 +222,7 @@ const verb = computed(() => {
                   @click="chat.cancel"><X :size="13" />{{ $t("common.cancel") }}</button>
         </div>
         <QueueStrip />
-        <PlanPanel v-if="chat.sessionPlan?.length" :entries="chat.sessionPlan" :active="chat.busy" />
+        <PlanPanel v-if="!planSide && chat.sessionPlan?.length" :entries="chat.sessionPlan" :active="chat.busy" />
         <PromptInput :busy="chat.busy" :draft-key="`${chat.instanceId}\0${chat.sessionAlias}`"
                      :instance-id="chat.instanceId" :session-alias="chat.sessionAlias"
                      @send="onSend" @cancel="chat.cancel" />

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -198,9 +198,9 @@ const verb = computed(() => {
            whitespace. The column itself never scrolls — scrolling stays inside the
            panel's list so the active-entry tracking keeps working. -->
       <aside v-if="planSide" data-test="plan-side-col"
-             class="flex w-72 shrink-0 flex-col py-3 pr-3 lg:py-5 lg:pr-5"
+             class="flex w-72 shrink-0 flex-col py-5 pr-5"
              :aria-label="$t('plan.title')">
-        <PlanPanel variant="side" :entries="chat.sessionPlan!" :active="chat.busy" />
+        <PlanPanel variant="side" :entries="chat.sessionPlan ?? []" :active="chat.busy" />
       </aside>
       </div>
       <!-- composer area. pb uses max(1rem, safe-area-inset-bottom) so the iOS home-indicator

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -32,6 +32,9 @@ const paneWidth = useElementWidth(paneEl);
 const planPlacement = ref<PlanPlacement>("inline");
 watch(paneWidth, (w) => { planPlacement.value = computePlanPlacement(w, planPlacement.value); });
 const planSide = computed(() => planPlacement.value === "side" && (chat.sessionPlan?.length ?? 0) > 0);
+// Owned here (not inside PlanPanel) so the manual expand/collapse survives the inline↔side
+// switch, which remounts the panel. Seeded from busy to match the panel's own default.
+const planExpanded = ref(chat.busy);
 
 function onSend(text: string, media: PromptAttachmentRef[] = []) {
   void chat.send(text, media);
@@ -200,7 +203,7 @@ const verb = computed(() => {
       <aside v-if="planSide" data-test="plan-side-col"
              class="flex w-72 shrink-0 flex-col py-5 pr-5"
              :aria-label="$t('plan.title')">
-        <PlanPanel variant="side" :entries="chat.sessionPlan ?? []" :active="chat.busy" />
+        <PlanPanel variant="side" v-model:expanded="planExpanded" :entries="chat.sessionPlan ?? []" :active="chat.busy" />
       </aside>
       </div>
       <!-- composer area. pb uses max(1rem, safe-area-inset-bottom) so the iOS home-indicator
@@ -222,7 +225,7 @@ const verb = computed(() => {
                   @click="chat.cancel"><X :size="13" />{{ $t("common.cancel") }}</button>
         </div>
         <QueueStrip />
-        <PlanPanel v-if="!planSide && chat.sessionPlan?.length" :entries="chat.sessionPlan" :active="chat.busy" />
+        <PlanPanel v-if="!planSide && chat.sessionPlan?.length" v-model:expanded="planExpanded" :entries="chat.sessionPlan" :active="chat.busy" />
         <PromptInput :busy="chat.busy" :draft-key="`${chat.instanceId}\0${chat.sessionAlias}`"
                      :instance-id="chat.instanceId" :session-alias="chat.sessionAlias"
                      @send="onSend" @cancel="chat.cancel" />

--- a/packages/relay-web/src/components/PlanPanel.vue
+++ b/packages/relay-web/src/components/PlanPanel.vue
@@ -5,7 +5,12 @@ import type { PlanEntryDto } from "@ganglion/xacpx-relay-protocol";
 
 // `active` defaults to `undefined` (not Vue's Boolean-cast `false`) so an unspecified prop
 // leaves the panel expanded and the auto expand/collapse watch dormant.
-const props = withDefaults(defineProps<{ entries: PlanEntryDto[]; active?: boolean }>(), { active: undefined });
+// `variant: "side"` renders in the wide-screen column right of the message list: the
+// `max-h-48` cap is dropped and the list flexes to the column height instead.
+const props = withDefaults(
+  defineProps<{ entries: PlanEntryDto[]; active?: boolean; variant?: "inline" | "side" }>(),
+  { active: undefined, variant: "inline" },
+);
 const expanded = ref(props.active ?? true);
 const listEl = ref<HTMLUListElement | null>(null);
 const done = computed(() => props.entries.filter((e) => e.status === "completed").length);
@@ -37,7 +42,8 @@ watch(() => props.active, (a) => { if (a !== undefined) expanded.value = a; });
 </script>
 
 <template>
-  <div v-if="entries.length" data-test="plan-panel" class="rounded-md border border-border bg-surface p-2 text-sm">
+  <div v-if="entries.length" data-test="plan-panel"
+       :class="['rounded-md border border-border bg-surface p-2 text-sm', variant === 'side' ? 'flex min-h-0 max-h-full flex-col' : '']">
     <button
       type="button"
       data-test="plan-toggle"
@@ -52,7 +58,8 @@ watch(() => props.active, (a) => { if (a !== undefined) expanded.value = a; });
       {{ $t("plan.title") }}
       <span class="ml-auto font-mono tabular-nums">{{ done }}/{{ entries.length }}</span>
     </button>
-    <ul v-show="expanded" id="plan-list" ref="listEl" class="max-h-48 overflow-y-auto thin-scroll space-y-0.5">
+    <ul v-show="expanded" id="plan-list" ref="listEl"
+        :class="['overflow-y-auto thin-scroll space-y-0.5', variant === 'side' ? 'min-h-0 flex-1' : 'max-h-48']">
       <li
         v-for="(e, i) in entries"
         :key="i"

--- a/packages/relay-web/src/components/PlanPanel.vue
+++ b/packages/relay-web/src/components/PlanPanel.vue
@@ -11,7 +11,11 @@ const props = withDefaults(
   defineProps<{ entries: PlanEntryDto[]; active?: boolean; variant?: "inline" | "side" }>(),
   { active: undefined, variant: "inline" },
 );
-const expanded = ref(props.active ?? true);
+// `expanded` is a two-way model so ChatPane can own it and preserve the expand/collapse
+// state across the inline↔side placement switch (which remounts this component). When no
+// v-model is bound (standalone use / tests) it is a local ref seeded below.
+const expanded = defineModel<boolean>("expanded", { default: undefined });
+if (expanded.value === undefined) expanded.value = props.active ?? true;
 const listEl = ref<HTMLUListElement | null>(null);
 const done = computed(() => props.entries.filter((e) => e.status === "completed").length);
 const activeIndex = computed(() => {

--- a/packages/relay-web/src/lib/plan-placement.ts
+++ b/packages/relay-web/src/lib/plan-placement.ts
@@ -6,6 +6,8 @@
 //   PLAN_SIDE_WIDTH   = w-72 on ChatPane's side column
 export const CHAT_CONTENT_MAX = 768;
 export const PLAN_SIDE_WIDTH = 288;
+// Approximate spacing budget, not a class mirror: the actual template chrome is
+// ~60px (scroller px-5 both sides + aside pr-5); the hysteresis margin absorbs it.
 export const PLAN_SIDE_GAP = 32;
 // Entering "side" requires more width than staying in it, so scrollbar appearance
 // (~15px) or window dragging near the boundary can't flip the layout back and forth.
@@ -15,9 +17,12 @@ export type PlanPlacement = "inline" | "side";
 
 const BASE = CHAT_CONTENT_MAX + PLAN_SIDE_WIDTH + PLAN_SIDE_GAP;
 
-// width <= 0 means "unmeasured" (no ResizeObserver, e.g. jsdom) → always inline.
+// width <= 0 means "unmeasured or hidden" (no ResizeObserver, e.g. jsdom, or the pane
+// sits display:none behind another tab) → keep the previous placement so a tab switch
+// doesn't destroy and rebuild the side panel. Without RO the width stays 0 and the
+// initial "inline" never changes, which preserves the narrow-screen fallback.
 export function computePlanPlacement(width: number, prev: PlanPlacement): PlanPlacement {
-  if (width <= 0) return "inline";
+  if (width <= 0) return prev;
   if (width >= BASE + PLAN_SIDE_HYSTERESIS) return "side";
   if (width < BASE) return "inline";
   return prev;

--- a/packages/relay-web/src/lib/plan-placement.ts
+++ b/packages/relay-web/src/lib/plan-placement.ts
@@ -1,0 +1,24 @@
+// Wide-screen placement for the plan panel (issue #231): when the chat pane is wide
+// enough, the panel moves from the composer area to a fixed-width column right of the
+// message list. These constants mirror Tailwind classes in the templates — change one,
+// change the other:
+//   CHAT_CONTENT_MAX  = max-w-3xl on MessageList's content wrapper
+//   PLAN_SIDE_WIDTH   = w-72 on ChatPane's side column
+export const CHAT_CONTENT_MAX = 768;
+export const PLAN_SIDE_WIDTH = 288;
+export const PLAN_SIDE_GAP = 32;
+// Entering "side" requires more width than staying in it, so scrollbar appearance
+// (~15px) or window dragging near the boundary can't flip the layout back and forth.
+export const PLAN_SIDE_HYSTERESIS = 32;
+
+export type PlanPlacement = "inline" | "side";
+
+const BASE = CHAT_CONTENT_MAX + PLAN_SIDE_WIDTH + PLAN_SIDE_GAP;
+
+// width <= 0 means "unmeasured" (no ResizeObserver, e.g. jsdom) → always inline.
+export function computePlanPlacement(width: number, prev: PlanPlacement): PlanPlacement {
+  if (width <= 0) return "inline";
+  if (width >= BASE + PLAN_SIDE_HYSTERESIS) return "side";
+  if (width < BASE) return "inline";
+  return prev;
+}

--- a/packages/relay-web/src/lib/use-element-width.ts
+++ b/packages/relay-web/src/lib/use-element-width.ts
@@ -1,19 +1,25 @@
-import { ref, onMounted, onBeforeUnmount, type Ref } from "vue";
+import { ref, watch, onMounted, onBeforeUnmount, type Ref } from "vue";
 
 // Reactive content-box width (px) of `target`, driven by ResizeObserver. Stays 0 when
 // ResizeObserver is unavailable (jsdom/embedded runtimes) so callers degrade to their
 // narrow-screen behavior — same philosophy as the matchMedia fallback in PromptInput.
+// The target may be null at mount (e.g. behind a v-if) — observation follows the ref.
 export function useElementWidth(target: Ref<HTMLElement | null>): Ref<number> {
   const width = ref(0);
   let observer: ResizeObserver | null = null;
 
   onMounted(() => {
-    if (typeof ResizeObserver !== "function" || !target.value) return;
+    if (typeof ResizeObserver !== "function") return;
     observer = new ResizeObserver((entries) => {
       const entry = entries[entries.length - 1];
       if (entry) width.value = entry.contentRect.width;
     });
-    observer.observe(target.value);
+    if (target.value) observer.observe(target.value);
+  });
+  watch(target, (el) => {
+    if (!observer) return;
+    observer.disconnect();
+    if (el) observer.observe(el);
   });
   onBeforeUnmount(() => {
     observer?.disconnect();

--- a/packages/relay-web/src/lib/use-element-width.ts
+++ b/packages/relay-web/src/lib/use-element-width.ts
@@ -1,0 +1,24 @@
+import { ref, onMounted, onBeforeUnmount, type Ref } from "vue";
+
+// Reactive content-box width (px) of `target`, driven by ResizeObserver. Stays 0 when
+// ResizeObserver is unavailable (jsdom/embedded runtimes) so callers degrade to their
+// narrow-screen behavior — same philosophy as the matchMedia fallback in PromptInput.
+export function useElementWidth(target: Ref<HTMLElement | null>): Ref<number> {
+  const width = ref(0);
+  let observer: ResizeObserver | null = null;
+
+  onMounted(() => {
+    if (typeof ResizeObserver !== "function" || !target.value) return;
+    observer = new ResizeObserver((entries) => {
+      const entry = entries[entries.length - 1];
+      if (entry) width.value = entry.contentRect.width;
+    });
+    observer.observe(target.value);
+  });
+  onBeforeUnmount(() => {
+    observer?.disconnect();
+    observer = null;
+  });
+
+  return width;
+}

--- a/packages/relay/src/cli.ts
+++ b/packages/relay/src/cli.ts
@@ -69,6 +69,8 @@ function hasFlag(args: string[], name: string): boolean {
 /**
  * Parses an invite TTL like "30m", "12h", "7d" into milliseconds.
  * Returns null for malformed input; undefined input yields the 7-day default.
+ * Capped at 10 years — beyond that Date arithmetic overflows the ECMAScript
+ * time range and toISOString() throws instead of printing usage.
  */
 export function parseTtlMs(raw: string | undefined): number | null {
   if (raw === undefined) return 7 * 24 * 60 * 60 * 1000;
@@ -77,7 +79,9 @@ export function parseTtlMs(raw: string | undefined): number | null {
   const n = Number(match[1]);
   if (n <= 0) return null;
   const unit = match[2] === "m" ? 60_000 : match[2] === "h" ? 3_600_000 : 86_400_000;
-  return n * unit;
+  const ms = n * unit;
+  const maxMs = 10 * 365 * 86_400_000;
+  return ms > maxMs ? null : ms;
 }
 
 export interface StartOptions {
@@ -161,7 +165,14 @@ export async function runRelayCli(args: string[], io: RelayCliIo): Promise<numbe
   // add invite [--label <l>] [--ttl <n>{m|h|d}] [--url <base>] --db <path>
   if (args[0] === "add" && args[1] === "invite") {
     const label = flag(args, "--label");
-    const ttlMs = parseTtlMs(flag(args, "--ttl"));
+    const ttlRaw = flag(args, "--ttl");
+    // A bare --ttl with a missing/flag-like value must error, not silently
+    // fall back to the 7-day default — the lifetime is security-relevant.
+    if (hasFlag(args, "--ttl") && ttlRaw === undefined) {
+      io.print(USAGE);
+      return 1;
+    }
+    const ttlMs = parseTtlMs(ttlRaw);
     if (ttlMs === null) {
       io.print(USAGE);
       return 1;
@@ -176,7 +187,7 @@ export async function runRelayCli(args: string[], io: RelayCliIo): Promise<numbe
       } else {
         io.print(`redeem path: /invite/${code}   (append to your hub URL)`);
       }
-      io.print(`(share it now — single-use, not shown again; expires ${expiresAt.slice(0, 16).replace("T", " ")})`);
+      io.print(`(share it now — single-use, not shown again; expires ${expiresAt.slice(0, 16).replace("T", " ")} UTC)`);
       return 0;
     } finally {
       runtime.close();
@@ -205,7 +216,7 @@ export async function runRelayCli(args: string[], io: RelayCliIo): Promise<numbe
         const nowMs = Date.now();
         io.print("");
         io.print("invites");
-        io.print("id        label                 expires               status");
+        io.print("id        label                 expires (UTC)         status");
         io.print("--------  --------------------  --------------------  -------");
         for (const inv of invites) {
           const shortId = inv.id.slice(0, 8);

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -255,7 +255,7 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       return c.json({ error: "too-many-attempts" }, 429);
     }
 
-    const r = deps.accounts.redeemInviteCode(body.code ?? "");
+    const r = deps.accounts.redeemInviteCode(typeof body.code === "string" ? body.code : "");
     if (!r) {
       recordFailure(ip, nowMs);
       deps.logger?.info("relay.invite.rejected", "invite redeem rejected", { reason: "invalid-code", ip });
@@ -267,7 +267,10 @@ export function createApp(deps: AppDeps): Hono<Vars> {
   });
 
   app.use("/api/*", async (c, next) => {
-    if (c.req.path === "/api/login") return next();
+    // Belt-and-braces exemptions mirroring the pre-gate registrations above;
+    // registration order alone already keeps these public, but if the gate is
+    // ever hoisted the exemption keeps behavior identical.
+    if (c.req.path === "/api/login" || c.req.path === "/api/invites/redeem") return next();
     const token = getCookie(c, SESSION_COOKIE);
     const account = token ? deps.accounts.getSessionAccount(token) : null;
     if (!account) return c.json({ error: "unauthorized" }, 401);

--- a/packages/relay/src/maintenance.ts
+++ b/packages/relay/src/maintenance.ts
@@ -21,7 +21,7 @@ export interface MaintenanceSummary {
   inviteCodesDeleted: number;
 }
 
-/** Runs one maintenance pass: prune old/excess messages, GC expired sessions/pairing tokens. */
+/** Runs one maintenance pass: prune old/excess messages, GC expired sessions/pairing tokens/invite codes. */
 export function runMaintenance(stores: MaintenanceStores, opts: MaintenanceOptions): MaintenanceSummary {
   const now = (opts.now ?? (() => new Date()))();
   const messagesDeleted = stores.messages.prune({

--- a/packages/relay/src/stores/accounts.ts
+++ b/packages/relay/src/stores/accounts.ts
@@ -291,7 +291,7 @@ export class AccountStore {
     this.db.exec("BEGIN");
     try {
       this.db.run(
-        "UPDATE invite_codes SET used_at = ?, used_account_id = ? WHERE code_hash = ?",
+        "UPDATE invite_codes SET used_at = ?, used_account_id = ? WHERE code_hash = ? AND used_at IS NULL",
         [nowIso, accountId, codeHash],
       );
       this.db.run(

--- a/tests/unit/packages/relay/cli.test.ts
+++ b/tests/unit/packages/relay/cli.test.ts
@@ -267,6 +267,27 @@ test("parseTtlMs: default 7d, m/h/d units, malformed → null", () => {
   expect(parseTtlMs("7w")).toBeNull();
 });
 
+test("parseTtlMs: capped at 10 years — overflow returns null instead of a Date RangeError", () => {
+  expect(parseTtlMs("3650d")).toBe(3650 * 86_400_000);
+  expect(parseTtlMs("3651d")).toBeNull();
+  expect(parseTtlMs("999999999999d")).toBeNull();
+});
+
+test("add invite with --ttl missing its value prints usage instead of silently defaulting", async () => {
+  const dbPath = makeTmpDb();
+  const io = makeIo();
+  const code = await runRelayCli(["add", "invite", "--ttl", "--label", "x", "--db", dbPath], io);
+  expect(code).toBe(1);
+  expect(io.lines.join("\n")).toContain("Usage");
+
+  const rt = await createRelayRuntime(dbPath);
+  try {
+    expect(rt.accounts.listInviteCodes().length).toBe(0);
+  } finally {
+    rt.close();
+  }
+});
+
 test("ls shows invite section with status transitions unused → used", async () => {
   const dbPath = makeTmpDb();
   const addIo = makeIo();

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -780,6 +780,27 @@ test("invite redeem without JSON content-type → 415", async () => {
   expect(res.status).toBe(415);
 });
 
+test("invite redeem with an expired code → 401 invalid-code (same as unknown)", async () => {
+  const { app, accounts } = await makeApp();
+  const { code } = accounts.issueInviteCode(undefined, 0);
+  const res = await app.request("/api/invites/redeem", {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ code }),
+  });
+  expect(res.status).toBe(401);
+  expect((await res.json() as { error: string }).error).toBe("invalid-code");
+});
+
+test("invite redeem with a non-string code → 401, not 500", async () => {
+  const { app } = await makeApp();
+  for (const code of [123, { a: 1 }, null, ["x"]]) {
+    const res = await app.request("/api/invites/redeem", {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ code }),
+    });
+    expect(res.status).toBe(401);
+    expect((await res.json() as { error: string }).error).toBe("invalid-code");
+  }
+});
+
 test("invite redeem shares the login rate-limit bucket", async () => {
   const { app } = await makeApp();
   const badRedeem = () => app.request("/api/invites/redeem", {


### PR DESCRIPTION
Closes #231

## Summary
- Wide chat panes relocate the plan panel from the composer area into a full-height `w-72` column right of the message history (left of the right sidebar); narrow panes keep the existing layout.
- Placement is driven by a ResizeObserver on the ChatPane root (left-rail collapse and right-panel drag both change usable width, so a viewport breakpoint is not enough), with a hysteresis band (`enter >= 1120px`, `exit < 1088px`) in `src/lib/plan-placement.ts` to prevent boundary flapping. Environments without ResizeObserver (jsdom/embedded) always fall back to the inline layout.
- `PlanPanel` gains a `variant="side"` that drops the `max-h-48` cap: the header stays pinned and the list scrolls within the column height, so active-entry tracking keeps working.

## Test plan
- [x] `plan-placement.test.ts`: enter/exit thresholds, hysteresis band, unmeasured-width fallback
- [x] `planpanel.test.ts`: inline keeps `max-h-48`; side variant flexes and still toggles
- [x] `chatpane-plan-side.test.ts`: jsdom fallback, wide→side / narrow→inline switching, empty plan, booting session, observer disconnect on unmount
- [x] Full relay-web suite: 111 files / 967 tests pass; `vue-tsc --noEmit` clean; `bun run build:relay` succeeds
- [ ] Manual browser check: drag window across the threshold, long plan scrolling, sidebar collapse/drag interplay