### PR TITLE
fix(relay-web): drop stale native-session RPC responses

### DIFF
--- a/packages/relay-web/src/__tests__/newsessiondialog.test.ts
+++ b/packages/relay-web/src/__tests__/newsessiondialog.test.ts
@@ -319,6 +319,37 @@ describe("NewSessionDialog", () => {
     expect(wrapper.get('[data-test="ns-create"]').attributes("disabled")).toBeDefined();
   });
 
+  it("ignores a stale native-list response that resolves after a newer selection", async () => {
+    const { wrapper, store } = mountDialog({
+      agents: [{ name: "codex", driver: "codex" }],
+      workspaces: [
+        { name: "backend", cwd: "/b" },
+        { name: "frontend", cwd: "/f" },
+      ],
+      agentCatalog: [{ driver: "codex", configured: true, installed: "builtin" }],
+      sessions: [],
+    });
+    // Deferred per workspace: the backend list hangs while the frontend list resolves
+    // right away — the stale backend response must not overwrite the newer one.
+    let resolveBackend!: (sessions: Array<{ sessionId: string; title?: string }>) => void;
+    vi.mocked(store.listNativeSessions).mockImplementation((_id, _agent, workspace) =>
+      workspace === "backend"
+        ? new Promise((resolve) => { resolveBackend = resolve; })
+        : Promise.resolve([{ sessionId: "ses_new", title: "Fresh frontend" }]),
+    );
+    await flushPromises();
+    await wrapper.get('[data-test="ns-source-native"]').trigger("click"); // starts the backend list
+    await pick(wrapper, "ns-workspace", "frontend"); // supersedes it before it resolves
+    await flushPromises();
+    // The newer (frontend) list has landed.
+    expect(wrapper.get('[data-test="ns-native"]').text()).toContain("Fresh frontend");
+    // Now the stale backend response finally resolves — it must be ignored.
+    resolveBackend([{ sessionId: "ses_old", title: "Stale backend" }]);
+    await flushPromises();
+    expect(wrapper.get('[data-test="ns-native"]').text()).toContain("Fresh frontend");
+    expect(wrapper.get('[data-test="ns-native"]').text()).not.toContain("Stale backend");
+  });
+
   it("renders Chinese strings when the locale is zh-CN", async () => {
     i18n.global.locale.value = "zh-CN";
     try {

--- a/packages/relay-web/src/components/NewSessionDialog.vue
+++ b/packages/relay-web/src/components/NewSessionDialog.vue
@@ -171,7 +171,13 @@ const aliasPlaceholder = computed(() =>
 // rollouts, so it requires a CONFIGURED agent and an EXISTING workspace.
 const agentIsConfigured = computed(() => configuredNames.value.has(agentValue.value));
 
+// Stale-response guard: switching agent/workspace fires a new list RPC while the
+// previous one may still be in flight; without a generation check, the slower
+// earlier response lands last and shows the previous selection's rollouts.
+let nativeReqSeq = 0;
+
 async function loadNativeSessions(): Promise<void> {
+  const seq = ++nativeReqSeq;
   nativeSel.value = "";
   nativeSessions.value = [];
   nativeError.value = "";
@@ -182,12 +188,15 @@ async function loadNativeSessions(): Promise<void> {
   }
   nativeLoading.value = true;
   try {
-    nativeSessions.value = await store.listNativeSessions(props.instanceId, agentValue.value, workspaceSel.value);
+    const sessions = await store.listNativeSessions(props.instanceId, agentValue.value, workspaceSel.value);
+    if (seq !== nativeReqSeq) return; // superseded by a newer selection
+    nativeSessions.value = sessions;
     nativeSel.value = nativeSessions.value[0]?.sessionId ?? "";
   } catch (e) {
+    if (seq !== nativeReqSeq) return;
     nativeError.value = e instanceof Error ? e.message : t("session.failedListNative");
   } finally {
-    nativeLoading.value = false;
+    if (seq === nativeReqSeq) nativeLoading.value = false;
   }
 }
 
@@ -204,10 +213,15 @@ watch([sessionSource, agentValue, workspaceSel], () => {
 // Best-effort: acpx can't enumerate an agent's models without a live session, so the
 // list is seeded from an existing same-agent+workspace session (empty otherwise). The
 // field stays a free-text input that defaults to "default", so [] is fine.
+// Same stale-response guard as loadNativeSessions: a slow earlier lookup must not
+// overwrite hints for the current selection.
+let modelSugSeq = 0;
 watch([agentValue, workspaceSel], async () => {
+  const seq = ++modelSugSeq;
   modelSuggestions.value = [];
   if (!agentValue.value || !workspaceSel.value) return;
-  modelSuggestions.value = await store.listModelSuggestions(props.instanceId, agentValue.value, workspaceSel.value);
+  const suggestions = await store.listModelSuggestions(props.instanceId, agentValue.value, workspaceSel.value);
+  if (seq === modelSugSeq) modelSuggestions.value = suggestions;
 });
 
 // Turn a raw backend error into a friendlier hint. Listing an agent's native sessions


### PR DESCRIPTION
在 relay-web 新建会话对话框中，切换到原生会话模式并快速更换 agent / 工作区时，`listNativeSessions` 会连续发起多次 RPC，但旧请求不会被取消。如果旧请求（较慢）比新请求更晚返回，就会用前一个选择的会话列表覆盖当前选择。模型建议列表的 `listModelSuggestions` watcher 有同样的竞态隐患。

**Fix:** 给两个异步调用分别加了 per-call generation counter。每次触发新请求时自增序号，异步返回时比对序号——如果已经不是最新的，就丢弃响应（数据、错误、loading 状态都不写入）。

为什么不直接用 AbortController 取消 fetch：`api.rpc` 不暴露 signal，而且列表是幂等请求，客户端侧丢弃过期响应改动最小，也足够解决展示错误数据的问题。

**Test:** 新增回归用例 `ignores a stale native-list response that resolves after a newer selection`，模拟第一个请求挂起时切换工作区（新请求立即完成），再让旧请求 resolve，验证旧数据不会覆盖新数据。并做了反向验证：去掉守卫时测试如期失败。

所有 24 个 NewSessionDialog 相关测试通过。