### PR TITLE
feat(relay-web): auto-load sessions and per-group sleeping pagination

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -205,8 +205,17 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
 - 每个实例可独立选择侧栏分组模式：`instance`（平铺，默认）/ `workspace` / `agent`。偏好存
   localStorage（`xacpx.sidebar.groupMode.<instanceId>`，helpers 在 `src/lib/sidebar-group-mode.ts`），
   响应式镜像在 instances store（`groupModeFor`/`setGroupMode`），改动即时生效。
-- **组只由 session 派生**（不读 workspaces/agents 目录 → 无空组），按服务器首现顺序排列；组内 active
-  保持顺序、archived 沉底置灰。分组模式下**取消 10 行截断**（组折叠即长度控制，折叠为会话内状态、不持久化）。
+- **组由活跃 session 派生**（不读 workspaces/agents 目录），按服务器首现顺序排列；组内 active
+  保持顺序。分组模式下**取消 10 行截断**（组折叠即长度控制，折叠为会话内状态、不持久化）。
+- **分组模式的睡眠会话按组分页加载**：每组底部有「显示已睡眠会话」开关，首次展开时经
+  `control.sessions.list {archivedOnly, workspace|agent, offset, limit:5}` 拉第一页，组内「加载更多」
+  每次追加一页直到 `hasMore=false`，可再次点击隐藏（缓存保留）。睡眠行排在该组活跃会话下方置灰。
+  组状态存 `InstanceView.groupArchived`（键 `${mode}:${groupKey}`，不并入 `inst.sessions`、不喂
+  `reconcileTailCache`），`sessions-changed`/archive/unarchive 只刷新已加载的组。最后一个活跃会话
+  被睡眠后，已加载过睡眠页的组仍保留显示。**平铺模式保持实例级一次性快照开关**（footer 按钮），
+  实例级「加载更多」在所有模式下保留（活跃列表超一页时的唯一入口）。
+- **会话列表自动加载**：进入页面、浏览器重连、实例从离线变在线时，自动为所有在线实例加载会话
+  列表（`loadSessionsForOnlineInstances`）；手动「加载会话」按钮保留为失败兜底。
 - **视觉**：实例=浅色卡片、组=更浅一层的底色块 + 极小缩进（tinted-zone，三种模式视觉同构）。组头 =
   折叠箭头 + 类型图标（workspace→文件夹 / agent→品牌图标）+ 名称 + 计数；agent 分组下行内品牌图标去除。
 - **前缀去重**（仅展示层）：workspace 组内剥掉 `<组名>-` 前缀、agent 组内剥掉 `-<组名>` 后缀

--- a/packages/channel-relay/src/control-bridge.ts
+++ b/packages/channel-relay/src/control-bridge.ts
@@ -154,8 +154,15 @@ async function dispatchControlRequest(
     case MSG.sessionsList: {
       const input = parseControlPayload(MSG.sessionsList, payload);
       if (!input) return errorPayload("invalid-payload", `${MSG.sessionsList}: malformed payload`);
-      if (input.offset !== undefined || input.limit !== undefined) {
-        return control.listSessionsPage(input.chatKey, input.offset, input.limit, input.includeArchived);
+      const hasFilters =
+        input.includeArchived !== undefined || input.archivedOnly !== undefined
+        || input.workspace !== undefined || input.agent !== undefined;
+      if (input.offset !== undefined || input.limit !== undefined || hasFilters) {
+        return control.listSessionsPage(input.chatKey, input.offset, input.limit, input.includeArchived, {
+          archivedOnly: input.archivedOnly,
+          workspace: input.workspace,
+          agent: input.agent,
+        });
       }
       return { sessions: control.listSessions(input.chatKey) }; // ControlSessionInfo is field-identical to SessionDto
     }

--- a/packages/relay-protocol/dist/index.js
+++ b/packages/relay-protocol/dist/index.js
@@ -414,7 +414,7 @@ var optArr = (v) => v === undefined || Array.isArray(v);
 var isStrArr = (v) => Array.isArray(v) && v.every(isStr);
 var validateSessionsList = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && optNum(o.offset) && optNum(o.limit) && optBool(o.includeArchived) ? o : null;
+  return o && isStr(o.chatKey) && optNum(o.offset) && optNum(o.limit) && optBool(o.includeArchived) && optBool(o.archivedOnly) && optStr(o.workspace) && optStr(o.agent) ? o : null;
 };
 var validateSessionsCreate = (p) => {
   const o = fields(p);

--- a/packages/relay-protocol/dist/messages.d.ts
+++ b/packages/relay-protocol/dist/messages.d.ts
@@ -184,6 +184,12 @@ export interface SessionsListPayload {
     limit?: number;
     /** Include sleeping sessions for explicit recovery/cache reconciliation queries. */
     includeArchived?: boolean;
+    /** Restrict the listing to sleeping (archived) sessions; wins over includeArchived. */
+    archivedOnly?: boolean;
+    /** Exact-match workspace filter (empty string matches sessions without a workspace). */
+    workspace?: string;
+    /** Exact-match agent filter (empty string matches sessions without an agent). */
+    agent?: string;
 }
 export interface SessionsListResult {
     sessions: SessionDto[];

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -184,6 +184,12 @@ export interface SessionsListPayload {
   limit?: number;
   /** Include sleeping sessions for explicit recovery/cache reconciliation queries. */
   includeArchived?: boolean;
+  /** Restrict the listing to sleeping (archived) sessions; wins over includeArchived. */
+  archivedOnly?: boolean;
+  /** Exact-match workspace filter (empty string matches sessions without a workspace). */
+  workspace?: string;
+  /** Exact-match agent filter (empty string matches sessions without an agent). */
+  agent?: string;
 }
 export interface SessionsListResult {
   sessions: SessionDto[];

--- a/packages/relay-protocol/src/payload-validators.ts
+++ b/packages/relay-protocol/src/payload-validators.ts
@@ -69,7 +69,8 @@ const isStrArr = (v: unknown): boolean => Array.isArray(v) && v.every(isStr);
 // --- session / agent / workspace ---
 const validateSessionsList: Validator<SessionsListPayload> = (p) => {
   const o = fields(p);
-  return o && isStr(o.chatKey) && optNum(o.offset) && optNum(o.limit) && optBool(o.includeArchived) ? (o as unknown as SessionsListPayload) : null;
+  return o && isStr(o.chatKey) && optNum(o.offset) && optNum(o.limit) && optBool(o.includeArchived)
+    && optBool(o.archivedOnly) && optStr(o.workspace) && optStr(o.agent) ? (o as unknown as SessionsListPayload) : null;
 };
 const validateSessionsCreate: Validator<SessionsCreatePayload> = (p) => {
   const o = fields(p);

--- a/packages/relay-web/src/__tests__/dashboard.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard.test.ts
@@ -50,6 +50,25 @@ test("dashboard renders three columns and loads instances on mount", async () =>
   expect(wrapper.findAll('[data-test="column"]').length).toBe(3);
 });
 
+test("mount auto-loads sessions for every online instance without user action", async () => {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo) => {
+    const url = typeof input === "string" ? input : String(input);
+    const body = url.includes("/rpc")
+      ? { result: { sessions: [], hasMore: false } }
+      : { instances: [
+        { id: "i1", name: "pc", online: true, lastSeenAt: null },
+        { id: "i2", name: "off", online: false, lastSeenAt: null },
+      ] };
+    return new Response(JSON.stringify(body), { status: 200 });
+  }));
+  mount(DashboardView, { global: { stubs: { ChatPane: true, InstanceTree: true, "router-link": true } } });
+  await flushPromises();
+  const store = useInstancesStore();
+  // No "load sessions" click needed: the online instance's list loads on entry.
+  expect(store.byId("i1")!.sessionsLoaded).toBe(true);
+  expect(store.byId("i2")!.sessionsLoaded).toBe(false);
+});
+
 test("selecting a session routes it into the chat store", async () => {
   const chat = useChatStore();
   const wrapper = mount(DashboardView, { global: { stubs: { ChatPane: true, "router-link": true } } });

--- a/packages/relay-web/src/__tests__/dashboard.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard.test.ts
@@ -69,6 +69,31 @@ test("mount auto-loads sessions for every online instance without user action", 
   expect(store.byId("i2")!.sessionsLoaded).toBe(false);
 });
 
+test("reconnect snapshot re-pull auto-loads sessions for online instances", async () => {
+  // Instance is OFFLINE at mount, so the initial auto-load skips it; it comes online
+  // only after a drop/reconnect cycle, and the re-pull must load it without user action.
+  let online = false;
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo) => {
+    const url = typeof input === "string" ? input : String(input);
+    const body = url.includes("/rpc")
+      ? { result: { sessions: [], hasMore: false } }
+      : { instances: [{ id: "i1", name: "pc", online, lastSeenAt: null }] };
+    return new Response(JSON.stringify(body), { status: 200 });
+  }));
+  mount(DashboardView, { global: { stubs: { ChatPane: true, InstanceTree: true, "router-link": true } } });
+  await flushPromises();
+  const store = useInstancesStore();
+  expect(store.byId("i1")!.sessionsLoaded).toBe(false);
+
+  online = true;
+  // A real socket fires open-status on connect; everOnline gates the re-pull on it.
+  captured.onStatus?.(true);
+  captured.onStatus?.(false);
+  captured.onStatus?.(true);
+  await flushPromises();
+  expect(store.byId("i1")!.sessionsLoaded).toBe(true);
+});
+
 test("selecting a session routes it into the chat store", async () => {
   const chat = useChatStore();
   const wrapper = mount(DashboardView, { global: { stubs: { ChatPane: true, "router-link": true } } });

--- a/packages/relay-web/src/__tests__/instances-group-archived.test.ts
+++ b/packages/relay-web/src/__tests__/instances-group-archived.test.ts
@@ -1,0 +1,130 @@
+import { setActivePinia, createPinia } from "pinia";
+import { beforeEach, expect, test, vi } from "vitest";
+import { useInstancesStore, groupArchivedKey } from "../stores/instances";
+
+beforeEach(() => setActivePinia(createPinia()));
+
+function seed() {
+  const store = useInstancesStore();
+  store.instances = [{
+    id: "i1", name: "pc", online: true, lastSeenAt: null,
+    sessions: [{ alias: "active", agent: "codex", workspace: "backend", transportSession: "t0", running: false, archived: false }],
+    sessionsLoaded: true, agents: [{ name: "codex", driver: "codex" }], workspaces: [], agentCatalog: [],
+  }];
+  return store;
+}
+
+const sleeping = (alias: string, workspace = "backend", agent = "codex") => ({
+  alias, agent, workspace, transportSession: `t-${alias}`, running: false, archived: true,
+});
+
+test("loadGroupArchivedSessions fetches one archivedOnly page scoped to the group", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [sleeping("s1"), sleeping("s2")], hasMore: true, nextOffset: 5 });
+
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+
+  expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.list", { offset: 0, limit: 5, archivedOnly: true, workspace: "backend" });
+  const state = store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!;
+  expect(state).toMatchObject({ loaded: true, hasMore: true, nextOffset: 5, sessions: [
+    expect.objectContaining({ alias: "s1" }), expect.objectContaining({ alias: "s2" }),
+  ] });
+  // Grouped sleeping rows stay OUT of the flat instance snapshot.
+  expect(store.byId("i1")!.sessions.map((s) => s.alias)).toEqual(["active"]);
+  vi.restoreAllMocks();
+});
+
+test("agent mode filters by agent instead of workspace", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [], hasMore: false });
+
+  await store.loadGroupArchivedSessions("i1", "agent", "codex");
+
+  expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.list", { offset: 0, limit: 5, archivedOnly: true, agent: "codex" });
+  vi.restoreAllMocks();
+});
+
+test("append pages from nextOffset and dedupes by alias", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc");
+  rpc.mockResolvedValueOnce({ sessions: [sleeping("s1"), sleeping("s2")], hasMore: true, nextOffset: 5 });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockResolvedValueOnce({ sessions: [sleeping("s2"), sleeping("s3")], hasMore: false, nextOffset: 10 });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend", true);
+
+  expect(rpc).toHaveBeenLastCalledWith("i1", "control.sessions.list", { offset: 5, limit: 5, archivedOnly: true, workspace: "backend" });
+  const state = store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!;
+  expect(state.sessions.map((s) => s.alias)).toEqual(["s1", "s2", "s3"]);
+  expect(state.hasMore).toBe(false);
+  vi.restoreAllMocks();
+});
+
+test("sessions-changed refreshes only loaded groups, never unloaded ones", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc");
+  rpc.mockResolvedValueOnce({ sessions: [sleeping("s1")], hasMore: false });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockClear();
+  rpc.mockResolvedValue({ sessions: [sleeping("fresh")], hasMore: false });
+
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "sessions-changed" } });
+  await new Promise((r) => setTimeout(r, 0));
+
+  const archivedCalls = rpc.mock.calls.filter((call) => (call[2] as { archivedOnly?: boolean })?.archivedOnly);
+  expect(archivedCalls).toEqual([["i1", "control.sessions.list", { offset: 0, limit: 5, archivedOnly: true, workspace: "backend" }]]);
+  expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual(["fresh"]);
+  vi.restoreAllMocks();
+});
+
+test("archiveSession refreshes loaded group pages", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc");
+  rpc.mockResolvedValueOnce({ sessions: [], hasMore: false });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockClear();
+  rpc.mockResolvedValue({ sessions: [], hasMore: false });
+
+  await store.archiveSession("i1", "active");
+
+  const archivedCalls = rpc.mock.calls.filter((call) => (call[2] as { archivedOnly?: boolean })?.archivedOnly);
+  expect(archivedCalls).toHaveLength(1);
+  vi.restoreAllMocks();
+});
+
+test("loadInstances preserves per-group archived state", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [sleeping("s1")], hasMore: false });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  vi.restoreAllMocks();
+
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    instances: [{ id: "i1", name: "pc", online: true, lastSeenAt: null }],
+  }), { status: 200 })));
+  await store.loadInstances();
+  expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual(["s1"]);
+  vi.unstubAllGlobals();
+});
+
+test("refresh refetches at least one page for an empty loaded group so new archives surface", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc");
+  rpc.mockResolvedValueOnce({ sessions: [], hasMore: false });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockClear();
+  rpc.mockResolvedValue({ sessions: [sleeping("newly-archived")], hasMore: false });
+
+  store.refreshLoadedGroupArchivedSessions("i1");
+  await new Promise((r) => setTimeout(r, 0));
+
+  const archivedCalls = rpc.mock.calls.filter((call) => (call[2] as { archivedOnly?: boolean })?.archivedOnly);
+  expect(archivedCalls).toHaveLength(1);
+  expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual(["newly-archived"]);
+  vi.restoreAllMocks();
+});

