### PR TITLE
docs: promote the relay hub in README and docs-site homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ English · **[中文](./docs/zh/README_zh.md)**
 
 If you need to code or work remotely on a temporary basis, `xacpx` gives you a fast, convenient **remote entry point** so you can get things done from WeChat or Feishu anytime, anywhere.
 
+Chat isn't the only entry point: xacpx also ships a self-hostable **[relay hub](#self-hosted-relay-hub--web-dashboard)** — a multi-tenant web dashboard that drives every one of your xacpx instances from a single browser tab (installable as a PWA on your phone).
+
 > For everyday use, remember `/ss` first: it creates or reuses an xacpx logical session. If you want to attach to an existing native session of a local agent such as Codex, use `/ssn`; see [native sessions](./docs/native-sessions.md).
 
 ## 5-minute quick start
@@ -173,9 +175,17 @@ take a look at today's API timeout issue
 /ssn 1
 ```
 
-## Self-hosted relay hub (optional)
+## Self-hosted relay hub — web dashboard
 
-If you run several xacpx instances and want to drive them all from one browser dashboard, you can self-host the **relay hub**. Each instance dials out to the hub over WebSocket and registers; you log in to a multi-tenant web dashboard and manage every instance's sessions — chat, scheduled tasks, and orchestration — from one place. The hub ships as an npm package (`@ganglion/xacpx-relay`) with the dashboard **bundled in**, served on a single port, with a single **access token** for both web login and connector pairing.
+If you run one or more xacpx instances and want to drive them from a browser instead of (or in addition to) chat, self-host the **relay hub**. Each instance dials out to the hub over WebSocket and registers; you log in to a multi-tenant web dashboard and manage every instance's sessions from one place.
+
+What you get:
+
+- **A three-pane IM-style dashboard** — instance/session tree on the left, live chat in the middle, scheduled tasks & orchestration panel on the right. English + 中文 UI.
+- **Live streaming replies** rendered as markdown, with tool-call and subagent activity inline; cancel running turns from the browser.
+- **Mobile-ready** — installs as a PWA, so it feels like an app on your phone.
+- **One package, one port** — `@ganglion/xacpx-relay` ships the dashboard **bundled in**; HTTP API, web socket, and instance gateway share a single port by default. SQLite storage via the built-in `node:sqlite`/`bun:sqlite` — no native addons to compile.
+- **Multi-tenant & token-based** — every token is a user who only sees their own instances; tokens and credentials are stored hashed. Onboard teammates with **single-use invite links** (`xacpx-relay add invite`) instead of handing out tokens.
 
 ```bash
 npm i -g @ganglion/xacpx-relay
@@ -188,7 +198,7 @@ xacpx channel add relay --url wss://relay.example.com --token <access-token> --n
 xacpx restart
 ```
 
-Full walkthrough — pairing, TLS/reverse-proxy, systemd, backups, troubleshooting: **[Self-Hosting the Relay Hub](https://gadzan.github.io/xacpx/guide/relay-self-hosting)** (or [relay-deployment.md](./docs/relay-deployment.md) for the terse runbook).
+The same access token works for both web login and connector pairing. Full walkthrough — pairing, invites, TLS/reverse-proxy, systemd, backups, troubleshooting: **[Self-Hosting the Relay Hub](https://gadzan.github.io/xacpx/guide/relay-self-hosting)** (or [relay-deployment.md](./docs/relay-deployment.md) for the terse runbook).
 
 ## Config and runtime files
 

--- a/docs/zh/README_zh.md
+++ b/docs/zh/README_zh.md
@@ -23,6 +23,8 @@
 
 如果你需要临时远程编码或办公，`xacpx` 提供的是一个方便快捷的**远程入口**，让你在微信或飞书里就能随时随地干活。
 
+聊天不是唯一入口：xacpx 还提供可自托管的 **[relay hub](#自托管-relay-hub网页看板)**——一个多租户网页看板，在一个浏览器标签页里遥控你的所有 xacpx 实例（手机上可安装为 PWA）。
+
 > 日常使用优先记 `/ss`：它负责创建或复用 xacpx 逻辑会话。如果你想接入本地 Codex 等 Agent 已有的原生会话，再用 `/ssn`；进阶说明见 [原生会话](./native-sessions_zh.md)。
 
 ## 5 分钟快速开始
@@ -171,9 +173,17 @@ worker 会话运行，默认需要人工确认。Codex、Claude Code 等外部 M
 /ssn 1
 ```
 
