### PR TITLE
fix(relay-web): avoid false send failures on network jitter

### DIFF
--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -540,6 +540,27 @@ test("a prompt RPC timeout does not surface an error (results stream via events)
   expect(chat.sending).toBe(false);
 });
 
+test("network jitter after a turn starts does not mark the accepted prompt as send-failed", async () => {
+  let rejectPrompt!: (error: unknown) => void;
+  rpc.mockReturnValueOnce(new Promise((_resolve, reject) => { rejectPrompt = reject; }));
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  const sending = chat.send("keep working");
+
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: {
+    type: "turn-started", chatKey: "relay:a1", sessionAlias: "s1",
+  } });
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: {
+    type: "turn-output", chatKey: "relay:a1", sessionAlias: "s1", chunk: "still running",
+  } });
+  rejectPrompt(new TypeError("Failed to fetch"));
+  await sending;
+
+  expect(chat.error).toBe("");
+  expect(chat.messages.at(-1)?.failed).toBeUndefined();
+  expect(chat.streaming).toBe("still running");
+});
+
 test("a non-timeout prompt error still surfaces", async () => {
   rpc.mockRejectedValueOnce(new ApiError("instance-offline", 503));
   const chat = useChatStore();

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -561,6 +561,20 @@ test("network jitter after a turn starts does not mark the accepted prompt as se
   expect(chat.streaming).toBe("still running");
 });
 
+test("network jitter without turn events converges the optimistic prompt from history", async () => {
+  rpc.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+  const fetchMock = vi.fn(async () => new Response(JSON.stringify({ messages: [] }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+  const chat = useChatStore();
+  chat.select("i1", "s1");
+  await chat.send("never arrived");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(fetchMock).toHaveBeenCalledWith("/api/instances/i1/sessions/s1/messages?limit=100", { credentials: "include" });
+  expect(chat.messages).toEqual([]);
+  expect(chat.error).toBe("");
+});
+
 test("a non-timeout prompt error still surfaces", async () => {
   rpc.mockRejectedValueOnce(new ApiError("instance-offline", 503));
   const chat = useChatStore();

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -693,6 +693,7 @@ export const useChatStore = defineStore("chat", () => {
     // only surface on the next list change (the next message). Mark failure through the proxy so
     // the bubble turns red — and shows Failed/Resend — the instant the send errors.
     const entry = messages.value[messages.value.length - 1]!;
+    let transportFailure = false;
     try {
       // The web dashboard is GUI-first: every message — including `/`-prefixed text —
       // is sent as a prompt so it streams as a normal turn. xacpx slash commands are
@@ -729,6 +730,7 @@ export const useChatStore = defineStore("chat", () => {
       // optimistic row as definitely failed (or invite an unsafe duplicate resend);
       // live events and the next history convergence provide the authoritative state.
       const isTransportFailure = e instanceof TypeError;
+      transportFailure = isTransportFailure;
       if (!isTimeout && !isTransportFailure) {
         error.value = e instanceof ApiError ? e.code : "send-failed";
         entry.failed = true;
@@ -740,9 +742,15 @@ export const useChatStore = defineStore("chat", () => {
       if (remaining > 0) pendingPromptRequests.set(pendingKey, remaining);
       else {
         pendingPromptRequests.delete(pendingKey);
-        const shouldReload = deferredHistoryLoads.delete(pendingKey);
-        if (shouldReload && selectedKey.value === pendingKey) void loadHistory().catch(() => {});
       }
+      // A transport failure is ambiguous: the prompt may have reached the Hub, or
+      // it may never have left the browser. Once all overlapping prompt RPCs settle,
+      // replace the optimistic transcript with the authoritative history page so a
+      // never-delivered bubble cannot remain forever. If another prompt is pending,
+      // defer the same convergence until that last request settles.
+      if (transportFailure) deferredHistoryLoads.add(pendingKey);
+      const shouldReload = remaining === 0 && deferredHistoryLoads.delete(pendingKey);
+      if (shouldReload && selectedKey.value === pendingKey) void loadHistory().catch(() => {});
       sending.value = false;
     }
   }

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -723,7 +723,13 @@ export const useChatStore = defineStore("chat", () => {
       }
     } catch (e) {
       const isTimeout = e instanceof ApiError && (e.status === 504 || e.code === "timeout");
-      if (!isTimeout) {
+      // Fetch reports a dropped connection as a bare TypeError, even when the Hub
+      // already accepted the prompt and the turn is streaming over WebSocket. Its
+      // delivery state is therefore indeterminate, just like a 504. Do not mark the
+      // optimistic row as definitely failed (or invite an unsafe duplicate resend);
+      // live events and the next history convergence provide the authoritative state.
+      const isTransportFailure = e instanceof TypeError;
+      if (!isTimeout && !isTransportFailure) {
         error.value = e instanceof ApiError ? e.code : "send-failed";
         entry.failed = true;
         rollbackIndicators();


### PR DESCRIPTION
## Summary

- Treat browser fetch TypeError during prompt RPC as an indeterminate delivery result.
- Keep the optimistic prompt visible without marking it send-failed; live events and history convergence remain authoritative.
- Add a regression test covering a dropped HTTP response after turn-started/turn-output.

## Validation

- Relay Web chat tests: 67 passed
- Full Relay Web suite: 1023 passed
- Relay Web typecheck and production build passed