### PR TITLE
fix daemon recovery after in-place upgrades

### DIFF
--- a/docs/code-wiki.md
+++ b/docs/code-wiki.md
@@ -278,7 +278,7 @@ Server side:
 
 `DaemonController`: external control surface (called by the CLI)
 
-- `getStatus()`: PID does not exist → stopped; PID exists but the process is gone → clean up runtime files; PID present but no status → indeterminate: [daemon-controller.ts](../src/daemon/daemon-controller.ts#L51-L73)
+- `getStatus()`: matching PID/status and a live process → running; a fresh status-only live daemon on non-Windows repairs its PID file; stale or incomplete live metadata → indeterminate; dead PID metadata is cleaned up: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
 - `start()`: spawn detached → write pid → wait for status ready (pid matches): [daemon-controller.ts](../src/daemon/daemon-controller.ts#L75-L93)
 - `stop()`: terminate → wait for exit → clean up pid/status: [daemon-controller.ts](../src/daemon/daemon-controller.ts#L96-L109)
 

--- a/docs/code-wiki.md
+++ b/docs/code-wiki.md
@@ -278,9 +278,10 @@ Server side:
 
 `DaemonController`: external control surface (called by the CLI)
 
-- `getStatus()`: matching PID/status and a live process → running; a fresh status-only live daemon on non-Windows repairs its PID file; stale or incomplete live metadata → indeterminate; dead PID metadata is cleaned up: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
-- `start()`: spawn detached → write pid → wait for status ready (pid matches): [daemon-controller.ts](../src/daemon/daemon-controller.ts#L75-L93)
-- `stop()`: terminate → wait for exit → clean up pid/status: [daemon-controller.ts](../src/daemon/daemon-controller.ts#L96-L109)
+- `getStatus()`: matching PID/status and a live process → running; conflicting or incomplete live metadata → read-only indeterminate; dead PID metadata is cleaned up: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
+- `start()`: spawn detached → write pid → wait for status ready (pid matches): [daemon-controller.ts](../src/daemon/daemon-controller.ts)
+- `stop()`: reconcile daemon identity → terminate → wait for exit → clean up pid/status; status-only POSIX recovery additionally requires consumer-lock and OS start-time proof: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
+- Windows `cli.js run` initializes the durable generation/orphan context shared with `buildApp`: [windows-daemon-runtime.ts](../src/daemon/windows-daemon-runtime.ts)
 
 ### 5.10 Orchestration (src/orchestration/*)
 

--- a/docs/code-wiki.md
+++ b/docs/code-wiki.md
@@ -114,10 +114,10 @@ The assembly point is in `buildApp()`: it injects capabilities such as worker di
 
 ### 4.1 Foreground Run (development/debugging)
 
-- Entrypoint: `xacpx run` -> [defaultRun()](../src/cli.ts#L487-L524)
+- Entrypoints: `xacpx run` and direct [main()](../src/main.ts) both delegate to [runDefaultRuntime()](../src/cli.ts)
 - Core steps:
   - Resolve runtimePaths: `resolveRuntimePaths()`: [main.ts](../src/main.ts#L653-L668)
-  - Create `DaemonRuntime` (writes status/heartbeat even in the foreground, for unified observability): [cli.ts](../src/cli.ts#L497-L523)
+  - Refuse to overlap a live/indeterminate daemon, then acquire the same core runtime ownership lock used by background mode; foreground runs do not create `DaemonRuntime` or write daemon PID/status: [cli.ts](../src/cli.ts)
   - Create the channels registry and enter `runConsole()`: [run-console.ts](../src/run-console.ts#L45-L152)
 
 ### 4.2 Background daemon (normal usage)
@@ -175,8 +175,8 @@ The assembly point is in `buildApp()`: it injects capabilities such as worker di
   - Write daemon runtime metadata: `daemonRuntime.start(...)`: [run-console.ts](../src/run-console.ts#L70-L82)
   - Start the orchestration IPC server: `runtime.orchestration.server.start()`: [run-console.ts](../src/run-console.ts#L75-L75)
   - Periodic heartbeat: [run-console.ts](../src/run-console.ts#L76-L81)
-- consumer lock (to avoid multiple processes consuming the same channel redundantly):
-  - A failed acquire throws `ActiveWeixinConsumerLockError`: [run-console.ts](../src/run-console.ts#L84-L129)
+- required runtime ownership lock (before shared-state reconciliation, orphan sweeps, scheduler, or channel activation):
+  - A failed acquire follows the generic `ActiveConsumerLockError` contract; POSIX core ownership is a kernel-held `flock`, while Windows uses the runtime-owner IPC guard: [runtime-consumer-lock.ts](../src/daemon/runtime-consumer-lock.ts), [run-console.ts](../src/run-console.ts)
 - Start the channels: `channels.startAll(...)`: [run-console.ts](../src/run-console.ts#L132-L137)
 - finally cleanup: stop IPC / dispose / stopAll / release lock: [run-console.ts](../src/run-console.ts#L154-L209)
 
@@ -281,7 +281,7 @@ Server side:
 - `getStatus()`: matching PID/status and a live process → running; conflicting or incomplete live metadata → read-only indeterminate; dead PID metadata is cleaned up: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
 - `start()`: spawn detached → write pid → wait for status ready (pid matches): [daemon-controller.ts](../src/daemon/daemon-controller.ts)
 - `stop()`: reconcile daemon identity → revalidate recovered POSIX process identity → terminate → wait for exit → clean up pid/status; status-only POSIX recovery additionally requires consumer-lock and OS start-time proof: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
-- Every default runtime holds a channel-independent core consumer lock (plus any legacy channel lock); internal Windows `cli.js run` publishes its generation/orphan context only after that ownership: [runtime-consumer-lock.ts](../src/daemon/runtime-consumer-lock.ts), [windows-daemon-runtime.ts](../src/daemon/windows-daemon-runtime.ts), [run-console.ts](../src/run-console.ts)
+- Every runtime entry holds a channel-independent, OS-held core consumer lock (plus any legacy channel lock); the stable core JSON file is diagnostic metadata rather than the mutex. Internal Windows `cli.js run` publishes its generation/orphan context only after that ownership: [runtime-consumer-lock.ts](../src/daemon/runtime-consumer-lock.ts), [windows-daemon-runtime.ts](../src/daemon/windows-daemon-runtime.ts), [run-console.ts](../src/run-console.ts)
 
 ### 5.10 Orchestration (src/orchestration/*)
 

--- a/docs/code-wiki.md
+++ b/docs/code-wiki.md
@@ -281,7 +281,7 @@ Server side:
 - `getStatus()`: matching PID/status and a live process → running; conflicting or incomplete live metadata → read-only indeterminate; dead PID metadata is cleaned up: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
 - `start()`: spawn detached → write pid → wait for status ready (pid matches): [daemon-controller.ts](../src/daemon/daemon-controller.ts)
 - `stop()`: reconcile daemon identity → revalidate recovered POSIX process identity → terminate → wait for exit → clean up pid/status; status-only POSIX recovery additionally requires consumer-lock and OS start-time proof: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
-- Internal Windows `cli.js run` prepares the generation/orphan context shared with `buildApp`, then publishes it only after consumer ownership: [windows-daemon-runtime.ts](../src/daemon/windows-daemon-runtime.ts), [run-console.ts](../src/run-console.ts)
+- Every default runtime holds a channel-independent core consumer lock (plus any legacy channel lock); internal Windows `cli.js run` publishes its generation/orphan context only after that ownership: [runtime-consumer-lock.ts](../src/daemon/runtime-consumer-lock.ts), [windows-daemon-runtime.ts](../src/daemon/windows-daemon-runtime.ts), [run-console.ts](../src/run-console.ts)
 
 ### 5.10 Orchestration (src/orchestration/*)
 

--- a/docs/code-wiki.md
+++ b/docs/code-wiki.md
@@ -280,8 +280,8 @@ Server side:
 
 - `getStatus()`: matching PID/status and a live process → running; conflicting or incomplete live metadata → read-only indeterminate; dead PID metadata is cleaned up: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
 - `start()`: spawn detached → write pid → wait for status ready (pid matches): [daemon-controller.ts](../src/daemon/daemon-controller.ts)
-- `stop()`: reconcile daemon identity → terminate → wait for exit → clean up pid/status; status-only POSIX recovery additionally requires consumer-lock and OS start-time proof: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
-- Windows `cli.js run` initializes the durable generation/orphan context shared with `buildApp`: [windows-daemon-runtime.ts](../src/daemon/windows-daemon-runtime.ts)
+- `stop()`: reconcile daemon identity → revalidate recovered POSIX process identity → terminate → wait for exit → clean up pid/status; status-only POSIX recovery additionally requires consumer-lock and OS start-time proof: [daemon-controller.ts](../src/daemon/daemon-controller.ts)
+- Internal Windows `cli.js run` prepares the generation/orphan context shared with `buildApp`, then publishes it only after consumer ownership: [windows-daemon-runtime.ts](../src/daemon/windows-daemon-runtime.ts), [run-console.ts](../src/run-console.ts)
 
 ### 5.10 Orchestration (src/orchestration/*)
 

--- a/docs/daemon-module.md
+++ b/docs/daemon-module.md
@@ -107,6 +107,23 @@ Taking `xacpx stop` as an example:
 4. Clean up the PID and status files.
 5. Return the stop result.
 
+On non-Windows platforms, an in-place upgrade can encounter a live legacy daemon
+whose `status.json` heartbeat is still current but whose PID file is missing. When
+the status PID is alive, its config root matches the active installation, and its
+heartbeat is recent and internally consistent, the controller atomically restores
+the PID file. `start` then reports the existing daemon, while `stop` and `restart`
+can terminate it through the normal lifecycle. Stale or conflicting status remains
+indeterminate and never permits a duplicate start.
+
+On Windows, a daemon started before durable generation identities were introduced
+can be stopped after an in-place upgrade without falling back to an unverified PID
+kill. The controller adopts that legacy daemon only when all independent evidence
+agrees: PID/status metadata, a recent heartbeat, the handle-derived creation time
+and executable, the current config root, and the exact `node cli.js run` command
+line. The adopted creation identity is written durably before the existing
+handle-fenced process-tree termination runs. Missing, stale, or conflicting
+evidence remains fail-closed.
+
 ## Key state model
 
 The daemon currently does not judge liveness by "looking at a single PID file"; it judges by combination:
@@ -114,10 +131,14 @@ The daemon currently does not judge liveness by "looking at a single PID file"; 
 - **Whether the process exists**: tells us "whether this PID is still alive now".
 - **Status file**: tells us "whether this daemon has completed self-registration".
 
-After combining these three, the result falls roughly into three categories:
-- **running**: there is a PID, the process exists, and there is a valid status file.
-- **stopped**: there is no PID, or there is no status information.
+After combining these three, the result falls roughly into four categories:
+- **running**: the process exists and PID/status metadata agree; on non-Windows,
+  fresh status-only metadata can first restore the missing PID file.
+- **stopped**: there is no evidence of a live daemon.
 - **stale stopped**: there is an old PID/status, but the corresponding process no longer exists, and the controller cleans up the remnants.
+- **indeterminate**: a process is alive but its PID/status metadata is incomplete,
+  inconsistent, or too stale to repair safely. It blocks a second daemon start;
+  runtime metadata must not be deleted while that PID is still alive.
 
 This is also the core value of `daemon-controller.ts`: it not only looks at files, but also performs **liveness validation**.
 

--- a/docs/daemon-module.md
+++ b/docs/daemon-module.md
@@ -109,13 +109,15 @@ Taking `xacpx stop` as an example:
 
 On non-Windows platforms, an in-place upgrade can encounter a live legacy daemon
 whose `status.json` heartbeat is still current but whose PID file is missing. When
-the status PID is alive, its config root matches the active installation, and its
-heartbeat is recent and internally consistent, the controller atomically restores
-the PID file. `start` then reports the existing daemon, while `stop` and `restart`
-can terminate it through the normal lifecycle. Stale or conflicting status remains
-indeterminate and never permits a duplicate start.
+queried, this remains read-only and indeterminate, so `start` cannot launch a
+duplicate. An explicit `stop` or `restart` can adopt the status PID only when the
+config/state paths, a daemon-mode consumer lock, a recent heartbeat, and the
+OS-reported process start time all agree. PID reuse, stale evidence, or conflicting
+metadata remains fail-closed.
 
-On Windows, a daemon started before durable generation identities were introduced
+New Windows daemons create and durably write their generation identity on the real
+published `cli.js run` startup path before `buildApp` receives the identity and
+orphan registry. A daemon started before durable generation identities were introduced
 can be stopped after an in-place upgrade without falling back to an unverified PID
 kill. The controller adopts that legacy daemon only when all independent evidence
 agrees: PID/status metadata, a recent heartbeat, the handle-derived creation time
@@ -132,13 +134,12 @@ The daemon currently does not judge liveness by "looking at a single PID file"; 
 - **Status file**: tells us "whether this daemon has completed self-registration".
 
 After combining these three, the result falls roughly into four categories:
-- **running**: the process exists and PID/status metadata agree; on non-Windows,
-  fresh status-only metadata can first restore the missing PID file.
+- **running**: the process exists and PID/status metadata agree.
 - **stopped**: there is no evidence of a live daemon.
 - **stale stopped**: there is an old PID/status, but the corresponding process no longer exists, and the controller cleans up the remnants.
 - **indeterminate**: a process is alive but its PID/status metadata is incomplete,
   inconsistent, or too stale to repair safely. It blocks a second daemon start;
-  runtime metadata must not be deleted while that PID is still alive.
+  ordinary status/doctor probes remain read-only while that PID is still alive.
 
 This is also the core value of `daemon-controller.ts`: it not only looks at files, but also performs **liveness validation**.
 

--- a/docs/daemon-module.md
+++ b/docs/daemon-module.md
@@ -118,12 +118,14 @@ the controller probes its OS start-time fingerprint again; a changed or unavaila
 fingerprint preserves the evidence and refuses the PID-only kill.
 
 New Windows daemons create their generation identity on the real published `cli.js run`
-startup path and pass an inactive identity context to `buildApp`. The generation is
-published only after the optional channel consumer guard is acquired and before any
-startup reconciliation or orphan sweep. Ordinary foreground `xacpx run` processes do
-not publish daemon generations, and a process that loses the consumer guard cannot
-overwrite or sweep the active daemon's durable evidence. A daemon started before
-durable generation identities were introduced
+startup path and pass an inactive identity context to `buildApp`. Every default runtime
+first acquires a channel-independent core consumer lock; when a channel also provides a
+legacy lock, both are held so upgraded runtimes still conflict with older daemons. The
+generation is published only after runtime ownership is acquired and before any startup
+reconciliation or orphan sweep. Ordinary foreground `xacpx run` processes neither
+publish daemon generations nor register daemon PID/status, and a process that loses an
+ownership lock cannot overwrite or sweep the active daemon's durable evidence. A daemon
+started before durable generation identities were introduced
 can be stopped after an in-place upgrade without falling back to an unverified PID
 kill. The controller adopts that legacy daemon only when all independent evidence
 agrees: PID/status metadata, a recent heartbeat, the handle-derived creation time

--- a/docs/daemon-module.md
+++ b/docs/daemon-module.md
@@ -124,6 +124,9 @@ first acquires a channel-independent core consumer lock; when a channel also pro
 legacy lock, both are held so upgraded runtimes still conflict with older daemons. The
 core lock is OS-held (`flock` on POSIX and the runtime-owner IPC guard on Windows), so a
 crash releases ownership without deleting or reclaiming its stable diagnostic JSON file.
+When Bun uses a Node helper to hold the POSIX native flock, the helper ignores process-group
+graceful-stop signals and releases only when the parent closes its control pipe; unexpected
+helper loss terminates the owner fail-closed before another runtime can proceed concurrently.
 Legacy POSIX channel metadata includes the owner's process-start fingerprint to distinguish
 PID reuse. Every runtime entry, including direct source `main()`, uses this same guarded path.
 The generation is published only after runtime ownership is acquired and before any startup

--- a/docs/daemon-module.md
+++ b/docs/daemon-module.md
@@ -113,11 +113,17 @@ queried, this remains read-only and indeterminate, so `start` cannot launch a
 duplicate. An explicit `stop` or `restart` can adopt the status PID only when the
 config/state paths, a daemon-mode consumer lock, a recent heartbeat, and the
 OS-reported process start time all agree. PID reuse, stale evidence, or conflicting
-metadata remains fail-closed.
+metadata remains fail-closed. Immediately before terminating a recovered process,
+the controller probes its OS start-time fingerprint again; a changed or unavailable
+fingerprint preserves the evidence and refuses the PID-only kill.
 
-New Windows daemons create and durably write their generation identity on the real
-published `cli.js run` startup path before `buildApp` receives the identity and
-orphan registry. A daemon started before durable generation identities were introduced
+New Windows daemons create their generation identity on the real published `cli.js run`
+startup path and pass an inactive identity context to `buildApp`. The generation is
+published only after the optional channel consumer guard is acquired and before any
+startup reconciliation or orphan sweep. Ordinary foreground `xacpx run` processes do
+not publish daemon generations, and a process that loses the consumer guard cannot
+overwrite or sweep the active daemon's durable evidence. A daemon started before
+durable generation identities were introduced
 can be stopped after an in-place upgrade without falling back to an unverified PID
 kill. The controller adopts that legacy daemon only when all independent evidence
 agrees: PID/status metadata, a recent heartbeat, the handle-derived creation time

--- a/docs/daemon-module.md
+++ b/docs/daemon-module.md
@@ -73,6 +73,7 @@ Responsibilities:
   - `stdout.log`
   - `stderr.log`
   - `app.log`
+  - `runtime-consumer.lock.json` (stable metadata path for the OS-held core lock)
 
 It does no reading or writing; it is only responsible for **consolidating the path conventions**.
 
@@ -121,7 +122,11 @@ New Windows daemons create their generation identity on the real published `cli.
 startup path and pass an inactive identity context to `buildApp`. Every default runtime
 first acquires a channel-independent core consumer lock; when a channel also provides a
 legacy lock, both are held so upgraded runtimes still conflict with older daemons. The
-generation is published only after runtime ownership is acquired and before any startup
+core lock is OS-held (`flock` on POSIX and the runtime-owner IPC guard on Windows), so a
+crash releases ownership without deleting or reclaiming its stable diagnostic JSON file.
+Legacy POSIX channel metadata includes the owner's process-start fingerprint to distinguish
+PID reuse. Every runtime entry, including direct source `main()`, uses this same guarded path.
+The generation is published only after runtime ownership is acquired and before any startup
 reconciliation or orphan sweep. Ordinary foreground `xacpx run` processes neither
 publish daemon generations nor register daemon PID/status, and a process that loses an
 ownership lock cannot overwrite or sweep the active daemon's durable evidence. A daemon

--- a/docs/developments.md
+++ b/docs/developments.md
@@ -118,7 +118,7 @@ One sentence per directory to make its responsibility clear; deeper content is i
 | --- | --- | --- |
 | `src/cli.ts` | Top-level CLI entry, `xacpx <command>` dispatch | `runCli()` |
 | `src/main.ts` | `buildApp()` assembles the runtime; `resolveRuntimePaths()` resolves paths | `buildApp` |
-| `src/run-console.ts` | Startup sequence: channel → daemon runtime → consumer lock → channel start | `runConsole()` |
+| `src/run-console.ts` | Startup sequence: build runtime → required core ownership lock → reconcile/reap → daemon ready → channel/scheduler start | `runConsole()` |
 | `src/console-agent.ts` | Bridges inbound messages to the router | `ConsoleAgent` |
 | `src/channels/` | Channel registry; built-in weixin; exposes `MessageChannelRuntime` to plugins | `channels/types.ts`, `channels/plugin.ts` |
 | `src/commands/` | Command parsing + handlers + router | `command-router.ts`, `parse-command.ts` |

--- a/docs/doctor-command.md
+++ b/docs/doctor-command.md
@@ -132,8 +132,8 @@ reported as `skipped` with a "stop the daemon first: `xacpx stop`" reason.
 Stop the daemon, re-run `xacpx doctor --fix`, then start it again.
 
 Daemon liveness is detected independently of any check output: the
-`indeterminate` state (a live daemon pid whose `status.json` is missing)
-is treated as a live daemon, so lock removal is not offered there either.
+`indeterminate` state (a live daemon process whose PID/status metadata cannot be
+safely reconciled) is treated as a live daemon, so lock removal is not offered there either.
 A process that exists but cannot be signalled (`EPERM`) also counts as
 alive. If daemon state cannot be determined at all, doctor fails safe and
 treats the daemon as running, withholding the state-mutating repairs.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -812,11 +812,13 @@ Every plugin command accepts `--restart` / `--no-restart`, and by default asks i
    4.2 factory(options, deps) → MessageChannelRuntime
 5. runConsole(...):
    5.1 channel.configureOrchestration?.(callbacks)
-   5.2 consumer lock acquire (optional)
-   5.3 channel.start({ agent, abortSignal, quota, logger })
+   5.2 acquire the required, channel-independent core runtime ownership lock
+   5.3 acquire a channel-provided consumer lock when available (legacy-daemon compatibility fence)
+   5.4 publish daemon identity, then reconcile shared state and reap stale owners
+   5.5 report daemon ready, then channel.start({ agent, abortSignal, quota, logger }) and scheduler.start()
 6. Receive messages: channel → agent.handle(chatKey, text) → router
 7. Send messages: orchestration → channel.notifyTaskCompletion / sendCoordinatorMessage
-8. SIGTERM / SIGINT: abortSignal aborted → channel cleans up itself → registry.stopAll: channel.stop?() (fallback: logout()) → daemon exit
+8. SIGTERM / SIGINT: abortSignal aborted → dispose/reap while ownership remains held → registry.stopAll: channel.stop?() (fallback: logout()) → release compatibility/core locks → daemon exit
 ```
 
 Normal exit goes through `abortSignal` plus the non-destructive `stop()`; the destructive `logout()` is triggered only when `xacpx logout` is explicitly invoked — except as the shutdown fallback for legacy channels that do not implement `stop()`.

--- a/docs/zh/code-wiki_zh.md
+++ b/docs/zh/code-wiki_zh.md
@@ -271,9 +271,10 @@ Bridge 的目标是把 acpx 驱动隔离到子进程，并提供更可控的并�
 
 `DaemonController`：外部控制面（CLI 调用）
 
-- `getStatus()`：PID/status 一致且进程存活→running；非 Windows 平台遇到新鲜的 status-only 存活 daemon 时补回 PID 文件；存活但元数据过期或不完整→indeterminate；PID 已失效时清理 runtime files：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
-- `start()`：spawn detached → 写 pid → 等待 status ready（pid 匹配）：[daemon-controller.ts](../../src/daemon/daemon-controller.ts#L75-L93)
-- `stop()`：terminate → 等待退出 → 清理 pid/status：[daemon-controller.ts](../../src/daemon/daemon-controller.ts#L96-L109)
+- `getStatus()`：PID/status 一致且进程存活→running；存活但元数据冲突或不完整→只读的 indeterminate；PID 已失效时清理 runtime files：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
+- `start()`：spawn detached → 写 pid → 等待 status ready（pid 匹配）：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
+- `stop()`：协调 daemon 身份 → terminate → 等待退出 → 清理 pid/status；POSIX status-only 恢复还要求 consumer lock 与 OS 启动时间证据：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
+- Windows `cli.js run` 会初始化传给 `buildApp` 的 durable generation/orphan 上下文：[windows-daemon-runtime.ts](../../src/daemon/windows-daemon-runtime.ts)
 
 ### 5.10 Orchestration（src/orchestration/*）
 

--- a/docs/zh/code-wiki_zh.md
+++ b/docs/zh/code-wiki_zh.md
@@ -274,7 +274,7 @@ Bridge 的目标是把 acpx 驱动隔离到子进程，并提供更可控的并�
 - `getStatus()`：PID/status 一致且进程存活→running；存活但元数据冲突或不完整→只读的 indeterminate；PID 已失效时清理 runtime files：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
 - `start()`：spawn detached → 写 pid → 等待 status ready（pid 匹配）：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
 - `stop()`：协调 daemon 身份 → 重新核验恢复出的 POSIX 进程身份 → terminate → 等待退出 → 清理 pid/status；POSIX status-only 恢复还要求 consumer lock 与 OS 启动时间证据：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
-- 内部 Windows `cli.js run` 会准备传给 `buildApp` 的 generation/orphan 上下文，并只在取得 consumer ownership 后发布：[windows-daemon-runtime.ts](../../src/daemon/windows-daemon-runtime.ts)、[run-console.ts](../../src/run-console.ts)
+- 每个默认 runtime 都持有与渠道无关的核心 consumer lock（以及可用的 legacy 渠道锁）；内部 Windows `cli.js run` 只在取得该 ownership 后发布 generation/orphan 上下文：[runtime-consumer-lock.ts](../../src/daemon/runtime-consumer-lock.ts)、[windows-daemon-runtime.ts](../../src/daemon/windows-daemon-runtime.ts)、[run-console.ts](../../src/run-console.ts)
 
 ### 5.10 Orchestration（src/orchestration/*）
 

--- a/docs/zh/code-wiki_zh.md
+++ b/docs/zh/code-wiki_zh.md
@@ -114,10 +114,10 @@
 
 ### 4.1 前台运行（开发调试）
 
-- 入口：`xacpx run` -> [defaultRun()](../../src/cli.ts#L487-L524)
+- 入口：`xacpx run` 与直接 [main()](../../src/main.ts) 都委托给 [runDefaultRuntime()](../../src/cli.ts)
 - 核心步骤：
   - 解析 runtimePaths：`resolveRuntimePaths()`：[main.ts](../../src/main.ts#L653-L668)
-  - 创建 `DaemonRuntime`（即使前台也写 status/heartbeat，便于统一观测）：[cli.ts](../../src/cli.ts#L497-L523)
+  - 先拒绝与 running/indeterminate daemon 重叠，再取得与后台模式相同的核心 runtime ownership lock；前台运行不创建 `DaemonRuntime`，也不写 daemon PID/status：[cli.ts](../../src/cli.ts)
   - 创建 channels registry 并进入 `runConsole()`：[run-console.ts](../../src/run-console.ts#L45-L152)
 
 ### 4.2 后台 daemon（常规使用）
@@ -174,8 +174,8 @@
   - 写 daemon runtime metadata：`daemonRuntime.start(...)`：[run-console.ts](../../src/run-console.ts#L70-L82)
   - 启动 orchestration IPC server：`runtime.orchestration.server.start()`：[run-console.ts](../../src/run-console.ts#L75-L75)
   - 定时 heartbeat：[run-console.ts](../../src/run-console.ts#L76-L81)
-- consumer lock（避免多进程重复消费同一渠道）：
-  - acquire 失败会抛出 `ActiveWeixinConsumerLockError`：[run-console.ts](../../src/run-console.ts#L84-L129)
+- 必需的 runtime ownership lock（必须先于共享状态协调、orphan sweep、scheduler 与渠道激活）：
+  - acquire 失败遵循通用 `ActiveConsumerLockError` 契约；POSIX 核心 ownership 使用内核持有的 `flock`，Windows 使用 runtime-owner IPC guard：[runtime-consumer-lock.ts](../../src/daemon/runtime-consumer-lock.ts)、[run-console.ts](../../src/run-console.ts)
 - 启动 channels：`channels.startAll(...)`：[run-console.ts](../../src/run-console.ts#L132-L137)
 - finally 清理：stop IPC / dispose / stopAll / release lock：[run-console.ts](../../src/run-console.ts#L154-L209)
 
@@ -274,7 +274,7 @@ Bridge 的目标是把 acpx 驱动隔离到子进程，并提供更可控的并�
 - `getStatus()`：PID/status 一致且进程存活→running；存活但元数据冲突或不完整→只读的 indeterminate；PID 已失效时清理 runtime files：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
 - `start()`：spawn detached → 写 pid → 等待 status ready（pid 匹配）：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
 - `stop()`：协调 daemon 身份 → 重新核验恢复出的 POSIX 进程身份 → terminate → 等待退出 → 清理 pid/status；POSIX status-only 恢复还要求 consumer lock 与 OS 启动时间证据：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
-- 每个默认 runtime 都持有与渠道无关的核心 consumer lock（以及可用的 legacy 渠道锁）；内部 Windows `cli.js run` 只在取得该 ownership 后发布 generation/orphan 上下文：[runtime-consumer-lock.ts](../../src/daemon/runtime-consumer-lock.ts)、[windows-daemon-runtime.ts](../../src/daemon/windows-daemon-runtime.ts)、[run-console.ts](../../src/run-console.ts)
+- 每个 runtime 入口都持有与渠道无关、由 OS 持有的核心 consumer lock（以及可用的 legacy 渠道锁）；稳定的核心 JSON 文件只是诊断元数据，不充当 mutex。内部 Windows `cli.js run` 只在取得该 ownership 后发布 generation/orphan 上下文：[runtime-consumer-lock.ts](../../src/daemon/runtime-consumer-lock.ts)、[windows-daemon-runtime.ts](../../src/daemon/windows-daemon-runtime.ts)、[run-console.ts](../../src/run-console.ts)
 
 ### 5.10 Orchestration（src/orchestration/*）
 

--- a/docs/zh/code-wiki_zh.md
+++ b/docs/zh/code-wiki_zh.md
@@ -271,7 +271,7 @@ Bridge 的目标是把 acpx 驱动隔离到子进程，并提供更可控的并�
 
 `DaemonController`：外部控制面（CLI 调用）
 
-- `getStatus()`：PID 不存在→stopped；PID 存在但进程不在→清理 runtime files；有 PID 但无 status→indeterminate：[daemon-controller.ts](../../src/daemon/daemon-controller.ts#L51-L73)
+- `getStatus()`：PID/status 一致且进程存活→running；非 Windows 平台遇到新鲜的 status-only 存活 daemon 时补回 PID 文件；存活但元数据过期或不完整→indeterminate；PID 已失效时清理 runtime files：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
 - `start()`：spawn detached → 写 pid → 等待 status ready（pid 匹配）：[daemon-controller.ts](../../src/daemon/daemon-controller.ts#L75-L93)
 - `stop()`：terminate → 等待退出 → 清理 pid/status：[daemon-controller.ts](../../src/daemon/daemon-controller.ts#L96-L109)
 

--- a/docs/zh/code-wiki_zh.md
+++ b/docs/zh/code-wiki_zh.md
@@ -273,8 +273,8 @@ Bridge 的目标是把 acpx 驱动隔离到子进程，并提供更可控的并�
 
 - `getStatus()`：PID/status 一致且进程存活→running；存活但元数据冲突或不完整→只读的 indeterminate；PID 已失效时清理 runtime files：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
 - `start()`：spawn detached → 写 pid → 等待 status ready（pid 匹配）：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
-- `stop()`：协调 daemon 身份 → terminate → 等待退出 → 清理 pid/status；POSIX status-only 恢复还要求 consumer lock 与 OS 启动时间证据：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
-- Windows `cli.js run` 会初始化传给 `buildApp` 的 durable generation/orphan 上下文：[windows-daemon-runtime.ts](../../src/daemon/windows-daemon-runtime.ts)
+- `stop()`：协调 daemon 身份 → 重新核验恢复出的 POSIX 进程身份 → terminate → 等待退出 → 清理 pid/status；POSIX status-only 恢复还要求 consumer lock 与 OS 启动时间证据：[daemon-controller.ts](../../src/daemon/daemon-controller.ts)
+- 内部 Windows `cli.js run` 会准备传给 `buildApp` 的 generation/orphan 上下文，并只在取得 consumer ownership 后发布：[windows-daemon-runtime.ts](../../src/daemon/windows-daemon-runtime.ts)、[run-console.ts](../../src/run-console.ts)
 
 ### 5.10 Orchestration（src/orchestration/*）
 

--- a/docs/zh/daemon-module_zh.md
+++ b/docs/zh/daemon-module_zh.md
@@ -108,12 +108,14 @@ daemon 进程内的运行时登记器。
 5. 返回停止结果。
 
 非 Windows 平台原地升级时，可能遇到旧 daemon 仍存活且 `status.json` 心跳仍新鲜、
-但 PID 文件缺失的情况。status 中的 PID 存活、配置根目录与当前安装一致，且心跳近期并
-内部一致时，controller 会原子补回 PID 文件；随后 `start` 会识别已有 daemon，`stop`
-和 `restart` 则可走正常生命周期终止它。过期或冲突的 status 仍保持 indeterminate，
-绝不会允许重复启动。
+但 PID 文件缺失的情况。普通查询保持只读并返回 indeterminate，因此 `start` 不能重复拉起。
+只有显式执行 `stop` 或 `restart`，且 config/state 路径、daemon 模式 consumer lock、近期心跳
+和 OS 报告的进程启动时间全部一致时，controller 才会接管 status 中的 PID。PID 复用、过期
+证据或冲突元数据一律 fail-closed。
 
-Windows 上，升级前启动、尚未写入 durable generation identity 的 daemon 可以在原地升级后安全停止，
+新的 Windows daemon 会在真实发布版 `cli.js run` 启动路径上创建并持久化 generation identity，
+再把 identity 和 orphan registry 传给 `buildApp`。升级前启动、尚未写入 durable generation identity
+的 daemon 可以在原地升级后安全停止，
 但不会退回到只凭 PID 强杀。controller 只有在 PID/status、近期心跳、handle 读取的创建时间与
 可执行文件、当前配置根目录和精确的 `node cli.js run` 命令行全部一致时，才接管这个 legacy daemon；
 接管得到的创建身份会先持久化，再进入现有的 handle-fenced 进程树终止流程。任何缺失、过期或冲突证据
@@ -127,12 +129,11 @@ daemon 当前不是靠“只看一个 PID 文件”判断是否存活，而是�
 - **状态文件**：告诉我们“这个 daemon 是否已经完成自我登记”。
 
 这三者组合后的结果大致有四类：
-- **running**：进程存在且 PID/status 一致；非 Windows 平台可先根据新鲜的 status-only
-  元数据补回缺失的 PID 文件。
+- **running**：进程存在且 PID/status 一致。
 - **stopped**：没有存活 daemon 的证据。
 - **stale stopped**：有旧 PID/状态，但对应进程已经不存在，控制器会清理残局。
 - **indeterminate**：进程仍存活，但 PID/status 元数据不完整、不一致，或过旧而无法安全修复。
-  该状态必须阻止启动第二个 daemon；PID 仍存活期间不得删除 runtime 元数据。
+  该状态必须阻止启动第二个 daemon；PID 仍存活期间普通 status/doctor 查询保持只读。
 
 这也是 `daemon-controller.ts` 的核心价值：它不只看文件，还做**活性校验**。
 

--- a/docs/zh/daemon-module_zh.md
+++ b/docs/zh/daemon-module_zh.md
@@ -119,7 +119,9 @@ daemon 进程内的运行时登记器。
 激活的 identity 上下文传给 `buildApp`。每个默认 runtime 都必须先取得与渠道无关的核心 consumer
 lock；若渠道还提供 legacy lock，则同时持有两把锁，以继续阻挡升级前启动的旧 daemon。核心锁由
 OS 持有（POSIX 使用 `flock`，Windows 使用 runtime-owner IPC guard），进程崩溃时会自动
-释放 ownership，无需删除或回收稳定的诊断 JSON 文件。POSIX legacy 渠道元数据还记录进程启动
+释放 ownership，无需删除或回收稳定的诊断 JSON 文件。Bun 通过 Node helper 持有 POSIX 原生 flock
+时，helper 会忽略进程组的优雅停机信号，只在父进程关闭控制管道后释放；若 helper 意外丢失，owner
+会在另一个 runtime 并发运行前 fail-closed 终止。POSIX legacy 渠道元数据还记录进程启动
 指纹，用来识别 PID 复用。包括直接源码 `main()` 在内的所有 runtime 入口都走同一受保护路径。只有取得
 runtime ownership 后、任何启动协调或 orphan sweep 之前，才会持久化 generation。普通前台
 `xacpx run` 既不发布 daemon generation，也不登记 daemon PID/status；ownership lock 冲突而退出

--- a/docs/zh/daemon-module_zh.md
+++ b/docs/zh/daemon-module_zh.md
@@ -107,6 +107,18 @@ daemon 进程内的运行时登记器。
 4. 清理 PID 和状态文件。
 5. 返回停止结果。
 
+非 Windows 平台原地升级时，可能遇到旧 daemon 仍存活且 `status.json` 心跳仍新鲜、
+但 PID 文件缺失的情况。status 中的 PID 存活、配置根目录与当前安装一致，且心跳近期并
+内部一致时，controller 会原子补回 PID 文件；随后 `start` 会识别已有 daemon，`stop`
+和 `restart` 则可走正常生命周期终止它。过期或冲突的 status 仍保持 indeterminate，
+绝不会允许重复启动。
+
+Windows 上，升级前启动、尚未写入 durable generation identity 的 daemon 可以在原地升级后安全停止，
+但不会退回到只凭 PID 强杀。controller 只有在 PID/status、近期心跳、handle 读取的创建时间与
+可执行文件、当前配置根目录和精确的 `node cli.js run` 命令行全部一致时，才接管这个 legacy daemon；
+接管得到的创建身份会先持久化，再进入现有的 handle-fenced 进程树终止流程。任何缺失、过期或冲突证据
+仍然 fail-closed。
+
 ## 关键状态模型
 
 daemon 当前不是靠“只看一个 PID 文件”判断是否存活，而是组合判断：
@@ -114,10 +126,13 @@ daemon 当前不是靠“只看一个 PID 文件”判断是否存活，而是�
 - **进程是否存在**：告诉我们“这个 PID 现在还活着没有”。
 - **状态文件**：告诉我们“这个 daemon 是否已经完成自我登记”。
 
-这三者组合后的结果大致有三类：
-- **running**：有 PID，进程存在，且有有效状态文件。
-- **stopped**：没有 PID，或者没有状态信息。
+这三者组合后的结果大致有四类：
+- **running**：进程存在且 PID/status 一致；非 Windows 平台可先根据新鲜的 status-only
+  元数据补回缺失的 PID 文件。
+- **stopped**：没有存活 daemon 的证据。
 - **stale stopped**：有旧 PID/状态，但对应进程已经不存在，控制器会清理残局。
+- **indeterminate**：进程仍存活，但 PID/status 元数据不完整、不一致，或过旧而无法安全修复。
+  该状态必须阻止启动第二个 daemon；PID 仍存活期间不得删除 runtime 元数据。
 
 这也是 `daemon-controller.ts` 的核心价值：它不只看文件，还做**活性校验**。
 

--- a/docs/zh/daemon-module_zh.md
+++ b/docs/zh/daemon-module_zh.md
@@ -115,9 +115,11 @@ daemon 进程内的运行时登记器。
 指纹；指纹变化或无法取得时会保留证据并拒绝只凭 PID 终止。
 
 新的 Windows daemon 会在真实发布版 `cli.js run` 启动路径上创建 generation identity，并把尚未
-激活的 identity 上下文传给 `buildApp`；只有在可选的渠道 consumer guard 获取成功后、任何启动
-协调或 orphan sweep 之前，才会持久化 generation。普通前台 `xacpx run` 不发布 daemon generation；
-consumer guard 冲突而退出的进程既不能覆盖，也不能清扫现有 daemon 的 durable 证据。
+激活的 identity 上下文传给 `buildApp`。每个默认 runtime 都必须先取得与渠道无关的核心 consumer
+lock；若渠道还提供 legacy lock，则同时持有两把锁，以继续阻挡升级前启动的旧 daemon。只有取得
+runtime ownership 后、任何启动协调或 orphan sweep 之前，才会持久化 generation。普通前台
+`xacpx run` 既不发布 daemon generation，也不登记 daemon PID/status；ownership lock 冲突而退出
+的进程既不能覆盖，也不能清扫现有 daemon 的 durable 证据。
 升级前启动、尚未写入 durable generation identity
 的 daemon 可以在原地升级后安全停止，
 但不会退回到只凭 PID 强杀。controller 只有在 PID/status、近期心跳、handle 读取的创建时间与

--- a/docs/zh/daemon-module_zh.md
+++ b/docs/zh/daemon-module_zh.md
@@ -73,6 +73,7 @@ daemon 进程内的运行时登记器。
   - `stdout.log`
   - `stderr.log`
   - `app.log`
+  - `runtime-consumer.lock.json`（OS 持有的核心锁所使用的稳定元数据路径）
 
 它不做读写，只负责**路径约定收口**。
 
@@ -116,7 +117,10 @@ daemon 进程内的运行时登记器。
 
 新的 Windows daemon 会在真实发布版 `cli.js run` 启动路径上创建 generation identity，并把尚未
 激活的 identity 上下文传给 `buildApp`。每个默认 runtime 都必须先取得与渠道无关的核心 consumer
-lock；若渠道还提供 legacy lock，则同时持有两把锁，以继续阻挡升级前启动的旧 daemon。只有取得
+lock；若渠道还提供 legacy lock，则同时持有两把锁，以继续阻挡升级前启动的旧 daemon。核心锁由
+OS 持有（POSIX 使用 `flock`，Windows 使用 runtime-owner IPC guard），进程崩溃时会自动
+释放 ownership，无需删除或回收稳定的诊断 JSON 文件。POSIX legacy 渠道元数据还记录进程启动
+指纹，用来识别 PID 复用。包括直接源码 `main()` 在内的所有 runtime 入口都走同一受保护路径。只有取得
 runtime ownership 后、任何启动协调或 orphan sweep 之前，才会持久化 generation。普通前台
 `xacpx run` 既不发布 daemon generation，也不登记 daemon PID/status；ownership lock 冲突而退出
 的进程既不能覆盖，也不能清扫现有 daemon 的 durable 证据。

--- a/docs/zh/daemon-module_zh.md
+++ b/docs/zh/daemon-module_zh.md
@@ -111,10 +111,14 @@ daemon 进程内的运行时登记器。
 但 PID 文件缺失的情况。普通查询保持只读并返回 indeterminate，因此 `start` 不能重复拉起。
 只有显式执行 `stop` 或 `restart`，且 config/state 路径、daemon 模式 consumer lock、近期心跳
 和 OS 报告的进程启动时间全部一致时，controller 才会接管 status 中的 PID。PID 复用、过期
-证据或冲突元数据一律 fail-closed。
+证据或冲突元数据一律 fail-closed。终止恢复出的进程前，controller 会再次探测 OS 启动时间
+指纹；指纹变化或无法取得时会保留证据并拒绝只凭 PID 终止。
 
-新的 Windows daemon 会在真实发布版 `cli.js run` 启动路径上创建并持久化 generation identity，
-再把 identity 和 orphan registry 传给 `buildApp`。升级前启动、尚未写入 durable generation identity
+新的 Windows daemon 会在真实发布版 `cli.js run` 启动路径上创建 generation identity，并把尚未
+激活的 identity 上下文传给 `buildApp`；只有在可选的渠道 consumer guard 获取成功后、任何启动
+协调或 orphan sweep 之前，才会持久化 generation。普通前台 `xacpx run` 不发布 daemon generation；
+consumer guard 冲突而退出的进程既不能覆盖，也不能清扫现有 daemon 的 durable 证据。
+升级前启动、尚未写入 durable generation identity
 的 daemon 可以在原地升级后安全停止，
 但不会退回到只凭 PID 强杀。controller 只有在 PID/status、近期心跳、handle 读取的创建时间与
 可执行文件、当前配置根目录和精确的 `node cli.js run` 命令行全部一致时，才接管这个 legacy daemon；

--- a/docs/zh/developments_zh.md
+++ b/docs/zh/developments_zh.md
@@ -118,7 +118,7 @@ xacpx/
 | --- | --- | --- |
 | `src/cli.ts` | CLI 总入口，`xacpx <command>` 派发 | `runCli()` |
 | `src/main.ts` | `buildApp()` 装配运行时；`resolveRuntimePaths()` 路径解析 | `buildApp` |
-| `src/run-console.ts` | 启动序列：channel → daemon runtime → consumer lock → channel start | `runConsole()` |
+| `src/run-console.ts` | 启动序列：构建 runtime → 必需的核心 ownership lock → reconcile/reap → daemon ready → channel/scheduler start | `runConsole()` |
 | `src/console-agent.ts` | 把入站消息桥接到 router | `ConsoleAgent` |
 | `src/channels/` | 频道注册中心；内置 weixin；暴露 `MessageChannelRuntime` 给插件 | `channels/types.ts`、`channels/plugin.ts` |
 | `src/commands/` | 命令解析 + handler + router | `command-router.ts`、`parse-command.ts` |

--- a/docs/zh/doctor-command_zh.md
+++ b/docs/zh/doctor-command_zh.md
@@ -119,8 +119,8 @@ WARN Runtime: daemon runtime dir should be private (mode 0700) (fixable — run:
 `xacpx stop`" 的原因报告。先停止 daemon，重跑 `xacpx doctor --fix`，再启动
 它。
 
-daemon 存活与否的判定独立于任何检查结果：`indeterminate` 状态（daemon pid
-存活但 `status.json` 缺失）被视为存活的 daemon，因此那种情况下也不会提供锁
+daemon 存活与否的判定独立于任何检查结果：`indeterminate` 状态（daemon 进程
+存活，但 PID/status 元数据无法安全协调）被视为存活的 daemon，因此那种情况下也不会提供锁
 清理。进程存在但无法发送信号（`EPERM`）同样算作存活。如果完全无法确定
 daemon 状态，doctor 会按安全方向处理：视为 daemon 正在运行，扣留所有改动
 状态的修复。

--- a/docs/zh/plugin-development_zh.md
+++ b/docs/zh/plugin-development_zh.md
@@ -812,11 +812,13 @@ CLI 不会自动 disable 出错的插件——需要用户手工 `xacpx plugin d
    4.2 factory(options, deps) → MessageChannelRuntime
 5. runConsole(...)：
    5.1 channel.configureOrchestration?.(callbacks)
-   5.2 consumer lock acquire（可选）
-   5.3 channel.start({ agent, abortSignal, quota, logger })
+   5.2 取得必需且与渠道无关的核心 runtime ownership lock
+   5.3 若渠道提供 consumer lock，则同时取得（作为兼容旧 daemon 的 fence）
+   5.4 发布 daemon identity，再协调共享状态并清理陈旧 owner
+   5.5 报告 daemon ready，再执行 channel.start({ agent, abortSignal, quota, logger }) 与 scheduler.start()
 6. 收消息：channel → agent.handle(chatKey, text) → router
 7. 出消息：orchestration → channel.notifyTaskCompletion / sendCoordinatorMessage
-8. SIGTERM / SIGINT：abortSignal aborted → channel 自己 cleanup → registry.stopAll：channel.stop?()（回退：logout()）→ daemon exit
+8. SIGTERM / SIGINT：abortSignal aborted → 持有 ownership 完成 dispose/reap → registry.stopAll：channel.stop?()（回退：logout()）→ 释放兼容锁与核心锁 → daemon exit
 ```
 
 正常退出走 `abortSignal` 加非破坏性的 `stop()`；破坏性的 `logout()` 只在 `xacpx logout` 显式调用时被触发——唯一例外是没有实现 `stop()` 的遗留频道，关停时会回退到 `logout()`。

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -107,6 +107,23 @@ export interface ConsumerLockMetadata {
   schemaVersion?: 2;
   lockId?: string;
   processCreationDate?: string | null;
+  processStartedAtMs?: number;
+}
+
+/**
+ * Shared conflict shape for runtime and channel compatibility locks. Keeping
+ * it in the generic channel contract lets the console report an active owner
+ * without importing a channel-specific implementation.
+ */
+export class ActiveConsumerLockError extends Error {
+  constructor(
+    message: string,
+    readonly lockFilePath: string,
+    readonly existing: ConsumerLockMetadata,
+  ) {
+    super(message);
+    this.name = "ActiveConsumerLockError";
+  }
 }
 
 export interface ConsumerLock {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,11 @@ import { loadConfig } from "./config/load-config";
 import { ensureConfigExists } from "./config/ensure-config";
 import { getAgentTemplate, listAgentTemplates, sameAgentConfig } from "./config/agent-templates";
 import { createDaemonController } from "./daemon/create-daemon-controller";
-import { resolveDaemonPaths, resolveRuntimeDirFromConfigPath } from "./daemon/daemon-files";
+import {
+  resolveDaemonPaths,
+  resolveRuntimeConsumerLockPath,
+  resolveRuntimeDirFromConfigPath,
+} from "./daemon/daemon-files";
 import type { DaemonController } from "./daemon/daemon-controller";
 import { DaemonRuntime } from "./daemon/daemon-runtime";
 import type { DaemonStatus } from "./daemon/daemon-status";
@@ -327,7 +331,7 @@ export async function runCli(args: string[], deps: CliDeps = {}): Promise<number
         isInteractive: deps.isInteractive,
         promptText: deps.promptText,
       });
-      await (deps.run ?? defaultRun)({ firstRunOnboarding: onboarding ?? undefined });
+      await (deps.run ?? runDefaultRuntime)({ firstRunOnboarding: onboarding ?? undefined });
       return 0;
     case "update": {
       const result = await (deps.update ?? ((subArgs) => defaultUpdate(subArgs, {
@@ -993,7 +997,7 @@ async function defaultLoadConfiguredPluginsForChannelCli(): Promise<void> {
 
 const DAEMON_RUN_ENV_SUFFIX = "DAEMON_RUN";
 
-async function defaultRun(options: { firstRunOnboarding?: FirstRunOnboardingPlan } = {}): Promise<void> {
+export async function runDefaultRuntime(options: { firstRunOnboarding?: FirstRunOnboardingPlan } = {}): Promise<void> {
   const [{ buildApp, resolveRuntimePaths, prepareChannelMedia }, { runConsole }] = await Promise.all([
     import("./main"),
     import("./run-console"),
@@ -1058,7 +1062,7 @@ async function defaultRun(options: { firstRunOnboarding?: FirstRunOnboardingPlan
     channelStartupPolicy: isDaemonRun ? "best-effort" : "require-one",
     ...(isDaemonRun ? { daemonRuntime } : {}),
     consumerLockFactory: (runtime) => createRuntimeConsumerLock({
-      runtimeDir: daemonPaths.runtimeDir,
+      lockFilePath: resolveRuntimeConsumerLockPath(daemonPaths.runtimeDir),
       ...(firstLockCreator
         ? { channelLock: firstLockCreator.create({
             lockFilePath: `${daemonPaths.runtimeDir}${sep}${firstLockCreator.channel.id}-consumer.lock.json`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { resolveDaemonPaths, resolveRuntimeDirFromConfigPath } from "./daemon/da
 import type { DaemonController } from "./daemon/daemon-controller";
 import { DaemonRuntime } from "./daemon/daemon-runtime";
 import type { DaemonStatus } from "./daemon/daemon-status";
+import { createRuntimeConsumerLock } from "./daemon/runtime-consumer-lock";
 import { initializeWindowsDaemonRuntime } from "./daemon/windows-daemon-runtime";
 import type { DoctorRunOptions } from "./doctor/doctor-types";
 import { runXacpxMcpServer } from "./mcp/xacpx-mcp-server";
@@ -1014,6 +1015,14 @@ async function defaultRun(options: { firstRunOnboarding?: FirstRunOnboardingPlan
   const daemonPaths = resolveDaemonPathsForCurrentConfig();
   const daemonRuntime = new DaemonRuntime(daemonPaths, { pid: process.pid });
   const isDaemonRun = coreEnv(DAEMON_RUN_ENV_SUFFIX) === "1";
+  if (!isDaemonRun) {
+    const current = await createDefaultController().getStatus();
+    if (current.state === "running" || current.state === "indeterminate") {
+      throw new Error(
+        `xacpx daemon process is already running (pid ${current.pid}); stop it before starting a foreground runtime`,
+      );
+    }
+  }
   const windowsDaemonRuntime = isDaemonRun
     ? await initializeWindowsDaemonRuntime({
         configPath: runtimePaths.configPath,
@@ -1047,18 +1056,21 @@ async function defaultRun(options: { firstRunOnboarding?: FirstRunOnboardingPlan
       : undefined,
     channels: channelRegistry,
     channelStartupPolicy: isDaemonRun ? "best-effort" : "require-one",
-    daemonRuntime,
-    ...(firstLockCreator
-      ? {
-          consumerLockFactory: (runtime) =>
-            firstLockCreator.create({
-              lockFilePath: `${daemonPaths.runtimeDir}${sep}${firstLockCreator.channel.id}-consumer.lock.json`,
-              onDiagnostic: async (event, context) => {
-                await runtime.logger.info(`${firstLockCreator.channel.id}.consumer_lock.${event}`, `${firstLockCreator.channel.id} consumer lock diagnostic`, context);
-              },
-            }),
-        }
-      : {}),
+    ...(isDaemonRun ? { daemonRuntime } : {}),
+    consumerLockFactory: (runtime) => createRuntimeConsumerLock({
+      runtimeDir: daemonPaths.runtimeDir,
+      ...(firstLockCreator
+        ? { channelLock: firstLockCreator.create({
+            lockFilePath: `${daemonPaths.runtimeDir}${sep}${firstLockCreator.channel.id}-consumer.lock.json`,
+            onDiagnostic: async (event, context) => {
+              await runtime.logger.info(`${firstLockCreator.channel.id}.consumer_lock.${event}`, `${firstLockCreator.channel.id} consumer lock diagnostic`, context);
+            },
+          }) }
+        : {}),
+      onDiagnostic: async (event, context) => {
+        await runtime.logger.info(`runtime.consumer_lock.${event}`, "runtime ownership lock diagnostic", context);
+      },
+    }),
   });
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -463,7 +463,7 @@ export async function runCli(args: string[], deps: CliDeps = {}): Promise<number
           return 0;
         }
         if (status.state === "indeterminate") {
-          throw new Error(`xacpx daemon process is already running (pid ${status.pid}) but status metadata is missing`);
+          throw new Error(`xacpx daemon process is already running (pid ${status.pid}) but daemon metadata is incomplete or inconsistent`);
         }
         const onboarding = await runOnboardingBeforeStart({
           print,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { resolveDaemonPaths, resolveRuntimeDirFromConfigPath } from "./daemon/da
 import type { DaemonController } from "./daemon/daemon-controller";
 import { DaemonRuntime } from "./daemon/daemon-runtime";
 import type { DaemonStatus } from "./daemon/daemon-status";
+import { initializeWindowsDaemonRuntime } from "./daemon/windows-daemon-runtime";
 import type { DoctorRunOptions } from "./doctor/doctor-types";
 import { runXacpxMcpServer } from "./mcp/xacpx-mcp-server";
 import {
@@ -1012,6 +1013,10 @@ async function defaultRun(options: { firstRunOnboarding?: FirstRunOnboardingPlan
   const { MessageChannelRegistry } = await import("./channels/channel-registry.js");
   const daemonPaths = resolveDaemonPathsForCurrentConfig();
   const daemonRuntime = new DaemonRuntime(daemonPaths, { pid: process.pid });
+  const windowsDaemonRuntime = await initializeWindowsDaemonRuntime({
+    configPath: runtimePaths.configPath,
+    runtimeDir: daemonPaths.runtimeDir,
+  });
   const { channelDeps } = await prepareChannelMedia(runtimePaths.configPath, config);
   const channelRegistry = new MessageChannelRegistry(createMessageChannels(config.channels, channelDeps));
   const lockCreators = channelRegistry.createConsumerLocks();
@@ -1023,6 +1028,7 @@ async function defaultRun(options: { firstRunOnboarding?: FirstRunOnboardingPlan
       buildApp(paths, {
         defaultLoggingLevel: resolveCliEntryPath().includes(`${sep}src${sep}`) ? "debug" : "info",
         channel: channelRegistry,
+        ...windowsDaemonRuntime,
       }),
     beforeReady: firstRunOnboarding
       ? async (runtime) => {
@@ -1183,13 +1189,16 @@ export async function restartDaemonCli(
 ): Promise<number> {
   const status = await controller.getStatus();
   if (status.state === "indeterminate") {
-    print(t().cli.restartIndeterminate);
-    print(`PID: ${status.pid}`);
-    print(t().cli.restartIndeterminateHint);
-    return 1;
-  }
-
-  if (status.state === "running") {
+    if (status.reason !== "missing-pid") {
+      print(t().cli.restartIndeterminate);
+      print(`PID: ${status.pid}`);
+      print(t().cli.restartIndeterminateHint);
+      return 1;
+    }
+    print(t().cli.restarting);
+    await controller.stop();
+    print(t().cli.stopped);
+  } else if (status.state === "running") {
     print(t().cli.restarting);
     await controller.stop();
     print(t().cli.stopped);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1013,10 +1013,15 @@ async function defaultRun(options: { firstRunOnboarding?: FirstRunOnboardingPlan
   const { MessageChannelRegistry } = await import("./channels/channel-registry.js");
   const daemonPaths = resolveDaemonPathsForCurrentConfig();
   const daemonRuntime = new DaemonRuntime(daemonPaths, { pid: process.pid });
-  const windowsDaemonRuntime = await initializeWindowsDaemonRuntime({
-    configPath: runtimePaths.configPath,
-    runtimeDir: daemonPaths.runtimeDir,
-  });
+  const isDaemonRun = coreEnv(DAEMON_RUN_ENV_SUFFIX) === "1";
+  const windowsDaemonRuntime = isDaemonRun
+    ? await initializeWindowsDaemonRuntime({
+        configPath: runtimePaths.configPath,
+        runtimeDir: daemonPaths.runtimeDir,
+      })
+    : {};
+  const { publishGeneration, ...windowsDaemonRuntimeDeps } = windowsDaemonRuntime;
+  let ownsRuntime = false;
   const { channelDeps } = await prepareChannelMedia(runtimePaths.configPath, config);
   const channelRegistry = new MessageChannelRegistry(createMessageChannels(config.channels, channelDeps));
   const lockCreators = channelRegistry.createConsumerLocks();
@@ -1028,15 +1033,20 @@ async function defaultRun(options: { firstRunOnboarding?: FirstRunOnboardingPlan
       buildApp(paths, {
         defaultLoggingLevel: resolveCliEntryPath().includes(`${sep}src${sep}`) ? "debug" : "info",
         channel: channelRegistry,
-        ...windowsDaemonRuntime,
+        canReapQueueOwners: () => ownsRuntime,
+        ...windowsDaemonRuntimeDeps,
       }),
+    afterConsumerLockAcquired: async () => {
+      await publishGeneration?.();
+      ownsRuntime = true;
+    },
     beforeReady: firstRunOnboarding
       ? async (runtime) => {
           await createFirstRunSession(runtime, firstRunOnboarding);
         }
       : undefined,
     channels: channelRegistry,
-    channelStartupPolicy: coreEnv(DAEMON_RUN_ENV_SUFFIX) === "1" ? "best-effort" : "require-one",
+    channelStartupPolicy: isDaemonRun ? "best-effort" : "require-one",
     daemonRuntime,
     ...(firstLockCreator
       ? {

--- a/src/daemon/create-daemon-controller.ts
+++ b/src/daemon/create-daemon-controller.ts
@@ -64,6 +64,8 @@ export function createDaemonController(
       }
     },
     terminateProcess: options.terminateProcess ?? defaultTerminateProcess,
+    expectedProcessExecPath: options.processExecPath,
+    expectedCliEntryPath: options.cliEntryPath,
   });
 }
 

--- a/src/daemon/daemon-controller.ts
+++ b/src/daemon/daemon-controller.ts
@@ -189,12 +189,13 @@ export class DaemonController {
     }
     const current = await this.getStatus();
     let pid: number;
+    let recoveredIdentity: { pid: number; startedAtMs: number } | null = null;
     if (current.state === "running") {
       pid = current.pid;
     } else if (current.state === "indeterminate" && current.reason === "missing-pid") {
       const status = await this.statusStore.load();
       if (!status || !this.deps.configRoot) throw this.indeterminateDaemonError(current.pid);
-      const verified = await verifyPosixStatusOnlyDaemon({
+      recoveredIdentity = await verifyPosixStatusOnlyDaemon({
         status,
         runtimeDir: this.paths.runtimeDir,
         configRoot: this.deps.configRoot,
@@ -204,7 +205,7 @@ export class DaemonController {
         maxFutureHeartbeatMs: LEGACY_DAEMON_MAX_FUTURE_HEARTBEAT_MS,
         probeIdentity: this.deps.probePosixIdentity ?? probePosixProcessIdentity,
       });
-      if (!verified || !this.deps.isProcessRunning(status.pid)) {
+      if (!recoveredIdentity || !this.deps.isProcessRunning(status.pid)) {
         throw this.indeterminateDaemonError(current.pid);
       }
       pid = status.pid;
@@ -215,6 +216,14 @@ export class DaemonController {
     }
 
     if (this.deps.isProcessRunning(pid)) {
+      if (recoveredIdentity) {
+        const finalProbe = await (this.deps.probePosixIdentity ?? probePosixProcessIdentity)(pid);
+        if (finalProbe.status !== "found"
+          || finalProbe.identity.pid !== recoveredIdentity.pid
+          || finalProbe.identity.startedAtMs !== recoveredIdentity.startedAtMs) {
+          throw this.indeterminateDaemonError(pid);
+        }
+      }
       await this.deps.terminateProcess(pid);
       await this.waitForShutdown(pid);
     }

--- a/src/daemon/daemon-controller.ts
+++ b/src/daemon/daemon-controller.ts
@@ -1,13 +1,22 @@
+import { randomUUID } from "node:crypto";
 import { open, readFile, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
+import { dirname, resolve, win32 } from "node:path";
 
 import type { DaemonPaths } from "./daemon-files";
 import { DaemonStatusStore, type DaemonStatus } from "./daemon-status";
 import { ensurePrivateRuntimeDir } from "./private-runtime-dir";
 import { acquireIpcGuard, type IpcGuard } from "../process/ipc-guard";
 import { probeWindowsProcessIdentity, terminateWindowsProcessTree } from "../process/windows-process-tree";
+import type { WindowsProcessIdentity } from "../process/windows-process-tree";
+import { parseCanonicalFileTime } from "../process/windows-process-identity";
 import { OrphanRegistry } from "../transport/orphan-registry";
 import { sweepWindowsOrphans } from "../transport/windows-orphan-reaper";
+
+const WINDOWS_FILETIME_UNIX_EPOCH_TICKS = 116_444_736_000_000_000n;
+const WINDOWS_FILETIME_TICKS_PER_MILLISECOND = 10_000n;
+const LEGACY_DAEMON_MAX_FUTURE_HEARTBEAT_MS = 5_000;
+const LEGACY_DAEMON_MAX_HEARTBEAT_AGE_MS = 90_000;
 
 export interface DaemonStartupWaitPoll {
   elapsedMs: number;
@@ -39,12 +48,14 @@ interface DaemonControllerDeps {
   probeWindowsIdentity?: typeof probeWindowsProcessIdentity;
   terminateWindowsTree?: typeof terminateWindowsProcessTree;
   sweepWindows?: typeof sweepWindowsOrphans;
+  expectedProcessExecPath?: string;
+  expectedCliEntryPath?: string;
 }
 
 type DaemonState =
   | { state: "stopped"; stale?: boolean }
   | { state: "running"; pid: number; status: DaemonStatus }
-  | { state: "indeterminate"; pid: number; reason: "missing-status" }
+  | { state: "indeterminate"; pid: number; reason: "missing-pid" | "missing-status" }
   | { state: "already-running"; pid: number };
 
 export class DaemonController {
@@ -86,6 +97,13 @@ export class DaemonController {
     const pid = await this.loadPid();
     const status = await this.statusStore.load();
 
+    if (!pid && status && this.deps.isProcessRunning(status.pid)) {
+      if (this.isRecoverableStatusOnlyDaemon(status) && await this.repairPidFile(status.pid)) {
+        return { state: "running", pid: status.pid, status };
+      }
+      return { state: "indeterminate", pid: status.pid, reason: "missing-pid" };
+    }
+
     if (!pid) {
       return { state: "stopped" };
     }
@@ -120,7 +138,7 @@ export class DaemonController {
     }
     if (current.state === "indeterminate") {
       throw new Error(
-        `xacpx daemon process is already running (pid ${current.pid}) but status metadata is missing`,
+        `xacpx daemon process is already running (pid ${current.pid}) but daemon metadata is incomplete or inconsistent`,
       );
     }
 
@@ -159,9 +177,18 @@ export class DaemonController {
     if ((this.deps.platform ?? process.platform) === "win32") {
       return await this.withWindowsLifecycleGuard(() => this.stopWindows());
     }
-    const pid = await this.loadPid();
+    let pid = await this.loadPid();
     if (!pid) {
-      return { state: "stopped", detail: "not-running" };
+      const current = await this.getStatus();
+      if (current.state === "running") {
+        pid = current.pid;
+      } else if (current.state === "indeterminate") {
+        throw new Error(
+          `xacpx daemon process is already running (pid ${current.pid}) but daemon metadata is incomplete or inconsistent`,
+        );
+      } else {
+        return { state: "stopped", detail: "not-running" };
+      }
     }
 
     if (this.deps.isProcessRunning(pid)) {
@@ -176,9 +203,15 @@ export class DaemonController {
   private async stopWindows(): Promise<{ state: "stopped"; detail: "not-running" | "stopped" }> {
     const registry = this.deps.orphanRegistry ?? new OrphanRegistry(this.paths.runtimeDir);
     await registry.initialize();
-    const generation = await registry.readGeneration();
+    let generation = await registry.readGeneration();
     const pid = await this.loadPid();
     if (!pid && !generation) return { state: "stopped", detail: "not-running" };
+    if (pid && generation && pid !== generation.daemonPid) {
+      throw new Error("cannot safely stop Windows daemon: durable daemon identity is missing or inconsistent");
+    }
+    if (pid && (!generation || generation.daemonCreationDate === null)) {
+      generation = await this.adoptLegacyWindowsGeneration(registry, pid, generation?.generationId);
+    }
     if (!generation || generation.daemonCreationDate === null || (pid !== null && pid !== generation.daemonPid)) {
       throw new Error("cannot safely stop Windows daemon: durable daemon identity is missing or inconsistent");
     }
@@ -206,6 +239,100 @@ export class DaemonController {
     await this.clearRuntimeFiles();
     await registry.deleteGeneration();
     return { state: "stopped", detail: "stopped" };
+  }
+
+  private async adoptLegacyWindowsGeneration(
+    registry: OrphanRegistry,
+    pid: number,
+    generationId?: string,
+  ) {
+    const status = await this.statusStore.load();
+    const probe = await (this.deps.probeWindowsIdentity ?? probeWindowsProcessIdentity)(pid);
+    if (probe.status !== "found" || !this.isVerifiedLegacyWindowsDaemon(pid, status, probe.identity)) {
+      throw new Error("cannot safely stop Windows daemon: durable daemon identity is missing or inconsistent");
+    }
+    const identity = {
+      generationId: generationId ?? randomUUID(),
+      daemonPid: pid,
+      daemonCreationDate: probe.identity.creationDate,
+      configRoot: this.deps.configRoot!,
+    };
+    await registry.writeGeneration(identity);
+    return identity;
+  }
+
+  private isRecoverableStatusOnlyDaemon(status: DaemonStatus): boolean {
+    if ((this.deps.platform ?? process.platform) === "win32" || !this.deps.configRoot) return false;
+    if (resolve(dirname(status.config_path)) !== resolve(this.deps.configRoot)) return false;
+
+    const startedAt = Date.parse(status.started_at);
+    const heartbeatAt = Date.parse(status.heartbeat_at);
+    const now = this.now();
+    return Number.isFinite(startedAt)
+      && Number.isFinite(heartbeatAt)
+      && startedAt <= heartbeatAt
+      && heartbeatAt <= now + LEGACY_DAEMON_MAX_FUTURE_HEARTBEAT_MS
+      && now - heartbeatAt <= LEGACY_DAEMON_MAX_HEARTBEAT_AGE_MS;
+  }
+
+  private async repairPidFile(pid: number): Promise<boolean> {
+    await ensurePrivateRuntimeDir(this.paths.runtimeDir);
+    let handle: FileHandle;
+    try {
+      handle = await open(this.paths.pidFile, "wx", 0o600);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        return await this.loadPid() === pid;
+      }
+      throw error;
+    }
+
+    try {
+      await handle.write(`${pid}\n`);
+      return true;
+    } catch (error) {
+      await rm(this.paths.pidFile, { force: true }).catch(() => {});
+      throw error;
+    } finally {
+      await handle.close().catch(() => {});
+    }
+  }
+
+  private isVerifiedLegacyWindowsDaemon(
+    pid: number,
+    status: DaemonStatus | null,
+    identity: WindowsProcessIdentity,
+  ): boolean {
+    const configRoot = this.deps.configRoot;
+    const expectedProcessExecPath = this.deps.expectedProcessExecPath;
+    const expectedCliEntryPath = this.deps.expectedCliEntryPath;
+    if (!status || status.pid !== pid || identity.pid !== pid || !configRoot
+      || !expectedProcessExecPath || !expectedCliEntryPath || !identity.commandLine) {
+      return false;
+    }
+    if (!sameWindowsPath(win32.dirname(status.config_path), configRoot)) return false;
+    if (!sameWindowsPath(identity.executablePath, expectedProcessExecPath)) return false;
+
+    const startedAt = Date.parse(status.started_at);
+    const heartbeatAt = Date.parse(status.heartbeat_at);
+    const creationTicks = parseCanonicalFileTime(identity.creationDate);
+    if (!Number.isFinite(startedAt) || !Number.isFinite(heartbeatAt) || creationTicks === null) return false;
+    const creationTime = Number(
+      (creationTicks - WINDOWS_FILETIME_UNIX_EPOCH_TICKS) / WINDOWS_FILETIME_TICKS_PER_MILLISECOND,
+    );
+    const now = this.now();
+    if (!Number.isSafeInteger(creationTime)
+      || creationTime > startedAt
+      || startedAt - creationTime > this.onboardingStartupTimeoutMs
+      || heartbeatAt < startedAt
+      || heartbeatAt > now + LEGACY_DAEMON_MAX_FUTURE_HEARTBEAT_MS
+      || now - heartbeatAt > LEGACY_DAEMON_MAX_HEARTBEAT_AGE_MS) return false;
+
+    const argv = splitWindowsCommandLine(identity.commandLine);
+    return argv?.length === 3
+      && sameWindowsPath(argv[0]!, expectedProcessExecPath)
+      && sameWindowsPath(argv[1]!, expectedCliEntryPath)
+      && argv[2]?.toLowerCase() === "run";
   }
 
   private async withWindowsLifecycleGuard<T>(operation: () => Promise<T>): Promise<T> {
@@ -299,4 +426,41 @@ export class DaemonController {
 
     throw new Error(`xacpx daemon did not exit within ${this.shutdownTimeoutMs}ms (pid ${pid})`);
   }
+}
+
+function sameWindowsPath(left: string, right: string): boolean {
+  return win32.normalize(left).toLowerCase() === win32.normalize(right).toLowerCase();
+}
+
+function splitWindowsCommandLine(commandLine: string): string[] | null {
+  const args: string[] = [];
+  let index = 0;
+  while (index < commandLine.length) {
+    while (index < commandLine.length && /\s/.test(commandLine[index]!)) index += 1;
+    if (index >= commandLine.length) break;
+
+    let arg = "";
+    let inQuotes = false;
+    while (index < commandLine.length) {
+      let backslashes = 0;
+      while (commandLine[index] === "\\") {
+        backslashes += 1;
+        index += 1;
+      }
+      if (commandLine[index] === '"') {
+        arg += "\\".repeat(Math.floor(backslashes / 2));
+        if (backslashes % 2 === 1) arg += '"';
+        else inQuotes = !inQuotes;
+        index += 1;
+        continue;
+      }
+      arg += "\\".repeat(backslashes);
+      if (index >= commandLine.length || (!inQuotes && /\s/.test(commandLine[index]!))) break;
+      arg += commandLine[index]!;
+      index += 1;
+    }
+    if (inQuotes) return null;
+    args.push(arg);
+  }
+  return args;
 }

--- a/src/daemon/daemon-controller.ts
+++ b/src/daemon/daemon-controller.ts
@@ -1,12 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { open, readFile, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
-import { dirname, resolve, win32 } from "node:path";
+import { win32 } from "node:path";
 
 import type { DaemonPaths } from "./daemon-files";
 import { DaemonStatusStore, type DaemonStatus } from "./daemon-status";
+import { verifyPosixStatusOnlyDaemon } from "./posix-daemon-recovery";
 import { ensurePrivateRuntimeDir } from "./private-runtime-dir";
 import { acquireIpcGuard, type IpcGuard } from "../process/ipc-guard";
+import { probePosixProcessIdentity } from "../process/posix-process-identity";
 import { probeWindowsProcessIdentity, terminateWindowsProcessTree } from "../process/windows-process-tree";
 import type { WindowsProcessIdentity } from "../process/windows-process-tree";
 import { parseCanonicalFileTime } from "../process/windows-process-identity";
@@ -50,12 +52,13 @@ interface DaemonControllerDeps {
   sweepWindows?: typeof sweepWindowsOrphans;
   expectedProcessExecPath?: string;
   expectedCliEntryPath?: string;
+  probePosixIdentity?: typeof probePosixProcessIdentity;
 }
 
 type DaemonState =
   | { state: "stopped"; stale?: boolean }
   | { state: "running"; pid: number; status: DaemonStatus }
-  | { state: "indeterminate"; pid: number; reason: "missing-pid" | "missing-status" }
+  | { state: "indeterminate"; pid: number; reason: "missing-pid" | "missing-status" | "pid-mismatch" }
   | { state: "already-running"; pid: number };
 
 export class DaemonController {
@@ -98,14 +101,21 @@ export class DaemonController {
     const status = await this.statusStore.load();
 
     if (!pid && status && this.deps.isProcessRunning(status.pid)) {
-      if (this.isRecoverableStatusOnlyDaemon(status) && await this.repairPidFile(status.pid)) {
-        return { state: "running", pid: status.pid, status };
-      }
       return { state: "indeterminate", pid: status.pid, reason: "missing-pid" };
     }
 
     if (!pid) {
       return { state: "stopped" };
+    }
+
+    if (status && status.pid !== pid) {
+      const pidIsRunning = this.deps.isProcessRunning(pid);
+      const statusPidIsRunning = this.deps.isProcessRunning(status.pid);
+      if (!pidIsRunning && !statusPidIsRunning) {
+        await this.clearRuntimeFiles();
+        return { state: "stopped", stale: true };
+      }
+      return { state: "indeterminate", pid, reason: "pid-mismatch" };
     }
 
     if (!this.deps.isProcessRunning(pid)) {
@@ -177,18 +187,31 @@ export class DaemonController {
     if ((this.deps.platform ?? process.platform) === "win32") {
       return await this.withWindowsLifecycleGuard(() => this.stopWindows());
     }
-    let pid = await this.loadPid();
-    if (!pid) {
-      const current = await this.getStatus();
-      if (current.state === "running") {
-        pid = current.pid;
-      } else if (current.state === "indeterminate") {
-        throw new Error(
-          `xacpx daemon process is already running (pid ${current.pid}) but daemon metadata is incomplete or inconsistent`,
-        );
-      } else {
-        return { state: "stopped", detail: "not-running" };
+    const current = await this.getStatus();
+    let pid: number;
+    if (current.state === "running") {
+      pid = current.pid;
+    } else if (current.state === "indeterminate" && current.reason === "missing-pid") {
+      const status = await this.statusStore.load();
+      if (!status || !this.deps.configRoot) throw this.indeterminateDaemonError(current.pid);
+      const verified = await verifyPosixStatusOnlyDaemon({
+        status,
+        runtimeDir: this.paths.runtimeDir,
+        configRoot: this.deps.configRoot,
+        now: this.now(),
+        startupTimeoutMs: this.onboardingStartupTimeoutMs,
+        maxHeartbeatAgeMs: LEGACY_DAEMON_MAX_HEARTBEAT_AGE_MS,
+        maxFutureHeartbeatMs: LEGACY_DAEMON_MAX_FUTURE_HEARTBEAT_MS,
+        probeIdentity: this.deps.probePosixIdentity ?? probePosixProcessIdentity,
+      });
+      if (!verified || !this.deps.isProcessRunning(status.pid)) {
+        throw this.indeterminateDaemonError(current.pid);
       }
+      pid = status.pid;
+    } else if (current.state === "indeterminate") {
+      throw this.indeterminateDaemonError(current.pid);
+    } else {
+      return { state: "stopped", detail: "not-running" };
     }
 
     if (this.deps.isProcessRunning(pid)) {
@@ -206,6 +229,9 @@ export class DaemonController {
     let generation = await registry.readGeneration();
     const pid = await this.loadPid();
     if (!pid && !generation) return { state: "stopped", detail: "not-running" };
+    if (generation && (!this.deps.configRoot || !sameWindowsPath(generation.configRoot, this.deps.configRoot))) {
+      throw new Error("cannot safely stop Windows daemon: durable daemon identity is missing or inconsistent");
+    }
     if (pid && generation && pid !== generation.daemonPid) {
       throw new Error("cannot safely stop Windows daemon: durable daemon identity is missing or inconsistent");
     }
@@ -261,43 +287,6 @@ export class DaemonController {
     return identity;
   }
 
-  private isRecoverableStatusOnlyDaemon(status: DaemonStatus): boolean {
-    if ((this.deps.platform ?? process.platform) === "win32" || !this.deps.configRoot) return false;
-    if (resolve(dirname(status.config_path)) !== resolve(this.deps.configRoot)) return false;
-
-    const startedAt = Date.parse(status.started_at);
-    const heartbeatAt = Date.parse(status.heartbeat_at);
-    const now = this.now();
-    return Number.isFinite(startedAt)
-      && Number.isFinite(heartbeatAt)
-      && startedAt <= heartbeatAt
-      && heartbeatAt <= now + LEGACY_DAEMON_MAX_FUTURE_HEARTBEAT_MS
-      && now - heartbeatAt <= LEGACY_DAEMON_MAX_HEARTBEAT_AGE_MS;
-  }
-
-  private async repairPidFile(pid: number): Promise<boolean> {
-    await ensurePrivateRuntimeDir(this.paths.runtimeDir);
-    let handle: FileHandle;
-    try {
-      handle = await open(this.paths.pidFile, "wx", 0o600);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-        return await this.loadPid() === pid;
-      }
-      throw error;
-    }
-
-    try {
-      await handle.write(`${pid}\n`);
-      return true;
-    } catch (error) {
-      await rm(this.paths.pidFile, { force: true }).catch(() => {});
-      throw error;
-    } finally {
-      await handle.close().catch(() => {});
-    }
-  }
-
   private isVerifiedLegacyWindowsDaemon(
     pid: number,
     status: DaemonStatus | null,
@@ -345,6 +334,12 @@ export class DaemonController {
       : acquireIpcGuard({ role: "lifecycle", configRoot: configRoot! }, { platform: "win32" }));
     try { return await operation(); }
     finally { await guard.release(); }
+  }
+
+  private indeterminateDaemonError(pid: number): Error {
+    return new Error(
+      `xacpx daemon process is already running (pid ${pid}) but daemon metadata is incomplete or inconsistent`,
+    );
   }
 
   private async loadPid(): Promise<number | null> {

--- a/src/daemon/daemon-files.ts
+++ b/src/daemon/daemon-files.ts
@@ -3,6 +3,8 @@ import { dirname, join } from "node:path";
 import { coreHomeDir } from "../runtime/core-home";
 import { resolveOrchestrationEndpoint } from "../orchestration/orchestration-ipc";
 
+export const RUNTIME_CONSUMER_LOCK_FILE = "runtime-consumer.lock.json";
+
 export interface DaemonPaths {
   runtimeDir: string;
   pidFile: string;
@@ -33,6 +35,11 @@ export function resolveDaemonPaths(options: ResolveDaemonPathsOptions): DaemonPa
 
 export function resolveRuntimeDirFromConfigPath(configPath: string): string {
   return join(dirname(configPath), "runtime");
+}
+
+/** Stable metadata path for the OS-held, channel-independent runtime lock. */
+export function resolveRuntimeConsumerLockPath(runtimeDir: string): string {
+  return join(runtimeDir, RUNTIME_CONSUMER_LOCK_FILE);
 }
 
 export function resolveDaemonOrchestrationSocketPath(

--- a/src/daemon/daemon-status.ts
+++ b/src/daemon/daemon-status.ts
@@ -23,7 +23,7 @@ export class DaemonStatusStore {
       if (content.trim() === "") {
         return null;
       }
-      return JSON.parse(content) as DaemonStatus;
+      return decodeDaemonStatus(JSON.parse(content));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         return null;
@@ -47,4 +47,26 @@ export class DaemonStatusStore {
   async clear(): Promise<void> {
     await rm(this.path, { force: true });
   }
+}
+
+function decodeDaemonStatus(value: unknown): DaemonStatus | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const status = value as Record<string, unknown>;
+  if (!Number.isSafeInteger(status.pid) || Number(status.pid) <= 0
+    || !validIsoDate(status.started_at)
+    || !validIsoDate(status.heartbeat_at)
+    || !nonempty(status.config_path)
+    || !nonempty(status.state_path)
+    || !nonempty(status.app_log)
+    || !nonempty(status.stdout_log)
+    || !nonempty(status.stderr_log)) return null;
+  return status as unknown as DaemonStatus;
+}
+
+function nonempty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function validIsoDate(value: unknown): value is string {
+  return nonempty(value) && Number.isFinite(Date.parse(value));
 }

--- a/src/daemon/posix-daemon-recovery.ts
+++ b/src/daemon/posix-daemon-recovery.ts
@@ -1,0 +1,85 @@
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+import type { DaemonStatus } from "./daemon-status";
+import type { PosixProcessIdentityProbe } from "../process/posix-process-identity";
+
+const CONSUMER_LOCK_SUFFIX = "-consumer.lock.json";
+const MAX_LOCK_TO_STATUS_SKEW_MS = 5_000;
+
+interface ConsumerLockMetadata {
+  pid: number;
+  mode: "foreground" | "daemon";
+  startedAt: string;
+  configPath: string;
+  statePath: string;
+}
+
+export async function verifyPosixStatusOnlyDaemon(input: {
+  status: DaemonStatus;
+  runtimeDir: string;
+  configRoot: string;
+  now: number;
+  startupTimeoutMs: number;
+  maxHeartbeatAgeMs: number;
+  maxFutureHeartbeatMs: number;
+  probeIdentity: (pid: number) => Promise<PosixProcessIdentityProbe>;
+}): Promise<boolean> {
+  const { status } = input;
+  if (!Number.isSafeInteger(status.pid) || status.pid <= 0) return false;
+  if (!samePath(dirname(status.config_path), input.configRoot)) return false;
+
+  const startedAt = Date.parse(status.started_at);
+  const heartbeatAt = Date.parse(status.heartbeat_at);
+  if (!Number.isFinite(startedAt) || !Number.isFinite(heartbeatAt)
+    || startedAt > heartbeatAt
+    || heartbeatAt > input.now + input.maxFutureHeartbeatMs
+    || input.now - heartbeatAt > input.maxHeartbeatAgeMs) return false;
+
+  const probe = await input.probeIdentity(status.pid);
+  if (probe.status !== "found" || probe.identity.pid !== status.pid) return false;
+  const processStartedAt = probe.identity.startedAtMs;
+  if (!Number.isSafeInteger(processStartedAt)
+    || processStartedAt > startedAt
+    || startedAt - processStartedAt > input.startupTimeoutMs) return false;
+
+  const locks = await loadConsumerLocks(input.runtimeDir);
+  return locks.some((lock) => {
+    const lockStartedAt = Date.parse(lock.startedAt);
+    return lock.pid === status.pid
+      && lock.mode === "daemon"
+      && samePath(lock.configPath, status.config_path)
+      && samePath(lock.statePath, status.state_path)
+      && Number.isFinite(lockStartedAt)
+      && processStartedAt <= lockStartedAt
+      && lockStartedAt - processStartedAt <= input.startupTimeoutMs
+      && lockStartedAt <= startedAt + MAX_LOCK_TO_STATUS_SKEW_MS
+      && startedAt - lockStartedAt <= input.startupTimeoutMs;
+  });
+}
+
+async function loadConsumerLocks(runtimeDir: string): Promise<ConsumerLockMetadata[]> {
+  try {
+    const names = (await readdir(runtimeDir)).filter((name) => name.endsWith(CONSUMER_LOCK_SUFFIX));
+    const locks = await Promise.all(names.map(async (name) => {
+      try {
+        const value = JSON.parse(await readFile(resolve(runtimeDir, name), "utf8")) as Record<string, unknown>;
+        if (!Number.isSafeInteger(value.pid) || Number(value.pid) <= 0
+          || (value.mode !== "foreground" && value.mode !== "daemon")
+          || typeof value.startedAt !== "string"
+          || typeof value.configPath !== "string"
+          || typeof value.statePath !== "string") return null;
+        return value as unknown as ConsumerLockMetadata;
+      } catch {
+        return null;
+      }
+    }));
+    return locks.filter((lock): lock is ConsumerLockMetadata => lock !== null);
+  } catch {
+    return [];
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  return resolve(left) === resolve(right);
+}

--- a/src/daemon/posix-daemon-recovery.ts
+++ b/src/daemon/posix-daemon-recovery.ts
@@ -15,6 +15,11 @@ interface ConsumerLockMetadata {
   statePath: string;
 }
 
+export interface VerifiedPosixDaemonIdentity {
+  pid: number;
+  startedAtMs: number;
+}
+
 export async function verifyPosixStatusOnlyDaemon(input: {
   status: DaemonStatus;
   runtimeDir: string;
@@ -24,27 +29,27 @@ export async function verifyPosixStatusOnlyDaemon(input: {
   maxHeartbeatAgeMs: number;
   maxFutureHeartbeatMs: number;
   probeIdentity: (pid: number) => Promise<PosixProcessIdentityProbe>;
-}): Promise<boolean> {
+}): Promise<VerifiedPosixDaemonIdentity | null> {
   const { status } = input;
-  if (!Number.isSafeInteger(status.pid) || status.pid <= 0) return false;
-  if (!samePath(dirname(status.config_path), input.configRoot)) return false;
+  if (!Number.isSafeInteger(status.pid) || status.pid <= 0) return null;
+  if (!samePath(dirname(status.config_path), input.configRoot)) return null;
 
   const startedAt = Date.parse(status.started_at);
   const heartbeatAt = Date.parse(status.heartbeat_at);
   if (!Number.isFinite(startedAt) || !Number.isFinite(heartbeatAt)
     || startedAt > heartbeatAt
     || heartbeatAt > input.now + input.maxFutureHeartbeatMs
-    || input.now - heartbeatAt > input.maxHeartbeatAgeMs) return false;
+    || input.now - heartbeatAt > input.maxHeartbeatAgeMs) return null;
 
   const probe = await input.probeIdentity(status.pid);
-  if (probe.status !== "found" || probe.identity.pid !== status.pid) return false;
+  if (probe.status !== "found" || probe.identity.pid !== status.pid) return null;
   const processStartedAt = probe.identity.startedAtMs;
   if (!Number.isSafeInteger(processStartedAt)
     || processStartedAt > startedAt
-    || startedAt - processStartedAt > input.startupTimeoutMs) return false;
+    || startedAt - processStartedAt > input.startupTimeoutMs) return null;
 
   const locks = await loadConsumerLocks(input.runtimeDir);
-  return locks.some((lock) => {
+  const matchingLock = locks.some((lock) => {
     const lockStartedAt = Date.parse(lock.startedAt);
     return lock.pid === status.pid
       && lock.mode === "daemon"
@@ -56,6 +61,7 @@ export async function verifyPosixStatusOnlyDaemon(input: {
       && lockStartedAt <= startedAt + MAX_LOCK_TO_STATUS_SKEW_MS
       && startedAt - lockStartedAt <= input.startupTimeoutMs;
   });
+  return matchingLock ? { pid: status.pid, startedAtMs: processStartedAt } : null;
 }
 
 async function loadConsumerLocks(runtimeDir: string): Promise<ConsumerLockMetadata[]> {

--- a/src/daemon/runtime-consumer-lock.ts
+++ b/src/daemon/runtime-consumer-lock.ts
@@ -12,6 +12,7 @@ import { acquireIpcGuard, IpcGuardBusyError } from "../process/ipc-guard";
 
 const require = createRequire(import.meta.url);
 const expectedHelperExits = new WeakSet<ChildProcessWithoutNullStreams>();
+const FLOCK_HELPER_RELEASE_TIMEOUT_MS = 5_000;
 
 interface FsExt {
   flock(
@@ -148,6 +149,10 @@ function createCoreRuntimeLock(options: CreateRuntimeConsumerLockOptions): Consu
             // kernel flock and ties its lifetime to this process via stdin.
             await handle.close();
             posixHelper = await acquireFlockHelper(options.lockFilePath);
+            await emitDiagnostic(onDiagnostic, "lock_helper_started", {
+              lockFilePath: options.lockFilePath,
+              helperPid: posixHelper.pid,
+            });
           } else {
             const fsExt = options.loadFsExt?.() ?? require("fs-ext") as FsExt;
             await flock(fsExt, handle.fd, "exnb");
@@ -218,8 +223,21 @@ async function releasePosixLock(
     expectedHelperExits.add(helper);
     if (helper.exitCode !== null || helper.signalCode !== null) return;
     const closePromise = new Promise<void>((resolve, reject) => {
-      helper.once("error", reject);
-      helper.once("close", (code) => code === 0 ? resolve() : reject(new Error(`runtime lock helper exited with code ${code}`)));
+      let settled = false;
+      const finish = (callback: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        callback();
+      };
+      const timer = setTimeout(() => {
+        helper.kill("SIGKILL");
+        finish(() => reject(new Error("runtime lock helper did not release within 5000ms")));
+      }, FLOCK_HELPER_RELEASE_TIMEOUT_MS);
+      helper.once("error", (error) => finish(() => reject(error)));
+      helper.once("close", (code) => finish(() => code === 0
+        ? resolve()
+        : reject(new Error(`runtime lock helper exited with code ${code}`))));
     });
     helper.stdin.end();
     await closePromise;
@@ -251,6 +269,12 @@ fsExt.flock(fd, "exnb", (error) => {
     process.exitCode = busy ? 2 : 1;
     return;
   }
+  // The daemon controller signals the whole POSIX process group during a
+  // graceful stop. Once ownership is acquired, only the parent stdin lifetime
+  // may release this helper's flock; group SIGTERM/SIGINT must not unlock it
+  // before the parent finishes dispose/reap/status cleanup.
+  process.on("SIGTERM", () => {});
+  process.on("SIGINT", () => {});
   process.stdout.write("ACQUIRED\n");
   process.stdin.resume();
   let released = false;
@@ -302,7 +326,7 @@ async function acquireFlockHelper(lockFilePath: string): Promise<ChildProcessWit
         // Running without the helper's kernel lock would violate the runtime
         // ownership invariant. End the Bun parent so its normal cleanup path
         // cannot keep serving or mutating shared state without ownership.
-        process.kill(process.pid, "SIGTERM");
+        process.kill(process.pid, "SIGKILL");
       }
     });
     return child;

--- a/src/daemon/runtime-consumer-lock.ts
+++ b/src/daemon/runtime-consumer-lock.ts
@@ -321,7 +321,11 @@ async function acquireFlockHelper(
       timedOut = true;
       child.kill("SIGKILL");
       killWaitTimer = setTimeout(() => {
-        finish(() => reject(new Error(`runtime lock helper did not exit after acquisition timeout${stderr ? `: ${stderr}` : ""}`)));
+        // Returning while this child might still own the kernel lock would
+        // abandon an untracked owner. If even SIGKILL cannot produce close,
+        // the parent must not continue through a catch handler without proof
+        // that acquisition cleanup completed.
+        process.kill(process.pid, "SIGKILL");
       }, 5_000);
     }, timeoutMs);
     const finish = (callback: () => void) => {
@@ -335,7 +339,12 @@ async function acquireFlockHelper(
       if (newline >= 0 && !timedOut) finish(() => resolve(stdout.slice(0, newline)));
     });
     child.stderr.on("data", (chunk) => { stderr += String(chunk); });
-    child.once("error", (error) => finish(() => reject(error)));
+    child.once("error", (error) => {
+      // Once timeout cleanup starts, only close proves the helper can no
+      // longer own flock. Keep waiting (or fail closed above) instead of
+      // losing the child reference through an early error rejection.
+      if (!timedOut) finish(() => reject(error));
+    });
     child.once("close", (code) => {
       if (timedOut) {
         finish(() => reject(new Error(`runtime lock helper timed out${stderr ? `: ${stderr}` : ""}`)));

--- a/src/daemon/runtime-consumer-lock.ts
+++ b/src/daemon/runtime-consumer-lock.ts
@@ -33,6 +33,8 @@ interface CreateRuntimeConsumerLockOptions {
   platform?: NodeJS.Platform;
   acquireGuard?: typeof acquireIpcGuard;
   loadFsExt?: () => FsExt;
+  helperAcquireTimeoutMs?: number;
+  helperHandshakeDelayMs?: number;
 }
 
 export class ActiveRuntimeConsumerLockError extends ActiveConsumerLockError {
@@ -148,7 +150,11 @@ function createCoreRuntimeLock(options: CreateRuntimeConsumerLockOptions): Consu
             // installed Node ABI binary, so a tiny Node child holds the same
             // kernel flock and ties its lifetime to this process via stdin.
             await handle.close();
-            posixHelper = await acquireFlockHelper(options.lockFilePath);
+            posixHelper = await acquireFlockHelper(
+              options.lockFilePath,
+              options.helperAcquireTimeoutMs,
+              options.helperHandshakeDelayMs,
+            );
             await emitDiagnostic(onDiagnostic, "lock_helper_started", {
               lockFilePath: options.lockFilePath,
               helperPid: posixHelper.pid,
@@ -260,6 +266,7 @@ const FLOCK_HELPER_SOURCE = String.raw`
 const fs = require("node:fs");
 const fsExt = require(process.argv[1]);
 const path = process.argv[2];
+const handshakeDelayMs = Number(process.argv[3] || 0);
 const fd = fs.openSync(path, "a+", 0o600);
 fsExt.flock(fd, "exnb", (error) => {
   if (error) {
@@ -275,7 +282,6 @@ fsExt.flock(fd, "exnb", (error) => {
   // before the parent finishes dispose/reap/status cleanup.
   process.on("SIGTERM", () => {});
   process.on("SIGINT", () => {});
-  process.stdout.write("ACQUIRED\n");
   process.stdin.resume();
   let released = false;
   const release = () => {
@@ -288,34 +294,52 @@ fsExt.flock(fd, "exnb", (error) => {
   };
   process.stdin.once("end", release);
   process.stdin.once("error", release);
+  const reportAcquired = () => process.stdout.write("ACQUIRED\n");
+  if (handshakeDelayMs > 0) setTimeout(reportAcquired, handshakeDelayMs);
+  else reportAcquired();
 });
 `;
 
-async function acquireFlockHelper(lockFilePath: string): Promise<ChildProcessWithoutNullStreams> {
+async function acquireFlockHelper(
+  lockFilePath: string,
+  timeoutMs = 10_000,
+  handshakeDelayMs = 0,
+): Promise<ChildProcessWithoutNullStreams> {
   const fsExtPath = require.resolve("fs-ext");
-  const child = spawn("node", ["-e", FLOCK_HELPER_SOURCE, fsExtPath, lockFilePath], {
+  const child = spawn("node", ["-e", FLOCK_HELPER_SOURCE, fsExtPath, lockFilePath, String(handshakeDelayMs)], {
     stdio: ["pipe", "pipe", "pipe"],
   });
   const line = await new Promise<string>((resolve, reject) => {
     let stdout = "";
     let stderr = "";
+    let timedOut = false;
+    let killWaitTimer: ReturnType<typeof setTimeout> | undefined;
     const timer = setTimeout(() => {
-      child.kill();
-      reject(new Error(`runtime lock helper timed out${stderr ? `: ${stderr}` : ""}`));
-    }, 10_000);
+      // The helper may already hold the flock and therefore ignore graceful
+      // group-stop signals. Before ownership has been handed to the caller,
+      // timeout cleanup must be unconditional or it can orphan the lock.
+      timedOut = true;
+      child.kill("SIGKILL");
+      killWaitTimer = setTimeout(() => {
+        finish(() => reject(new Error(`runtime lock helper did not exit after acquisition timeout${stderr ? `: ${stderr}` : ""}`)));
+      }, 5_000);
+    }, timeoutMs);
     const finish = (callback: () => void) => {
       clearTimeout(timer);
+      if (killWaitTimer) clearTimeout(killWaitTimer);
       callback();
     };
     child.stdout.on("data", (chunk) => {
       stdout += String(chunk);
       const newline = stdout.indexOf("\n");
-      if (newline >= 0) finish(() => resolve(stdout.slice(0, newline)));
+      if (newline >= 0 && !timedOut) finish(() => resolve(stdout.slice(0, newline)));
     });
     child.stderr.on("data", (chunk) => { stderr += String(chunk); });
     child.once("error", (error) => finish(() => reject(error)));
     child.once("close", (code) => {
-      if (!stdout.includes("\n")) {
+      if (timedOut) {
+        finish(() => reject(new Error(`runtime lock helper timed out${stderr ? `: ${stderr}` : ""}`)));
+      } else if (!stdout.includes("\n")) {
         finish(() => reject(new Error(`runtime lock helper exited with code ${code}${stderr ? `: ${stderr}` : ""}`)));
       }
     });

--- a/src/daemon/runtime-consumer-lock.ts
+++ b/src/daemon/runtime-consumer-lock.ts
@@ -1,28 +1,42 @@
-import { join } from "node:path";
+import { createRequire } from "node:module";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdir, open, readFile, writeFile, type FileHandle } from "node:fs/promises";
+import { dirname } from "node:path";
 
-import type { ConsumerLock, ConsumerLockMetadata } from "../channels/types";
-import { createWeixinConsumerLock } from "../weixin/monitor/consumer-lock";
+import {
+  ActiveConsumerLockError,
+  type ConsumerLock,
+  type ConsumerLockMetadata,
+} from "../channels/types";
+import { acquireIpcGuard, IpcGuardBusyError } from "../process/ipc-guard";
+
+const require = createRequire(import.meta.url);
+const expectedHelperExits = new WeakSet<ChildProcessWithoutNullStreams>();
+
+interface FsExt {
+  flock(
+    fd: number,
+    operation: "exnb" | "un",
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ): void;
+}
 
 interface CreateRuntimeConsumerLockOptions {
-  runtimeDir: string;
+  lockFilePath: string;
   channelLock?: ConsumerLock;
   onDiagnostic?: (
     event: string,
     context: Record<string, string | number | boolean | undefined>,
   ) => void | Promise<void>;
   createCoreLock?: () => ConsumerLock;
+  platform?: NodeJS.Platform;
+  acquireGuard?: typeof acquireIpcGuard;
+  loadFsExt?: () => FsExt;
 }
 
-/**
- * Every console instance owns this core lock regardless of configured channels.
- * A channel lock is acquired as a second, compatibility fence so a new runtime
- * also conflicts with daemons started before the core lock existed.
- */
-export function createRuntimeConsumerLock(options: CreateRuntimeConsumerLockOptions): ConsumerLock {
-  const coreLock = (options.createCoreLock ?? (() => createWeixinConsumerLock({
-    lockFilePath: join(options.runtimeDir, "runtime-consumer.lock.json"),
-    windowsGuardRole: "runtime-owner",
-    activeLockError: (_lockFilePath, existing) => new Error(
+export class ActiveRuntimeConsumerLockError extends ActiveConsumerLockError {
+  constructor(lockFilePath: string, existing: ConsumerLockMetadata) {
+    super(
       [
         "xacpx runtime is already running.",
         `pid: ${existing.pid}`,
@@ -30,9 +44,24 @@ export function createRuntimeConsumerLock(options: CreateRuntimeConsumerLockOpti
         `config: ${existing.configPath}`,
         `state: ${existing.statePath}`,
       ].join("\n"),
-    ),
-    onDiagnostic: options.onDiagnostic,
-  })))();
+      lockFilePath,
+      existing,
+    );
+    this.name = "ActiveRuntimeConsumerLockError";
+  }
+}
+
+/**
+ * Every console instance owns this core lock regardless of configured channels.
+ * POSIX uses a kernel-held flock that is released by process exit; Windows uses
+ * the existing named-pipe guard. The JSON file is stable diagnostic metadata,
+ * never an existence/PID mutex and never removed as stale state.
+ *
+ * A channel lock is acquired second as a compatibility fence so a new runtime
+ * also conflicts with daemons started before the core lock existed.
+ */
+export function createRuntimeConsumerLock(options: CreateRuntimeConsumerLockOptions): ConsumerLock {
+  const coreLock = (options.createCoreLock ?? (() => createCoreRuntimeLock(options)))();
   let coreAcquired = false;
   let channelAcquired = false;
 
@@ -66,5 +95,279 @@ export function createRuntimeConsumerLock(options: CreateRuntimeConsumerLockOpti
       }
       if (releaseError) throw releaseError;
     },
+  };
+}
+
+function createCoreRuntimeLock(options: CreateRuntimeConsumerLockOptions): ConsumerLock {
+  const platform = options.platform ?? process.platform;
+  const onDiagnostic = options.onDiagnostic;
+  let windowsGuard: Awaited<ReturnType<typeof acquireIpcGuard>> | undefined;
+  let posixHandle: FileHandle | undefined;
+  let posixHelper: ChildProcessWithoutNullStreams | undefined;
+
+  return {
+    async acquire(metadata): Promise<void> {
+      await mkdir(dirname(options.lockFilePath), { recursive: true, mode: 0o700 });
+      if (platform === "win32") {
+        try {
+          windowsGuard = await (options.acquireGuard ?? acquireIpcGuard)(
+            { role: "runtime-owner", configRoot: dirname(metadata.configPath) },
+            { platform },
+          );
+        } catch (error) {
+          if (!(error instanceof IpcGuardBusyError)) throw error;
+          const existing = await loadMetadata(options.lockFilePath) ?? metadata;
+          await emitDiagnostic(onDiagnostic, "lock_active_conflict", conflictContext(options.lockFilePath, metadata, existing));
+          throw new ActiveRuntimeConsumerLockError(options.lockFilePath, existing);
+        }
+
+        try {
+          await writeFile(
+            options.lockFilePath,
+            `${JSON.stringify(metadata, null, 2)}\n`,
+            { encoding: "utf8", mode: 0o600 },
+          );
+        } catch (error) {
+          await windowsGuard.release().catch(() => {});
+          windowsGuard = undefined;
+          throw error;
+        }
+        await emitDiagnostic(onDiagnostic, "lock_acquired", acquiredContext(options.lockFilePath, metadata));
+        return;
+      }
+
+      // fs-ext is optional only so Windows installs do not load a Unix native
+      // module. On POSIX it is mandatory: failure to load or flock fails closed.
+      const handle = await open(options.lockFilePath, "a+", 0o600);
+      try {
+        await handle.chmod(0o600);
+        try {
+          if (isBunRuntime() && !options.loadFsExt) {
+            // fs-ext is a Node native addon. Bun cannot safely dlopen the
+            // installed Node ABI binary, so a tiny Node child holds the same
+            // kernel flock and ties its lifetime to this process via stdin.
+            await handle.close();
+            posixHelper = await acquireFlockHelper(options.lockFilePath);
+          } else {
+            const fsExt = options.loadFsExt?.() ?? require("fs-ext") as FsExt;
+            await flock(fsExt, handle.fd, "exnb");
+            posixHandle = handle;
+          }
+        } catch (error) {
+          if (!isBusy(error)) throw error;
+          const existing = await loadMetadata(options.lockFilePath) ?? metadata;
+          await emitDiagnostic(onDiagnostic, "lock_active_conflict", conflictContext(options.lockFilePath, metadata, existing));
+          throw new ActiveRuntimeConsumerLockError(options.lockFilePath, existing);
+        }
+        try {
+          const metadataHandle = posixHandle ?? await open(options.lockFilePath, "r+");
+          try {
+            await metadataHandle.truncate(0);
+            await metadataHandle.writeFile(`${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+            await metadataHandle.sync();
+          } finally {
+            if (!posixHandle) await metadataHandle.close();
+          }
+        } catch (error) {
+          await releasePosixLock(options, posixHandle, posixHelper).catch(() => {});
+          posixHandle = undefined;
+          posixHelper = undefined;
+          throw error;
+        }
+        await emitDiagnostic(onDiagnostic, "lock_acquired", acquiredContext(options.lockFilePath, metadata));
+      } catch (error) {
+        if (handle !== posixHandle) await handle.close().catch(() => {});
+        throw error;
+      }
+    },
+
+    async release(): Promise<void> {
+      if (platform === "win32") {
+        await windowsGuard?.release();
+        windowsGuard = undefined;
+      } else if (posixHandle || posixHelper) {
+        const handle = posixHandle;
+        const helper = posixHelper;
+        posixHandle = undefined;
+        posixHelper = undefined;
+        await releasePosixLock(options, handle, helper);
+      }
+      await emitDiagnostic(onDiagnostic, "lock_released", { lockFilePath: options.lockFilePath });
+    },
+  };
+}
+
+async function emitDiagnostic(
+  callback: CreateRuntimeConsumerLockOptions["onDiagnostic"],
+  event: string,
+  context: Record<string, string | number | boolean | undefined>,
+): Promise<void> {
+  try {
+    await callback?.(event, context);
+  } catch {
+    // Diagnostics must never acquire, lose, or mask runtime ownership.
+  }
+}
+
+async function releasePosixLock(
+  options: CreateRuntimeConsumerLockOptions,
+  handle: FileHandle | undefined,
+  helper: ChildProcessWithoutNullStreams | undefined,
+): Promise<void> {
+  if (helper) {
+    expectedHelperExits.add(helper);
+    if (helper.exitCode !== null || helper.signalCode !== null) return;
+    const closePromise = new Promise<void>((resolve, reject) => {
+      helper.once("error", reject);
+      helper.once("close", (code) => code === 0 ? resolve() : reject(new Error(`runtime lock helper exited with code ${code}`)));
+    });
+    helper.stdin.end();
+    await closePromise;
+    return;
+  }
+  if (!handle) return;
+  const fsExt = options.loadFsExt?.() ?? require("fs-ext") as FsExt;
+  try {
+    await flock(fsExt, handle.fd, "un");
+  } finally {
+    await handle.close();
+  }
+}
+
+function isBunRuntime(): boolean {
+  return Boolean((globalThis as { Bun?: unknown }).Bun);
+}
+
+const FLOCK_HELPER_SOURCE = String.raw`
+const fs = require("node:fs");
+const fsExt = require(process.argv[1]);
+const path = process.argv[2];
+const fd = fs.openSync(path, "a+", 0o600);
+fsExt.flock(fd, "exnb", (error) => {
+  if (error) {
+    const busy = error.code === "EAGAIN" || error.code === "EWOULDBLOCK";
+    process.stdout.write(busy ? "BUSY\n" : "ERROR:" + Buffer.from(String(error.stack || error)).toString("base64") + "\n");
+    fs.closeSync(fd);
+    process.exitCode = busy ? 2 : 1;
+    return;
+  }
+  process.stdout.write("ACQUIRED\n");
+  process.stdin.resume();
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    fsExt.flock(fd, "un", () => {
+      fs.closeSync(fd);
+      process.exit(0);
+    });
+  };
+  process.stdin.once("end", release);
+  process.stdin.once("error", release);
+});
+`;
+
+async function acquireFlockHelper(lockFilePath: string): Promise<ChildProcessWithoutNullStreams> {
+  const fsExtPath = require.resolve("fs-ext");
+  const child = spawn("node", ["-e", FLOCK_HELPER_SOURCE, fsExtPath, lockFilePath], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const line = await new Promise<string>((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`runtime lock helper timed out${stderr ? `: ${stderr}` : ""}`));
+    }, 10_000);
+    const finish = (callback: () => void) => {
+      clearTimeout(timer);
+      callback();
+    };
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+      const newline = stdout.indexOf("\n");
+      if (newline >= 0) finish(() => resolve(stdout.slice(0, newline)));
+    });
+    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+    child.once("error", (error) => finish(() => reject(error)));
+    child.once("close", (code) => {
+      if (!stdout.includes("\n")) {
+        finish(() => reject(new Error(`runtime lock helper exited with code ${code}${stderr ? `: ${stderr}` : ""}`)));
+      }
+    });
+  });
+  if (line === "ACQUIRED") {
+    child.once("close", () => {
+      if (!expectedHelperExits.has(child)) {
+        // Running without the helper's kernel lock would violate the runtime
+        // ownership invariant. End the Bun parent so its normal cleanup path
+        // cannot keep serving or mutating shared state without ownership.
+        process.kill(process.pid, "SIGTERM");
+      }
+    });
+    return child;
+  }
+
+  child.stdin.end();
+  if (line === "BUSY") {
+    const error = new Error("runtime lock is busy") as NodeJS.ErrnoException;
+    error.code = "EWOULDBLOCK";
+    throw error;
+  }
+  if (line.startsWith("ERROR:")) {
+    throw new Error(Buffer.from(line.slice("ERROR:".length), "base64").toString("utf8"));
+  }
+  throw new Error(`unexpected runtime lock helper response: ${line}`);
+}
+
+function flock(fsExt: FsExt, fd: number, operation: "exnb" | "un"): Promise<void> {
+  return new Promise((resolve, reject) => {
+    fsExt.flock(fd, operation, (error) => error ? reject(error) : resolve());
+  });
+}
+
+function isBusy(error: unknown): boolean {
+  const code = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
+  return code === "EAGAIN" || code === "EWOULDBLOCK";
+}
+
+async function loadMetadata(path: string): Promise<ConsumerLockMetadata | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Partial<ConsumerLockMetadata>;
+    if (!Number.isSafeInteger(parsed.pid) || Number(parsed.pid) <= 0
+      || (parsed.mode !== "foreground" && parsed.mode !== "daemon")
+      || typeof parsed.startedAt !== "string"
+      || typeof parsed.configPath !== "string"
+      || typeof parsed.statePath !== "string") return null;
+    return parsed as ConsumerLockMetadata;
+  } catch {
+    return null;
+  }
+}
+
+function acquiredContext(lockFilePath: string, metadata: ConsumerLockMetadata) {
+  return {
+    lockFilePath,
+    pid: metadata.pid,
+    mode: metadata.mode,
+    configPath: metadata.configPath,
+    statePath: metadata.statePath,
+    hostname: metadata.hostname,
+  };
+}
+
+function conflictContext(
+  lockFilePath: string,
+  requested: ConsumerLockMetadata,
+  existing: ConsumerLockMetadata,
+) {
+  return {
+    lockFilePath,
+    activePid: existing.pid,
+    activeMode: existing.mode,
+    activeConfigPath: existing.configPath,
+    activeStatePath: existing.statePath,
+    requestedPid: requested.pid,
+    requestedMode: requested.mode,
   };
 }

--- a/src/daemon/runtime-consumer-lock.ts
+++ b/src/daemon/runtime-consumer-lock.ts
@@ -1,0 +1,70 @@
+import { join } from "node:path";
+
+import type { ConsumerLock, ConsumerLockMetadata } from "../channels/types";
+import { createWeixinConsumerLock } from "../weixin/monitor/consumer-lock";
+
+interface CreateRuntimeConsumerLockOptions {
+  runtimeDir: string;
+  channelLock?: ConsumerLock;
+  onDiagnostic?: (
+    event: string,
+    context: Record<string, string | number | boolean | undefined>,
+  ) => void | Promise<void>;
+  createCoreLock?: () => ConsumerLock;
+}
+
+/**
+ * Every console instance owns this core lock regardless of configured channels.
+ * A channel lock is acquired as a second, compatibility fence so a new runtime
+ * also conflicts with daemons started before the core lock existed.
+ */
+export function createRuntimeConsumerLock(options: CreateRuntimeConsumerLockOptions): ConsumerLock {
+  const coreLock = (options.createCoreLock ?? (() => createWeixinConsumerLock({
+    lockFilePath: join(options.runtimeDir, "runtime-consumer.lock.json"),
+    windowsGuardRole: "runtime-owner",
+    activeLockError: (_lockFilePath, existing) => new Error(
+      [
+        "xacpx runtime is already running.",
+        `pid: ${existing.pid}`,
+        `mode: ${existing.mode}`,
+        `config: ${existing.configPath}`,
+        `state: ${existing.statePath}`,
+      ].join("\n"),
+    ),
+    onDiagnostic: options.onDiagnostic,
+  })))();
+  let coreAcquired = false;
+  let channelAcquired = false;
+
+  return {
+    async acquire(metadata: ConsumerLockMetadata): Promise<void> {
+      await coreLock.acquire(metadata);
+      coreAcquired = true;
+      try {
+        if (options.channelLock) {
+          await options.channelLock.acquire(metadata);
+          channelAcquired = true;
+        }
+      } catch (error) {
+        await coreLock.release().catch(() => {});
+        coreAcquired = false;
+        throw error;
+      }
+    },
+
+    async release(): Promise<void> {
+      let releaseError: unknown;
+      if (channelAcquired) {
+        try { await options.channelLock!.release(); }
+        catch (error) { releaseError = error; }
+        channelAcquired = false;
+      }
+      if (coreAcquired) {
+        try { await coreLock.release(); }
+        catch (error) { releaseError ??= error; }
+        coreAcquired = false;
+      }
+      if (releaseError) throw releaseError;
+    },
+  };
+}

--- a/src/daemon/windows-daemon-runtime.ts
+++ b/src/daemon/windows-daemon-runtime.ts
@@ -1,0 +1,37 @@
+import { dirname } from "node:path";
+
+import {
+  createDaemonIdentity,
+  OrphanRegistry,
+  type DaemonIdentity,
+} from "../transport/orphan-registry";
+
+interface InitializeWindowsDaemonRuntimeOptions {
+  configPath: string;
+  runtimeDir: string;
+  platform?: NodeJS.Platform;
+  createIdentity?: typeof createDaemonIdentity;
+  createRegistry?: (runtimeDir: string) => OrphanRegistry;
+}
+
+export type WindowsDaemonRuntimeDeps = {
+  daemonIdentity?: DaemonIdentity;
+  orphanRegistry?: OrphanRegistry;
+};
+
+export async function initializeWindowsDaemonRuntime(
+  options: InitializeWindowsDaemonRuntimeOptions,
+): Promise<WindowsDaemonRuntimeDeps> {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") return {};
+
+  const configRoot = dirname(options.configPath);
+  const orphanRegistry = (options.createRegistry ?? ((runtimeDir) => new OrphanRegistry(runtimeDir)))(options.runtimeDir);
+  await orphanRegistry.initialize();
+  const daemonIdentity = await (options.createIdentity ?? createDaemonIdentity)({
+    configRoot,
+    platform: "win32",
+  });
+  await orphanRegistry.writeGeneration(daemonIdentity);
+  return { daemonIdentity, orphanRegistry };
+}

--- a/src/daemon/windows-daemon-runtime.ts
+++ b/src/daemon/windows-daemon-runtime.ts
@@ -17,6 +17,7 @@ interface InitializeWindowsDaemonRuntimeOptions {
 export type WindowsDaemonRuntimeDeps = {
   daemonIdentity?: DaemonIdentity;
   orphanRegistry?: OrphanRegistry;
+  publishGeneration?: () => Promise<void>;
 };
 
 export async function initializeWindowsDaemonRuntime(
@@ -32,6 +33,15 @@ export async function initializeWindowsDaemonRuntime(
     configRoot,
     platform: "win32",
   });
-  await orphanRegistry.writeGeneration(daemonIdentity);
-  return { daemonIdentity, orphanRegistry };
+  let generationPublished = false;
+  const publishGeneration = async (): Promise<void> => {
+    if (generationPublished) return;
+    await orphanRegistry.writeGeneration(daemonIdentity);
+    generationPublished = true;
+  };
+  return {
+    daemonIdentity,
+    orphanRegistry,
+    publishGeneration,
+  };
 }

--- a/src/doctor/checks/daemon-check.ts
+++ b/src/doctor/checks/daemon-check.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { createDaemonController } from "../../daemon/create-daemon-controller";
 import {
   isProcessAlive,
+  RUNTIME_CONSUMER_LOCK_FILE,
   resolveDaemonPaths,
   resolveRuntimeDirFromConfigPath,
   type DaemonPaths,
@@ -168,7 +169,9 @@ async function detectStaleConsumerLockFix(
   const lockFiles = await deps.listConsumerLocks(runtimeDir);
   const stalePaths: string[] = [];
   for (const fileName of lockFiles) {
-    if (!fileName.endsWith(CONSUMER_LOCK_SUFFIX)) {
+    // The core runtime file is stable metadata for an OS-held lock. Deleting
+    // its pathname can split future flock contenders onto a different inode.
+    if (fileName === RUNTIME_CONSUMER_LOCK_FILE || !fileName.endsWith(CONSUMER_LOCK_SUFFIX)) {
       continue;
     }
     const lockPath = join(runtimeDir, fileName);

--- a/src/i18n/messages/en/cli.ts
+++ b/src/i18n/messages/en/cli.ts
@@ -32,7 +32,7 @@ export const cli: CliMessages = {
   // status command
   running: "xacpx is running",
   notRunning: "xacpx is not running",
-  indeterminate: "xacpx process is still running but status metadata is missing",
+  indeterminate: "xacpx process is still running but daemon metadata is incomplete or inconsistent",
 
   // stop command
   stopped: "xacpx stopped",
@@ -41,8 +41,8 @@ export const cli: CliMessages = {
   restarting: "xacpx restarting...",
   restartNotRunning: "xacpx is not running, starting...",
   restartFailed: (detail) => `xacpx failed to restart: ${detail}`,
-  restartIndeterminate: "xacpx process is still running but status metadata is missing",
-  restartIndeterminateHint: "Run `xacpx stop` first, or manually clean up the stale PID/status before retrying.",
+  restartIndeterminate: "xacpx process is still running but daemon metadata is incomplete or inconsistent",
+  restartIndeterminateHint: "Verify the PID shown above and stop that process before retrying; do not delete runtime metadata while it is still alive.",
 
   // daemon log hints
   checkAppLog: (path) => `Check App Log: ${path}`,

--- a/src/i18n/messages/zh/cli.ts
+++ b/src/i18n/messages/zh/cli.ts
@@ -32,7 +32,7 @@ export const cli: CliMessages = {
   // status command
   running: "xacpx 正在运行",
   notRunning: "xacpx 未运行",
-  indeterminate: "xacpx 进程仍在运行，但状态元数据缺失",
+  indeterminate: "xacpx 进程仍在运行，但 daemon 元数据不完整或不一致",
 
   // stop command
   stopped: "xacpx 已停止",
@@ -41,8 +41,8 @@ export const cli: CliMessages = {
   restarting: "xacpx 正在重启...",
   restartNotRunning: "xacpx 未运行，正在启动...",
   restartFailed: (detail) => `xacpx 重启失败：${detail}`,
-  restartIndeterminate: "xacpx 进程仍在运行，但状态元数据缺失",
-  restartIndeterminateHint: "请先执行 `xacpx stop`，或手动清理 stale PID/status 后再重试。",
+  restartIndeterminate: "xacpx 进程仍在运行，但 daemon 元数据不完整或不一致",
+  restartIndeterminateHint: "请先核对上方 PID 并停止该进程；进程仍存活时不要删除 runtime 元数据。",
 
   // daemon log hints
   checkAppLog: (path) => `请查看 App Log: ${path}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,6 @@ import { createAcpxAgentRegistryLoader } from "./transport/agent-registry";
 import { startConfigWatcher } from "./config/config-watcher";
 import type { DaemonIdentity, OrphanRegistry } from "./transport/orphan-registry";
 import { sweepWindowsOrphans } from "./transport/windows-orphan-reaper";
-import { initializeWindowsDaemonRuntime } from "./daemon/windows-daemon-runtime";
 import { replaceRuntimeState } from "./state/replace-runtime-state";
 import { LaunchIntentCoordinator } from "./transport/launch-intent-coordinator";
 import { withAdapterOperationLock } from "./adapters/adapter-locks";
@@ -150,6 +149,7 @@ interface RuntimeDeps {
   stateSaveDebounceMs?: number;
   daemonIdentity?: DaemonIdentity;
   orphanRegistry?: OrphanRegistry;
+  canReapQueueOwners?: () => boolean;
   /**
    * Provision xacpx-managed acpx agent overlays before transport creation.
    * Injectable for tests; defaults to provisioning from the loaded config.
@@ -1075,6 +1075,7 @@ export async function buildApp(paths: RuntimePaths, deps: RuntimeDeps = {}): Pro
   // bounded: failures/timeouts just leave owners to expire on TTL.
   const reapWarmQueueOwners = async (phase: "startup" | "periodic" | "shutdown"): Promise<void> => {
     try {
+      if (deps.canReapQueueOwners && !deps.canReapQueueOwners()) return;
       if (deps.orphanRegistry && deps.daemonIdentity) {
         const outcome = await sweepWindowsOrphans(
           deps.orphanRegistry,
@@ -1188,10 +1189,6 @@ export async function main(): Promise<void> {
 
   try {
     const { createMessageChannels } = await import("./channels/create-channel.js");
-    const { daemonIdentity, orphanRegistry } = await initializeWindowsDaemonRuntime({
-      configPath: paths.configPath,
-      runtimeDir: resolveRuntimeDirFromConfigPath(paths.configPath),
-    });
     await ensureConfigExists(paths.configPath);
     const startupConfig = await loadConfig(paths.configPath);
 
@@ -1208,7 +1205,7 @@ export async function main(): Promise<void> {
     const { channelDeps } = await prepareChannelMedia(paths.configPath, startupConfig);
     const channelRegistry = new MessageChannelRegistry(createMessageChannels(startupConfig.channels, channelDeps));
     await runConsole(paths, {
-      buildApp: (paths) => buildApp(paths, { channel: channelRegistry, daemonIdentity, orphanRegistry }),
+      buildApp: (paths) => buildApp(paths, { channel: channelRegistry }),
       channels: channelRegistry,
     });
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,8 +60,9 @@ import { UploadStore } from "./control/upload-store.js";
 import { listAgentCatalog } from "./config/agent-catalog";
 import { createAcpxAgentRegistryLoader } from "./transport/agent-registry";
 import { startConfigWatcher } from "./config/config-watcher";
-import { createDaemonIdentity, OrphanRegistry, type DaemonIdentity } from "./transport/orphan-registry";
+import type { DaemonIdentity, OrphanRegistry } from "./transport/orphan-registry";
 import { sweepWindowsOrphans } from "./transport/windows-orphan-reaper";
+import { initializeWindowsDaemonRuntime } from "./daemon/windows-daemon-runtime";
 import { replaceRuntimeState } from "./state/replace-runtime-state";
 import { LaunchIntentCoordinator } from "./transport/launch-intent-coordinator";
 import { withAdapterOperationLock } from "./adapters/adapter-locks";
@@ -1187,15 +1188,10 @@ export async function main(): Promise<void> {
 
   try {
     const { createMessageChannels } = await import("./channels/create-channel.js");
-    let daemonIdentity: DaemonIdentity | undefined;
-    let orphanRegistry: OrphanRegistry | undefined;
-    if (process.platform === "win32") {
-      const configRoot = dirname(paths.configPath);
-      orphanRegistry = new OrphanRegistry(join(configRoot, "runtime"));
-      await orphanRegistry.initialize();
-      daemonIdentity = await createDaemonIdentity({ configRoot });
-      await orphanRegistry.writeGeneration(daemonIdentity);
-    }
+    const { daemonIdentity, orphanRegistry } = await initializeWindowsDaemonRuntime({
+      configPath: paths.configPath,
+      runtimeDir: resolveRuntimeDirFromConfigPath(paths.configPath),
+    });
     await ensureConfigExists(paths.configPath);
     const startupConfig = await loadConfig(paths.configPath);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,6 @@ import { createActiveTurnRegistry, type ActiveTurnRegistry } from "./sessions/ac
 import { DebouncedStateStore } from "./state/debounced-state-store";
 import { StateStore } from "./state/state-store";
 import type { AppState } from "./state/types";
-import { runConsole } from "./run-console";
 import { spawnAcpxBridgeClient } from "./transport/acpx-bridge/acpx-bridge-client";
 import { AcpxBridgeTransport } from "./transport/acpx-bridge/acpx-bridge-transport";
 import { AcpxCliTransport } from "./transport/acpx-cli/acpx-cli-transport";
@@ -44,7 +43,6 @@ import type { ResolvedSession, SessionTransport } from "./transport/types";
 import { reapQueueOwners } from "./transport/queue-owner-reaper";
 import { collectReapTargets } from "./transport/collect-reap-targets";
 import type { MessageChannelRuntime, CoordinatorMessageInput } from "./channels/types.js";
-import { MessageChannelRegistry } from "./channels/channel-registry.js";
 import { RuntimeMediaStore } from "./channels/media-store.js";
 import { isQuotaDeferredError } from "./weixin/messaging/quota-errors";
 import { normalizeWeixinUserIdFromChatKey } from "./weixin/messaging/inbound.js";
@@ -1184,30 +1182,20 @@ function replaceRuntimeConfig(target: AppConfig, source: AppConfig): void {
   Object.assign(target, source);
 }
 
-export async function main(): Promise<void> {
+interface MainDeps {
+  runRuntime?: () => Promise<void>;
+}
+
+/**
+ * The source entrypoint delegates to the same guarded runtime path as
+ * `xacpx run`; it must never grow a second, lock-free startup sequence.
+ */
+export async function main(deps: MainDeps = {}): Promise<void> {
   const paths = resolveRuntimePaths();
 
   try {
-    const { createMessageChannels } = await import("./channels/create-channel.js");
-    await ensureConfigExists(paths.configPath);
-    const startupConfig = await loadConfig(paths.configPath);
-
-    const { loadConfiguredPlugins } = await import("./plugins/plugin-loader.js");
-    await loadConfiguredPlugins({
-      plugins: startupConfig.plugins,
-      onPluginError: ({ name, error }) => {
-        console.error(
-          `[xacpx] skipping plugin ${name}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      },
-    });
-
-    const { channelDeps } = await prepareChannelMedia(paths.configPath, startupConfig);
-    const channelRegistry = new MessageChannelRegistry(createMessageChannels(startupConfig.channels, channelDeps));
-    await runConsole(paths, {
-      buildApp: (paths) => buildApp(paths, { channel: channelRegistry }),
-      channels: channelRegistry,
-    });
+    const runRuntime = deps.runRuntime ?? (await import("./cli.js")).runDefaultRuntime;
+    await runRuntime();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1182,19 +1182,15 @@ function replaceRuntimeConfig(target: AppConfig, source: AppConfig): void {
   Object.assign(target, source);
 }
 
-interface MainDeps {
-  runRuntime?: () => Promise<void>;
-}
-
 /**
  * The source entrypoint delegates to the same guarded runtime path as
  * `xacpx run`; it must never grow a second, lock-free startup sequence.
  */
-export async function main(deps: MainDeps = {}): Promise<void> {
+export async function main(): Promise<void> {
   const paths = resolveRuntimePaths();
 
   try {
-    const runRuntime = deps.runRuntime ?? (await import("./cli.js")).runDefaultRuntime;
+    const runRuntime = (await import("./cli.js")).runDefaultRuntime;
     await runRuntime();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -1210,7 +1206,13 @@ export async function main(deps: MainDeps = {}): Promise<void> {
 }
 
 if (import.meta.main) {
-  await main();
+  // Do not top-level-await main(): runDefaultRuntime imports this module's
+  // buildApp exports, so awaiting here would leave both sides of that dynamic
+  // import cycle waiting for this module evaluation to finish.
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+    process.exitCode = 1;
+  });
 }
 
 export async function prepareChannelMedia(configPath: string, config: AppConfig): Promise<{

--- a/src/process/posix-process-identity.ts
+++ b/src/process/posix-process-identity.ts
@@ -1,0 +1,51 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface PosixProcessIdentity {
+  pid: number;
+  startedAtMs: number;
+}
+
+export type PosixProcessIdentityProbe =
+  | { status: "found"; identity: PosixProcessIdentity }
+  | { status: "missing" | "unavailable" };
+
+interface ProbePosixProcessIdentityOptions {
+  runPs?: (pid: number) => Promise<string | null>;
+}
+
+export async function probePosixProcessIdentity(
+  pid: number,
+  options: ProbePosixProcessIdentityOptions = {},
+): Promise<PosixProcessIdentityProbe> {
+  try {
+    const output = await (options.runPs ?? defaultRunPs)(pid);
+    if (output === null) return { status: "missing" };
+    const startedAtMs = Date.parse(output.trim());
+    if (!Number.isFinite(startedAtMs)) return { status: "unavailable" };
+    return { status: "found", identity: { pid, startedAtMs } };
+  } catch {
+    return { status: "unavailable" };
+  }
+}
+
+async function defaultRunPs(pid: number): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-p", String(pid), "-o", "lstart="],
+      {
+        env: { ...process.env, LC_ALL: "C" },
+        timeout: 5_000,
+        maxBuffer: 4_096,
+      },
+    );
+    return stdout;
+  } catch (error) {
+    const code = (error as { code?: unknown }).code;
+    if (code === 1 || code === "1") return null;
+    throw error;
+  }
+}

--- a/src/process/windows-process-tree.ts
+++ b/src/process/windows-process-tree.ts
@@ -33,6 +33,7 @@ export interface WindowsProcessIdentity {
   pid: number;
   creationDate: string;
   executablePath: string;
+  commandLine?: string;
 }
 
 export interface WindowsTokenProcess {
@@ -151,7 +152,12 @@ export async function queryWindowsProcessIdentity(
     if (item.pid !== pid || parseCanonicalFileTime(item.creationDate) === null || typeof item.executablePath !== "string" || !item.executablePath) {
       return null;
     }
-    return { pid, creationDate: String(item.creationDate), executablePath: item.executablePath };
+    return {
+      pid,
+      creationDate: String(item.creationDate),
+      executablePath: item.executablePath,
+      ...(typeof item.commandLine === "string" && item.commandLine ? { commandLine: item.commandLine } : {}),
+    };
   } catch {
     return null;
   }
@@ -312,7 +318,18 @@ if($request.action -eq 'identity'){
   try {
     $creation=[XacpxNativeProcess]::Creation($h);$image=[XacpxNativeProcess]::Image($h)
     if(!$creation -or !$image){Write-Output (@{status='unavailable'} | ConvertTo-Json -Compress);exit 0}
-    Write-Output (@{status='found';identity=@{pid=[int]$request.pid;creationDate=$creation;executablePath=$image}} | ConvertTo-Json -Depth 4 -Compress)
+    $commandLine=$null
+    try {
+      $cim=Get-CimInstance Win32_Process -Filter ("ProcessId = "+[int]$request.pid)
+      if($cim -and $cim.CreationDate){
+        $cimCreation=$cim.CreationDate.ToUniversalTime().ToFileTimeUtc().ToString()
+        $delta=[Numerics.BigInteger]::Abs([Numerics.BigInteger]::Parse($creation)-[Numerics.BigInteger]::Parse($cimCreation))
+        if($delta -le 9 -and [string]::Equals([string]$image,[string]$cim.ExecutablePath,[StringComparison]::OrdinalIgnoreCase)){
+          $commandLine=$cim.CommandLine
+        }
+      }
+    } catch {}
+    Write-Output (@{status='found';identity=@{pid=[int]$request.pid;creationDate=$creation;executablePath=$image;commandLine=$commandLine}} | ConvertTo-Json -Depth 4 -Compress)
     exit 0
   } finally {[XacpxNativeProcess]::Close($h)}
 }

--- a/src/run-console.ts
+++ b/src/run-console.ts
@@ -143,6 +143,9 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
       }
     }
 
+    if (!consumerLock && deps.afterConsumerLockAcquired) {
+      throw new Error("runtime ownership lock is required before activating shared runtime state");
+    }
     if (deps.afterConsumerLockAcquired) {
       await deps.afterConsumerLockAcquired(runtime);
     }

--- a/src/run-console.ts
+++ b/src/run-console.ts
@@ -21,6 +21,11 @@ type ChannelStartupPolicy = "require-one" | "best-effort";
 interface RunConsoleDeps {
   buildApp: (paths: RuntimePaths) => Promise<AppRuntime>;
   afterBuild?: (runtime: AppRuntime) => Promise<void>;
+  /**
+   * Activates durable process-owned state after the optional consumer lock is
+   * held, but before reconciliation or orphan cleanup can mutate shared state.
+   */
+  afterConsumerLockAcquired?: (runtime: AppRuntime) => Promise<void>;
   beforeReady?: (runtime: AppRuntime) => Promise<void>;
   channels: ChannelRegistry;
   channelStartupPolicy?: ChannelStartupPolicy;
@@ -83,19 +88,6 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
     if (deps.afterBuild) {
       await deps.afterBuild(runtime);
     }
-    // Drain any tasks that were queued at shutdown and close stale ephemeral
-    // worker sessions left over from a previous run.
-    try {
-      await runtime.orchestration.service.reconcileParallelSlots();
-    } catch (reconcileError) {
-      await runtime.logger.error(
-        "orchestration.parallel.reconcile_failed",
-        "failed to reconcile parallel slots at startup",
-        {
-          message: reconcileError instanceof Error ? reconcileError.message : String(reconcileError),
-        },
-      );
-    }
     consumerLock = deps.consumerLock ?? deps.consumerLockFactory?.(runtime);
 
     if (consumerLock) {
@@ -149,6 +141,26 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
         }
         throw error;
       }
+    }
+
+    if (deps.afterConsumerLockAcquired) {
+      await deps.afterConsumerLockAcquired(runtime);
+    }
+
+    // Drain any tasks that were queued at shutdown and close stale ephemeral
+    // worker sessions left over from a previous run. This must happen only
+    // after this process owns the consumer/runtime identity; a conflicting
+    // foreground process must not mutate the active daemon's state.
+    try {
+      await runtime.orchestration.service.reconcileParallelSlots();
+    } catch (reconcileError) {
+      await runtime.logger.error(
+        "orchestration.parallel.reconcile_failed",
+        "failed to reconcile parallel slots at startup",
+        {
+          message: reconcileError instanceof Error ? reconcileError.message : String(reconcileError),
+        },
+      );
     }
 
     // Sweep warm acpx queue owners orphaned by a previous daemon that exited without a

--- a/src/run-console.ts
+++ b/src/run-console.ts
@@ -1,6 +1,10 @@
 import type { AppRuntime, RuntimePaths } from "./main";
-import type { ChannelStartInput, ConsumerLock, ConsumerLockMetadata } from "./channels/types.js";
-import { ActiveWeixinConsumerLockError } from "./weixin/monitor/consumer-lock";
+import {
+  ActiveConsumerLockError,
+  type ChannelStartInput,
+  type ConsumerLock,
+  type ConsumerLockMetadata,
+} from "./channels/types.js";
 import { listXacpxCommandHints } from "./commands/command-hints.js";
 import { XACPX_CORE_VERSION } from "./version.js";
 import { getLocale } from "./i18n/index.js";
@@ -22,7 +26,7 @@ interface RunConsoleDeps {
   buildApp: (paths: RuntimePaths) => Promise<AppRuntime>;
   afterBuild?: (runtime: AppRuntime) => Promise<void>;
   /**
-   * Activates durable process-owned state after the optional consumer lock is
+   * Activates durable process-owned state after the required consumer lock is
    * held, but before reconciliation or orphan cleanup can mutate shared state.
    */
   afterConsumerLockAcquired?: (runtime: AppRuntime) => Promise<void>;
@@ -104,7 +108,7 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
           processCreationDate: runtime.daemonIdentity.daemonCreationDate,
         } : {}),
       };
-      await runtime.logger.info("weixin.consumer_lock.acquire_attempt", "attempting to acquire weixin consumer lock", {
+      await runtime.logger.info("runtime.consumer_lock.acquire_attempt", "attempting to acquire runtime ownership lock", {
         pid: lockMeta.pid,
         mode: lockMeta.mode,
         configPath: lockMeta.configPath,
@@ -114,15 +118,15 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
       try {
         await consumerLock.acquire(lockMeta);
         consumerLockAcquired = true;
-        await runtime.logger.info("weixin.consumer_lock.acquired", "acquired weixin consumer lock", {
+        await runtime.logger.info("runtime.consumer_lock.acquired", "acquired runtime ownership lock", {
           pid: lockMeta.pid,
           mode: lockMeta.mode,
           configPath: lockMeta.configPath,
           statePath: lockMeta.statePath,
         });
       } catch (error) {
-        if (error instanceof ActiveWeixinConsumerLockError) {
-          await runtime.logger.error("weixin.consumer_lock.acquire_failed", "weixin consumer lock is already held by another process", {
+        if (error instanceof ActiveConsumerLockError) {
+          await runtime.logger.error("runtime.consumer_lock.acquire_failed", "runtime ownership lock is already held by another process", {
             conflictType: "active_lock_holder",
             activePid: error.existing.pid,
             activeMode: error.existing.mode,
@@ -132,7 +136,7 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
             requestedMode: lockMeta.mode,
           });
         } else {
-          await runtime.logger.error("weixin.consumer_lock.acquire_failed", "failed to acquire weixin consumer lock", {
+          await runtime.logger.error("runtime.consumer_lock.acquire_failed", "failed to acquire runtime ownership lock", {
             conflictType: deps.daemonRuntime ? "daemon_startup_lock_failure" : "foreground_startup_lock_failure",
             requestedPid: lockMeta.pid,
             requestedMode: lockMeta.mode,
@@ -143,7 +147,7 @@ export async function runConsole(paths: RuntimePaths, deps: RunConsoleDeps): Pro
       }
     }
 
-    if (!consumerLock && deps.afterConsumerLockAcquired) {
+    if (!consumerLock) {
       throw new Error("runtime ownership lock is required before activating shared runtime state");
     }
     if (deps.afterConsumerLockAcquired) {
@@ -366,7 +370,7 @@ async function runCleanupSequence(input: RunCleanupSequenceInput): Promise<void>
     try {
       await input.consumerLock?.release();
       if (input.runtime) {
-        await input.runtime.logger.info("weixin.consumer_lock.released", "released weixin consumer lock", {
+        await input.runtime.logger.info("runtime.consumer_lock.released", "released runtime ownership lock", {
           pid: input.processPid,
         });
       }

--- a/src/weixin/monitor/consumer-lock.ts
+++ b/src/weixin/monitor/consumer-lock.ts
@@ -49,6 +49,11 @@ interface CreateWeixinConsumerLockOptions {
   isProcessRunning?: (pid: number) => boolean;
   platform?: NodeJS.Platform;
   acquireGuard?: typeof acquireIpcGuard;
+  windowsGuardRole?: string;
+  activeLockError?: (
+    lockFilePath: string,
+    existing: WeixinConsumerLockMetadata,
+  ) => Error;
   onDiagnostic?: (
     event:
       | "lock_exists"
@@ -78,13 +83,14 @@ export function createWeixinConsumerLock(
       if (platform === "win32") {
         try {
           windowsGuard = await (options.acquireGuard ?? acquireIpcGuard)(
-            { role: "consumer", configRoot: dirname(meta.configPath) },
+            { role: options.windowsGuardRole ?? "consumer", configRoot: dirname(meta.configPath) },
             { platform },
           );
         } catch (error) {
           if (!(error instanceof IpcGuardBusyError)) throw error;
           const existing = await loadLockMetadata(lockFilePath) ?? meta;
-          throw new ActiveWeixinConsumerLockError(lockFilePath, existing);
+          throw options.activeLockError?.(lockFilePath, existing)
+            ?? new ActiveWeixinConsumerLockError(lockFilePath, existing);
         }
         windowsLockId = meta.lockId ?? randomUUID();
         const metadata: WeixinConsumerLockMetadata = {
@@ -166,7 +172,8 @@ export function createWeixinConsumerLock(
             requestedPid: meta.pid,
             requestedMode: meta.mode,
           });
-          throw new ActiveWeixinConsumerLockError(lockFilePath, existing);
+          throw options.activeLockError?.(lockFilePath, existing)
+            ?? new ActiveWeixinConsumerLockError(lockFilePath, existing);
         }
       }
     },

--- a/src/weixin/monitor/consumer-lock.ts
+++ b/src/weixin/monitor/consumer-lock.ts
@@ -5,6 +5,8 @@ import { homedir } from "node:os";
 
 import { coreHomeDir } from "../../runtime/core-home";
 import { acquireIpcGuard, IpcGuardBusyError } from "../../process/ipc-guard";
+import { probePosixProcessIdentity } from "../../process/posix-process-identity";
+import { ActiveConsumerLockError } from "../../channels/types";
 
 export interface WeixinConsumerLockMetadata {
   pid: number;
@@ -16,6 +18,7 @@ export interface WeixinConsumerLockMetadata {
   schemaVersion?: 2;
   lockId?: string;
   processCreationDate?: string | null;
+  processStartedAtMs?: number;
 }
 
 export interface WeixinConsumerLock {
@@ -23,10 +26,7 @@ export interface WeixinConsumerLock {
   release: () => Promise<void>;
 }
 
-export class ActiveWeixinConsumerLockError extends Error {
-  readonly existing: WeixinConsumerLockMetadata;
-  readonly lockFilePath: string;
-
+export class ActiveWeixinConsumerLockError extends ActiveConsumerLockError {
   constructor(lockFilePath: string, existing: WeixinConsumerLockMetadata) {
     super(
       [
@@ -37,10 +37,10 @@ export class ActiveWeixinConsumerLockError extends Error {
         `state: ${existing.statePath}`,
         "Try stopping the existing instance or close the foreground `xacpx run` process before starting a new one.",
       ].join("\n"),
+      lockFilePath,
+      existing,
     );
     this.name = "ActiveWeixinConsumerLockError";
-    this.lockFilePath = lockFilePath;
-    this.existing = existing;
   }
 }
 
@@ -49,11 +49,7 @@ interface CreateWeixinConsumerLockOptions {
   isProcessRunning?: (pid: number) => boolean;
   platform?: NodeJS.Platform;
   acquireGuard?: typeof acquireIpcGuard;
-  windowsGuardRole?: string;
-  activeLockError?: (
-    lockFilePath: string,
-    existing: WeixinConsumerLockMetadata,
-  ) => Error;
+  probeProcessIdentity?: typeof probePosixProcessIdentity;
   onDiagnostic?: (
     event:
       | "lock_exists"
@@ -75,6 +71,7 @@ export function createWeixinConsumerLock(
   const platform = options.platform ?? process.platform;
   let windowsGuard: Awaited<ReturnType<typeof acquireIpcGuard>> | undefined;
   let windowsLockId: string | undefined;
+  let posixLockId: string | undefined;
 
   return {
     async acquire(meta) {
@@ -83,14 +80,13 @@ export function createWeixinConsumerLock(
       if (platform === "win32") {
         try {
           windowsGuard = await (options.acquireGuard ?? acquireIpcGuard)(
-            { role: options.windowsGuardRole ?? "consumer", configRoot: dirname(meta.configPath) },
+            { role: "consumer", configRoot: dirname(meta.configPath) },
             { platform },
           );
         } catch (error) {
           if (!(error instanceof IpcGuardBusyError)) throw error;
           const existing = await loadLockMetadata(lockFilePath) ?? meta;
-          throw options.activeLockError?.(lockFilePath, existing)
-            ?? new ActiveWeixinConsumerLockError(lockFilePath, existing);
+          throw new ActiveWeixinConsumerLockError(lockFilePath, existing);
         }
         windowsLockId = meta.lockId ?? randomUUID();
         const metadata: WeixinConsumerLockMetadata = {
@@ -111,11 +107,17 @@ export function createWeixinConsumerLock(
         return;
       }
 
+      const requestedIdentity = await (options.probeProcessIdentity ?? probePosixProcessIdentity)(meta.pid);
+      posixLockId = meta.lockId ?? randomUUID();
+      const requested = requestedIdentity.status === "found"
+        ? { ...meta, schemaVersion: 2 as const, lockId: posixLockId, processStartedAtMs: requestedIdentity.identity.startedAtMs }
+        : { ...meta, schemaVersion: 2 as const, lockId: posixLockId };
+
       while (true) {
         try {
           const handle = await open(lockFilePath, "wx");
           try {
-            await handle.writeFile(`${JSON.stringify(meta, null, 2)}\n`, "utf8");
+            await handle.writeFile(`${JSON.stringify(requested, null, 2)}\n`, "utf8");
           } finally {
             await handle.close();
           }
@@ -150,7 +152,10 @@ export function createWeixinConsumerLock(
             continue;
           }
 
-          if (!isProcessRunning(existing.pid)) {
+          if (!await isSamePosixProcess(existing, {
+            isProcessRunning,
+            probeProcessIdentity: options.probeProcessIdentity ?? probePosixProcessIdentity,
+          })) {
             await rm(lockFilePath, { force: true });
             await onDiagnostic?.("lock_stale_removed", {
               lockFilePath,
@@ -158,7 +163,7 @@ export function createWeixinConsumerLock(
               staleMode: existing.mode,
               staleConfigPath: existing.configPath,
               staleStatePath: existing.statePath,
-              reason: "owner_process_not_running",
+              reason: "owner_process_missing_or_identity_changed",
             });
             continue;
           }
@@ -172,8 +177,7 @@ export function createWeixinConsumerLock(
             requestedPid: meta.pid,
             requestedMode: meta.mode,
           });
-          throw options.activeLockError?.(lockFilePath, existing)
-            ?? new ActiveWeixinConsumerLockError(lockFilePath, existing);
+          throw new ActiveWeixinConsumerLockError(lockFilePath, existing);
         }
       }
     },
@@ -187,12 +191,33 @@ export function createWeixinConsumerLock(
         await onDiagnostic?.("lock_released", { lockFilePath });
         return;
       }
-      await rm(lockFilePath, { force: true });
+      const metadata = await loadLockMetadata(lockFilePath);
+      if (metadata?.lockId === posixLockId) await rm(lockFilePath, { force: true });
+      posixLockId = undefined;
       await onDiagnostic?.("lock_released", {
         lockFilePath,
       });
     },
   };
+}
+
+async function isSamePosixProcess(
+  metadata: WeixinConsumerLockMetadata,
+  deps: {
+    isProcessRunning: (pid: number) => boolean;
+    probeProcessIdentity: typeof probePosixProcessIdentity;
+  },
+): Promise<boolean> {
+  if (!deps.isProcessRunning(metadata.pid)) return false;
+  const probe = await deps.probeProcessIdentity(metadata.pid);
+  // Identity lookup failure is not permission to delete another process's
+  // compatibility fence. Normal macOS/Linux probes distinguish PID reuse.
+  if (probe.status !== "found") return probe.status === "unavailable";
+  if (Number.isSafeInteger(metadata.processStartedAtMs)) {
+    return probe.identity.startedAtMs === metadata.processStartedAtMs;
+  }
+  const acquiredAt = Date.parse(metadata.startedAt);
+  return Number.isFinite(acquiredAt) && probe.identity.startedAtMs <= acquiredAt + 1_000;
 }
 
 async function loadLockMetadata(path: string): Promise<WeixinConsumerLockMetadata | null> {

--- a/src/weixin/monitor/consumer-lock.ts
+++ b/src/weixin/monitor/consumer-lock.ts
@@ -103,7 +103,7 @@ export function createWeixinConsumerLock(
           windowsLockId = undefined;
           throw error;
         }
-        await onDiagnostic?.("lock_acquired", { lockFilePath, pid: meta.pid, mode: meta.mode });
+        await emitDiagnostic(onDiagnostic, "lock_acquired", { lockFilePath, pid: meta.pid, mode: meta.mode });
         return;
       }
 
@@ -121,7 +121,7 @@ export function createWeixinConsumerLock(
           } finally {
             await handle.close();
           }
-          await onDiagnostic?.("lock_acquired", {
+          await emitDiagnostic(onDiagnostic, "lock_acquired", {
             lockFilePath,
             pid: meta.pid,
             mode: meta.mode,
@@ -136,7 +136,7 @@ export function createWeixinConsumerLock(
             throw error;
           }
 
-          await onDiagnostic?.("lock_exists", {
+          await emitDiagnostic(onDiagnostic, "lock_exists", {
             lockFilePath,
             pid: meta.pid,
             mode: meta.mode,
@@ -145,7 +145,7 @@ export function createWeixinConsumerLock(
           const existing = await loadLockMetadata(lockFilePath);
           if (!existing) {
             await rm(lockFilePath, { force: true });
-            await onDiagnostic?.("lock_invalid_removed", {
+            await emitDiagnostic(onDiagnostic, "lock_invalid_removed", {
               lockFilePath,
               reason: "invalid_or_unreadable_metadata",
             });
@@ -157,7 +157,7 @@ export function createWeixinConsumerLock(
             probeProcessIdentity: options.probeProcessIdentity ?? probePosixProcessIdentity,
           })) {
             await rm(lockFilePath, { force: true });
-            await onDiagnostic?.("lock_stale_removed", {
+            await emitDiagnostic(onDiagnostic, "lock_stale_removed", {
               lockFilePath,
               stalePid: existing.pid,
               staleMode: existing.mode,
@@ -168,7 +168,7 @@ export function createWeixinConsumerLock(
             continue;
           }
 
-          await onDiagnostic?.("lock_active_conflict", {
+          await emitDiagnostic(onDiagnostic, "lock_active_conflict", {
             lockFilePath,
             activePid: existing.pid,
             activeMode: existing.mode,
@@ -188,17 +188,29 @@ export function createWeixinConsumerLock(
         await windowsGuard?.release();
         windowsGuard = undefined;
         windowsLockId = undefined;
-        await onDiagnostic?.("lock_released", { lockFilePath });
+        await emitDiagnostic(onDiagnostic, "lock_released", { lockFilePath });
         return;
       }
       const metadata = await loadLockMetadata(lockFilePath);
       if (metadata?.lockId === posixLockId) await rm(lockFilePath, { force: true });
       posixLockId = undefined;
-      await onDiagnostic?.("lock_released", {
+      await emitDiagnostic(onDiagnostic, "lock_released", {
         lockFilePath,
       });
     },
   };
+}
+
+async function emitDiagnostic(
+  callback: CreateWeixinConsumerLockOptions["onDiagnostic"],
+  event: Parameters<NonNullable<CreateWeixinConsumerLockOptions["onDiagnostic"]>>[0],
+  context: Record<string, string | number | boolean | undefined>,
+): Promise<void> {
+  try {
+    await callback?.(event, context);
+  } catch {
+    // Diagnostics must not acquire, leak, or release compatibility ownership.
+  }
 }
 
 async function isSamePosixProcess(

--- a/tests/helpers/runtime-consumer-lock-child.ts
+++ b/tests/helpers/runtime-consumer-lock-child.ts
@@ -1,0 +1,34 @@
+import { join } from "node:path";
+
+import {
+  ActiveRuntimeConsumerLockError,
+  createRuntimeConsumerLock,
+} from "../../src/daemon/runtime-consumer-lock";
+
+const runtimeRoot = process.argv[2]!;
+const hold = process.argv[3] === "hold";
+const lock = createRuntimeConsumerLock({
+  lockFilePath: join(runtimeRoot, "runtime-consumer.lock.json"),
+});
+
+try {
+  await lock.acquire({
+    pid: process.pid,
+    mode: "daemon",
+    startedAt: new Date().toISOString(),
+    configPath: join(runtimeRoot, "config.json"),
+    statePath: join(runtimeRoot, "state.json"),
+  });
+  process.stdout.write(`ACQUIRED:${process.pid}\n`);
+  if (hold) {
+    await new Promise(() => { setInterval(() => {}, 60_000); });
+  } else {
+    await lock.release();
+  }
+} catch (error) {
+  if (error instanceof ActiveRuntimeConsumerLockError) {
+    process.stdout.write("BUSY\n");
+  } else {
+    throw error;
+  }
+}

--- a/tests/helpers/runtime-consumer-lock-child.ts
+++ b/tests/helpers/runtime-consumer-lock-child.ts
@@ -6,10 +6,32 @@ import {
 } from "../../src/daemon/runtime-consumer-lock";
 
 const runtimeRoot = process.argv[2]!;
-const hold = process.argv[3] === "hold";
+const mode = process.argv[3];
+const hold = mode === "hold" || mode === "lose-helper" || mode === "graceful-group";
+if (mode === "lose-helper") {
+  process.on("SIGTERM", () => {
+    process.stdout.write("SIGTERM_CAUGHT\n");
+  });
+}
 const lock = createRuntimeConsumerLock({
   lockFilePath: join(runtimeRoot, "runtime-consumer.lock.json"),
+  onDiagnostic: (event, context) => {
+    if (event === "lock_helper_started") {
+      process.stdout.write(`HELPER:${context.helperPid}\n`);
+    }
+  },
 });
+if (mode === "graceful-group") {
+  let releasing = false;
+  process.on("SIGTERM", () => {
+    if (releasing) return;
+    releasing = true;
+    void lock.release().then(
+      () => process.exit(0),
+      () => process.exit(1),
+    );
+  });
+}
 
 try {
   await lock.acquire({

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -5,3 +5,11 @@ import { main } from "../../src/main";
 test("app bootstrap exports a runnable entry module", () => {
   expect(typeof main).toBe("function");
 });
+
+test("the direct source entry delegates to the guarded default runtime", async () => {
+  let calls = 0;
+  await main({
+    runRuntime: async () => { calls += 1; },
+  });
+  expect(calls).toBe(1);
+});

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -1,15 +1,71 @@
 import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { createRuntimeConsumerLock } from "../../src/daemon/runtime-consumer-lock";
 import { main } from "../../src/main";
 
 test("app bootstrap exports a runnable entry module", () => {
   expect(typeof main).toBe("function");
 });
 
-test("the direct source entry delegates to the guarded default runtime", async () => {
-  let calls = 0;
-  await main({
-    runRuntime: async () => { calls += 1; },
+test("the direct source entry reaches the guarded default runtime without a TLA import deadlock", async () => {
+  const root = await mkdtemp(join(tmpdir(), "xacpx-direct-main-"));
+  const configPath = join(root, ".xacpx", "config.json");
+  const statePath = join(root, ".xacpx", "state.json");
+  const lockFilePath = join(root, ".xacpx", "runtime", "runtime-consumer.lock.json");
+  await mkdir(join(root, ".xacpx"), { recursive: true });
+  await writeFile(configPath, JSON.stringify({
+    transport: { type: "acpx-cli", command: "acpx" },
+    channel: { type: "weixin" },
+    agents: { codex: { driver: "codex" } },
+    workspaces: { home: { cwd: root } },
+  }));
+
+  const owner = createRuntimeConsumerLock({ lockFilePath });
+  await owner.acquire({
+    pid: process.pid,
+    mode: "daemon",
+    startedAt: new Date().toISOString(),
+    configPath,
+    statePath,
   });
-  expect(calls).toBe(1);
-});
+
+  try {
+    const child = spawn("bun", ["run", "./src/main.ts"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: root,
+        XACPX_CONFIG: configPath,
+        XACPX_STATE: statePath,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => { output += String(chunk); });
+    child.stderr.on("data", (chunk) => { output += String(chunk); });
+    const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error(`direct main timed out: ${output}`));
+      }, 15_000);
+      child.once("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.once("close", (code, signal) => {
+        clearTimeout(timer);
+        resolve({ code, signal });
+      });
+    });
+
+    expect(result).toEqual({ code: 1, signal: null });
+    expect(output).toContain("xacpx runtime is already running");
+  } finally {
+    await owner.release();
+    await rm(root, { recursive: true, force: true });
+  }
+}, 20_000);

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1800,6 +1800,32 @@ test("restart rejects indeterminate daemon state", async () => {
   ]);
 });
 
+test("restart explicitly recovers a status-only daemon before starting the replacement", async () => {
+  setLocale("zh");
+  const lines: string[] = [];
+  const events: string[] = [];
+
+  await expect(
+    runCli(["restart"], {
+      controller: {
+        getStatus: async () => ({ state: "indeterminate", pid: 444, reason: "missing-pid" }),
+        stop: async () => {
+          events.push("stop");
+          return { state: "stopped", detail: "stopped" };
+        },
+        start: async () => {
+          events.push("start");
+          return { state: "started", pid: 555 };
+        },
+      },
+      print: (line) => lines.push(line),
+    }),
+  ).resolves.toBe(0);
+
+  expect(events).toEqual(["stop", "start"]);
+  expect(lines).toEqual([t().cli.restarting, t().cli.stopped, t().cli.started, "PID: 555"]);
+});
+
 test("prints help for '-h' flag and exits 0", async () => {
   setLocale("zh");
   const lines: string[] = [];

--- a/tests/unit/daemon/daemon-controller.test.ts
+++ b/tests/unit/daemon/daemon-controller.test.ts
@@ -54,6 +54,42 @@ test("Windows stop uses four-state identity fencing and never kills a reused pid
   expect(await registry.readGeneration()).toBeNull();
 });
 
+test("Windows stop adopts a verified daemon started before durable identities were introduced", async () => {
+  const fixture = await createLegacyWindowsStopFixture();
+
+  await expect(fixture.controller.stop()).resolves.toEqual({ state: "stopped", detail: "stopped" });
+  expect(fixture.terminationRoots).toEqual([{
+    pid: fixture.pid,
+    creationDate: "133801632000000000",
+    executablePath: "C:\\Program Files\\nodejs\\node.exe",
+  }]);
+  expect(await fixture.registry.readGeneration()).toBeNull();
+
+  await rm(fixture.dir, { recursive: true, force: true });
+});
+
+test("Windows stop refuses legacy adoption when the handle-bound executable does not match the daemon command", async () => {
+  const fixture = await createLegacyWindowsStopFixture({
+    identityExecutablePath: "C:\\Windows\\System32\\not-node.exe",
+  });
+
+  await expect(fixture.controller.stop()).rejects.toThrow("durable daemon identity is missing or inconsistent");
+  expect(fixture.terminationRoots).toEqual([]);
+  expect(await fixture.registry.readGeneration()).toBeNull();
+
+  await rm(fixture.dir, { recursive: true, force: true });
+});
+
+test("Windows stop refuses to adopt a legacy generation recorded for a different pid", async () => {
+  const fixture = await createLegacyWindowsStopFixture({ generationDaemonPid: 11111 });
+
+  await expect(fixture.controller.stop()).rejects.toThrow("durable daemon identity is missing or inconsistent");
+  expect(fixture.terminationRoots).toEqual([]);
+  expect(await fixture.registry.readGeneration()).toMatchObject({ daemonPid: 11111, daemonCreationDate: null });
+
+  await rm(fixture.dir, { recursive: true, force: true });
+});
+
 test("Windows stop retains frozen evidence when identity or tree termination is unconfirmed", async () => {
   for (const mode of ["identity", "termination"] as const) {
     const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-stop-win-"));
@@ -135,6 +171,69 @@ test("reports indeterminate when pid is alive but status metadata is missing", a
   await rm(dir, { recursive: true, force: true });
 });
 
+test("repairs a missing pid file from fresh status metadata for a live non-Windows daemon", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
+  const controller = createController(dir, {
+    isProcessRunning: (pid) => pid === 12345,
+    now: () => Date.parse("2026-03-26T00:01:30.000Z"),
+  });
+  await new DaemonStatusStore(join(dir, "status.json")).save({
+    pid: 12345,
+    started_at: "2026-03-26T00:00:00.000Z",
+    heartbeat_at: "2026-03-26T00:01:00.000Z",
+    config_path: join(dir, "config.json"),
+    state_path: join(dir, "state.json"),
+    app_log: "/app",
+    stdout_log: "/out",
+    stderr_log: "/err",
+  });
+
+  await expect(controller.getStatus()).resolves.toEqual({
+    state: "running",
+    pid: 12345,
+    status: {
+      pid: 12345,
+      started_at: "2026-03-26T00:00:00.000Z",
+      heartbeat_at: "2026-03-26T00:01:00.000Z",
+      config_path: join(dir, "config.json"),
+      state_path: join(dir, "state.json"),
+      app_log: "/app",
+      stdout_log: "/out",
+      stderr_log: "/err",
+    },
+  });
+  await expect(readFile(join(dir, "daemon.pid"), "utf8")).resolves.toBe("12345\n");
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("keeps a status-only daemon indeterminate when its heartbeat is stale", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
+  const controller = createController(dir, {
+    isProcessRunning: (pid) => pid === 12345,
+    now: () => Date.parse("2026-03-26T00:03:00.001Z"),
+  });
+  await new DaemonStatusStore(join(dir, "status.json")).save({
+    pid: 12345,
+    started_at: "2026-03-26T00:00:00.000Z",
+    heartbeat_at: "2026-03-26T00:01:00.000Z",
+    config_path: join(dir, "config.json"),
+    state_path: join(dir, "state.json"),
+    app_log: "/app",
+    stdout_log: "/out",
+    stderr_log: "/err",
+  });
+
+  await expect(controller.getStatus()).resolves.toEqual({
+    state: "indeterminate",
+    pid: 12345,
+    reason: "missing-pid",
+  });
+  await expect(Bun.file(join(dir, "daemon.pid")).exists()).resolves.toBe(false);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
 test("treats dead pid files as stale and clears runtime files", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
   const controller = createController(dir, {
@@ -207,8 +306,37 @@ test("start refuses to spawn a second daemon when pid is alive but status metada
   });
   await writeFile(join(dir, "daemon.pid"), "22222\n");
 
-  await expect(controller.start()).rejects.toThrow("status metadata is missing");
+  await expect(controller.start()).rejects.toThrow("daemon metadata is incomplete or inconsistent");
   expect(spawned).toBe(false);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("start repairs a missing pid file and reports the live daemon instead of spawning a second one", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
+  let spawned = false;
+  const controller = createController(dir, {
+    isProcessRunning: (pid) => pid === 22222,
+    now: () => Date.parse("2026-03-26T00:01:30.000Z"),
+    spawnDetached: async () => {
+      spawned = true;
+      return 33333;
+    },
+  });
+  await new DaemonStatusStore(join(dir, "status.json")).save({
+    pid: 22222,
+    started_at: "2026-03-26T00:00:00.000Z",
+    heartbeat_at: "2026-03-26T00:01:00.000Z",
+    config_path: join(dir, "config.json"),
+    state_path: join(dir, "state.json"),
+    app_log: "/app",
+    stdout_log: "/out",
+    stderr_log: "/err",
+  });
+
+  await expect(controller.start()).resolves.toEqual({ state: "already-running", pid: 22222 });
+  expect(spawned).toBe(false);
+  await expect(readFile(join(dir, "daemon.pid"), "utf8")).resolves.toBe("22222\n");
 
   await rm(dir, { recursive: true, force: true });
 });
@@ -316,6 +444,37 @@ test("stop handles missing pid file gracefully", async () => {
     state: "stopped",
     detail: "not-running",
   });
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("stop recovers a fresh status-only non-Windows daemon before terminating it", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
+  let running = true;
+  let terminatedPid: number | null = null;
+  const controller = createController(dir, {
+    now: () => Date.parse("2026-03-26T00:01:30.000Z"),
+    isProcessRunning: (pid) => pid === 24680 && running,
+    terminateProcess: async (pid) => {
+      terminatedPid = pid;
+      running = false;
+    },
+  });
+  await new DaemonStatusStore(join(dir, "status.json")).save({
+    pid: 24680,
+    started_at: "2026-03-26T00:00:00.000Z",
+    heartbeat_at: "2026-03-26T00:01:00.000Z",
+    config_path: join(dir, "config.json"),
+    state_path: join(dir, "state.json"),
+    app_log: "/app",
+    stdout_log: "/out",
+    stderr_log: "/err",
+  });
+
+  await expect(controller.stop()).resolves.toEqual({ state: "stopped", detail: "stopped" });
+  expect(terminatedPid).toBe(24680);
+  await expect(Bun.file(join(dir, "daemon.pid")).exists()).resolves.toBe(false);
+  await expect(Bun.file(join(dir, "status.json")).exists()).resolves.toBe(false);
 
   await rm(dir, { recursive: true, force: true });
 });
@@ -570,6 +729,72 @@ function pathsFor(runtimeDir: string): DaemonPaths {
     stdoutLog: join(runtimeDir, "stdout.log"),
     stderrLog: join(runtimeDir, "stderr.log"),
   };
+}
+
+async function createLegacyWindowsStopFixture(options: {
+  generationDaemonPid?: number;
+  identityExecutablePath?: string;
+} = {}) {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-stop-win-legacy-"));
+  const registry = new OrphanRegistry(dir);
+  const configRoot = "C:\\Users\\tester\\.xacpx";
+  const processExecPath = "C:\\Program Files\\nodejs\\node.exe";
+  const cliEntryPath = "C:\\Users\\tester\\AppData\\Roaming\\npm\\node_modules\\@ganglion\\xacpx\\dist\\cli.js";
+  const pid = 75792;
+  const terminationRoots: Array<{ pid: number; creationDate: string | null; executablePath?: string }> = [];
+
+  await registry.initialize();
+  if (options.generationDaemonPid !== undefined) {
+    await registry.writeGeneration({
+      generationId: "33333333-3333-4333-8333-333333333333",
+      daemonPid: options.generationDaemonPid,
+      daemonCreationDate: null,
+      configRoot,
+    });
+  }
+  await writeFile(join(dir, "daemon.pid"), `${pid}\n`);
+  await new DaemonStatusStore(join(dir, "status.json")).save({
+    pid,
+    started_at: "2025-01-01T00:00:01.000Z",
+    heartbeat_at: "2025-01-01T00:00:45.000Z",
+    config_path: `${configRoot}\\config.json`,
+    state_path: `${configRoot}\\state.json`,
+    app_log: `${configRoot}\\runtime\\app.log`,
+    stdout_log: `${configRoot}\\runtime\\stdout.log`,
+    stderr_log: `${configRoot}\\runtime\\stderr.log`,
+  });
+
+  const controller = new DaemonController(pathsFor(dir), {
+    platform: "win32",
+    configRoot,
+    expectedProcessExecPath: processExecPath,
+    expectedCliEntryPath: cliEntryPath,
+    isProcessRunning: () => true,
+    spawnDetached: async () => 1,
+    terminateProcess: async () => {},
+    now: () => Date.parse("2025-01-01T00:01:00.000Z"),
+    acquireLifecycleGuard: async () => ({ release: async () => {} }),
+    orphanRegistry: registry,
+    probeWindowsIdentity: async () => ({
+      status: "found",
+      identity: {
+        pid,
+        creationDate: "133801632000000000",
+        executablePath: options.identityExecutablePath ?? processExecPath,
+        commandLine: `"${processExecPath}" "${cliEntryPath}" run`,
+      },
+    }),
+    terminateWindowsTree: async (root) => {
+      terminationRoots.push(root);
+      return {
+        rootOutcome: "killed",
+        outcomes: [{ target: root, outcome: "killed" }],
+      };
+    },
+    sweepWindows: async () => emptySweep(),
+  });
+
+  return { controller, dir, pid, registry, terminationRoots };
 }
 
 function emptySweep() {

--- a/tests/unit/daemon/daemon-controller.test.ts
+++ b/tests/unit/daemon/daemon-controller.test.ts
@@ -90,6 +90,22 @@ test("Windows stop refuses to adopt a legacy generation recorded for a different
   await rm(fixture.dir, { recursive: true, force: true });
 });
 
+test("Windows stop refuses to adopt a legacy generation recorded for a different config root", async () => {
+  const fixture = await createLegacyWindowsStopFixture({
+    generationConfigRoot: "C:\\Users\\other\\.xacpx",
+  });
+
+  await expect(fixture.controller.stop()).rejects.toThrow("durable daemon identity is missing or inconsistent");
+  expect(fixture.terminationRoots).toEqual([]);
+  expect(await fixture.registry.readGeneration()).toMatchObject({
+    daemonPid: fixture.pid,
+    daemonCreationDate: null,
+    configRoot: "C:\\Users\\other\\.xacpx",
+  });
+
+  await rm(fixture.dir, { recursive: true, force: true });
+});
+
 test("Windows stop retains frozen evidence when identity or tree termination is unconfirmed", async () => {
   for (const mode of ["identity", "termination"] as const) {
     const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-stop-win-"));
@@ -171,7 +187,41 @@ test("reports indeterminate when pid is alive but status metadata is missing", a
   await rm(dir, { recursive: true, force: true });
 });
 
-test("repairs a missing pid file from fresh status metadata for a live non-Windows daemon", async () => {
+test("pid/status disagreement stays indeterminate and cannot spawn or terminate", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
+  let spawned = false;
+  let terminated = false;
+  const controller = createController(dir, {
+    isProcessRunning: (pid) => pid === 12345 || pid === 54321,
+    spawnDetached: async () => { spawned = true; return 99999; },
+    terminateProcess: async () => { terminated = true; },
+  });
+  await writeFile(join(dir, "daemon.pid"), "12345\n");
+  await new DaemonStatusStore(join(dir, "status.json")).save({
+    pid: 54321,
+    started_at: "2026-03-26T00:00:00.000Z",
+    heartbeat_at: "2026-03-26T00:01:00.000Z",
+    config_path: join(dir, "config.json"),
+    state_path: join(dir, "state.json"),
+    app_log: "/app",
+    stdout_log: "/out",
+    stderr_log: "/err",
+  });
+
+  await expect(controller.getStatus()).resolves.toEqual({
+    state: "indeterminate",
+    pid: 12345,
+    reason: "pid-mismatch",
+  });
+  await expect(controller.start()).rejects.toThrow("daemon metadata is incomplete or inconsistent");
+  await expect(controller.stop()).rejects.toThrow("daemon metadata is incomplete or inconsistent");
+  expect(spawned).toBe(false);
+  expect(terminated).toBe(false);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("reports a fresh status-only live daemon without mutating runtime metadata", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
   const controller = createController(dir, {
     isProcessRunning: (pid) => pid === 12345,
@@ -189,20 +239,11 @@ test("repairs a missing pid file from fresh status metadata for a live non-Windo
   });
 
   await expect(controller.getStatus()).resolves.toEqual({
-    state: "running",
+    state: "indeterminate",
     pid: 12345,
-    status: {
-      pid: 12345,
-      started_at: "2026-03-26T00:00:00.000Z",
-      heartbeat_at: "2026-03-26T00:01:00.000Z",
-      config_path: join(dir, "config.json"),
-      state_path: join(dir, "state.json"),
-      app_log: "/app",
-      stdout_log: "/out",
-      stderr_log: "/err",
-    },
+    reason: "missing-pid",
   });
-  await expect(readFile(join(dir, "daemon.pid"), "utf8")).resolves.toBe("12345\n");
+  await expect(Bun.file(join(dir, "daemon.pid")).exists()).resolves.toBe(false);
 
   await rm(dir, { recursive: true, force: true });
 });
@@ -312,7 +353,7 @@ test("start refuses to spawn a second daemon when pid is alive but status metada
   await rm(dir, { recursive: true, force: true });
 });
 
-test("start repairs a missing pid file and reports the live daemon instead of spawning a second one", async () => {
+test("start refuses a fresh status-only live daemon without spawning or repairing metadata", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
   let spawned = false;
   const controller = createController(dir, {
@@ -334,9 +375,9 @@ test("start repairs a missing pid file and reports the live daemon instead of sp
     stderr_log: "/err",
   });
 
-  await expect(controller.start()).resolves.toEqual({ state: "already-running", pid: 22222 });
+  await expect(controller.start()).rejects.toThrow("daemon metadata is incomplete or inconsistent");
   expect(spawned).toBe(false);
-  await expect(readFile(join(dir, "daemon.pid"), "utf8")).resolves.toBe("22222\n");
+  await expect(Bun.file(join(dir, "daemon.pid")).exists()).resolves.toBe(false);
 
   await rm(dir, { recursive: true, force: true });
 });
@@ -459,6 +500,10 @@ test("stop recovers a fresh status-only non-Windows daemon before terminating it
       terminatedPid = pid;
       running = false;
     },
+    probePosixIdentity: async (pid) => ({
+      status: "found",
+      identity: { pid, startedAtMs: Date.parse("2026-03-26T00:00:00.000Z") },
+    }),
   });
   await new DaemonStatusStore(join(dir, "status.json")).save({
     pid: 24680,
@@ -470,11 +515,55 @@ test("stop recovers a fresh status-only non-Windows daemon before terminating it
     stdout_log: "/out",
     stderr_log: "/err",
   });
+  await writeFile(join(dir, "weixin-consumer.lock.json"), JSON.stringify({
+    pid: 24680,
+    mode: "daemon",
+    startedAt: "2026-03-26T00:00:00.000Z",
+    configPath: join(dir, "config.json"),
+    statePath: join(dir, "state.json"),
+  }));
 
   await expect(controller.stop()).resolves.toEqual({ state: "stopped", detail: "stopped" });
   expect(terminatedPid).toBe(24680);
   await expect(Bun.file(join(dir, "daemon.pid")).exists()).resolves.toBe(false);
   await expect(Bun.file(join(dir, "status.json")).exists()).resolves.toBe(false);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("stop refuses a fresh status-only daemon when its pid was reused by a newer process", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
+  let terminated = false;
+  const controller = createController(dir, {
+    now: () => Date.parse("2026-03-26T00:01:30.000Z"),
+    isProcessRunning: (pid) => pid === 24680,
+    terminateProcess: async () => { terminated = true; },
+    probePosixIdentity: async (pid) => ({
+      status: "found",
+      identity: { pid, startedAtMs: Date.parse("2026-03-26T00:01:15.000Z") },
+    }),
+  });
+  await new DaemonStatusStore(join(dir, "status.json")).save({
+    pid: 24680,
+    started_at: "2026-03-26T00:00:00.000Z",
+    heartbeat_at: "2026-03-26T00:01:00.000Z",
+    config_path: join(dir, "config.json"),
+    state_path: join(dir, "state.json"),
+    app_log: "/app",
+    stdout_log: "/out",
+    stderr_log: "/err",
+  });
+  await writeFile(join(dir, "weixin-consumer.lock.json"), JSON.stringify({
+    pid: 24680,
+    mode: "daemon",
+    startedAt: "2026-03-26T00:00:00.000Z",
+    configPath: join(dir, "config.json"),
+    statePath: join(dir, "state.json"),
+  }));
+
+  await expect(controller.stop()).rejects.toThrow("daemon metadata is incomplete or inconsistent");
+  expect(terminated).toBe(false);
+  await expect(Bun.file(join(dir, "status.json")).exists()).resolves.toBe(true);
 
   await rm(dir, { recursive: true, force: true });
 });
@@ -703,6 +792,7 @@ function createController(
     shutdownTimeoutMs: overrides.shutdownTimeoutMs ?? 50,
     onShutdownPoll: overrides.onShutdownPoll ?? (async () => {}),
     ...(overrides.now ? { now: overrides.now } : {}),
+    ...(overrides.probePosixIdentity ? { probePosixIdentity: overrides.probePosixIdentity } : {}),
   });
 }
 
@@ -718,6 +808,10 @@ interface ControllerDeps {
   shutdownTimeoutMs: number;
   onShutdownPoll: () => Promise<void>;
   now: () => number;
+  probePosixIdentity: (pid: number) => Promise<
+    | { status: "found"; identity: { pid: number; startedAtMs: number } }
+    | { status: "missing" | "unavailable" }
+  >;
 }
 
 function pathsFor(runtimeDir: string): DaemonPaths {
@@ -733,6 +827,7 @@ function pathsFor(runtimeDir: string): DaemonPaths {
 
 async function createLegacyWindowsStopFixture(options: {
   generationDaemonPid?: number;
+  generationConfigRoot?: string;
   identityExecutablePath?: string;
 } = {}) {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-stop-win-legacy-"));
@@ -744,12 +839,12 @@ async function createLegacyWindowsStopFixture(options: {
   const terminationRoots: Array<{ pid: number; creationDate: string | null; executablePath?: string }> = [];
 
   await registry.initialize();
-  if (options.generationDaemonPid !== undefined) {
+  if (options.generationDaemonPid !== undefined || options.generationConfigRoot !== undefined) {
     await registry.writeGeneration({
       generationId: "33333333-3333-4333-8333-333333333333",
-      daemonPid: options.generationDaemonPid,
+      daemonPid: options.generationDaemonPid ?? pid,
       daemonCreationDate: null,
-      configRoot,
+      configRoot: options.generationConfigRoot ?? configRoot,
     });
   }
   await writeFile(join(dir, "daemon.pid"), `${pid}\n`);

--- a/tests/unit/daemon/daemon-controller.test.ts
+++ b/tests/unit/daemon/daemon-controller.test.ts
@@ -568,6 +568,51 @@ test("stop refuses a fresh status-only daemon when its pid was reused by a newer
   await rm(dir, { recursive: true, force: true });
 });
 
+test("stop refuses a status-only daemon replaced after identity verification", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
+  let probes = 0;
+  let terminated = false;
+  const originalStartedAt = Date.parse("2026-03-26T00:00:00.000Z");
+  const controller = createController(dir, {
+    now: () => Date.parse("2026-03-26T00:01:30.000Z"),
+    isProcessRunning: (pid) => pid === 24680,
+    terminateProcess: async () => { terminated = true; },
+    probePosixIdentity: async (pid) => ({
+      status: "found",
+      identity: {
+        pid,
+        startedAtMs: probes++ === 0
+          ? originalStartedAt
+          : Date.parse("2026-03-26T00:01:20.000Z"),
+      },
+    }),
+  });
+  await new DaemonStatusStore(join(dir, "status.json")).save({
+    pid: 24680,
+    started_at: "2026-03-26T00:00:00.000Z",
+    heartbeat_at: "2026-03-26T00:01:00.000Z",
+    config_path: join(dir, "config.json"),
+    state_path: join(dir, "state.json"),
+    app_log: "/app",
+    stdout_log: "/out",
+    stderr_log: "/err",
+  });
+  await writeFile(join(dir, "weixin-consumer.lock.json"), JSON.stringify({
+    pid: 24680,
+    mode: "daemon",
+    startedAt: "2026-03-26T00:00:00.000Z",
+    configPath: join(dir, "config.json"),
+    statePath: join(dir, "state.json"),
+  }));
+
+  await expect(controller.stop()).rejects.toThrow("daemon metadata is incomplete or inconsistent");
+  expect(probes).toBe(2);
+  expect(terminated).toBe(false);
+  await expect(Bun.file(join(dir, "status.json")).exists()).resolves.toBe(true);
+
+  await rm(dir, { recursive: true, force: true });
+});
+
 test("stop waits for the daemon process to exit before clearing runtime files", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-controller-"));
   await writeFile(join(dir, "daemon.pid"), "12345\n");

--- a/tests/unit/daemon/daemon-files.test.ts
+++ b/tests/unit/daemon/daemon-files.test.ts
@@ -1,7 +1,11 @@
 import { expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 
-import { isProcessAlive, resolveDaemonPaths } from "../../../src/daemon/daemon-files";
+import {
+  isProcessAlive,
+  resolveDaemonPaths,
+  resolveRuntimeConsumerLockPath,
+} from "../../../src/daemon/daemon-files";
 
 function killError(code: string): NodeJS.ErrnoException {
   const error = new Error(`kill failed: ${code}`) as NodeJS.ErrnoException;
@@ -38,6 +42,12 @@ test("allows overriding the runtime directory", () => {
     stderrLog: join("/tmp/weacpx-runtime", "stderr.log"),
     appLog: join("/tmp/weacpx-runtime", "app.log"),
   });
+});
+
+test("centralizes the stable core runtime lock metadata path", () => {
+  expect(resolveRuntimeConsumerLockPath("/tmp/xacpx-runtime")).toBe(
+    join("/tmp/xacpx-runtime", "runtime-consumer.lock.json"),
+  );
 });
 
 test("isProcessAlive reports the current process as alive", () => {

--- a/tests/unit/daemon/daemon-status.test.ts
+++ b/tests/unit/daemon/daemon-status.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -8,6 +8,25 @@ import { DaemonStatusStore, type DaemonStatus } from "../../../src/daemon/daemon
 test("returns null when the daemon status file is missing", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-status-"));
   const store = new DaemonStatusStore(join(dir, "status.json"));
+
+  await expect(store.load()).resolves.toBeNull();
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("returns null for parseable status JSON with an invalid schema", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-daemon-status-"));
+  const store = new DaemonStatusStore(join(dir, "status.json"));
+  await writeFile(join(dir, "status.json"), JSON.stringify({
+    pid: "12345",
+    started_at: "not-a-date",
+    heartbeat_at: "2026-03-26T00:01:00.000Z",
+    config_path: "/cfg",
+    state_path: "/state",
+    app_log: "/app",
+    stdout_log: "/out",
+    stderr_log: "/err",
+  }));
 
   await expect(store.load()).resolves.toBeNull();
 

--- a/tests/unit/daemon/runtime-consumer-lock.test.ts
+++ b/tests/unit/daemon/runtime-consumer-lock.test.ts
@@ -143,6 +143,107 @@ test("POSIX core ownership is crash-released and exclusive across processes", as
   expect(await output(replacement, /ACQUIRED/)).toContain("ACQUIRED");
 }, 20_000);
 
+test("Bun exits uncatchably if its flock helper dies after ownership is acquired", async () => {
+  if (process.platform === "win32") return;
+  const root = await mkdtemp(join(tmpdir(), "xacpx-runtime-helper-loss-"));
+  roots.push(root);
+  const victim = spawn(
+    "bun",
+    ["run", join(process.cwd(), "tests", "helpers", "runtime-consumer-lock-child.ts"), root, "lose-helper"],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  let combined = "";
+  const acquired = new Promise<number>((resolveHelper, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout: ${combined}`)), 10_000);
+    const inspect = () => {
+      const match = combined.match(/HELPER:(\d+)[\s\S]*ACQUIRED:/);
+      if (match) {
+        clearTimeout(timer);
+        resolveHelper(Number(match[1]));
+      }
+    };
+    victim.stdout.on("data", (chunk) => { combined += String(chunk); inspect(); });
+    victim.stderr.on("data", (chunk) => { combined += String(chunk); inspect(); });
+    victim.once("error", reject);
+  });
+  const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveClose, reject) => {
+    const timer = setTimeout(() => {
+      victim.kill("SIGKILL");
+      reject(new Error(`victim did not fail closed: ${combined}`));
+    }, 10_000);
+    victim.once("close", (code, signal) => {
+      clearTimeout(timer);
+      resolveClose({ code, signal });
+    });
+  });
+
+  const helperPid = await acquired;
+  process.kill(helperPid, "SIGKILL");
+  expect(await closed).toEqual({ code: null, signal: "SIGKILL" });
+
+  // The helper's kernel lock was released, so a replacement can take over
+  // immediately even though the killed owner left diagnostic metadata behind.
+  const replacement = createRuntimeConsumerLock({
+    lockFilePath: join(root, "runtime-consumer.lock.json"),
+  });
+  await replacement.acquire({
+    ...metadata,
+    pid: process.pid,
+    configPath: join(root, "config.json"),
+    statePath: join(root, "state.json"),
+  });
+  await replacement.release();
+}, 20_000);
+
+test("Bun keeps the flock through a graceful process-group SIGTERM until parent release", async () => {
+  if (process.platform === "win32") return;
+  const root = await mkdtemp(join(tmpdir(), "xacpx-runtime-helper-group-stop-"));
+  roots.push(root);
+  const victim = spawn(
+    "bun",
+    ["run", join(process.cwd(), "tests", "helpers", "runtime-consumer-lock-child.ts"), root, "graceful-group"],
+    { detached: true, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  let combined = "";
+  const acquired = new Promise<void>((resolveAcquired, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout: ${combined}`)), 10_000);
+    const inspect = () => {
+      if (/HELPER:\d+[\s\S]*ACQUIRED:/.test(combined)) {
+        clearTimeout(timer);
+        resolveAcquired();
+      }
+    };
+    victim.stdout.on("data", (chunk) => { combined += String(chunk); inspect(); });
+    victim.stderr.on("data", (chunk) => { combined += String(chunk); inspect(); });
+    victim.once("error", reject);
+  });
+  const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveClose, reject) => {
+    const timer = setTimeout(() => {
+      try { process.kill(-victim.pid!, "SIGKILL"); } catch {}
+      reject(new Error(`graceful group stop timed out: ${combined}`));
+    }, 10_000);
+    victim.once("close", (code, signal) => {
+      clearTimeout(timer);
+      resolveClose({ code, signal });
+    });
+  });
+
+  await acquired;
+  process.kill(-victim.pid!, "SIGTERM");
+  expect(await closed).toEqual({ code: 0, signal: null });
+
+  const replacement = createRuntimeConsumerLock({
+    lockFilePath: join(root, "runtime-consumer.lock.json"),
+  });
+  await replacement.acquire({
+    ...metadata,
+    pid: process.pid,
+    configPath: join(root, "config.json"),
+    statePath: join(root, "state.json"),
+  });
+  await replacement.release();
+}, 20_000);
+
 function fakeLock(name: string, events: string[]): ConsumerLock {
   return {
     acquire: async (input) => { events.push(`${name}:acquire:${input.pid}`); },

--- a/tests/unit/daemon/runtime-consumer-lock.test.ts
+++ b/tests/unit/daemon/runtime-consumer-lock.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createRuntimeConsumerLock } from "../../../src/daemon/runtime-consumer-lock";
+import type { ConsumerLock, ConsumerLockMetadata } from "../../../src/channels/types";
+
+const metadata: ConsumerLockMetadata = {
+  pid: 70002,
+  mode: "daemon",
+  startedAt: "2026-08-06T13:00:00.000Z",
+  configPath: "/cfg/config.json",
+  statePath: "/cfg/state.json",
+};
+
+test("runtime ownership composes the core lock with a legacy channel lock", async () => {
+  const events: string[] = [];
+  const core = fakeLock("core", events);
+  const channel = fakeLock("channel", events);
+  const lock = createRuntimeConsumerLock({
+    runtimeDir: "/runtime",
+    channelLock: channel,
+    createCoreLock: () => core,
+  });
+
+  await lock.acquire(metadata);
+  await lock.release();
+
+  expect(events).toEqual([
+    "core:acquire:70002",
+    "channel:acquire:70002",
+    "channel:release",
+    "core:release",
+  ]);
+});
+
+test("channel lock failure releases the core ownership claim", async () => {
+  const events: string[] = [];
+  const lock = createRuntimeConsumerLock({
+    runtimeDir: "/runtime",
+    createCoreLock: () => fakeLock("core", events),
+    channelLock: {
+      acquire: async () => {
+        events.push("channel:acquire");
+        throw new Error("channel already owned");
+      },
+      release: async () => { events.push("channel:release"); },
+    },
+  });
+
+  await expect(lock.acquire(metadata)).rejects.toThrow("channel already owned");
+  expect(events).toEqual(["core:acquire:70002", "channel:acquire", "core:release"]);
+});
+
+test("the core runtime lock is exclusive without any channel lock", async () => {
+  const root = await mkdtemp(join(tmpdir(), "xacpx-runtime-consumer-lock-"));
+  const first = createRuntimeConsumerLock({ runtimeDir: join(root, "runtime") });
+  const second = createRuntimeConsumerLock({ runtimeDir: join(root, "runtime") });
+  const input: ConsumerLockMetadata = {
+    ...metadata,
+    pid: process.pid,
+    configPath: join(root, "config.json"),
+    statePath: join(root, "state.json"),
+  };
+
+  await first.acquire(input);
+  await expect(second.acquire(input)).rejects.toThrow("xacpx runtime is already running");
+  await first.release();
+  await second.acquire(input);
+  await second.release();
+
+  await rm(root, { recursive: true, force: true });
+});
+
+function fakeLock(name: string, events: string[]): ConsumerLock {
+  return {
+    acquire: async (input) => { events.push(`${name}:acquire:${input.pid}`); },
+    release: async () => { events.push(`${name}:release`); },
+  };
+}

--- a/tests/unit/daemon/runtime-consumer-lock.test.ts
+++ b/tests/unit/daemon/runtime-consumer-lock.test.ts
@@ -80,6 +80,33 @@ test("the core runtime lock is exclusive without any channel lock", async () => 
 
 });
 
+test("Bun acquisition timeout kills a helper that already holds flock before its handshake", async () => {
+  if (process.platform === "win32") return;
+  const root = await mkdtemp(join(tmpdir(), "xacpx-runtime-helper-acquire-timeout-"));
+  roots.push(root);
+  const lockFilePath = join(root, "runtime-consumer.lock.json");
+  const input: ConsumerLockMetadata = {
+    ...metadata,
+    pid: process.pid,
+    configPath: join(root, "config.json"),
+    statePath: join(root, "state.json"),
+  };
+  const timedOut = createRuntimeConsumerLock({
+    lockFilePath,
+    helperAcquireTimeoutMs: 100,
+    // The Node helper takes the flock before delaying its protocol response.
+    helperHandshakeDelayMs: 2_000,
+  });
+
+  await expect(timedOut.acquire(input)).rejects.toThrow("runtime lock helper timed out");
+
+  // Timeout rejection waits for SIGKILL/close, so no unreferenced helper can
+  // retain the kernel lock after acquire() has told the caller it failed.
+  const replacement = createRuntimeConsumerLock({ lockFilePath });
+  await replacement.acquire(input);
+  await replacement.release();
+}, 20_000);
+
 test("Windows core ownership uses the dedicated runtime-owner guard", async () => {
   const root = await mkdtemp(join(tmpdir(), "xacpx-runtime-consumer-lock-win-"));
   roots.push(root);

--- a/tests/unit/daemon/runtime-consumer-lock.test.ts
+++ b/tests/unit/daemon/runtime-consumer-lock.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,6 +9,7 @@ import { createRuntimeConsumerLock } from "../../../src/daemon/runtime-consumer-
 import type { ConsumerLock, ConsumerLockMetadata } from "../../../src/channels/types";
 
 const roots: string[] = [];
+const require = createRequire(import.meta.url);
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
@@ -93,12 +95,28 @@ test("Bun acquisition timeout kills a helper that already holds flock before its
   };
   const timedOut = createRuntimeConsumerLock({
     lockFilePath,
-    helperAcquireTimeoutMs: 100,
+    helperAcquireTimeoutMs: 3_000,
     // The Node helper takes the flock before delaying its protocol response.
-    helperHandshakeDelayMs: 2_000,
+    helperHandshakeDelayMs: 10_000,
   });
 
-  await expect(timedOut.acquire(input)).rejects.toThrow("runtime lock helper timed out");
+  const acquisition = timedOut.acquire(input).then(
+    () => ({ ok: true as const }),
+    (error: unknown) => ({ ok: false as const, error }),
+  );
+  const busyDeadline = Date.now() + 2_000;
+  let observedBusy = false;
+  while (!observedBusy && Date.now() < busyDeadline) {
+    observedBusy = await probeFlockBusy(lockFilePath);
+    if (!observedBusy) await Bun.sleep(25);
+  }
+  expect(observedBusy).toBe(true);
+
+  const result = await acquisition;
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.error).toEqual(expect.objectContaining({
+    message: expect.stringContaining("runtime lock helper timed out"),
+  }));
 
   // Timeout rejection waits for SIGKILL/close, so no unreferenced helper can
   // retain the kernel lock after acquire() has told the caller it failed.
@@ -276,4 +294,48 @@ function fakeLock(name: string, events: string[]): ConsumerLock {
     acquire: async (input) => { events.push(`${name}:acquire:${input.pid}`); },
     release: async () => { events.push(`${name}:release`); },
   };
+}
+
+const FLOCK_PROBE_SOURCE = String.raw`
+const fs = require("node:fs");
+const fsExt = require(process.argv[1]);
+const fd = fs.openSync(process.argv[2], "a+", 0o600);
+fsExt.flock(fd, "exnb", (error) => {
+  if (error) {
+    const busy = error.code === "EAGAIN" || error.code === "EWOULDBLOCK";
+    if (busy) {
+      process.stdout.write("BUSY\n");
+      fs.closeSync(fd);
+      return;
+    }
+    process.stderr.write(String(error.stack || error));
+    fs.closeSync(fd);
+    process.exitCode = 1;
+    return;
+  }
+  fsExt.flock(fd, "un", () => {
+    fs.closeSync(fd);
+    process.stdout.write("FREE\n");
+  });
+});
+`;
+
+function probeFlockBusy(lockFilePath: string): Promise<boolean> {
+  const child = spawn("node", [
+    "-e",
+    FLOCK_PROBE_SOURCE,
+    require.resolve("fs-ext"),
+    lockFilePath,
+  ], { stdio: ["ignore", "pipe", "pipe"] });
+  return new Promise((resolveProbe, reject) => {
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code !== 0) reject(new Error(`flock probe exited with code ${code}: ${stderr}`));
+      else resolveProbe(stdout.trim() === "BUSY");
+    });
+  });
 }

--- a/tests/unit/daemon/runtime-consumer-lock.test.ts
+++ b/tests/unit/daemon/runtime-consumer-lock.test.ts
@@ -1,10 +1,16 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { createRuntimeConsumerLock } from "../../../src/daemon/runtime-consumer-lock";
 import type { ConsumerLock, ConsumerLockMetadata } from "../../../src/channels/types";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
 
 const metadata: ConsumerLockMetadata = {
   pid: 70002,
@@ -19,7 +25,7 @@ test("runtime ownership composes the core lock with a legacy channel lock", asyn
   const core = fakeLock("core", events);
   const channel = fakeLock("channel", events);
   const lock = createRuntimeConsumerLock({
-    runtimeDir: "/runtime",
+    lockFilePath: "/runtime/runtime-consumer.lock.json",
     channelLock: channel,
     createCoreLock: () => core,
   });
@@ -38,7 +44,7 @@ test("runtime ownership composes the core lock with a legacy channel lock", asyn
 test("channel lock failure releases the core ownership claim", async () => {
   const events: string[] = [];
   const lock = createRuntimeConsumerLock({
-    runtimeDir: "/runtime",
+    lockFilePath: "/runtime/runtime-consumer.lock.json",
     createCoreLock: () => fakeLock("core", events),
     channelLock: {
       acquire: async () => {
@@ -55,8 +61,10 @@ test("channel lock failure releases the core ownership claim", async () => {
 
 test("the core runtime lock is exclusive without any channel lock", async () => {
   const root = await mkdtemp(join(tmpdir(), "xacpx-runtime-consumer-lock-"));
-  const first = createRuntimeConsumerLock({ runtimeDir: join(root, "runtime") });
-  const second = createRuntimeConsumerLock({ runtimeDir: join(root, "runtime") });
+  roots.push(root);
+  const lockFilePath = join(root, "runtime", "runtime-consumer.lock.json");
+  const first = createRuntimeConsumerLock({ lockFilePath });
+  const second = createRuntimeConsumerLock({ lockFilePath });
   const input: ConsumerLockMetadata = {
     ...metadata,
     pid: process.pid,
@@ -70,8 +78,70 @@ test("the core runtime lock is exclusive without any channel lock", async () => 
   await second.acquire(input);
   await second.release();
 
-  await rm(root, { recursive: true, force: true });
 });
+
+test("Windows core ownership uses the dedicated runtime-owner guard", async () => {
+  const root = await mkdtemp(join(tmpdir(), "xacpx-runtime-consumer-lock-win-"));
+  roots.push(root);
+  let role: string | undefined;
+  const lock = createRuntimeConsumerLock({
+    lockFilePath: join(root, "runtime", "runtime-consumer.lock.json"),
+    platform: "win32",
+    acquireGuard: async (key) => {
+      role = key.role;
+      return { release: async () => {} };
+    },
+  });
+
+  await lock.acquire({
+    ...metadata,
+    configPath: join(root, "config.json"),
+    statePath: join(root, "state.json"),
+  });
+  expect(role).toBe("runtime-owner");
+  await lock.release();
+});
+
+test("POSIX core ownership is crash-released and exclusive across processes", async () => {
+  if (process.platform === "win32") return;
+  const root = await mkdtemp(join(tmpdir(), "xacpx-runtime-consumer-flock-"));
+  roots.push(root);
+  const outdir = await mkdtemp(join(process.cwd(), "node_modules", ".runtime-lock-test-"));
+  roots.push(outdir);
+  const result = await Bun.build({
+    entrypoints: [join(process.cwd(), "tests", "helpers", "runtime-consumer-lock-child.ts")],
+    outdir,
+    target: "node",
+    external: ["fs-ext"],
+  });
+  if (!result.success) throw new Error(result.logs.map(String).join("\n"));
+  const helper = join(outdir, "runtime-consumer-lock-child.js");
+  const start = (mode?: "hold") => spawn("node", [helper, root, ...(mode ? [mode] : [])], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const output = (child: ReturnType<typeof start>, pattern: RegExp) => new Promise<string>((resolveOutput, reject) => {
+    let value = "";
+    const timer = setTimeout(() => reject(new Error(`timeout: ${value}`)), 10_000);
+    child.stdout.on("data", (chunk) => {
+      value += String(chunk);
+      if (pattern.test(value)) {
+        clearTimeout(timer);
+        resolveOutput(value);
+      }
+    });
+    child.stderr.on("data", (chunk) => { value += String(chunk); });
+    child.once("error", reject);
+  });
+
+  const holder = start("hold");
+  await output(holder, /ACQUIRED/);
+  const contender = start();
+  expect(await output(contender, /BUSY/)).toContain("BUSY");
+  holder.kill("SIGKILL");
+  await new Promise<void>((resolveClose) => holder.once("close", () => resolveClose()));
+  const replacement = start();
+  expect(await output(replacement, /ACQUIRED/)).toContain("ACQUIRED");
+}, 20_000);
 
 function fakeLock(name: string, events: string[]): ConsumerLock {
   return {

--- a/tests/unit/daemon/windows-daemon-runtime.test.ts
+++ b/tests/unit/daemon/windows-daemon-runtime.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { initializeWindowsDaemonRuntime } from "../../../src/daemon/windows-daemon-runtime";
+
+test("published daemon startup writes and returns durable Windows identity dependencies", async () => {
+  const root = await mkdtemp(join(tmpdir(), "xacpx-windows-daemon-runtime-"));
+  const runtimeDir = join(root, "runtime");
+  const identity = {
+    generationId: "33333333-3333-4333-8333-333333333333",
+    daemonPid: 75792,
+    daemonCreationDate: "133801632000000000",
+    configRoot: root,
+  };
+
+  const result = await initializeWindowsDaemonRuntime({
+    platform: "win32",
+    configPath: join(root, "config.json"),
+    runtimeDir,
+    createIdentity: async (input) => {
+      expect(input).toMatchObject({ configRoot: root, platform: "win32" });
+      return identity;
+    },
+  });
+
+  expect(result.daemonIdentity).toEqual(identity);
+  expect(result.orphanRegistry?.root).toBe(join(runtimeDir, "orphans"));
+  await expect(result.orphanRegistry?.readGeneration()).resolves.toEqual(identity);
+
+  await rm(root, { recursive: true, force: true });
+});
+
+test("non-Windows daemon startup does not create Windows identity state", async () => {
+  await expect(initializeWindowsDaemonRuntime({
+    platform: "darwin",
+    configPath: "/tmp/xacpx/config.json",
+    runtimeDir: "/tmp/xacpx/runtime",
+  })).resolves.toEqual({});
+});

--- a/tests/unit/daemon/windows-daemon-runtime.test.ts
+++ b/tests/unit/daemon/windows-daemon-runtime.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { initializeWindowsDaemonRuntime } from "../../../src/daemon/windows-daemon-runtime";
+import { OrphanRegistry } from "../../../src/transport/orphan-registry";
 
 test("published daemon startup writes and returns durable Windows identity dependencies", async () => {
   const root = await mkdtemp(join(tmpdir(), "xacpx-windows-daemon-runtime-"));
@@ -27,6 +28,9 @@ test("published daemon startup writes and returns durable Windows identity depen
 
   expect(result.daemonIdentity).toEqual(identity);
   expect(result.orphanRegistry?.root).toBe(join(runtimeDir, "orphans"));
+  await expect(result.orphanRegistry?.readGeneration()).resolves.toBeNull();
+
+  await result.publishGeneration?.();
   await expect(result.orphanRegistry?.readGeneration()).resolves.toEqual(identity);
 
   await rm(root, { recursive: true, force: true });
@@ -38,4 +42,35 @@ test("non-Windows daemon startup does not create Windows identity state", async 
     configPath: "/tmp/xacpx/config.json",
     runtimeDir: "/tmp/xacpx/runtime",
   })).resolves.toEqual({});
+});
+
+test("preparing a competing Windows runtime does not overwrite the active generation", async () => {
+  const root = await mkdtemp(join(tmpdir(), "xacpx-windows-daemon-runtime-"));
+  const runtimeDir = join(root, "runtime");
+  const registry = new OrphanRegistry(runtimeDir);
+  const activeIdentity = {
+    generationId: "33333333-3333-4333-8333-333333333333",
+    daemonPid: 70001,
+    daemonCreationDate: "133801632000000000",
+    configRoot: root,
+  };
+  await registry.initialize();
+  await registry.writeGeneration(activeIdentity);
+
+  const competing = await initializeWindowsDaemonRuntime({
+    platform: "win32",
+    configPath: join(root, "config.json"),
+    runtimeDir,
+    createRegistry: () => registry,
+    createIdentity: async () => ({
+      generationId: "44444444-4444-4444-8444-444444444444",
+      daemonPid: 70002,
+      daemonCreationDate: "133801632000100000",
+      configRoot: root,
+    }),
+  });
+
+  await expect(registry.readGeneration()).resolves.toEqual(activeIdentity);
+
+  await rm(root, { recursive: true, force: true });
 });

--- a/tests/unit/doctor/checks/daemon-check.test.ts
+++ b/tests/unit/doctor/checks/daemon-check.test.ts
@@ -136,6 +136,25 @@ test("daemon check ignores a missing consumer lock", async () => {
   }
 });
 
+test("daemon check never removes the stable metadata file for the OS-held core lock", async () => {
+  const home = await createTempHome();
+  const runtimeDir = join(home, ".xacpx", "runtime");
+  try {
+    await writeLock(runtimeDir, 99999, "runtime");
+    const removed: string[] = [];
+    const result = await checkDaemon({
+      home,
+      isProcessRunning: () => false,
+      removeConsumerLock: async (path) => { removed.push(path); },
+    });
+
+    expect(result.fixes?.some((entry) => entry.id === "daemon.clear-stale-lock") ?? false).toBe(false);
+    expect(removed).toEqual([]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
 test("daemon check detects a stale non-weixin (feishu) consumer lock", async () => {
   const home = await createTempHome();
   const runtimeDir = join(home, ".xacpx", "runtime");

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -7,6 +7,7 @@ import { buildApp as buildAppRaw, resolveRuntimePaths } from "../../src/main";
 import { coreHomeDir } from "../../src/runtime/core-home";
 import { sameWorkspacePath } from "../../src/commands/workspace-path";
 import { setLocale } from "../../src/i18n";
+import { OrphanRegistry } from "../../src/transport/orphan-registry";
 
 beforeEach(() => { setLocale("zh"); });
 afterAll(() => { setLocale("en"); });
@@ -71,6 +72,48 @@ test("builds the runtime services from config and state paths", async () => {
     configStore: expect.anything(),
     orchestration: expect.anything(),
   });
+
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("an unowned runtime cannot sweep the active daemon's orphan registry during cleanup", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-app-unowned-"));
+  const configPath = join(dir, "config.json");
+  const statePath = join(dir, "state.json");
+  await writeFile(configPath, JSON.stringify({
+    transport: { type: "acpx-cli", command: "acpx" },
+    agents: { codex: { driver: "codex" } },
+    workspaces: {},
+  }));
+  const registry = new OrphanRegistry(join(dir, "runtime"));
+  await registry.initialize();
+  let generationReads = 0;
+  registry.readGeneration = async () => {
+    generationReads += 1;
+    return null;
+  };
+
+  const runtime = await buildApp({ configPath, statePath }, {
+    daemonIdentity: {
+      generationId: "44444444-4444-4444-8444-444444444444",
+      daemonPid: 70002,
+      daemonCreationDate: "133801632000100000",
+      configRoot: dir,
+    },
+    orphanRegistry: registry,
+    canReapQueueOwners: () => false,
+    createCliTransport: () => ({
+      ensureSession: async () => {},
+      prompt: async () => ({ text: "ok" }),
+      cancel: async () => ({ cancelled: true, message: "cancelled" }),
+      hasSession: async () => true,
+      listSessions: async () => [],
+    }),
+  });
+
+  await runtime.reapStaleQueueOwners();
+  await runtime.dispose();
+  expect(generationReads).toBe(0);
 
   await rm(dir, { recursive: true, force: true });
 });

--- a/tests/unit/process/posix-process-identity.test.ts
+++ b/tests/unit/process/posix-process-identity.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+
+import { probePosixProcessIdentity } from "../../../src/process/posix-process-identity";
+
+test("parses the locale-stable ps process start time", async () => {
+  await expect(probePosixProcessIdentity(42, {
+    runPs: async () => "Thu Aug  6 20:00:00 2026\n",
+  })).resolves.toEqual({
+    status: "found",
+    identity: {
+      pid: 42,
+      startedAtMs: Date.parse("Thu Aug  6 20:00:00 2026"),
+    },
+  });
+});
+
+test("distinguishes a missing process from an unavailable identity probe", async () => {
+  await expect(probePosixProcessIdentity(42, {
+    runPs: async () => null,
+  })).resolves.toEqual({ status: "missing" });
+
+  await expect(probePosixProcessIdentity(42, {
+    runPs: async () => "not-a-date\n",
+  })).resolves.toEqual({ status: "unavailable" });
+
+  await expect(probePosixProcessIdentity(42, {
+    runPs: async () => { throw new Error("ps unavailable"); },
+  })).resolves.toEqual({ status: "unavailable" });
+});

--- a/tests/unit/process/windows-process-tree.test.ts
+++ b/tests/unit/process/windows-process-tree.test.ts
@@ -56,9 +56,19 @@ test("malformed, duplicate, missing-root, and inconsistent worker results fail c
 
 test("identity queries accept only handle-derived canonical fingerprints", async () => {
   const valid = await queryWindowsProcessIdentity(42, {
-    runWorker: async () => ({ pid: 42, creationDate: "133830000000000000", executablePath: "C:\\node.exe" }),
+    runWorker: async () => ({
+      pid: 42,
+      creationDate: "133830000000000000",
+      executablePath: "C:\\node.exe",
+      commandLine: '"C:\\node.exe" "C:\\xacpx\\dist\\cli.js" run',
+    }),
   });
-  expect(valid).toEqual({ pid: 42, creationDate: "133830000000000000", executablePath: "C:\\node.exe" });
+  expect(valid).toEqual({
+    pid: 42,
+    creationDate: "133830000000000000",
+    executablePath: "C:\\node.exe",
+    commandLine: '"C:\\node.exe" "C:\\xacpx\\dist\\cli.js" run',
+  });
   const invalid = await queryWindowsProcessIdentity(42, {
     runWorker: async () => ({ pid: 42, creationDate: "0133830000000000000", executablePath: "C:\\node.exe" }),
   });

--- a/tests/unit/run-console-consumer-lock.test.ts
+++ b/tests/unit/run-console-consumer-lock.test.ts
@@ -55,6 +55,44 @@ test("acquires and releases the weixin consumer lock around sdk.start", async ()
   expect(events).toEqual(["lock:acquire:foreground", "channel:start", "dispose", "lock:release"]);
 });
 
+test("publishes durable runtime state only after the consumer lock is held", async () => {
+  const events: string[] = [];
+
+  await runConsole(
+    { configPath: "/cfg", statePath: "/state" },
+    {
+      buildApp: async () => ({
+        agent: {} as never,
+        router: {} as never,
+        sessions: {} as never,
+        stateStore: {} as never,
+        configStore: {} as never,
+        scheduled: createScheduledRuntime(),
+        logger: createNoopAppLogger(),
+        reapStaleQueueOwners: async () => { events.push("reap"); },
+        dispose: async () => { events.push("dispose"); },
+      }),
+      channels: {
+        startAll: async () => { events.push("channel:start"); },
+      },
+      consumerLock: {
+        acquire: async () => { events.push("lock:acquire"); },
+        release: async () => { events.push("lock:release"); },
+      },
+      afterConsumerLockAcquired: async () => { events.push("generation:publish"); },
+    },
+  );
+
+  expect(events).toEqual([
+    "lock:acquire",
+    "generation:publish",
+    "reap",
+    "channel:start",
+    "dispose",
+    "lock:release",
+  ]);
+});
+
 test("releases the weixin consumer lock when sdk.start fails", async () => {
   const events: string[] = [];
 
@@ -133,6 +171,9 @@ test("does not release the lock if acquisition fails before startup", async () =
           release: async () => {
             events.push("lock:release");
           },
+        },
+        afterConsumerLockAcquired: async () => {
+          events.push("generation:publish");
         },
       },
     ),

--- a/tests/unit/run-console-consumer-lock.test.ts
+++ b/tests/unit/run-console-consumer-lock.test.ts
@@ -93,7 +93,7 @@ test("publishes durable runtime state only after the consumer lock is held", asy
   ]);
 });
 
-test("refuses runtime activation when no consumer ownership lock exists", async () => {
+test("refuses runtime activation when no consumer ownership lock exists, even without an activation hook", async () => {
   const events: string[] = [];
 
   await expect(runConsole(
@@ -118,7 +118,6 @@ test("refuses runtime activation when no consumer ownership lock exists", async 
       channels: {
         startAll: async () => { events.push("channel:start"); },
       },
-      afterConsumerLockAcquired: async () => { events.push("generation:publish"); },
     },
   )).rejects.toThrow("runtime ownership lock is required");
 
@@ -264,8 +263,8 @@ test("logs active lock holder diagnostics when another consumer already owns the
     ),
   ).rejects.toThrow("xacpx Weixin consumer is already running.");
 
-  expect(logs.some((line) => line.includes("info:weixin.consumer_lock.acquire_attempt"))).toBe(true);
-  expect(logs.some((line) => line.includes("error:weixin.consumer_lock.acquire_failed"))).toBe(true);
+  expect(logs.some((line) => line.includes("info:runtime.consumer_lock.acquire_attempt"))).toBe(true);
+  expect(logs.some((line) => line.includes("error:runtime.consumer_lock.acquire_failed"))).toBe(true);
   expect(logs.some((line) => line.includes("\"activePid\":123"))).toBe(true);
   expect(logs.some((line) => line.includes("\"conflictType\":\"active_lock_holder\""))).toBe(true);
 });

--- a/tests/unit/run-console-consumer-lock.test.ts
+++ b/tests/unit/run-console-consumer-lock.test.ts
@@ -93,6 +93,38 @@ test("publishes durable runtime state only after the consumer lock is held", asy
   ]);
 });
 
+test("refuses runtime activation when no consumer ownership lock exists", async () => {
+  const events: string[] = [];
+
+  await expect(runConsole(
+    { configPath: "/cfg", statePath: "/state" },
+    {
+      buildApp: async () => ({
+        agent: {} as never,
+        router: {} as never,
+        sessions: {} as never,
+        stateStore: {} as never,
+        configStore: {} as never,
+        scheduled: createScheduledRuntime(),
+        logger: createNoopAppLogger(),
+        orchestration: {
+          service: {
+            reconcileParallelSlots: async () => { events.push("reconcile"); },
+          },
+        } as never,
+        reapStaleQueueOwners: async () => { events.push("reap"); },
+        dispose: async () => { events.push("dispose"); },
+      }),
+      channels: {
+        startAll: async () => { events.push("channel:start"); },
+      },
+      afterConsumerLockAcquired: async () => { events.push("generation:publish"); },
+    },
+  )).rejects.toThrow("runtime ownership lock is required");
+
+  expect(events).toEqual(["dispose"]);
+});
+
 test("releases the weixin consumer lock when sdk.start fails", async () => {
   const events: string[] = [];
 

--- a/tests/unit/run-console.test.ts
+++ b/tests/unit/run-console.test.ts
@@ -1,7 +1,17 @@
 import { expect, test } from "bun:test";
 
 import { createNoopAppLogger } from "../../src/logging/app-logger";
-import { runConsole } from "../../src/run-console";
+import { runConsole as runConsoleWithOwnership } from "../../src/run-console";
+
+const noOpConsumerLock = {
+  acquire: async () => {},
+  release: async () => {},
+};
+
+const runConsole = (
+  paths: Parameters<typeof runConsoleWithOwnership>[0],
+  deps: Parameters<typeof runConsoleWithOwnership>[1],
+) => runConsoleWithOwnership(paths, { consumerLock: noOpConsumerLock, ...deps });
 
 function createScheduledRuntime() {
   return {

--- a/tests/unit/weixin/consumer-lock.test.ts
+++ b/tests/unit/weixin/consumer-lock.test.ts
@@ -177,6 +177,33 @@ test("POSIX release does not unlink a replacement lock owned by another process"
   expect(JSON.parse(await readFile(lockFilePath, "utf8"))).toMatchObject({ lockId: "replacement", pid: 789 });
 });
 
+test("diagnostic failures cannot leak an acquired compatibility lock", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-consumer-lock-diagnostic-"));
+  const lockFilePath = join(dir, "weixin-consumer.lock.json");
+  const create = () => createWeixinConsumerLock({
+    lockFilePath,
+    probeProcessIdentity: async (pid) => ({
+      status: "found",
+      identity: { pid, startedAtMs: Date.parse("2026-04-05T00:00:00.000Z") },
+    }),
+    onDiagnostic: async () => { throw new Error("logger unavailable"); },
+  });
+  const input = {
+    pid: process.pid,
+    mode: "daemon" as const,
+    startedAt: "2026-04-05T00:01:00.000Z",
+    configPath: "/cfg",
+    statePath: "/state",
+  };
+
+  const first = create();
+  await first.acquire(input);
+  await first.release();
+  const replacement = create();
+  await replacement.acquire(input);
+  await replacement.release();
+});
+
 test("Windows guard is acquired before diagnostic metadata v2 and release is ownership checked", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-consumer-lock-win-"));
   const lockFilePath = join(dir, "weixin-consumer.lock.json");

--- a/tests/unit/weixin/consumer-lock.test.ts
+++ b/tests/unit/weixin/consumer-lock.test.ts
@@ -135,6 +135,30 @@ test("Windows guard is acquired before diagnostic metadata v2 and release is own
   expect(events).toEqual(["guard", "release"]);
 });
 
+test("Windows consumer lock accepts a dedicated runtime ownership guard role", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-consumer-lock-win-"));
+  let acquiredRole: string | undefined;
+  const lock = createWeixinConsumerLock({
+    lockFilePath: join(dir, "runtime-consumer.lock.json"),
+    platform: "win32",
+    windowsGuardRole: "runtime-owner",
+    acquireGuard: async (key) => {
+      acquiredRole = key.role;
+      return { release: async () => {} };
+    },
+  });
+
+  await lock.acquire({
+    pid: 456,
+    mode: "daemon",
+    startedAt: "2026-04-05T00:01:00.000Z",
+    configPath: join(dir, "config.json"),
+    statePath: join(dir, "state.json"),
+  });
+  expect(acquiredRole).toBe("runtime-owner");
+  await lock.release();
+});
+
 test("Windows duplicate consumer trusts the guard, not stale metadata liveness", async () => {
   const dir = await mkdtemp(join(tmpdir(), "weacpx-consumer-lock-win-"));
   const lockFilePath = join(dir, "weixin-consumer.lock.json");

--- a/tests/unit/weixin/consumer-lock.test.ts
+++ b/tests/unit/weixin/consumer-lock.test.ts
@@ -20,6 +20,10 @@ test("rejects when an active consumer lock already exists", async () => {
   const lock = createWeixinConsumerLock({
     lockFilePath,
     isProcessRunning: (pid) => pid === 123,
+    probeProcessIdentity: async () => ({
+      status: "found",
+      identity: { pid: 123, startedAtMs: Date.parse("2026-04-04T23:59:00.000Z") },
+    }),
   });
 
   try {
@@ -99,8 +103,78 @@ test("emits diagnostics when it replaces a stale lock", async () => {
 
   expect(diagnostics.some((line) => line.includes("lock_exists"))).toBe(true);
   expect(diagnostics.some((line) => line.includes("lock_stale_removed"))).toBe(true);
-  expect(diagnostics.some((line) => line.includes("\"reason\":\"owner_process_not_running\""))).toBe(true);
+  expect(diagnostics.some((line) => line.includes("\"reason\":\"owner_process_missing_or_identity_changed\""))).toBe(true);
   expect(diagnostics.some((line) => line.includes("lock_acquired"))).toBe(true);
+});
+
+test("reclaims a legacy POSIX lock when its pid was reused by a different process", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-consumer-lock-reused-pid-"));
+  const lockFilePath = join(dir, "weixin-consumer.lock.json");
+  await writeFile(lockFilePath, JSON.stringify({
+    pid: 123,
+    mode: "daemon",
+    startedAt: "2026-04-05T00:00:00.000Z",
+    configPath: "/cfg-old",
+    statePath: "/state-old",
+  }));
+  const lock = createWeixinConsumerLock({
+    lockFilePath,
+    isProcessRunning: () => true,
+    probeProcessIdentity: async (pid) => ({
+      status: "found",
+      identity: {
+        pid,
+        startedAtMs: pid === 123
+          ? Date.parse("2026-04-05T01:00:00.000Z")
+          : Date.parse("2026-04-05T00:59:00.000Z"),
+      },
+    }),
+  });
+
+  await lock.acquire({
+    pid: 456,
+    mode: "daemon",
+    startedAt: "2026-04-05T01:01:00.000Z",
+    configPath: "/cfg-new",
+    statePath: "/state-new",
+  });
+  expect(JSON.parse(await readFile(lockFilePath, "utf8"))).toMatchObject({
+    pid: 456,
+    schemaVersion: 2,
+    processStartedAtMs: Date.parse("2026-04-05T00:59:00.000Z"),
+  });
+  await lock.release();
+});
+
+test("POSIX release does not unlink a replacement lock owned by another process", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "weacpx-consumer-lock-release-"));
+  const lockFilePath = join(dir, "weixin-consumer.lock.json");
+  const lock = createWeixinConsumerLock({
+    lockFilePath,
+    probeProcessIdentity: async (pid) => ({
+      status: "found",
+      identity: { pid, startedAtMs: Date.parse("2026-04-05T00:00:00.000Z") },
+    }),
+  });
+  await lock.acquire({
+    pid: 456,
+    mode: "daemon",
+    startedAt: "2026-04-05T00:01:00.000Z",
+    configPath: "/cfg",
+    statePath: "/state",
+  });
+  await writeFile(lockFilePath, JSON.stringify({
+    schemaVersion: 2,
+    lockId: "replacement",
+    pid: 789,
+    mode: "daemon",
+    startedAt: "2026-04-05T00:02:00.000Z",
+    configPath: "/cfg",
+    statePath: "/state",
+  }));
+
+  await lock.release();
+  expect(JSON.parse(await readFile(lockFilePath, "utf8"))).toMatchObject({ lockId: "replacement", pid: 789 });
 });
 
 test("Windows guard is acquired before diagnostic metadata v2 and release is ownership checked", async () => {
@@ -133,30 +207,6 @@ test("Windows guard is acquired before diagnostic metadata v2 and release is own
   });
   await lock.release();
   expect(events).toEqual(["guard", "release"]);
-});
-
-test("Windows consumer lock accepts a dedicated runtime ownership guard role", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "weacpx-consumer-lock-win-"));
-  let acquiredRole: string | undefined;
-  const lock = createWeixinConsumerLock({
-    lockFilePath: join(dir, "runtime-consumer.lock.json"),
-    platform: "win32",
-    windowsGuardRole: "runtime-owner",
-    acquireGuard: async (key) => {
-      acquiredRole = key.role;
-      return { release: async () => {} };
-    },
-  });
-
-  await lock.acquire({
-    pid: 456,
-    mode: "daemon",
-    startedAt: "2026-04-05T00:01:00.000Z",
-    configPath: join(dir, "config.json"),
-    statePath: join(dir, "state.json"),
-  });
-  expect(acquiredRole).toBe("runtime-owner");
-  await lock.release();
 });
 
 test("Windows duplicate consumer trusts the guard, not stale metadata liveness", async () => {


### PR DESCRIPTION
## What changed

- keep non-Windows status queries read-only and block duplicate starts when `status.json` identifies a live daemon but `daemon.pid` is missing
- allow explicit non-Windows `stop`/`restart` recovery only when status paths, a daemon consumer lock, a fresh heartbeat, and two matching OS process-start probes identify the same daemon generation
- let Windows adopt a pre-durable-identity daemon only when PID/status, heartbeat, config root, handle-derived creation time and executable, and the exact `node cli.js run` argv all agree
- require every runtime entry, including direct source `main()`, to hold a channel-independent OS-backed core lock, plus any legacy channel lock for upgrade compatibility
- use kernel `flock` ownership on POSIX and the dedicated runtime-owner IPC guard on Windows; keep the core JSON file as stable diagnostics instead of a PID/existence mutex
- keep Bun's Node flock helper alive through process-group graceful-stop signals, release it only through the parent control pipe, and terminate fail-closed if the helper disappears unexpectedly
- route the direct source `main()` entry through the guarded runtime without a top-level-await import cycle
- fingerprint legacy POSIX channel-lock owners so PID reuse cannot permanently block a later start, and make release ownership-checked
- prepare durable Windows identity from the published internal `cli.js run` path, but publish it only after runtime ownership; ordinary foreground runs neither publish daemon generation nor register daemon PID/status
- prevent a process that loses either ownership lock from reconciling queue owners or orphan records during failure cleanup
- preserve handle-fenced Windows tree termination and fail closed on missing, stale, or conflicting evidence
- reject conflicting PID/status metadata and Windows generation records from another config root without spawning or terminating a process
- make indeterminate daemon messages actionable and update English/Chinese daemon and doctor docs

## Why

An in-place npm upgrade can leave the old daemon running while the new CLI sees metadata written by an older lifecycle implementation. On macOS this could be misclassified as stopped and launch a second daemon that immediately lost the consumer-lock race. On Windows, the new durable-generation stop fence correctly refused the older daemon, but had no verified migration path.

## Impact

Upgrades can now restart the existing daemon without manual runtime-file deletion. Non-Windows recovery requires independent evidence from the OS process start time and the daemon consumer lock in addition to matching status metadata, then revalidates the start-time fingerprint immediately before termination. Ordinary status and doctor queries do not repair lifecycle files. Runtime ownership no longer depends on a channel implementing its own lock; POSIX ownership is crash-released by the kernel, while Windows identity publication and all queue-owner/orphan cleanup are ownership-gated. `runConsole` refuses all lock-free activation. Termination remains fail-closed and handle-bound and never falls back to killing by PID alone.

The npm `EBADENGINE` warning remains separate from this lifecycle bug: installation completed, but users should still run a Node version accepted by `write-file-atomic@8`.

## Checks

- `npm test`
- `npx tsc --noEmit`
- `bun run build`
- `git diff --check`

The full suite passed with 1031 tests and 2 skips across 113 relay-web test files in addition to the root/unit suites.

Smoke tests were not run because they require real acpx and WeChat infrastructure.
