### PR TITLE
feat(agents): add built-in hermes agent template

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -98,15 +98,15 @@ xacpx agents list
 xacpx agent rm kimi
 ```
 
-The current built-in templates align with acpx's built-in agents:
+The current built-in templates align with acpx's built-in agents (plus `hermes`, which ships an explicit command):
 
 ```text
 codex, claude, pi, openclaw, gemini, cursor, copilot, droid,
-factory-droid, factorydroid, grok-build, iflow, kilocode, kimi,
-kiro, mux, opencode, qoder, qwen, trae
+factory-droid, factorydroid, grok-build, hermes, iflow, kilocode,
+kimi, kiro, mux, opencode, qoder, qwen, trae
 ```
 
-These templates only write `driver`. xacpx supplies exact npx pins for the managed `codex` and `claude` adapters; other launch commands follow the normal runtime/acpx resolution path. For example, `/agent add kimi` saves `{ "driver": "kimi" }`. For config fields see [config-reference.md](./config-reference.md).
+Most templates only write `driver`. xacpx supplies exact npx pins for the managed `codex` and `claude` adapters; other launch commands follow the normal runtime/acpx resolution path. For example, `/agent add kimi` saves `{ "driver": "kimi" }`. `hermes` is not in acpx's registry, so its template also saves `"command": "hermes acp"`. For config fields see [config-reference.md](./config-reference.md).
 
 ## `adapter` CLI
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,7 +56,7 @@ An agent is the configuration of the underlying tool you want to drive, e.g. `co
 | Command | Description |
 |------|------|
 | `/agents` | View registered agents |
-| `/agent add <codex|claude|pi|openclaw|gemini|cursor|copilot|droid|factory-droid|factorydroid|grok-build|iflow|kilocode|kimi|kiro|mux|opencode|qoder|qwen|trae>` | Add a built-in agent template; an existing agent with the same name but a different configuration will not be overwritten |
+| `/agent add <codex|claude|pi|openclaw|gemini|cursor|copilot|droid|factory-droid|factorydroid|grok-build|hermes|iflow|kilocode|kimi|kiro|mux|opencode|qoder|qwen|trae>` | Add a built-in agent template; an existing agent with the same name but a different configuration will not be overwritten |
 | `/agent add <template> --model <id>` | Add (or update) the agent and set its default model (e.g. `gpt-5.2[high]`), used by every session of that agent unless overridden |
 | `/agent rm <name>` | Delete an agent |
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -550,6 +550,7 @@ The following built-in templates are used when you send `/agent add <name>` via 
 | `factory-droid` | `"factory-droid"` | None (uses acpx default) |
 | `factorydroid` | `"factorydroid"` | None (uses acpx default) |
 | `grok-build` | `"grok-build"` | None (uses acpx default) |
+| `hermes` | `"hermes"` | `"hermes acp"` |
 | `iflow` | `"iflow"` | None (uses acpx default) |
 | `kilocode` | `"kilocode"` | None (uses acpx default) |
 | `kimi` | `"kimi"` | None (uses acpx default) |
@@ -559,6 +560,8 @@ The following built-in templates are used when you send `/agent add <name>` via 
 | `qoder` | `"qoder"` | None (uses acpx default) |
 | `qwen` | `"qwen"` | None (uses acpx default) |
 | `trae` | `"trae"` | None (uses acpx default) |
+
+`hermes` is not in acpx's builtin registry, so its template ships an explicit `command`. It requires [Hermes Agent](https://hermes-agent.nousresearch.com/) installed locally with its ACP extra (`uv pip install -e '.[acp]'`) and provider credentials configured under `~/.hermes/`.
 
 ### Example
 

--- a/docs/zh/cli-reference_zh.md
+++ b/docs/zh/cli-reference_zh.md
@@ -93,15 +93,15 @@ xacpx agents list
 xacpx agent rm kimi
 ```
 
-当前内置模板与 acpx 的 built-in agents 对齐：
+当前内置模板与 acpx 的 built-in agents 对齐（另含自带显式命令的 `hermes`）：
 
 ```text
 codex, claude, pi, openclaw, gemini, cursor, copilot, droid,
