### PR TITLE
fix(relay-web): keep transcript scrollbar at pane edge beside plan column

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -303,7 +303,11 @@ DOMPurify（svg profile）净化，并按 `theme+源码` 缓存；`StreamMarkdow
   - 半透明 backdrop 点击关闭；选中会话自动关左抽屉直达对话；抽屉头部有 `✕` 关闭按钮（`lg:hidden`）。
 - 中栏聊天始终占据剩余宽度；登录页/设置页（`max-w-2xl mx-auto`）本身是流式宽度，移动端无需额外处理。
 - **宽屏 Plan 侧列**（issue #231）：中栏足够宽时,`PlanPanel` 从 composer 区移到消息历史右侧的
-  `w-72` 全高列（`ChatPane.vue` 的 `data-test="plan-side-col"`,右栏左边）。判定不是视口断点而是
+  `w-72` 全高列（`ChatPane.vue` 的 `data-test="plan-side-col"`,右栏左边）。侧列不是 flex 兄弟列而是
+  **绝对定位浮层**:`MessageList` 收 `side-gutter` prop 在滚动容器内侧留出 `pr-[19.25rem]` 空档
+  （消息居中几何与分栏方案一致）,滚动条因此留在中栏最右缘（面板右侧）而非卡在消息与面板之间;
+  浮层容器 `pointer-events-none`（面板本体恢复 `pointer-events-auto`）保证其 padding 盖到的滚动条仍可点击。
+  判定不是视口断点而是
   **ResizeObserver 实测 ChatPane 根宽**（左栏折叠/右栏拖拽都会改变可用宽）,阈值带迟滞
   （`src/lib/plan-placement.ts`:进入 ≥ 768+288+32+32=1120px,退出 < 1088px,防滚动条/拖窗抖动）;
   宽度 ≤ 0（无 ResizeObserver 的 jsdom/嵌入式环境,或 ChatPane 被 `v-show` 藏在其他 tab 后）时**保持上次判定**——

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -313,7 +313,8 @@ DOMPurify（svg profile）净化，并按 `theme+源码` 缓存；`StreamMarkdow
   宽度 ≤ 0（无 ResizeObserver 的 jsdom/嵌入式环境,或 ChatPane 被 `v-show` 藏在其他 tab 后）时**保持上次判定**——
   无 RO 时初始即 inline 故恒回落原位,宽屏下切 tab 再切回也不会销毁重建侧列面板。侧列形态用
   `PlanPanel` 的 `variant="side"`:放开 `max-h-48`,header 钉住、列表在列高内滚动。
-  常量与模板 class 是双份事实（`CHAT_CONTENT_MAX`↔`max-w-3xl`、`PLAN_SIDE_WIDTH`↔`w-72`),改一处须同步另一处。
+  常量与模板 class 是双份事实（`CHAT_CONTENT_MAX`↔`max-w-3xl`、`PLAN_SIDE_WIDTH`↔`w-72` 及其两个
+  派生字面量:MessageList 的 `pr-[19.25rem]`=lg:pr-5+w-72、`left-[calc(50%-9rem)]`=w-72/2）,改一处须同步全部。
   两插槽 `v-if` 切换会重建 PlanPanel,但 `expanded` 折叠状态由 ChatPane 用 `v-model:expanded` 持有,跨切换保留。
 
 ## 文件地图

