### PR TITLE
docs(site): document relay invite codes (guide + CLI reference)

### DIFF
--- a/packages/docs/guide/relay-self-hosting.md
+++ b/packages/docs/guide/relay-self-hosting.md
@@ -49,7 +49,7 @@ The entry point is then `packages/relay/dist/cli.js` — run `node packages/rela
 
 ## 2. Quickstart (zero flags needed)
 
-Auth is entirely token-based — **no passwords, no admin accounts, no invite flow**. A token IS a user. Mint one and start the server:
+Auth is entirely token-based — **no passwords, no admin accounts**. A token IS a user. Mint one and start the server:
 
 ```bash
 # Step A — create a user + token (DB auto-created at ~/.xacpx-relay/relay.db)
@@ -77,7 +77,7 @@ Open `http://<host>:8787`, paste the token into the **Access token** field, and 
 
 ## 3. Token management
 
-The hub has exactly **4 CLI commands**; all flags are optional:
+All hub administration happens through a handful of CLI subcommands (`add token` / `add invite` / `ls` / `rm token` / `rm invite` / `start` / `update`); all flags are optional:
 
 ### `add token` — create a user + login token
 
@@ -106,6 +106,33 @@ xacpx-relay rm token <value-or-id> [--db <path>]
 ```
 
 Deletes the user behind that token and cascades to its instances, web sessions, and cached messages. Revocation kills that token's web sessions on the next request; an already-open dashboard `/ws` socket lingers until reconnect. To hard-cut all sessions: stop the hub, run `sqlite3 <db> "DELETE FROM web_sessions;"`, then restart.
+
+### `add invite` — invite someone via a link
+
+When you can't (or don't want to) mint a token on the server for someone else, hand them a **single-use invite link** instead:
+
+```bash
+xacpx-relay add invite [--label <note>] [--ttl <n>{m|h|d}] [--url <base>] [--db <path>]
+```
+
+Prints the invite code **once**, plus a ready-to-share redeem link when `--url` is given (otherwise a `/invite/<code>` path to append to your hub URL):
+
+```
+invite code: mJ3…
+redeem link: https://relay.example.com/invite/mJ3…
+(share it now — single-use, not shown again; expires 2026-08-02 12:00 UTC)
+```
+
+Opening the link shows a redeem page; the recipient **clicks to redeem** (link previews and crawlers can't burn the code), which creates a fresh account and shows its access token exactly once — same semantics as `add token`, just self-service.
+
+- `--ttl` defaults to `7d` (e.g. `30m`, `12h`, `3d`; capped at 10 years).
+- Codes are single-use and hashed at rest; used/expired codes are swept hourly.
+- The redeem endpoint shares the login rate-limit bucket (per-IP — remember `--trust-proxy` behind a proxy).
+- `ls` gains an **invites** section (short id, label, expiry, status `unused|used|expired`); remove one with `rm invite <code-or-id>` (does not affect already-redeemed accounts).
+
+::: warning Invite links appear in proxy logs
+The plaintext code travels in the URL path, so your reverse proxy's access log will record **unredeemed** invite links (once redeemed they're worthless). If that matters to you, use a short `--ttl` or disable access logging for `/invite/` paths.
+:::
 
 ### `start` — start the server
 

--- a/packages/docs/reference/cli.md
+++ b/packages/docs/reference/cli.md
@@ -164,21 +164,25 @@ For identity rules, `workingDirectory` semantics, the full tool list, and troubl
 
 ## Relay hub — `xacpx-relay`
 
-A **separate** binary for [self-hosting the relay hub](/guide/relay-self-hosting) (not part of the `xacpx` CLI). It has four subcommands; until the relay packages are published to npm, invoke them as `node packages/relay/dist/cli.js <command>` from a repo checkout.
+A **separate** binary for [self-hosting the relay hub](/guide/relay-self-hosting) (not part of the `xacpx` CLI). Until the relay packages are published to npm, invoke the subcommands as `node packages/relay/dist/cli.js <command>` from a repo checkout.
 
 ```bash
 xacpx-relay start [--db <path>] [--web-root <dir>] [--host 0.0.0.0] [--http-port 8787] [--ws-port 8788] [--history-retention-days 30] [--request-timeout-ms 120000] [--trust-proxy]
 xacpx-relay add token [--label <note>] [--db <path>]
