### PR TITLE
feat(relay-web): hold transcript hidden until pinned, then play staggered entrance

### DIFF
--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -702,4 +702,47 @@ describe("entrance choreography", () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.find(".enter-hold").exists()).toBe(false);
   });
+
+  it("keeps the hold armed through a slow initial load and still plays on arrival", async () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: null, sessionKey: "a\0one" },
+    });
+    // The initial page goes in flight → the skeleton owns the pane and the safety
+    // cap suspends, so a >800ms load cannot burn the hold prematurely.
+    await wrapper.setProps({ loadingHistory: true });
+    vi.advanceTimersByTime(2000);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="history-skeleton"]').exists()).toBe(true);
+    // The late page lands with rows → still held until the bottom pin settles.
+    await wrapper.setProps({ messages: many(5), loadingHistory: false });
+    expect(wrapper.find(".enter-hold").exists()).toBe(true);
+    await wrapper.vm.$nextTick();
+    await flushFrames(wrapper);
+    expect(wrapper.find(".enter-hold").exists()).toBe(false);
+    expect(wrapper.findAll(".enter-row").length).toBe(5);
+  });
+
+  // Spec #205 SWR: the cached tail renders instantly (with the entrance), and the
+  // later authoritative replace must not re-hold the pane or replay the animation.
+  it("does not re-hold or replay the entrance when a cache seed is replaced by the authoritative page", async () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: null, sessionKey: "a\0one" },
+    });
+    await wrapper.setProps({ messages: many(20) }); // cached tail seed
+    await wrapper.vm.$nextTick();
+    await flushFrames(wrapper);
+    expect(wrapper.find(".enter-hold").exists()).toBe(false);
+    vi.advanceTimersByTime(700); // entrance fully played → idle
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll(".enter-row").length).toBe(0);
+    // Authoritative page replaces the seed (loadHistory) — no second entrance.
+    await wrapper.setProps({ loadingHistory: true });
+    await wrapper.setProps({ messages: many(100), loadingHistory: false });
+    expect(wrapper.find(".enter-hold").exists()).toBe(false);
+    expect(wrapper.findAll(".enter-row").length).toBe(0);
+    await flushFrames(wrapper); // progressive reveal of the prepended older rows
+    expect(wrapper.find(".enter-hold").exists()).toBe(false);
+    expect(wrapper.findAll(".enter-row").length).toBe(0);
+    expect(wrapper.findAll(".cv-row").length).toBe(100);
+  });
 });

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -619,3 +619,87 @@ describe("progressive tail-first mounting", () => {
     expect(wrapper.findAll(".cv-row").length).toBe(100);
   });
 });