-## 自托管 relay hub（可选）
+## 自托管 relay hub——网页看板
 
-如果你跑了多个 xacpx 实例，想用一个浏览器看板统一遥控，可以自托管 **relay hub**。每个实例通过 WebSocket 拨向 hub 并注册；你登录一个多租户 web 看板，在一个地方管理所有实例的会话——聊天、定时任务、编排。hub 以 npm 包（`@ganglion/xacpx-relay`）形式分发，看板**已内置打包**，单端口服务，登录和连接器配对共用一个 **access token**。
+如果你跑了一个或多个 xacpx 实例，想用浏览器（替代或补充聊天入口）统一遥控，可以自托管 **relay hub**。每个实例通过 WebSocket 拨向 hub 并注册；你登录一个多租户 web 看板，在一个地方管理所有实例的会话。
+
+你会得到：
+
+- **三栏 IM 式看板**——左栏实例/会话树，中栏实时聊天流，右栏定时任务 + 编排面板。界面支持 English + 中文。
+- **实时流式回复**以 markdown 渲染，工具调用与子 Agent 活动内联展示；可直接在浏览器里取消运行中的任务。
+- **移动端友好**——可安装为 PWA，在手机上像原生应用一样使用。
+- **一个包、一个端口**——`@ganglion/xacpx-relay` **内置打包**了看板；HTTP API、网页 WebSocket 和实例网关默认共用一个端口。存储用内置的 `node:sqlite`/`bun:sqlite`——无需编译任何原生依赖。
+- **多租户 + 令牌认证**——一个令牌就是一个用户，只能看到自己的实例；令牌与凭据均哈希落盘。给同伴开号可用**一次性邀请链接**（`xacpx-relay add invite`），无需在服务器上代发令牌。
 
 ```bash
 npm i -g @ganglion/xacpx-relay
@@ -186,7 +196,7 @@ xacpx channel add relay --url wss://relay.example.com --token <access-token> --n
 xacpx restart
 ```
 
