### PR TITLE
ci(test): skip terminal-windows job on unrelated PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,41 @@ jobs:
         run: bun run build:packages
 
   terminal-windows:
+    # On PRs, only run when changes touch Windows/terminal/daemon/adapter/transport
+    # surface or shared infra that could break the Windows build. Always runs on
+    # push to main so the default branch stays green.
+    if: github.event_name == 'push' || steps.paths.outputs.windows == 'true'
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Detect Windows-relevant changes
+        id: paths
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            windows:
+              - 'src/daemon/**'
+              - 'src/transport/**'
+              - 'src/process/**'
+              - 'src/adapters/**'
+              - 'src/bridge/**'
+              - 'src/cli/**'
+              - 'tests/unit/daemon/**'
+              - 'tests/unit/transport/**'
+              - 'tests/unit/process/**'
+              - 'tests/unit/adapters/**'
+              - 'tests/unit/integration/**'
+              - 'tests/smoke/**'
+              - 'scripts/smoke-*.mjs'
+              - 'src/config/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'package-lock.json'
+              - '.github/workflows/test.yml'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/packages/relay-web/src/__tests__/newsessiondialog.test.ts
+++ b/packages/relay-web/src/__tests__/newsessiondialog.test.ts
@@ -319,6 +319,37 @@ describe("NewSessionDialog", () => {
     expect(wrapper.get('[data-test="ns-create"]').attributes("disabled")).toBeDefined();
   });
 
+  it("ignores a stale native-list response that resolves after a newer selection", async () => {
+    const { wrapper, store } = mountDialog({
+      agents: [{ name: "codex", driver: "codex" }],
+      workspaces: [
+        { name: "backend", cwd: "/b" },
+        { name: "frontend", cwd: "/f" },
+      ],
+      agentCatalog: [{ driver: "codex", configured: true, installed: "builtin" }],
+      sessions: [],
+    });
+    // Deferred per workspace: the backend list hangs while the frontend list resolves
+    // right away — the stale backend response must not overwrite the newer one.
+    let resolveBackend!: (sessions: Array<{ sessionId: string; title?: string }>) => void;
+    vi.mocked(store.listNativeSessions).mockImplementation((_id, _agent, workspace) =>
+      workspace === "backend"
+        ? new Promise((resolve) => { resolveBackend = resolve; })
+        : Promise.resolve([{ sessionId: "ses_new", title: "Fresh frontend" }]),
+    );
+    await flushPromises();
+    await wrapper.get('[data-test="ns-source-native"]').trigger("click"); // starts the backend list
+    await pick(wrapper, "ns-workspace", "frontend"); // supersedes it before it resolves
+    await flushPromises();
+    // The newer (frontend) list has landed.
+    expect(wrapper.get('[data-test="ns-native"]').text()).toContain("Fresh frontend");
+    // Now the stale backend response finally resolves — it must be ignored.
+    resolveBackend([{ sessionId: "ses_old", title: "Stale backend" }]);
+    await flushPromises();
+    expect(wrapper.get('[data-test="ns-native"]').text()).toContain("Fresh frontend");
+    expect(wrapper.get('[data-test="ns-native"]').text()).not.toContain("Stale backend");
+  });
+
   it("renders Chinese strings when the locale is zh-CN", async () => {
     i18n.global.locale.value = "zh-CN";
     try {

--- a/packages/relay-web/src/components/NewSessionDialog.vue
+++ b/packages/relay-web/src/components/NewSessionDialog.vue
@@ -171,7 +171,13 @@ const aliasPlaceholder = computed(() =>
 // rollouts, so it requires a CONFIGURED agent and an EXISTING workspace.
 const agentIsConfigured = computed(() => configuredNames.value.has(agentValue.value));
 
+// Stale-response guard: switching agent/workspace fires a new list RPC while the
+// previous one may still be in flight; without a generation check, the slower
+// earlier response lands last and shows the previous selection's rollouts.
+let nativeReqSeq = 0;
+
 async function loadNativeSessions(): Promise<void> {
+  const seq = ++nativeReqSeq;
   nativeSel.value = "";
   nativeSessions.value = [];
   nativeError.value = "";
@@ -182,12 +188,15 @@ async function loadNativeSessions(): Promise<void> {
   }
   nativeLoading.value = true;
   try {
-    nativeSessions.value = await store.listNativeSessions(props.instanceId, agentValue.value, workspaceSel.value);
+    const sessions = await store.listNativeSessions(props.instanceId, agentValue.value, workspaceSel.value);
+    if (seq !== nativeReqSeq) return; // superseded by a newer selection
+    nativeSessions.value = sessions;
     nativeSel.value = nativeSessions.value[0]?.sessionId ?? "";
   } catch (e) {
+    if (seq !== nativeReqSeq) return;
     nativeError.value = e instanceof Error ? e.message : t("session.failedListNative");
   } finally {
-    nativeLoading.value = false;
+    if (seq === nativeReqSeq) nativeLoading.value = false;
   }
 }
 
@@ -204,10 +213,15 @@ watch([sessionSource, agentValue, workspaceSel], () => {
 // Best-effort: acpx can't enumerate an agent's models without a live session, so the
 // list is seeded from an existing same-agent+workspace session (empty otherwise). The
 // field stays a free-text input that defaults to "default", so [] is fine.
+// Same stale-response guard as loadNativeSessions: a slow earlier lookup must not
+// overwrite hints for the current selection.
+let modelSugSeq = 0;
 watch([agentValue, workspaceSel], async () => {
+  const seq = ++modelSugSeq;
   modelSuggestions.value = [];
   if (!agentValue.value || !workspaceSel.value) return;
-  modelSuggestions.value = await store.listModelSuggestions(props.instanceId, agentValue.value, workspaceSel.value);
+  const suggestions = await store.listModelSuggestions(props.instanceId, agentValue.value, workspaceSel.value);
+  if (seq === modelSugSeq) modelSuggestions.value = suggestions;
 });
 
 // Turn a raw backend error into a friendlier hint. Listing an agent's native sessions


### PR DESCRIPTION
用 dorny/paths-filter 给 `terminal-windows` job 加上路径门控：

- **PR 中**：只在变更触及 Windows 相关代码（daemon / transport / process / adapters / bridge / cli / config / 对应测试 / workflow 文件 / 锁文件）时才启动 Windows runner
- **push 到 main**：始终运行，保证默认分支完整绿色

对于 relay-web / docs / 渠道包等不相关改动的 PR，可以省下 Windows job 的 3-5 分钟。