+
+// Entrance choreography: a freshly selected session must not paint its intermediate
+// scroll states (flash at the top, then a yank to the bottom). The transcript HOLDs
+// invisible until the first content is pinned, then PLAYs a staggered rise.
+describe("entrance choreography", () => {
+  let rafQueue: FrameRequestCallback[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    rafQueue = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  const many = (n: number): ChatMessage[] =>
+    Array.from({ length: n }, (_, i) => msg({ direction: "in", text: `m${i}`, id: i + 1 }));
+
+  async function flushFrames(wrapper: ReturnType<typeof mount>): Promise<void> {
+    while (rafQueue.length) {
+      for (const cb of rafQueue.splice(0)) cb(0);
+      await wrapper.vm.$nextTick();
+    }
+  }
+
+  it("holds a fresh selection hidden until content lands, then plays a staggered rise", async () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: null, sessionKey: "a\0one" },
+    });
+    // Mounted with a selection and no rows yet → the transcript wrapper is held.
+    expect(wrapper.find(".enter-hold").exists()).toBe(true);
+
+    await wrapper.setProps({ messages: many(5) });
+    // Rows exist but the bottom pin hasn't run — still hidden. (The ready watcher
+    // queues its rAF inside its own nextTick, one microtask after setProps.)
+    expect(wrapper.find(".enter-hold").exists()).toBe(true);
+    await wrapper.vm.$nextTick();
+    await flushFrames(wrapper);
+    // Revealed: the hold lifts and rows cascade toward the newest message.
+    expect(wrapper.find(".enter-hold").exists()).toBe(false);
+    const rows = wrapper.findAll(".enter-row");
+    expect(rows.length).toBe(5);
+    expect(rows[4]!.attributes("style")).toContain("--enter-delay: 275ms"); // newest lands last
+    expect(rows[3]!.attributes("style")).toContain("--enter-delay: 220ms");
+
+    // After the play window the animation classes drop back to pristine rows.
+    vi.advanceTimersByTime(700);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll(".enter-row").length).toBe(0);
+    expect(wrapper.findAll(".cv-row").length).toBe(5);
+  });
+
+  it("re-holds on a session switch and releases an empty session when its load settles", async () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: many(3), liveTurn: null, sessionKey: "a\0one" },
+    });
+    expect(wrapper.find(".enter-hold").exists()).toBe(false);
+    // Switching sessions re-arms the hold (select() empties the transcript).
+    await wrapper.setProps({ messages: [], sessionKey: "a\0two" });
+    expect(wrapper.find(".enter-hold").exists()).toBe(true);
+    // While the initial page is in flight the skeleton branch takes over the pane.
+    await wrapper.setProps({ loadingHistory: true });
+    expect(wrapper.find('[data-test="history-skeleton"]').exists()).toBe(true);
+    // The page resolves empty → nothing to position, release immediately.
+    await wrapper.setProps({ loadingHistory: false });
+    expect(wrapper.find(".enter-hold").exists()).toBe(false);
+  });
+
+  it("never holds longer than the safety window even without a ready signal", async () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: null, sessionKey: "a\0one" },
+    });
+    expect(wrapper.find(".enter-hold").exists()).toBe(true);
+    vi.advanceTimersByTime(800);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".enter-hold").exists()).toBe(false);
+  });
+});

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -96,6 +96,7 @@ onBeforeUnmount(() => {
   revealRaf = 0;
   if (settleRaf) cancelAnimationFrame(settleRaf);
   settleRaf = 0;
+  clearEnterWaits();
 });
 
 // Arm progressive mounting when a freshly selected session's rows land. Two shapes:
@@ -156,6 +157,87 @@ watch(
   },
 );
 