+xacpx-relay add invite [--label <note>] [--ttl <30m|12h|7d>] [--url <hub-base-url>] [--db <path>]
 xacpx-relay ls [--db <path>]
 xacpx-relay rm token <value-or-id> [--db <path>]
+xacpx-relay rm invite <code-or-id> [--db <path>]
 ```
 
 | Command | Description |
 |---|---|
 | `start` | Run the hub. `--db` defaults to `~/.xacpx-relay/relay.db` (auto-creates the directory). `--web-root` defaults to the bundled `packages/relay-web/dist` — the dashboard is served even if omitted. No `stop`/`status` — use `SIGTERM`. |
 | `add token` | Create a user and mint a login token; printed **once**. The same token is used for both the web dashboard login (paste into the "Access token" field) and the connector (`--token`). |
-| `ls` | List tokens: short id, label, created date, and number of connected instances. |
+| `add invite` | Mint a **single-use invite code** and print a redeem link (`/invite/<code>`). The recipient opens the link and clicks redeem to create their own account and receive a token. `--ttl` defaults to `7d`. See [invites](/guide/relay-self-hosting#add-invite-invite-someone-via-a-link). |
+| `ls` | List tokens (short id, label, created date, connected instances) and pending/used invite codes. |
 | `rm token <value-or-id>` | Remove the user behind that token (cascades all data). |
+| `rm invite <code-or-id>` | Delete an invite code (does not affect accounts already redeemed from it). |
 
 **Example — mint a token:**
 

--- a/packages/docs/zh/guide/relay-self-hosting.md
+++ b/packages/docs/zh/guide/relay-self-hosting.md
@@ -49,7 +49,7 @@ bun install && bun run build:relay
 
 ## 2. 快速上手（无需任何参数）
 
-认证完全基于令牌——**没有密码、没有管理员账户、没有邀请流程**。一个令牌就是一个用户。签发令牌后启动服务端：
+认证完全基于令牌——**没有密码、没有管理员账户**。一个令牌就是一个用户。签发令牌后启动服务端：
 
 ```bash
 # 步骤 A — 创建用户 + 令牌（DB 自动创建于 ~/.xacpx-relay/relay.db）
