### PR TITLE
feat(relay-web): cache session view snapshots

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -254,6 +254,14 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   （`seededFromCache`，保持 #199 的重选中途拉取语义）；播种（≤30 行）→ 权威整页替换
   不经过 0→N，`MessageList` 的渐进挂载对该替换同样重新触发
   （prev ≤ INITIAL_ROWS 且一次增长 ≥ REVEAL_BATCH 视为新 transcript）。
+- **切换视图快照缓存**（`src/lib/view-snapshot-cache.ts`）：切换会话时仍需读取的轻量只读数据采用
+  stale-while-revalidate。缓存按 `[user, namespace, instanceId, scope]` 隔离，内存热缓存让同页往返
+  同步恢复，IndexedDB `xacpx.view-snapshots` 让刷新后也能先恢复；model、effort、scheduled tasks、
+  orchestration tasks、workspace git summary，以及文件面板的目录导航/git 状态快照都先读缓存，再由
+  原有 RPC 权威结果覆盖并写回。任何缓存读写失败均静默降级为原实时请求，7 天 TTL 惰性过期；
+  删除会话清该会话的 model/effort/scheduled 快照，logout 清全部视图快照。实时 turn、plan、usage、
+  slash commands、queue 已由 WebSocket 按会话常驻内存，不重复落此缓存；文件正文、完整 diff 与终端
+  状态不缓存，避免把易陈旧、可参与写操作的数据伪装成当前权威状态。
 
 hub 侧配套：tool step 全字段 32K 字符写入截断（见 docs/relay-module.md 的 `TOOL_DETAIL_CAP`）。
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -259,9 +259,13 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   同步恢复，IndexedDB `xacpx.view-snapshots` 让刷新后也能先恢复；model、effort、scheduled tasks、
   orchestration tasks、workspace git summary，以及文件面板的目录导航/git 状态快照都先读缓存，再由
   原有 RPC 权威结果覆盖并写回。任何缓存读写失败均静默降级为原实时请求，7 天 TTL 惰性过期；
-  删除会话清该会话的 model/effort/scheduled 快照，logout 清全部视图快照。实时 turn、plan、usage、
-  slash commands、queue 已由 WebSocket 按会话常驻内存，不重复落此缓存；文件正文、完整 diff 与终端
-  状态不缓存，避免把易陈旧、可参与写操作的数据伪装成当前权威状态。
+  每个异步刷新在发起时捕获 write generation，删除会话/登出先推进 generation 再清理，因此更早发起的
+  model/effort/task 响应不能在清理后复活旧快照；删除会话会等待该会话的 model/effort/scheduled
+  快照清理完成，logout 清全部视图快照。账号变化同时重置 controls/tasks/files 的 Pinia 可见状态，
+  防止同 instance/session key 跨账号复用。git 状态刷新遇到传输/临时 RPC 错误会保留已播种 badge，
+  仅权威 `not-a-git-repo` 清空。实时 turn、plan、usage、slash commands、queue 已由 WebSocket 按会话
+  常驻内存，不重复落此缓存；文件正文、完整 diff 与终端状态不缓存，避免把易陈旧、可参与写操作的数据
+  伪装成当前权威状态。
 
 hub 侧配套：tool step 全字段 32K 字符写入截断（见 docs/relay-module.md 的 `TOOL_DETAIL_CAP`）。
 

--- a/packages/relay-web/src/__tests__/auth.test.ts
+++ b/packages/relay-web/src/__tests__/auth.test.ts
@@ -1,7 +1,11 @@
 // packages/relay-web/src/__tests__/auth.test.ts
 import { setActivePinia, createPinia } from "pinia";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { nextTick } from "vue";
 import { useAuthStore } from "../stores/auth";
+import { useFilesStore } from "../stores/files";
+import { useSessionControlsStore } from "../stores/session-controls";
+import { useTasksStore } from "../stores/tasks";
 
 beforeEach(() => setActivePinia(createPinia()));
 afterEach(() => vi.restoreAllMocks());
@@ -37,4 +41,39 @@ test("fetchMe populates account when a session exists", async () => {
   expect(auth.account?.username).toBe("u");
   // No role on the account
   expect((auth.account as Record<string, unknown>).role).toBeUndefined();
+});
+
+test("logout clears account-owned view state before another user can reuse the stores", async () => {
+  vi.stubGlobal("fetch", vi.fn(async () => new Response("{}", { status: 200 })));
+  const auth = useAuthStore();
+  auth.account = { username: "alice" };
+  const controls = useSessionControlsStore();
+  const tasks = useTasksStore();
+  const files = useFilesStore();
+  controls.modelCurrent = "alice-model";
+  controls.modelAvailable = ["alice-model"];
+  controls.effortCurrent = "high";
+  controls.effortAvailable = ["high"];
+  tasks.scope = { instanceId: "i1", sessionAlias: "s1" };
+  tasks.scheduled = [{ id: "alice-task" }] as never;
+  tasks.orchestration = [{ taskId: "alice-agent" }] as never;
+  files.instanceId = "i1";
+  files.workspace = "alice-workspace";
+  files.tree = { "": [{ name: "alice-secret.ts", type: "file" }] };
+  files.gitSummary = { workspace: "alice-workspace", changedCount: 1 };
+
+  await auth.logout();
+  await nextTick();
+
+  expect(controls.modelCurrent).toBeUndefined();
+  expect(controls.modelAvailable).toEqual([]);
+  expect(controls.effortCurrent).toBeUndefined();
+  expect(controls.effortAvailable).toEqual([]);
+  expect(tasks.scope).toBeNull();
+  expect(tasks.scheduled).toEqual([]);
+  expect(tasks.orchestration).toEqual([]);
+  expect(files.instanceId).toBeNull();
+  expect(files.workspace).toBeNull();
+  expect(files.tree).toEqual({});
+  expect(files.gitSummary).toBeNull();
 });

--- a/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/chat-tail-cache.test.ts
@@ -3,6 +3,11 @@ import { beforeEach, expect, test, vi } from "vitest";
 import { IDBFactory } from "fake-indexeddb";
 import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
 import { read, resetTailCacheForTests, write } from "../lib/session-tail-cache";
+import {
+  read as readViewSnapshot,
+  resetViewSnapshotCacheForTests,
+  write as writeViewSnapshot,
+} from "../lib/view-snapshot-cache";
 
 const getMock = vi.fn();
 const rpc = vi.fn();
