### PR TITLE
fix(relay-web): ignore stale expanded directories

### DIFF
--- a/packages/relay-web/src/__tests__/files.test.ts
+++ b/packages/relay-web/src/__tests__/files.test.ts
@@ -71,6 +71,31 @@ describe("files store", () => {
     expect(s.tree[""]?.map((entry) => entry.name)).toEqual(["new.ts"]);
   });
 
+  it("ignores missing cached expanded directories during workspace refresh", async () => {
+    // Spy must be restored before the test exits — beforeEach only resets the rpc mock,
+    // and a leaked localStorage getter poisons every later test's expanded-set rehydration.
+    const lsGet = vi.spyOn(globalThis, "localStorage", "get").mockReturnValue({
+      getItem: () => JSON.stringify([".qoder/skills/release"]),
+      setItem: vi.fn(),
+    } as unknown as Storage);
+    try {
+      const s = useFilesStore();
+      rpc
+        .mockResolvedValueOnce({ workspace: "ws", path: "", root: "/ws", sep: "/", entries: [] })
+        .mockResolvedValueOnce({ error: { code: "internal", message: "not-found" } });
+      s.instanceId = "i1";
+      s.workspace = "ws";
+      s.expanded = new Set([".qoder/skills/release"]);
+      rpc.mockResolvedValueOnce({ error: { code: "internal", message: "not-found" } });
+      await s.selectWorkspace("i1", "ws");
+
+      expect(s.error).toBe("");
+      expect(s.expanded.has(".qoder/skills/release")).toBe(false);
+    } finally {
+      lsGet.mockRestore();
+    }
+  });
+
   it("selects a workspace and lists the root", async () => {
     rpc.mockResolvedValueOnce({ workspace: "ws", path: "", entries: [
       { name: "src", type: "dir" },

--- a/packages/relay-web/src/stores/files.ts
+++ b/packages/relay-web/src/stores/files.ts
@@ -69,6 +69,7 @@ export const useFilesStore = defineStore("files", () => {
   const hits = ref<FsSearchHitDto[]>([]);
   let diffRequestId = 0;
   let workspaceEpoch = 0;
+  let lastListTreeError = "";
   let gitSummaryRevision = 0;
   let activeGitSummaryKey = "";
   const searchOpts = ref<{ mode: "name" | "content"; matchCase: boolean; wholeWord: boolean; regex: boolean; include: string; exclude: string }>({
@@ -164,8 +165,23 @@ export const useFilesStore = defineStore("files", () => {
     entries.value = tree.value[""] ?? [];
     // Revalidate every expanded cached layer (best-effort). Keeping a cached
     // directory forever merely because it already exists would violate SWR.
+    const staleExpanded = [...expanded.value].filter(Boolean);
     await Promise.all(
-      [...expanded.value].filter(Boolean).map((dir) => listTree(dir).catch(() => {})),
+      staleExpanded.map(async (dir) => {
+        try {
+          await listTree(dir, { quiet: true });
+        } catch {
+          // A cached expanded directory may have been removed since the last visit.
+          // Drop only confirmed missing paths; transient transport failures should not
+          // destroy the user's navigation state.
+          if (lastListTreeError === "not-found" || lastListTreeError === "unknown-workspace") {
+            const next = new Set(expanded.value);
+            next.delete(dir);
+            expanded.value = next;
+            try { localStorage.setItem(expandedKey(), JSON.stringify([...next])); } catch { /* ignore */ }
+          }
+        }
+      }),
     );
     void loadStatus();
   }
@@ -267,7 +283,7 @@ export const useFilesStore = defineStore("files", () => {
   function expandedKey(): string { return `xacpx.fileTree.expanded.${workspace.value ?? ""}`; }
 
   /** Fetch one directory layer into the tree cache, recording root/sep along the way. */
-  async function listTree(dir: string): Promise<void> {
+  async function listTree(dir: string, options: { quiet?: boolean } = {}): Promise<void> {
     if (!instanceId.value || !workspace.value) return;
     const id = instanceId.value;
     const ws = workspace.value;
@@ -277,6 +293,7 @@ export const useFilesStore = defineStore("files", () => {
       && workspace.value === ws;
     loadingDirs.value = new Set(loadingDirs.value).add(dir);
     try {
+      lastListTreeError = "";
       const r = unwrap(await api.rpc<FsListResult>(id, "control.fs.list", { workspace: ws, path: dir }));
       if (!isCurrent()) return;
       root.value = r.root; sepChar.value = r.sep;
@@ -284,7 +301,9 @@ export const useFilesStore = defineStore("files", () => {
       persistWorkspaceSnapshot();
     } catch (e) {
       if (!isCurrent()) return;
-      error.value = e instanceof Error ? e.message : "list-failed";
+      lastListTreeError = e instanceof Error ? e.message : "list-failed";
+      if (!options.quiet) error.value = e instanceof Error ? e.message : "list-failed";
+      else throw e;
     } finally {
       if (isCurrent()) {
         const next = new Set(loadingDirs.value); next.delete(dir); loadingDirs.value = next;

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -912,6 +912,7 @@ export class SessionService {
         model: sameAgentExisting?.model,
         effort: sameAgentExisting?.effort,
         reply_mode: sameAgentExisting?.reply_mode,
+        display_name: sameAgentExisting?.display_name,
         created_at: existingSession?.created_at ?? now,
         last_used_at: now,
       };

--- a/tests/unit/sessions/session-service.test.ts
+++ b/tests/unit/sessions/session-service.test.ts
@@ -230,6 +230,18 @@ test("rebinds an existing alias to a different transport session", async () => {
   expect(session.transportSession).toBe("existing-review");
 });
 
+test("preserves a display name when an alias is recreated on the same agent", async () => {
+  const store = new MemoryStateStore();
+  const service = new SessionService(createConfig(), store, createEmptyState());
+
+  await service.createSession("api-fix", "codex", "backend");
+  await service.setDisplayName("api-fix", "API hotfix");
+
+  const session = await service.attachSession("api-fix", "codex", "backend", "fresh-session");
+
+  expect(session.displayName).toBe("API hotfix");
+});
+
 test("sets and resolves current session by chat key", async () => {
   const store = new MemoryStateStore();
   const service = new SessionService(createConfig(), store, createEmptyState());


### PR DESCRIPTION
## Summary
- keep stale expanded-directory refreshes from showing  in the Files panel
- remove only confirmed missing directories from persisted expanded state
- preserve expanded state across transient refresh failures
- add regression coverage for the workspace-switch case

## Verification
- 
- bun test v1.3.14 (0d9b296a) (33 passed)