### PR TITLE
feat(relay-web): render edit tool cards as aligned line diffs

### DIFF
--- a/packages/channel-relay/src/tool-presentation.ts
+++ b/packages/channel-relay/src/tool-presentation.ts
@@ -3,6 +3,7 @@ import type { ToolStepDto, ToolDetailDto } from "@ganglion/xacpx-relay-protocol"
 
 const TEXT_CAP = 8000;
 const DIFF_CAP = 4000;
+const INSTRUCTION_CAP = 300;
 
 function cap(s: string, n = TEXT_CAP): string {
   return s.length > n ? s.slice(0, n) + "\n…(truncated)" : s;
@@ -133,12 +134,21 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
 
   if (event.kind === "edit") {
     const diff = diffBlock(blocks);
-    if (diff) {
-      const path = asString(diff.path) ?? locationPath(event) ?? asString(input.file_path) ?? asString(input.path) ?? fallbackTitle;
-      const detail: ToolDetailDto = { type: "diff", path, oldText: cap(asString(diff.oldText) ?? "", DIFF_CAP), newText: cap(asString(diff.newText) ?? "", DIFF_CAP) };
+    const path =
+      asString(diff?.path) ?? locationPath(event) ?? asString(input.file_path) ?? asString(input.path) ?? fallbackTitle;
+    const oldText = asString(diff?.oldText) ?? asString(input.old_string) ?? asString(input.oldText);
+    const newText = asString(diff?.newText) ?? asString(input.new_string) ?? asString(input.newText) ?? asString(input.content);
+    const instruction = asString(input.instruction) ?? asString(input.description);
+    if (diff || oldText !== undefined || newText !== undefined) {
+      const detail: ToolDetailDto = {
+        type: "diff",
+        path,
+        oldText: cap(oldText ?? "", DIFF_CAP),
+        newText: cap(newText ?? "", DIFF_CAP),
+        ...(instruction ? { instruction: cap(instruction, INSTRUCTION_CAP) } : {}),
+      };
       return { ...base, title: path, detail };
     }
-    const path = locationPath(event) ?? asString(input.file_path) ?? asString(input.path) ?? fallbackTitle;
     return { ...base, title: path, detail: { type: "fields", fields: primitiveFields(input) } };
   }
 

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -130,7 +130,9 @@ export type ToolStepKind = "read" | "search" | "execute" | "edit" | "think" | "o
 
 /** Friendly, presentation-ready detail for one tool call (no raw JSON crosses the wire). */
 export type ToolDetailDto =
-  | { type: "diff"; path: string; oldText: string; newText: string }
+  // `instruction` carries an edit's human-readable intent (Edit's instruction/description);
+  // optional so old connectors and old web builds stay wire-compatible.
+  | { type: "diff"; path: string; oldText: string; newText: string; instruction?: string }
   | { type: "read"; path: string; lines?: string; preview?: string }
   | { type: "command"; command: string; output?: string; exitCode?: number }
   | { type: "search"; query: string; output?: string }

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -159,7 +159,7 @@ function validAgentCommand(value: unknown): boolean {
 function validToolDetail(d: Record<string, unknown>): boolean {
   switch (d.type) {
     case "diff":
-      return isStr(d.path) && isStr(d.oldText) && isStr(d.newText);
+      return isStr(d.path) && isStr(d.oldText) && isStr(d.newText) && optStr(d.instruction);
     case "read":
       return isStr(d.path) && optStr(d.lines) && optStr(d.preview);
     case "command":

--- a/packages/relay-web/src/__tests__/line-diff.test.ts
+++ b/packages/relay-web/src/__tests__/line-diff.test.ts
@@ -43,11 +43,28 @@ describe("diffLines", () => {
     expect(add).toMatchObject({ oldNo: null, newNo: 2 });
   });
 
+  it("treats an empty old side as a pure addition (new file), no phantom del row", () => {
+    const d = diffLines("", "line1\nline2");
+    expect(d.del).toBe(0);
+    expect(d.add).toBe(2);
+    expect(d.rows.every((r) => r.type === "add")).toBe(true);
+    expect(d.rows).toHaveLength(2);
+  });
+
+  it("treats an empty new side as a pure deletion (full delete), no phantom add row", () => {
+    const d = diffLines("a\nb", "");
+    expect(d.add).toBe(0);
+    expect(d.del).toBe(2);
+    expect(d.rows.every((r) => r.type === "del")).toBe(true);
+    expect(d.rows).toHaveLength(2);
+  });
+
   it("falls back to naive block for pathologically large inputs", () => {
     const big = Array.from({ length: 1600 }, (_, i) => `line ${i}`).join("\n");
     const d = diffLines(big, "");
-    // Naive path: every old line is a deletion, no context rows.
+    // Naive path: every old line is a deletion, no context rows, no phantom addition.
     expect(d.del).toBe(1600);
+    expect(d.add).toBe(0);
     expect(d.rows.some((r) => r.type === "context")).toBe(false);
   });
 });

--- a/packages/relay-web/src/__tests__/line-diff.test.ts
+++ b/packages/relay-web/src/__tests__/line-diff.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { diffLines } from "../lib/line-diff";
+
+describe("diffLines", () => {
+  it("treats identical text as all context", () => {
+    const d = diffLines("a\nb\nc", "a\nb\nc");
+    expect(d.add).toBe(0);
+    expect(d.del).toBe(0);
+    expect(d.rows.every((r) => r.type === "context")).toBe(true);
+    expect(d.rows).toHaveLength(3);
+  });
+
+  it("reports pure insertions", () => {
+    const d = diffLines("a\nb", "a\nb\nc\nd");
+    expect(d.add).toBe(2);
+    expect(d.del).toBe(0);
+    const adds = d.rows.filter((r) => r.type === "add").map((r) => r.text);
+    expect(adds).toEqual(["c", "d"]);
+  });
+
+  it("reports pure deletions", () => {
+    const d = diffLines("a\nb\nc", "a");
+    expect(d.add).toBe(0);
+    expect(d.del).toBe(2);
+    const dels = d.rows.filter((r) => r.type === "del").map((r) => r.text);
+    expect(dels).toEqual(["b", "c"]);
+  });
+
+  it("renders a single-line modification as one del + one add around context", () => {
+    const d = diffLines("keep\nold\ntail", "keep\nnew\ntail");
+    expect(d.add).toBe(1);
+    expect(d.del).toBe(1);
+    expect(d.rows.filter((r) => r.type === "context").map((r) => r.text)).toEqual(["keep", "tail"]);
+    expect(d.rows.find((r) => r.type === "del")?.text).toBe("old");
+    expect(d.rows.find((r) => r.type === "add")?.text).toBe("new");
+  });
+
+  it("assigns old/new line numbers correctly", () => {
+    const d = diffLines("a\nb\nc", "a\nx\nc");
+    const del = d.rows.find((r) => r.type === "del");
+    const add = d.rows.find((r) => r.type === "add");
+    expect(del).toMatchObject({ oldNo: 2, newNo: null });
+    expect(add).toMatchObject({ oldNo: null, newNo: 2 });
+  });
+
+  it("falls back to naive block for pathologically large inputs", () => {
+    const big = Array.from({ length: 1600 }, (_, i) => `line ${i}`).join("\n");
+    const d = diffLines(big, "");
+    // Naive path: every old line is a deletion, no context rows.
+    expect(d.del).toBe(1600);
+    expect(d.rows.some((r) => r.type === "context")).toBe(false);
+  });
+});

--- a/packages/relay-web/src/__tests__/tooldetail.test.ts
+++ b/packages/relay-web/src/__tests__/tooldetail.test.ts
@@ -14,11 +14,23 @@ describe("ToolDetail", () => {
     expect(w.find('[data-test="diff-add"]').text()).toContain("const a = 2");
   });
 
-  it("shows +N/−N stat badges for a diff", () => {
+  it("shows +N/−N stat badges from a real line diff", () => {
     const w = render({ type: "diff", path: "src/x.ts", oldText: "a\nb", newText: "a\nb\nc\nd" });
     const stats = w.find('[data-test="diff-stats"]').text();
-    expect(stats).toContain("+4"); // 4 non-empty added lines
-    expect(stats).toContain("−2"); // 2 non-empty removed lines
+    expect(stats).toContain("+2"); // 2 appended lines
+    expect(stats).not.toContain("−"); // nothing removed
+  });
+
+  it("renders the edit instruction at the top of a diff card", () => {
+    const w = render({ type: "diff", path: "src/x.ts", oldText: "a", newText: "b", instruction: "rename the thing" });
+    expect(w.find('[data-test="diff-instruction"]').text()).toContain("rename the thing");
+  });
+
+  it("keeps unchanged lines as context, not duplicated add/del", () => {
+    const w = render({ type: "diff", path: "src/x.ts", oldText: "keep\nold", newText: "keep\nnew" });
+    expect(w.findAll('[data-test="diff-context"]').length).toBe(1); // "keep"
+    expect(w.find('[data-test="diff-del"]').text()).toContain("old");
+    expect(w.find('[data-test="diff-add"]').text()).toContain("new");
   });
 
   it("renders a command with a terminal output block and exit code", () => {

--- a/packages/relay-web/src/components/ToolDetail.vue
+++ b/packages/relay-web/src/components/ToolDetail.vue
@@ -3,35 +3,52 @@ import { computed } from "vue";
 import type { ToolDetailDto } from "@ganglion/xacpx-relay-protocol";
 import { File, Search } from "lucide-vue-next";
 import ExpandableBlock from "./ExpandableBlock.vue";
+import { diffLines } from "../lib/line-diff";
 
 const props = defineProps<{ detail: ToolDetailDto }>();
 
-// Split a diff body into rendered +/- lines.
-const diffLines = computed(() => {
-  if (props.detail.type !== "diff") return { del: [] as string[], add: [] as string[] };
-  return { del: props.detail.oldText.split("\n"), add: props.detail.newText.split("\n") };
-});
-// Non-empty changed-line counts for the +N/−N stat badges.
-const diffStats = computed(() => ({
-  add: diffLines.value.add.filter((l) => l.length > 0).length,
-  del: diffLines.value.del.filter((l) => l.length > 0).length,
-}));
+// Line-level diff of the two blobs, with old/new line numbers and true +/− counts.
+const parsedDiff = computed(() =>
+  props.detail.type === "diff" ? diffLines(props.detail.oldText, props.detail.newText) : null,
+);
+// Result-line count for the search badge (non-empty output lines).
+const searchCount = computed(() =>
+  props.detail.type === "search" && props.detail.output
+    ? props.detail.output.split("\n").filter((l) => l.length > 0).length
+    : 0,
+);
 </script>
 
 <template>
   <div class="mt-1 space-y-1 text-xs">
     <template v-if="detail.type === 'diff'">
+      <p
+        v-if="detail.instruction"
+        data-test="diff-instruction"
+        class="line-clamp-2 text-fg-muted"
+        :title="detail.instruction"
+      >{{ detail.instruction }}</p>
       <div class="flex min-w-0 items-center gap-2 font-mono text-fg-muted">
         <span class="inline-flex min-w-0 items-center gap-1"><File :size="14" class="shrink-0" /><span class="truncate">{{ detail.path }}</span></span>
         <span data-test="diff-stats" class="ml-auto flex shrink-0 items-center gap-2 font-mono text-[10px]">
-          <span v-if="diffStats.add" class="text-run">+{{ diffStats.add }}</span>
-          <span v-if="diffStats.del" class="text-danger">−{{ diffStats.del }}</span>
+          <span v-if="parsedDiff && parsedDiff.add" class="text-run">+{{ parsedDiff.add }}</span>
+          <span v-if="parsedDiff && parsedDiff.del" class="text-danger">−{{ parsedDiff.del }}</span>
         </span>
       </div>
-      <ExpandableBlock>
-        <div class="overflow-x-auto rounded bg-bg p-2 font-mono">
-          <div v-for="(l, i) in diffLines.del" :key="'d' + i" data-test="diff-del" class="whitespace-pre text-danger">- {{ l }}</div>
-          <div v-for="(l, i) in diffLines.add" :key="'a' + i" data-test="diff-add" class="whitespace-pre text-run">+ {{ l }}</div>
+      <ExpandableBlock v-if="parsedDiff && parsedDiff.rows.length">
+        <div class="overflow-x-auto rounded bg-bg font-mono leading-relaxed">
+          <div
+            v-for="(r, i) in parsedDiff.rows"
+            :key="i"
+            :data-test="r.type === 'add' ? 'diff-add' : r.type === 'del' ? 'diff-del' : 'diff-context'"
+            class="flex"
+            :class="r.type === 'add' ? 'bg-run/10' : r.type === 'del' ? 'bg-danger/10' : ''"
+          >
+            <span class="w-8 shrink-0 select-none border-r border-border px-1 text-right tabular-nums text-fg-muted/60">{{ r.oldNo ?? "" }}</span>
+            <span class="w-8 shrink-0 select-none border-r border-border px-1 text-right tabular-nums text-fg-muted/60">{{ r.newNo ?? "" }}</span>
+            <span class="w-3 shrink-0 select-none text-center" :class="r.type === 'add' ? 'text-run' : r.type === 'del' ? 'text-danger' : 'text-fg-muted/40'">{{ r.type === 'add' ? '+' : r.type === 'del' ? '-' : '' }}</span>
+            <span class="whitespace-pre px-1" :class="r.type === 'add' ? 'text-run' : r.type === 'del' ? 'text-danger' : 'text-fg'">{{ r.text }}</span>
+          </div>
         </div>
       </ExpandableBlock>
     </template>
@@ -41,7 +58,7 @@ const diffStats = computed(() => ({
       <ExpandableBlock v-if="detail.output">
         <pre data-test="cmd-output" class="overflow-x-auto rounded bg-raised p-2 font-mono text-fg whitespace-pre-wrap">{{ detail.output }}</pre>
       </ExpandableBlock>
-      <div v-if="detail.exitCode !== undefined" class="text-fg-muted">exit {{ detail.exitCode }}</div>
+      <div v-if="detail.exitCode !== undefined" :class="detail.exitCode !== 0 ? 'text-danger' : 'text-fg-muted'">exit {{ detail.exitCode }}</div>
     </template>
 
     <template v-else-if="detail.type === 'read'">
@@ -52,7 +69,7 @@ const diffStats = computed(() => ({
     </template>
 
     <template v-else-if="detail.type === 'search'">
-      <div data-test="search-query" class="flex min-w-0 items-center gap-1 font-mono text-fg"><Search :size="14" class="shrink-0" /><span class="truncate">{{ detail.query }}</span></div>
+      <div data-test="search-query" class="flex min-w-0 items-center gap-1 font-mono text-fg"><Search :size="14" class="shrink-0" /><span class="truncate">{{ detail.query }}</span><span v-if="searchCount" data-test="search-count" class="ml-auto shrink-0 text-[10px] text-fg-muted">{{ searchCount }}</span></div>
       <ExpandableBlock v-if="detail.output">
         <pre data-test="search-output" class="overflow-x-auto rounded bg-bg p-2 font-mono text-fg-muted whitespace-pre-wrap">{{ detail.output }}</pre>
       </ExpandableBlock>

--- a/packages/relay-web/src/lib/line-diff.ts
+++ b/packages/relay-web/src/lib/line-diff.ts
@@ -27,8 +27,10 @@ function naiveDiff(oldLines: string[], newLines: string[]): ParsedDiff {
 /** Diff two independent text blobs at line granularity via classic LCS DP, then
  *  backtrack into renderable rows with old/new line numbers. */
 export function diffLines(oldText: string, newText: string): ParsedDiff {
-  const oldLines = oldText.split("\n");
-  const newLines = newText.split("\n");
+  // "".split("\n") returns [""], not []; treat an empty blob as zero lines so a
+  // new-file or full-delete edit doesn't emit a phantom empty row / miscount.
+  const oldLines = oldText ? oldText.split("\n") : [];
+  const newLines = newText ? newText.split("\n") : [];
   const n = oldLines.length;
   const m = newLines.length;
 

--- a/packages/relay-web/src/lib/line-diff.ts
+++ b/packages/relay-web/src/lib/line-diff.ts
@@ -1,0 +1,78 @@
+import type { DiffRow, ParsedDiff } from "./unified-diff";
+
+// Guard against pathological O(n·m) LCS on large inputs. Connector already caps
+// each side at DIFF_CAP=4000 chars, so this is rarely hit.
+const MAX_CELLS = 250_000;
+const MAX_SIDE = 1500;
+
+/** Naive fallback: render every old line as a deletion, then every new line as
+ *  an addition. Used when the LCS table would be too large. */
+function naiveDiff(oldLines: string[], newLines: string[]): ParsedDiff {
+  const rows: DiffRow[] = [];
+  let oldNo = 1;
+  let newNo = 1;
+  let del = 0;
+  let add = 0;
+  for (const text of oldLines) {
+    rows.push({ type: "del", oldNo: oldNo++, newNo: null, text });
+    del++;
+  }
+  for (const text of newLines) {
+    rows.push({ type: "add", oldNo: null, newNo: newNo++, text });
+    add++;
+  }
+  return { rows, add, del };
+}
+
+/** Diff two independent text blobs at line granularity via classic LCS DP, then
+ *  backtrack into renderable rows with old/new line numbers. */
+export function diffLines(oldText: string, newText: string): ParsedDiff {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+  const n = oldLines.length;
+  const m = newLines.length;
+
+  if (n > MAX_SIDE || m > MAX_SIDE || n * m > MAX_CELLS) {
+    return naiveDiff(oldLines, newLines);
+  }
+
+  // lcs[i][j] = length of the longest common subsequence of oldLines[i:] and newLines[j:].
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = oldLines[i] === newLines[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const rows: DiffRow[] = [];
+  let add = 0;
+  let del = 0;
+  let i = 0;
+  let j = 0;
+  let oldNo = 1;
+  let newNo = 1;
+  while (i < n && j < m) {
+    if (oldLines[i] === newLines[j]) {
+      rows.push({ type: "context", oldNo: oldNo++, newNo: newNo++, text: oldLines[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      rows.push({ type: "del", oldNo: oldNo++, newNo: null, text: oldLines[i] });
+      del++;
+      i++;
+    } else {
+      rows.push({ type: "add", oldNo: null, newNo: newNo++, text: newLines[j] });
+      add++;
+      j++;
+    }
+  }
+  while (i < n) {
+    rows.push({ type: "del", oldNo: oldNo++, newNo: null, text: oldLines[i++] });
+    del++;
+  }
+  while (j < m) {
+    rows.push({ type: "add", oldNo: null, newNo: newNo++, text: newLines[j++] });
+    add++;
+  }
+  return { rows, add, del };
+}

--- a/tests/unit/packages/channel-relay/tool-presentation.test.ts
+++ b/tests/unit/packages/channel-relay/tool-presentation.test.ts
@@ -12,6 +12,34 @@ test("edit reads the content diff block", () => {
   });
 });
 
+test("edit builds a diff from raw old_string/new_string when no diff block", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "e1", toolName: "Edit", kind: "edit", status: "success",
+    rawInput: { file_path: "src/a.ts", old_string: "let a = 1", new_string: "let a = 2" },
+  });
+  expect(step.title).toBe("src/a.ts");
+  expect(step.detail).toMatchObject({ type: "diff", path: "src/a.ts", oldText: "let a = 1", newText: "let a = 2" });
+});
+
+test("edit carries a capped instruction on the diff detail", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "e2", toolName: "Edit", kind: "edit", status: "success",
+    rawInput: { file_path: "src/a.ts", old_string: "a", new_string: "b", instruction: "x".repeat(500) },
+  });
+  const detail = step.detail as { type: "diff"; instruction?: string };
+  expect(detail.type).toBe("diff");
+  expect(detail.instruction?.startsWith("x".repeat(300))).toBe(true);
+  expect(detail.instruction?.length).toBeLessThanOrEqual(320); // 300 + "…(truncated)"
+});
+
+test("edit falls back to fields when neither diff block nor old/new text exist", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "e3", toolName: "Edit", kind: "edit", status: "success",
+    rawInput: { file_path: "src/a.ts", mode: "insert" },
+  });
+  expect(step.detail?.type).toBe("fields");
+});
+
 test("execute reads command + stdout + exit code", () => {
   const step = toolUseEventToStepDto({
     toolCallId: "t2", toolName: "Bash", kind: "execute", status: "success",

--- a/tests/unit/packages/channel-relay/tool-presentation.test.ts
+++ b/tests/unit/packages/channel-relay/tool-presentation.test.ts
@@ -40,6 +40,24 @@ test("edit falls back to fields when neither diff block nor old/new text exist",
   expect(step.detail?.type).toBe("fields");
 });
 
+test("edit maps Write-style rawInput.content to the diff newText with empty oldText", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "e4", toolName: "Write", kind: "edit", status: "success",
+    rawInput: { file_path: "src/new.ts", content: "export const x = 1\n" },
+  });
+  expect(step.title).toBe("src/new.ts");
+  expect(step.detail).toMatchObject({ type: "diff", path: "src/new.ts", oldText: "", newText: "export const x = 1\n" });
+});
+
+test("edit prefers the ACP diff block over conflicting rawInput old/new text", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "e5", toolName: "Edit", kind: "edit", status: "success",
+    content: [{ type: "diff", path: "src/b.ts", oldText: "block old", newText: "block new" }],
+    rawInput: { file_path: "src/ignored.ts", old_string: "raw old", new_string: "raw new" },
+  });
+  expect(step.detail).toMatchObject({ type: "diff", path: "src/b.ts", oldText: "block old", newText: "block new" });
+});
+
 test("execute reads command + stdout + exit code", () => {
   const step = toolUseEventToStepDto({
     toolCallId: "t2", toolName: "Bash", kind: "execute", status: "success",


### PR DESCRIPTION
Show old_string/new_string edits as a real line-level diff (LCS-aligned rows with line numbers and true +N/−N counts) instead of a flat fields dump, surface the edit instruction (clamped) at the top of the card, and carry it over the wire via an optional ToolDetailDto.diff.instruction. Also color nonzero command exit codes and add a search result-count badge.