### PR TITLE
fix(relay): preserve ACP narrative activity order

### DIFF
--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -108,6 +108,12 @@
 agent 返回的最终文本（`response.text`）也以同一事件再发一次。
 turn 结束时无论成功或失败都发出 `turn-finished`（失败时含 `errorMessage`）。
 
+传输层按 ACP 帧顺序交付叙事事件：工具或推理开始前会先 flush 已到达的文本，因此
+`turn-output → tool-event/turn-thought → turn-output` 不会被重排成「活动在前、文字合并在后」。
+`agent_message_chunk.messageId` 是文本块边界的权威信号：同一 id 即使被活动插入也保持
+Markdown 连续，不同 id 之间补一个空行。没有 messageId 的 adapter 只在活动前文本以
+Unicode `Sentence_Terminal`（另含常见省略号）结束时补空行；否则按连续文本处理。
+
 ### metadata 约定
 
 `prompt` 和 `executeCommand` 的 metadata 固定为：

--- a/docs/control-module.md
+++ b/docs/control-module.md
@@ -108,8 +108,9 @@
 agent 返回的最终文本（`response.text`）也以同一事件再发一次。
 turn 结束时无论成功或失败都发出 `turn-finished`（失败时含 `errorMessage`）。
 
-传输层按 ACP 帧顺序交付叙事事件：工具或推理开始前会先 flush 已到达的文本，因此
+传输层按 ACP 帧顺序交付叙事事件：每个工具事件或推理事件前都会先 flush 已到达的文本，因此
 `turn-output → tool-event/turn-thought → turn-output` 不会被重排成「活动在前、文字合并在后」。
+同一工具的后续状态更新只保证交付顺序，不建立新的活动位置或文本块边界。
 `agent_message_chunk.messageId` 是文本块边界的权威信号：同一 id 即使被活动插入也保持
 Markdown 连续，不同 id 之间补一个空行。没有 messageId 的 adapter 只在活动前文本以
 Unicode `Sentence_Terminal`（另含常见省略号）结束时补空行；否则按连续文本处理。

--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -143,6 +143,11 @@
 - `{ type: "turn-thought"; chatKey; sessionAlias; chunk: string }` — reasoning 文本分片（流式追加）。
 - `{ type: "turn-finished"; chatKey; sessionAlias; ok; errorMessage?; cancelled?: boolean }` — 终态信号；`cancelled` 为 true 表示用户手动取消。
 
+叙事相关事件保持 transport 的 ACP 到达顺序。工具/推理前的文本会先作为
+`turn-output` 发出；transport 还会把 agent 的 messageId 边界编码为空行。这样 Web
+可在同一 messageId 内维持完整 Markdown 块，并把活动放在不同文本块之间。缺少
+messageId 时的句末判断使用 Unicode 句子终止属性，不绑定中文或英文字符表。
+
 ### 连接器规整（packages/channel-relay/src/tool-presentation.ts）
 
 `toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto` 将核心层的原始 `ToolUseEvent` 规整为友好的、有上限的呈现 DTO：

--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -143,10 +143,11 @@
 - `{ type: "turn-thought"; chatKey; sessionAlias; chunk: string }` — reasoning 文本分片（流式追加）。
 - `{ type: "turn-finished"; chatKey; sessionAlias; ok; errorMessage?; cancelled?: boolean }` — 终态信号；`cancelled` 为 true 表示用户手动取消。
 
-叙事相关事件保持 transport 的 ACP 到达顺序。工具/推理前的文本会先作为
+叙事相关事件保持 transport 的 ACP 到达顺序。每个工具事件或推理事件前的文本会先作为
 `turn-output` 发出；transport 还会把 agent 的 messageId 边界编码为空行。这样 Web
 可在同一 messageId 内维持完整 Markdown 块，并把活动放在不同文本块之间。缺少
 messageId 时的句末判断使用 Unicode 句子终止属性，不绑定中文或英文字符表。
+同一 toolCallId 的状态更新只更新原活动项，不新建活动位置或段落边界。
 
 ### 连接器规整（packages/channel-relay/src/tool-presentation.ts）
 

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -29,7 +29,7 @@ describe("deriveTurnPresentation", () => {
     ]);
   });
 