--- a/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
@@ -75,13 +75,17 @@ it("moves the plan panel to the side column on wide panes and back on narrow one
   expect(side.exists()).toBe(true);
   expect(side.classes()).toContain("pointer-events-none");
   expect(side.find('[data-test="plan-panel"]').exists()).toBe(true);
+  expect(side.find('[data-test="plan-panel"]').classes()).toContain("pointer-events-auto");
   expect(w.find('[data-test="composer-area"] [data-test="plan-panel"]').exists()).toBe(false);
   expect(w.find('[data-test="msg-scroller"]').classes()).toContain("pr-[19.25rem]");
+  // Jump-to-latest shifts by half the gutter to stay centered over the transcript.
+  expect(w.find('[data-test="jump-latest"]').classes()).toContain("left-[calc(50%-9rem)]");
   // Narrow pane → back to the composer area.
   await resize(w, 800);
   expect(w.find('[data-test="plan-side-col"]').exists()).toBe(false);
   expect(w.find('[data-test="composer-area"] [data-test="plan-panel"]').exists()).toBe(true);
   expect(w.find('[data-test="msg-scroller"]').classes()).not.toContain("pr-[19.25rem]");
+  expect(w.find('[data-test="jump-latest"]').classes()).toContain("left-1/2");
 });
 
 it("preserves the manual expand/collapse state across the placement switch", async () => {

--- a/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane-plan-side.test.ts
@@ -67,16 +67,21 @@ it("moves the plan panel to the side column on wide panes and back on narrow one
   seedPlan(chat);
   const w = mount(ChatPane);
   await w.vm.$nextTick();
-  // Wide pane → side column hosts the panel, composer copy disappears.
+  // Wide pane → side column hosts the panel, composer copy disappears. The column is a
+  // pointer-events-none overlay; the scroller reserves its area so the scrollbar stays
+  // at the pane's right edge.
   await resize(w, 1400);
   const side = w.find('[data-test="plan-side-col"]');
   expect(side.exists()).toBe(true);
+  expect(side.classes()).toContain("pointer-events-none");
   expect(side.find('[data-test="plan-panel"]').exists()).toBe(true);
   expect(w.find('[data-test="composer-area"] [data-test="plan-panel"]').exists()).toBe(false);
+  expect(w.find('[data-test="msg-scroller"]').classes()).toContain("pr-[19.25rem]");
   // Narrow pane → back to the composer area.
   await resize(w, 800);
   expect(w.find('[data-test="plan-side-col"]').exists()).toBe(false);
   expect(w.find('[data-test="composer-area"] [data-test="plan-panel"]').exists()).toBe(true);
+  expect(w.find('[data-test="msg-scroller"]').classes()).not.toContain("pr-[19.25rem]");
 });
 
 it("preserves the manual expand/collapse state across the placement switch", async () => {

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -190,7 +190,7 @@ const verb = computed(() => {
       <!-- min-h-0 keeps the column height chain intact (flex min-height:auto would let a
            long transcript blow past the pane); the row's default align-stretch is what
            gives MessageList (and the side column) their full height. -->
-      <div class="flex min-h-0 flex-1" data-test="chat-body">
+      <div class="flex min-h-0 flex-1" :class="{ 'has-plan-side': planSide }" data-test="chat-body">
       <MessageList class="min-w-0" :messages="chat.messages" :live-turn="chat.liveTurn" :driver="currentDriver"
                    :session-key="`${chat.instanceId}\0${chat.sessionAlias}`"
                    :scroll-to-scheduled="chat.scrollRequest"
@@ -234,3 +234,12 @@ const verb = computed(() => {
     </template>
   </div>
 </template>
+
+<style scoped>
+.has-plan-side :deep([data-test="msg-scroller"]) {
+  scrollbar-width: none;
+}
+.has-plan-side :deep([data-test="msg-scroller"])::-webkit-scrollbar {
+  display: none;
+}
+</style>

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -188,22 +188,26 @@ const verb = computed(() => {
       </div>
       <template v-else>
       <!-- min-h-0 keeps the column height chain intact (flex min-height:auto would let a
-           long transcript blow past the pane); the row's default align-stretch is what
-           gives MessageList (and the side column) their full height. -->
-      <div class="flex min-h-0 flex-1" :class="{ 'has-plan-side': planSide }" data-test="chat-body">
+           long transcript blow past the pane); relative anchors the absolutely positioned
+           plan side column below. -->
+      <div class="relative flex min-h-0 flex-1" data-test="chat-body">
       <MessageList class="min-w-0" :messages="chat.messages" :live-turn="chat.liveTurn" :driver="currentDriver"
                    :session-key="`${chat.instanceId}\0${chat.sessionAlias}`"
                    :scroll-to-scheduled="chat.scrollRequest"
+                   :side-gutter="planSide"
                    :has-more-older="chat.hasMoreOlder" :loading-older="chat.loadingOlder"
                    :loading-history="chat.loadingHistory"
                    @resend="chat.resend" @load-older="chat.loadOlder" />
-      <!-- Wide panes only: the plan panel moves into the message history's right-hand
-           whitespace. The column itself never scrolls — scrolling stays inside the
-           panel's list so the active-entry tracking keeps working. -->
+      <!-- Wide panes only: the plan panel floats over the right-hand gutter MessageList
+           reserves via `side-gutter`, so the transcript scrollbar stays at the pane's true
+           right edge (right of the panel) instead of landing between the two columns.
+           pointer-events-none on the container keeps the scrollbar under its padding strip
+           clickable; the panel re-enables its own pointer events. The column itself never
+           scrolls — scrolling stays inside the panel's list so active-entry tracking works. -->
       <aside v-if="planSide" data-test="plan-side-col"
-             class="flex w-72 shrink-0 flex-col py-5 pr-5"
+             class="pointer-events-none absolute inset-y-0 right-0 flex w-72 flex-col py-5 pr-5"
              :aria-label="$t('plan.title')">
-        <PlanPanel variant="side" v-model:expanded="planExpanded" :entries="chat.sessionPlan ?? []" :active="chat.busy" />
+        <PlanPanel class="pointer-events-auto" variant="side" v-model:expanded="planExpanded" :entries="chat.sessionPlan ?? []" :active="chat.busy" />
       </aside>
       </div>
       <!-- composer area. pb uses max(1rem, safe-area-inset-bottom) so the iOS home-indicator
@@ -234,12 +238,3 @@ const verb = computed(() => {
     </template>
   </div>
 </template>
-
-<style scoped>
-.has-plan-side :deep([data-test="msg-scroller"]) {
-  scrollbar-width: none;
-}
-.has-plan-side :deep([data-test="msg-scroller"])::-webkit-scrollbar {
-  display: none;
-}
-</style>

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -11,7 +11,7 @@ import AgentIcon from "./AgentIcon.vue";
 import MessageAttachments from "./MessageAttachments.vue";
 import { fmtTime, fmtDateTime } from "../lib/format";
 
-const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; driver?: string | null; hasMoreOlder?: boolean; loadingOlder?: boolean; loadingHistory?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null }>();
+const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; driver?: string | null; hasMoreOlder?: boolean; loadingOlder?: boolean; loadingHistory?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null; sideGutter?: boolean }>();
 const emit = defineEmits<{ resend: [message: ChatMessage]; loadOlder: [] }>();
 
 import type { ScheduledOriginDto } from "@ganglion/xacpx-relay-protocol";
@@ -231,7 +231,11 @@ watch(
 
 <template>
   <div class="relative flex-1 overflow-hidden">
-    <div ref="scroller" data-test="msg-scroller" class="thin-scroll h-full overflow-y-auto px-3 py-4 lg:px-5 lg:py-5" @scroll="onScroll">
+    <!-- side-gutter reserves the plan side-column area as padding INSIDE the scroller
+         (19.25rem = the normal lg:pr-5 + the w-72 column) so the scrollbar stays at the
+         component's right edge and content centering matches the two-column geometry. -->
+    <div ref="scroller" data-test="msg-scroller" class="thin-scroll h-full overflow-y-auto py-4 pl-3 lg:py-5 lg:pl-5"
+         :class="sideGutter ? 'pr-[19.25rem]' : 'pr-3 lg:pr-5'" @scroll="onScroll">
       <!-- Initial-history skeleton: top-anchored to match how the real transcript stacks
            top-to-bottom, then swap for the real content the instant rows arrive. -->
       <div v-if="showSkeleton" data-test="history-skeleton" aria-hidden="true"
@@ -343,7 +347,8 @@ watch(
       v-show="!atBottom"
       data-test="jump-latest"
       type="button"
-      class="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-full border border-border bg-raised px-3 py-1 text-xs text-fg-muted shadow hover:bg-fg/5"
+      class="absolute bottom-3 -translate-x-1/2 rounded-full border border-border bg-raised px-3 py-1 text-xs text-fg-muted shadow hover:bg-fg/5"
+      :class="sideGutter ? 'left-[calc(50%-9rem)]' : 'left-1/2'"
       @click="scrollToBottom(true)"
     >
       {{ $t("chat.jumpLatest") }}

--- a/packages/relay-web/src/lib/plan-placement.ts
+++ b/packages/relay-web/src/lib/plan-placement.ts
@@ -3,7 +3,9 @@
 // message list. These constants mirror Tailwind classes in the templates — change one,
 // change the other:
 //   CHAT_CONTENT_MAX  = max-w-3xl on MessageList's content wrapper
-//   PLAN_SIDE_WIDTH   = w-72 on ChatPane's side column
+//   PLAN_SIDE_WIDTH   = w-72 on ChatPane's side column, and two derived literals in
+//                       MessageList: the side-gutter pr-[19.25rem] (lg:pr-5 + w-72)
+//                       and the jump-latest left-[calc(50%-9rem)] (w-72 / 2)
 export const CHAT_CONTENT_MAX = 768;
 export const PLAN_SIDE_WIDTH = 288;
 // Approximate spacing budget, not a class mirror: the actual template chrome is


### PR DESCRIPTION
## Summary
- The MessageList scrollbar appeared between the transcript and the wide-pane plan side column, looking visually disconnected
- Instead of hiding the scrollbar (first commit), the final approach restores it to its natural position: the plan column is now an absolutely positioned overlay, and MessageList reserves its area as scroller `padding-right` via a new `side-gutter` prop — the scrollbar lands at the pane's true right edge, right of the panel
- Message centering geometry is identical to the old flex layout; `pointer-events-none` on the overlay container keeps the scrollbar clickable, and the jump-to-latest button shifts to stay centered over the transcript

## Test plan
- [ ] On a wide pane with an active plan, the scrollbar sits at the pane's right edge (right of the plan panel)
- [ ] Scrollbar remains draggable along its full height (overlay does not block it)
- [ ] Jump-to-latest button stays centered over the transcript in both modes
- [ ] Narrow panes (plan inline) unchanged
- [x] `vitest run` in packages/relay-web — 1006 tests pass
- [x] `vue-tsc --noEmit` clean

Follow-up UI nit from #236.