### PR TITLE
feat(relay-web): layered composer stack for status, plan, and input

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -98,8 +98,11 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
 - Cursor 的 `Task`（带 `subagent_type`/`prompt`）同样在 transport 层标记为 subagent，并把 `Read`、`Grep`、`Glob`、
   `Shell`、`StrReplace` 等 provider 工具名归一化为 relay 的通用 kind。`Glob` 的 `glob_pattern` 与 `target_directory`
   会合并成搜索卡片的可读查询，避免 Web 只显示通用工具名。
-- Cursor 的 `TodoWrite` 是 tool call 而非 ACP `session/update` 的 `plan` 事件。transport 会把 `todos`（包括
-  `merge: true` 的增量更新）转换成完整 `PlanEntry[]`，交给同一 `onPlan` 管线，并抑制重复的普通工具卡；显式空列表会清除旧计划。
+- Cursor 的计划工具（`TodoWrite` / `updateTodos` / `todoRead` 等）是 tool call 而非 ACP `session/update` 的
+  `plan` 事件。transport 优先用 `rawInput._toolName` 识别工具（显示 title 是散文，会随版本变化），再从
+  `rawInput`（必要时回退 `rawOutput`）读取 `todos`/`todoList`，把 `merge: true` 的增量更新转换成完整
+  `PlanEntry[]`，交给同一 `onPlan` 管线并抑制重复的普通工具卡。显式空列表会清除旧计划；仅带 `_toolName`、
+  没有条目的公告帧不会清掉已有计划。
 - Claude subagent 内部工具的 `parentToolUseId` 继续标准化为 `parentToolCallId`，经 channel-relay 和 `ToolStepDto`
   原样进入 Relay Web。Qoder、Kimi、Codex 当前 ACP 主流没有提供子工具父子关系，因此不虚构执行时间线；channel-relay
   在 `event.isSubagent` 步骤上把委派 prompt 放入 `detail.text`、把子代理流式/最终输出放入 `detail.output`，