-  it("places a tool at an explicit paragraph boundary", () => {
+  it("places a tool at the semantic paragraph boundary inserted by the transport", () => {
     expect(visibleShape([
       { type: "text", text: "before\n\n" },
       { type: "tool", step: tool("read-1") },

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -1083,7 +1083,7 @@ export async function runStreamingPrompt(
       mode: toolEventMode,
       driver: options.driver,
       rawStream,
-      onActivityBoundary: () => {
+      onBeforeActivityEvent: () => {
         flushPendingText();
       },
       ...(onEvent && (toolEventMode === "structured" || toolEventMode === "both")

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -1078,10 +1078,14 @@ export async function runStreamingPrompt(
     let stdout = "";
     let stderr = "";
     const toolEventMode: ToolEventMode = options.toolEventMode ?? "text";
+    let flushPendingText = () => {};
     const state = createStreamingPromptState(options.formatToolCalls ?? false, {
       mode: toolEventMode,
       driver: options.driver,
       rawStream,
+      onActivityBoundary: () => {
+        flushPendingText();
+      },
       ...(onEvent && (toolEventMode === "structured" || toolEventMode === "both")
         ? { onToolEvent: (toolEvent) => onEvent({ type: "prompt.tool_event", event: toolEvent }) }
         : {}),
@@ -1113,6 +1117,14 @@ export async function runStreamingPrompt(
         onEvent?.({ type: "prompt.segment", text: remaining });
         lastReplyAt = now();
       }
+    };
+
+    flushPendingText = () => {
+      for (const segment of state.segments.splice(0)) {
+        onEvent?.({ type: "prompt.segment", text: segment });
+        lastReplyAt = now();
+      }
+      flushBuffer();
     };
 
     const timer = setIntervalFn(() => {

--- a/src/transport/acpx-bridge/acpx-bridge-transport.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-transport.ts
@@ -81,18 +81,21 @@ export class AcpxBridgeTransport implements SessionTransport {
             ...(replyContext ? { replyContext } : {}),
           })
       : null;
-    let segmentError: unknown;
-    let segmentChain = Promise.resolve();
-    let toolEventError: unknown;
-    let toolEventChain = Promise.resolve();
-    let thoughtError: unknown;
-    let thoughtChain = Promise.resolve();
+    let transcriptError: unknown;
+    let transcriptChain = Promise.resolve();
     let planError: unknown;
     let planChain = Promise.resolve();
     let usageError: unknown;
     let usageChain = Promise.resolve();
     let commandsError: unknown;
     let commandsChain = Promise.resolve();
+    const enqueueTranscriptEvent = (callback: () => void | Promise<void>) => {
+      transcriptChain = transcriptChain
+        .then(callback)
+        .catch((error) => {
+          transcriptError ??= error;
+        });
+    };
     let toolEventMode = resolveToolEventMode(options);
     // Safety net: structured/both without an onToolEvent handler would
     // silently drop tool calls. Demote to 'text' so verbose tool calls
@@ -112,27 +115,19 @@ export class AcpxBridgeTransport implements SessionTransport {
     }, (event) => {
       if (event.type === "prompt.segment") {
         const onSegment = options?.onSegment;
-        if (onSegment) {
-          const segmentText = event.text;
-          segmentChain = segmentChain
-            .then(() => onSegment(segmentText))
-            .catch((error) => {
-              segmentError ??= error;
-            });
-        }
-        sink?.feedSegment(event.text);
+        const segmentText = event.text;
+        enqueueTranscriptEvent(async () => {
+          const segmentResult = onSegment?.(segmentText);
+          sink?.feedSegment(segmentText);
+          await segmentResult;
+        });
         return;
       }
       if (event.type === "prompt.tool_event") {
         const onToolEvent = options?.onToolEvent;
         if (onToolEvent) {
           const toolEvent = event.event;
-          // Serialize handler invocations; first error wins.
-          toolEventChain = toolEventChain
-            .then(() => onToolEvent(toolEvent))
-            .catch((error) => {
-              toolEventError ??= error;
-            });
+          enqueueTranscriptEvent(() => onToolEvent(toolEvent));
         }
         return;
       }
@@ -140,12 +135,7 @@ export class AcpxBridgeTransport implements SessionTransport {
         const onThought = options?.onThought;
         if (onThought) {
           const thoughtText = event.text;
-          // Serialize handler invocations; first error wins.
-          thoughtChain = thoughtChain
-            .then(() => onThought(thoughtText))
-            .catch((error) => {
-              thoughtError ??= error;
-            });
+          enqueueTranscriptEvent(() => onThought(thoughtText));
         }
         return;
       }
@@ -188,9 +178,7 @@ export class AcpxBridgeTransport implements SessionTransport {
         return;
       }
     });
-    await segmentChain;
-    await toolEventChain;
-    await thoughtChain;
+    await transcriptChain;
     await planChain;
     await usageChain;
     await commandsChain;
@@ -211,14 +199,8 @@ export class AcpxBridgeTransport implements SessionTransport {
       // surface a final-tier text when overflow happened — in that case the
       // summary is new info AND result.text carries the agent's final answer
       // that may have been partially or fully dropped from the stream.
-      if (segmentError) {
-        throw segmentError;
-      }
-      if (toolEventError) {
-        throw toolEventError;
-      }
-      if (thoughtError) {
-        throw thoughtError;
+      if (transcriptError) {
+        throw transcriptError;
       }
       if (planError) {
         throw planError;
@@ -231,14 +213,8 @@ export class AcpxBridgeTransport implements SessionTransport {
       }
       return { text: summary ? `${summary}\n\n${result.text}` : "" };
     }
-    if (segmentError) {
-      throw segmentError;
-    }
-    if (toolEventError) {
-      throw toolEventError;
-    }
-    if (thoughtError) {
-      throw thoughtError;
+    if (transcriptError) {
+      throw transcriptError;
     }
     if (planError) {
       throw planError;

--- a/src/transport/acpx-bridge/acpx-bridge-transport.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-transport.ts
@@ -15,6 +15,7 @@ import {
   createQuotaGatedReplySink,
   createVerbatimReplySink,
 } from "../quota-gated-reply-sink";
+import { createSerializedCallbackQueue } from "../serialized-callback-queue";
 import { resolveToolEventMode } from "../tool-event-mode.js";
 import type { BridgeMethod } from "./acpx-bridge-protocol";
 import type { BridgeEvent } from "./acpx-bridge-client";
@@ -81,21 +82,13 @@ export class AcpxBridgeTransport implements SessionTransport {
             ...(replyContext ? { replyContext } : {}),
           })
       : null;
-    let transcriptError: unknown;
-    let transcriptChain = Promise.resolve();
+    const transcriptEvents = createSerializedCallbackQueue();
     let planError: unknown;
     let planChain = Promise.resolve();
     let usageError: unknown;
     let usageChain = Promise.resolve();
     let commandsError: unknown;
     let commandsChain = Promise.resolve();
-    const enqueueTranscriptEvent = (callback: () => void | Promise<void>) => {
-      transcriptChain = transcriptChain
-        .then(callback)
-        .catch((error) => {
-          transcriptError ??= error;
-        });
-    };
     let toolEventMode = resolveToolEventMode(options);
     // Safety net: structured/both without an onToolEvent handler would
     // silently drop tool calls. Demote to 'text' so verbose tool calls
@@ -116,7 +109,7 @@ export class AcpxBridgeTransport implements SessionTransport {
       if (event.type === "prompt.segment") {
         const onSegment = options?.onSegment;
         const segmentText = event.text;
-        enqueueTranscriptEvent(async () => {
+        transcriptEvents.enqueue(async () => {
           const segmentResult = onSegment?.(segmentText);
           sink?.feedSegment(segmentText);
           await segmentResult;
@@ -127,7 +120,7 @@ export class AcpxBridgeTransport implements SessionTransport {
         const onToolEvent = options?.onToolEvent;
         if (onToolEvent) {
           const toolEvent = event.event;
-          enqueueTranscriptEvent(() => onToolEvent(toolEvent));
+          transcriptEvents.enqueue(() => onToolEvent(toolEvent));
         }
         return;
       }
@@ -135,7 +128,7 @@ export class AcpxBridgeTransport implements SessionTransport {
         const onThought = options?.onThought;
         if (onThought) {
           const thoughtText = event.text;
-          enqueueTranscriptEvent(() => onThought(thoughtText));
+          transcriptEvents.enqueue(() => onThought(thoughtText));
         }
         return;
       }
@@ -178,7 +171,7 @@ export class AcpxBridgeTransport implements SessionTransport {
         return;
       }
     });
-    await transcriptChain;
+    await transcriptEvents.drain();
     await planChain;
     await usageChain;
     await commandsChain;
@@ -199,6 +192,7 @@ export class AcpxBridgeTransport implements SessionTransport {
       // surface a final-tier text when overflow happened — in that case the
       // summary is new info AND result.text carries the agent's final answer
       // that may have been partially or fully dropped from the stream.
+      const transcriptError = transcriptEvents.getError();
       if (transcriptError) {
         throw transcriptError;
       }
@@ -213,6 +207,7 @@ export class AcpxBridgeTransport implements SessionTransport {
       }
       return { text: summary ? `${summary}\n\n${result.text}` : "" };
     }
+    const transcriptError = transcriptEvents.getError();
     if (transcriptError) {
       throw transcriptError;
     }

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -789,12 +789,8 @@ export class AcpxCliTransport implements SessionTransport {
       let stdout = "";
       let stderr = "";
       let lastReplyAt = now();
-      let segmentChain = Promise.resolve();
-      let segmentError: unknown;
-      let toolEventChain = Promise.resolve();
-      let toolEventError: unknown;
-      let thoughtChain = Promise.resolve();
-      let thoughtError: unknown;
+      let transcriptChain = Promise.resolve();
+      let transcriptError: unknown;
       let planChain = Promise.resolve();
       let planError: unknown;
       let usageChain = Promise.resolve();
@@ -806,32 +802,34 @@ export class AcpxCliTransport implements SessionTransport {
       const userOnPlan = onPlan;
       const userOnUsage = onUsage;
       const userOnCommands = onCommands;
+      let flushPendingText = () => {};
+
+      const enqueueTranscriptEvent = (callback: () => void | Promise<void>) => {
+        transcriptChain = transcriptChain
+          .then(callback)
+          .catch((error) => {
+            transcriptError ??= error;
+          });
+      };
 
       const state = createStreamingPromptState(formatToolCalls, {
         mode: toolEventMode,
         driver,
         rawStream,
+        onActivityBoundary: () => {
+          flushPendingText();
+        },
         ...(userOnToolEvent
           ? {
               onToolEvent: (event) => {
-                // Serialize handler invocations; first error wins.
-                toolEventChain = toolEventChain
-                  .then(() => userOnToolEvent(event))
-                  .catch((error) => {
-                    toolEventError ??= error;
-                  });
+                enqueueTranscriptEvent(() => userOnToolEvent(event));
               },
             }
           : {}),
         ...(userOnThought
           ? {
               onThought: (chunk) => {
-                // Serialize handler invocations; first error wins.
-                thoughtChain = thoughtChain
-                  .then(() => userOnThought(chunk))
-                  .catch((error) => {
-                    thoughtError ??= error;
-                  });
+                enqueueTranscriptEvent(() => userOnThought(chunk));
               },
             }
           : {}),
@@ -883,14 +881,11 @@ export class AcpxCliTransport implements SessionTransport {
         : null;
 
       const feedSegment = (segment: string) => {
-        if (onSegment) {
-          segmentChain = segmentChain
-            .then(() => onSegment(segment))
-            .catch((error) => {
-              segmentError ??= error;
-            });
-        }
-        sink?.feedSegment(segment);
+        enqueueTranscriptEvent(async () => {
+          const segmentResult = onSegment?.(segment);
+          sink?.feedSegment(segment);
+          await segmentResult;
+        });
         lastReplyAt = now();
       };
 
@@ -901,6 +896,13 @@ export class AcpxCliTransport implements SessionTransport {
           state.buffer = "";
           feedSegment(remaining);
         }
+      };
+
+      flushPendingText = () => {
+        for (const segment of state.segments.splice(0)) {
+          feedSegment(segment);
+        }
+        flushBuffer();
       };
 
       // Periodic timer: flush accumulated text if waiting too long
@@ -933,38 +935,28 @@ export class AcpxCliTransport implements SessionTransport {
         if (remaining.length > 0) {
           feedSegment(remaining);
         }
-        const { overflowCount } = sink?.finalize() ?? { overflowCount: 0 };
-        // Note: any aggregator trailing text is folded into the overflow
-        // summary path via the final agent message (caller appends summary).
-        // Wait for all in-flight reply() rejections to settle before deciding
-        // whether to reject the prompt with a QuotaDeferredError. Without
-        // draining, the deferred error from an outbound pushReply could
-        // arrive after we already resolved, and the wake-coordinator catch
-        // would never see it — silently clearing injectionPending.
-        void Promise.all([
-          sink?.drain({ timeoutMs: 30_000 }) ?? Promise.resolve(),
-          segmentChain,
-          toolEventChain,
-          thoughtChain,
-          planChain,
-          usageChain,
-          commandsChain,
-        ]).then(() => {
+        void (async () => {
+          await Promise.all([
+            transcriptChain,
+            planChain,
+            usageChain,
+            commandsChain,
+          ]);
+          // All queued text must reach the sink before it is finalized. This also
+          // preserves ACP's text → activity → text order across async callbacks.
+          const { overflowCount } = sink?.finalize() ?? { overflowCount: 0 };
+          // Note: any aggregator trailing text is folded into the overflow
+          // summary path via the final agent message (caller appends summary).
+          // Wait for all in-flight reply() rejections to settle before deciding
+          // whether to reject the prompt with a QuotaDeferredError.
+          await (sink?.drain({ timeoutMs: 30_000 }) ?? Promise.resolve());
           const deferred = sink?.getPendingError();
           if (deferred) {
             reject(deferred);
             return;
           }
-          if (segmentError) {
-            reject(segmentError);
-            return;
-          }
-          if (toolEventError) {
-            reject(toolEventError);
-            return;
-          }
-          if (thoughtError) {
-            reject(thoughtError);
+          if (transcriptError) {
+            reject(transcriptError);
             return;
           }
           if (planError) {
@@ -983,7 +975,7 @@ export class AcpxCliTransport implements SessionTransport {
             result: { code: code ?? 1, stdout, stderr },
             overflowCount,
           });
-        }).catch((error) => {
+        })().catch((error) => {
           reject(error);
         });
       });

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -27,6 +27,7 @@ import { getPromptText, normalizeCommandError } from "../prompt-output";
 import { isModelNotAdvertisedError } from "../model-not-advertised";
 import { createStructuredPromptFile } from "../prompt-media";
 import { createStreamingPromptState, parseStreamingDataChunk } from "../streaming-prompt";
+import { createSerializedCallbackQueue } from "../serialized-callback-queue";
 import {
   buildOverflowSummary,
   createQuotaGatedReplySink,
@@ -789,8 +790,7 @@ export class AcpxCliTransport implements SessionTransport {
       let stdout = "";
       let stderr = "";
       let lastReplyAt = now();
-      let transcriptChain = Promise.resolve();
-      let transcriptError: unknown;
+      const transcriptEvents = createSerializedCallbackQueue();
       let planChain = Promise.resolve();
       let planError: unknown;
       let usageChain = Promise.resolve();
@@ -804,14 +804,6 @@ export class AcpxCliTransport implements SessionTransport {
       const userOnCommands = onCommands;
       let flushPendingText = () => {};
 
-      const enqueueTranscriptEvent = (callback: () => void | Promise<void>) => {
-        transcriptChain = transcriptChain
-          .then(callback)
-          .catch((error) => {
-            transcriptError ??= error;
-          });
-      };
-
       const state = createStreamingPromptState(formatToolCalls, {
         mode: toolEventMode,
         driver,
@@ -822,14 +814,14 @@ export class AcpxCliTransport implements SessionTransport {
         ...(userOnToolEvent
           ? {
               onToolEvent: (event) => {
-                enqueueTranscriptEvent(() => userOnToolEvent(event));
+                transcriptEvents.enqueue(() => userOnToolEvent(event));
               },
             }
           : {}),
         ...(userOnThought
           ? {
               onThought: (chunk) => {
-                enqueueTranscriptEvent(() => userOnThought(chunk));
+                transcriptEvents.enqueue(() => userOnThought(chunk));
               },
             }
           : {}),
@@ -881,7 +873,7 @@ export class AcpxCliTransport implements SessionTransport {
         : null;
 
       const feedSegment = (segment: string) => {
-        enqueueTranscriptEvent(async () => {
+        transcriptEvents.enqueue(async () => {
           const segmentResult = onSegment?.(segment);
           sink?.feedSegment(segment);
           await segmentResult;
@@ -937,7 +929,7 @@ export class AcpxCliTransport implements SessionTransport {
         }
         void (async () => {
           await Promise.all([
-            transcriptChain,
+            transcriptEvents.drain(),
             planChain,
             usageChain,
             commandsChain,
@@ -955,6 +947,7 @@ export class AcpxCliTransport implements SessionTransport {
             reject(deferred);
             return;
           }
+          const transcriptError = transcriptEvents.getError();
           if (transcriptError) {
             reject(transcriptError);
             return;

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -816,7 +816,7 @@ export class AcpxCliTransport implements SessionTransport {
         mode: toolEventMode,
         driver,
         rawStream,
-        onActivityBoundary: () => {
+        onBeforeActivityEvent: () => {
           flushPendingText();
         },
         ...(userOnToolEvent

--- a/src/transport/serialized-callback-queue.ts
+++ b/src/transport/serialized-callback-queue.ts
@@ -1,0 +1,26 @@
+export interface SerializedCallbackQueue {
+  enqueue(callback: () => void | Promise<void>): void;
+  drain(): Promise<void>;
+  getError(): unknown;
+}
+
+export function createSerializedCallbackQueue(): SerializedCallbackQueue {
+  let chain = Promise.resolve();
+  let firstError: unknown;
+
+  return {
+    enqueue(callback) {
+      chain = chain
+        .then(callback)
+        .catch((error) => {
+          firstError ??= error;
+        });
+    },
+    async drain() {
+      await chain;
+    },
+    getError() {
+      return firstError;
+    },
+  };
+}

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -31,7 +31,7 @@ export interface StreamingPromptState {
   lastMessageId?: string;
   lastTextTail: string;
   activitySinceLastText: boolean;
-  onActivityBoundary?: () => void;
+  onBeforeActivityEvent?: () => void;
   onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
   onThought?: (chunk: string) => void | Promise<void>;
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
@@ -92,7 +92,7 @@ export type CreateStreamingPromptStateOptions =
       mode?: ToolEventMode;
       driver?: string;
       rawStream?: boolean;
-      onActivityBoundary?: () => void;
+      onBeforeActivityEvent?: () => void;
       onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
       onThought?: (chunk: string) => void | Promise<void>;
       onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
@@ -112,7 +112,7 @@ export function createStreamingPromptState(
   let onCommands: ((commands: AgentCommand[]) => void | Promise<void>) | undefined;
   let rawStream = false;
   let driver: string | undefined;
-  let onActivityBoundary: (() => void) | undefined;
+  let onBeforeActivityEvent: (() => void) | undefined;
 
   if (options === undefined) {
     toolEventMode = "text";
@@ -129,7 +129,7 @@ export function createStreamingPromptState(
     onCommands = options.onCommands;
     rawStream = options.rawStream ?? false;
     driver = options.driver?.trim().toLowerCase() || undefined;
-    onActivityBoundary = options.onActivityBoundary;
+    onBeforeActivityEvent = options.onBeforeActivityEvent;
     toolEventMode = resolveToolEventMode({
       toolEventMode: options.mode,
       onToolEvent,
@@ -150,7 +150,7 @@ export function createStreamingPromptState(
     rawStream,
     lastTextTail: "",
     activitySinceLastText: false,
-    onActivityBoundary,
+    onBeforeActivityEvent,
     onToolEvent,
     onThought,
     onPlan,
@@ -204,6 +204,8 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
     if (isInitialToolEvent) {
       if (update.toolCallId) state.positionedToolCallIds.add(update.toolCallId);
       markActivityBoundary(state);
+    } else {
+      flushBeforeActivityEvent(state);
     }
 
     // Structured consumers (e.g. the relay web dashboard) render tool calls in
@@ -316,7 +318,7 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
     state.activitySinceLastText &&
     (state.lastMessageId === undefined || messageId === undefined) &&
     endsWithSentenceTerminal(state.lastTextTail);
-  if ((messageIdChanged || fallbackBoundary) && !state.buffer.endsWith("\n\n") && !chunk.startsWith("\n\n")) {
+  if ((messageIdChanged || fallbackBoundary) && !hasParagraphBoundaryAtJoin(state.lastTextTail, chunk)) {
     chunk = `\n\n${chunk}`;
     state.lastTextTail = "";
   }
@@ -343,14 +345,31 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
 
 const SENTENCE_TERMINAL_AT_END =
   /(?:\p{Sentence_Terminal}|…|⋯)[\p{Close_Punctuation}\p{Final_Punctuation}"“”‘’*_~`]*$/u;
+const PARAGRAPH_BOUNDARY_AT_END = /\r?\n[\t ]*\r?\n[\t ]*$/;
+const PARAGRAPH_BOUNDARY_AT_START = /^[\t ]*\r?\n[\t ]*\r?\n/;
+const LINE_BREAK_AT_END = /\r?\n[\t ]*$/;
+const LINE_BREAK_AT_START = /^[\t ]*\r?\n/;
 
 function endsWithSentenceTerminal(text: string): boolean {
   return SENTENCE_TERMINAL_AT_END.test(text.trimEnd());
 }
 
+function hasParagraphBoundaryAtJoin(left: string, right: string): boolean {
+  const leftHasBoundary = PARAGRAPH_BOUNDARY_AT_END.test(left);
+  const rightHasBoundary = PARAGRAPH_BOUNDARY_AT_START.test(right);
+  const boundarySpansJoin =
+    LINE_BREAK_AT_END.test(left) &&
+    LINE_BREAK_AT_START.test(right);
+  return leftHasBoundary || rightHasBoundary || boundarySpansJoin;
+}
+
 function markActivityBoundary(state: StreamingPromptState): void {
-  state.onActivityBoundary?.();
+  flushBeforeActivityEvent(state);
   state.activitySinceLastText = state.hasAgentMessage;
+}
+
+function flushBeforeActivityEvent(state: StreamingPromptState): void {
+  state.onBeforeActivityEvent?.();
 }
 
 function formatToolCallEvent(update: NonNullable<StreamEvent["params"]>["update"], sessionUpdate: string): string | null {

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -349,6 +349,7 @@ const PARAGRAPH_BOUNDARY_AT_END = /\r?\n[\t ]*\r?\n[\t ]*$/;
 const PARAGRAPH_BOUNDARY_AT_START = /^[\t ]*\r?\n[\t ]*\r?\n/;
 const LINE_BREAK_AT_END = /\r?\n[\t ]*$/;
 const LINE_BREAK_AT_START = /^[\t ]*\r?\n/;
+const PARTIAL_CRLF_PARAGRAPH_BOUNDARY_AT_END = /\r?\n[\t ]*\r$/;
 
 function endsWithSentenceTerminal(text: string): boolean {
   return SENTENCE_TERMINAL_AT_END.test(text.trimEnd());
@@ -360,7 +361,10 @@ function hasParagraphBoundaryAtJoin(left: string, right: string): boolean {
   const boundarySpansJoin =
     LINE_BREAK_AT_END.test(left) &&
     LINE_BREAK_AT_START.test(right);
-  return leftHasBoundary || rightHasBoundary || boundarySpansJoin;
+  const crlfBoundarySpansJoin =
+    PARTIAL_CRLF_PARAGRAPH_BOUNDARY_AT_END.test(left) &&
+    right.startsWith("\n");
+  return leftHasBoundary || rightHasBoundary || boundarySpansJoin || crlfBoundarySpansJoin;
 }
 
 function markActivityBoundary(state: StreamingPromptState): void {

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -12,6 +12,7 @@ export interface StreamingPromptState {
   pendingLine: string;
   formatToolCalls: boolean;
   emittedToolCallIds: Set<string>;
+  positionedToolCallIds: Set<string>;
   // ACP `tool_call_update` frames are PARTIAL: each carries only the fields that
   // changed, keyed by toolCallId. In particular the terminal (completed/failed)
   // frame typically omits kind/title/content and only sets status + rawOutput. We
@@ -27,6 +28,10 @@ export interface StreamingPromptState {
   // trades the batched paragraph model (good for discrete chat messages) for low
   // first-token latency and smooth token streaming.
   rawStream: boolean;
+  lastMessageId?: string;
+  lastTextTail: string;
+  activitySinceLastText: boolean;
+  onActivityBoundary?: () => void;
   onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
   onThought?: (chunk: string) => void | Promise<void>;
   onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
@@ -40,6 +45,7 @@ interface StreamEvent {
   params?: {
     update?: {
       sessionUpdate?: string;
+      messageId?: string;
       content?: {
         type?: string;
         text?: string;
@@ -86,6 +92,7 @@ export type CreateStreamingPromptStateOptions =
       mode?: ToolEventMode;
       driver?: string;
       rawStream?: boolean;
+      onActivityBoundary?: () => void;
       onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
       onThought?: (chunk: string) => void | Promise<void>;
       onPlan?: (entries: PlanEntry[]) => void | Promise<void>;
@@ -105,6 +112,7 @@ export function createStreamingPromptState(
   let onCommands: ((commands: AgentCommand[]) => void | Promise<void>) | undefined;
   let rawStream = false;
   let driver: string | undefined;
+  let onActivityBoundary: (() => void) | undefined;
 
   if (options === undefined) {
     toolEventMode = "text";
@@ -121,6 +129,7 @@ export function createStreamingPromptState(
     onCommands = options.onCommands;
     rawStream = options.rawStream ?? false;
     driver = options.driver?.trim().toLowerCase() || undefined;
+    onActivityBoundary = options.onActivityBoundary;
     toolEventMode = resolveToolEventMode({
       toolEventMode: options.mode,
       onToolEvent,
@@ -134,10 +143,14 @@ export function createStreamingPromptState(
     pendingLine: "",
     formatToolCalls,
     emittedToolCallIds: new Set(),
+    positionedToolCallIds: new Set(),
     toolCalls: new Map(),
     toolEventMode,
     driver,
     rawStream,
+    lastTextTail: "",
+    activitySinceLastText: false,
+    onActivityBoundary,
     onToolEvent,
     onThought,
     onPlan,
@@ -185,6 +198,14 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
   if (!update) return;
 
   if (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") {
+    const isInitialToolEvent = typeof update.toolCallId === "string"
+      ? !state.positionedToolCallIds.has(update.toolCallId)
+      : update.sessionUpdate === "tool_call";
+    if (isInitialToolEvent) {
+      if (update.toolCallId) state.positionedToolCallIds.add(update.toolCallId);
+      markActivityBoundary(state);
+    }
+
     // Structured consumers (e.g. the relay web dashboard) render tool calls in
     // their own UI, so they receive events through `onToolEvent` regardless of the
     // channel's text replyMode. Only the legacy inline-text rendering — which
@@ -264,6 +285,7 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
   if (isThoughtChunk) {
     const chunk = update.content!.text as string;
     if (chunk.length > 0) {
+      markActivityBoundary(state);
       // Fire-and-forget at the state level — transports that need serialized
       // awaiting wrap the user callback before passing it in (mirrors onToolEvent).
       void state.onThought?.(chunk);
@@ -279,10 +301,30 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
   if (!isMessageChunk) return;
 
   state.hasAgentMessage = true;
-  const chunk = update.content!.text ?? "";
+  let chunk = update.content!.text ?? "";
   if (chunk.length === 0) return;
 
+  const messageId =
+    typeof update.messageId === "string" && update.messageId.length > 0
+      ? update.messageId
+      : undefined;
+  const messageIdChanged =
+    state.lastMessageId !== undefined &&
+    messageId !== undefined &&
+    state.lastMessageId !== messageId;
+  const fallbackBoundary =
+    state.activitySinceLastText &&
+    (state.lastMessageId === undefined || messageId === undefined) &&
+    endsWithSentenceTerminal(state.lastTextTail);
+  if ((messageIdChanged || fallbackBoundary) && !state.buffer.endsWith("\n\n") && !chunk.startsWith("\n\n")) {
+    chunk = `\n\n${chunk}`;
+    state.lastTextTail = "";
+  }
+
   state.buffer += chunk;
+  state.lastMessageId = messageId;
+  state.activitySinceLastText = false;
+  state.lastTextTail = `${state.lastTextTail}${chunk}`.slice(-256);
 
   // Raw streaming: leave the text in `buffer` untouched — the transport's short flush
   // timer drains it verbatim, so paragraph structure is preserved without splitting.
@@ -297,6 +339,18 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
       state.segments.push(segment);
     }
   }
+}
+
+const SENTENCE_TERMINAL_AT_END =
+  /(?:\p{Sentence_Terminal}|…|⋯)[\p{Close_Punctuation}\p{Final_Punctuation}"“”‘’*_~`]*$/u;
+
+function endsWithSentenceTerminal(text: string): boolean {
+  return SENTENCE_TERMINAL_AT_END.test(text.trimEnd());
+}
+
+function markActivityBoundary(state: StreamingPromptState): void {
+  state.onActivityBoundary?.();
+  state.activitySinceLastText = state.hasAgentMessage;
 }
 
 function formatToolCallEvent(update: NonNullable<StreamEvent["params"]>["update"], sessionUpdate: string): string | null {

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -263,6 +263,83 @@ test("runStreamingPrompt emits structured tool events when toolEventMode is 'str
   ]);
 });
 
+test("runStreamingPrompt preserves text → tool → text order in raw bridge events", async () => {
+  const events: unknown[] = [];
+  let dataHandler: ((chunk: string | Buffer) => void) | undefined;
+  let closeHandler: ((code: number | null) => void) | undefined;
+
+  const resultPromise = runStreamingPrompt(
+    "acpx",
+    ["prompt"],
+    (event) => events.push(event),
+    {
+      spawnPrompt: () =>
+        ({
+          stdout: {
+            setEncoding: () => {},
+            on: (event: "data", handler: (chunk: string | Buffer) => void) => {
+              if (event === "data") dataHandler = handler;
+            },
+          },
+          stderr: { on: () => {} },
+          on: (event: "close" | "error", handler: (code: number | null) => void) => {
+            if (event === "close") closeHandler = handler;
+          },
+        }) as never,
+      setIntervalFn: () => 1,
+      clearIntervalFn: () => {},
+      rawStream: true,
+      toolEventMode: "structured",
+    },
+  );
+
+  const lines = [
+    {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          messageId: "message-1",
+          content: { type: "text", text: "before。" },
+        },
+      },
+    },
+    {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "tool-1",
+          kind: "read",
+          title: "Read File",
+        },
+      },
+    },
+    {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          messageId: "message-2",
+          content: { type: "text", text: "after" },
+        },
+      },
+    },
+  ];
+  dataHandler?.(`${lines.map((line) => JSON.stringify(line)).join("\n")}\n`);
+  closeHandler?.(0);
+
+  await resultPromise;
+  expect(events).toEqual([
+    { type: "prompt.segment", text: "before。" },
+    expect.objectContaining({
+      type: "prompt.tool_event",
+      event: expect.objectContaining({ toolCallId: "tool-1" }),
+    }),
+    { type: "prompt.segment", text: "\n\nafter" },
+  ]);
+});
+
 test("selectLatestAcpxSessionIndexTmp ignores malformed files and picks latest timestamp", () => {
   expect(selectLatestAcpxSessionIndexTmp([
     "index.json",

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -325,6 +325,16 @@ test("runStreamingPrompt preserves text → tool → text order in raw bridge ev
         },
       },
     },
+    {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tool-1",
+          status: "completed",
+        },
+      },
+    },
   ];
   dataHandler?.(`${lines.map((line) => JSON.stringify(line)).join("\n")}\n`);
   closeHandler?.(0);
@@ -337,6 +347,10 @@ test("runStreamingPrompt preserves text → tool → text order in raw bridge ev
       event: expect.objectContaining({ toolCallId: "tool-1" }),
     }),
     { type: "prompt.segment", text: "\n\nafter" },
+    expect.objectContaining({
+      type: "prompt.tool_event",
+      event: expect.objectContaining({ toolCallId: "tool-1", status: "success" }),
+    }),
   ]);
 });
 

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
@@ -189,6 +189,56 @@ test("stream-mode session forwards fine-grained segments verbatim (no \\n-join)"
   expect(segments.join("")).toBe("| # | 功能 | 说明 |");
 });
 
+test("stream-mode bridge preserves text → tool → text callback order", async () => {
+  const request = mock(async (_method, _params, onEvent?: (event: {
+    type: string;
+    text?: string;
+    event?: {
+      type: "tool_use";
+      toolCallId: string;
+      toolName: string;
+      kind: "read";
+      status: "running";
+    };
+  }) => void) => {
+    onEvent?.({ type: "prompt.segment", text: "before。" });
+    onEvent?.({
+      type: "prompt.tool_event",
+      event: {
+        type: "tool_use",
+        toolCallId: "tool-1",
+        toolName: "Read File",
+        kind: "read",
+        status: "running",
+      },
+    });
+    onEvent?.({ type: "prompt.segment", text: "\n\nafter" });
+    return { text: "done" };
+  });
+  const events: string[] = [];
+  const transport = new AcpxBridgeTransport({ request });
+
+  await transport.prompt(
+    { ...session, effectiveReplyMode: "stream" },
+    "hello",
+    async (text) => {
+      events.push(`text:${text}`);
+    },
+    undefined,
+    {
+      onToolEvent: async (event) => {
+        events.push(`tool:${event.toolCallId}`);
+      },
+    },
+  );
+
+  expect(events).toEqual([
+    "text:before。",
+    "tool:tool-1",
+    "text:\n\nafter",
+  ]);
+});
+
 
 test("runs prompt segment observers serially in bridge event order", async () => {
   const request = mock(async (_method, _params, onEvent?: (event: { type: string; text: string }) => void) => {

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -1504,6 +1504,21 @@ function makeToolCallLine(toolCallId: string, title: string, kind = "read"): str
   });
 }
 
+function makeToolCallUpdateLine(toolCallId: string, status: string): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId: "abc",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId,
+        status,
+      },
+    },
+  });
+}
+
 function makeAgentChunkLine(text: string, messageId?: string): string {
   return JSON.stringify({
     jsonrpc: "2.0",
@@ -1768,6 +1783,86 @@ test("raw stream preserves text → reasoning → text order", async () => {
     "text:before。",
     "reasoning:checking",
     "text:\n\nafter",
+  ]);
+});
+
+test("raw stream delivers text before a later update to an existing tool", async () => {
+  const events: string[] = [];
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeToolCallLine("tool-1", "Read file", "read"),
+        makeAgentChunkLine("between", "message-1"),
+        makeToolCallUpdateLine("tool-1", "completed"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await transport.prompt(
+    { ...session, replyMode: "stream" },
+    "hello",
+    async (text) => {
+      events.push(`text:${text}`);
+    },
+    undefined,
+    {
+      onToolEvent: async (event) => {
+        events.push(`tool:${event.status}`);
+      },
+    },
+  );
+
+  expect(events).toEqual([
+    "tool:running",
+    "text:between",
+    "tool:success",
+  ]);
+});
+
+test("updating an existing tool does not invent a new text-block boundary", async () => {
+  const events: string[] = [];
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeToolCallLine("tool-1", "Read file", "read"),
+        makeAgentChunkLine("between."),
+        makeToolCallUpdateLine("tool-1", "completed"),
+        makeAgentChunkLine("continued"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await transport.prompt(
+    { ...session, replyMode: "stream" },
+    "hello",
+    async (text) => {
+      events.push(`text:${text}`);
+    },
+    undefined,
+    {
+      onToolEvent: async (event) => {
+        events.push(`tool:${event.status}`);
+      },
+    },
+  );
+
+  expect(events).toEqual([
+    "tool:running",
+    "text:between.",
+    "tool:success",
+    "text:continued",
   ]);
 });
 

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -1504,7 +1504,7 @@ function makeToolCallLine(toolCallId: string, title: string, kind = "read"): str
   });
 }
 
-function makeAgentChunkLine(text: string): string {
+function makeAgentChunkLine(text: string, messageId?: string): string {
   return JSON.stringify({
     jsonrpc: "2.0",
     method: "session/update",
@@ -1512,6 +1512,21 @@ function makeAgentChunkLine(text: string): string {
       sessionId: "abc",
       update: {
         sessionUpdate: "agent_message_chunk",
+        ...(messageId ? { messageId } : {}),
+        content: { type: "text", text },
+      },
+    },
+  });
+}
+
+function makeAgentThoughtLine(text: string): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId: "abc",
+      update: {
+        sessionUpdate: "agent_thought_chunk",
         content: { type: "text", text },
       },
     },
@@ -1544,6 +1559,217 @@ function makeFakeSpawn(lines: string[]) {
 
   return process as unknown as ReturnType<typeof makeFakeSpawn>;
 }
+
+test("raw stream preserves text → tool → text order and separates different messageIds", async () => {
+  const events: string[] = [];
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeAgentChunkLine("先说明。", "message-1"),
+        makeToolCallLine("tool-1", "Read file", "read"),
+        makeAgentChunkLine("再总结", "message-2"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await transport.prompt(
+    { ...session, replyMode: "stream" },
+    "hello",
+    async (text) => {
+      events.push(`text:${text}`);
+    },
+    undefined,
+    {
+      onToolEvent: async (event) => {
+        events.push(`tool:${event.toolCallId}`);
+      },
+    },
+  );
+
+  expect(events).toEqual([
+    "text:先说明。",
+    "tool:tool-1",
+    "text:\n\n再总结",
+  ]);
+});
+
+test("raw stream keeps the same messageId as one Markdown block across a tool call", async () => {
+  const events: string[] = [];
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeAgentChunkLine("**连续", "message-1"),
+        makeToolCallLine("tool-1", "Read file", "read"),
+        makeAgentChunkLine("文本**", "message-1"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await transport.prompt(
+    { ...session, replyMode: "stream" },
+    "hello",
+    async (text) => {
+      events.push(`text:${text}`);
+    },
+    undefined,
+    {
+      onToolEvent: async (event) => {
+        events.push(`tool:${event.toolCallId}`);
+      },
+    },
+  );
+
+  expect(events).toEqual([
+    "text:**连续",
+    "tool:tool-1",
+    "text:文本**",
+  ]);
+});
+
+test("raw stream uses multilingual sentence-terminal punctuation when messageId is absent", async () => {
+  const sentenceEndings = [
+    "English.",
+    "中文。",
+    "العربية؟",
+    "Հայերեն։",
+    "हिन्दी।",
+    "አማርኛ።",
+    "全角！",
+    "省略…",
+    "省略⋯",
+    "带引号！”",
+    "Markdown。**",
+  ];
+
+  for (const before of sentenceEndings) {
+    const events: string[] = [];
+    const transport = new AcpxCliTransport(
+      { command: "acpx" },
+      undefined,
+      undefined,
+      undefined,
+      {
+        spawnPrompt: () => makeFakeSpawn([
+          makeAgentChunkLine(before),
+          makeToolCallLine("tool-1", "Read file", "read"),
+          makeAgentChunkLine("after"),
+        ]),
+        setIntervalFn: () => 0,
+        clearIntervalFn: () => {},
+      },
+    );
+
+    await transport.prompt(
+      { ...session, replyMode: "stream" },
+      "hello",
+      async (text) => {
+        events.push(`text:${text}`);
+      },
+      undefined,
+      {
+        onToolEvent: async (event) => {
+          events.push(`tool:${event.toolCallId}`);
+        },
+      },
+    );
+
+    expect(events).toEqual([
+      `text:${before}`,
+      "tool:tool-1",
+      "text:\n\nafter",
+    ]);
+  }
+});
+
+test("raw stream does not invent a text block boundary without messageId or sentence punctuation", async () => {
+  const events: string[] = [];
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeAgentChunkLine("continuous "),
+        makeToolCallLine("tool-1", "Read file", "read"),
+        makeAgentChunkLine("text"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await transport.prompt(
+    { ...session, replyMode: "stream" },
+    "hello",
+    async (text) => {
+      events.push(`text:${text}`);
+    },
+    undefined,
+    {
+      onToolEvent: async (event) => {
+        events.push(`tool:${event.toolCallId}`);
+      },
+    },
+  );
+
+  expect(events).toEqual([
+    "text:continuous ",
+    "tool:tool-1",
+    "text:text",
+  ]);
+});
+
+test("raw stream preserves text → reasoning → text order", async () => {
+  const events: string[] = [];
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    undefined,
+    undefined,
+    undefined,
+    {
+      spawnPrompt: () => makeFakeSpawn([
+        makeAgentChunkLine("before。", "message-1"),
+        makeAgentThoughtLine("checking"),
+        makeAgentChunkLine("after", "message-2"),
+      ]),
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => {},
+    },
+  );
+
+  await transport.prompt(
+    { ...session, replyMode: "stream" },
+    "hello",
+    async (text) => {
+      events.push(`text:${text}`);
+    },
+    undefined,
+    {
+      onThought: async (text) => {
+        events.push(`reasoning:${text}`);
+      },
+    },
+  );
+
+  expect(events).toEqual([
+    "text:before。",
+    "reasoning:checking",
+    "text:\n\nafter",
+  ]);
+});
 
 test("toolEventMode: no onToolEvent + no toolEventMode → resolves to text, tool call appears as segment", async () => {
   const segments: string[] = [];

--- a/tests/unit/transport/streaming-prompt.test.ts
+++ b/tests/unit/transport/streaming-prompt.test.ts
@@ -93,6 +93,17 @@ test("messageId change preserves a paragraph boundary split across chunks", () =
   expect(flushed + state.buffer).toBe("before\n\nafter");
 });
 
+test("messageId change preserves a CRLF paragraph boundary split inside a line ending", () => {
+  const state = createStreamingPromptState(false, { rawStream: true });
+
+  parseStreamingChunks(state, makeChunkLine("before\r\n\r", "message-1"));
+  const flushed = state.buffer;
+  state.buffer = "";
+  parseStreamingChunks(state, makeChunkLine("\nafter", "message-2"));
+
+  expect(flushed + state.buffer).toBe("before\r\n\r\nafter");
+});
+
 test("parseStreamingChunks handles multiple paragraph boundaries", () => {
   const state = createStreamingPromptState();
 

--- a/tests/unit/transport/streaming-prompt.test.ts
+++ b/tests/unit/transport/streaming-prompt.test.ts
@@ -5,12 +5,13 @@ import {
   parseStreamingDataChunk,
 } from "../../../src/transport/streaming-prompt";
 
-function makeChunkLine(text: string): string {
+function makeChunkLine(text: string, messageId?: string): string {
   return JSON.stringify({
     method: "session/update",
     params: {
       update: {
         sessionUpdate: "agent_message_chunk",
+        ...(messageId ? { messageId } : {}),
         content: { type: "text", text },
       },
     },
@@ -68,6 +69,28 @@ test("rawStream keeps text verbatim in the buffer (no paragraph split/trim)", ()
   // finalize() returns the buffer untrimmed in raw mode.
   parseStreamingChunks(state, makeChunkLine("  trailing  "));
   expect(state.finalize()).toBe("Hello World\n\nNew paragraph  trailing  ");
+});
+
+test("messageId change preserves a paragraph boundary that was already flushed", () => {
+  const state = createStreamingPromptState(false, { rawStream: true });
+
+  parseStreamingChunks(state, makeChunkLine("before\n\n", "message-1"));
+  const flushed = state.buffer;
+  state.buffer = "";
+  parseStreamingChunks(state, makeChunkLine("after", "message-2"));
+
+  expect(flushed + state.buffer).toBe("before\n\nafter");
+});
+
+test("messageId change preserves a paragraph boundary split across chunks", () => {
+  const state = createStreamingPromptState(false, { rawStream: true });
+
+  parseStreamingChunks(state, makeChunkLine("before\n", "message-1"));
+  const flushed = state.buffer;
+  state.buffer = "";
+  parseStreamingChunks(state, makeChunkLine("\nafter", "message-2"));
+
+  expect(flushed + state.buffer).toBe("before\n\nafter");
 });
 
 test("parseStreamingChunks handles multiple paragraph boundaries", () => {


### PR DESCRIPTION
## Summary

- flush pending narrative text before tool and reasoning activity so ACP text → activity → text order survives transport delivery
- use ACP messageId changes as authoritative text-block boundaries while keeping the same messageId Markdown-continuous
- fall back to Unicode sentence-terminal punctuation, including common ellipsis forms and Markdown closers, for adapters without messageId
- serialize narrative callbacks consistently across acpx-cli, bridge runtime, and bridge client

## Why

PR #221 and #232 had to reconstruct activity placement after the transport had already merged or reordered text around tool calls. Real acpx stream logs show Codex message chunks carry stable messageId values, while some other adapters omit them. Preserving this information at the transport seam avoids downstream guesswork.

## Verification

- npm test
- npx tsc --noEmit
- 158 focused transport and bridge tests
- 48 focused Relay Web presentation tests
- bun run build
- Relay Web production build

The multilingual fallback regression covers English, Chinese, Arabic, Armenian, Devanagari, Ethiopic, full-width punctuation, ellipses, quotes, and Markdown closing markers.