@@ -50,6 +55,7 @@ async function goneEventually(user: string, instanceId: string, alias: string): 
 beforeEach(async () => {
   setActivePinia(createPinia());
   await resetTailCacheForTests();
+  await resetViewSnapshotCacheForTests();
   (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
   localStorage.clear();
   getMock.mockReset();
@@ -164,6 +170,7 @@ test("loadHistory failure keeps showing the cached tail", async () => {
 test("removeSession purges the cache; archiveSession (sleep) keeps it", async () => {
   await write("alice", "i1", "s1", [row(1)]);
   await write("alice", "i1", "s2", [row(2)]);
+  await writeViewSnapshot("alice", "session-model", "i1", "s2", { current: "old-model" });
   rpc.mockImplementation(async (_id: string, type: string) => {
     if (type === "control.sessions.list") {
       return { sessions: [
@@ -179,6 +186,7 @@ test("removeSession purges the cache; archiveSession (sleep) keeps it", async ()
   expect(await read("alice", "i1", "s1")).not.toBeNull();
   await instances.removeSession("i1", "s2");
   expect(await goneEventually("alice", "i1", "s2")).toBe(true);
+  expect(await readViewSnapshot("alice", "session-model", "i1", "s2")).toBeNull();
 });
 
 test("loadSessions reconciles the cache against alive aliases, keeping sleeping sessions", async () => {

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -280,6 +280,19 @@ describe("files store", () => {
     expect(s.gitSummary).toBeNull();
   });
 
+  it("loadGitSummary keeps a cached summary for a transient error payload", async () => {
+    useAuthStore().account = { username: "alice" };
+    await writeViewSnapshot("alice", "git-summary", "i1", "ws", {
+      summary: { workspace: "ws", changedCount: 3, branch: "cached" },
+    });
+    const s = useFilesStore();
+    rpc.mockResolvedValueOnce({ error: { code: "timeout", message: "connector timed out" } });
+
+    await s.loadGitSummary("i1", "ws");
+
+    expect(s.gitSummary).toEqual({ workspace: "ws", changedCount: 3, branch: "cached" });
+  });
+
   it("refresh() re-lists the current dir and refreshes git badges on the Files tab", async () => {
     rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [] });
     const s = useFilesStore();

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -219,6 +219,30 @@ describe("files store", () => {
     expect(s.error).toBe(""); // browsing stays clean — no error surfaced
   });
 
+  it("loadStatus keeps cached git badges when the refresh request fails", async () => {
+    const s = useFilesStore();
+    s.instanceId = "i1";
+    s.workspace = "ws";
+    s.changed = { "cached.ts": " M" };
+    rpc.mockRejectedValueOnce(new Error("network"));
+
+    await s.loadStatus();
+
+    expect(s.changed).toEqual({ "cached.ts": " M" });
+  });
+
+  it("loadStatus only clears cached badges for a confirmed non-git workspace", async () => {
+    const s = useFilesStore();
+    s.instanceId = "i1";
+    s.workspace = "ws";
+    s.changed = { "cached.ts": " M" };
+    rpc.mockResolvedValueOnce({ error: { code: "timeout", message: "connector timed out" } });
+
+    await s.loadStatus();
+
+    expect(s.changed).toEqual({ "cached.ts": " M" });
+  });
+
   it("loadGitSummary stores a changed-file count for a workspace", async () => {
     const s = useFilesStore();
     rpc.mockResolvedValueOnce({ workspace: "ws", files: [{ path: "a.ts", status: " M" }, { path: "b.ts", status: "??" }], diff: "", truncated: false });

--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -8,6 +8,8 @@ vi.mock("../api/client", () => ({
 }));
 
 import { useFilesStore } from "../stores/files";
+import { useAuthStore } from "../stores/auth";
+import { write as writeViewSnapshot } from "../lib/view-snapshot-cache";
 
 beforeEach(() => {
   setActivePinia(createPinia());
@@ -78,6 +80,37 @@ describe("files store", () => {
     await s.selectWorkspace("i1", "ws");
     expect(rpc).toHaveBeenCalledWith("i1", "control.fs.list", { workspace: "ws", path: "" });
     expect(s.entries.map((e) => e.name)).toEqual(["src", "README.md"]);
+  });
+
+  it("selectWorkspace paints a cached tree before the root refresh settles", async () => {
+    useAuthStore().account = { username: "tree-cache-user" };
+    await writeViewSnapshot("tree-cache-user", "workspace-view", "i1", "ws", {
+      root: "/cached/ws",
+      sep: "/",
+      tree: { "": [{ name: "cached.ts", type: "file", size: 1 }] },
+      changed: { "cached.ts": " M" },
+    });
+    let resolveRoot!: (value: unknown) => void;
+    rpc
+      .mockReturnValueOnce(new Promise((resolve) => { resolveRoot = resolve; }))
+      .mockResolvedValueOnce({ workspace: "ws", files: [], diff: "", truncated: false });
+    const s = useFilesStore();
+    const pending = s.selectWorkspace("i1", "ws");
+
+    expect(s.root).toBe("/cached/ws");
+    expect(s.entries.map((entry) => entry.name)).toEqual(["cached.ts"]);
+    expect(s.changed).toEqual({ "cached.ts": " M" });
+
+    resolveRoot({
+      workspace: "ws",
+      root: "/fresh/ws",
+      sep: "/",
+      path: "",
+      entries: [{ name: "fresh.ts", type: "file", size: 1 }],
+    });
+    await pending;
+    expect(s.root).toBe("/fresh/ws");
+    expect(s.entries.map((entry) => entry.name)).toEqual(["fresh.ts"]);
   });
 
   it("descends into a directory and opens a file", async () => {
@@ -199,6 +232,21 @@ describe("files store", () => {
     rpc.mockResolvedValueOnce({ workspace: "ws", branch: "main", files: [], diff: "", truncated: false });
     await s.loadGitSummary("i1", "ws");
     expect(s.gitSummary).toEqual({ workspace: "ws", changedCount: 0, branch: "main" });
+  });
+
+  it("loadGitSummary paints a workspace cache before the refresh settles", async () => {
+    useAuthStore().account = { username: "alice" };
+    await writeViewSnapshot("alice", "git-summary", "i1", "ws", {
+      summary: { workspace: "ws", changedCount: 3, branch: "cached" },
+    });
+    let resolveRpc!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveRpc = resolve; }));
+    const s = useFilesStore();
+    const pending = s.loadGitSummary("i1", "ws");
+    expect(s.gitSummary).toEqual({ workspace: "ws", changedCount: 3, branch: "cached" });
+    resolveRpc({ workspace: "ws", files: [], diff: "", truncated: false, branch: "fresh" });
+    await pending;
+    expect(s.gitSummary).toEqual({ workspace: "ws", changedCount: 0, branch: "fresh" });
   });
 
   it("loadGitSummary clears the summary for a non-git workspace (error payload)", async () => {

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -9,7 +9,11 @@ vi.mock("../api/client", () => ({
 
 import { useSessionControlsStore } from "../stores/session-controls";
 import { useAuthStore } from "../stores/auth";
-import { write as writeViewSnapshot } from "../lib/view-snapshot-cache";
+import {
+  dropSession as dropSessionViewSnapshots,
+  read as readViewSnapshot,
+  write as writeViewSnapshot,
+} from "../lib/view-snapshot-cache";
 import { dismissToast, useToasts } from "../lib/use-toasts";
 
 beforeEach(() => {
@@ -80,6 +84,23 @@ describe("session-controls store", () => {
     resolveLoad({ current: "fresh-model", available: ["fresh-model"] });
     await pendingLoad;
     expect(s.modelCurrent).toBe("fresh-model");
+  });
+
+  it("does not repopulate a deleted session cache from an older model refresh", async () => {
+    useAuthStore().account = { username: "delete-race-user" };
+    let resolveLoad!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveLoad = resolve; }));
+    const s = useSessionControlsStore();
+    const pendingLoad = s.loadModel("i1", "deleted-session");
+    await vi.waitFor(() => expect(rpc).toHaveBeenCalled());
+
+    await dropSessionViewSnapshots("delete-race-user", "i1", "deleted-session");
+    resolveLoad({ current: "stale-model", available: ["stale-model"] });
+    await pendingLoad;
+
+    expect(
+      await readViewSnapshot("delete-race-user", "session-model", "i1", "deleted-session"),
+    ).toBeNull();
   });
 
   it("setModel updates current optimistically before the RPC resolves", async () => {

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -8,6 +8,8 @@ vi.mock("../api/client", () => ({
 }));
 
 import { useSessionControlsStore } from "../stores/session-controls";
+import { useAuthStore } from "../stores/auth";
+import { write as writeViewSnapshot } from "../lib/view-snapshot-cache";
 import { dismissToast, useToasts } from "../lib/use-toasts";
 
 beforeEach(() => {
@@ -58,6 +60,26 @@ describe("session-controls store", () => {
     resolveLoad({ current: "model-b", available: ["model-b"] });
     await pendingLoad;
     expect(s.modelCurrent).toBe("model-b");
+  });
+
+  it("shows a cached model immediately while revalidating", async () => {
+    useAuthStore().account = { username: "alice" };
+    await writeViewSnapshot("alice", "session-model", "i1", "session-b", {
+      current: "cached-model",
+      available: ["cached-model"],
+    });
+    let resolveLoad!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveLoad = resolve; }));
+    const s = useSessionControlsStore();
+    const pendingLoad = s.loadModel("i1", "session-b");
+
+    expect(s.modelCurrent).toBe("cached-model");
+    expect(s.modelAvailable).toEqual(["cached-model"]);
+    expect(s.modelLoading).toBe(true);
+
+    resolveLoad({ current: "fresh-model", available: ["fresh-model"] });
+    await pendingLoad;
+    expect(s.modelCurrent).toBe("fresh-model");
   });
 
   it("setModel updates current optimistically before the RPC resolves", async () => {

--- a/packages/relay-web/src/__tests__/session-controls.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls.test.ts
@@ -152,6 +152,52 @@ describe("session-controls store", () => {
     log.mockRestore();
   });
 
+  it("does not reuse the previous account's authoritative model for rollback", async () => {
+    useAuthStore().account = { username: "alice" };
+    rpc.mockResolvedValueOnce({ current: "alice-model", available: ["alice-model"] });
+    const s = useSessionControlsStore();
+    await s.loadModel("i1", "backend");
+
+    useAuthStore().account = { username: "bob" };
+    rpc.mockResolvedValueOnce({ error: { code: "internal", message: "bob set failed" } });
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(s.setModel("i1", "backend", "bob-model")).resolves.toBe(false);
+
+    expect(s.modelCurrent).toBeUndefined();
+    log.mockRestore();
+  });
+
+  it("does not make a new account wait for the previous account's model mutation", async () => {
+    useAuthStore().account = { username: "alice" };
+    await writeViewSnapshot("bob", "session-model", "i1", "backend", {
+      current: "bob-cached",
+      available: ["bob-cached"],
+    });
+    let resolveAliceSet!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveAliceSet = resolve; }));
+    const s = useSessionControlsStore();
+    const aliceSet = s.setModel("i1", "backend", "alice-model");
+
+    useAuthStore().account = { username: "bob" };
+    let bobLoadStarted = false;
+    rpc.mockImplementationOnce(async () => {
+      bobLoadStarted = true;
+      return { current: "bob-model", available: ["bob-model"] };
+    });
+    const bobLoad = s.loadModel("i1", "backend");
+    await Promise.resolve();
+    await Promise.resolve();
+    const startedBeforeAliceSettled = bobLoadStarted;
+
+    resolveAliceSet({ ok: true, current: "alice-model" });
+    await aliceSet;
+    await bobLoad;
+
+    expect(startedBeforeAliceSettled).toBe(true);
+    expect(s.modelCurrent).toBe("bob-model");
+  });
+
   it("ignores a model-set response that arrives after switching sessions", async () => {
     rpc.mockResolvedValueOnce({ current: "model-a", available: ["model-a", "model-b"] });
     const s = useSessionControlsStore();
@@ -325,6 +371,25 @@ describe("session-controls store", () => {
     await setting;
     await waiting;
     expect(settled).toBe(true);
+  });
+
+  it("does not let a late previous-account effort mutation seed rollback state", async () => {
+    useAuthStore().account = { username: "alice" };
+    let resolveAliceSet!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveAliceSet = resolve; }));
+    const s = useSessionControlsStore();
+    const aliceSet = s.setEffort("i1", "backend", "high");
+
+    useAuthStore().account = { username: "bob" };
+    resolveAliceSet({ ok: true, current: "high" });
+    await aliceSet;
+
+    rpc.mockResolvedValueOnce({ error: { code: "internal", message: "bob set failed" } });
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await expect(s.setEffort("i1", "backend", "low")).resolves.toBe(false);
+
+    expect(s.effortCurrent).toBeUndefined();
+    log.mockRestore();
   });
 
   it("clears effort when a failed set reports an authoritative null current", async () => {

--- a/packages/relay-web/src/__tests__/tasks.test.ts
+++ b/packages/relay-web/src/__tests__/tasks.test.ts
@@ -8,6 +8,8 @@ vi.mock("../api/client", () => ({
 
 import { api } from "../api/client";
 import { useTasksStore } from "../stores/tasks";
+import { useAuthStore } from "../stores/auth";
+import { write as writeViewSnapshot } from "../lib/view-snapshot-cache";
 
 const rpc = api.rpc as unknown as ReturnType<typeof vi.fn>;
 
@@ -31,6 +33,45 @@ describe("tasks store", () => {
     await store.loadOrchestration("inst");
     expect(rpc).toHaveBeenCalledWith("inst", "control.orchestration.list");
     expect(store.orchestration).toHaveLength(1);
+  });
+
+  it("loadFor paints cached tasks before both refreshes settle", async () => {
+    useAuthStore().account = { username: "alice" };
+    const scheduledTask = {
+      id: "cached",
+      sessionAlias: "backend",
+      executeAt: "2030-01-01T00:00:00Z",
+      message: "cached",
+      status: "pending",
+      createdAt: "x",
+    };
+    await writeViewSnapshot("alice", "scheduled-tasks", "inst", "backend", [scheduledTask]);
+    await writeViewSnapshot("alice", "orchestration-tasks", "inst", "", [{
+      taskId: "cached-orchestration",
+      status: "running",
+      targetAgent: "claude",
+      workspace: "/w",
+      task: "cached",
+      summary: "",
+      createdAt: "x",
+      updatedAt: "x",
+    }]);
+    let resolveScheduled!: (value: unknown) => void;
+    let resolveOrchestration!: (value: unknown) => void;
+    rpc
+      .mockReturnValueOnce(new Promise((resolve) => { resolveScheduled = resolve; }))
+      .mockReturnValueOnce(new Promise((resolve) => { resolveOrchestration = resolve; }));
+    const store = useTasksStore();
+    const pending = store.loadFor("inst", "backend");
+
+    expect(store.scheduled.map((task) => task.id)).toEqual(["cached"]);
+    expect(store.orchestration.map((task) => task.taskId)).toEqual(["cached-orchestration"]);
+
+    resolveScheduled({ tasks: [] });
+    resolveOrchestration({ tasks: [] });
+    await pending;
+    expect(store.scheduled).toEqual([]);
+    expect(store.orchestration).toEqual([]);
   });
 
   it("createScheduled posts then reloads", async () => {

--- a/packages/relay-web/src/__tests__/tasks.test.ts
+++ b/packages/relay-web/src/__tests__/tasks.test.ts
@@ -39,6 +39,33 @@ describe("tasks store", () => {
     expect(store.orchestration).toHaveLength(1);
   });
 
+  it("loadOrchestration keeps cached tasks for an error payload", async () => {
+    useAuthStore().account = { username: "orchestration-error-user" };
+    const cachedTask = {
+      taskId: "cached",
+      status: "running",
+      targetAgent: "claude",
+      workspace: "/w",
+      task: "cached",
+      summary: "",
+      createdAt: "x",
+      updatedAt: "x",
+    };
+    await writeViewSnapshot(
+      "orchestration-error-user",
+      "orchestration-tasks",
+      "inst",
+      "",
+      [cachedTask],
+    );
+    rpc.mockResolvedValueOnce({ error: { code: "timeout", message: "connector timed out" } });
+    const store = useTasksStore();
+
+    await store.loadOrchestration("inst");
+
+    expect(store.orchestration.map((task) => task.taskId)).toEqual(["cached"]);
+  });
+
   it("loadFor paints cached tasks before both refreshes settle", async () => {
     useAuthStore().account = { username: "alice" };
     const scheduledTask = {

--- a/packages/relay-web/src/__tests__/tasks.test.ts
+++ b/packages/relay-web/src/__tests__/tasks.test.ts
@@ -9,7 +9,11 @@ vi.mock("../api/client", () => ({
 import { api } from "../api/client";
 import { useTasksStore } from "../stores/tasks";
 import { useAuthStore } from "../stores/auth";
-import { write as writeViewSnapshot } from "../lib/view-snapshot-cache";
+import {
+  dropSession as dropSessionViewSnapshots,
+  read as readViewSnapshot,
+  write as writeViewSnapshot,
+} from "../lib/view-snapshot-cache";
 
 const rpc = api.rpc as unknown as ReturnType<typeof vi.fn>;
 
@@ -72,6 +76,30 @@ describe("tasks store", () => {
     await pending;
     expect(store.scheduled).toEqual([]);
     expect(store.orchestration).toEqual([]);
+  });
+
+  it("does not repopulate a deleted session cache from an older task refresh", async () => {
+    useAuthStore().account = { username: "task-delete-race-user" };
+    let resolveScheduled!: (value: unknown) => void;
+    rpc.mockReturnValueOnce(new Promise((resolve) => { resolveScheduled = resolve; }));
+    const store = useTasksStore();
+    const pending = store.loadScheduled("inst", "deleted-session");
+    await vi.waitFor(() => expect(rpc).toHaveBeenCalled());
+
+    await dropSessionViewSnapshots("task-delete-race-user", "inst", "deleted-session");
+    resolveScheduled({ tasks: [{
+      id: "stale-task",
+      sessionAlias: "deleted-session",
+      executeAt: "2030-01-01T00:00:00Z",
+      message: "stale",
+      status: "pending",
+      createdAt: "x",
+    }] });
+    await pending;
+
+    expect(
+      await readViewSnapshot("task-delete-race-user", "scheduled-tasks", "inst", "deleted-session"),
+    ).toBeNull();
   });
 
   it("createScheduled posts then reloads", async () => {

--- a/packages/relay-web/src/__tests__/view-snapshot-cache.test.ts
+++ b/packages/relay-web/src/__tests__/view-snapshot-cache.test.ts
@@ -1,0 +1,70 @@
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  dropAll,
+  dropSession,
+  peek,
+  read,
+  resetViewSnapshotCacheForTests,
+  write,
+} from "../lib/view-snapshot-cache";
+
+beforeEach(async () => {
+  await resetViewSnapshotCacheForTests();
+  (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+});
+
+describe("view-snapshot-cache", () => {
+  it("updates the hot cache synchronously and survives a memory reset", async () => {
+    const pending = write("alice", "session-model", "i1", "s1", {
+      current: "gpt-5",
+      available: ["gpt-5"],
+    });
+    expect(peek("alice", "session-model", "i1", "s1")).toEqual({
+      current: "gpt-5",
+      available: ["gpt-5"],
+    });
+    await pending;
+    await resetViewSnapshotCacheForTests();
+    expect(await read("alice", "session-model", "i1", "s1")).toEqual({
+      current: "gpt-5",
+      available: ["gpt-5"],
+    });
+  });
+
+  it("isolates users and scopes", async () => {
+    await write("alice", "scheduled-tasks", "i1", "s1", ["a"]);
+    await write("alice", "scheduled-tasks", "i1", "s2", ["b"]);
+    expect(await read("alice", "scheduled-tasks", "i1", "s1")).toEqual(["a"]);
+    expect(await read("alice", "scheduled-tasks", "i1", "s2")).toEqual(["b"]);
+    expect(await read("bob", "scheduled-tasks", "i1", "s1")).toBeNull();
+  });
+
+  it("drops only session-owned namespaces when a session is deleted", async () => {
+    await write("alice", "session-effort", "i1", "s1", { current: "high" });
+    await write("alice", "orchestration-tasks", "i1", "", ["shared"]);
+    await dropSession("alice", "i1", "s1");
+    expect(await read("alice", "session-effort", "i1", "s1")).toBeNull();
+    expect(await read("alice", "orchestration-tasks", "i1", "")).toEqual(["shared"]);
+  });
+
+  it("dropAll clears memory and IndexedDB", async () => {
+    await write("alice", "git-summary", "i1", "ws", { changedCount: 2 });
+    await dropAll();
+    expect(peek("alice", "git-summary", "i1", "ws")).toBeNull();
+    expect(await read("alice", "git-summary", "i1", "ws")).toBeNull();
+  });
+
+  it("never throws when IndexedDB is unavailable", async () => {
+    await resetViewSnapshotCacheForTests();
+    const original = globalThis.indexedDB;
+    Object.defineProperty(globalThis, "indexedDB", { configurable: true, value: undefined });
+    try {
+      await expect(read("alice", "session-model", "i1", "s1")).resolves.toBeNull();
+      await expect(write("alice", "session-model", "i1", "s1", { current: "x" })).resolves.toBeUndefined();
+      expect(peek("alice", "session-model", "i1", "s1")).toEqual({ current: "x" });
+    } finally {
+      Object.defineProperty(globalThis, "indexedDB", { configurable: true, value: original });
+    }
+  });
+});

--- a/packages/relay-web/src/__tests__/view-snapshot-cache.test.ts
+++ b/packages/relay-web/src/__tests__/view-snapshot-cache.test.ts
@@ -1,7 +1,7 @@
 import { IDBFactory } from "fake-indexeddb";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-  captureWriteToken,
+  captureGenerationToken,
   dropAll,
   dropSession,
   peek,
@@ -76,7 +76,7 @@ describe("view-snapshot-cache", () => {
   });
 
   it("rejects a stale session write captured before the session was dropped", async () => {
-    const staleWrite = captureWriteToken("alice", "session-model", "i1", "s1");
+    const staleWrite = captureGenerationToken("alice", "session-model", "i1", "s1");
     await dropSession("alice", "i1", "s1");
 
     await write(
@@ -99,7 +99,7 @@ describe("view-snapshot-cache", () => {
   });
 
   it("rejects a stale write captured before all snapshots were dropped", async () => {
-    const staleWrite = captureWriteToken("alice", "orchestration-tasks", "i1", "");
+    const staleWrite = captureGenerationToken("alice", "orchestration-tasks", "i1", "");
     await dropAll();
 
     await write("alice", "orchestration-tasks", "i1", "", ["stale"], staleWrite);

--- a/packages/relay-web/src/__tests__/view-snapshot-cache.test.ts
+++ b/packages/relay-web/src/__tests__/view-snapshot-cache.test.ts
@@ -16,6 +16,32 @@ beforeEach(async () => {
 });
 
 describe("view-snapshot-cache", () => {
+  function pauseNextDatabaseOpen(): {
+    opened: Promise<void>;
+    release: () => void;
+  } {
+    const factory = globalThis.indexedDB;
+    const originalOpen = factory.open.bind(factory);
+    let release!: () => void;
+    let markOpened!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const opened = new Promise<void>((resolve) => { markOpened = resolve; });
+    factory.open = ((...args: Parameters<IDBFactory["open"]>) => {
+      const request = originalOpen(...args);
+      let success: ((this: IDBRequest, ev: Event) => unknown) | null = null;
+      Object.defineProperty(request, "onsuccess", {
+        configurable: true,
+        get: () => success && ((event: Event) => {
+          markOpened();
+          void gate.then(() => success?.call(request, event));
+        }),
+        set: (handler) => { success = handler; },
+      });
+      return request;
+    }) as IDBFactory["open"];
+    return { opened, release };
+  }
+
   it("updates the hot cache synchronously and survives a memory reset", async () => {
     const pending = write("alice", "session-model", "i1", "s1", {
       current: "gpt-5",
@@ -79,6 +105,36 @@ describe("view-snapshot-cache", () => {
     await write("alice", "orchestration-tasks", "i1", "", ["stale"], staleWrite);
 
     expect(await read("alice", "orchestration-tasks", "i1", "")).toBeNull();
+  });
+
+  it("rejects an IndexedDB read that finishes after its session was dropped", async () => {
+    await write("alice", "session-model", "i1", "s1", { current: "deleted" });
+    await resetViewSnapshotCacheForTests();
+    const gate = pauseNextDatabaseOpen();
+
+    const pendingRead = read("alice", "session-model", "i1", "s1");
+    await gate.opened;
+    const pendingDrop = dropSession("alice", "i1", "s1");
+    gate.release();
+
+    await expect(pendingRead).resolves.toBeNull();
+    await pendingDrop;
+    expect(peek("alice", "session-model", "i1", "s1")).toBeNull();
+  });
+
+  it("rejects an IndexedDB read that finishes after all snapshots were dropped", async () => {
+    await write("alice", "git-summary", "i1", "ws", { changedCount: 2 });
+    await resetViewSnapshotCacheForTests();
+    const gate = pauseNextDatabaseOpen();
+
+    const pendingRead = read("alice", "git-summary", "i1", "ws");
+    await gate.opened;
+    const pendingDrop = dropAll();
+    gate.release();
+
+    await expect(pendingRead).resolves.toBeNull();
+    await pendingDrop;
+    expect(peek("alice", "git-summary", "i1", "ws")).toBeNull();
   });
 
   it("never throws when IndexedDB is unavailable", async () => {

--- a/packages/relay-web/src/__tests__/view-snapshot-cache.test.ts
+++ b/packages/relay-web/src/__tests__/view-snapshot-cache.test.ts
@@ -1,6 +1,7 @@
 import { IDBFactory } from "fake-indexeddb";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  captureWriteToken,
   dropAll,
   dropSession,
   peek,
@@ -48,11 +49,36 @@ describe("view-snapshot-cache", () => {
     expect(await read("alice", "orchestration-tasks", "i1", "")).toEqual(["shared"]);
   });
 
+  it("rejects a stale session write captured before the session was dropped", async () => {
+    const staleWrite = captureWriteToken("alice", "session-model", "i1", "s1");
+    await dropSession("alice", "i1", "s1");
+
+    await write(
+      "alice",
+      "session-model",
+      "i1",
+      "s1",
+      { current: "deleted-session-model" },
+      staleWrite,
+    );
+
+    expect(await read("alice", "session-model", "i1", "s1")).toBeNull();
+  });
+
   it("dropAll clears memory and IndexedDB", async () => {
     await write("alice", "git-summary", "i1", "ws", { changedCount: 2 });
     await dropAll();
     expect(peek("alice", "git-summary", "i1", "ws")).toBeNull();
     expect(await read("alice", "git-summary", "i1", "ws")).toBeNull();
+  });
+
+  it("rejects a stale write captured before all snapshots were dropped", async () => {
+    const staleWrite = captureWriteToken("alice", "orchestration-tasks", "i1", "");
+    await dropAll();
+
+    await write("alice", "orchestration-tasks", "i1", "", ["stale"], staleWrite);
+
+    expect(await read("alice", "orchestration-tasks", "i1", "")).toBeNull();
   });
 
   it("never throws when IndexedDB is unavailable", async () => {

--- a/packages/relay-web/src/components/FilesPanel.vue
+++ b/packages/relay-web/src/components/FilesPanel.vue
@@ -177,7 +177,12 @@ watch(
     selectedDiff.value = null;
     if (!id) return;
     files.instanceId = id;
-    await instances.loadWorkspaces(id).catch(() => {});
+    // Reuse the instance store's already-loaded workspace list immediately on a
+    // session switch; refresh it in the background. First load still waits because
+    // there is no cached option from which to choose a fallback workspace.
+    const hasCachedWorkspaces = (instances.byId(id)?.workspaces.length ?? 0) > 0;
+    const workspaceRefresh = instances.loadWorkspaces(id).catch(() => {});
+    if (!hasCachedWorkspaces) await workspaceRefresh;
     if (selectionId !== workspaceSelectionId || props.instanceId !== id || activeWorkspace.value !== ws) return;
     // Default to the active session's workspace; fall back to the first configured one.
     const target = ws ?? instances.byId(id)?.workspaces?.[0]?.name;

--- a/packages/relay-web/src/lib/view-snapshot-cache.ts
+++ b/packages/relay-web/src/lib/view-snapshot-cache.ts
@@ -40,18 +40,18 @@ const memory = new Map<string, { value: unknown; updatedAt: number }>();
 let globalGeneration = 0;
 const keyGenerations = new Map<string, number>();
 
-export type SnapshotWriteToken = {
+export type SnapshotGenerationToken = {
   cacheKey: string;
   globalGeneration: number;
   keyGeneration: number;
 };
 
-export function captureWriteToken(
+export function captureGenerationToken(
   user: string,
   namespace: SnapshotNamespace,
   instanceId: string,
   scope = "",
-): SnapshotWriteToken {
+): SnapshotGenerationToken {
   const cacheKey = memoryKey(...keyOf(user, namespace, instanceId, scope));
   return {
     cacheKey,
@@ -60,7 +60,7 @@ export function captureWriteToken(
   };
 }
 
-function acceptsWrite(token: SnapshotWriteToken): boolean {
+function isTokenCurrent(token: SnapshotGenerationToken): boolean {
   return token.globalGeneration === globalGeneration
     && token.keyGeneration === (keyGenerations.get(token.cacheKey) ?? 0);
 }
@@ -143,7 +143,7 @@ export async function read<T>(
 ): Promise<T | null> {
   const hot = peek<T>(user, namespace, instanceId, scope);
   if (hot !== null) return hot;
-  const token = captureWriteToken(user, namespace, instanceId, scope);
+  const token = captureGenerationToken(user, namespace, instanceId, scope);
   try {
     const key = keyOf(user, namespace, instanceId, scope);
     const db = await openDb();
@@ -152,7 +152,7 @@ export async function read<T>(
     );
     // A logout or session deletion may finish while IndexedDB is reading. Never
     // return or reheat a snapshot captured before that invalidation boundary.
-    if (!acceptsWrite(token)) return null;
+    if (!isTokenCurrent(token)) return null;
     if (!record || Date.now() - record.updatedAt > TTL_MS) {
       if (record) {
         const tx = db.transaction(STORE, "readwrite");
@@ -175,18 +175,18 @@ export async function write<T>(
   instanceId: string,
   scope: string,
   value: T,
-  token = captureWriteToken(user, namespace, instanceId, scope),
+  token = captureGenerationToken(user, namespace, instanceId, scope),
 ): Promise<void> {
   try {
     const key = keyOf(user, namespace, instanceId, scope);
     const cacheKey = memoryKey(...key);
-    if (token.cacheKey !== cacheKey || !acceptsWrite(token)) return;
+    if (token.cacheKey !== cacheKey || !isTokenCurrent(token)) return;
     const snapshot = cloneForCache(value);
     const updatedAt = Date.now();
     memory.set(cacheKey, { value: snapshot, updatedAt });
     if (typeof indexedDB === "undefined") return;
     const db = await openDb();
-    if (!acceptsWrite(token)) return;
+    if (!isTokenCurrent(token)) return;
     const tx = db.transaction(STORE, "readwrite");
     tx.objectStore(STORE).put({ user, namespace, instanceId, scope, value: snapshot, updatedAt });
     await txDone(tx);

--- a/packages/relay-web/src/lib/view-snapshot-cache.ts
+++ b/packages/relay-web/src/lib/view-snapshot-cache.ts
@@ -1,0 +1,203 @@
+import { toRaw } from "vue";
+
+/** Disposable stale-while-revalidate snapshots for lightweight session views.
+ *
+ * The in-memory layer makes same-page switches synchronous. IndexedDB restores
+ * the same snapshots after a reload. Callers always revalidate against the
+ * backend; this module is only an early paint and never an authority. */
+
+const DB_NAME = "xacpx.view-snapshots";
+const DB_VERSION = 1;
+const STORE = "snapshots";
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type SnapshotNamespace =
+  | "session-model"
+  | "session-effort"
+  | "scheduled-tasks"
+  | "orchestration-tasks"
+  | "git-summary"
+  | "workspace-view";
+
+type SnapshotRecord = {
+  user: string;
+  namespace: SnapshotNamespace;
+  instanceId: string;
+  scope: string;
+  value: unknown;
+  updatedAt: number;
+};
+
+type SnapshotKey = [string, SnapshotNamespace, string, string];
+const keyOf = (
+  user: string,
+  namespace: SnapshotNamespace,
+  instanceId: string,
+  scope: string,
+): SnapshotKey => [user, namespace, instanceId, scope];
+const memoryKey = (...key: SnapshotKey): string => JSON.stringify(key);
+const memory = new Map<string, { value: unknown; updatedAt: number }>();
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+function openDb(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+  const opened = new Promise<IDBDatabase>((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new Error("indexeddb-unavailable"));
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (db.objectStoreNames.contains(STORE)) db.deleteObjectStore(STORE);
+      db.createObjectStore(STORE, { keyPath: ["user", "namespace", "instanceId", "scope"] });
+    };
+    let blocked = false;
+    req.onsuccess = () => {
+      if (blocked) {
+        req.result.close();
+        return;
+      }
+      resolve(req.result);
+    };
+    req.onerror = () => reject(req.error ?? new Error("open-failed"));
+    req.onblocked = () => {
+      blocked = true;
+      reject(new Error("open-blocked"));
+    };
+  });
+  dbPromise = opened;
+  opened.catch(() => {
+    if (dbPromise === opened) dbPromise = null;
+  });
+  return opened;
+}
+
+const asPromise = <T>(req: IDBRequest<T>): Promise<T> =>
+  new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("request-failed"));
+  });
+
+const txDone = (tx: IDBTransaction): Promise<void> =>
+  new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onabort = () => reject(tx.error ?? new Error("tx-aborted"));
+    tx.onerror = () => reject(tx.error ?? new Error("tx-failed"));
+  });
+
+function cloneForCache<T>(value: T): T {
+  return JSON.parse(JSON.stringify(toRaw(value))) as T;
+}
+
+/** Synchronous same-page lookup. */
+export function peek<T>(
+  user: string,
+  namespace: SnapshotNamespace,
+  instanceId: string,
+  scope = "",
+): T | null {
+  const key = keyOf(user, namespace, instanceId, scope);
+  const cached = memory.get(memoryKey(...key));
+  if (!cached) return null;
+  if (Date.now() - cached.updatedAt > TTL_MS) {
+    memory.delete(memoryKey(...key));
+    return null;
+  }
+  return cached.value as T;
+}
+
+/** Memory-first IndexedDB lookup. */
+export async function read<T>(
+  user: string,
+  namespace: SnapshotNamespace,
+  instanceId: string,
+  scope = "",
+): Promise<T | null> {
+  const hot = peek<T>(user, namespace, instanceId, scope);
+  if (hot !== null) return hot;
+  try {
+    const key = keyOf(user, namespace, instanceId, scope);
+    const db = await openDb();
+    const record = await asPromise<SnapshotRecord | undefined>(
+      db.transaction(STORE, "readonly").objectStore(STORE).get(key) as IDBRequest<SnapshotRecord | undefined>,
+    );
+    if (!record || Date.now() - record.updatedAt > TTL_MS) {
+      if (record) {
+        const tx = db.transaction(STORE, "readwrite");
+        tx.objectStore(STORE).delete(key);
+        await txDone(tx);
+      }
+      return null;
+    }
+    memory.set(memoryKey(...key), { value: record.value, updatedAt: record.updatedAt });
+    return record.value as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Update memory immediately, then persist best-effort. */
+export async function write<T>(
+  user: string,
+  namespace: SnapshotNamespace,
+  instanceId: string,
+  scope: string,
+  value: T,
+): Promise<void> {
+  try {
+    const key = keyOf(user, namespace, instanceId, scope);
+    const snapshot = cloneForCache(value);
+    const updatedAt = Date.now();
+    memory.set(memoryKey(...key), { value: snapshot, updatedAt });
+    if (typeof indexedDB === "undefined") return;
+    const db = await openDb();
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).put({ user, namespace, instanceId, scope, value: snapshot, updatedAt });
+    await txDone(tx);
+  } catch (err) {
+    console.debug("[relay-web] view-snapshot write failed", err);
+  }
+}
+
+const SESSION_NAMESPACES: SnapshotNamespace[] = [
+  "session-model",
+  "session-effort",
+  "scheduled-tasks",
+];
+
+/** Remove snapshots whose identity belongs to a deleted session. */
+export async function dropSession(user: string, instanceId: string, alias: string): Promise<void> {
+  for (const namespace of SESSION_NAMESPACES) {
+    memory.delete(memoryKey(...keyOf(user, namespace, instanceId, alias)));
+  }
+  try {
+    const db = await openDb();
+    const tx = db.transaction(STORE, "readwrite");
+    const store = tx.objectStore(STORE);
+    for (const namespace of SESSION_NAMESPACES) {
+      store.delete(keyOf(user, namespace, instanceId, alias));
+    }
+    await txDone(tx);
+  } catch { /* best-effort */ }
+}
+
+/** Shared-machine logout hygiene. */
+export async function dropAll(): Promise<void> {
+  memory.clear();
+  try {
+    const db = await openDb();
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).clear();
+    await txDone(tx);
+  } catch { /* best-effort */ }
+}
+
+export async function resetViewSnapshotCacheForTests(): Promise<void> {
+  memory.clear();
+  const pending = dbPromise;
+  dbPromise = null;
+  if (pending) {
+    try { (await pending).close(); } catch { /* already broken */ }
+  }
+}

--- a/packages/relay-web/src/lib/view-snapshot-cache.ts
+++ b/packages/relay-web/src/lib/view-snapshot-cache.ts
@@ -143,12 +143,16 @@ export async function read<T>(
 ): Promise<T | null> {
   const hot = peek<T>(user, namespace, instanceId, scope);
   if (hot !== null) return hot;
+  const token = captureWriteToken(user, namespace, instanceId, scope);
   try {
     const key = keyOf(user, namespace, instanceId, scope);
     const db = await openDb();
     const record = await asPromise<SnapshotRecord | undefined>(
       db.transaction(STORE, "readonly").objectStore(STORE).get(key) as IDBRequest<SnapshotRecord | undefined>,
     );
+    // A logout or session deletion may finish while IndexedDB is reading. Never
+    // return or reheat a snapshot captured before that invalidation boundary.
+    if (!acceptsWrite(token)) return null;
     if (!record || Date.now() - record.updatedAt > TTL_MS) {
       if (record) {
         const tx = db.transaction(STORE, "readwrite");

--- a/packages/relay-web/src/lib/view-snapshot-cache.ts
+++ b/packages/relay-web/src/lib/view-snapshot-cache.ts
@@ -37,6 +37,33 @@ const keyOf = (
 ): SnapshotKey => [user, namespace, instanceId, scope];
 const memoryKey = (...key: SnapshotKey): string => JSON.stringify(key);
 const memory = new Map<string, { value: unknown; updatedAt: number }>();
+let globalGeneration = 0;
+const keyGenerations = new Map<string, number>();
+
+export type SnapshotWriteToken = {
+  cacheKey: string;
+  globalGeneration: number;
+  keyGeneration: number;
+};
+
+export function captureWriteToken(
+  user: string,
+  namespace: SnapshotNamespace,
+  instanceId: string,
+  scope = "",
+): SnapshotWriteToken {
+  const cacheKey = memoryKey(...keyOf(user, namespace, instanceId, scope));
+  return {
+    cacheKey,
+    globalGeneration,
+    keyGeneration: keyGenerations.get(cacheKey) ?? 0,
+  };
+}
+
+function acceptsWrite(token: SnapshotWriteToken): boolean {
+  return token.globalGeneration === globalGeneration
+    && token.keyGeneration === (keyGenerations.get(token.cacheKey) ?? 0);
+}
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 function openDb(): Promise<IDBDatabase> {
@@ -144,14 +171,18 @@ export async function write<T>(
   instanceId: string,
   scope: string,
   value: T,
+  token = captureWriteToken(user, namespace, instanceId, scope),
 ): Promise<void> {
   try {
     const key = keyOf(user, namespace, instanceId, scope);
+    const cacheKey = memoryKey(...key);
+    if (token.cacheKey !== cacheKey || !acceptsWrite(token)) return;
     const snapshot = cloneForCache(value);
     const updatedAt = Date.now();
-    memory.set(memoryKey(...key), { value: snapshot, updatedAt });
+    memory.set(cacheKey, { value: snapshot, updatedAt });
     if (typeof indexedDB === "undefined") return;
     const db = await openDb();
+    if (!acceptsWrite(token)) return;
     const tx = db.transaction(STORE, "readwrite");
     tx.objectStore(STORE).put({ user, namespace, instanceId, scope, value: snapshot, updatedAt });
     await txDone(tx);
@@ -169,7 +200,9 @@ const SESSION_NAMESPACES: SnapshotNamespace[] = [
 /** Remove snapshots whose identity belongs to a deleted session. */
 export async function dropSession(user: string, instanceId: string, alias: string): Promise<void> {
   for (const namespace of SESSION_NAMESPACES) {
-    memory.delete(memoryKey(...keyOf(user, namespace, instanceId, alias)));
+    const cacheKey = memoryKey(...keyOf(user, namespace, instanceId, alias));
+    keyGenerations.set(cacheKey, (keyGenerations.get(cacheKey) ?? 0) + 1);
+    memory.delete(cacheKey);
   }
   try {
     const db = await openDb();
@@ -184,6 +217,7 @@ export async function dropSession(user: string, instanceId: string, alias: strin
 
 /** Shared-machine logout hygiene. */
 export async function dropAll(): Promise<void> {
+  globalGeneration += 1;
   memory.clear();
   try {
     const db = await openDb();
@@ -195,6 +229,8 @@ export async function dropAll(): Promise<void> {
 
 export async function resetViewSnapshotCacheForTests(): Promise<void> {
   memory.clear();
+  globalGeneration = 0;
+  keyGenerations.clear();
   const pending = dbPromise;
   dbPromise = null;
   if (pending) {

--- a/packages/relay-web/src/stores/auth.ts
+++ b/packages/relay-web/src/stores/auth.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import { ApiError, api } from "../api/client";
 import { dropAll as dropAllTailCaches } from "../lib/session-tail-cache";
+import { dropAll as dropAllViewSnapshots } from "../lib/view-snapshot-cache";
 
 export interface Account {
   username: string;
@@ -37,8 +38,8 @@ export const useAuthStore = defineStore("auth", () => {
     await api.post("/api/logout").catch(() => {});
     account.value = null;
     // Shared-machine hygiene: the next login must not be able to read cached
-    // transcripts from IndexedDB (spec #205 user story 5).
-    await dropAllTailCaches();
+    // transcripts or view snapshots from IndexedDB.
+    await Promise.all([dropAllTailCaches(), dropAllViewSnapshots()]);
   }
 
   return { account, error, login, fetchMe, logout };

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -13,6 +13,8 @@ import {
 } from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
 import { pushToast } from "../lib/use-toasts";
+import * as viewCache from "../lib/view-snapshot-cache";
+import { useAuthStore } from "./auth";
 
 function unwrap<T>(result: T | { error: { code: string; message: string } }): T {
   if (isErrorPayload(result)) throw new Error(result.error.message || result.error.code);
@@ -23,6 +25,14 @@ function unwrap<T>(result: T | { error: { code: string; message: string } }): T 
 function baseName(rel: string): string {
   return rel.split("/").pop() || rel;
 }
+
+type GitSummary = { workspace: string; changedCount: number; branch?: string; detached?: boolean };
+type WorkspaceViewSnapshot = {
+  root: string;
+  sep: "/" | "\\";
+  tree: Record<string, FsEntryDto[]>;
+  changed: Record<string, string>;
+};
 
 export const useFilesStore = defineStore("files", () => {
   const instanceId = ref<string | null>(null);
@@ -37,7 +47,7 @@ export const useFilesStore = defineStore("files", () => {
   const changed = ref<Record<string, string>>({}); // relPath -> git porcelain status, for Files-tab badges
   // Standalone read-only summary for the header chip — independent of the browsed
   // workspace above, so showing it never disturbs file-browser navigation state.
-  const gitSummary = ref<{ workspace: string; changedCount: number; branch?: string; detached?: boolean } | null>(null);
+  const gitSummary = ref<GitSummary | null>(null);
   const query = ref("");
   const results = ref<string[]>([]);
   const searchTruncated = ref(false);
@@ -54,11 +64,37 @@ export const useFilesStore = defineStore("files", () => {
   const hits = ref<FsSearchHitDto[]>([]);
   let diffRequestId = 0;
   let workspaceEpoch = 0;
+  let gitSummaryRevision = 0;
+  let activeGitSummaryKey = "";
   const searchOpts = ref<{ mode: "name" | "content"; matchCase: boolean; wholeWord: boolean; regex: boolean; include: string; exclude: string }>({
     mode: "content", matchCase: false, wholeWord: false, regex: false, include: "", exclude: "",
   });
 
+  const cacheUser = (): string | null => useAuthStore().account?.username ?? null;
+  function workspaceSnapshot(): WorkspaceViewSnapshot {
+    return {
+      root: root.value,
+      sep: sepChar.value,
+      tree: tree.value,
+      changed: changed.value,
+    };
+  }
+  function applyWorkspaceSnapshot(snapshot: WorkspaceViewSnapshot): void {
+    root.value = typeof snapshot.root === "string" ? snapshot.root : "";
+    sepChar.value = snapshot.sep === "\\" ? "\\" : "/";
+    tree.value = snapshot.tree && typeof snapshot.tree === "object" ? snapshot.tree : {};
+    changed.value = snapshot.changed && typeof snapshot.changed === "object" ? snapshot.changed : {};
+    path.value = "";
+    entries.value = tree.value[""] ?? [];
+  }
+  function persistWorkspaceSnapshot(): void {
+    const user = cacheUser();
+    if (!user || !instanceId.value || !workspace.value) return;
+    void viewCache.write(user, "workspace-view", instanceId.value, workspace.value, workspaceSnapshot());
+  }
+
   function reset(): void {
+    persistWorkspaceSnapshot();
     diffRequestId++;
     workspaceEpoch++;
     workspace.value = null;
@@ -85,6 +121,7 @@ export const useFilesStore = defineStore("files", () => {
   }
 
   async function selectWorkspace(id: string, ws: string): Promise<void> {
+    persistWorkspaceSnapshot();
     diffRequestId++;
     const epoch = ++workspaceEpoch;
     instanceId.value = id;
@@ -99,14 +136,24 @@ export const useFilesStore = defineStore("files", () => {
     results.value = [];
     tree.value = {}; hits.value = [];
     try { expanded.value = new Set(JSON.parse(localStorage.getItem(expandedKey()) ?? "[]") as string[]); } catch { expanded.value = new Set(); }
+    const user = cacheUser();
+    if (user) {
+      const hot = viewCache.peek<WorkspaceViewSnapshot>(user, "workspace-view", id, ws);
+      const cached = hot ?? await viewCache.read<WorkspaceViewSnapshot>(user, "workspace-view", id, ws);
+      if (epoch !== workspaceEpoch || instanceId.value !== id || workspace.value !== ws || cacheUser() !== user) return;
+      if (cached) applyWorkspaceSnapshot(cached);
+    }
     await listTree("");
     if (epoch !== workspaceEpoch || instanceId.value !== id || workspace.value !== ws) return;
     // Mirror the root layer into the flat path/entries state — the Changes tab and
     // any surviving flat-view consumers read those, not `tree`, after selectWorkspace.
     path.value = "";
     entries.value = tree.value[""] ?? [];
-    // Re-hydrate previously expanded layers (best-effort).
-    for (const dir of [...expanded.value]) { if (dir && !tree.value[dir]) await listTree(dir).catch(() => {}); }
+    // Revalidate every expanded cached layer (best-effort). Keeping a cached
+    // directory forever merely because it already exists would violate SWR.
+    await Promise.all(
+      [...expanded.value].filter(Boolean).map((dir) => listTree(dir).catch(() => {})),
+    );
     void loadStatus();
   }
 
@@ -115,17 +162,29 @@ export const useFilesStore = defineStore("files", () => {
    *  stays clean — the Changes tab's loadDiff() is what surfaces git errors. */
   async function loadStatus(): Promise<void> {
     if (!instanceId.value || !workspace.value) return;
+    const id = instanceId.value;
+    const ws = workspace.value;
+    const epoch = workspaceEpoch;
+    const isCurrent = () => epoch === workspaceEpoch
+      && instanceId.value === id
+      && workspace.value === ws;
     try {
-      const r = await api.rpc<FsDiffResult>(instanceId.value, "control.fs.diff", { workspace: workspace.value });
+      const r = await api.rpc<FsDiffResult>(id, "control.fs.diff", { workspace: ws });
+      if (!isCurrent()) return;
       if (isErrorPayload(r)) {
         changed.value = {};
+        persistWorkspaceSnapshot();
         return;
       }
       const map: Record<string, string> = {};
       for (const f of r.files) map[f.path] = f.status;
       changed.value = map;
+      persistWorkspaceSnapshot();
     } catch {
-      changed.value = {};
+      if (isCurrent()) {
+        changed.value = {};
+        persistWorkspaceSnapshot();
+      }
     }
   }
 
@@ -138,10 +197,23 @@ export const useFilesStore = defineStore("files", () => {
       gitSummary.value = null;
       return;
     }
+    const key = `${id}\0${ws}`;
+    const revision = ++gitSummaryRevision;
+    if (activeGitSummaryKey !== key) gitSummary.value = null;
+    activeGitSummaryKey = key;
+    const user = cacheUser();
+    if (user) {
+      const hot = viewCache.peek<{ summary: GitSummary | null }>(user, "git-summary", id, ws);
+      const cached = hot ?? await viewCache.read<{ summary: GitSummary | null }>(user, "git-summary", id, ws);
+      if (revision !== gitSummaryRevision || activeGitSummaryKey !== key || cacheUser() !== user) return;
+      if (cached) gitSummary.value = cached.summary;
+    }
     try {
       const r = await api.rpc<FsDiffResult>(id, "control.fs.diff", { workspace: ws });
+      if (revision !== gitSummaryRevision || activeGitSummaryKey !== key) return;
       if (isErrorPayload(r)) {
         gitSummary.value = null;
+        if (user && cacheUser() === user) void viewCache.write(user, "git-summary", id, ws, { summary: null });
         return;
       }
       const branch = typeof r.branch === "string" ? r.branch : undefined;
@@ -152,8 +224,10 @@ export const useFilesStore = defineStore("files", () => {
         ...(branch ? { branch } : {}),
         ...(detached ? { detached: true } : {}),
       };
+      if (user && cacheUser() === user) void viewCache.write(user, "git-summary", id, ws, { summary: gitSummary.value });
     } catch {
-      gitSummary.value = null;
+      // A transient refresh failure keeps a cache-seeded summary visible.
+      if (revision === gitSummaryRevision && activeGitSummaryKey === key && !user) gitSummary.value = null;
     }
   }
 
@@ -190,6 +264,7 @@ export const useFilesStore = defineStore("files", () => {
       if (!isCurrent()) return;
       root.value = r.root; sepChar.value = r.sep;
       tree.value = { ...tree.value, [dir]: r.entries };
+      persistWorkspaceSnapshot();
     } catch (e) {
       if (!isCurrent()) return;
       error.value = e instanceof Error ? e.message : "list-failed";
@@ -211,6 +286,7 @@ export const useFilesStore = defineStore("files", () => {
     }
     expanded.value = next;
     try { localStorage.setItem(expandedKey(), JSON.stringify([...next])); } catch { /* ignore */ }
+    persistWorkspaceSnapshot();
   }
 
   /** Resolve a workspace-relative path to an absolute path using the workspace root/sep. */

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import {
   isErrorPayload,
   type FsDiffResult,
@@ -93,8 +93,8 @@ export const useFilesStore = defineStore("files", () => {
     void viewCache.write(user, "workspace-view", instanceId.value, workspace.value, workspaceSnapshot());
   }
 
-  function reset(): void {
-    persistWorkspaceSnapshot();
+  function reset(options: { persist?: boolean } = {}): void {
+    if (options.persist !== false) persistWorkspaceSnapshot();
     diffRequestId++;
     workspaceEpoch++;
     workspace.value = null;
@@ -118,6 +118,14 @@ export const useFilesStore = defineStore("files", () => {
     // the next workspace and silently filters out all of its results. The rest
     // (mode/matchCase/wholeWord/regex/exclude) are user preferences and survive on purpose.
     searchOpts.value.include = "";
+  }
+
+  function resetForAccountChange(): void {
+    reset({ persist: false });
+    instanceId.value = null;
+    gitSummaryRevision += 1;
+    activeGitSummaryKey = "";
+    gitSummary.value = null;
   }
 
   async function selectWorkspace(id: string, ws: string): Promise<void> {
@@ -172,8 +180,10 @@ export const useFilesStore = defineStore("files", () => {
       const r = await api.rpc<FsDiffResult>(id, "control.fs.diff", { workspace: ws });
       if (!isCurrent()) return;
       if (isErrorPayload(r)) {
-        changed.value = {};
-        persistWorkspaceSnapshot();
+        if (r.error.code === "not-a-git-repo" || r.error.message === "not-a-git-repo") {
+          changed.value = {};
+          persistWorkspaceSnapshot();
+        }
         return;
       }
       const map: Record<string, string> = {};
@@ -181,10 +191,8 @@ export const useFilesStore = defineStore("files", () => {
       changed.value = map;
       persistWorkspaceSnapshot();
     } catch {
-      if (isCurrent()) {
-        changed.value = {};
-        persistWorkspaceSnapshot();
-      }
+      // Stale-while-revalidate: a transport failure says nothing about the
+      // workspace's current git state, so keep the cached badges visible.
     }
   }
 
@@ -490,6 +498,9 @@ export const useFilesStore = defineStore("files", () => {
   ): Promise<FsWriteResult> {
     return unwrap(await api.rpc<FsWriteResult>(id, "control.fs.write", { workspace: ws, path: filePath, content, expected }));
   }
+
+  const auth = useAuthStore();
+  watch(() => auth.account?.username ?? null, () => resetForAccountChange(), { flush: "sync" });
 
   return {
     instanceId, workspace, path, entries, file, diff, diffPath, notGit, changed, gitSummary, tab, query, results, searchTruncated, searching, loading, error,

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -21,6 +21,11 @@ function unwrap<T>(result: T | { error: { code: string; message: string } }): T 
   return result;
 }
 
+function isNotGitError(result: unknown): boolean {
+  return isErrorPayload(result)
+    && (result.error.code === "not-a-git-repo" || result.error.message === "not-a-git-repo");
+}
+
 /** Basename of a workspace-relative path, for toast messages. */
 function baseName(rel: string): string {
   return rel.split("/").pop() || rel;
@@ -165,9 +170,9 @@ export const useFilesStore = defineStore("files", () => {
     void loadStatus();
   }
 
-  /** Quietly fetch git status for badge annotation. Failures (e.g. a non-git
-   *  workspace) clear the badges without surfacing an error, so plain browsing
-   *  stays clean — the Changes tab's loadDiff() is what surfaces git errors. */
+  /** Quietly fetch git status for badge annotation. A confirmed non-git
+   *  workspace clears the badges; transient failures preserve the cached state.
+   *  Neither case surfaces an error while the user is browsing files. */
   async function loadStatus(): Promise<void> {
     if (!instanceId.value || !workspace.value) return;
     const id = instanceId.value;
@@ -180,7 +185,7 @@ export const useFilesStore = defineStore("files", () => {
       const r = await api.rpc<FsDiffResult>(id, "control.fs.diff", { workspace: ws });
       if (!isCurrent()) return;
       if (isErrorPayload(r)) {
-        if (r.error.code === "not-a-git-repo" || r.error.message === "not-a-git-repo") {
+        if (isNotGitError(r)) {
           changed.value = {};
           persistWorkspaceSnapshot();
         }
@@ -220,8 +225,12 @@ export const useFilesStore = defineStore("files", () => {
       const r = await api.rpc<FsDiffResult>(id, "control.fs.diff", { workspace: ws });
       if (revision !== gitSummaryRevision || activeGitSummaryKey !== key) return;
       if (isErrorPayload(r)) {
-        gitSummary.value = null;
-        if (user && cacheUser() === user) void viewCache.write(user, "git-summary", id, ws, { summary: null });
+        if (isNotGitError(r)) {
+          gitSummary.value = null;
+          if (user && cacheUser() === user) {
+            void viewCache.write(user, "git-summary", id, ws, { summary: null });
+          }
+        }
         return;
       }
       const branch = typeof r.branch === "string" ? r.branch : undefined;

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -311,7 +311,7 @@ export const useInstancesStore = defineStore("instances", () => {
     // store so a pending debounced write-back targeting it is cancelled too.
     useChatStore().purgeTailCache(instanceId, alias);
     const user = useAuthStore().account?.username;
-    if (user) void dropSessionViewSnapshots(user, instanceId, alias);
+    if (user) await dropSessionViewSnapshots(user, instanceId, alias);
     await loadSessions(instanceId);
   }
 

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -3,6 +3,8 @@ import { ref } from "vue";
 import { isErrorPayload, type AgentCatalogEntryDto, type AgentDto, type NativeSessionDto, type SessionDto, type SessionModelResult, type WebServerEvent, type WorkspaceDto } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 import { useChatStore } from "./chat";
+import { useAuthStore } from "./auth";
+import { dropSession as dropSessionViewSnapshots } from "../lib/view-snapshot-cache";
 import { loadGroupMode, saveGroupMode, type SidebarGroupMode } from "../lib/sidebar-group-mode";
 
 // An instance-side RPC error comes back as a 200 with an `{error:{code,message}}`
@@ -308,6 +310,8 @@ export const useInstancesStore = defineStore("instances", () => {
     // resurface as a ghost transcript from the cache. Routed through the chat
     // store so a pending debounced write-back targeting it is cancelled too.
     useChatStore().purgeTailCache(instanceId, alias);
+    const user = useAuthStore().account?.username;
+    if (user) void dropSessionViewSnapshots(user, instanceId, alias);
     await loadSessions(instanceId);
   }
 

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -80,7 +80,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     instanceId: string,
     alias: string,
     snapshot: ControlSnapshot,
-    token: viewCache.SnapshotWriteToken | null,
+    token: viewCache.SnapshotGenerationToken | null,
   ): void {
     if (user && token && cacheUser() === user) {
       void viewCache.write(user, "session-model", instanceId, alias, snapshot, token);
@@ -91,7 +91,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     instanceId: string,
     alias: string,
     snapshot: ControlSnapshot,
-    token: viewCache.SnapshotWriteToken | null,
+    token: viewCache.SnapshotGenerationToken | null,
   ): void {
     if (user && token && cacheUser() === user) {
       void viewCache.write(user, "session-effort", instanceId, alias, snapshot, token);
@@ -117,7 +117,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     const revision = ++requestRevision;
     const cacheOwner = cacheUser();
     const cacheToken = cacheOwner
-      ? viewCache.captureWriteToken(cacheOwner, "session-model", instanceId, alias)
+      ? viewCache.captureGenerationToken(cacheOwner, "session-model", instanceId, alias)
       : null;
     modelLoading.value = true;
     let seeded = false;
@@ -171,7 +171,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     activeContext = context;
     const cacheOwner = cacheUser();
     const cacheToken = cacheOwner
-      ? viewCache.captureWriteToken(cacheOwner, "session-model", instanceId, alias)
+      ? viewCache.captureGenerationToken(cacheOwner, "session-model", instanceId, alias)
       : null;
     const prev = modelCurrent.value;
     const availableAtSet = [...modelAvailable.value];
@@ -246,7 +246,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     const revision = ++effortRevision;
     const cacheOwner = cacheUser();
     const cacheToken = cacheOwner
-      ? viewCache.captureWriteToken(cacheOwner, "session-effort", instanceId, alias)
+      ? viewCache.captureGenerationToken(cacheOwner, "session-effort", instanceId, alias)
       : null;
     effortLoading.value = true;
     let seeded = false;
@@ -289,7 +289,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     effortActiveContext = context;
     const cacheOwner = cacheUser();
     const cacheToken = cacheOwner
-      ? viewCache.captureWriteToken(cacheOwner, "session-effort", instanceId, alias)
+      ? viewCache.captureGenerationToken(cacheOwner, "session-effort", instanceId, alias)
       : null;
     const previous = authoritativeEfforts.get(context)?.current ?? effortCurrent.value;
     const availableAtSet = [...effortAvailable.value];

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -31,6 +31,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   let effortRevision = 0;
   const pendingEffortSets = new Map<string, Promise<void>>();
   const authoritativeEfforts = new Map<string, { revision: number; current: string | undefined }>();
+  let accountGeneration = 0;
 
   const cacheUser = (): string | null => useAuthStore().account?.username ?? null;
   const contextKey = (instanceId: string, alias: string): string => `${instanceId}\u0000${alias}`;
@@ -109,6 +110,15 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     clearEffortState();
   }
 
+  function resetForAccountChange(): void {
+    accountGeneration += 1;
+    reset();
+    pendingModelSets.clear();
+    authoritativeModels.clear();
+    pendingEffortSets.clear();
+    authoritativeEfforts.clear();
+  }
+
   async function loadModel(instanceId: string | null, alias: string | null): Promise<void> {
     if (!instanceId || !alias) { reset(); return; }
     const context = contextKey(instanceId, alias);
@@ -170,6 +180,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     if (activeContext !== context) clearModelState();
     activeContext = context;
     const cacheOwner = cacheUser();
+    const ownerGeneration = accountGeneration;
     const cacheToken = cacheOwner
       ? viewCache.captureGenerationToken(cacheOwner, "session-model", instanceId, alias)
       : null;
@@ -194,7 +205,9 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
           const observed = r.current === null
             ? undefined
             : typeof r.current === "string" ? r.current : rollbackModel(context, prev);
-          recordAuthoritativeModel(context, revision, observed);
+          if (ownerGeneration === accountGeneration) {
+            recordAuthoritativeModel(context, revision, observed);
+          }
           cacheModel(cacheOwner, instanceId, alias, { current: observed, available: availableAtSet }, cacheToken);
           if (isCurrentRequest(context, revision)) {
             modelCurrent.value = observed;
@@ -207,7 +220,9 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
         const observed = r.current === null
           ? undefined
           : typeof r.current === "string" ? r.current : id;
-        recordAuthoritativeModel(context, revision, observed);
+        if (ownerGeneration === accountGeneration) {
+          recordAuthoritativeModel(context, revision, observed);
+        }
         cacheModel(cacheOwner, instanceId, alias, { current: observed, available: availableAtSet }, cacheToken);
         if (isCurrentRequest(context, revision)) {
           modelCurrent.value = observed;
@@ -288,6 +303,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     if (effortActiveContext !== context) clearEffortState();
     effortActiveContext = context;
     const cacheOwner = cacheUser();
+    const ownerGeneration = accountGeneration;
     const cacheToken = cacheOwner
       ? viewCache.captureGenerationToken(cacheOwner, "session-effort", instanceId, alias)
       : null;
@@ -307,7 +323,9 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
             let observed = rollbackEffort(context, previous);
             if (!isErrorPayload(setResult) && (setResult.current === null || typeof setResult.current === "string")) {
               observed = setResult.current ?? undefined;
-              recordAuthoritativeEffort(context, revision, observed);
+              if (ownerGeneration === accountGeneration) {
+                recordAuthoritativeEffort(context, revision, observed);
+              }
               cacheEffort(cacheOwner, instanceId, alias, { current: observed, available: availableAtSet }, cacheToken);
             }
             effortCurrent.value = observed;
@@ -316,7 +334,9 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
           return false;
         }
         const observed = typeof setResult.current === "string" ? setResult.current : effort;
-        recordAuthoritativeEffort(context, revision, observed);
+        if (ownerGeneration === accountGeneration) {
+          recordAuthoritativeEffort(context, revision, observed);
+        }
         cacheEffort(cacheOwner, instanceId, alias, { current: observed, available: availableAtSet }, cacheToken);
         if (effortActiveContext === context && effortRevision === revision) effortCurrent.value = observed;
         return true;
@@ -342,7 +362,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   }
 
   const auth = useAuthStore();
-  watch(() => auth.account?.username ?? null, () => reset(), { flush: "sync" });
+  watch(() => auth.account?.username ?? null, () => resetForAccountChange(), { flush: "sync" });
 
   return {
     modelCurrent, modelAvailable, modelLoading, reset, loadModel, setModel,

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import {
   isErrorPayload,
   type SessionEffortResult,
@@ -32,6 +32,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   const pendingEffortSets = new Map<string, Promise<void>>();
   const authoritativeEfforts = new Map<string, { revision: number; current: string | undefined }>();
 
+  const cacheUser = (): string | null => useAuthStore().account?.username ?? null;
   const contextKey = (instanceId: string, alias: string): string => `${instanceId}\u0000${alias}`;
   const isCurrentRequest = (context: string, revision: number): boolean =>
     activeContext === context && requestRevision === revision;
@@ -66,7 +67,6 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     effortAvailable.value = [];
   }
 
-  const cacheUser = (): string | null => useAuthStore().account?.username ?? null;
   function applyModelSnapshot(snapshot: ControlSnapshot): void {
     modelCurrent.value = snapshot.current;
     modelAvailable.value = Array.isArray(snapshot.available) ? snapshot.available : [];
@@ -75,13 +75,27 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     effortCurrent.value = snapshot.current;
     effortAvailable.value = Array.isArray(snapshot.available) ? snapshot.available : [];
   }
-  function cacheModel(instanceId: string, alias: string, snapshot: ControlSnapshot): void {
-    const user = cacheUser();
-    if (user) void viewCache.write(user, "session-model", instanceId, alias, snapshot);
+  function cacheModel(
+    user: string | null,
+    instanceId: string,
+    alias: string,
+    snapshot: ControlSnapshot,
+    token: viewCache.SnapshotWriteToken | null,
+  ): void {
+    if (user && token && cacheUser() === user) {
+      void viewCache.write(user, "session-model", instanceId, alias, snapshot, token);
+    }
   }
-  function cacheEffort(instanceId: string, alias: string, snapshot: ControlSnapshot): void {
-    const user = cacheUser();
-    if (user) void viewCache.write(user, "session-effort", instanceId, alias, snapshot);
+  function cacheEffort(
+    user: string | null,
+    instanceId: string,
+    alias: string,
+    snapshot: ControlSnapshot,
+    token: viewCache.SnapshotWriteToken | null,
+  ): void {
+    if (user && token && cacheUser() === user) {
+      void viewCache.write(user, "session-effort", instanceId, alias, snapshot, token);
+    }
   }
 
   function reset(): void {
@@ -101,6 +115,10 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     if (activeContext !== context) clearModelState();
     activeContext = context;
     const revision = ++requestRevision;
+    const cacheOwner = cacheUser();
+    const cacheToken = cacheOwner
+      ? viewCache.captureWriteToken(cacheOwner, "session-model", instanceId, alias)
+      : null;
     modelLoading.value = true;
     let seeded = false;
     try {
@@ -111,7 +129,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
         await pendingSet;
         if (!isCurrentRequest(context, revision)) return;
       }
-      const user = cacheUser();
+      const user = cacheOwner;
       if (user) {
         const snapshot = viewCache.peek<ControlSnapshot>(user, "session-model", instanceId, alias)
           ?? await viewCache.read<ControlSnapshot>(user, "session-model", instanceId, alias);
@@ -136,7 +154,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
       // Never trust the wire to hand back an array — a malformed/partial result must
       // not blow up the composer's `available.length` reads (white-screens the input).
       modelAvailable.value = Array.isArray(r.available) ? r.available : [];
-      cacheModel(instanceId, alias, { current: modelCurrent.value, available: modelAvailable.value });
+      cacheModel(cacheOwner, instanceId, alias, { current: modelCurrent.value, available: modelAvailable.value }, cacheToken);
     } catch {
       if (isCurrentRequest(context, revision) && !seeded) clearModelState();
     } finally {
@@ -151,6 +169,10 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     const context = contextKey(instanceId, alias);
     if (activeContext !== context) clearModelState();
     activeContext = context;
+    const cacheOwner = cacheUser();
+    const cacheToken = cacheOwner
+      ? viewCache.captureWriteToken(cacheOwner, "session-model", instanceId, alias)
+      : null;
     const prev = modelCurrent.value;
     const availableAtSet = [...modelAvailable.value];
     const revision = ++requestRevision;
@@ -173,7 +195,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
             ? undefined
             : typeof r.current === "string" ? r.current : rollbackModel(context, prev);
           recordAuthoritativeModel(context, revision, observed);
-          cacheModel(instanceId, alias, { current: observed, available: availableAtSet });
+          cacheModel(cacheOwner, instanceId, alias, { current: observed, available: availableAtSet }, cacheToken);
           if (isCurrentRequest(context, revision)) {
             modelCurrent.value = observed;
             reportModelSwitchFailure(
@@ -186,7 +208,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
           ? undefined
           : typeof r.current === "string" ? r.current : id;
         recordAuthoritativeModel(context, revision, observed);
-        cacheModel(instanceId, alias, { current: observed, available: availableAtSet });
+        cacheModel(cacheOwner, instanceId, alias, { current: observed, available: availableAtSet }, cacheToken);
         if (isCurrentRequest(context, revision)) {
           modelCurrent.value = observed;
         }
@@ -222,6 +244,10 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     if (effortActiveContext !== context) clearEffortState();
     effortActiveContext = context;
     const revision = ++effortRevision;
+    const cacheOwner = cacheUser();
+    const cacheToken = cacheOwner
+      ? viewCache.captureWriteToken(cacheOwner, "session-effort", instanceId, alias)
+      : null;
     effortLoading.value = true;
     let seeded = false;
     try {
@@ -230,7 +256,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
         await pendingSet;
         if (effortActiveContext !== context || effortRevision !== revision) return;
       }
-      const user = cacheUser();
+      const user = cacheOwner;
       if (user) {
         const snapshot = viewCache.peek<ControlSnapshot>(user, "session-effort", instanceId, alias)
           ?? await viewCache.read<ControlSnapshot>(user, "session-effort", instanceId, alias);
@@ -249,7 +275,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
       effortCurrent.value = typeof effortResult.current === "string" ? effortResult.current : undefined;
       recordAuthoritativeEffort(context, revision, effortCurrent.value);
       effortAvailable.value = Array.isArray(effortResult.available) ? effortResult.available : [];
-      cacheEffort(instanceId, alias, { current: effortCurrent.value, available: effortAvailable.value });
+      cacheEffort(cacheOwner, instanceId, alias, { current: effortCurrent.value, available: effortAvailable.value }, cacheToken);
     } catch {
       if (effortActiveContext === context && effortRevision === revision && !seeded) clearEffortState();
     } finally {
@@ -261,6 +287,10 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     const context = contextKey(instanceId, alias);
     if (effortActiveContext !== context) clearEffortState();
     effortActiveContext = context;
+    const cacheOwner = cacheUser();
+    const cacheToken = cacheOwner
+      ? viewCache.captureWriteToken(cacheOwner, "session-effort", instanceId, alias)
+      : null;
     const previous = authoritativeEfforts.get(context)?.current ?? effortCurrent.value;
     const availableAtSet = [...effortAvailable.value];
     const revision = ++effortRevision;
@@ -278,7 +308,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
             if (!isErrorPayload(setResult) && (setResult.current === null || typeof setResult.current === "string")) {
               observed = setResult.current ?? undefined;
               recordAuthoritativeEffort(context, revision, observed);
-              cacheEffort(instanceId, alias, { current: observed, available: availableAtSet });
+              cacheEffort(cacheOwner, instanceId, alias, { current: observed, available: availableAtSet }, cacheToken);
             }
             effortCurrent.value = observed;
             reportEffortSwitchFailure(isErrorPayload(setResult) ? setResult.error.message : `requested ${effort} was not applied`);
@@ -287,7 +317,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
         }
         const observed = typeof setResult.current === "string" ? setResult.current : effort;
         recordAuthoritativeEffort(context, revision, observed);
-        cacheEffort(instanceId, alias, { current: observed, available: availableAtSet });
+        cacheEffort(cacheOwner, instanceId, alias, { current: observed, available: availableAtSet }, cacheToken);
         if (effortActiveContext === context && effortRevision === revision) effortCurrent.value = observed;
         return true;
       } catch (error) {
@@ -310,6 +340,9 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   function waitForEffortSet(instanceId: string, alias: string): Promise<void> | undefined {
     return pendingEffortSets.get(contextKey(instanceId, alias));
   }
+
+  const auth = useAuthStore();
+  watch(() => auth.account?.username ?? null, () => reset(), { flush: "sync" });
 
   return {
     modelCurrent, modelAvailable, modelLoading, reset, loadModel, setModel,

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -9,6 +9,10 @@ import {
 } from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
 import { pushToast } from "../lib/use-toasts";
+import * as viewCache from "../lib/view-snapshot-cache";
+import { useAuthStore } from "./auth";
+
+type ControlSnapshot = { current?: string; available: string[] };
 
 /** Per-session model and effort controls for the composer chips. The hub stamps chatKey for
  *  these chat-scoped RPCs, so the web only sends sessionAlias. */
@@ -62,6 +66,24 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     effortAvailable.value = [];
   }
 
+  const cacheUser = (): string | null => useAuthStore().account?.username ?? null;
+  function applyModelSnapshot(snapshot: ControlSnapshot): void {
+    modelCurrent.value = snapshot.current;
+    modelAvailable.value = Array.isArray(snapshot.available) ? snapshot.available : [];
+  }
+  function applyEffortSnapshot(snapshot: ControlSnapshot): void {
+    effortCurrent.value = snapshot.current;
+    effortAvailable.value = Array.isArray(snapshot.available) ? snapshot.available : [];
+  }
+  function cacheModel(instanceId: string, alias: string, snapshot: ControlSnapshot): void {
+    const user = cacheUser();
+    if (user) void viewCache.write(user, "session-model", instanceId, alias, snapshot);
+  }
+  function cacheEffort(instanceId: string, alias: string, snapshot: ControlSnapshot): void {
+    const user = cacheUser();
+    if (user) void viewCache.write(user, "session-effort", instanceId, alias, snapshot);
+  }
+
   function reset(): void {
     activeContext = null;
     requestRevision += 1;
@@ -80,26 +102,43 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     activeContext = context;
     const revision = ++requestRevision;
     modelLoading.value = true;
+    let seeded = false;
     try {
-      // A remount/session round-trip can request a fresh read while an earlier
-      // selection for this same session is still being reconciled. Read only
-      // after the latest mutation settles, otherwise the load can publish the
-      // pre-mutation model and make the later set response look stale.
+      // Never paint a pre-mutation cache while a model change for this exact
+      // session is still settling. The authoritative cache is updated by setModel.
       const pendingSet = pendingModelSets.get(context);
       if (pendingSet) {
         await pendingSet;
         if (!isCurrentRequest(context, revision)) return;
       }
+      const user = cacheUser();
+      if (user) {
+        const snapshot = viewCache.peek<ControlSnapshot>(user, "session-model", instanceId, alias)
+          ?? await viewCache.read<ControlSnapshot>(user, "session-model", instanceId, alias);
+        if (!isCurrentRequest(context, revision) || cacheUser() !== user) return;
+        if (snapshot) {
+          applyModelSnapshot(snapshot);
+          seeded = true;
+        }
+      }
+      // A remount/session round-trip can request a fresh read while an earlier
+      // selection for this same session is still being reconciled. Read only
+      // after the latest mutation settles, otherwise the load can publish the
+      // pre-mutation model and make the later set response look stale.
       const r = await api.rpc<SessionModelResult>(instanceId, "control.session.model.get", { sessionAlias: alias });
       if (!isCurrentRequest(context, revision)) return;
-      if (isErrorPayload(r)) { clearModelState(); return; }
+      if (isErrorPayload(r)) {
+        if (!seeded) clearModelState();
+        return;
+      }
       modelCurrent.value = typeof r.current === "string" ? r.current : undefined;
       recordAuthoritativeModel(context, revision, modelCurrent.value);
       // Never trust the wire to hand back an array — a malformed/partial result must
       // not blow up the composer's `available.length` reads (white-screens the input).
       modelAvailable.value = Array.isArray(r.available) ? r.available : [];
+      cacheModel(instanceId, alias, { current: modelCurrent.value, available: modelAvailable.value });
     } catch {
-      if (isCurrentRequest(context, revision)) clearModelState();
+      if (isCurrentRequest(context, revision) && !seeded) clearModelState();
     } finally {
       if (isCurrentRequest(context, revision)) modelLoading.value = false;
     }
@@ -113,6 +152,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     if (activeContext !== context) clearModelState();
     activeContext = context;
     const prev = modelCurrent.value;
+    const availableAtSet = [...modelAvailable.value];
     const revision = ++requestRevision;
     // This mutation supersedes any in-flight model load for the same UI store.
     // Its stale finally block is intentionally ignored, so clear the spinner now.
@@ -133,6 +173,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
             ? undefined
             : typeof r.current === "string" ? r.current : rollbackModel(context, prev);
           recordAuthoritativeModel(context, revision, observed);
+          cacheModel(instanceId, alias, { current: observed, available: availableAtSet });
           if (isCurrentRequest(context, revision)) {
             modelCurrent.value = observed;
             reportModelSwitchFailure(
@@ -145,6 +186,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
           ? undefined
           : typeof r.current === "string" ? r.current : id;
         recordAuthoritativeModel(context, revision, observed);
+        cacheModel(instanceId, alias, { current: observed, available: availableAtSet });
         if (isCurrentRequest(context, revision)) {
           modelCurrent.value = observed;
         }
@@ -181,20 +223,35 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     effortActiveContext = context;
     const revision = ++effortRevision;
     effortLoading.value = true;
+    let seeded = false;
     try {
       const pendingSet = pendingEffortSets.get(context);
       if (pendingSet) {
         await pendingSet;
         if (effortActiveContext !== context || effortRevision !== revision) return;
       }
+      const user = cacheUser();
+      if (user) {
+        const snapshot = viewCache.peek<ControlSnapshot>(user, "session-effort", instanceId, alias)
+          ?? await viewCache.read<ControlSnapshot>(user, "session-effort", instanceId, alias);
+        if (effortActiveContext !== context || effortRevision !== revision || cacheUser() !== user) return;
+        if (snapshot) {
+          applyEffortSnapshot(snapshot);
+          seeded = true;
+        }
+      }
       const effortResult = await api.rpc<SessionEffortResult>(instanceId, "control.session.effort.get", { sessionAlias: alias });
       if (effortActiveContext !== context || effortRevision !== revision) return;
-      if (isErrorPayload(effortResult)) { clearEffortState(); return; }
+      if (isErrorPayload(effortResult)) {
+        if (!seeded) clearEffortState();
+        return;
+      }
       effortCurrent.value = typeof effortResult.current === "string" ? effortResult.current : undefined;
       recordAuthoritativeEffort(context, revision, effortCurrent.value);
       effortAvailable.value = Array.isArray(effortResult.available) ? effortResult.available : [];
+      cacheEffort(instanceId, alias, { current: effortCurrent.value, available: effortAvailable.value });
     } catch {
-      if (effortActiveContext === context && effortRevision === revision) clearEffortState();
+      if (effortActiveContext === context && effortRevision === revision && !seeded) clearEffortState();
     } finally {
       if (effortActiveContext === context && effortRevision === revision) effortLoading.value = false;
     }
@@ -205,6 +262,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     if (effortActiveContext !== context) clearEffortState();
     effortActiveContext = context;
     const previous = authoritativeEfforts.get(context)?.current ?? effortCurrent.value;
+    const availableAtSet = [...effortAvailable.value];
     const revision = ++effortRevision;
     effortLoading.value = false;
     effortCurrent.value = effort;
@@ -220,6 +278,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
             if (!isErrorPayload(setResult) && (setResult.current === null || typeof setResult.current === "string")) {
               observed = setResult.current ?? undefined;
               recordAuthoritativeEffort(context, revision, observed);
+              cacheEffort(instanceId, alias, { current: observed, available: availableAtSet });
             }
             effortCurrent.value = observed;
             reportEffortSwitchFailure(isErrorPayload(setResult) ? setResult.error.message : `requested ${effort} was not applied`);
@@ -228,6 +287,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
         }
         const observed = typeof setResult.current === "string" ? setResult.current : effort;
         recordAuthoritativeEffort(context, revision, observed);
+        cacheEffort(instanceId, alias, { current: observed, available: availableAtSet });
         if (effortActiveContext === context && effortRevision === revision) effortCurrent.value = observed;
         return true;
       } catch (error) {

--- a/packages/relay-web/src/stores/tasks.ts
+++ b/packages/relay-web/src/stores/tasks.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import type { OrchestrationTaskDto, ScheduledTaskDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
 import * as viewCache from "../lib/view-snapshot-cache";
@@ -24,9 +24,20 @@ export const useTasksStore = defineStore("tasks", () => {
   const isOrchestrationScope = (instanceId: string): boolean =>
     scope.value === null || scope.value.instanceId === instanceId;
 
+  function reset(): void {
+    scheduledRevision += 1;
+    orchestrationRevision += 1;
+    scope.value = null;
+    scheduled.value = [];
+    orchestration.value = [];
+  }
+
   async function loadScheduled(instanceId: string, sessionAlias: string): Promise<void> {
     const revision = ++scheduledRevision;
     const user = cacheUser();
+    const cacheToken = user
+      ? viewCache.captureWriteToken(user, "scheduled-tasks", instanceId, sessionAlias)
+      : null;
     if (user) {
       const cached = viewCache.peek<ScheduledTaskDto[]>(user, "scheduled-tasks", instanceId, sessionAlias)
         ?? await viewCache.read<ScheduledTaskDto[]>(user, "scheduled-tasks", instanceId, sessionAlias);
@@ -35,13 +46,18 @@ export const useTasksStore = defineStore("tasks", () => {
     }
     const { tasks } = await api.rpc<{ tasks: ScheduledTaskDto[] }>(instanceId, "control.scheduled.list");
     const filtered = tasks.filter((t) => t.sessionAlias === sessionAlias);
-    if (user && cacheUser() === user) void viewCache.write(user, "scheduled-tasks", instanceId, sessionAlias, filtered);
+    if (user && cacheToken && cacheUser() === user) {
+      void viewCache.write(user, "scheduled-tasks", instanceId, sessionAlias, filtered, cacheToken);
+    }
     if (revision === scheduledRevision && isScheduledScope(instanceId, sessionAlias)) scheduled.value = filtered;
   }
 
   async function loadOrchestration(instanceId: string): Promise<void> {
     const revision = ++orchestrationRevision;
     const user = cacheUser();
+    const cacheToken = user
+      ? viewCache.captureWriteToken(user, "orchestration-tasks", instanceId, "")
+      : null;
     if (user) {
       const cached = viewCache.peek<OrchestrationTaskDto[]>(user, "orchestration-tasks", instanceId, "")
         ?? await viewCache.read<OrchestrationTaskDto[]>(user, "orchestration-tasks", instanceId, "");
@@ -49,7 +65,9 @@ export const useTasksStore = defineStore("tasks", () => {
       if (Array.isArray(cached)) orchestration.value = cached;
     }
     const { tasks } = await api.rpc<{ tasks: OrchestrationTaskDto[] }>(instanceId, "control.orchestration.list");
-    if (user && cacheUser() === user) void viewCache.write(user, "orchestration-tasks", instanceId, "", tasks);
+    if (user && cacheToken && cacheUser() === user) {
+      void viewCache.write(user, "orchestration-tasks", instanceId, "", tasks, cacheToken);
+    }
     if (revision === orchestrationRevision && isOrchestrationScope(instanceId)) orchestration.value = tasks;
   }
 
@@ -93,5 +111,8 @@ export const useTasksStore = defineStore("tasks", () => {
     else if (event.event.type === "orchestration-changed") void loadOrchestration(s.instanceId).catch(() => {});
   }
 
-  return { scheduled, orchestration, scope, loadScheduled, loadOrchestration, loadFor, createScheduled, cancelScheduled, cancelOrchestration, applyEvent };
+  const auth = useAuthStore();
+  watch(() => auth.account?.username ?? null, () => reset(), { flush: "sync" });
+
+  return { scheduled, orchestration, scope, reset, loadScheduled, loadOrchestration, loadFor, createScheduled, cancelScheduled, cancelOrchestration, applyEvent };
 });

--- a/packages/relay-web/src/stores/tasks.ts
+++ b/packages/relay-web/src/stores/tasks.ts
@@ -2,6 +2,8 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import type { OrchestrationTaskDto, ScheduledTaskDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
+import * as viewCache from "../lib/view-snapshot-cache";
+import { useAuthStore } from "./auth";
 
 export interface TasksScope {
   instanceId: string;
@@ -12,22 +14,55 @@ export const useTasksStore = defineStore("tasks", () => {
   const scheduled = ref<ScheduledTaskDto[]>([]);
   const orchestration = ref<OrchestrationTaskDto[]>([]);
   const scope = ref<TasksScope | null>(null);
+  let scheduledRevision = 0;
+  let orchestrationRevision = 0;
+
+  const cacheUser = (): string | null => useAuthStore().account?.username ?? null;
+  const isScheduledScope = (instanceId: string, sessionAlias: string): boolean =>
+    scope.value === null
+    || (scope.value.instanceId === instanceId && scope.value.sessionAlias === sessionAlias);
+  const isOrchestrationScope = (instanceId: string): boolean =>
+    scope.value === null || scope.value.instanceId === instanceId;
 
   async function loadScheduled(instanceId: string, sessionAlias: string): Promise<void> {
+    const revision = ++scheduledRevision;
+    const user = cacheUser();
+    if (user) {
+      const cached = viewCache.peek<ScheduledTaskDto[]>(user, "scheduled-tasks", instanceId, sessionAlias)
+        ?? await viewCache.read<ScheduledTaskDto[]>(user, "scheduled-tasks", instanceId, sessionAlias);
+      if (revision !== scheduledRevision || !isScheduledScope(instanceId, sessionAlias) || cacheUser() !== user) return;
+      if (Array.isArray(cached)) scheduled.value = cached;
+    }
     const { tasks } = await api.rpc<{ tasks: ScheduledTaskDto[] }>(instanceId, "control.scheduled.list");
-    scheduled.value = tasks.filter((t) => t.sessionAlias === sessionAlias);
+    const filtered = tasks.filter((t) => t.sessionAlias === sessionAlias);
+    if (user && cacheUser() === user) void viewCache.write(user, "scheduled-tasks", instanceId, sessionAlias, filtered);
+    if (revision === scheduledRevision && isScheduledScope(instanceId, sessionAlias)) scheduled.value = filtered;
   }
 
   async function loadOrchestration(instanceId: string): Promise<void> {
+    const revision = ++orchestrationRevision;
+    const user = cacheUser();
+    if (user) {
+      const cached = viewCache.peek<OrchestrationTaskDto[]>(user, "orchestration-tasks", instanceId, "")
+        ?? await viewCache.read<OrchestrationTaskDto[]>(user, "orchestration-tasks", instanceId, "");
+      if (revision !== orchestrationRevision || !isOrchestrationScope(instanceId) || cacheUser() !== user) return;
+      if (Array.isArray(cached)) orchestration.value = cached;
+    }
     const { tasks } = await api.rpc<{ tasks: OrchestrationTaskDto[] }>(instanceId, "control.orchestration.list");
-    orchestration.value = tasks;
+    if (user && cacheUser() === user) void viewCache.write(user, "orchestration-tasks", instanceId, "", tasks);
+    if (revision === orchestrationRevision && isOrchestrationScope(instanceId)) orchestration.value = tasks;
   }
 
   async function loadFor(instanceId: string, sessionAlias: string): Promise<void> {
+    const previous = scope.value;
+    const sameSession = previous?.instanceId === instanceId && previous.sessionAlias === sessionAlias;
+    const sameInstance = previous?.instanceId === instanceId;
     scope.value = { instanceId, sessionAlias };
+    if (!sameSession) scheduled.value = [];
+    if (!sameInstance) orchestration.value = [];
     await Promise.all([
-      loadScheduled(instanceId, sessionAlias).catch(() => { scheduled.value = []; }),
-      loadOrchestration(instanceId).catch(() => { orchestration.value = []; }),
+      loadScheduled(instanceId, sessionAlias).catch(() => {}),
+      loadOrchestration(instanceId).catch(() => {}),
     ]);
   }
 

--- a/packages/relay-web/src/stores/tasks.ts
+++ b/packages/relay-web/src/stores/tasks.ts
@@ -1,6 +1,11 @@
 import { defineStore } from "pinia";
 import { ref, watch } from "vue";
-import type { OrchestrationTaskDto, ScheduledTaskDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
+import {
+  isErrorPayload,
+  type OrchestrationTaskDto,
+  type ScheduledTaskDto,
+  type WebServerEvent,
+} from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
 import * as viewCache from "../lib/view-snapshot-cache";
 import { useAuthStore } from "./auth";
@@ -36,7 +41,7 @@ export const useTasksStore = defineStore("tasks", () => {
     const revision = ++scheduledRevision;
     const user = cacheUser();
     const cacheToken = user
-      ? viewCache.captureWriteToken(user, "scheduled-tasks", instanceId, sessionAlias)
+      ? viewCache.captureGenerationToken(user, "scheduled-tasks", instanceId, sessionAlias)
       : null;
     if (user) {
       const cached = viewCache.peek<ScheduledTaskDto[]>(user, "scheduled-tasks", instanceId, sessionAlias)
@@ -56,7 +61,7 @@ export const useTasksStore = defineStore("tasks", () => {
     const revision = ++orchestrationRevision;
     const user = cacheUser();
     const cacheToken = user
-      ? viewCache.captureWriteToken(user, "orchestration-tasks", instanceId, "")
+      ? viewCache.captureGenerationToken(user, "orchestration-tasks", instanceId, "")
       : null;
     if (user) {
       const cached = viewCache.peek<OrchestrationTaskDto[]>(user, "orchestration-tasks", instanceId, "")
@@ -64,7 +69,12 @@ export const useTasksStore = defineStore("tasks", () => {
       if (revision !== orchestrationRevision || !isOrchestrationScope(instanceId) || cacheUser() !== user) return;
       if (Array.isArray(cached)) orchestration.value = cached;
     }
-    const { tasks } = await api.rpc<{ tasks: OrchestrationTaskDto[] }>(instanceId, "control.orchestration.list");
+    const result = await api.rpc<{ tasks: OrchestrationTaskDto[] }>(
+      instanceId,
+      "control.orchestration.list",
+    );
+    if (isErrorPayload(result)) return;
+    const { tasks } = result;
     if (user && cacheToken && cacheUser() === user) {
       void viewCache.write(user, "orchestration-tasks", instanceId, "", tasks, cacheToken);
     }


### PR DESCRIPTION
## Summary

- add a user-scoped IndexedDB snapshot cache with an in-memory hot layer for instant same-page session switches
- seed model, effort, scheduled/orchestration tasks, workspace git summaries, and file-tree/git-status navigation state before background revalidation
- preserve request ordering and session/workspace guards so stale responses cannot overwrite the newly selected scope
- clear session-owned snapshots on session deletion and clear all view snapshots on logout
- keep file contents, full diffs, terminal state, and WebSocket-owned live state out of this cache

## Why

Message history already uses an IndexedDB tail cache, but switching sessions still blanked or delayed several other read-only surfaces while their RPCs completed. These snapshots let the UI paint the last known state immediately while retaining the backend as the authoritative source.

## User impact

Returning to a previously viewed session now restores composer controls, tasks, git context, and file navigation immediately. Fresh data continues to arrive in the background without blocking the switch.

## Review fixes

- capture write-generation tokens when async refreshes start so deletion/logout invalidates older responses
- wait for per-session snapshot deletion before `removeSession` completes
- reset controls/tasks/files Pinia state synchronously when the authenticated account changes
- retain cached git badges on transient refresh failures; clear only for authoritative `not-a-git-repo`

## Validation

- `npx tsc --noEmit`
- relay-web production build
- relay-web full suite: 110 files, 987 tests passed
- final focused suite: 6 files, 89 tests passed
- `git diff --check`