--- a/packages/relay-web/src/__tests__/instances-group-archived.test.ts
+++ b/packages/relay-web/src/__tests__/instances-group-archived.test.ts
@@ -128,3 +128,53 @@ test("refresh refetches at least one page for an empty loaded group so new archi
   expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual(["newly-archived"]);
   vi.restoreAllMocks();
 });
+
+test("replays sessions-changed during an in-flight append page and discards the stale result", async () => {
+  vi.useFakeTimers();
+  try {
+    const store = seed();
+    const { api } = await import("../api/client");
+    const rpc = vi.spyOn(api, "rpc");
+    // First page settles normally → group is loaded (only loaded groups refresh on events).
+    rpc.mockResolvedValueOnce({ sessions: [sleeping("s1")], hasMore: true, nextOffset: 5 });
+    await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+
+    // The append page hangs; a sessions-changed lands mid-flight and must force a
+    // discard-and-refetch from offset 0 once the append settles.
+    let resolveAppend!: (value: unknown) => void;
+    const appendPage = new Promise((resolve) => { resolveAppend = resolve; });
+    rpc.mockImplementationOnce(() => appendPage as never);
+    const append = store.loadGroupArchivedSessions("i1", "workspace", "backend", true);
+    store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "sessions-changed" } });
+    resolveAppend({ sessions: [sleeping("stale")], hasMore: false });
+    rpc.mockResolvedValue({ sessions: [sleeping("fresh")], hasMore: false });
+    await append;
+    // The refresh waiter polls on a 25ms timer; advance past it so it observes the drain.
+    await vi.advanceTimersByTimeAsync(100);
+
+    const archivedCalls = rpc.mock.calls.filter((call) => (call[2] as { archivedOnly?: boolean })?.archivedOnly);
+    expect(archivedCalls).toHaveLength(3);
+    // The refetch replaces from offset 0 — the stale appended row never survives.
+    expect(archivedCalls[2]).toEqual(["i1", "control.sessions.list", { offset: 0, limit: 5, archivedOnly: true, workspace: "backend" }]);
+    expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual(["fresh"]);
+    vi.restoreAllMocks();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("unarchiveSession refreshes loaded group pages", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc");
+  rpc.mockResolvedValueOnce({ sessions: [sleeping("s1")], hasMore: false });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockClear();
+  rpc.mockResolvedValue({ sessions: [], hasMore: false });
+
+  await store.unarchiveSession("i1", "s1");
+
+  const archivedCalls = rpc.mock.calls.filter((call) => (call[2] as { archivedOnly?: boolean })?.archivedOnly);
+  expect(archivedCalls).toHaveLength(1);
+  vi.restoreAllMocks();
+});

--- a/packages/relay-web/src/__tests__/instances.test.ts
+++ b/packages/relay-web/src/__tests__/instances.test.ts
@@ -162,15 +162,32 @@ test("loadInstances does not eagerly load sessions for online instances", async 
   vi.unstubAllGlobals();
 });
 
-test("applyEvent instance-status does not load sessions before the user requests them", async () => {
+test("loadSessionsForOnlineInstances loads all online instances and skips offline/loaded ones", async () => {
   const store = useInstancesStore();
-  store.instances = [{ id: "i1", name: "pc", online: false, lastSeenAt: null, sessions: [], sessionsLoaded: false, agents: [], workspaces: [], agentCatalog: [] }];
+  store.instances = [
+    { id: "i1", name: "pc", online: true, lastSeenAt: null, sessions: [], sessionsLoaded: false, agents: [{ name: "a", driver: "codex" }], workspaces: [], agentCatalog: [] },
+    { id: "i2", name: "off", online: false, lastSeenAt: null, sessions: [], sessionsLoaded: false, agents: [], workspaces: [], agentCatalog: [] },
+    { id: "i3", name: "done", online: true, lastSeenAt: null, sessions: [{ alias: "x", agent: "a", workspace: "/w", transportSession: "t", running: false, archived: false }], sessionsLoaded: true, agents: [], workspaces: [], agentCatalog: [] },
+  ];
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [], hasMore: false });
+  store.loadSessionsForOnlineInstances();
+  await new Promise((r) => setTimeout(r, 0));
+  const listed = rpc.mock.calls.filter((call) => call[1] === "control.sessions.list").map((call) => call[0]);
+  expect(listed).toEqual(["i1"]);
+  vi.restoreAllMocks();
+});
+
+test("applyEvent instance-status auto-loads sessions when an instance comes online", async () => {
+  const store = useInstancesStore();
+  store.instances = [{ id: "i1", name: "pc", online: false, lastSeenAt: null, sessions: [], sessionsLoaded: false, agents: [{ name: "a", driver: "codex" }], workspaces: [], agentCatalog: [] }];
   const { api } = await import("../api/client");
   const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [{ alias: "backend", agent: "claude", workspace: "/w", transportSession: "t", running: false }] });
   store.applyEvent({ kind: "instance-status", instanceId: "i1", online: true });
   await new Promise((r) => setTimeout(r, 0));
-  expect(rpc).not.toHaveBeenCalled();
-  expect(store.byId("i1")!.sessionsLoaded).toBe(false);
+  // Auto-load: no prior sessionsLoaded gate — coming online fetches the session list.
+  expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.list", { offset: 0, limit: 20 });
+  expect(store.byId("i1")!.sessionsLoaded).toBe(true);
   vi.restoreAllMocks();
 });
 

--- a/packages/relay-web/src/__tests__/instancetree-group-archived.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree-group-archived.test.ts
@@ -87,7 +87,7 @@ describe("InstanceTree grouped sleeping sessions", () => {
     await flushPromises();
     expect(load).toHaveBeenCalledWith("i1", "agent", "codex");
     expect(w.text()).toContain("s1");
-    // No active-list load-more involvement for a fully-loaded group.
+    // A fully-loaded group (hasMore=false) shows no group load-more button.
     expect(w.find('[data-test="group-load-more"]').exists()).toBe(false);
   });
 