-完整流程——配对、TLS/反向代理、systemd、备份、故障排查见：**[自托管 Relay Hub](https://gadzan.github.io/xacpx/guide/relay-self-hosting)**（或 [relay-deployment.md](../relay-deployment.md) 精简 runbook）。
+登录和连接器配对共用同一个 access token。完整流程——配对、邀请码、TLS/反向代理、systemd、备份、故障排查见：**[自托管 Relay Hub](https://gadzan.github.io/xacpx/guide/relay-self-hosting)**（或 [relay-deployment.md](../relay-deployment.md) 精简 runbook）。
 
 ## 配置与运行文件
 

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -10,6 +10,9 @@ hero:
       text: Get Started
       link: /guide/getting-started
     - theme: alt
+      text: Web Dashboard
+      link: /guide/relay-self-hosting
+    - theme: alt
       text: View on GitHub
       link: https://github.com/gadzan/xacpx
 
@@ -92,9 +95,21 @@ Third-party channels follow the same plugin interface. Install a channel plugin 
 
 ## Web dashboard (relay hub)
 
-Chat is not the only way to drive xacpx. If you run several instances, self-host the **relay hub** — an npm package (`@ganglion/xacpx-relay`) with a web dashboard bundled in. Each instance dials into the hub over WebSocket and registers; you log in to a multi-tenant dashboard and manage every instance's sessions — chat, scheduled tasks, and orchestration — from one place. Agent replies render as live markdown, and the dashboard installs as a PWA on mobile. A single access token serves both web login and connector pairing.
+Chat is not the only way to drive xacpx. Self-host the **relay hub** — an npm package (`@ganglion/xacpx-relay`) with a multi-tenant web dashboard bundled in — and manage every instance from a single browser tab. Each instance dials into the hub over WebSocket and registers; the hub never owns your sessions, it just fans them out to your browser.
 
-See [Self-Hosting the Relay Hub](/guide/relay-self-hosting) for the full walkthrough.
+- **Three-pane IM layout** — instance/session tree, live chat stream, and a scheduled-tasks + orchestration panel side by side. English + 中文 UI.
+- **Live markdown streaming** — replies render as they arrive, with tool-call and subagent activity inline; cancel running turns from the browser.
+- **PWA on mobile** — install it to your home screen and it feels like an app.
+- **Trivial to deploy** — one `npm i -g`, one port by default, SQLite via the built-in `node:sqlite`/`bun:sqlite`, no native addons.
+- **Multi-tenant & token-based** — a token IS a user; tokens are stored hashed, and a single access token serves both web login and connector pairing. Onboard others with single-use **invite links** (`xacpx-relay add invite`).
+
+```bash
+npm i -g @ganglion/xacpx-relay
+xacpx-relay add token   # prints the access token once
+xacpx-relay start       # dashboard + API on :8787
+```
+
+See [Self-Hosting the Relay Hub](/guide/relay-self-hosting) for the full walkthrough — pairing, invites, TLS, systemd, and backups.
 
 ## Next steps
 

--- a/packages/docs/zh/index.md
+++ b/packages/docs/zh/index.md
@@ -10,6 +10,9 @@ hero:
       text: 快速开始
       link: /zh/guide/getting-started
     - theme: alt
+      text: 网页看板
+      link: /zh/guide/relay-self-hosting
+    - theme: alt
       text: 在 GitHub 查看
       link: https://github.com/gadzan/xacpx
 
@@ -92,9 +95,21 @@ xacpx 内置微信作为默认频道。其他频道以官方插件包形式分�
 
 ## 网页看板（relay hub）
 
-聊天并不是驱动 xacpx 的唯一方式。如果你跑了多个实例，可以自托管 **relay hub**——一个内置网页看板的 npm 包（`@ganglion/xacpx-relay`）。每个实例通过 WebSocket 拨入 hub 并注册；你登录一个多租户看板，在一个地方管理所有实例的会话——聊天、定时任务、编排。Agent 回复以实时 markdown 渲染，看板可作为 PWA 安装到移动端。登录与连接器配对共用同一个 access token。
+聊天并不是驱动 xacpx 的唯一方式。你可以自托管 **relay hub**——一个内置多租户网页看板的 npm 包（`@ganglion/xacpx-relay`），在一个浏览器标签页里管理所有实例。每个实例通过 WebSocket 拨入 hub 并注册；hub 不持有你的会话，只负责把它们扇出到浏览器。
 
-完整流程见 [自托管 Relay Hub](/zh/guide/relay-self-hosting)。
+- **三栏 IM 布局**——实例/会话树、实时聊天流、定时任务 + 编排面板并排呈现。界面支持 English + 中文。
+- **实时 markdown 流式渲染**——回复边到边渲染，工具调用与子 Agent 活动内联展示；可直接在浏览器里取消运行中的任务。
+- **移动端 PWA**——添加到主屏幕后，用起来就像原生应用。
+- **部署极简**——一条 `npm i -g`，默认单端口，SQLite 用内置的 `node:sqlite`/`bun:sqlite`，无需编译原生依赖。
+- **多租户 + 令牌认证**——一个令牌就是一个用户；令牌哈希落盘，同一个 access token 既用于网页登录也用于连接器配对。给他人开号可用一次性**邀请链接**（`xacpx-relay add invite`）。
+
+```bash
+npm i -g @ganglion/xacpx-relay
+xacpx-relay add token   # 仅打印一次 access token
+xacpx-relay start       # 看板 + API 在 :8787
+```
+
+完整流程——配对、邀请码、TLS、systemd、备份——见[自托管 Relay Hub](/zh/guide/relay-self-hosting)。
 
 ## 下一步
 


### PR DESCRIPTION
## Summary
- The relay hub web dashboard was under-sold: a short "(optional)" section at the bottom of the READMEs and a single paragraph on the docs homepage.
- README (en + zh): mention the relay hub up front in "What is this", rename the section to drop "(optional)", and add a "What you get" feature list — three-pane IM dashboard, live markdown streaming with inline tool activity, PWA install, single-package/single-port deploy with built-in SQLite, multi-tenant hashed tokens + single-use invite links.
- Docs-site homepage (en + zh): add a "Web Dashboard" hero action linking to the self-hosting guide, and expand the "Web dashboard (relay hub)" section with the same feature bullets plus a 3-line quickstart.

## Test plan
- [x] `bun run build` in `packages/docs` passes (dead-link check included)
- [x] README anchor links verified against GitHub slug rules (en + zh)