-factory-droid, factorydroid, grok-build, iflow, kilocode, kimi,
-kiro, mux, opencode, qoder, qwen, trae
+factory-droid, factorydroid, grok-build, hermes, iflow, kilocode,
+kimi, kiro, mux, opencode, qoder, qwen, trae
 ```
 
-这些模板只写入 `driver`，实际启动命令交给 acpx 解析；例如 `/agent add kimi` 会保存 `{ "driver": "kimi" }`。配置字段见 [config-reference_zh.md](./config-reference_zh.md)。
+多数模板只写入 `driver`，实际启动命令交给 acpx 解析；例如 `/agent add kimi` 会保存 `{ "driver": "kimi" }`。`hermes` 不在 acpx 注册表中，其模板会同时保存 `"command": "hermes acp"`。配置字段见 [config-reference_zh.md](./config-reference_zh.md)。
 
 ## `doctor`
 

--- a/docs/zh/commands_zh.md
+++ b/docs/zh/commands_zh.md
@@ -55,7 +55,7 @@ Agent 是你要驱动的底层工具配置，例如 `codex`、`claude`、`kimi`�
 | 命令 | 说明 |
 |------|------|
 | `/agents` | 查看已注册的 agent |
-| `/agent add <codex|claude|pi|openclaw|gemini|cursor|copilot|droid|factory-droid|factorydroid|grok-build|iflow|kilocode|kimi|kiro|mux|opencode|qoder|qwen|trae>` | 添加一个内置 agent 模板；已存在且配置不同的同名 agent 不会被覆盖 |
+| `/agent add <codex|claude|pi|openclaw|gemini|cursor|copilot|droid|factory-droid|factorydroid|grok-build|hermes|iflow|kilocode|kimi|kiro|mux|opencode|qoder|qwen|trae>` | 添加一个内置 agent 模板；已存在且配置不同的同名 agent 不会被覆盖 |
 | `/agent rm <name>` | 删除一个 agent |
 
 示例：

--- a/docs/zh/config-reference_zh.md
+++ b/docs/zh/config-reference_zh.md
@@ -453,6 +453,7 @@ xacpx channel add <channel-type>
 | `factory-droid` | `"factory-droid"` | 无（使用 acpx 默认） |
 | `factorydroid` | `"factorydroid"` | 无（使用 acpx 默认） |
 | `grok-build` | `"grok-build"` | 无（使用 acpx 默认） |
+| `hermes` | `"hermes"` | `"hermes acp"` |
 | `iflow` | `"iflow"` | 无（使用 acpx 默认） |
 | `kilocode` | `"kilocode"` | 无（使用 acpx 默认） |
 | `kimi` | `"kimi"` | 无（使用 acpx 默认） |
@@ -462,6 +463,8 @@ xacpx channel add <channel-type>
 | `qoder` | `"qoder"` | 无（使用 acpx 默认） |
 | `qwen` | `"qwen"` | 无（使用 acpx 默认） |
 | `trae` | `"trae"` | 无（使用 acpx 默认） |
+
+`hermes` 不在 acpx 内置注册表中，模板自带显式 `command`。使用前需本机安装 [Hermes Agent](https://hermes-agent.nousresearch.com/) 及其 ACP 依赖（`uv pip install -e '.[acp]'`），并在 `~/.hermes/` 下配置好模型凭据。
 
 ### 示例
 

--- a/packages/relay-web/src/__tests__/agenticon.test.ts
+++ b/packages/relay-web/src/__tests__/agenticon.test.ts
@@ -5,7 +5,7 @@ import AgentIcon from "../components/AgentIcon.vue";
 
 describe("agentIconSvg", () => {
   it("returns brand SVG markup for known drivers", () => {
-    for (const driver of ["codex", "claude", "gemini", "copilot", "cursor", "qwen", "kimi", "opencode"]) {
+    for (const driver of ["codex", "claude", "gemini", "copilot", "cursor", "hermes", "qwen", "kimi", "opencode"]) {
       const svg = agentIconSvg(driver);
       expect(svg, driver).toBeTruthy();
       expect(svg!).toContain("<svg");

--- a/packages/relay-web/src/lib/agent-icons.ts
+++ b/packages/relay-web/src/lib/agent-icons.ts
@@ -9,6 +9,7 @@ import claude from "@lobehub/icons-static-svg/icons/claudecode-color.svg?raw";
 import gemini from "@lobehub/icons-static-svg/icons/gemini-color.svg?raw";
 import copilot from "@lobehub/icons-static-svg/icons/copilot-color.svg?raw";
 import cursor from "@lobehub/icons-static-svg/icons/cursor.svg?raw";
+import hermes from "@lobehub/icons-static-svg/icons/hermesagent.svg?raw";
 import qwen from "@lobehub/icons-static-svg/icons/qwen-color.svg?raw";
 import kimi from "@lobehub/icons-static-svg/icons/kimi-color.svg?raw";
 import opencode from "@lobehub/icons-static-svg/icons/opencode.svg?raw";
@@ -27,6 +28,7 @@ const ICONS: Record<string, string> = {
   gemini,
   copilot,
   cursor,
+  hermes,
   qwen,
   kimi,
   opencode,

--- a/src/config/agent-templates.ts
+++ b/src/config/agent-templates.ts
@@ -34,6 +34,11 @@ const TEMPLATES: Record<string, AgentConfig> = {
   "grok-build": {
     driver: "grok-build",
   },
+  // Not in acpx's builtin registry; the explicit command makes acpx spawn it raw.
+  hermes: {
+    driver: "hermes",
+    command: "hermes acp",
+  },
   iflow: {
     driver: "iflow",
   },

--- a/tests/unit/config/agent-catalog.test.ts
+++ b/tests/unit/config/agent-catalog.test.ts
@@ -24,6 +24,19 @@ test("grok-build and mux are explicit usable templates", () => {
   expect(listAgentTemplates()).toContain("mux");
 });
 
+// hermes is not in acpx's registry; the template ships the raw ACP server command.
+test("hermes template carries the explicit acp command", () => {
+  expect(getAgentTemplate("hermes")).toEqual({ driver: "hermes", command: "hermes acp" });
+  expect(listAgentTemplates()).toContain("hermes");
+});
+
+test("hermes is 'yes' when the hermes binary is on PATH, else 'unknown'", () => {
+  const yes = catalog(cfg({}), { probe: (bin) => bin === "hermes" });
+  expect(yes.find((e) => e.driver === "hermes")!.installed).toBe("yes");
+  const no = catalog(cfg({}), { probe: () => false });
+  expect(no.find((e) => e.driver === "hermes")!.installed).toBe("unknown");
+});
+
 test("codex and claude are always builtin and configured-aware", () => {
   const cat = catalog(cfg({ codex: { driver: "codex" } }), { probe: () => false });
   const codex = cat.find((e) => e.driver === "codex")!;
@@ -77,8 +90,13 @@ test("configured is true when a config agent uses the driver under a different n
 test("every template driver is still known to the acpx registry", () => {
   const registry = createAgentRegistry();
   const known = new Set(registry.list());
+  // Templates with an explicit command (e.g. hermes) never consult the acpx
+  // registry, so they are exempt from the drift guard.
   const dropped = listAgentTemplates().filter(
-    (driver) => !known.has(driver) && registry.resolve(driver) === driver,
+    (driver) =>
+      !getAgentTemplate(driver)?.command &&
+      !known.has(driver) &&
+      registry.resolve(driver) === driver,
   );
   expect(dropped).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- Add a built-in `hermes` agent template (`driver: "hermes"`, `command: "hermes acp"`). Hermes Agent speaks ACP over stdio but is not in acpx's builtin registry, so the template ships an explicit command that acpx spawns raw via its `--agent` escape hatch.
- Exempt command-carrying templates from the acpx registry drift guard, and add hermes template/catalog probe tests.
- Sync template lists across docs (config-reference, commands, cli-reference — en/zh) with install prerequisites (Hermes + `uv pip install -e '.[acp]'`).
- Register the hermes brand icon in relay-web (`hermesagent.svg` from @lobehub/icons-static-svg) instead of the generic bot fallback.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (1011 tests pass; drift guard now skips command-carrying templates)
- [x] `npx vitest run src/__tests__/agenticon.test.ts` in packages/relay-web
- [x] dry-run: `/agent add hermes` writes `{ "driver": "hermes", "command": "hermes acp" }`
- [ ] optional real smoke: `xacpx doctor --smoke --agent hermes --workspace <ws>` with Hermes installed