### PR TITLE
ci(test): gate terminal-windows via a pre-job path filter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Pre-job: classify the PR diff so downstream jobs can gate on path groups.
+  # Lives on Ubuntu because it only runs checkout + paths-filter (no build).
+  # Skipped on push-to-main since terminal-windows already runs unconditionally
+  # there via the `github.event_name == 'push'` clause in its `if`.
+  paths:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      windows: ${{ steps.filter.outputs.windows }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # dorny/paths-filter diffs against the PR base ref; fetch the full
+          # history so that comparison is reliable.
+          fetch-depth: 0
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            windows:
+              - 'src/daemon/**'
+              - 'src/transport/**'
+              - 'src/process/**'
+              - 'src/adapters/**'
+              - 'src/bridge/**'
+              - 'src/cli/**'
+              - 'src/config/**'
+              - 'tests/unit/daemon/**'
+              - 'tests/unit/transport/**'
+              - 'tests/unit/process/**'
+              - 'tests/unit/adapters/**'
+              - 'tests/unit/integration/**'
+              - 'tests/smoke/**'
+              - 'scripts/smoke-*.mjs'
+              - 'package.json'
+              - 'bun.lock'
+              - 'package-lock.json'
+              - '.github/workflows/test.yml'
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -50,41 +93,19 @@ jobs:
         run: bun run build:packages
 
   terminal-windows:
-    # On PRs, only run when changes touch Windows/terminal/daemon/adapter/transport
-    # surface or shared infra that could break the Windows build. Always runs on
-    # push to main so the default branch stays green.
-    if: github.event_name == 'push' || steps.paths.outputs.windows == 'true'
+    # On PRs, only run when the diff touches the Windows/daemon/transport/
+    # adapter surface or shared infra that could break the Windows build.
+    # Always runs on push to main so the default branch stays green.
+    # `needs.paths.outputs.windows` is job-level-safe; the previous
+    # `steps.paths.outputs.windows` form silently failed because the `steps`
+    # context does not exist at job-level `if` evaluation.
+    needs: paths
+    if: github.event_name == 'push' || needs.paths.outputs.windows == 'true'
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Detect Windows-relevant changes
-        id: paths
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            windows:
-              - 'src/daemon/**'
-              - 'src/transport/**'
-              - 'src/process/**'
-              - 'src/adapters/**'
-              - 'src/bridge/**'
-              - 'src/cli/**'
-              - 'tests/unit/daemon/**'
-              - 'tests/unit/transport/**'
-              - 'tests/unit/process/**'
-              - 'tests/unit/adapters/**'
-              - 'tests/unit/integration/**'
-              - 'tests/smoke/**'
-              - 'scripts/smoke-*.mjs'
-              - 'src/config/**'
-              - 'package.json'
-              - 'bun.lock'
-              - 'package-lock.json'
-              - '.github/workflows/test.yml'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Bug

The terminal-windows job added in #257 used a dorny/paths-filter result inside the job-level `if`:

```yaml
terminal-windows:
  if: github.event_name == 'push' || steps.paths.outputs.windows == 'true'
  steps:
    - id: paths
      uses: dorny/paths-filter@v3
```

The `steps` context is only populated **after** the job's steps begin executing. Job-level `if` is evaluated before that, so `steps.paths.outputs.windows` is always `null` on PRs, the condition reduces to `false`, and the terminal-windows job **silently skips on every PR** — including Windows-specific ones like #258. `gh pr checks` for #258 reports `no checks reported on the 'fix/windows-process-worker' branch`.

This is the only mechanism gating Windows CI today, so a Windows-only regression could land without any Windows signal at all.

## Fix

Lift the path filter into a dedicated `paths` job that runs only on `pull_request`, expose the result as a job output, and reference it from `terminal-windows` via the `needs` context (which is valid at job-level `if` evaluation):

```yaml
jobs:
  paths:
    if: github.event_name == 'pull_request'
    runs-on: ubuntu-latest
    permissions: { contents: read, pull-requests: read }
    outputs:
      windows: ${{ steps.filter.outputs.windows }}
    steps:
      - uses: actions/checkout@v6
        with: { fetch-depth: 0 }
      - id: filter
        uses: dorny/paths-filter@v3
        with: { filters: ... }

  terminal-windows:
    needs: paths
    if: github.event_name == 'push' || needs.paths.outputs.windows == 'true'
    ...
```

`fetch-depth: 0` is set so paths-filter reliably diffs against the PR base ref.

## Behavior preserved

* Push to `main`: `github.event_name == 'push'` clause fires, terminal-windows runs (paths job is skipped — cheap).
* PR touching only docs / relay-web / channel / unrelated infra: `needs.paths.outputs.windows == 'false'`, terminal-windows skipped — keeps the ~3–5 min Windows runner savings the original PR targeted.
* PR touching the Windows-relevant surface (`src/process/**`, `src/daemon/**`, `src/transport/**`, `src/adapters/**`, `src/bridge/**`, `src/cli/**`, `src/config/**`, the corresponding `tests/unit/**`, `tests/smoke/**`, `scripts/smoke-*.mjs`, `package.json`, lockfiles, or this workflow file): `needs.paths.outputs.windows == 'true'`, terminal-windows runs — actually green.

## Verification

Once merged, this unblocks #258 (Windows process worker fix) so its terminal-windows job runs for real instead of being silently skipped. I'll rebase #258 onto `main` after merge and confirm the Windows suite — `windows-process-tree`, `windows-process-identity`, `daemon-controller`, `orphan-registry`, `windows-orphan-reaper`, packaged CLI smoke, `acpx compat` — goes green.

## Note

No code paths changed; this is a CI-only edit and does not require touching any source.