@@ -77,7 +77,7 @@ xacpx-relay listening: http :8787, instance gateway: merged on http :8787 (path 
 
 ## 3. 令牌管理
 
-Hub 一共有 **4 条 CLI 命令**，所有标志均为可选：
+Hub 的全部管理操作都通过少量 CLI 子命令完成（`add token` / `add invite` / `ls` / `rm token` / `rm invite` / `start` / `update`），所有标志均为可选：
 
 ### `add token` — 创建用户 + 登录令牌
 
@@ -106,6 +106,33 @@ xacpx-relay rm token <值或ID> [--db <路径>]
 ```
 
 删除该令牌对应的用户，并级联删除其实例、Web 会话和缓存消息。吊销后，该令牌的 Web 会话将在下次请求时失效；已打开的看板 `/ws` 长连接会在下次重连时才断开。若要立即强制断开所有会话：停止 Hub，执行 `sqlite3 <db> "DELETE FROM web_sessions;"`，然后重启。
+
+### `add invite` — 通过链接邀请他人
+
+不方便（或不想）在服务器上替对方铸令牌时，可以给对方一个**一次性邀请链接**：
+
+```bash
+xacpx-relay add invite [--label <备注>] [--ttl <n>{m|h|d}] [--url <站点地址>] [--db <路径>]
+```
+
+邀请码只打印**一次**；传 `--url` 时会额外打印可直接分享的兑换链接（不传则打印 `/invite/<code>` 路径，自行拼到 hub 域名后即可）：
+
+```
+invite code: mJ3…
+redeem link: https://relay.example.com/invite/mJ3…
+(share it now — single-use, not shown again; expires 2026-08-02 12:00 UTC)
+```
+
+对方打开链接后看到兑换页面，**点击按钮才会兑换**（链接预览和爬虫抓取不会烧掉邀请码）；兑换即创建一个全新账号，并且其访问令牌只显示这一次——语义与 `add token` 完全一致，只是变成了自助领取。
+
+- `--ttl` 默认 `7d`（支持 `30m`、`12h`、`3d` 等，上限 10 年）。
+- 邀请码单次有效、哈希落盘；已用/过期的码由每小时 GC 自动清理。
+- 兑换端点与登录共用同一限流桶（按 IP 统计——反代后方记得 `--trust-proxy`）。
+- `ls` 会追加 **invites** 段（短 id、标签、过期时间、状态 `unused|used|expired`）；用 `rm invite <码或ID>` 删除（不影响已兑换出的账号）。
+
+::: warning 邀请链接会出现在反代日志中
+邀请码明文位于 URL 路径中，反向代理的 access log 会记录**未兑换**的邀请链接（兑换后即作废，无风险）。在意的话可缩短 `--ttl`，或在反代对 `/invite/` 路径关闭访问日志。
+:::
 
 ### `start` — 启动服务端
 

--- a/packages/docs/zh/reference/cli.md
+++ b/packages/docs/zh/reference/cli.md
@@ -164,21 +164,25 @@ xacpx mcp-stdio --coordinator-session <session> --source-handle <handle> --works
 
 ## Relay hub — `xacpx-relay`
 
-[自托管 Relay Hub](/zh/guide/relay-self-hosting) 用的**独立**命令（不属于 `xacpx` CLI）。共四个子命令；在 relay 各包发布到 npm 之前，从仓库 checkout 用 `node packages/relay/dist/cli.js <命令>` 调用。
+[自托管 Relay Hub](/zh/guide/relay-self-hosting) 用的**独立**命令（不属于 `xacpx` CLI）。在 relay 各包发布到 npm 之前，从仓库 checkout 用 `node packages/relay/dist/cli.js <命令>` 调用。
 
 ```bash
 xacpx-relay start [--db <path>] [--web-root <dir>] [--host 0.0.0.0] [--http-port 8787] [--ws-port 8788] [--history-retention-days 30] [--request-timeout-ms 120000] [--trust-proxy]
 xacpx-relay add token [--label <note>] [--db <path>]
+xacpx-relay add invite [--label <note>] [--ttl <30m|12h|7d>] [--url <hub-base-url>] [--db <path>]
 xacpx-relay ls [--db <path>]
 xacpx-relay rm token <value-or-id> [--db <path>]
+xacpx-relay rm invite <code-or-id> [--db <path>]
 ```
 
 | 命令 | 说明 |
 |---|---|
 | `start` | 启动 hub。`--db` 默认 `~/.xacpx-relay/relay.db`（自动创建目录）。`--web-root` 默认指向内置的 `packages/relay-web/dist`，不传也能提供看板 UI。没有 `stop`/`status`——用 `SIGTERM`。 |
 | `add token` | 创建用户并生成登录令牌，**只打印一次**。同一个令牌既用于网页看板登录（粘贴到"访问令牌"输入框），也用于连接器（`--token`）。 |
-| `ls` | 列出所有令牌：短 id、标签、创建时间、已连接实例数。 |
+| `add invite` | 生成**一次性邀请码**并打印兑换链接（`/invite/<code>`）。对方打开链接、点击兑换即可自助创建账号并获得令牌。`--ttl` 默认 `7d`。详见[邀请码](/zh/guide/relay-self-hosting#add-invite-通过链接邀请他人)。 |
+| `ls` | 列出所有令牌（短 id、标签、创建时间、已连接实例数）及未用/已用邀请码。 |
 | `rm token <value-or-id>` | 删除该令牌对应的用户（级联删除所有关联数据）。 |
+| `rm invite <code-or-id>` | 删除邀请码（不影响已兑换出的账号）。 |
 
 **示例——生成令牌：**
 


### PR DESCRIPTION
## Summary
- The invite-code feature (#234, hardened in #235) updated the repo `docs/` but the VitePress docs site (`packages/docs`) was left stale.
- Adds an `add invite` section to the self-hosting guide (en + zh): usage, example output, TTL default/cap, single-use hash-at-rest semantics, shared login rate-limit bucket, `ls`/`rm invite`, and a warning about invite links in reverse-proxy access logs.
- Updates the `xacpx-relay` CLI reference (en + zh): full subcommand block and table now include `add invite` / `rm invite`; removes the outdated "four subcommands" and "no invite flow" claims.

## Test plan
- [x] `bun run build` in `packages/docs` passes (VitePress dead-link check included)