--- a/packages/relay-web/src/__tests__/instancetree-group-archived.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree-group-archived.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import InstanceTree from "../components/InstanceTree.vue";
+import { useInstancesStore, groupArchivedKey } from "../stores/instances";
+
+const instance = (sessions: unknown[] = []) => ({
+  id: "i1", name: "pc", online: true, lastSeenAt: null, sessions, sessionsLoaded: true,
+  agents: [], workspaces: [], agentCatalog: [],
+});
+
+const active = (alias: string, workspace: string, agent = "codex") => ({
+  alias, agent, workspace, transportSession: `t-${alias}`, running: false, archived: false,
+});
+const sleeping = (alias: string, workspace: string, agent = "codex") => ({
+  alias, agent, workspace, transportSession: `t-${alias}`, running: false, archived: true,
+});
+
+const mountTree = () => mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+
+describe("InstanceTree grouped sleeping sessions", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it("renders a per-group sleeping toggle in workspace mode and hides the instance-level one", () => {
+    const store = useInstancesStore();
+    store.instances = [instance([active("a", "backend"), active("b", "web")])] as never;
+    store.setGroupMode("i1", "workspace");
+    const w = mountTree();
+    expect(w.findAll('[data-test="group-toggle-archived"]')).toHaveLength(2);
+    expect(w.find('[data-test="toggle-archived-sessions"]').exists()).toBe(false);
+  });
+
+  it("keeps the instance-level sleeping toggle in flat mode and shows no group toggles", () => {
+    const store = useInstancesStore();
+    // Distinct id: other tests persist "workspace" for i1 in shared localStorage.
+    store.instances = [{ ...instance([active("a", "backend")]), id: "i-flat" }] as never;
+    const w = mountTree();
+    expect(w.find('[data-test="toggle-archived-sessions"]').exists()).toBe(true);
+    expect(w.find('[data-test="group-toggle-archived"]').exists()).toBe(false);
+  });
+
+  it("loads the first sleeping page on expand, renders rows below the group, and hides on second click", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([active("a", "backend")])] as never;
+    store.setGroupMode("i1", "workspace");
+    const load = vi.spyOn(store, "loadGroupArchivedSessions").mockImplementation(async (instanceId, mode, groupKey) => {
+      store.byId(instanceId)!.groupArchived = {
+        [groupArchivedKey(mode, groupKey)]: {
+          sessions: [sleeping("s1", "backend")], loaded: true, hasMore: true, nextOffset: 5,
+        },
+      };
+    });
+    const w = mountTree();
+
+    await w.find('[data-test="group-toggle-archived"]').trigger("click");
+    await flushPromises();
+    expect(load).toHaveBeenCalledWith("i1", "workspace", "backend");
+    expect(w.find('[data-test="session-name"]').element.textContent).toContain("a");
+    expect(w.text()).toContain("s1");
+    // hasMore + expanded → the per-group load-more button appears.
+    expect(w.find('[data-test="group-load-more"]').exists()).toBe(true);
+
+    await w.find('[data-test="group-toggle-archived"]').trigger("click");
+    expect(w.text()).not.toContain("s1");
+    expect(w.find('[data-test="group-load-more"]').exists()).toBe(false);
+    // Hiding keeps the cache: no second fetch.
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("appends the next page via load-more until hasMore is false", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([active("a", "backend")])] as never;
+    store.setGroupMode("i1", "workspace");
+    const state = { sessions: [sleeping("s1", "backend")], loaded: true, hasMore: true, nextOffset: 5 };
+    store.byId("i1")!.groupArchived = { [groupArchivedKey("workspace", "backend")]: state };
+    const load = vi.spyOn(store, "loadGroupArchivedSessions").mockImplementation(async (instanceId, mode, groupKey, append) => {
+      const key = groupArchivedKey(mode, groupKey);
+      const inst = store.byId(instanceId)!;
+      const prev = inst.groupArchived![key]!;
+      if (append) {
+        inst.groupArchived![key] = { ...prev, sessions: [...prev.sessions, sleeping("s2", "backend")], hasMore: false, nextOffset: 10 };
+      }
+    });
+    const w = mountTree();
+
+    // Show the loaded group first.
+    await w.find('[data-test="group-toggle-archived"]').trigger("click");
+    await flushPromises();
+    expect(w.find('[data-test="group-load-more"]').exists()).toBe(true);
+    await w.find('[data-test="group-load-more"]').trigger("click");
+    await flushPromises();
+    expect(load).toHaveBeenCalledWith("i1", "workspace", "backend", true);
+    expect(w.text()).toContain("s2");
+    // hasMore=false → the load-more button disappears.
+    expect(w.find('[data-test="group-load-more"]').exists()).toBe(false);
+  });
+
+  it("hides group sleeping controls for offline instances", () => {
+    const store = useInstancesStore();
+    store.instances = [{ ...instance([active("a", "backend")]), online: false }] as never;
+    store.setGroupMode("i1", "workspace");
+    const w = mountTree();
+    expect(w.find('[data-test="group-toggle-archived"]').exists()).toBe(false);
+  });
+});

--- a/packages/relay-web/src/__tests__/instancetree-group-archived.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree-group-archived.test.ts
@@ -67,6 +67,30 @@ describe("InstanceTree grouped sleeping sessions", () => {
     expect(load).toHaveBeenCalledTimes(1);
   });
 
