### PR TITLE
fix(relay): preserve renamed session after clear

### DIFF
--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -912,6 +912,7 @@ export class SessionService {
         model: sameAgentExisting?.model,
         effort: sameAgentExisting?.effort,
         reply_mode: sameAgentExisting?.reply_mode,
+        display_name: sameAgentExisting?.display_name,
         created_at: existingSession?.created_at ?? now,
         last_used_at: now,
       };

--- a/tests/unit/sessions/session-service.test.ts
+++ b/tests/unit/sessions/session-service.test.ts
@@ -230,6 +230,18 @@ test("rebinds an existing alias to a different transport session", async () => {
   expect(session.transportSession).toBe("existing-review");
 });
 
+test("preserves a display name when an alias is recreated on the same agent", async () => {
+  const store = new MemoryStateStore();
+  const service = new SessionService(createConfig(), store, createEmptyState());
+
+  await service.createSession("api-fix", "codex", "backend");
+  await service.setDisplayName("api-fix", "API hotfix");
+
+  const session = await service.attachSession("api-fix", "codex", "backend", "fresh-session");
+
+  expect(session.displayName).toBe("API hotfix");
+});
+
 test("sets and resolves current session by chat key", async () => {
   const store = new MemoryStateStore();
   const service = new SessionService(createConfig(), store, createEmptyState());


### PR DESCRIPTION
## Summary\n- preserve relay-web session display names when a logical session is recreated\n- add a regression test covering rename followed by rebind/clear\n\n## Verification\n- bun test tests/unit/sessions/session-service.test.ts\n- npx tsc --noEmit