### PR TITLE
fix(daemon): repair Windows process worker so stop/restart work

### DIFF
--- a/src/adapters/adapter-verifier.ts
+++ b/src/adapters/adapter-verifier.ts
@@ -43,13 +43,16 @@ export async function verifyAcpInitialize(
   let stdoutBuffer = "";
   let settled = false;
   let timer: NodeJS.Timeout | undefined;
-  let windowsTarget: BatchTarget | undefined;
-  if (process.platform === "win32" && child.pid) {
+  // Probe concurrently with the initialize wait: awaiting it up front would
+  // delay listener registration past an early-exiting child's "close" event
+  // (and with it the E404 guidance path). probeWindowsProcessIdentity never
+  // rejects; the finally block awaits this before terminating.
+  const windowsProbe: Promise<BatchTarget | undefined> = (async () => {
+    if (process.platform !== "win32" || !child.pid) return undefined;
     const identity = await probeWindowsProcessIdentity(child.pid);
-    if (identity.status === "found") {
-      windowsTarget = { pid: child.pid, creationDate: identity.identity.creationDate, executablePath: identity.identity.executablePath };
-    }
-  }
+    if (identity.status !== "found") return undefined;
+    return { pid: child.pid, creationDate: identity.identity.creationDate, executablePath: identity.identity.executablePath };
+  })();
 
   try {
     await new Promise<void>((resolve, reject) => {
@@ -135,6 +138,7 @@ export async function verifyAcpInitialize(
     child.stdin.destroy();
     child.stdout.destroy();
     child.stderr.destroy();
+    const windowsTarget = await windowsProbe;
     if (process.platform !== "win32" || windowsTarget) {
       await terminateProcessTree(windowsTarget ?? child.pid ?? 0, { detachedProcessGroup: detached });
     }

--- a/src/process/windows-process-tree.ts
+++ b/src/process/windows-process-tree.ts
@@ -79,8 +79,10 @@ function decodeTarget(value: unknown): BatchTarget | null {
   const item = value as Record<string, unknown>;
   if (!Number.isSafeInteger(item.pid) || Number(item.pid) <= 0) return null;
   if (parseCanonicalFileTime(item.creationDate) === null) return null;
-  if (item.commandLine !== undefined && typeof item.commandLine !== "string") return null;
-  if (item.executablePath !== undefined && typeof item.executablePath !== "string") return null;
+  // The worker emits JSON null for fingerprints the caller did not supply;
+  // treat null like an absent field rather than rejecting the whole response.
+  if (item.commandLine !== undefined && item.commandLine !== null && typeof item.commandLine !== "string") return null;
+  if (item.executablePath !== undefined && item.executablePath !== null && typeof item.executablePath !== "string") return null;
   return {
     pid: Number(item.pid),
     creationDate: String(item.creationDate),
@@ -215,8 +217,16 @@ export async function terminateWindowsResidual(
 
 async function runPowerShellWorker(request: WindowsWorkerRequest, deadlineMs: number): Promise<unknown> {
   return await new Promise((resolve, reject) => {
-    const child = spawn("powershell.exe", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "-"], {
-      stdio: ["pipe", "pipe", "pipe"],
+    // Windows PowerShell 5.1 processes `-Command -` stdin line by line and
+    // silently discards any line that opens a multi-line construct (blocks,
+    // here-strings), so piping the script leaves the worker producing no
+    // output at all. `-EncodedCommand` (base64 UTF-16LE) delivers the script
+    // intact — the same transport buildWindowsLauncherScript already uses.
+    // Ceiling: the encoded script must fit the 32767-char CreateProcess
+    // command line; keep the worker script compact.
+    const encodedScript = Buffer.from(WINDOWS_TREE_WORKER_SCRIPT, "utf16le").toString("base64");
+    const child = spawn("powershell.exe", ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encodedScript], {
+      stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
       env: {
         ...process.env,
@@ -244,7 +254,6 @@ async function runPowerShellWorker(request: WindowsWorkerRequest, deadlineMs: nu
     child.stderr.on("data", (chunk) => { stderr += String(chunk); });
     child.once("error", (error) => finish(error));
     child.once("close", (code) => code === 0 ? finish() : finish(new Error(`Windows process worker failed (${code}): ${stderr}`)));
-    child.stdin.end(WINDOWS_TREE_WORKER_SCRIPT);
   });
 }
 
@@ -344,7 +353,14 @@ if($request.action -eq 'terminate-one-cim'){
   if(!$check.ok){Write-Output (@{outcome=$check.status} | ConvertTo-Json -Compress);exit 0}
   try {
     if(![XacpxNativeProcess]::Alive($check.handle)){$status='already-exited'}
-    elseif(![XacpxNativeProcess]::Kill($check.handle)){$status=if([XacpxNativeProcess]::LastError() -eq 5){'access-denied'}else{'query-failed'}}
+    elseif(![XacpxNativeProcess]::Kill($check.handle)){
+      $code=[XacpxNativeProcess]::LastError()
+      # Ancestor kills can cascade through Job objects (libuv/Node children
+      # die with their parent), so a failed kill on an already-dying process
+      # is a confirmed exit, not a denial.
+      if([XacpxNativeProcess]::WaitDead($check.handle)){$status='already-exited'}
+      else{$status=if($code -eq 5){'access-denied'}else{'query-failed'}}
+    }
     else{$status=if([XacpxNativeProcess]::WaitDead($check.handle)){'killed'}else{'kill-requested-unconfirmed'}}
     Write-Output (@{outcome=$status} | ConvertTo-Json -Compress);exit 0
   } finally {[XacpxNativeProcess]::Close($check.handle)}
@@ -399,7 +415,15 @@ try {
   foreach($node in $nodes){
     $h=$handles[$node.pid]
     if(![XacpxNativeProcess]::Alive($h)){[void]$outcomes.Add((Outcome $node 'already-exited'));continue}
-    if(![XacpxNativeProcess]::Kill($h)){$status=if([XacpxNativeProcess]::LastError() -eq 5){'access-denied'}else{'query-failed'};[void]$outcomes.Add((Outcome $node $status));continue}
+    if(![XacpxNativeProcess]::Kill($h)){
+      $code=[XacpxNativeProcess]::LastError()
+      # Ancestor kills can cascade through Job objects (libuv/Node children
+      # die with their parent), so a failed kill on an already-dying process
+      # is a confirmed exit, not a denial.
+      if([XacpxNativeProcess]::WaitDead($h)){$status='already-exited'}
+      else{$status=if($code -eq 5){'access-denied'}else{'query-failed'}}
+      [void]$outcomes.Add((Outcome $node $status));continue
+    }
     $status=if([XacpxNativeProcess]::WaitDead($h)){'killed'}else{'kill-requested-unconfirmed'}
     [void]$outcomes.Add((Outcome $node $status))
   }

--- a/src/process/windows-process-tree.ts
+++ b/src/process/windows-process-tree.ts
@@ -259,7 +259,9 @@ async function runPowerShellWorker(request: WindowsWorkerRequest, deadlineMs: nu
 
 // One PowerShell process owns every verified handle from identity check through
 // termination. No verified PID is ever handed to Stop-Process/taskkill later.
-const WINDOWS_TREE_WORKER_SCRIPT = String.raw`
+// Exported so the test suite can statically guard against the encoded payload
+// exceeding Windows' CreateProcess command-line ceiling.
+export const WINDOWS_TREE_WORKER_SCRIPT = String.raw`
 $ErrorActionPreference = 'Stop'
 $request = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($env:XACPX_PROCESS_REQUEST)) | ConvertFrom-Json
 Add-Type -TypeDefinition @'

--- a/tests/unit/adapters/adapter-verifier.test.ts
+++ b/tests/unit/adapters/adapter-verifier.test.ts
@@ -38,8 +38,11 @@ test("times out and terminates an adapter that never initializes", async () => {
   const startedAt = Date.now();
   await expect(verifyAcpInitialize(process.execPath, ["-e", script], { timeoutMs: 30 }))
     .rejects.toThrow("timed out after 30ms");
-  expect(Date.now() - startedAt).toBeLessThan(2_000);
-});
+  // On Windows the teardown really probes and kills the tree through the
+  // PowerShell worker (CIM enumeration included), which takes seconds; the
+  // budget only needs to prove the 30ms timeout fired instead of hanging.
+  expect(Date.now() - startedAt).toBeLessThan(process.platform === "win32" ? 15_000 : 2_000);
+}, 20_000);
 
 test("npm E404 failures point users to the adapter registry setting", async () => {
   await expect(verifyAcpInitialize(

--- a/tests/unit/process/windows-process-tree.test.ts
+++ b/tests/unit/process/windows-process-tree.test.ts
@@ -10,6 +10,7 @@ import {
   terminateWindowsProcessTree,
   type BatchTarget,
 } from "../../../src/process/windows-process-tree";
+import { parseCanonicalFileTime } from "../../../src/process/windows-process-identity";
 
 const root: BatchTarget = {
   pid: 100,
@@ -104,6 +105,18 @@ test("token snapshots and residual termination reject malformed worker responses
 
 const windowsTest = process.platform === "win32" ? test : test.skip;
 
+// Regression: the real worker must actually run on Windows. Piping the script
+// to `powershell -Command -` let PS 5.1 drop every multi-line construct and
+// return empty output, which the tree test below masked by skipping.
+windowsTest("real worker resolves the current process identity", async () => {
+  const probe = await probeWindowsProcessIdentity(process.pid);
+  expect(probe.status).toBe("found");
+  if (probe.status !== "found") return;
+  expect(probe.identity.pid).toBe(process.pid);
+  expect(parseCanonicalFileTime(probe.identity.creationDate)).not.toBeNull();
+  expect(probe.identity.executablePath.length).toBeGreaterThan(0);
+}, 15_000);
+
 windowsTest("real worker rejects a replaced identity and kills a verified tree through retained handles", async () => {
   const rootProcess = spawn("node", ["-e", [
     "const {spawn}=require('node:child_process')",
@@ -145,7 +158,9 @@ windowsTest("real worker rejects a replaced identity and kills a verified tree t
     executablePath: identity!.executablePath,
   });
   expect(result.rootOutcome).toBe("killed");
-  expect(result.outcomes.some((item) => item.target.pid === childPid && item.outcome === "killed")).toBe(true);
+  // Node/libuv children are bound to a kill-on-close Job, so the leaf may be
+  // reaped by the parent's cascade before our retained handle reaches it.
+  expect(result.outcomes.some((item) => item.target.pid === childPid && (item.outcome === "killed" || item.outcome === "already-exited"))).toBe(true);
   expect(() => process.kill(rootProcess.pid!, 0)).toThrow();
   expect(() => process.kill(childPid, 0)).toThrow();
 }, 30_000);

--- a/tests/unit/process/windows-process-tree.test.ts
+++ b/tests/unit/process/windows-process-tree.test.ts
@@ -8,6 +8,7 @@ import {
   snapshotWindowsProcessesByToken,
   terminateWindowsResidual,
   terminateWindowsProcessTree,
+  WINDOWS_TREE_WORKER_SCRIPT,
   type BatchTarget,
 } from "../../../src/process/windows-process-tree";
 import { parseCanonicalFileTime } from "../../../src/process/windows-process-identity";
@@ -104,6 +105,16 @@ test("token snapshots and residual termination reject malformed worker responses
 });
 
 const windowsTest = process.platform === "win32" ? test : test.skip;
+
+test("encoded Windows worker command line stays below the CreateProcess ceiling", () => {
+  // `powershell.exe -NoLogo -NoProfile -NonInteractive -EncodedCommand <encoded>`
+  // is 67 fixed chars plus the base64 payload. The hard ceiling is 32767 chars
+  // (CreateProcessW); this asserts a slightly tighter budget so future script
+  // growth fails loudly instead of silently truncating. The current payload is
+  // ~29 KB so headroom is intentionally small.
+  const encoded = Buffer.from(WINDOWS_TREE_WORKER_SCRIPT, "utf16le").toString("base64");
+  expect(67 + encoded.length).toBeLessThan(32_500);
+});
 
 // Regression: the real worker must actually run on Windows. Piping the script
 // to `powershell -Command -` let PS 5.1 drop every multi-line construct and


### PR DESCRIPTION
## Symptoms (Windows, PowerShell 5.1)

On a fresh `xacpx start` from 0.20.0 — and on any `xacpx restart` after upgrading from a beta — `xacpx stop` and `xacpx restart` fail with:

> cannot safely stop Windows daemon: durable daemon identity is missing or inconsistent

`xacpx status` reports the daemon as running; it just cannot be stopped from the CLI.

## Root cause

`src/process/windows-process-tree.ts` invoked the worker as `powershell -Command -` and piped the ~10KB script via stdin. PowerShell 5.1 processes `-Command -` stdin **line by line** and silently drops any line that opens a multi-line construct (here-strings, `if {` blocks). The worker therefore produces no output, exits 0, and every caller falls back to "unavailable":

* `createDaemonIdentity` writes `generation.daemonCreationDate: null`.
* `stopWindows` always takes `adoptLegacyWindowsGeneration`, which probes the same broken worker and refuses the daemon with the "missing or inconsistent" error.
* `terminateWindowsProcessTree` loses its verification path entirely.

The existing Windows test in `tests/unit/process/windows-process-tree.test.ts` silently `console.warn`s and returns when the worker is unavailable — which is exactly how this regression slipped through 0.20.0.

Two further correctness bugs surfaced once the worker actually ran, both fixed here:

1. **`decodeTarget` rejected null fingerprints.** ConvertTo-Json emits `null` for omitted `commandLine` / `executablePath`; the old check (`typeof !== "string"`) rejected the whole response and the tree kill always reported `query-failed`.
2. **Job cascade misreported as `access-denied`.** Node/libuv puts children in a kill-on-close Job, so killing an ancestor kicks descendants into termination before the retained handle reaches them. `TerminateProcess` then returns `ERROR_ACCESS_DENIED`, which is non-terminal — `stopWindows` would still throw "tree termination was not fully confirmed" even though the tree was dead. Rechecking liveness after a failed `TerminateProcess` now reports cascade-killed nodes as `already-exited`.

## Changes

* `src/process/windows-process-tree.ts`
  * worker uses `-EncodedCommand` (base64 UTF-16LE) — same transport `buildWindowsLauncherScript` already uses, with a comment on the 32767-char command-line ceiling
  * `decodeTarget` treats JSON `null` like an absent field
  * kill loop rechecks liveness after a failed `TerminateProcess`
* `src/adapters/adapter-verifier.ts`
  * probe the child identity concurrently with the initialize wait (await in the finally block only). Bonus fix uncovered while running the full suite: `xacpx adapter set` against an unreachable registry previously hung for the full 120 s default timeout because an early-exiting child's `close` event fired before any listener was attached.
* `tests/unit/process/windows-process-tree.test.ts`
  * new regression test: the real worker resolves the current process identity
  * tree-termination assertion accepts `already-exited` for the leaf (cascade race)
* `tests/unit/adapters/adapter-verifier.test.ts`
  * 30 ms timeout budget bumped to 15 s on Windows (real worker timings; was relying on the buggy fast-skip)
  * explicit bun test timeout of 20 s

## Verification

* `npx tsc --noEmit` — clean
* `bun test tests/unit/process/windows-process-tree.test.ts` — 8/8
* `bun test tests/unit/adapters/adapter-verifier.test.ts` — 4/4 (was 1/4 — including the 121 s E404 hang)
* End-to-end against an isolated config root: `start` writes a real `daemonCreationDate`, `status` shows the daemon, `stop` returns exit 0, `restart` returns exit 0.

Two unrelated pre-existing Windows test failures are still red on this machine (`hermes-shim.test.ts` uses a POSIX-style `file:///opt/...` URL; `bootstrap.test.ts` named-pipe listen case). Out of scope here.

## Operator note for 0.20.0 users

Until this ships, `xacpx stop` is still broken. To stop the daemon safely (pid is in `~/.xacpx/runtime/daemon.pid`):

    taskkill /PID <pid> /T /F
    rm -f ~/.xacpx/runtime/daemon.pid ~/.xacpx/runtime/status.json ~/.xacpx/runtime/orphans/generation.json