+  it("loads per-group sleeping pages filtered by agent in agent mode", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([active("a", "backend", "codex"), active("b", "web", "claude")])] as never;
+    store.setGroupMode("i1", "agent");
+    const load = vi.spyOn(store, "loadGroupArchivedSessions").mockImplementation(async (instanceId, mode, groupKey) => {
+      store.byId(instanceId)!.groupArchived = {
+        [groupArchivedKey(mode, groupKey)]: {
+          sessions: [sleeping("s1", "backend", groupKey)], loaded: true, hasMore: false, nextOffset: 5,
+        },
+      };
+    });
+    const w = mountTree();
+
+    const toggles = w.findAll('[data-test="group-toggle-archived"]');
+    expect(toggles).toHaveLength(2);
+    // First group in first-appearance order is codex.
+    await toggles[0]!.trigger("click");
+    await flushPromises();
+    expect(load).toHaveBeenCalledWith("i1", "agent", "codex");
+    expect(w.text()).toContain("s1");
+    // No active-list load-more involvement for a fully-loaded group.
+    expect(w.find('[data-test="group-load-more"]').exists()).toBe(false);
+  });
+
   it("appends the next page via load-more until hasMore is false", async () => {
     const store = useInstancesStore();
     store.instances = [instance([active("a", "backend")])] as never;

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -133,8 +133,8 @@ function sectionsFor(inst: InstanceView): SidebarSection[] {
   const mode = groupModeOf(inst);
   if (mode === "instance") return [{ key: null, sessions: visibleSessions(inst) }];
   // Grouped modes page sleeping sessions PER GROUP from the server; groups come from
-  // active sessions plus any group that already has a loaded sleeping page (so a group
-  // whose last active session was just archived stays visible with its sleeping rows).
+  // active sessions plus any group already tracked in groupArchived (so a group whose
+  // last active session was just archived stays visible with its sleeping rows).
   const groups = groupSessions(activeSessions(inst), mode);
   const present = new Set(groups.map((g) => g.key));
   for (const recordKey of Object.keys(inst.groupArchived ?? {})) {
@@ -152,6 +152,11 @@ function sectionsFor(inst: InstanceView): SidebarSection[] {
       archivedState: state,
     };
   });
+}
+
+/** A section's renderable rows: active rows, then any expanded sleeping rows. */
+function sectionRows(section: SidebarSection): InstanceView["sessions"] {
+  return [...section.sessions, ...(section.archivedSessions ?? [])];
 }
 
 // Per-group sleeping-session expansion (grouped modes). Keyed by mode like
@@ -343,7 +348,7 @@ const rowSwipes = computed(() => {
   for (const inst of store.instances) {
     if (!inst.online) continue;
     for (const section of sectionsFor(inst)) {
-      for (const s of [...section.sessions, ...(section.archivedSessions ?? [])]) {
+      for (const s of sectionRows(section)) {
         const key = `${inst.id}:${s.alias}`;
         if (map[key]) continue;
         const reveal = revealPx(s);
@@ -420,7 +425,7 @@ const rowSwipes = computed(() => {
           </div>
           <div v-show="grp.key === null || !isGroupCollapsed(inst, grp.key)" class="space-y-px" :class="grp.key !== null ? 'pl-2' : ''">
             <div
-              v-for="s in [...grp.sessions, ...(grp.archivedSessions ?? [])]"
+              v-for="s in sectionRows(grp)"
               :key="s.alias"
               data-test="session-row"
               class="group relative rounded-md"

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -158,11 +158,14 @@ function sectionsFor(inst: InstanceView): SidebarSection[] {
 // collapsedGroups so switching modes never carries stale expansion over. Hiding
 // keeps the loaded page cached; re-showing only refetches when never loaded.
 const groupArchivedExpanded = ref<Set<string>>(new Set());
+function groupViewKey(inst: InstanceView, key: string): string {
+  return `${inst.id}:${groupModeOf(inst)}:${key}`;
+}
 function groupArchivedIsExpanded(inst: InstanceView, key: string): boolean {
-  return groupArchivedExpanded.value.has(grpKey(inst, key));
+  return groupArchivedExpanded.value.has(groupViewKey(inst, key));
 }
 async function toggleGroupArchived(inst: InstanceView, key: string): Promise<void> {
-  const k = grpKey(inst, key);
+  const k = groupViewKey(inst, key);
   const next = new Set(groupArchivedExpanded.value);
   if (next.has(k)) {
     next.delete(k);
@@ -181,16 +184,13 @@ function loadMoreGroupArchived(inst: InstanceView, key: string): void {
 }
 
 // Group collapse is in-session view state only (not persisted), keyed by mode so
-// switching modes never carries stale collapse over.
+// switching modes never carries stale collapse over. Shares groupViewKey (above).
 const collapsedGroups = ref<Set<string>>(new Set());
-function grpKey(inst: InstanceView, key: string): string {
-  return `${inst.id}:${groupModeOf(inst)}:${key}`;
-}
 function isGroupCollapsed(inst: InstanceView, key: string): boolean {
-  return collapsedGroups.value.has(grpKey(inst, key));
+  return collapsedGroups.value.has(groupViewKey(inst, key));
 }
 function toggleGroup(inst: InstanceView, key: string): void {
-  const k = grpKey(inst, key);
+  const k = groupViewKey(inst, key);
   const next = new Set(collapsedGroups.value);
   if (next.has(k)) next.delete(k);
   else next.add(k);

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { ArchiveRestore, ChevronDown, ChevronRight, Folder, Link2, Loader2, Moon, MoreHorizontal, Pencil, Plus, Settings2, Trash2, Unplug } from "lucide-vue-next";
-import { useInstancesStore } from "../stores/instances";
+import { useInstancesStore, groupArchivedKey } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { useTerminalStore } from "../stores/terminal";
@@ -15,7 +15,7 @@ import { groupSessions, dedupedSessionName, archivedLast } from "../lib/sidebar-
 import NewSessionDialog from "./NewSessionDialog.vue";
 import ManageInstanceDialog from "./ManageInstanceDialog.vue";
 import AgentIcon from "./AgentIcon.vue";
-import type { InstanceView } from "../stores/instances";
+import type { GroupArchivedMode, GroupArchivedState, InstanceView } from "../stores/instances";
 
 // Local directive: focus + select an element on mount (the rename input).
 const vFocus = {
@@ -125,11 +125,60 @@ interface SidebarSection {
   /** Group name (workspace or agent), or null for the flat (ungrouped) section. */
   key: string | null;
   sessions: InstanceView["sessions"];
+  /** Sleeping rows paged in for this group (grouped modes only, when expanded). */
+  archivedSessions?: InstanceView["sessions"];
+  archivedState?: GroupArchivedState;
 }
 function sectionsFor(inst: InstanceView): SidebarSection[] {
   const mode = groupModeOf(inst);
   if (mode === "instance") return [{ key: null, sessions: visibleSessions(inst) }];
-  return groupSessions(displaySessions(inst), mode);
+  // Grouped modes page sleeping sessions PER GROUP from the server; groups come from
+  // active sessions plus any group that already has a loaded sleeping page (so a group
+  // whose last active session was just archived stays visible with its sleeping rows).
+  const groups = groupSessions(activeSessions(inst), mode);
+  const present = new Set(groups.map((g) => g.key));
+  for (const recordKey of Object.keys(inst.groupArchived ?? {})) {
+    const sep = recordKey.indexOf(":");
+    if (recordKey.slice(0, sep) !== mode) continue;
+    const groupKey = recordKey.slice(sep + 1);
+    if (!present.has(groupKey)) groups.push({ key: groupKey, sessions: [] });
+  }
+  return groups.map((g) => {
+    const state = inst.groupArchived?.[groupArchivedKey(mode, g.key)];
+    const expanded = groupArchivedIsExpanded(inst, g.key);
+    return {
+      key: g.key,
+      sessions: g.sessions,
+      archivedSessions: expanded && state ? archivedLast(state.sessions) : [],
+      archivedState: state,
+    };
+  });
+}
+
+// Per-group sleeping-session expansion (grouped modes). Keyed by mode like
+// collapsedGroups so switching modes never carries stale expansion over. Hiding
+// keeps the loaded page cached; re-showing only refetches when never loaded.
+const groupArchivedExpanded = ref<Set<string>>(new Set());
+function groupArchivedIsExpanded(inst: InstanceView, key: string): boolean {
+  return groupArchivedExpanded.value.has(grpKey(inst, key));
+}
+async function toggleGroupArchived(inst: InstanceView, key: string): Promise<void> {
+  const k = grpKey(inst, key);
+  const next = new Set(groupArchivedExpanded.value);
+  if (next.has(k)) {
+    next.delete(k);
+    groupArchivedExpanded.value = next;
+    return;
+  }
+  const mode = groupModeOf(inst) as GroupArchivedMode;
+  const state = inst.groupArchived?.[groupArchivedKey(mode, key)];
+  if (!state?.loaded) await store.loadGroupArchivedSessions(inst.id, mode, key).catch(() => {});
+  next.add(k);
+  groupArchivedExpanded.value = next;
+}
+function loadMoreGroupArchived(inst: InstanceView, key: string): void {
+  const mode = groupModeOf(inst) as GroupArchivedMode;
+  void store.loadGroupArchivedSessions(inst.id, mode, key, true).catch(() => {});
 }
 
 // Group collapse is in-session view state only (not persisted), keyed by mode so
@@ -294,21 +343,24 @@ const rowSwipes = computed(() => {
   const map: Record<string, ReturnType<typeof useSwipeActions>["handlers"]> = {};
   for (const inst of store.instances) {
     if (!inst.online) continue;
-    for (const s of displaySessions(inst)) {
-      const key = `${inst.id}:${s.alias}`;
-      const reveal = revealPx(s);
-      map[key] = useSwipeActions({
-        pointerTypes: ["touch", "pen"],
-        onMove: (dx) => { openMenuFor.value = null; draggingKey.value = key; dragDx.value = dx; },
-        onEnd: (dx) => {
-          // Snap open if the row ended past the halfway point, else closed.
-          const base = openSwipeFor.value === key ? -reveal : 0;
-          const finalX = Math.max(-reveal, Math.min(0, base + dx));
-          openSwipeFor.value = finalX <= -reveal / 2 ? key : null;
-          draggingKey.value = null;
-          dragDx.value = 0;
-        },
-      }).handlers;
+    for (const section of sectionsFor(inst)) {
+      for (const s of [...section.sessions, ...(section.archivedSessions ?? [])]) {
+        const key = `${inst.id}:${s.alias}`;
+        if (map[key]) continue;
+        const reveal = revealPx(s);
+        map[key] = useSwipeActions({
+          pointerTypes: ["touch", "pen"],
+          onMove: (dx) => { openMenuFor.value = null; draggingKey.value = key; dragDx.value = dx; },
+          onEnd: (dx) => {
+            // Snap open if the row ended past the halfway point, else closed.
+            const base = openSwipeFor.value === key ? -reveal : 0;
+            const finalX = Math.max(-reveal, Math.min(0, base + dx));
+            openSwipeFor.value = finalX <= -reveal / 2 ? key : null;
+            draggingKey.value = null;
+            dragDx.value = 0;
+          },
+        }).handlers;
+      }
     }
   }
   return map;
@@ -369,7 +421,7 @@ const rowSwipes = computed(() => {
           </div>
           <div v-show="grp.key === null || !isGroupCollapsed(inst, grp.key)" class="space-y-px" :class="grp.key !== null ? 'pl-2' : ''">
             <div
-              v-for="s in grp.sessions"
+              v-for="s in [...grp.sessions, ...(grp.archivedSessions ?? [])]"
               :key="s.alias"
               data-test="session-row"
               class="group relative rounded-md"
@@ -466,6 +518,23 @@ const rowSwipes = computed(() => {
               <button data-test="delete-session" class="flex w-full items-center gap-2 px-2.5 py-1 text-left text-[12px] text-danger hover:bg-danger/10" @click.stop="askDelete(inst.id, s.alias)"><Trash2 :size="12" />{{ $t("common.delete") }}</button>
             </div>
             </div>
+            <!-- Per-group sleeping-session controls (grouped modes): page sleeping rows
+                 from the server 5 at a time instead of flat mode's one-shot snapshot. -->
+            <template v-if="grp.key !== null && inst.online">
+              <button data-test="group-toggle-archived"
+                      class="flex w-full items-center gap-1.5 rounded px-2.5 py-1 text-left text-[11px] font-medium text-fg-muted transition-colors hover:bg-fg/5 hover:text-fg"
+                      @click.stop="void toggleGroupArchived(inst, grp.key)">
+                <ArchiveRestore :size="11" class="shrink-0" />
+                {{ $t(groupArchivedIsExpanded(inst, grp.key) ? "instance.hideArchivedSessions" : "instance.showArchivedSessions") }}
+              </button>
+              <div v-if="grp.archivedState?.loading" data-test="group-archived-loading"
+                   class="py-0.5 pl-2.5 text-[11px] text-fg-muted">{{ $t("instance.loading") }}</div>
+              <button v-else-if="groupArchivedIsExpanded(inst, grp.key) && grp.archivedState?.hasMore" data-test="group-load-more"
+                      class="w-full py-0.5 pl-2.5 text-left text-[11px] font-medium text-accent hover:text-fg"
+                      @click.stop="loadMoreGroupArchived(inst, grp.key)">
+                {{ $t("instance.loadMoreSessions") }}
+              </button>
+            </template>
           </div>
         </div>
 
@@ -494,7 +563,7 @@ const rowSwipes = computed(() => {
 
         <!-- Per-instance footer: icon-only actions (new session / manage), labelled via title+aria. -->
         <div class="flex items-center gap-0.5 pb-px pl-2 pt-0.5">
-          <button v-if="inst.online && inst.sessionsLoaded" data-test="toggle-archived-sessions"
+          <button v-if="inst.online && inst.sessionsLoaded && groupModeOf(inst) === 'instance'" data-test="toggle-archived-sessions"
                   :title="$t(archivedIsExpanded(inst.id) ? 'instance.hideArchivedSessions' : 'instance.showArchivedSessions')"
                   :aria-label="$t(archivedIsExpanded(inst.id) ? 'instance.hideArchivedSessions' : 'instance.showArchivedSessions')"
                   class="grid h-6 w-6 place-items-center rounded text-fg-muted transition-colors hover:bg-raised hover:text-fg"

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { ArchiveRestore, ChevronDown, ChevronRight, Folder, Link2, Loader2, Moon, MoreHorizontal, Pencil, Plus, Settings2, Trash2, Unplug } from "lucide-vue-next";
-import { useInstancesStore, groupArchivedKey } from "../stores/instances";
+import { useInstancesStore, groupArchivedKey, parseGroupArchivedKey } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { useTerminalStore } from "../stores/terminal";
@@ -138,10 +138,9 @@ function sectionsFor(inst: InstanceView): SidebarSection[] {
   const groups = groupSessions(activeSessions(inst), mode);
   const present = new Set(groups.map((g) => g.key));
   for (const recordKey of Object.keys(inst.groupArchived ?? {})) {
-    const sep = recordKey.indexOf(":");
-    if (recordKey.slice(0, sep) !== mode) continue;
-    const groupKey = recordKey.slice(sep + 1);
-    if (!present.has(groupKey)) groups.push({ key: groupKey, sessions: [] });
+    const parsed = parseGroupArchivedKey(recordKey);
+    if (!parsed || parsed.mode !== mode) continue;
+    if (!present.has(parsed.groupKey)) groups.push({ key: parsed.groupKey, sessions: [] });
   }
   return groups.map((g) => {
     const state = inst.groupArchived?.[groupArchivedKey(mode, g.key)];
@@ -553,6 +552,8 @@ const rowSwipes = computed(() => {
           {{ $t("instance.collapseSessions") }}
         </button>
 
+              <!-- Instance-level ACTIVE-list load-more, deliberately NOT mode-gated: grouped modes
+                   still page active sessions 20 at a time, and this is their only "next page" entry. -->
               <button v-if="inst.sessionsHasMore && !inst.sessionsLoading" data-test="sessions-load-more"
                 class="w-full py-1 pl-2.5 text-left text-[11px] font-medium text-accent hover:text-fg"
                 @click.stop="store.loadMoreSessions(inst.id).catch(() => {})">

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -77,6 +77,14 @@ export function groupArchivedKey(mode: GroupArchivedMode, groupKey: string): str
   return `${mode}:${groupKey}`;
 }
 
+/** Inverse of {@link groupArchivedKey}; null for keys not in `${mode}:${groupKey}` form. */
+export function parseGroupArchivedKey(key: string): { mode: GroupArchivedMode; groupKey: string } | null {
+  const sep = key.indexOf(":");
+  const mode = key.slice(0, sep);
+  if (sep < 0 || (mode !== "workspace" && mode !== "agent")) return null;
+  return { mode, groupKey: key.slice(sep + 1) };
+}
+
 export const useInstancesStore = defineStore("instances", () => {
   const instances = ref<InstanceView[]>([]);
   const pendingSessionRenames = new Map<string, {
@@ -90,6 +98,20 @@ export const useInstancesStore = defineStore("instances", () => {
 
   function sessionRenameKey(instanceId: string, alias: string): string {
     return JSON.stringify([instanceId, alias]);
+  }
+
+  // Snapshot pending-rename confirmation revisions at request time so a stale list
+  // response cannot downgrade a rename confirmed while the request was in flight.
+  function renameRevisionsAtRequest(): Map<string, number> {
+    return new Map([...pendingSessionRenames].map(([key, pending]) => [key, pending.confirmedRevision]));
+  }
+
+  function emptyGroupArchivedState(): GroupArchivedState {
+    return { sessions: [], loaded: false, hasMore: false, nextOffset: 0 };
+  }
+
+  function groupArchivedFilter(mode: GroupArchivedMode, groupKey: string): { workspace: string } | { agent: string } {
+    return mode === "workspace" ? { workspace: groupKey } : { agent: groupKey };
   }
 
   function overlaySessionRename(instanceId: string, session: SessionDto, confirmedRevisionsAtRequest: Map<string, number>): SessionRow {
@@ -174,9 +196,7 @@ export const useInstancesStore = defineStore("instances", () => {
     try {
       do {
         pendingArchivedRefreshes.delete(instanceId);
-        const confirmedRevisionsAtRequest = new Map(
-          [...pendingSessionRenames].map(([key, pending]) => [key, pending.confirmedRevision]),
-        );
+        const confirmedRevisionsAtRequest = renameRevisionsAtRequest();
         let offset = 0;
         const all: SessionDto[] = [];
         let hasMore = true;
@@ -229,12 +249,18 @@ export const useInstancesStore = defineStore("instances", () => {
       return;
     }
     let appendPage = append;
+    let rerun = false;
     do {
       pendingGroupArchivedRefreshes.delete(pk);
       const current = byId(instanceId)?.groupArchived?.[groupArchivedKey(mode, groupKey)];
       const offset = appendPage && current ? current.nextOffset : 0;
-      await fetchGroupArchivedPage(instanceId, mode, groupKey, offset, GROUP_ARCHIVED_PAGE, appendPage);
+      // A pending refresh re-enters through loadGroupArchivedSessions (offset 0, replace):
+      // fetchGroupArchivedPage's loading guard would otherwise bail and drop the refresh.
+      if (appendPage) await fetchGroupArchivedPage(instanceId, mode, groupKey, offset, GROUP_ARCHIVED_PAGE, true);
+      else if (rerun) await loadGroupArchivedSessions(instanceId, mode, groupKey, false);
+      else await fetchGroupArchivedPage(instanceId, mode, groupKey, 0, GROUP_ARCHIVED_PAGE, false);
       appendPage = false;
+      rerun = true;
     } while (pendingGroupArchivedRefreshes.has(pk));
   }
 
@@ -243,17 +269,15 @@ export const useInstancesStore = defineStore("instances", () => {
     const instBefore = byId(instanceId);
     if (!instBefore) return;
     instBefore.groupArchived ??= {};
-    const state = instBefore.groupArchived[key] ?? { sessions: [], loaded: false, hasMore: false, nextOffset: 0 };
+    const state = instBefore.groupArchived[key] ?? emptyGroupArchivedState();
     if (state.loading) return;
     state.loading = true;
     instBefore.groupArchived[key] = state;
-    const confirmedRevisionsAtRequest = new Map(
-      [...pendingSessionRenames].map(([renameKey, pending]) => [renameKey, pending.confirmedRevision]),
-    );
+    const confirmedRevisionsAtRequest = renameRevisionsAtRequest();
     try {
       const page = await api.rpc<{ sessions: SessionDto[]; hasMore?: boolean; nextOffset?: number }>(instanceId, "control.sessions.list", {
         offset, limit, archivedOnly: true,
-        ...(mode === "workspace" ? { workspace: groupKey } : { agent: groupKey }),
+        ...groupArchivedFilter(mode, groupKey),
       });
       const inst = byId(instanceId);
       if (inst) {
@@ -278,11 +302,12 @@ export const useInstancesStore = defineStore("instances", () => {
     const inst = byId(instanceId);
     if (!inst?.groupArchived) return;
     for (const [key, state] of Object.entries(inst.groupArchived)) {
-      if (!state.loaded || state.loading) continue;
-      const sep = key.indexOf(":");
-      const mode = key.slice(0, sep) as GroupArchivedMode;
-      const groupKey = key.slice(sep + 1);
-      void refetchGroupArchived(instanceId, mode, groupKey, state.sessions.length).catch(() => {});
+      if (!state.loaded) continue;
+      const parsed = parseGroupArchivedKey(key);
+      if (!parsed) continue;
+      // Loading groups are NOT skipped: refetchGroupArchived waits for the in-flight
+      // page and lets its pending-drain perform the discard-and-refetch.
+      void refetchGroupArchived(instanceId, parsed.mode, parsed.groupKey, state.sessions.length).catch(() => {});
     }
   }
 
@@ -292,19 +317,20 @@ export const useInstancesStore = defineStore("instances", () => {
   async function refetchGroupArchived(instanceId: string, mode: GroupArchivedMode, groupKey: string, loadedCount: number): Promise<void> {
     const key = groupArchivedKey(mode, groupKey);
     const pk = groupArchivedPendingKey(instanceId, mode, groupKey);
-    const state = byId(instanceId)?.groupArchived?.[key];
-    if (state?.loading) {
+    // A page load may already be in flight for this group. Its own pending-drain loop
+    // performs the discard-and-refetch, so mark pending and wait for it to settle
+    // instead of racing a second fetch (a bare return would leave the mark un-consumed).
+    while (byId(instanceId)?.groupArchived?.[key]?.loading) {
       pendingGroupArchivedRefreshes.add(pk);
-      return;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      if (!pendingGroupArchivedRefreshes.has(pk)) return;
     }
-    const confirmedRevisionsAtRequest = new Map(
-      [...pendingSessionRenames].map(([renameKey, pending]) => [renameKey, pending.confirmedRevision]),
-    );
+    const confirmedRevisionsAtRequest = renameRevisionsAtRequest();
     const patchState = (patch: Partial<GroupArchivedState>): void => {
       const inst = byId(instanceId);
       if (!inst) return;
       inst.groupArchived ??= {};
-      const prev = inst.groupArchived[key] ?? { sessions: [], loaded: false, hasMore: false, nextOffset: 0 };
+      const prev = inst.groupArchived[key] ?? emptyGroupArchivedState();
       inst.groupArchived[key] = { ...prev, ...patch };
     };
     patchState({ loading: true });
@@ -319,7 +345,7 @@ export const useInstancesStore = defineStore("instances", () => {
         while (all.length < target) {
           const page = await api.rpc<{ sessions: SessionDto[]; hasMore?: boolean; nextOffset?: number }>(instanceId, "control.sessions.list", {
             offset, limit: Math.min(100, target - all.length), archivedOnly: true,
-            ...(mode === "workspace" ? { workspace: groupKey } : { agent: groupKey }),
+            ...groupArchivedFilter(mode, groupKey),
           });
           all.push(...page.sessions.map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest)));
           hasMore = page.hasMore === true;
@@ -339,12 +365,7 @@ export const useInstancesStore = defineStore("instances", () => {
     const instBefore = byId(instanceId);
     if (instBefore?.sessionsLoading) return;
     if (instBefore) instBefore.sessionsLoading = true;
-    // A list request can start before a rename succeeds and return afterwards.
-    // Snapshot confirmation revisions so that stale response cannot downgrade a
-    // newer value confirmed while the request was in flight.
-    const confirmedRevisionsAtRequest = new Map(
-      [...pendingSessionRenames].map(([key, pending]) => [key, pending.confirmedRevision]),
-    );
+    const confirmedRevisionsAtRequest = renameRevisionsAtRequest();
     // Pull the configured agents alongside the session list (once) so the sidebar and chat
     // can map each session's agent NAME → driver for the brand icon. Agents otherwise only
     // load when a create/manage dialog opens (loadFormOptions), so in the normal
@@ -644,7 +665,6 @@ export const useInstancesStore = defineStore("instances", () => {
         // prior state (auto-load covers instances that were offline at mount too).
         if (event.online) {
           void loadSessions(event.instanceId).catch(() => {});
-          if (inst.archivedSessionsLoaded) void loadArchivedSessions(event.instanceId).catch(() => {});
           refreshLoadedGroupArchivedSessions(event.instanceId);
         }
       }

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -252,6 +252,16 @@ export const useInstancesStore = defineStore("instances", () => {
     return byId(instanceId)?.groupArchived?.[groupArchivedKey(mode, groupKey)];
   }
 
+  /** Merge a patch into a group's archived state, creating the record if needed. */
+  function patchGroupArchivedState(instanceId: string, mode: GroupArchivedMode, groupKey: string, patch: Partial<GroupArchivedState>): void {
+    const inst = byId(instanceId);
+    if (!inst) return;
+    inst.groupArchived ??= {};
+    const key = groupArchivedKey(mode, groupKey);
+    const prev = inst.groupArchived[key] ?? emptyGroupArchivedState();
+    inst.groupArchived[key] = { ...prev, ...patch };
+  }
+
   async function loadGroupArchivedSessions(instanceId: string, mode: GroupArchivedMode, groupKey: string, append = false): Promise<void> {
     const pk = groupArchivedPendingKey(instanceId, mode, groupKey);
     const state = groupArchivedStateFor(instanceId, mode, groupKey);
@@ -275,14 +285,8 @@ export const useInstancesStore = defineStore("instances", () => {
   }
 
   async function fetchGroupArchivedPage(instanceId: string, mode: GroupArchivedMode, groupKey: string, offset: number, limit: number, append: boolean): Promise<void> {
-    const key = groupArchivedKey(mode, groupKey);
-    const instBefore = byId(instanceId);
-    if (!instBefore) return;
-    instBefore.groupArchived ??= {};
-    const state = instBefore.groupArchived[key] ?? emptyGroupArchivedState();
-    if (state.loading) return;
-    state.loading = true;
-    instBefore.groupArchived[key] = state;
+    if (groupArchivedStateFor(instanceId, mode, groupKey)?.loading) return;
+    patchGroupArchivedState(instanceId, mode, groupKey, { loading: true });
     const confirmedRevisionsAtRequest = renameRevisionsAtRequest();
     try {
       const page = await api.rpc<{ sessions: SessionDto[]; hasMore?: boolean; nextOffset?: number }>(instanceId, "control.sessions.list", {
@@ -291,19 +295,18 @@ export const useInstancesStore = defineStore("instances", () => {
       });
       const inst = byId(instanceId);
       if (inst) {
-        inst.groupArchived ??= {};
+        const key = groupArchivedKey(mode, groupKey);
         const rows = page.sessions.map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest));
-        const base = append ? (inst.groupArchived[key]?.sessions ?? []) : [];
-        inst.groupArchived[key] = {
+        const base = append ? (inst.groupArchived?.[key]?.sessions ?? []) : [];
+        patchGroupArchivedState(instanceId, mode, groupKey, {
           sessions: [...base, ...rows.filter((row) => !base.some((old) => old.alias === row.alias))],
           loaded: true,
           hasMore: page.hasMore === true,
           nextOffset: page.nextOffset ?? offset + page.sessions.length,
-        };
+        });
       }
     } finally {
-      const current = groupArchivedStateFor(instanceId, mode, groupKey);
-      if (current) current.loading = false;
+      patchGroupArchivedState(instanceId, mode, groupKey, { loading: false });
     }
   }
 
@@ -325,7 +328,6 @@ export const useInstancesStore = defineStore("instances", () => {
   // so a refresh never flickers rows away. An empty group still probes one page so a
   // newly archived session surfaces without hide/show.
   async function refetchGroupArchived(instanceId: string, mode: GroupArchivedMode, groupKey: string, loadedCount: number): Promise<void> {
-    const key = groupArchivedKey(mode, groupKey);
     const pk = groupArchivedPendingKey(instanceId, mode, groupKey);
     // A page load may already be in flight for this group. Its own pending-drain loop
     // performs the discard-and-refetch, so mark pending and wait for it to settle
@@ -336,14 +338,7 @@ export const useInstancesStore = defineStore("instances", () => {
       if (!pendingGroupArchivedRefreshes.has(pk)) return;
     }
     const confirmedRevisionsAtRequest = renameRevisionsAtRequest();
-    const patchState = (patch: Partial<GroupArchivedState>): void => {
-      const inst = byId(instanceId);
-      if (!inst) return;
-      inst.groupArchived ??= {};
-      const prev = inst.groupArchived[key] ?? emptyGroupArchivedState();
-      inst.groupArchived[key] = { ...prev, ...patch };
-    };
-    patchState({ loading: true });
+    patchGroupArchivedState(instanceId, mode, groupKey, { loading: true });
     try {
       await drainPendingRefresh(pendingGroupArchivedRefreshes, pk, async () => {
         const target = Math.max(GROUP_ARCHIVED_PAGE, loadedCount);
@@ -363,10 +358,10 @@ export const useInstancesStore = defineStore("instances", () => {
           offset = nextOffset;
         }
         if (pendingGroupArchivedRefreshes.has(pk)) return;
-        patchState({ sessions: all, loaded: true, hasMore, nextOffset });
+        patchGroupArchivedState(instanceId, mode, groupKey, { sessions: all, loaded: true, hasMore, nextOffset });
       });
     } finally {
-      patchState({ loading: false });
+      patchGroupArchivedState(instanceId, mode, groupKey, { loading: false });
     }
   }
 

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -115,6 +115,16 @@ export const useInstancesStore = defineStore("instances", () => {
     return mode === "workspace" ? { workspace: groupKey } : { agent: groupKey };
   }
 
+  // Discard-and-refetch idiom shared by every session-list loader: an event that
+  // lands while a fetch is in flight leaves a pending mark; once the fetch settles,
+  // re-run the work until no new mark survives a full pass.
+  async function drainPendingRefresh(pending: Set<string>, key: string, work: () => Promise<void>): Promise<void> {
+    do {
+      pending.delete(key);
+      await work();
+    } while (pending.has(key));
+  }
+
   function overlaySessionRename(instanceId: string, session: SessionDto, confirmedRevisionsAtRequest: Map<string, number>): SessionRow {
     const key = sessionRenameKey(instanceId, session.alias);
     const pending = pendingSessionRenames.get(key);
@@ -162,10 +172,7 @@ export const useInstancesStore = defineStore("instances", () => {
       pendingSessionRefreshes.add(instanceId);
       return;
     }
-    do {
-      pendingSessionRefreshes.delete(instanceId);
-      await fetchSessionsPage(instanceId, 0, true);
-    } while (pendingSessionRefreshes.has(instanceId));
+    await drainPendingRefresh(pendingSessionRefreshes, instanceId, () => fetchSessionsPage(instanceId, 0, true));
   }
 
   async function loadMoreSessions(instanceId: string): Promise<void> {
@@ -195,8 +202,7 @@ export const useInstancesStore = defineStore("instances", () => {
     }
     if (inst) inst.archivedSessionsLoading = true;
     try {
-      do {
-        pendingArchivedRefreshes.delete(instanceId);
+      await drainPendingRefresh(pendingArchivedRefreshes, instanceId, async () => {
         const confirmedRevisionsAtRequest = renameRevisionsAtRequest();
         let offset = 0;
         const all: SessionDto[] = [];
@@ -211,7 +217,7 @@ export const useInstancesStore = defineStore("instances", () => {
         }
         // If an event arrived while this snapshot was in flight, discard it and
         // immediately fetch a fresh authoritative snapshot before publishing.
-        if (pendingArchivedRefreshes.has(instanceId)) continue;
+        if (pendingArchivedRefreshes.has(instanceId)) return;
         const current = byId(instanceId);
         if (current) {
           // The full response is authoritative. Keep only local transient rows that
@@ -225,7 +231,7 @@ export const useInstancesStore = defineStore("instances", () => {
           current.archivedSessionsLoaded = true;
         }
         useChatStore().reconcileTailCache(instanceId, all.map((s) => ({ alias: s.alias, incarnation: s.transportSession })));
-      } while (pendingArchivedRefreshes.has(instanceId));
+      });
     } finally {
       const current = byId(instanceId);
       if (current) current.archivedSessionsLoading = false;
@@ -251,8 +257,7 @@ export const useInstancesStore = defineStore("instances", () => {
     }
     let appendPage = append;
     let rerun = false;
-    do {
-      pendingGroupArchivedRefreshes.delete(pk);
+    await drainPendingRefresh(pendingGroupArchivedRefreshes, pk, async () => {
       const current = byId(instanceId)?.groupArchived?.[groupArchivedKey(mode, groupKey)];
       const offset = appendPage && current ? current.nextOffset : 0;
       // A pending refresh re-enters through loadGroupArchivedSessions (offset 0, replace):
@@ -262,7 +267,7 @@ export const useInstancesStore = defineStore("instances", () => {
       else await fetchGroupArchivedPage(instanceId, mode, groupKey, 0, GROUP_ARCHIVED_PAGE, false);
       appendPage = false;
       rerun = true;
-    } while (pendingGroupArchivedRefreshes.has(pk));
+    });
   }
 
   async function fetchGroupArchivedPage(instanceId: string, mode: GroupArchivedMode, groupKey: string, offset: number, limit: number, append: boolean): Promise<void> {
@@ -336,8 +341,7 @@ export const useInstancesStore = defineStore("instances", () => {
     };
     patchState({ loading: true });
     try {
-      do {
-        pendingGroupArchivedRefreshes.delete(pk);
+      await drainPendingRefresh(pendingGroupArchivedRefreshes, pk, async () => {
         const target = Math.max(GROUP_ARCHIVED_PAGE, loadedCount);
         let offset = 0;
         const all: SessionRow[] = [];
@@ -354,9 +358,9 @@ export const useInstancesStore = defineStore("instances", () => {
           if (!hasMore || nextOffset <= offset) break;
           offset = nextOffset;
         }
-        if (pendingGroupArchivedRefreshes.has(pk)) continue;
+        if (pendingGroupArchivedRefreshes.has(pk)) return;
         patchState({ sessions: all, loaded: true, hasMore, nextOffset });
-      } while (pendingGroupArchivedRefreshes.has(pk));
+      });
     } finally {
       patchState({ loading: false });
     }

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -80,8 +80,9 @@ export function groupArchivedKey(mode: GroupArchivedMode, groupKey: string): str
 /** Inverse of {@link groupArchivedKey}; null for keys not in `${mode}:${groupKey}` form. */
 export function parseGroupArchivedKey(key: string): { mode: GroupArchivedMode; groupKey: string } | null {
   const sep = key.indexOf(":");
+  if (sep < 0) return null;
   const mode = key.slice(0, sep);
-  if (sep < 0 || (mode !== "workspace" && mode !== "agent")) return null;
+  if (mode !== "workspace" && mode !== "agent") return null;
   return { mode, groupKey: key.slice(sep + 1) };
 }
 

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -54,9 +54,27 @@ export interface InstanceView {
   sessionsLoading?: boolean;
   archivedSessionsLoaded?: boolean;
   archivedSessionsLoading?: boolean;
+  // Grouped sidebar modes page sleeping sessions PER GROUP from the server instead of
+  // merging them into `sessions` (flat mode's one-shot snapshot). Keyed `${mode}:${groupKey}`.
+  groupArchived?: Record<string, GroupArchivedState>;
   agents: AgentDto[];
   workspaces: WorkspaceDto[];
   agentCatalog: AgentCatalogEntryDto[];
+}
+
+/** Sidebar grouping modes that support per-group sleeping-session pages. */
+export type GroupArchivedMode = "workspace" | "agent";
+
+export interface GroupArchivedState {
+  sessions: SessionRow[];
+  loaded: boolean;
+  hasMore: boolean;
+  nextOffset: number;
+  loading?: boolean;
+}
+
+export function groupArchivedKey(mode: GroupArchivedMode, groupKey: string): string {
+  return `${mode}:${groupKey}`;
 }
 
 export const useInstancesStore = defineStore("instances", () => {
@@ -108,7 +126,7 @@ export const useInstancesStore = defineStore("instances", () => {
     const { instances: rows } = await api.get<{ instances: Array<Omit<InstanceView, "sessions" | "sessionsLoaded" | "agents" | "workspaces" | "agentCatalog">> }>("/api/instances");
     instances.value = rows.map((r) => {
       const prev = byId(r.id);
-      return { ...r, sessions: prev?.sessions ?? [], sessionsLoaded: prev?.sessionsLoaded ?? false, sessionsHasMore: prev?.sessionsHasMore ?? false, sessionsNextOffset: prev?.sessionsNextOffset ?? 0, sessionsLoading: false, archivedSessionsLoaded: prev?.archivedSessionsLoaded ?? false, archivedSessionsLoading: false, agents: prev?.agents ?? [], workspaces: prev?.workspaces ?? [], agentCatalog: prev?.agentCatalog ?? [] };
+      return { ...r, sessions: prev?.sessions ?? [], sessionsLoaded: prev?.sessionsLoaded ?? false, sessionsHasMore: prev?.sessionsHasMore ?? false, sessionsNextOffset: prev?.sessionsNextOffset ?? 0, sessionsLoading: false, archivedSessionsLoaded: prev?.archivedSessionsLoaded ?? false, archivedSessionsLoading: false, groupArchived: prev?.groupArchived, agents: prev?.agents ?? [], workspaces: prev?.workspaces ?? [], agentCatalog: prev?.agentCatalog ?? [] };
     });
   }
 
@@ -132,6 +150,17 @@ export const useInstancesStore = defineStore("instances", () => {
     if (!inst || !inst.sessionsHasMore || inst.sessionsLoading) return;
     await fetchSessionsPage(instanceId, inst.sessionsNextOffset ?? inst.sessions.length, false);
     if (pendingSessionRefreshes.has(instanceId)) await loadSessions(instanceId);
+  }
+
+  // Auto-load entry point: fire session fetches for every online instance not yet
+  // loaded (the dashboard calls this on mount and on reconnect). loadSessions
+  // coalesces, so re-firing for an in-flight instance is harmless.
+  function loadSessionsForOnlineInstances(): void {
+    for (const inst of instances.value) {
+      if (inst.online && !inst.sessionsLoaded && !inst.sessionsLoading) {
+        void loadSessions(inst.id).catch(() => {});
+      }
+    }
   }
 
   /** Load the full session set only when the user asks to recover sleeping sessions. */
@@ -179,6 +208,130 @@ export const useInstancesStore = defineStore("instances", () => {
     } finally {
       const current = byId(instanceId);
       if (current) current.archivedSessionsLoading = false;
+    }
+  }
+
+  // Per-group sleeping-session paging for the grouped sidebar modes. Unlike flat
+  // mode's one-shot `loadArchivedSessions`, these pages stay OUTSIDE `inst.sessions`
+  // and never call reconcileTailCache (a partial page would purge valid tails).
+  const GROUP_ARCHIVED_PAGE = 5;
+  const pendingGroupArchivedRefreshes = new Set<string>();
+
+  function groupArchivedPendingKey(instanceId: string, mode: GroupArchivedMode, groupKey: string): string {
+    return `${instanceId}|${groupArchivedKey(mode, groupKey)}`;
+  }
+
+  async function loadGroupArchivedSessions(instanceId: string, mode: GroupArchivedMode, groupKey: string, append = false): Promise<void> {
+    const pk = groupArchivedPendingKey(instanceId, mode, groupKey);
+    const state = byId(instanceId)?.groupArchived?.[groupArchivedKey(mode, groupKey)];
+    if (state?.loading) {
+      if (!append) pendingGroupArchivedRefreshes.add(pk);
+      return;
+    }
+    let appendPage = append;
+    do {
+      pendingGroupArchivedRefreshes.delete(pk);
+      const current = byId(instanceId)?.groupArchived?.[groupArchivedKey(mode, groupKey)];
+      const offset = appendPage && current ? current.nextOffset : 0;
+      await fetchGroupArchivedPage(instanceId, mode, groupKey, offset, GROUP_ARCHIVED_PAGE, appendPage);
+      appendPage = false;
+    } while (pendingGroupArchivedRefreshes.has(pk));
+  }
+
+  async function fetchGroupArchivedPage(instanceId: string, mode: GroupArchivedMode, groupKey: string, offset: number, limit: number, append: boolean): Promise<void> {
+    const key = groupArchivedKey(mode, groupKey);
+    const instBefore = byId(instanceId);
+    if (!instBefore) return;
+    instBefore.groupArchived ??= {};
+    const state = instBefore.groupArchived[key] ?? { sessions: [], loaded: false, hasMore: false, nextOffset: 0 };
+    if (state.loading) return;
+    state.loading = true;
+    instBefore.groupArchived[key] = state;
+    const confirmedRevisionsAtRequest = new Map(
+      [...pendingSessionRenames].map(([renameKey, pending]) => [renameKey, pending.confirmedRevision]),
+    );
+    try {
+      const page = await api.rpc<{ sessions: SessionDto[]; hasMore?: boolean; nextOffset?: number }>(instanceId, "control.sessions.list", {
+        offset, limit, archivedOnly: true,
+        ...(mode === "workspace" ? { workspace: groupKey } : { agent: groupKey }),
+      });
+      const inst = byId(instanceId);
+      if (inst) {
+        inst.groupArchived ??= {};
+        const rows = page.sessions.map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest));
+        const base = append ? (inst.groupArchived[key]?.sessions ?? []) : [];
+        inst.groupArchived[key] = {
+          sessions: [...base, ...rows.filter((row) => !base.some((old) => old.alias === row.alias))],
+          loaded: true,
+          hasMore: page.hasMore === true,
+          nextOffset: page.nextOffset ?? offset + page.sessions.length,
+        };
+      }
+    } finally {
+      const current = byId(instanceId)?.groupArchived?.[key];
+      if (current) current.loading = false;
+    }
+  }
+
+  /** Re-fetch every already-loaded group page (e.g. after sessions-changed). Never loads unloaded groups. */
+  function refreshLoadedGroupArchivedSessions(instanceId: string): void {
+    const inst = byId(instanceId);
+    if (!inst?.groupArchived) return;
+    for (const [key, state] of Object.entries(inst.groupArchived)) {
+      if (!state.loaded || state.loading) continue;
+      const sep = key.indexOf(":");
+      const mode = key.slice(0, sep) as GroupArchivedMode;
+      const groupKey = key.slice(sep + 1);
+      void refetchGroupArchived(instanceId, mode, groupKey, state.sessions.length).catch(() => {});
+    }
+  }
+
+  // Refetch a loaded group's rows atomically (collect all pages first, publish once)
+  // so a refresh never flickers rows away. An empty group still probes one page so a
+  // newly archived session surfaces without hide/show.
+  async function refetchGroupArchived(instanceId: string, mode: GroupArchivedMode, groupKey: string, loadedCount: number): Promise<void> {
+    const key = groupArchivedKey(mode, groupKey);
+    const pk = groupArchivedPendingKey(instanceId, mode, groupKey);
+    const state = byId(instanceId)?.groupArchived?.[key];
+    if (state?.loading) {
+      pendingGroupArchivedRefreshes.add(pk);
+      return;
+    }
+    const confirmedRevisionsAtRequest = new Map(
+      [...pendingSessionRenames].map(([renameKey, pending]) => [renameKey, pending.confirmedRevision]),
+    );
+    const patchState = (patch: Partial<GroupArchivedState>): void => {
+      const inst = byId(instanceId);
+      if (!inst) return;
+      inst.groupArchived ??= {};
+      const prev = inst.groupArchived[key] ?? { sessions: [], loaded: false, hasMore: false, nextOffset: 0 };
+      inst.groupArchived[key] = { ...prev, ...patch };
+    };
+    patchState({ loading: true });
+    try {
+      do {
+        pendingGroupArchivedRefreshes.delete(pk);
+        const target = Math.max(GROUP_ARCHIVED_PAGE, loadedCount);
+        let offset = 0;
+        const all: SessionRow[] = [];
+        let hasMore = false;
+        let nextOffset = 0;
+        while (all.length < target) {
+          const page = await api.rpc<{ sessions: SessionDto[]; hasMore?: boolean; nextOffset?: number }>(instanceId, "control.sessions.list", {
+            offset, limit: Math.min(100, target - all.length), archivedOnly: true,
+            ...(mode === "workspace" ? { workspace: groupKey } : { agent: groupKey }),
+          });
+          all.push(...page.sessions.map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest)));
+          hasMore = page.hasMore === true;
+          nextOffset = page.nextOffset ?? offset + page.sessions.length;
+          if (!hasMore || nextOffset <= offset) break;
+          offset = nextOffset;
+        }
+        if (pendingGroupArchivedRefreshes.has(pk)) continue;
+        patchState({ sessions: all, loaded: true, hasMore, nextOffset });
+      } while (pendingGroupArchivedRefreshes.has(pk));
+    } finally {
+      patchState({ loading: false });
     }
   }
 
@@ -400,12 +553,14 @@ export const useInstancesStore = defineStore("instances", () => {
     // lets waking it paint instantly.
     await loadSessions(instanceId);
     if (byId(instanceId)?.archivedSessionsLoaded) await loadArchivedSessions(instanceId);
+    refreshLoadedGroupArchivedSessions(instanceId);
   }
 
   async function unarchiveSession(instanceId: string, alias: string): Promise<void> {
     await api.rpc(instanceId, "control.sessions.unarchive", { alias });
     if (byId(instanceId)?.archivedSessionsLoaded) await loadArchivedSessions(instanceId);
     else await loadSessions(instanceId);
+    refreshLoadedGroupArchivedSessions(instanceId);
   }
 
   // The display label lives in core session state. Update the local row before the
@@ -485,14 +640,19 @@ export const useInstancesStore = defineStore("instances", () => {
       const inst = byId(event.instanceId);
       if (inst) {
         inst.online = event.online;
-        // An instance that just came online may not have had its sessions fetched yet
-        // (it was offline at the initial snapshot) — pull them now so the sidebar fills in.
-        if (event.online && inst.sessionsLoaded) void loadSessions(event.instanceId).catch(() => {});
+        // An instance that just came online needs its sessions fetched regardless of
+        // prior state (auto-load covers instances that were offline at mount too).
+        if (event.online) {
+          void loadSessions(event.instanceId).catch(() => {});
+          if (inst.archivedSessionsLoaded) void loadArchivedSessions(event.instanceId).catch(() => {});
+          refreshLoadedGroupArchivedSessions(event.instanceId);
+        }
       }
     } else if (event.kind === "control-event" && event.event.type === "sessions-changed") {
       const inst = byId(event.instanceId);
       if (inst?.sessionsLoaded) void loadSessions(event.instanceId).catch(() => {});
       if (inst?.archivedSessionsLoaded) void loadArchivedSessions(event.instanceId).catch(() => {});
+      if (inst) refreshLoadedGroupArchivedSessions(event.instanceId);
     } else if (event.kind === "control-event" && event.event.type === "workspaces-changed") {
       // A workspace was added/removed/edited on the instance (e.g. `xacpx workspace add`
       // from the terminal) — re-fetch so the file browser + create-session form reflect it.
@@ -504,5 +664,5 @@ export const useInstancesStore = defineStore("instances", () => {
     return instances.value.find((i) => i.id === id);
   }
 
-  return { instances, groupModes, groupModeFor, setGroupMode, loadInstances, loadSessions, loadMoreSessions, loadArchivedSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, beginSessionCreation, cancelSessionCreation, listNativeSessions, listModelSuggestions, removeSession, archiveSession, unarchiveSession, renameSession, renameInstance, applyEvent, byId };
+  return { instances, groupModes, groupModeFor, setGroupMode, loadInstances, loadSessions, loadMoreSessions, loadSessionsForOnlineInstances, loadArchivedSessions, loadGroupArchivedSessions, refreshLoadedGroupArchivedSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, beginSessionCreation, cancelSessionCreation, listNativeSessions, listModelSuggestions, removeSession, archiveSession, unarchiveSession, renameSession, renameInstance, applyEvent, byId };
 });

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -248,9 +248,13 @@ export const useInstancesStore = defineStore("instances", () => {
     return `${instanceId}|${groupArchivedKey(mode, groupKey)}`;
   }
 
+  function groupArchivedStateFor(instanceId: string, mode: GroupArchivedMode, groupKey: string): GroupArchivedState | undefined {
+    return byId(instanceId)?.groupArchived?.[groupArchivedKey(mode, groupKey)];
+  }
+
   async function loadGroupArchivedSessions(instanceId: string, mode: GroupArchivedMode, groupKey: string, append = false): Promise<void> {
     const pk = groupArchivedPendingKey(instanceId, mode, groupKey);
-    const state = byId(instanceId)?.groupArchived?.[groupArchivedKey(mode, groupKey)];
+    const state = groupArchivedStateFor(instanceId, mode, groupKey);
     if (state?.loading) {
       if (!append) pendingGroupArchivedRefreshes.add(pk);
       return;
@@ -258,7 +262,7 @@ export const useInstancesStore = defineStore("instances", () => {
     let appendPage = append;
     let rerun = false;
     await drainPendingRefresh(pendingGroupArchivedRefreshes, pk, async () => {
-      const current = byId(instanceId)?.groupArchived?.[groupArchivedKey(mode, groupKey)];
+      const current = groupArchivedStateFor(instanceId, mode, groupKey);
       const offset = appendPage && current ? current.nextOffset : 0;
       // A pending refresh re-enters through loadGroupArchivedSessions (offset 0, replace):
       // fetchGroupArchivedPage's loading guard would otherwise bail and drop the refresh.
@@ -298,7 +302,7 @@ export const useInstancesStore = defineStore("instances", () => {
         };
       }
     } finally {
-      const current = byId(instanceId)?.groupArchived?.[key];
+      const current = groupArchivedStateFor(instanceId, mode, groupKey);
       if (current) current.loading = false;
     }
   }
@@ -326,7 +330,7 @@ export const useInstancesStore = defineStore("instances", () => {
     // A page load may already be in flight for this group. Its own pending-drain loop
     // performs the discard-and-refetch, so mark pending and wait for it to settle
     // instead of racing a second fetch (a bare return would leave the mark un-consumed).
-    while (byId(instanceId)?.groupArchived?.[key]?.loading) {
+    while (groupArchivedStateFor(instanceId, mode, groupKey)?.loading) {
       pendingGroupArchivedRefreshes.add(pk);
       await new Promise((resolve) => setTimeout(resolve, 25));
       if (!pendingGroupArchivedRefreshes.has(pk)) return;

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -165,6 +165,11 @@ const validSessionKeys = computed(() => {
   for (const inst of instances.instances) {
     if (!inst.sessionsLoaded || inst.sessionsHasMore) continue;
     for (const s of inst.sessions) keys.add(sessionKey(inst.id, s.alias));
+    // Grouped sleeping pages live outside `sessions`; count their loaded rows as valid
+    // too or an open sleeping session's tabs get pruned here.
+    for (const state of Object.values(inst.groupArchived ?? {})) {
+      for (const s of state.sessions) keys.add(sessionKey(inst.id, s.alias));
+    }
   }
   return keys;
 });
@@ -208,6 +213,7 @@ let everOnline = false;
 const subscribedInstanceIds = (): string[] => instances.instances.map((instance) => instance.id);
 async function reloadSnapshot() {
   await instances.loadInstances().catch(() => {});
+  instances.loadSessionsForOnlineInstances();
   if (chat.instanceId && chat.sessionAlias) {
     await instances.loadSessions(chat.instanceId).catch(() => {});
     await chat.loadHistory().catch(() => {});
@@ -240,6 +246,7 @@ onMounted(async () => {
     desktopMql.addEventListener("change", onDesktopChange);
   }
   await instances.loadInstances();
+  instances.loadSessionsForOnlineInstances();
   disconnect = connectEvents((event) => {
     instances.applyEvent(event);
     chat.applyEvent(event);

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -605,8 +605,24 @@ export class ControlService {
       });
   }
 
-  listSessionsPage(chatKey: string, offset = 0, limit = 20, includeArchived = false): { sessions: ControlSessionInfo[]; hasMore: boolean; nextOffset: number } {
-    const all = this.listSessions(chatKey).filter((session) => includeArchived || !session.archived);
+  listSessionsPage(
+    chatKey: string,
+    offset = 0,
+    limit = 20,
+    includeArchived = false,
+    filters?: { archivedOnly?: boolean; workspace?: string; agent?: string },
+  ): { sessions: ControlSessionInfo[]; hasMore: boolean; nextOffset: number } {
+    const archivedVisible = (session: ControlSessionInfo): boolean => {
+      if (filters?.archivedOnly) return session.archived;
+      return includeArchived || !session.archived;
+    };
+    // Filters use !== undefined (not truthiness) so "" matches sessions lacking the field.
+    const all = this.listSessions(chatKey).filter((session) => {
+      if (!archivedVisible(session)) return false;
+      if (filters?.workspace !== undefined && (session.workspace ?? "") !== filters.workspace) return false;
+      if (filters?.agent !== undefined && (session.agent ?? "") !== filters.agent) return false;
+      return true;
+    });
     const safeOffset = Math.max(0, Math.floor(offset));
     const safeLimit = Math.min(100, Math.max(1, Math.floor(limit)));
     const sessions = all.slice(safeOffset, safeOffset + safeLimit);

--- a/tests/unit/control/control-service-sessions.test.ts
+++ b/tests/unit/control/control-service-sessions.test.ts
@@ -94,6 +94,28 @@ test("listSessionsPage filters sleeping sessions and returns a server cursor", (
   expect(control.listSessionsPage("relay:acct", 0, 2, true).sessions.map((session) => session.alias)).toEqual(["s0", "s1"]);
 });
 
+test("listSessionsPage supports archivedOnly, workspace and agent filters", () => {
+  const { deps } = makeDeps();
+  deps.sessions.listAllResolvedSessions = () => [
+    { alias: "a", agent: "claude", workspace: "/ws/a", transportSession: "t-a" },
+    { alias: "b", agent: "claude", workspace: "/ws/b", transportSession: "t-b", archived: true },
+    { alias: "c", agent: "codex", workspace: "/ws/a", transportSession: "t-c", archived: true },
+    { alias: "d", agent: "codex", transportSession: "t-d", archived: true },
+  ];
+  const control = new ControlService(deps as never);
+
+  // archivedOnly returns only sleeping sessions, ignoring includeArchived.
+  expect(control.listSessionsPage("relay:acct", 0, 10, false, { archivedOnly: true }).sessions.map((s) => s.alias)).toEqual(["b", "c", "d"]);
+  // Workspace filter narrows the sleeping page; cursor math runs on the filtered set.
+  expect(control.listSessionsPage("relay:acct", 0, 1, false, { archivedOnly: true, workspace: "/ws/a" }))
+    .toMatchObject({ sessions: [expect.objectContaining({ alias: "c" })], hasMore: false, nextOffset: 1 });
+  // Empty-string workspace matches sessions without a workspace.
+  expect(control.listSessionsPage("relay:acct", 0, 10, false, { archivedOnly: true, workspace: "" }).sessions.map((s) => s.alias)).toEqual(["d"]);
+  // Agent filter works on the active listing too.
+  expect(control.listSessionsPage("relay:acct", 0, 10, false, { agent: "codex" }).sessions.map((s) => s.alias)).toEqual([]);
+  expect(control.listSessionsPage("relay:acct", 0, 10, true, { agent: "codex" }).sessions.map((s) => s.alias)).toEqual(["c", "d"]);
+});
+
 test("listSessions marks an agent-side (native) session with native: true", () => {
   const { deps } = makeDeps();
   // A native-attached session carries source "agent-side"; a fresh xacpx session does not.

--- a/tests/unit/packages/channel-relay/control-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/control-bridge.test.ts
@@ -108,6 +108,35 @@ test("sessions.list / prompt / command.execute dispatch and shape results", asyn
   expect(await dispatch(bridge, req(MSG.commandExecute, { chatKey: "k", text: "/status", senderId: "acct" }))).toEqual({ output: "output" });
 });
 
+test("sessions.list routes filter-only payloads to the paginated path and passes filters through", async () => {
+  const paged: Array<Record<string, unknown>> = [];
+  const { control } = makeFakeControl({
+    listSessionsPage: (chatKey: string, offset: number | undefined, limit: number | undefined, includeArchived: boolean | undefined, filters: unknown) => {
+      paged.push({ chatKey, offset, limit, includeArchived, filters });
+      return { sessions: [], hasMore: false, nextOffset: 0 };
+    },
+  });
+  const bridge = createControlBridge(control as never);
+
+  // archivedOnly + workspace without offset/limit must still hit the paginated path.
+  expect(await dispatch(bridge, req(MSG.sessionsList, { chatKey: "relay:acct", archivedOnly: true, workspace: "/ws", limit: 5 })))
+    .toEqual({ sessions: [], hasMore: false, nextOffset: 0 });
+  expect(paged).toEqual([{
+    chatKey: "relay:acct", offset: undefined, limit: 5, includeArchived: undefined,
+    filters: { archivedOnly: true, workspace: "/ws", agent: undefined },
+  }]);
+
+  // includeArchived alone also takes the paginated path (previously ignored without offset/limit).
+  await dispatch(bridge, req(MSG.sessionsList, { chatKey: "relay:acct", includeArchived: true }));
+  expect(paged[1]).toMatchObject({ includeArchived: true, filters: { archivedOnly: undefined, workspace: undefined, agent: undefined } });
+
+  // A bare payload keeps the full-list path.
+  expect(await dispatch(bridge, req(MSG.sessionsList, { chatKey: "relay:acct" }))).toEqual({
+    sessions: [{ alias: "a", agent: "claude", workspace: "/ws", transportSession: "t", running: false }],
+  });
+  expect(paged).toHaveLength(2);
+});
+
 test("queue.cancel dispatches to cancelQueuedItem and returns its result", async () => {
   const { control, calls } = makeFakeControl();
   const bridge = createControlBridge(control as never);

--- a/tests/unit/packages/relay-protocol/payload-validators.test.ts
+++ b/tests/unit/packages/relay-protocol/payload-validators.test.ts
@@ -39,6 +39,12 @@ test("fsCreate enforces the kind literal union", () => {
 test("chatKey-only and chatKey+alias families validate their shape", () => {
   expect(parseControlPayload(MSG.sessionsList, { chatKey: "relay:a1" })).not.toBeNull();
   expect(parseControlPayload(MSG.sessionsList, {})).toBeNull();
+  expect(parseControlPayload(MSG.sessionsList, {
+    chatKey: "relay:a1", offset: 0, limit: 5, archivedOnly: true, workspace: "",
+  })).not.toBeNull();
+  expect(parseControlPayload(MSG.sessionsList, { chatKey: "relay:a1", agent: "codex" })).not.toBeNull();
+  expect(parseControlPayload(MSG.sessionsList, { chatKey: "relay:a1", archivedOnly: "yes" })).toBeNull();
+  expect(parseControlPayload(MSG.sessionsList, { chatKey: "relay:a1", workspace: 3 })).toBeNull();
   expect(parseControlPayload(MSG.sessionsRemove, { chatKey: "relay:a1", alias: "s" })).not.toBeNull();
   expect(parseControlPayload(MSG.sessionsRemove, { chatKey: "relay:a1" })).toBeNull();
 });


### PR DESCRIPTION
## Summary
- Dashboard auto-loads session lists for all online instances on page entry, on reconnect, and when an instance comes online — no more manual "load sessions" click (the button remains as a failure fallback).
- Workspace/agent grouping modes now give each group its own "show sleeping sessions" toggle: sleeping rows page from the server 5 at a time with a load-more button until `hasMore=false`, render below the group's active sessions, and can be hidden again. Flat mode keeps the existing instance-level one-shot toggle.
- Extends `control.sessions.list` with `archivedOnly` / `workspace` / `agent` filters (relay-protocol payload + validator, core `ControlService.listSessionsPage`, channel-relay dispatch); the relay hub forwards verbatim, no hub change.

## Test plan
- [x] `npx tsc --noEmit` + relay-web `vue-tsc` pass
- [x] Root unit suite passes (one pre-existing flaky `main.test.ts` hot-reload case passes on re-run, unrelated)
- [x] relay-web vitest: 1047 tests pass, incl. new store/component suites for group paging and dashboard auto-load
- [x] New server tests: validator accepts/rejects new fields (incl. empty-string workspace), `listSessionsPage` filter + cursor semantics, control-bridge routing of filter-only payloads
- [x] `bun run build:packages` builds all packages
- [ ] Manual: run a local relay hub + instance, verify auto-load on entry, per-group show/load-more/hide flow, offline→online auto-reload