### PR TITLE
fix(relay): let mid-turn web prompts reach the connector queue

### DIFF
--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -101,22 +101,30 @@ function boundField<T extends string | undefined>(v: T): T {
 type SessionRpcLocks = {
   alias: string;
   lifecycle: boolean;
-  turn: boolean;
+  turn: "none" | "shared" | "exclusive";
 };
 
-// Prompts serialize with other turns but not cosmetic metadata writes. Rename
-// serializes with identity-changing lifecycle operations but not turns. Lifecycle
-// operations take both locks so they cannot race either category.
+// Prompts take the turn lock in SHARED mode: concurrent prompts must reach the
+// connector while a turn is running so its TurnQueue can see the busy session and
+// enqueue them (exclusive mode would serialize prompt-vs-prompt at the hub and the
+// queue would never engage). Lifecycle operations take the turn lock exclusively so
+// they still wait for running turns, plus the lifecycle lock so they cannot race
+// each other. Rename only serializes with lifecycle operations, not turns.
 function rpcSessionLocks(type: string, payload: unknown): SessionRpcLocks | undefined {
   const value = payload as { alias?: unknown; sessionAlias?: unknown };
-  if (type === MSG.prompt || type === MSG.commandExecute) {
+  if (type === MSG.prompt) {
     return typeof value.sessionAlias === "string" && value.sessionAlias
-      ? { alias: value.sessionAlias, lifecycle: false, turn: true }
+      ? { alias: value.sessionAlias, lifecycle: false, turn: "shared" }
+      : undefined;
+  }
+  if (type === MSG.commandExecute) {
+    return typeof value.sessionAlias === "string" && value.sessionAlias
+      ? { alias: value.sessionAlias, lifecycle: false, turn: "exclusive" }
       : undefined;
   }
   if (type === MSG.sessionsRename) {
     return typeof value.alias === "string" && value.alias
-      ? { alias: value.alias, lifecycle: true, turn: false }
+      ? { alias: value.alias, lifecycle: true, turn: "none" }
       : undefined;
   }
   if (
@@ -126,7 +134,7 @@ function rpcSessionLocks(type: string, payload: unknown): SessionRpcLocks | unde
     type === MSG.sessionsUnarchive
   ) {
     return typeof value.alias === "string" && value.alias
-      ? { alias: value.alias, lifecycle: true, turn: true }
+      ? { alias: value.alias, lifecycle: true, turn: "exclusive" }
       : undefined;
   }
   return undefined;
@@ -154,6 +162,72 @@ function createKeyedRpcLock(): (key: string) => Promise<() => void> {
   };
 }
 
+// Keyed read-write lock: shared holders run concurrently; an exclusive holder waits
+// for every prior holder and blocks later acquirers. A shared acquirer arriving after
+// a queued exclusive opens a NEW group behind it (FIFO, so writers are never starved).
+function createKeyedRwLock(): {
+  acquireShared: (key: string) => Promise<() => void>;
+  acquireExclusive: (key: string) => Promise<() => void>;
+} {
+  type SharedGroup = { count: number; settle: () => void; start: Promise<void> };
+  const tails = new Map<string, Promise<void>>();
+  const openShared = new Map<string, SharedGroup>();
+
+  function setTail(key: string, tail: Promise<void>): void {
+    tails.set(key, tail);
+    void tail.then(() => {
+      if (tails.get(key) === tail) tails.delete(key);
+    });
+  }
+
+  return {
+    async acquireExclusive(key: string) {
+      // Close the joinable group: shared acquirers arriving after this writer must
+      // queue behind it instead of piggybacking on the running group.
+      openShared.delete(key);
+      const previous = tails.get(key) ?? Promise.resolve();
+      let release!: () => void;
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      setTail(key, previous.then(() => held));
+      await previous;
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        release();
+      };
+    },
+    async acquireShared(key: string) {
+      let group = openShared.get(key);
+      if (!group) {
+        const previous = tails.get(key) ?? Promise.resolve();
+        let settle!: () => void;
+        const settled = new Promise<void>((resolve) => {
+          settle = resolve;
+        });
+        group = { count: 0, settle, start: previous };
+        openShared.set(key, group);
+        setTail(key, previous.then(() => settled));
+      }
+      group.count += 1;
+      const g = group;
+      await g.start;
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        g.count -= 1;
+        if (g.count === 0) {
+          if (openShared.get(key) === g) openShared.delete(key);
+          g.settle();
+        }
+      };
+    },
+  };
+}
+
 type Vars = { Variables: { account: AccountRow } };
 
 export function createApp(deps: AppDeps): Hono<Vars> {
@@ -162,7 +236,7 @@ export function createApp(deps: AppDeps): Hono<Vars> {
   const trustProxy = deps.trustProxy ?? false;
   const now = deps.now ?? (() => new Date());
   const acquireSessionLifecycleRpcLock = createKeyedRpcLock();
-  const acquireSessionTurnRpcLock = createKeyedRpcLock();
+  const sessionTurnRpcLock = createKeyedRwLock();
 
   // Per-IP failure tracking
   const loginFailures = new Map<string, { count: number; windowStart: number }>();
@@ -447,8 +521,10 @@ export function createApp(deps: AppDeps): Hono<Vars> {
         if (sessionLocks.lifecycle) {
           releaseSessionRpcLocks.push(await acquireSessionLifecycleRpcLock(key));
         }
-        if (sessionLocks.turn) {
-          releaseSessionRpcLocks.push(await acquireSessionTurnRpcLock(key));
+        if (sessionLocks.turn === "shared") {
+          releaseSessionRpcLocks.push(await sessionTurnRpcLock.acquireShared(key));
+        } else if (sessionLocks.turn === "exclusive") {
+          releaseSessionRpcLocks.push(await sessionTurnRpcLock.acquireExclusive(key));
         }
       }
       // Persist the inbound user message BEFORE awaiting the turn: sendRequest

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -658,6 +658,10 @@ export class ControlService {
 
   async removeSession(chatKey: string, alias: string): Promise<{ wasActive: boolean }> {
     const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, alias);
+    // Drop queued prompts and abort a running turn BEFORE tearing down the transport:
+    // a drained turn starting mid-removal (or turn events landing after it) would write
+    // history rows for a session that no longer exists.
+    await this.turnQueue.clearSession(chatKey, alias);
     const result = await this.deps.removeSessionWithTransport(internalAlias);
     this.deps.events.emit({ type: "sessions-changed" });
     return result;
@@ -665,6 +669,9 @@ export class ControlService {
 
   async archiveSession(chatKey: string, alias: string): Promise<void> {
     const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, alias);
+    // Queued prompts must not drain onto the session the user just archived — a drained
+    // turn would cold-start a fresh queue owner and effectively undo the archive.
+    await this.turnQueue.clearSession(chatKey, alias);
     await this.deps.archiveSessionWithTransport(internalAlias);
     // Archive just killed the warm owner — correct the tracker now so an
     // immediate undo-wake doesn't show a stale warm reading until the next poll.

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -167,6 +167,9 @@ export interface ControlServiceDeps {
   // Observability hook fired when the inactivity watchdog reclaims a wedged turn, carrying the
   // concrete threshold. main.ts wires this to the app logger. Optional ⇒ no logging.
   onTurnIdleTimeout?: (detail: TurnIdleTimeoutDetail) => void;
+  // Test override for how long clearSession waits for an aborted turn to unwind before
+  // remove/archive gives up; production uses the TurnQueue default.
+  cancelDrainTimeoutMs?: number;
 }
 
 export interface ControlPromptInput {
@@ -232,6 +235,7 @@ export class ControlService {
       runTurn: (req, signal, onActivity) => this.runner.run(req, signal, onActivity),
       ...(this.deps.turnIdleTimeoutMs ? { turnIdleTimeoutMs: this.deps.turnIdleTimeoutMs } : {}),
       ...(this.deps.onTurnIdleTimeout ? { onIdleTimeout: this.deps.onTurnIdleTimeout } : {}),
+      ...(this.deps.cancelDrainTimeoutMs !== undefined ? { cancelDrainTimeoutMs: this.deps.cancelDrainTimeoutMs } : {}),
       emitQueueUpdated: (chatKey, sessionAlias, items) =>
         this.deps.events.emit({ type: "queue-updated", chatKey, sessionAlias, items }),
       detectSessionsChanged: async (detection) => {
@@ -661,7 +665,10 @@ export class ControlService {
     // Drop queued prompts and abort a running turn BEFORE tearing down the transport:
     // a drained turn starting mid-removal (or turn events landing after it) would write
     // history rows for a session that no longer exists.
-    await this.turnQueue.clearSession(chatKey, alias);
+    const { cleared } = await this.turnQueue.clearSession(chatKey, alias);
+    if (!cleared) {
+      throw new Error(`session "${alias}" still has a turn winding down; stop it and retry`);
+    }
     const result = await this.deps.removeSessionWithTransport(internalAlias);
     this.deps.events.emit({ type: "sessions-changed" });
     return result;
@@ -671,7 +678,10 @@ export class ControlService {
     const internalAlias = await this.deps.sessions.resolveAliasForChat(chatKey, alias);
     // Queued prompts must not drain onto the session the user just archived — a drained
     // turn would cold-start a fresh queue owner and effectively undo the archive.
-    await this.turnQueue.clearSession(chatKey, alias);
+    const { cleared } = await this.turnQueue.clearSession(chatKey, alias);
+    if (!cleared) {
+      throw new Error(`session "${alias}" still has a turn winding down; stop it and retry`);
+    }
     await this.deps.archiveSessionWithTransport(internalAlias);
     // Archive just killed the warm owner — correct the tracker now so an
     // immediate undo-wake doesn't show a stale warm reading until the next poll.

--- a/src/control/turn-queue.ts
+++ b/src/control/turn-queue.ts
@@ -6,6 +6,7 @@ import {
   turnKey,
   raceWithTimeout,
   CANCEL_DRAIN_TIMEOUT_MS,
+  QUEUE_MAX_DEPTH,
   QUEUE_PREVIEW_MAX,
   TURN_IDLE_TIMEOUT_REASON,
   type QueuedPrompt,
@@ -124,6 +125,10 @@ export class TurnQueue {
       const busy = this.draining.has(key) || (existing !== undefined && !existing.controller.signal.aborted);
       if (busy) {
         if (params.queueable) {
+          const q = this.queues.get(key) ?? [];
+          if (q.length >= QUEUE_MAX_DEPTH) {
+            return { ok: false, errorMessage: "queue-full" };
+          }
           const id = randomUUID();
           const item: QueuedPrompt = {
             id,
@@ -134,7 +139,6 @@ export class TurnQueue {
             ...(params.accountId !== undefined ? { accountId: params.accountId } : {}),
             ...(params.media !== undefined ? { media: params.media } : {}),
           };
-          const q = this.queues.get(key) ?? [];
           q.push(item);
           this.queues.set(key, q);
           this.emitQueueUpdated(params.chatKey, params.sessionAlias);
@@ -320,6 +324,24 @@ export class TurnQueue {
     }
     entry.controller.abort();
     return true;
+  }
+
+  /** Tear down all turn state for a session that is being removed or archived: drop every
+   *  queued prompt, abort a running turn, and wait (bounded) for it to unwind. The queue is
+   *  cleared BEFORE the abort so the aborting turn's finally sees it empty and releases the
+   *  slot instead of draining a head onto the dead session. Without this, a drained turn can
+   *  start after removal and its events write history rows for a session that no longer
+   *  exists. */
+  async clearSession(chatKey: string, sessionAlias: string): Promise<void> {
+    const key = turnKey(chatKey, sessionAlias);
+    // queues never holds empty arrays, so a successful delete means items were dropped.
+    if (this.queues.delete(key)) {
+      this.emitQueueUpdated(chatKey, sessionAlias);
+    }
+    const entry = this.inFlight.get(key);
+    if (!entry) return;
+    entry.controller.abort();
+    await raceWithTimeout(entry.settled, CANCEL_DRAIN_TIMEOUT_MS);
   }
 
   /** Remove a pending queued prompt (by id) before it drains. No-ops (returns

--- a/src/control/turn-queue.ts
+++ b/src/control/turn-queue.ts
@@ -38,6 +38,9 @@ export interface TurnQueueDeps {
   // Injectable timers (default setTimeout/clearTimeout), for deterministic tests.
   setTimer?: (fn: () => void, ms: number) => unknown;
   clearTimer?: (id: unknown) => void;
+  // Bound on how long clearSession waits for an aborted turn to unwind before reporting
+  // `cleared: false`. Defaults to CANCEL_DRAIN_TIMEOUT_MS; injectable for tests.
+  cancelDrainTimeoutMs?: number;
 }
 
 export interface SubmitParams {
@@ -72,10 +75,12 @@ export type SubmitResult = TurnResult | { ok: true; queued: true; queueItemId: s
 export class TurnQueue {
   private readonly setTimer: (fn: () => void, ms: number) => unknown;
   private readonly clearTimer: (id: unknown) => void;
+  private readonly cancelDrainTimeoutMs: number;
 
   constructor(private readonly deps: TurnQueueDeps) {
     this.setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
     this.clearTimer = deps.clearTimer ?? ((id) => clearTimeout(id as ReturnType<typeof setTimeout>));
+    this.cancelDrainTimeoutMs = deps.cancelDrainTimeoutMs ?? CANCEL_DRAIN_TIMEOUT_MS;
   }
 
   // Each in-flight turn carries its AbortController plus a `settled` promise that resolves
@@ -329,19 +334,30 @@ export class TurnQueue {
   /** Tear down all turn state for a session that is being removed or archived: drop every
    *  queued prompt, abort a running turn, and wait (bounded) for it to unwind. The queue is
    *  cleared BEFORE the abort so the aborting turn's finally sees it empty and releases the
-   *  slot instead of draining a head onto the dead session. Without this, a drained turn can
-   *  start after removal and its events write history rows for a session that no longer
-   *  exists. */
-  async clearSession(chatKey: string, sessionAlias: string): Promise<void> {
+   *  slot instead of draining a head onto the dead session. Returns `cleared: false` when the
+   *  session still holds turn state after the bounded wait (a wedged turn that outlived the
+   *  timeout, or a fresh prompt that slipped in during the unwind) — the caller MUST NOT
+   *  proceed with removal/archive then, or the surviving turn's events would write history
+   *  rows for a session that no longer exists. */
+  async clearSession(chatKey: string, sessionAlias: string): Promise<{ cleared: boolean }> {
     const key = turnKey(chatKey, sessionAlias);
     // queues never holds empty arrays, so a successful delete means items were dropped.
     if (this.queues.delete(key)) {
       this.emitQueueUpdated(chatKey, sessionAlias);
     }
     const entry = this.inFlight.get(key);
-    if (!entry) return;
-    entry.controller.abort();
-    await raceWithTimeout(entry.settled, CANCEL_DRAIN_TIMEOUT_MS);
+    if (entry) {
+      entry.controller.abort();
+      await raceWithTimeout(entry.settled, this.cancelDrainTimeoutMs);
+      // The await is a window: new prompts may have enqueued (behind the aborted-but-live
+      // turn) — drop those too so nothing drains later.
+      if (this.queues.delete(key)) {
+        this.emitQueueUpdated(chatKey, sessionAlias);
+      }
+    }
+    // Re-check rather than trusting the race: `inFlight` still present means the turn
+    // outlived the timeout (or a fresh turn started); `draining` means a hand-off is live.
+    return { cleared: !this.inFlight.has(key) && !this.draining.has(key) };
   }
 
   /** Remove a pending queued prompt (by id) before it drains. No-ops (returns

--- a/src/control/turn-support.ts
+++ b/src/control/turn-support.ts
@@ -21,6 +21,10 @@ export const CANCEL_DRAIN_TIMEOUT_MS = 5000;
 // event, so a very long queued prompt doesn't bloat the snapshot payload.
 export const QUEUE_PREVIEW_MAX = 120;
 
+// Upper bound on queued prompts per session. The queue is unbounded connector memory
+// otherwise — a client spamming prompts mid-turn would grow it without limit.
+export const QUEUE_MAX_DEPTH = 20;
+
 // Resolve when `promise` settles or `ms` elapses, whichever comes first. The timer
 // is cleared on the winning path so a fast drain doesn't keep the event loop alive.
 export async function raceWithTimeout(promise: Promise<void>, ms: number): Promise<void> {

--- a/tests/unit/control/control-service-queue.test.ts
+++ b/tests/unit/control/control-service-queue.test.ts
@@ -15,6 +15,8 @@ function makeService(opts?: {
   // executeTurn finally's post-turn `await getSession` window actually run (the C3 drain
   // hand-off window), so a test can act during that await.
   getSession?: (alias: string) => Promise<unknown>;
+  // Shorten clearSession's bounded wait so the wedged-turn guard path is testable.
+  cancelDrainTimeoutMs?: number;
 }) {
   const events = createControlEventBus();
   const seen: ControlEvent[] = [];
@@ -53,6 +55,7 @@ function makeService(opts?: {
     archiveSessionWithTransport: async (internalAlias: string) => {
       lifecycleCalls.push(`archive:${internalAlias}`);
     },
+    ...(opts?.cancelDrainTimeoutMs !== undefined ? { cancelDrainTimeoutMs: opts.cancelDrainTimeoutMs } : {}),
     events,
   } as never);
 
@@ -288,4 +291,21 @@ test("archiveSession drops queued prompts so no drained turn un-archives the ses
   const started = events.filter((e): e is TurnStarted => e.type === "turn-started");
   expect(started.length).toBe(1);
   expect(started.some((e) => e.queueItemId !== undefined)).toBe(false);
+});
+
+test("removeSession refuses to delete when the aborted turn outlives the drain timeout", async () => {
+  const { service, lifecycleCalls, releaseChat } = makeService({ cancelDrainTimeoutMs: 20 });
+  const p1 = service.prompt({ chatKey: "c", sessionAlias: "s", text: "wedged", senderId: "u" });
+  await tick();
+
+  // The turn never unwinds within the timeout — removal must fail instead of deleting
+  // under a live turn (whose later events would write ghost history).
+  await expect(service.removeSession("c", "s")).rejects.toThrow(/still has a turn winding down/);
+  expect(lifecycleCalls).toEqual([]); // transport removal never reached
+
+  // After the turn actually unwinds, a retry deletes cleanly.
+  releaseChat();
+  await p1;
+  await service.removeSession("c", "s");
+  expect(lifecycleCalls).toEqual(["remove:s"]);
 });

--- a/tests/unit/control/control-service-queue.test.ts
+++ b/tests/unit/control/control-service-queue.test.ts
@@ -32,6 +32,7 @@ function makeService(opts?: {
     return { text: "done" };
   };
 
+  const lifecycleCalls: string[] = [];
   const service = new ControlService({
     agent: { chat },
     sessions: {
@@ -45,12 +46,20 @@ function makeService(opts?: {
     activeTurns: { isActiveAnywhere: () => false },
     scheduled: {} as never,
     orchestration: {} as never,
+    removeSessionWithTransport: async (internalAlias: string) => {
+      lifecycleCalls.push(`remove:${internalAlias}`);
+      return { wasActive: false };
+    },
+    archiveSessionWithTransport: async (internalAlias: string) => {
+      lifecycleCalls.push(`archive:${internalAlias}`);
+    },
     events,
   } as never);
 
   return {
     service,
     events: seen,
+    lifecycleCalls,
     releaseChat: () => {
       while (pending.length) pending.shift()!();
     },
@@ -235,4 +244,48 @@ test("cancelQueuedItem removes a queued item and emits queue-updated; false for 
   expect(service.cancelQueuedItem("c", "s", "nope")).toEqual({ cancelled: false });
   releaseChat();
   await p1;
+});
+
+test("removeSession drops queued prompts and aborts the running turn before transport removal", async () => {
+  const { service, events, lifecycleCalls, nextChat } = makeService();
+  const p1 = service.prompt({ chatKey: "c", sessionAlias: "s", text: "first", senderId: "u" });
+  await tick();
+  const r2 = await service.prompt({ chatKey: "c", sessionAlias: "s", text: "queued", senderId: "u" });
+  expect(r2.queued).toBe(true);
+
+  const removed = service.removeSession("c", "s");
+  await tick();
+  // The queue badge is cleared synchronously; removal then waits for the aborted turn.
+  const qEvents = events.filter((e): e is QueueUpdated => e.type === "queue-updated");
+  expect(qEvents.at(-1)?.items).toEqual([]);
+  expect(lifecycleCalls).toEqual([]); // transport removal not reached while the turn unwinds
+
+  nextChat(); // the aborted turn's chat resolves -> turn settles -> removal proceeds
+  await removed;
+  await p1;
+  await tick();
+  expect(lifecycleCalls).toEqual(["remove:s"]);
+  // The queued prompt never started a drained turn on the removed session: exactly one
+  // turn-started (the direct prompt), and none carrying a drained head's queueItemId.
+  const started = events.filter((e): e is TurnStarted => e.type === "turn-started");
+  expect(started.length).toBe(1);
+  expect(started.some((e) => e.queueItemId !== undefined)).toBe(false);
+});
+
+test("archiveSession drops queued prompts so no drained turn un-archives the session", async () => {
+  const { service, events, lifecycleCalls, nextChat } = makeService();
+  const p1 = service.prompt({ chatKey: "c", sessionAlias: "s", text: "first", senderId: "u" });
+  await tick();
+  await service.prompt({ chatKey: "c", sessionAlias: "s", text: "queued", senderId: "u" });
+
+  const archived = service.archiveSession("c", "s");
+  await tick();
+  nextChat();
+  await archived;
+  await p1;
+  await tick();
+  expect(lifecycleCalls).toEqual(["archive:s"]);
+  const started = events.filter((e): e is TurnStarted => e.type === "turn-started");
+  expect(started.length).toBe(1);
+  expect(started.some((e) => e.queueItemId !== undefined)).toBe(false);
 });

--- a/tests/unit/control/turn-queue.test.ts
+++ b/tests/unit/control/turn-queue.test.ts
@@ -406,7 +406,7 @@ test("clearSession drops queued prompts, aborts the running turn, and starts no 
 
   // clearSession resolves only after the aborted turn unwinds (settled).
   h.resolveNext({ ok: false, errorMessage: "aborted" });
-  await cleared;
+  expect(await cleared).toEqual({ cleared: true });
   await p1;
   await tick();
   expect(h.started).toEqual(["running"]); // neither queued item started a drained turn
@@ -416,7 +416,23 @@ test("clearSession drops queued prompts, aborts the running turn, and starts no 
 test("clearSession on an idle session with an empty queue is a no-op", async () => {
   const emitted: unknown[] = [];
   const { queue } = makeQueue({ emitQueueUpdated: (_c, _s, items) => emitted.push(items) });
-  await queue.clearSession("c", "s");
+  expect(await queue.clearSession("c", "s")).toEqual({ cleared: true });
   expect(emitted).toEqual([]); // no spurious queue-updated for a session that had nothing
   expect(queue.isBusy("c", "s")).toBe(false);
+});
+
+test("clearSession reports cleared:false when the aborted turn outlives the drain timeout", async () => {
+  const h = makeQueue({ cancelDrainTimeoutMs: 20 });
+  const p1 = h.queue.submit({ ...BASE, text: "wedged", queueable: true });
+  await tick();
+  await h.queue.submit({ ...BASE, text: "queued", queueable: true });
+
+  // The turn never settles within the (shortened) timeout — the caller must not delete.
+  expect(await h.queue.clearSession("c", "s")).toEqual({ cleared: false });
+  expect(h.queue.queueLength("c", "s")).toBe(0); // queued prompts still dropped
+
+  // Once the wedged turn finally unwinds, a retry succeeds.
+  h.resolveNext({ ok: false, errorMessage: "aborted" });
+  await p1;
+  expect(await h.queue.clearSession("c", "s")).toEqual({ cleared: true });
 });

--- a/tests/unit/control/turn-queue.test.ts
+++ b/tests/unit/control/turn-queue.test.ts
@@ -7,7 +7,7 @@
 import { expect, test } from "bun:test";
 import { TurnQueue, type TurnQueueDeps } from "../../../src/control/turn-queue";
 import type { TurnRequest, TurnResult } from "../../../src/control/session-turn-runner";
-import { TURN_IDLE_TIMEOUT_REASON } from "../../../src/control/turn-support";
+import { QUEUE_MAX_DEPTH, TURN_IDLE_TIMEOUT_REASON } from "../../../src/control/turn-support";
 
 // Wires a TurnQueue to a controllable deferred runTurn. `runTurn` records each turn's text into
 // `started` (so drain-order tests can assert it) and parks on a pending promise the test resolves
@@ -361,4 +361,62 @@ test("watchdog: a turn whose external abortSignal is already aborted arms no wat
   void q.queue.submit({ ...BASE, text: "A", queueable: true, abortSignal: pre.signal });
   expect(q.setCount()).toBe(0);      // armIdle short-circuited on the already-aborted controller
   expect(q.idleArmed()).toBe(false);
+});
+
+test("queue depth cap: the submit that would exceed QUEUE_MAX_DEPTH rejects with queue-full", async () => {
+  const { queue, resolveNext } = makeQueue();
+  const p1 = queue.submit({ ...BASE, text: "running", queueable: true });
+  await tick();
+  for (let i = 0; i < QUEUE_MAX_DEPTH; i++) {
+    const r = await queue.submit({ ...BASE, text: `q${i}`, queueable: true });
+    expect(r).toMatchObject({ ok: true, queued: true });
+  }
+  const overflow = await queue.submit({ ...BASE, text: "overflow", queueable: true });
+  expect(overflow).toEqual({ ok: false, errorMessage: "queue-full" });
+  expect(queue.queueLength("c", "s")).toBe(QUEUE_MAX_DEPTH);
+  // Drain one item — the queue is below the cap again, so the next submit enqueues.
+  resolveNext();
+  await tick();
+  const afterDrain = await queue.submit({ ...BASE, text: "fits-now", queueable: true });
+  expect(afterDrain).toMatchObject({ ok: true, queued: true });
+  for (let i = 0; i <= QUEUE_MAX_DEPTH; i++) {
+    resolveNext();
+    await tick();
+  }
+  await p1;
+});
+
+test("clearSession drops queued prompts, aborts the running turn, and starts no drained turn", async () => {
+  const emitted: Array<Array<{ id: string }>> = [];
+  const h = makeQueue({
+    emitQueueUpdated: (_chatKey, _sessionAlias, items) => emitted.push(items),
+  });
+  const p1 = h.queue.submit({ ...BASE, text: "running", queueable: true });
+  await tick();
+  await h.queue.submit({ ...BASE, text: "queued-1", queueable: true });
+  await h.queue.submit({ ...BASE, text: "queued-2", queueable: true });
+  expect(h.queue.queueLength("c", "s")).toBe(2);
+  const runningSignal = h.head()!.signal;
+
+  const cleared = h.queue.clearSession("c", "s");
+  // Synchronous part: queue emptied (badge cleared) and running turn aborted.
+  expect(h.queue.queueLength("c", "s")).toBe(0);
+  expect(emitted.at(-1)).toEqual([]);
+  expect(runningSignal.aborted).toBe(true);
+
+  // clearSession resolves only after the aborted turn unwinds (settled).
+  h.resolveNext({ ok: false, errorMessage: "aborted" });
+  await cleared;
+  await p1;
+  await tick();
+  expect(h.started).toEqual(["running"]); // neither queued item started a drained turn
+  expect(h.queue.isBusy("c", "s")).toBe(false);
+});
+
+test("clearSession on an idle session with an empty queue is a no-op", async () => {
+  const emitted: unknown[] = [];
+  const { queue } = makeQueue({ emitQueueUpdated: (_c, _s, items) => emitted.push(items) });
+  await queue.clearSession("c", "s");
+  expect(emitted).toEqual([]); // no spurious queue-updated for a session that had nothing
+  expect(queue.isBusy("c", "s")).toBe(false);
 });

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -430,6 +430,132 @@ test("session removal still waits for a prompt on the same session", async () =>
   await expect(removeForwarded.promise).resolves.toBeUndefined();
 });
 
+test("second prompt is forwarded while a prompt on the same session is still running", async () => {
+  // Regression: the hub turn lock used to serialize prompt-vs-prompt, so a message
+  // sent mid-turn never reached the connector's TurnQueue and bypassed the queue.
+  const firstStarted = deferred<void>();
+  const firstRelease = deferred<unknown>();
+  const secondForwarded = deferred<void>();
+  let promptCount = 0;
+  const { app, instances, loginToken, login } = await makeApp({
+    sendRequest: async (_instanceId, type) => {
+      if (type === MSG.prompt) {
+        promptCount += 1;
+        if (promptCount === 1) {
+          firstStarted.resolve(undefined);
+          return await firstRelease.promise;
+        }
+        secondForwarded.resolve(undefined);
+        return { ok: true, queued: true, queueItemId: "q1" };
+      }
+      return {};
+    },
+  });
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const redeemed = instances.redeemPairingToken(token)!;
+  const rpcPath = `/api/instances/${redeemed.instanceId}/rpc`;
+
+  const firstResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "long task" } }),
+  });
+  await firstStarted.promise;
+
+  const secondResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "queue me" } }),
+  });
+  const forwardedBeforeFirstFinished = await Promise.race([
+    secondForwarded.promise.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+  ]);
+  expect(forwardedBeforeFirstFinished).toBe(true);
+
+  firstRelease.resolve({ ok: true });
+  expect((await firstResponse).status).toBe(200);
+  const second = await secondResponse;
+  expect(second.status).toBe(200);
+  expect(((await second.json()) as { result: { queued?: boolean } }).result.queued).toBe(true);
+});
+
+test("prompt arriving after a queued removal waits behind it (no writer starvation)", async () => {
+  const firstPromptStarted = deferred<void>();
+  const firstPromptRelease = deferred<unknown>();
+  const removeForwarded = deferred<void>();
+  const removeRelease = deferred<unknown>();
+  const latePromptForwarded = deferred<void>();
+  let promptCount = 0;
+  const { app, instances, loginToken, login } = await makeApp({
+    sendRequest: async (_instanceId, type) => {
+      if (type === MSG.prompt) {
+        promptCount += 1;
+        if (promptCount === 1) {
+          firstPromptStarted.resolve(undefined);
+          return await firstPromptRelease.promise;
+        }
+        latePromptForwarded.resolve(undefined);
+        return { ok: true };
+      }
+      if (type === MSG.sessionsRemove) {
+        removeForwarded.resolve(undefined);
+        return await removeRelease.promise;
+      }
+      return {};
+    },
+  });
+  const { cookie } = await login(loginToken);
+  const tokenRes = await app.request("/api/instances/pairing-token", {
+    method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ name: "pc" }),
+  });
+  const { token } = (await tokenRes.json()) as { token: string };
+  const redeemed = instances.redeemPairingToken(token)!;
+  const rpcPath = `/api/instances/${redeemed.instanceId}/rpc`;
+
+  const firstPromptResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "long task" } }),
+  });
+  await firstPromptStarted.promise;
+
+  const removeResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.sessionsRemove, payload: { alias: "backend" } }),
+  });
+  // Let the removal reach the exclusive-lock queue before issuing the late prompt.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const latePromptResponse = app.request(rpcPath, {
+    method: "POST", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "late" } }),
+  });
+
+  // While the first turn runs, neither the removal nor the late prompt is forwarded.
+  const anyForwardedEarly = await Promise.race([
+    removeForwarded.promise.then(() => true),
+    latePromptForwarded.promise.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+  ]);
+  expect(anyForwardedEarly).toBe(false);
+
+  // Turn ends → removal (queued first) goes; the late prompt still waits behind it.
+  firstPromptRelease.resolve({ ok: true });
+  await removeForwarded.promise;
+  const latePromptOvertook = await Promise.race([
+    latePromptForwarded.promise.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+  ]);
+  expect(latePromptOvertook).toBe(false);
+
+  removeRelease.resolve({ ok: true });
+  await latePromptForwarded.promise;
+  expect((await firstPromptResponse).status).toBe(200);
+  expect((await removeResponse).status).toBe(200);
+  expect((await latePromptResponse).status).toBe(200);
+});
+
 test("session rename waits for a lifecycle operation on the same session", async () => {
   const removeStarted = deferred<void>();
   const removeRelease = deferred<unknown>();


### PR DESCRIPTION
## Summary
- Regression since #187: the hub's exclusive per-session turn lock held `MSG.prompt` for the whole turn, so a second web prompt sent while an agent was running never reached the connector's TurnQueue — it bypassed the message queue and ran directly after the turn ended.
- Hub fix: the turn lock is now a keyed read-write lock. Prompts acquire it shared (the connector TurnQueue orders prompt-vs-prompt and enqueues with `queued:true`); lifecycle ops (create/remove/archive/unarchive, commandExecute) stay exclusive so they still wait for running turns (#187); rename keeps bypassing turns (#233).
- Connector hardening surfaced by review: `removeSession`/`archiveSession` now call `TurnQueue.clearSession` (drop queued prompts, abort the running turn, bounded wait for unwind) so no drained turn starts on a removed/archived session and writes ghost history; the per-session queue is capped at `QUEUE_MAX_DEPTH` (20) with a `queue-full` rejection.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `bun test tests/unit` — 0 failures
- [x] New hub tests: second prompt forwarded mid-turn (returns `queued:true`); prompt after a queued removal waits behind it (no writer starvation); existing "remove waits for prompt" / "rename doesn't wait" tests unchanged
- [x] New connector tests: queue-full cap + recovery after drain; `clearSession` drops queue, aborts turn, starts no drained turn; `removeSession`/`archiveSession` wiring
- [ ] Manual: send a message from relay web while a turn is running — it should show the queue chip and be cancelable