@@ -316,10 +319,11 @@ DOMPurify（svg profile）净化，并按 `theme+源码` 缓存；`StreamMarkdow
     所以抽屉开合 `leftOpen`/`rightOpen` 仅在移动端可见、桌面无副作用——无需 JS 断点检测。
   - 半透明 backdrop 点击关闭；选中会话自动关左抽屉直达对话；抽屉头部有 `✕` 关闭按钮（`lg:hidden`）。
 - 中栏聊天始终占据剩余宽度；登录页/设置页（`max-w-2xl mx-auto`）本身是流式宽度，移动端无需额外处理。
-- **Composer 上方的层叠状态面板**：`ChatPane.vue` 在 composer 的 `relative` 容器中用 `absolute bottom-full` 的
-  stack 放置 `PlanPanel` 与 turn HUD；两者不会改变消息列表高度，也不会为宽屏额外保留侧列 gutter。外层
-  `pointer-events-none`，面板自身恢复 `pointer-events-auto`，避免遮挡输入区之外的点击；`PlanPanel variant="overlay"`
-  使用最大高度和独立滚动，`TransitionGroup` 负责面板出现/消失动画。
+- **Composer 层叠状态面板**：`ChatPane.vue` 在文档流 `composer-stack` 中按「状态条 → 计划面板 → 输入框」
+  垂直排列（输入框在最上层）。视觉重叠用负 `margin-top` + 下层预留的 `padding-bottom`（`--stack-overlap`，
+  桌面 16px / 窄屏 12px）实现，内容不被裁切；递进缩进让下层卡片边缘露出。消息列表与底部 stack 分栏，
+  气泡不被遮挡。`PlanPanel variant="stack"` 限制最大高度并独立滚动；`TransitionGroup` 负责出现/消失动画。
+  `PromptInput` 自身结构与样式尽量保持不变，只由外层 stack 包裹。
 
 ## 文件地图
 

--- a/packages/channel-relay/src/tool-presentation.ts
+++ b/packages/channel-relay/src/tool-presentation.ts
@@ -81,13 +81,30 @@ function readLines(input: Record<string, unknown>): string | undefined {
   if (typeof limit === "number") return `first ${limit}`;
   return undefined;
 }
+/** Adapter bookkeeping that names the tool rather than describing the call
+ *  (cursor-agent stamps every rawInput with `_toolName`). The card already shows
+ *  the tool name in its header, so rendering it again is pure noise. */
+const INTERNAL_INPUT_KEYS = new Set(["_toolName"]);
+
 function primitiveFields(input: Record<string, unknown>): Array<{ label: string; value: string }> {
   const out: Array<{ label: string; value: string }> = [];
   for (const [label, v] of Object.entries(input)) {
+    if (INTERNAL_INPUT_KEYS.has(label)) continue;
     const value = asString(v);
     if (value !== undefined) out.push({ label, value: cap(value) });
   }
   return out;
+}
+
+/** Cursor reports search results as counts instead of matched text
+ *  (`{totalMatches,truncated}` for grep, `{totalFiles,truncated}` for Find). */
+function countSummary(output: Record<string, unknown>): string | undefined {
+  const parts: string[] = [];
+  if (typeof output.totalMatches === "number") parts.push(`${output.totalMatches} matches`);
+  if (typeof output.totalFiles === "number") parts.push(`${output.totalFiles} files`);
+  if (parts.length === 0) return undefined;
+  if (output.truncated === true) parts.push("truncated");
+  return parts.join(" · ");
 }
 
 /** Normalize a raw core ToolUseEvent into a friendly, capped, presentation-ready step. */
@@ -160,7 +177,9 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
   if (event.kind === "read") {
     const path = asString(input.file_path) ?? asString(input.path) ?? asString(pc?.name) ?? locationPath(event) ?? fallbackTitle;
     const lines = readLines(input);
-    const preview = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
+    // `output.content` is cursor-agent's file body — without it a Cursor read card
+    // has no preview at all, since it sends neither content blocks nor stdout.
+    const preview = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? asString(output.content) ?? rawOutputText;
     const detail: ToolDetailDto = { type: "read", path, ...(lines ? { lines } : {}), ...(preview ? { preview: cap(preview) } : {}) };
     return { ...base, title: path, detail };
   }
@@ -179,7 +198,7 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
     const query = globPattern
       ? (targetDirectory ? `${globPattern} in ${targetDirectory}` : globPattern)
       : asString(input.query) ?? asString(input.pattern) ?? asString(input.search) ?? asString(input.command) ?? asString(pc?.cmd) ?? fallbackTitle;
-    const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
+    const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText ?? countSummary(output);
     const detail: ToolDetailDto = { type: "search", query, ...(out ? { output: cap(out) } : {}) };
     return { ...base, title: query, detail };
   }
@@ -190,9 +209,15 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
     const text = mode && explanation
       ? `${mode}: ${explanation}`
       : explanation ?? mode ?? asString(input.description) ?? asString(input.prompt) ?? textFromBlocks(blocks) ?? "";
+    // A think step whose payload the adapter withheld (Cursor's todo tool announces
+    // itself with no arguments) has nothing to expand into — omit the detail so the
+    // card renders as a single header row instead of an empty drawer.
+    if (!text) return { ...base, title: fallbackTitle };
     return { ...base, title: fallbackTitle, detail: { type: "text", text: cap(text) } };
   }
 
   const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
-  return { ...base, title: fallbackTitle, detail: { type: "fields", fields: primitiveFields(input), ...(out ? { output: cap(out) } : {}) } };
+  const fields = primitiveFields(input);
+  if (fields.length === 0 && !out) return { ...base, title: fallbackTitle };
+  return { ...base, title: fallbackTitle, detail: { type: "fields", fields, ...(out ? { output: cap(out) } : {}) } };
 }

--- a/packages/channel-relay/src/tool-presentation.ts
+++ b/packages/channel-relay/src/tool-presentation.ts
@@ -82,8 +82,9 @@ function readLines(input: Record<string, unknown>): string | undefined {
   return undefined;
 }
 /** Adapter bookkeeping that names the tool rather than describing the call
- *  (cursor-agent stamps every rawInput with `_toolName`). The card already shows
- *  the tool name in its header, so rendering it again is pure noise. */
+ *  (cursor-agent stamps every rawInput with `_toolName`). Keep in sync with
+ *  `CURSOR_TOOL_NAME_KEY` in `src/transport/streaming-prompt.ts` — channel-relay
+ *  cannot import transport. The card already shows the tool name in its header. */
 const INTERNAL_INPUT_KEYS = new Set(["_toolName"]);
 
 function primitiveFields(input: Record<string, unknown>): Array<{ label: string; value: string }> {
@@ -171,7 +172,9 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
       };
       return { ...base, title: path, detail };
     }
-    return { ...base, title: path, detail: { type: "fields", fields: primitiveFields(input) } };
+    const fields = primitiveFields(input);
+    if (fields.length === 0) return { ...base, title: path };
+    return { ...base, title: path, detail: { type: "fields", fields } };
   }
 
   if (event.kind === "read") {

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -76,7 +76,7 @@ it("shows a working HUD while a live turn is active", async () => {
   expect(w.find('[data-test="turn-hud"]').text()).toContain("Working");
 });
 
-it("stacks the plan panel and working HUD above the composer as overlays", async () => {
+it("stacks status, plan, and composer as document-flow layers (status → plan → input)", async () => {
   seedInstance();
   const chat = useChatStore();
   chat.select("i1", "backend");
@@ -88,16 +88,33 @@ it("stacks the plan panel and working HUD above the composer as overlays", async
   const w = mount(ChatPane);
   await w.vm.$nextTick();
 
-  const composer = w.find('[data-test="composer-area"]');
-  expect(composer.exists()).toBe(true);
-  expect(composer.classes()).toContain("relative");
+  const area = w.find('[data-test="composer-area"]');
+  expect(area.exists()).toBe(true);
+  const stack = area.find('[data-test="composer-stack"]');
+  expect(stack.exists()).toBe(true);
+  expect(stack.classes()).toContain("composer-stack");
+  expect(stack.classes()).not.toContain("absolute");
 
-  const overlayStack = composer.find(".absolute.bottom-full");
-  expect(overlayStack.exists()).toBe(true);
-  expect(overlayStack.find('[data-test="plan-panel"]').exists()).toBe(true);
-  expect(overlayStack.find('[data-test="turn-hud"]').exists()).toBe(true);
-  expect(overlayStack.find('[data-test="turn-hud"]').classes()).toContain("shadow-e2");
-  expect(overlayStack.find('[data-test="turn-hud"]').classes()).toContain("backdrop-blur-md");
+  const status = stack.find('[data-test="turn-hud"]');
+  const plan = stack.find('[data-test="plan-panel"]');
+  expect(status.exists()).toBe(true);
+  expect(plan.exists()).toBe(true);
+  expect(status.classes()).toContain("stack-layer--status");
+  expect(plan.classes()).toContain("stack-layer--plan");
+  expect(plan.classes()).toContain("stack-layer--pull");
+  expect(status.classes()).toContain("shadow-e2");
+  expect(status.classes()).toContain("backdrop-blur-md");
+
+  // DOM order: status (bottom layer) → plan (middle) → composer (top).
+  const stackEl = stack.element as HTMLElement;
+  const statusEl = status.element as HTMLElement;
+  const planEl = plan.element as HTMLElement;
+  const composerEl = stackEl.querySelector(".stack-layer--composer") as HTMLElement | null;
+  expect(composerEl).toBeTruthy();
+  expect(composerEl!.classList.contains("stack-layer--pull")).toBe(true);
+  const kids = [...stackEl.children] as HTMLElement[];
+  expect(kids.indexOf(statusEl)).toBeLessThan(kids.indexOf(planEl));
+  expect(kids.indexOf(planEl)).toBeLessThan(kids.indexOf(composerEl!));
 });
 
 it("localizes the empty-state prompt when locale is zh-CN", () => {

--- a/packages/relay-web/src/__tests__/planpanel.test.ts
+++ b/packages/relay-web/src/__tests__/planpanel.test.ts
@@ -44,8 +44,8 @@ describe("PlanPanel", () => {
     expect(classes).toContain("max-h-48");
     expect(classes).toContain("overflow-y-auto");
   });
-  it("bounds the list height in the overlay variant", () => {
-    const w = mount(PlanPanel, { props: { variant: "overlay", entries: [
+  it("bounds the list height in the stack variant", () => {
+    const w = mount(PlanPanel, { props: { variant: "stack", entries: [
       { content: "a", status: "in_progress" },
     ] } });
     const classes = w.find("#plan-list").classes();
@@ -54,8 +54,8 @@ describe("PlanPanel", () => {
     expect(classes).toContain("overflow-y-auto");
     expect(w.find('[data-test="plan-panel"]').classes()).toContain("max-h-[min(40vh,20rem)]");
   });
-  it("still toggles in the overlay variant", async () => {
-    const w = mount(PlanPanel, { props: { variant: "overlay", entries: [
+  it("still toggles in the stack variant", async () => {
+    const w = mount(PlanPanel, { props: { variant: "stack", entries: [
       { content: "a", status: "in_progress" },
     ] } });
     expect(w.find('[data-test="plan-toggle"]').attributes("aria-expanded")).toBe("true");

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -22,9 +22,12 @@ const composer = useComposerStore();
 // composer's safe-area bottom padding is just a gap — drop it then (see the template).
 const keyboardInset = useVirtualKeyboardInset();
 
-// Plan and live status now share the composer stack as overlays above the input.
-// Keep expansion state here so toggles survive rerenders of the surrounding stack.
+// Plan and live status share a document-flow composer stack with the input:
+// status (bottom layer) → plan (middle) → input (top). Visual overlap uses
+// negative margin + reserved padding so content is never clipped.
+// Keep expansion state here so toggles survive stack rerenders.
 const planExpanded = ref(chat.busy);
+const showPlan = computed(() => (chat.sessionPlan?.length ?? 0) > 0);
 
 function onSend(text: string, media: PromptAttachmentRef[] = []) {
   void chat.send(text, media);
@@ -190,20 +193,20 @@ const verb = computed(() => {
       <!-- composer area. pb uses max(1rem, safe-area-inset-bottom) so the iOS home-indicator
            inset is applied ONCE here (the bottommost element) and never stacks on top of the
            composer's own padding — env() is 0 off-PWA, so desktop stays at 1rem. -->
-      <div class="relative shrink-0 bg-gradient-to-t from-bg to-transparent px-2 lg:px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-1.5"
+      <div class="shrink-0 bg-gradient-to-t from-bg to-transparent px-2 lg:px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-1.5"
            :style="keyboardInset ? { paddingBottom: '0.5rem' } : undefined"
            data-test="composer-area">
-        <!-- Layered composer stack: plan/status float above the input instead of taking
-             a separate side column or pushing the composer down. -->
+        <!-- Document-flow stack: status (bottom) → plan (middle) → input (top).
+             Overlap is visual only — lower layers reserve padding-bottom equal to the
+             pull-up so content stays fully visible. -->
         <TransitionGroup
           tag="div"
           name="composer-layer"
-          class="pointer-events-none absolute inset-x-2 bottom-full z-30 mb-2 space-y-2 lg:inset-x-5"
+          class="composer-stack flex flex-col"
+          data-test="composer-stack"
         >
-          <PlanPanel v-if="chat.sessionPlan?.length" key="plan-layer" v-model:expanded="planExpanded" :entries="chat.sessionPlan" :active="chat.busy" variant="overlay"
-                     class="pointer-events-auto ml-auto w-full max-w-xl border border-border/70 bg-surface/95 shadow-e3 backdrop-blur-md transition-transform duration-200 ease-out" />
           <div v-if="chat.busy" key="status-layer" data-test="turn-hud"
-               class="pointer-events-auto ml-auto flex w-full max-w-xl items-center gap-2 rounded-lg border border-run/20 bg-surface/95 px-3 py-1.5 shadow-e2 backdrop-blur-md transition-transform duration-200 ease-out">
+               class="stack-layer stack-layer--status relative z-10 mx-4 flex items-center gap-2 rounded-xl border border-run/20 bg-surface/95 px-3 pt-1.5 pb-[calc(0.375rem+var(--stack-overlap))] shadow-e2 backdrop-blur-md sm:mx-6">
             <span class="h-2 w-2 rounded-full bg-run pulse-dot" aria-hidden="true" />
             <span class="text-[12px] font-semibold text-run">{{ verb }}…</span>
             <span class="font-mono text-[12px] font-semibold tabular-nums text-run">{{ elapsed }}</span>
@@ -213,13 +216,19 @@ const verb = computed(() => {
                     class="flex items-center gap-1.5 text-[11.5px] font-medium text-danger transition-opacity hover:opacity-80"
                     @click="chat.cancel"><X :size="13" />{{ $t("common.cancel") }}</button>
           </div>
+          <PlanPanel v-if="showPlan" key="plan-layer" v-model:expanded="planExpanded" :entries="chat.sessionPlan!" :active="chat.busy" variant="overlay"
+                     class="stack-layer stack-layer--plan relative z-20 mx-2 pb-[var(--stack-overlap)] shadow-e3 sm:mx-3"
+                     :class="{ 'stack-layer--pull': chat.busy }" />
+          <div key="composer-layer" class="stack-layer stack-layer--composer relative z-30"
+               :class="{ 'stack-layer--pull': chat.busy || showPlan }">
+            <div class="space-y-2">
+              <QueueStrip />
+              <PromptInput :busy="chat.busy" :draft-key="`${chat.instanceId}\0${chat.sessionAlias}`"
+                           :instance-id="chat.instanceId" :session-alias="chat.sessionAlias"
+                           @send="onSend" @cancel="chat.cancel" />
+            </div>
+          </div>
         </TransitionGroup>
-        <div class="space-y-2">
-          <QueueStrip />
-          <PromptInput :busy="chat.busy" :draft-key="`${chat.instanceId}\0${chat.sessionAlias}`"
-                       :instance-id="chat.instanceId" :session-alias="chat.sessionAlias"
-                       @send="onSend" @cancel="chat.cancel" />
-        </div>
       </div>
       </template>
     </template>
@@ -227,6 +236,18 @@ const verb = computed(() => {
 </template>
 
 <style scoped>
+.composer-stack {
+  --stack-overlap: 16px;
+}
+@media (max-width: 640px) {
+  .composer-stack {
+    --stack-overlap: 12px;
+  }
+}
+/* Pull the next layer up by the reserved overlap; padding is set via Tailwind. */
+.stack-layer--pull {
+  margin-top: calc(-1 * var(--stack-overlap));
+}
 .composer-layer-enter-active,
 .composer-layer-leave-active {
   transition: opacity 180ms ease, transform 220ms cubic-bezier(0.22, 1, 0.36, 1);

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -216,7 +216,7 @@ const verb = computed(() => {
                     class="flex items-center gap-1.5 text-[11.5px] font-medium text-danger transition-opacity hover:opacity-80"
                     @click="chat.cancel"><X :size="13" />{{ $t("common.cancel") }}</button>
           </div>
-          <PlanPanel v-if="showPlan" key="plan-layer" v-model:expanded="planExpanded" :entries="chat.sessionPlan!" :active="chat.busy" variant="overlay"
+          <PlanPanel v-if="showPlan" key="plan-layer" v-model:expanded="planExpanded" :entries="chat.sessionPlan!" :active="chat.busy" variant="stack"
                      class="stack-layer stack-layer--plan relative z-20 mx-2 pb-[var(--stack-overlap)] shadow-e3 sm:mx-3"
                      :class="{ 'stack-layer--pull': chat.busy }" />
           <div key="composer-layer" class="stack-layer stack-layer--composer relative z-30"

--- a/packages/relay-web/src/components/PlanPanel.vue
+++ b/packages/relay-web/src/components/PlanPanel.vue
@@ -5,8 +5,8 @@ import type { PlanEntryDto } from "@ganglion/xacpx-relay-protocol";
 
 // `active` defaults to `undefined` (not Vue's Boolean-cast `false`) so an unspecified prop
 // leaves the panel expanded and the auto expand/collapse watch dormant.
-// `variant: "overlay"` renders in the composer stack as a floating panel above the
-// input: the list keeps a bounded height instead of expanding into a side column.
+// `variant: "overlay"` renders in the composer document-flow stack (between the
+// status bar and the input): the list keeps a bounded height for mobile space.
 const props = withDefaults(
   defineProps<{ entries: PlanEntryDto[]; active?: boolean; variant?: "inline" | "overlay" }>(),
   { active: undefined, variant: "inline" },
@@ -47,7 +47,7 @@ watch(() => props.active, (a) => { if (a !== undefined) expanded.value = a; });
 
 <template>
   <div v-if="entries.length" data-test="plan-panel"
-       :class="['rounded-md border border-border bg-surface p-2 text-sm', variant === 'overlay' ? 'max-h-[min(40vh,20rem)] overflow-hidden rounded-xl border-border/70 bg-surface/95 backdrop-blur-md' : '']">
+       :class="['rounded-md border border-border bg-surface text-sm', variant === 'overlay' ? 'max-h-[min(40vh,20rem)] overflow-hidden rounded-xl border-border/70 bg-surface/95 px-2 pt-2 backdrop-blur-md' : 'p-2']">
     <button
       type="button"
       data-test="plan-toggle"

--- a/packages/relay-web/src/components/PlanPanel.vue
+++ b/packages/relay-web/src/components/PlanPanel.vue
@@ -5,10 +5,10 @@ import type { PlanEntryDto } from "@ganglion/xacpx-relay-protocol";
 
 // `active` defaults to `undefined` (not Vue's Boolean-cast `false`) so an unspecified prop
 // leaves the panel expanded and the auto expand/collapse watch dormant.
-// `variant: "overlay"` renders in the composer document-flow stack (between the
+// `variant: "stack"` renders in the composer document-flow stack (between the
 // status bar and the input): the list keeps a bounded height for mobile space.
 const props = withDefaults(
-  defineProps<{ entries: PlanEntryDto[]; active?: boolean; variant?: "inline" | "overlay" }>(),
+  defineProps<{ entries: PlanEntryDto[]; active?: boolean; variant?: "inline" | "stack" }>(),
   { active: undefined, variant: "inline" },
 );
 // `expanded` is a two-way model so ChatPane can own it and preserve the expand/collapse
@@ -47,7 +47,7 @@ watch(() => props.active, (a) => { if (a !== undefined) expanded.value = a; });
 
 <template>
   <div v-if="entries.length" data-test="plan-panel"
-       :class="['rounded-md border border-border bg-surface text-sm', variant === 'overlay' ? 'max-h-[min(40vh,20rem)] overflow-hidden rounded-xl border-border/70 bg-surface/95 px-2 pt-2 backdrop-blur-md' : 'p-2']">
+       :class="['rounded-md border border-border bg-surface text-sm', variant === 'stack' ? 'max-h-[min(40vh,20rem)] overflow-hidden rounded-xl border-border/70 bg-surface/95 px-2 pt-2 backdrop-blur-md' : 'p-2']">
     <button
       type="button"
       data-test="plan-toggle"
@@ -63,7 +63,7 @@ watch(() => props.active, (a) => { if (a !== undefined) expanded.value = a; });
       <span class="ml-auto font-mono tabular-nums">{{ done }}/{{ entries.length }}</span>
     </button>
     <ul v-show="expanded" id="plan-list" ref="listEl"
-        :class="['overflow-y-auto thin-scroll space-y-0.5', variant === 'overlay' ? 'max-h-[calc(min(40vh,20rem)-2.5rem)]' : 'max-h-48']">
+        :class="['overflow-y-auto thin-scroll space-y-0.5', variant === 'stack' ? 'max-h-[calc(min(40vh,20rem)-2.5rem)]' : 'max-h-48']">
       <li
         v-for="(e, i) in entries"
         :key="i"

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -554,13 +554,15 @@ function normalizeCursorPlanUpdate(
   if (!CURSOR_PLAN_TOOL_NAMES.has(cursorToolIdentity(update))) return undefined;
 
   const input = cursorToolInput(update.rawInput);
+  const output = cursorToolInput(update.rawOutput);
   // cursor-agent ≥2026.08 announces the todo tool but ships no entries with it
   // (`rawInput` is just `{_toolName:"updateTodos"}`), so there is nothing to feed
   // the plan panel. Leave it to the tool card rather than clearing a good plan.
-  const todos = readCursorTodoList(input);
+  // `todoRead` may also put the list only on `rawOutput`.
+  const todos = readCursorTodoList(input) ?? readCursorTodoList(output);
   if (todos === undefined) return undefined;
 
-  const merge = input?.merge === true;
+  const merge = input?.merge === true || output?.merge === true;
   if (todos.length === 0) {
     state.cursorPlanEntries.clear();
     return [];
@@ -589,11 +591,11 @@ function normalizeCursorPlanUpdate(
   return [...state.cursorPlanEntries.values()];
 }
 
-/** The todo array under whichever key the running cursor-agent uses, or undefined
- *  when the call carries no list at all (announcement-only frames). */
+/** The todo array under the keys cursor-agent has used, or undefined when the
+ *  call carries no list at all (announcement-only frames). */
 function readCursorTodoList(input: Record<string, unknown> | undefined): unknown[] | undefined {
   if (!input) return undefined;
-  for (const key of ["todos", "todoList", "items", "entries", "plan"]) {
+  for (const key of ["todos", "todoList"] as const) {
     if (Array.isArray(input[key])) return input[key];
   }
   return undefined;

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -538,7 +538,12 @@ function buildToolUseEvent(
   };
 }
 
-const CURSOR_PLAN_TOOL_NAMES = new Set(["todowrite", "createplan", "updateplan", "plan"]);
+/** Internal marker cursor-agent injects into `rawInput` to name the tool. */
+export const CURSOR_TOOL_NAME_KEY = "_toolName";
+
+const CURSOR_PLAN_TOOL_NAMES = new Set([
+  "todowrite", "createplan", "updateplan", "plan", "updatetodos", "todoread",
+]);
 
 /** Convert Cursor's TodoWrite tool protocol into the provider-neutral ACP plan shape. */
 function normalizeCursorPlanUpdate(
@@ -546,19 +551,22 @@ function normalizeCursorPlanUpdate(
   update: MergedToolUpdate,
 ): PlanEntry[] | undefined {
   if (state.driver !== "cursor") return undefined;
-  const title = normalizeCursorToolName(update.title);
-  if (!CURSOR_PLAN_TOOL_NAMES.has(title)) return undefined;
+  if (!CURSOR_PLAN_TOOL_NAMES.has(cursorToolIdentity(update))) return undefined;
 
   const input = cursorToolInput(update.rawInput);
-  if (!Array.isArray(input?.todos)) return undefined;
+  // cursor-agent ≥2026.08 announces the todo tool but ships no entries with it
+  // (`rawInput` is just `{_toolName:"updateTodos"}`), so there is nothing to feed
+  // the plan panel. Leave it to the tool card rather than clearing a good plan.
+  const todos = readCursorTodoList(input);
+  if (todos === undefined) return undefined;
 
-  const merge = input.merge === true;
-  if (input.todos.length === 0) {
+  const merge = input?.merge === true;
+  if (todos.length === 0) {
     state.cursorPlanEntries.clear();
     return [];
   }
 
-  const patches = input.todos
+  const patches = todos
     .map((todo, index) => parseCursorPlanTodo(todo, index))
     .filter((todo): todo is CursorPlanTodo => todo !== undefined);
   // A non-empty but entirely malformed payload should not erase a good plan.
@@ -579,6 +587,16 @@ function normalizeCursorPlanUpdate(
   }
 
   return [...state.cursorPlanEntries.values()];
+}
+
+/** The todo array under whichever key the running cursor-agent uses, or undefined
+ *  when the call carries no list at all (announcement-only frames). */
+function readCursorTodoList(input: Record<string, unknown> | undefined): unknown[] | undefined {
+  if (!input) return undefined;
+  for (const key of ["todos", "todoList", "items", "entries", "plan"]) {
+    if (Array.isArray(input[key])) return input[key];
+  }
+  return undefined;
 }
 
 interface CursorPlanTodo {
@@ -644,6 +662,17 @@ function normalizeCursorToolName(title: string | undefined): string {
   return (title ?? "").trim().toLowerCase().replace(/[\s_-]+/g, "");
 }
 
+/** cursor-agent labels a call with a display `title` ("Update TODOs", "Read File")
+ *  and puts the machine name in `rawInput._toolName` ("updateTodos"). Match on the
+ *  machine name first — the display title is prose and varies between releases. */
+function cursorToolIdentity(update: { title?: string; rawInput?: unknown }): string {
+  const input = cursorToolInput(update.rawInput);
+  const declared = typeof input?.[CURSOR_TOOL_NAME_KEY] === "string"
+    ? (input[CURSOR_TOOL_NAME_KEY] as string)
+    : undefined;
+  return normalizeCursorToolName(declared ?? update.title);
+}
+
 const CURSOR_SUBAGENT_TOOL_NAMES = new Set(["task", "delegate", "runsubagent", "subagent"]);
 
 function normalizeToolKind(
@@ -655,12 +684,14 @@ function normalizeToolKind(
     case "read": case "search": case "execute": case "edit": case "think": return kindRaw;
   }
   if (driver !== "cursor") return "other";
-  switch (normalizeCursorToolName(update?.title)) {
+  switch (cursorToolIdentity(update ?? {})) {
     case "read":
     case "readfile":
       return "read";
     case "grep":
     case "glob":
+    case "find":
+    case "codebasesearch":
     case "search":
       return "search";
     case "shell":
@@ -678,6 +709,8 @@ function normalizeToolKind(
     case "runsubagent":
     case "switchmode":
     case "todowrite":
+    case "updatetodos":
+    case "todoread":
     case "createplan":
     case "updateplan":
     case "plan":
@@ -688,8 +721,7 @@ function normalizeToolKind(
 }
 
 function isCursorSubagentInput(rawInput: unknown, title: string): boolean {
-  const normalizedTitle = normalizeCursorToolName(title);
-  if (!CURSOR_SUBAGENT_TOOL_NAMES.has(normalizedTitle)) return false;
+  if (!CURSOR_SUBAGENT_TOOL_NAMES.has(cursorToolIdentity({ title, rawInput }))) return false;
   const input = cursorToolInput(rawInput);
   return input !== undefined
     && readFirstString(input, ["subagent_type", "subagentType", "agent", "agentType", "prompt", "instructions"]) !== undefined;

--- a/tests/unit/packages/channel-relay/tool-presentation.test.ts
+++ b/tests/unit/packages/channel-relay/tool-presentation.test.ts
@@ -239,6 +239,13 @@ test("omits the detail entirely when the adapter sent nothing to show", () => {
     rawInput: { _toolName: "mcp_thing" },
   });
   expect(other.detail).toBeUndefined();
+
+  const edit = toolUseEventToStepDto({
+    toolCallId: "e1", toolName: "Edit", kind: "edit", status: "success",
+    rawInput: { _toolName: "edit" },
+  });
+  expect(edit.detail).toBeUndefined();
+  expect(edit.title).toBe("Edit");
 });
 
 test("preserves subagent ownership metadata for Relay Web grouping", () => {

--- a/tests/unit/packages/channel-relay/tool-presentation.test.ts
+++ b/tests/unit/packages/channel-relay/tool-presentation.test.ts
@@ -195,6 +195,52 @@ test("Cursor SwitchMode shows its target mode and explanation", () => {
   expect(step.detail).toEqual({ type: "text", text: "plan: Inspect the UI before editing" });
 });
 
+test("Cursor read shows the file body it returns as rawOutput.content", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "r-cursor", toolName: "Read File", kind: "read", status: "success",
+    rawInput: {},
+    rawOutput: { content: "127.0.0.1\tlocalhost\n" },
+  });
+  expect(step.detail).toMatchObject({ type: "read", preview: "127.0.0.1\tlocalhost\n" });
+});
+
+test("Cursor search summarizes count-only results instead of rendering nothing", () => {
+  const grep = toolUseEventToStepDto({
+    toolCallId: "s1", toolName: "grep", kind: "search", status: "success",
+    rawInput: {}, rawOutput: { totalMatches: 4, truncated: false },
+  });
+  expect(grep.detail).toMatchObject({ type: "search", output: "4 matches" });
+
+  const find = toolUseEventToStepDto({
+    toolCallId: "s2", toolName: "Find", kind: "search", status: "success",
+    rawInput: {}, rawOutput: { totalFiles: 3087, truncated: true },
+  });
+  expect(find.detail).toMatchObject({ type: "search", output: "3087 files · truncated" });
+});
+
+test("drops the adapter's internal _toolName marker from rendered fields", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "m1", toolName: "MCP: tool", kind: "other", status: "success",
+    rawInput: { _toolName: "mcp_do_thing", scope: "repo" },
+  });
+  expect(step.detail).toEqual({ type: "fields", fields: [{ label: "scope", value: "repo" }] });
+});
+
+test("omits the detail entirely when the adapter sent nothing to show", () => {
+  const think = toolUseEventToStepDto({
+    toolCallId: "todo-1", toolName: "Update TODOs", kind: "think", status: "success",
+    rawInput: { _toolName: "updateTodos" },
+  });
+  expect(think.detail).toBeUndefined();
+  expect(think.title).toBe("Update TODOs");
+
+  const other = toolUseEventToStepDto({
+    toolCallId: "o1", toolName: "MCP: tool", kind: "other", status: "success",
+    rawInput: { _toolName: "mcp_thing" },
+  });
+  expect(other.detail).toBeUndefined();
+});
+
 test("preserves subagent ownership metadata for Relay Web grouping", () => {
   const parent = toolUseEventToStepDto({
     toolCallId: "agent-1", toolName: "Task", kind: "think", status: "running",

--- a/tests/unit/transport/streaming-prompt.test.ts
+++ b/tests/unit/transport/streaming-prompt.test.ts
@@ -743,6 +743,52 @@ test("adapts Cursor TodoWrite calls into merged plan updates instead of tool car
   expect(toolEvents).toEqual([]);
 });
 
+test("recognizes the Cursor todo tool by rawInput._toolName, not its prose title", () => {
+  const plans: unknown[] = [];
+  const state = createStreamingPromptState(false, {
+    mode: "structured",
+    driver: "cursor",
+    onPlan: (entries) => plans.push(entries),
+    onToolEvent: () => {},
+  });
+  parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update: {
+    sessionUpdate: "tool_call",
+    toolCallId: "todo-1",
+    title: "Update TODOs",
+    kind: "other",
+    rawInput: { _toolName: "updateTodos", todos: [{ id: "a", content: "Ship it", status: "pending" }] },
+  } } }));
+
+  expect(plans).toEqual([[{ content: "Ship it", status: "pending" }]]);
+});
+
+test("keeps an announcement-only Cursor todo call as a think card without clearing the plan", () => {
+  const plans: unknown[] = [];
+  const events: Array<Record<string, unknown>> = [];
+  const state = createStreamingPromptState(false, {
+    mode: "structured",
+    driver: "cursor",
+    onPlan: (entries) => plans.push(entries),
+    onToolEvent: (event) => events.push(event as unknown as Record<string, unknown>),
+  });
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+
+  send({
+    sessionUpdate: "tool_call", toolCallId: "todo-1", title: "TodoWrite", kind: "other",
+    rawInput: { todos: [{ id: "a", content: "Ship it", status: "pending" }] },
+  });
+  // cursor-agent ≥2026.08 announces the tool with no entries attached.
+  send({
+    sessionUpdate: "tool_call", toolCallId: "todo-2", title: "Update TODOs", kind: "other",
+    rawInput: { _toolName: "updateTodos" },
+  });
+
+  expect(plans).toEqual([[{ content: "Ship it", status: "pending" }]]);
+  expect(events).toHaveLength(1);
+  expect(events[0]).toMatchObject({ toolCallId: "todo-2", kind: "think" });
+});
+
 test("normalizes Cursor Task and built-in tool names for structured cards", () => {
   const events: Array<Record<string, unknown>> = [];
   const state = createStreamingPromptState(false, {

--- a/tests/unit/transport/streaming-prompt.test.ts
+++ b/tests/unit/transport/streaming-prompt.test.ts
@@ -789,6 +789,26 @@ test("keeps an announcement-only Cursor todo call as a think card without cleari
   expect(events[0]).toMatchObject({ toolCallId: "todo-2", kind: "think" });
 });
 
+test("reads Cursor todoRead lists from rawOutput when rawInput has none", () => {
+  const plans: unknown[] = [];
+  const state = createStreamingPromptState(false, {
+    mode: "structured",
+    driver: "cursor",
+    onPlan: (entries) => plans.push(entries),
+    onToolEvent: () => {},
+  });
+  parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update: {
+    sessionUpdate: "tool_call",
+    toolCallId: "todo-read-1",
+    title: "Todo Read",
+    kind: "other",
+    rawInput: { _toolName: "todoRead" },
+    rawOutput: { todoList: [{ id: "a", content: "Ship it", status: "completed" }] },
+  } } }));
+
+  expect(plans).toEqual([[{ content: "Ship it", status: "completed" }]]);
+});
+
 test("normalizes Cursor Task and built-in tool names for structured cards", () => {
   const events: Array<Record<string, unknown>> = [];
   const state = createStreamingPromptState(false, {


### PR DESCRIPTION
## Summary
- Replace absolute plan/status overlays with a document-flow composer stack: status (bottom) → plan (middle) → input (top), using reserved padding so visual overlap never clips content.
- Improve Cursor tool/plan presentation: resolve `_toolName`, show `rawOutput.content` for reads, summarize search counts, and omit empty detail drawers.

## Test plan
- [ ] Open relay-web with a busy turn + plan entries; confirm status → plan → input stack with stepped indent and no clipped text
- [ ] Collapse/expand the plan panel; confirm input stays usable and messages are not covered
- [ ] Mobile/narrow width: overlap shrinks, margins stay tight
- [ ] With Cursor agent: read/search tool cards show useful previews; empty `updateTodos` does not clear a valid plan
- [ ] `npx vitest run src/__tests__/chatpane.test.ts src/__tests__/planpanel.test.ts` in `packages/relay-web`
- [ ] Unit tests for `streaming-prompt` and `tool-presentation` still pass


Made with [Cursor](https://cursor.com)