+// Entrance choreography: switching sessions repositions the scroller several times
+// before the pane truly rests at the newest message (cache seed lands, the
+// authoritative page replaces it, content-visibility estimates settle). Painting
+// those intermediate states reads as a flash-then-yank. Instead HOLD the transcript
+// invisible (opacity only — layout and scroll math run as usual) until the first
+// content is pinned to the bottom, then PLAY a bottom-anchored staggered rise, so
+// the first frame the user perceives is already resting at the latest message.
+const enterPhase = ref<"idle" | "hold" | "play">(props.sessionKey && props.messages.length === 0 ? "hold" : "idle");
+let enterRaf = 0;
+let enterTimer: ReturnType<typeof setTimeout> | null = null;
+const ENTER_HOLD_MAX_MS = 800; // safety: never keep a pane hidden if no ready signal arrives
+const ENTER_PLAY_MS = 700; // wrapper fade + longest row stagger; then drop the anim classes
+
+function clearEnterWaits(): void {
+  if (enterRaf) { cancelAnimationFrame(enterRaf); enterRaf = 0; }
+  if (enterTimer !== null) { clearTimeout(enterTimer); enterTimer = null; }
+}
+
+function beginEnter(): void {
+  clearEnterWaits();
+  enterPhase.value = "hold";
+  enterTimer = setTimeout(finishEnter, ENTER_HOLD_MAX_MS);
+}
+
+function finishEnter(): void {
+  if (enterPhase.value !== "hold") return;
+  clearEnterWaits();
+  enterPhase.value = "play";
+  // Back to pristine (no animation/filter classes) once the entrance has fully played.
+  enterTimer = setTimeout(() => {
+    enterTimer = null;
+    if (enterPhase.value === "play") enterPhase.value = "idle";
+  }, ENTER_PLAY_MS);
+}
+
+// The component may mount with a session already selected (page refresh restores the
+// selection before ChatPane renders) — that first load needs the same hold.
+if (enterPhase.value === "hold") enterTimer = setTimeout(finishEnter, ENTER_HOLD_MAX_MS);
+
+// Ready signal 1: content landed (history rows or a live turn). Let the bottom pin and
+// the first settle frames run while still hidden, then reveal.
+watch(
+  () => [props.messages.length, props.liveTurn?.parts.length ?? 0] as const,
+  ([msgs, liveParts]) => {
+    if (enterPhase.value !== "hold" || (msgs === 0 && liveParts === 0)) return;
+    void nextTick(() => {
+      if (enterPhase.value !== "hold") return;
+      if (typeof requestAnimationFrame !== "function") { finishEnter(); return; }
+      if (enterRaf) cancelAnimationFrame(enterRaf);
+      enterRaf = requestAnimationFrame(() => {
+        enterRaf = requestAnimationFrame(() => { enterRaf = 0; finishEnter(); });
+      });
+    });
+  },
+);
+
+// Ready signal 2: the initial page loaded and the session is genuinely empty — there
+// is nothing to position, release the hold right away.
+watch(
+  () => props.loadingHistory,
+  (now, prev) => {
+    if (prev && !now && enterPhase.value === "hold" && props.messages.length === 0) finishEnter();
+  },
+);
+
+// Staggered rise: during PLAY every row shares the same rise, but the last few rows
+// cascade individually toward the newest message (largest delay = the freshest row
+// lands last). Older rows all start at delay 0 — most sit above the viewport anyway,
+// and content-visibility skips painting them.
+const ENTER_STAGGER = 6;
+const ENTER_STEP_MS = 55;
+const enterRowClass = computed(() => (enterPhase.value === "play" ? "enter-row" : ""));
+const newestRowIndex = computed(() =>
+  visibleMessages.value.length - (props.liveTurn && props.liveTurn.parts.length ? 0 : 1));
+function enterStyle(rowIndex: number): Record<string, string> | undefined {
+  if (enterPhase.value !== "play") return undefined;
+  const fromBottom = newestRowIndex.value - rowIndex;
+  const rank = Math.max(0, ENTER_STAGGER - 1 - fromBottom);
+  return rank > 0 ? { "--enter-delay": `${rank * ENTER_STEP_MS}ms` } : undefined;
+}
+
 let settleRaf = 0;
 function scrollToBottom(smooth = false): void {
   const el = scroller.value;
@@ -189,6 +271,7 @@ watch(
   () => {
     atBottom.value = true;
     pendingDistFromBottom = null;
+    beginEnter();
     void nextTick(() => scrollToBottom(false));
   },
 );
@@ -254,7 +337,7 @@ watch(
           </div>
         </template>
       </div>
-      <div v-else class="mx-auto max-w-3xl space-y-5">
+      <div v-else class="mx-auto max-w-3xl space-y-5" :class="{ 'enter-hold': enterPhase === 'hold' }">
         <!-- Older-history affordance: a spinner while a page loads, else a hint that more
              exists. Prepending older rows keeps the scroll position pinned (see watcher). -->
         <div v-if="loadingOlder" data-test="loading-older" class="flex justify-center py-1 text-[11px] text-fg-muted">
@@ -267,7 +350,8 @@ watch(
              keys stay stable while older rows are still being revealed above. -->
         <template v-for="(m, i) in visibleMessages" :key="messageKey(m, hiddenCount + i)">
           <!-- USER row -->
-          <div v-if="m.direction === 'in'" class="cv-row flex justify-end"
+          <div v-if="m.direction === 'in'" class="cv-row flex justify-end" :class="enterRowClass"
+               :style="enterStyle(i)"
                :data-scheduled-task="schedOf(m)?.taskId">
             <!-- min-w-0: without it the flex item's min-width:auto tracks a wide <pre>/table
                  min-content and can defeat the max-w-[80%] cap. -->
@@ -300,7 +384,7 @@ watch(
             </div>
           </div>
           <!-- ASSISTANT row -->
-          <div v-else class="cv-row group flex gap-2.5">
+          <div v-else class="cv-row group flex gap-2.5" :class="enterRowClass" :style="enterStyle(i)">
             <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden">
               <AgentIcon :driver="driver" :size="15" fill />
             </div>
@@ -328,7 +412,8 @@ watch(
         </template>
 
         <!-- live streaming assistant row -->
-        <div v-if="liveTurn && liveTurn.parts.length" class="flex gap-2.5">
+        <div v-if="liveTurn && liveTurn.parts.length" class="flex gap-2.5" :class="enterRowClass"
+             :style="enterStyle(visibleMessages.length)">
           <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden">
             <AgentIcon :driver="driver" :size="15" fill />
           </div>
@@ -362,6 +447,34 @@ watch(
 .cv-row {
   content-visibility: auto;
   contain-intrinsic-size: auto 88px;
+}
+
+/* Entrance choreography (see enterPhase): HOLD keeps the transcript laid out but
+   invisible while the scroller is being positioned — opacity (not display/visibility)
+   so scrollHeight/scrollTop math behaves exactly as when visible. PLAY then lifts the
+   rows in from below with a slight de-blur; each of the last few rows adds
+   --enter-delay so the cascade lands on the newest message. */
+.enter-hold {
+  opacity: 0;
+}
+.enter-row {
+  animation: enter-rise 380ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--enter-delay, 0ms);
+}
+@keyframes enter-rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.985);
+    filter: blur(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .enter-row { animation: none; }
 }
 
 /* Skeleton shimmer: each row inherits --sk-delay from its root so the pulse cascades

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -158,27 +158,37 @@ watch(
 );
 
 // Entrance choreography: switching sessions repositions the scroller several times
-// before the pane truly rests at the newest message (cache seed lands, the
-// authoritative page replaces it, content-visibility estimates settle). Painting
-// those intermediate states reads as a flash-then-yank. Instead HOLD the transcript
-// invisible (opacity only — layout and scroll math run as usual) until the first
-// content is pinned to the bottom, then PLAY a bottom-anchored staggered rise, so
-// the first frame the user perceives is already resting at the latest message.
-const enterPhase = ref<"idle" | "hold" | "play">(props.sessionKey && props.messages.length === 0 ? "hold" : "idle");
+// before the pane rests at the newest message (the cache seed or first page lands,
+// then content-visibility estimates settle). Painting those intermediate states
+// reads as a flash-then-yank. Instead HOLD the transcript invisible (opacity only —
+// layout and scroll math run as usual) until the FIRST content is pinned to the
+// bottom, then PLAY a bottom-anchored staggered rise, so the first frame the user
+// perceives is already resting at the latest message. The later authoritative
+// replace of a cache-seeded tail is NOT covered by the hold — it stays flicker-free
+// through stable row keys and the bottom pin instead (spec #205).
+const enterPhase = ref<"idle" | "hold" | "play">("idle");
 let enterRaf = 0;
 let enterTimer: ReturnType<typeof setTimeout> | null = null;
-const ENTER_HOLD_MAX_MS = 800; // safety: never keep a pane hidden if no ready signal arrives
-const ENTER_PLAY_MS = 700; // wrapper fade + longest row stagger; then drop the anim classes
+const ENTER_HOLD_MAX_MS = 800; // safety: never keep landed content hidden if the pin frames stall
+// Play window: must cover the CSS enter-rise duration (380ms, see <style>) plus the
+// newest row's stagger delay ((ENTER_STAGGER - 1) * ENTER_STEP_MS = 275ms) — keep the
+// three in step. Afterwards the anim classes drop so rows return to pristine.
+const ENTER_PLAY_MS = 700;
 
 function clearEnterWaits(): void {
   if (enterRaf) { cancelAnimationFrame(enterRaf); enterRaf = 0; }
   if (enterTimer !== null) { clearTimeout(enterTimer); enterTimer = null; }
 }
 
+function armEnterCap(): void {
+  if (enterTimer !== null) clearTimeout(enterTimer);
+  enterTimer = setTimeout(finishEnter, ENTER_HOLD_MAX_MS);
+}
+
 function beginEnter(): void {
   clearEnterWaits();
   enterPhase.value = "hold";
-  enterTimer = setTimeout(finishEnter, ENTER_HOLD_MAX_MS);
+  armEnterCap();
 }
 
 function finishEnter(): void {
@@ -194,10 +204,13 @@ function finishEnter(): void {
 
 // The component may mount with a session already selected (page refresh restores the
 // selection before ChatPane renders) — that first load needs the same hold.
-if (enterPhase.value === "hold") enterTimer = setTimeout(finishEnter, ENTER_HOLD_MAX_MS);
+if (props.sessionKey && props.messages.length === 0) beginEnter();
 
-// Ready signal 1: content landed (history rows or a live turn). Let the bottom pin and
-// the first settle frames run while still hidden, then reveal.
+// Ready signal 1: content landed (history rows or a live turn). Release only once the
+// bottom pin has settled — scrollToBottom's content-visibility settle loop re-pins for
+// up to 4 frames on long histories, so wait (bounded) for it to drain instead of a
+// fixed frame count; releasing earlier would let late settle frames move scrollTop
+// mid-PLAY.
 watch(
   () => [props.messages.length, props.liveTurn?.parts.length ?? 0] as const,
   ([msgs, liveParts]) => {
@@ -206,19 +219,37 @@ watch(
       if (enterPhase.value !== "hold") return;
       if (typeof requestAnimationFrame !== "function") { finishEnter(); return; }
       if (enterRaf) cancelAnimationFrame(enterRaf);
-      enterRaf = requestAnimationFrame(() => {
-        enterRaf = requestAnimationFrame(() => { enterRaf = 0; finishEnter(); });
-      });
+      let framesLeft = 8;
+      const waitPinned = (): void => {
+        enterRaf = 0;
+        if (enterPhase.value !== "hold") return;
+        framesLeft -= 1;
+        // At least two frames for the pin to paint, then require the settle loop idle.
+        if (framesLeft <= 0 || (framesLeft <= 6 && settleRaf === 0)) { finishEnter(); return; }
+        enterRaf = requestAnimationFrame(waitPinned);
+      };
+      enterRaf = requestAnimationFrame(waitPinned);
     });
   },
 );
 
-// Ready signal 2: the initial page loaded and the session is genuinely empty — there
-// is nothing to position, release the hold right away.
+// Ready signal 2 + slow-load guard: while the initial page is in flight the skeleton
+// owns the pane, so SUSPEND the safety cap — otherwise a >800ms load would burn the
+// hold behind the skeleton and the late-landing transcript would paint unheld (the
+// exact yank this exists to prevent). The load's completion always re-signals: an
+// empty session releases immediately (nothing to position); a page with rows is
+// released by ready signal 1's pin frames, with the cap re-armed as the fallback.
 watch(
   () => props.loadingHistory,
   (now, prev) => {
-    if (prev && !now && enterPhase.value === "hold" && props.messages.length === 0) finishEnter();
+    if (enterPhase.value !== "hold") return;
+    if (now) {
+      if (enterTimer !== null) { clearTimeout(enterTimer); enterTimer = null; }
+      return;
+    }
+    if (!prev) return;
+    if (props.messages.length === 0 && !(props.liveTurn && props.liveTurn.parts.length)) finishEnter();
+    else armEnterCap();
   },
 );
 


### PR DESCRIPTION
## Summary
- Switching sessions used to paint the transcript at the top, then yank it to the bottom across several settle frames (cache seed → authoritative page replace → `content-visibility` estimate settling), reading as a flash/jitter.
- Introduce an entrance choreography in `MessageList.vue`: HOLD the transcript invisible (opacity only, so scroll math still runs) until the first content is pinned to the bottom, then PLAY a bottom-anchored staggered rise (lift + de-blur, newest rows cascade last), so the first perceived frame already rests at the latest message.
- Ready signals: content landed + two pin frames; empty session releases when `loadingHistory` settles; 800ms safety cap so a pane can never stay hidden. `prefers-reduced-motion` degrades to an instant reveal.
- Stale-while-revalidate flow is preserved: the cached tail still renders near-instantly, and the authoritative replace reuses stable row keys so no second animation plays.

## Test plan
- [x] `vitest run src/__tests__/messagelist.test.ts` — 43 tests, incl. 3 new entrance-choreography cases (hold until pinned, re-hold on session switch / empty release, safety-window release)
- [x] Full relay-web suite: 112 files / 1009 tests pass
- [x] `vue-tsc --noEmit` clean
- [ ] Manual check against a live relay hub: switch between sessions with long histories and verify no flash/scroll jump