### PR TITLE
fix: auto-derive unique alias when desired session name collides with archived session

### DIFF
--- a/packages/relay-web/src/__tests__/instances-optimistic-create.test.ts
+++ b/packages/relay-web/src/__tests__/instances-optimistic-create.test.ts
@@ -81,6 +81,40 @@ describe("optimistic session creation", () => {
     expect(store.beginSessionCreation("i1", "fresh", "codex", "home")).toBe(true);
   });
 
+  it("patches the optimistic row alias when the backend auto-derives a different one", async () => {
+    const store = useInstancesStore();
+    store.instances = [inst()] as never;
+    const rpc = vi.spyOn(api, "rpc")
+      .mockResolvedValueOnce({ ok: true, alias: "backend-2" } as never) // create returns adjusted alias
+      .mockResolvedValueOnce({ sessions: [{ alias: "backend-2", agent: "codex", workspace: "home", transportSession: "t", running: false, archived: false }] } as never)
+      .mockResolvedValue({ agents: [] } as never);
+    store.beginSessionCreation("i1", "backend", "codex", "home");
+    // Before RPC resolves, the optimistic row carries the requested alias.
+    const before = store.byId("i1")!.sessions.find((s) => s.creating);
+    expect(before?.alias).toBe("backend");
+    await flushPromises();
+    const sessions = store.byId("i1")!.sessions;
+    expect(sessions).toHaveLength(1);
+    // After RPC resolves, the optimistic row is patched to the backend-chosen alias
+    // and then replaced by loadSessions with the final (non-creating) row.
+    expect(sessions[0]).toMatchObject({ alias: "backend-2", transportSession: "t" });
+    expect(sessions[0]!.creating).toBeUndefined();
+    expect(rpc).toHaveBeenCalledWith("i1", "control.sessions.create", { alias: "backend", agent: "codex", workspace: "home" });
+  });
+
+  it("returns true and fires the create RPC when the alias collides with an archived session", () => {
+    const store = useInstancesStore();
+    store.instances = [inst([{ alias: "archived-alias", agent: "codex", workspace: "home", transportSession: "t", running: false, archived: true }])] as never;
+    const rpc = vi.spyOn(api, "rpc").mockReturnValue(new Promise(() => {}) as never);
+    const ok = store.beginSessionCreation("i1", "archived-alias", "codex", "home");
+    expect(ok).toBe(true);
+    // An optimistic row is inserted (temporarily sharing the alias with the archived
+    // entry) so the backend can auto-derive a free one and return it to be patched.
+    const creatingRows = store.byId("i1")!.sessions.filter((s) => s.creating);
+    expect(creatingRows).toHaveLength(1);
+    expect(rpc).toHaveBeenCalled();
+  });
+
   it("cancelSessionCreation drops a booting/failed row but spares a materialised one", () => {
     const store = useInstancesStore();
     store.instances = [inst([

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -512,7 +512,7 @@ export const useInstancesStore = defineStore("instances", () => {
   // false return as a duplicate-alias error instead.
   function beginSessionCreation(instanceId: string, alias: string, agent: string, workspace: string, agentSessionId?: string, model?: string): boolean {
     const inst = byId(instanceId);
-    if (!inst || inst.sessions.some((s) => s.alias === alias)) return false;
+    if (!inst || inst.sessions.some((s) => s.alias === alias && !s.archived)) return false;
     inst.sessions = [
       // A native attach (agentSessionId set) yields a native session — badge the optimistic
       // row immediately so the marker doesn't pop in only once the server row lands.

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -464,16 +464,35 @@ export const useInstancesStore = defineStore("instances", () => {
   // so a timeout is reported as `{pending:true}` (not a hard error). Every other
   // failure — including the instance-side `{error}` payload surfaced by `unwrap` —
   // is a real failure and rethrows.
+  //
+  // The RPC returns the ACTUAL alias chosen by the backend, which may differ from
+  // the request alias when the desired name collides with an existing archived
+  // session (the backend derives `<alias>-2`, `<alias>-3`, …). When that happens
+  // we patch the optimistic row to the final alias BEFORE reloading the session
+  // list, so `loadSessions` can match the real row against the corrected one and
+  // the user never sees a stale "name not found" error card.
   async function createSession(instanceId: string, alias: string, agent: string, workspace: string, agentSessionId?: string, model?: string): Promise<{ pending: boolean }> {
+    let result: SessionDto | undefined;
     try {
       // agentSessionId, when set, resumes an existing agent-native session instead of
       // creating a fresh transport session (the web "attach native session" option).
       // model, when set, overrides the agent's default model for the new session
       // (empty/"default" is omitted so the agent default is used).
-      unwrap(await api.rpc(instanceId, "control.sessions.create", { alias, agent, workspace, ...(agentSessionId ? { agentSessionId } : {}), ...(model ? { model } : {}) }));
+      result = unwrap(await api.rpc<SessionDto>(instanceId, "control.sessions.create", { alias, agent, workspace, ...(agentSessionId ? { agentSessionId } : {}), ...(model ? { model } : {}) }));
     } catch (e) {
       if (e instanceof ApiError && (e.status === 504 || e.code === "timeout")) return { pending: true };
       throw e;
+    }
+    if (result && result.alias !== alias) {
+      const inst = byId(instanceId);
+      if (inst) {
+        const idx = inst.sessions.findIndex((s) => s.alias === alias && !!s.creating);
+        if (idx >= 0) {
+          // Preserve any in-flight optimistic fields (creating, creatingSince, native)
+          // while retargeting the row to the server-chosen alias.
+          inst.sessions.splice(idx, 1, { ...inst.sessions[idx]!, alias: result.alias });
+        }
+      }
     }
     await loadSessions(instanceId);
     return { pending: false };

--- a/src/commands/handlers/native-session-handler.ts
+++ b/src/commands/handlers/native-session-handler.ts
@@ -207,12 +207,57 @@ async function attachNativeSession(
     };
   }
 
+  const channelId = getChannelIdFromChatKey(chatKey);
   const requestedAlias = alias?.trim() || buildDefaultNativeAlias(nativeTarget.agent, session.sessionId);
-  const displayAlias = await allocateUniqueNativeAlias(context, chatKey, requestedAlias);
-  const internalAlias = scopeDisplayAliasToInternal(getChannelIdFromChatKey(chatKey), displayAlias);
-  const transportSession = context.sessions.buildDefaultTransportSessionForChat(chatKey, displayAlias);
-  const resolvedSession = context.lifecycle.resolveSession(internalAlias, nativeTarget.agent, nativeTarget.workspace, transportSession);
-  const releaseReservation = await context.lifecycle.reserveTransportSession(resolvedSession.transportSession);
+
+  // `allocateUniqueNativeAlias` already checks both logical alias visibility AND the
+  // transport-session non-sharing constraint that native attaches require, but it
+  // has no atomic reservation step. To close the TOCTOU gap between allocation and
+  // the alias being claimed, re-run derivation bounded times and fall back to the
+  // generic logical-only reserve on the last attempt (the transport uniqueness
+  // check is best-effort, never a correctness contract — colliding transport
+  // sessions are just a perf footgun, not a data-loss bug).
+  let reserved: { alias: string; release: () => void } | null = null;
+  let finalDisplayAlias = requestedAlias;
+  // Each iteration re-runs allocateUniqueNativeAlias to pick a fresh transport-unique
+  // display name (it handles its own suffix derivation internally). The retry exists
+  // because between its `listSessions`-based check and our atomic alias reserve,
+  // another concurrent attach could have claimed the slot — on the next attempt
+  // allocateUniqueNativeAlias will see the newly-claimed row and move the suffix on
+  // its own. We must NOT manually prepend `-N` to the requested alias here, or the
+  // two suffix-derivation layers would compound (`xxx-2-2` style).
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const candidateDisplay = await allocateUniqueNativeAlias(context, chatKey, requestedAlias);
+    const candidateInternal = scopeDisplayAliasToInternal(channelId, candidateDisplay);
+    const release = context.sessions.tryReserveNewSessionAlias(candidateInternal);
+    if (release) {
+      reserved = { alias: candidateInternal, release };
+      finalDisplayAlias = candidateDisplay;
+      break;
+    }
+  }
+  // Fallback: the transport-unique derivation above kept losing the TOCTOU race.
+  // Drop to a logical-only free reservation (the transport uniqueness constraint is
+  // advisory for native attach, never a correctness barrier).
+  let finalInternalAlias: string;
+  let releaseAliasReservation: () => void;
+  if (reserved) {
+    finalInternalAlias = reserved.alias;
+    releaseAliasReservation = reserved.release;
+  } else {
+    const desiredInternal = scopeDisplayAliasToInternal(channelId, finalDisplayAlias);
+    const free = context.sessions.tryReserveFreeSessionAlias(desiredInternal);
+    if (!free) {
+      return { text: t().session.sessionAlreadyExists(finalDisplayAlias, nativeTarget.agent, nativeTarget.workspace) };
+    }
+    finalInternalAlias = free.alias;
+    releaseAliasReservation = free.release;
+    finalDisplayAlias = toDisplaySessionAlias(finalInternalAlias);
+  }
+
+  const transportSession = context.sessions.buildDefaultTransportSessionForChat(chatKey, finalDisplayAlias);
+  const resolvedSession = context.lifecycle.resolveSession(finalInternalAlias, nativeTarget.agent, nativeTarget.workspace, transportSession);
+  const releaseTransportReservation = await context.lifecycle.reserveTransportSession(resolvedSession.transportSession);
 
   try {
     try {
@@ -226,7 +271,7 @@ async function attachNativeSession(
     }
 
     await context.sessions.attachNativeSession({
-      alias: internalAlias,
+      alias: finalInternalAlias,
       agent: nativeTarget.agent,
       workspace: nativeTarget.workspace,
       transportSession,
@@ -237,14 +282,18 @@ async function attachNativeSession(
       title: session.title,
       updatedAt: session.updatedAt,
     });
-    await context.sessions.useSession(chatKey, internalAlias);
-    await refreshAgentCommandBestEffort(context, internalAlias);
+    await context.sessions.useSession(chatKey, finalInternalAlias);
+    await refreshAgentCommandBestEffort(context, finalInternalAlias);
 
     return {
-      text: t().nativeSession.attachedAndSwitched(target.agentDisplayName, toDisplaySessionAlias(internalAlias)),
+      text: t().nativeSession.attachedAndSwitched(target.agentDisplayName, toDisplaySessionAlias(finalInternalAlias)),
     };
   } finally {
-    await releaseReservation();
+    try {
+      await releaseTransportReservation();
+    } finally {
+      releaseAliasReservation();
+    }
   }
 }
 

--- a/src/commands/handlers/session-handler.ts
+++ b/src/commands/handlers/session-handler.ts
@@ -218,12 +218,14 @@ export async function handleSessionNew(
   // either reuse the old transport session (stale history) or orphan it, and
   // a native session's agent_session_id would be silently dropped. Internal
   // repair paths (resolveSession) intentionally bypass this guard.
-  const existing = context.sessions.getResolvedSessionByInternalAlias(internalAlias);
-  if (existing) {
-    return { text: t().session.sessionAlreadyExists(alias, existing.agent, existing.workspace) };
-  }
-  const releaseAliasReservation = context.sessions.tryReserveNewSessionAlias(internalAlias);
-  if (!releaseAliasReservation) {
+  //
+  // When the desired alias collides with an existing session (active OR archived),
+  // instead of failing outright we derive a free alias by appending `-2`, `-3`, …
+  // The user is told in the reply text that the name was adjusted so the creation
+  // still succeeds transparently when the input came from a default/auto-generated
+  // source (the common archived-session collision case).
+  const reserved = context.sessions.tryReserveFreeSessionAlias(internalAlias);
+  if (!reserved) {
     const claimed = context.sessions.getResolvedSessionByInternalAlias(internalAlias);
     return {
       text: claimed
@@ -231,11 +233,14 @@ export async function handleSessionNew(
         : t().session.sessionAlreadyExists(alias, agent, workspace),
     };
   }
+  const { alias: finalInternalAlias, release: releaseAliasReservation } = reserved;
+  const finalDisplayAlias = toDisplaySessionAlias(finalInternalAlias);
+  const aliasWasAdjusted = finalInternalAlias !== internalAlias;
 
   try {
-    const stableTransportSession = `${workspace}:${internalAlias}`;
+    const stableTransportSession = `${workspace}:${finalInternalAlias}`;
     const session = context.lifecycle.resolveSession(
-      internalAlias,
+      finalInternalAlias,
       agent,
       workspace,
       context.sessions.buildFreshTransportSession(stableTransportSession),
@@ -260,7 +265,7 @@ export async function handleSessionNew(
       }
 
       await context.sessions.attachSession(
-        internalAlias,
+        finalInternalAlias,
         agent,
         workspace,
         session.transportSession,
@@ -269,16 +274,24 @@ export async function handleSessionNew(
         session.agentArgv,
       );
       if (normalizedModel) {
-        await context.sessions.setSessionModel(internalAlias, normalizedModel);
+        await context.sessions.setSessionModel(finalInternalAlias, normalizedModel);
       }
-      await context.sessions.useSession(chatKey, internalAlias);
-      await refreshSessionTransportAgentCommandBestEffort(context, internalAlias, "session.agent_command_refresh_failed");
+      await context.sessions.useSession(chatKey, finalInternalAlias);
+      await refreshSessionTransportAgentCommandBestEffort(context, finalInternalAlias, "session.agent_command_refresh_failed");
       await context.logger.info("session.created", "created and selected logical session", {
-        alias: internalAlias,
+        alias: finalInternalAlias,
         agent,
         workspace,
       });
-      return { text: t().session.sessionCreated(alias) };
+      if (aliasWasAdjusted) {
+        return {
+          text: [
+            t().session.sessionAliasCollided(alias, finalDisplayAlias),
+            t().session.sessionCreated(finalDisplayAlias),
+          ].join("\n"),
+        };
+      }
+      return { text: t().session.sessionCreated(finalDisplayAlias) };
     } finally {
       await releaseTransportReservation();
     }

--- a/src/commands/handlers/session-shortcut-handler.ts
+++ b/src/commands/handlers/session-shortcut-handler.ts
@@ -45,34 +45,41 @@ export async function handleSessionShortcutCommand(
   const baseAlias = `${workspace.name}:${agent}`;
   const channelId = getChannelIdFromChatKey(chatKey);
   const scopedBase = scopeDisplayAliasToInternal(channelId, baseAlias);
-  const alias = createNew ? await allocateUniqueSessionAlias(context, scopedBase, chatKey) : scopedBase;
-  const display = toDisplaySessionAlias(alias);
+  // `allocateUniqueSessionAlias` used to do suffix derivation before alias reservation
+  // landed. Now `tryReserveFreeSessionAlias` (below) is the single source of truth for
+  // unique suffix derivation — it sees every alias including archived ones and has
+  // atomic reservation. Skip the pre-derivation on the create-new path to avoid the
+  // redundant (and in edge cases compounding) double suffix.
+  const desiredAlias = scopedBase;
+  const desiredDisplay = toDisplaySessionAlias(desiredAlias);
 
-  if (!createNew && (await hasLogicalSession(context, alias, chatKey))) {
-    await context.sessions.useSession(chatKey, alias);
+  if (!createNew && (await hasLogicalSession(context, desiredAlias, chatKey))) {
+    await context.sessions.useSession(chatKey, desiredAlias);
     await context.logger.info("session.shortcut.reused", "reused existing logical session", {
-      alias,
+      alias: desiredAlias,
       workspace: workspace.name,
       agent,
     });
     return {
       text: [
-        t().shortcut.reuseHeader(display),
+        t().shortcut.reuseHeader(desiredDisplay),
         t().shortcut.reuseWorkspace(workspace.name),
-        t().shortcut.reuseSession(display),
+        t().shortcut.reuseSession(desiredDisplay),
       ].join("\n"),
     };
   }
 
-  const releaseAliasReservation = context.sessions.tryReserveNewSessionAlias(alias);
-  if (!releaseAliasReservation) {
-    return renderShortcutSessionCreationError(workspace, display);
+  const reserved = context.sessions.tryReserveFreeSessionAlias(desiredAlias);
+  if (!reserved) {
+    return renderShortcutSessionCreationError(workspace, desiredDisplay);
   }
+  const { alias: finalAlias, release: releaseAliasReservation } = reserved;
+  const finalDisplay = toDisplaySessionAlias(finalAlias);
 
   try {
-    const stableTransportSession = channelId === "weixin" ? alias : context.sessions.buildDefaultTransportSessionForChat(chatKey, display);
+    const stableTransportSession = channelId === "weixin" ? finalAlias : context.sessions.buildDefaultTransportSessionForChat(chatKey, finalDisplay);
     const session = ops.resolveSession(
-      alias,
+      finalAlias,
       agent,
       workspace.name,
       context.sessions.buildFreshTransportSession(stableTransportSession),
@@ -83,15 +90,15 @@ export async function handleSessionShortcutCommand(
         await ops.ensureTransportSession(session);
         const exists = await ops.checkTransportSession(session);
         if (!exists) {
-          return renderShortcutSessionCreationError(workspace, display);
+          return renderShortcutSessionCreationError(workspace, finalDisplay);
         }
       } catch (err) {
         if (err instanceof AutoInstallFailedError) throw err;
-        return renderShortcutSessionCreationError(workspace, display);
+        return renderShortcutSessionCreationError(workspace, finalDisplay);
       }
 
       await context.sessions.attachSession(
-        alias,
+        finalAlias,
         agent,
         workspace.name,
         session.transportSession,
@@ -99,17 +106,17 @@ export async function handleSessionShortcutCommand(
         session.acpxAgent,
         session.agentArgv,
       );
-      await context.sessions.useSession(chatKey, alias);
+      await context.sessions.useSession(chatKey, finalAlias);
       try {
-        await ops.refreshSessionTransportAgentCommand(alias);
+        await ops.refreshSessionTransportAgentCommand(finalAlias);
       } catch (error) {
         await context.logger.error("session.shortcut.agent_command_refresh_failed", "failed to refresh session agent command", {
-          alias,
+          alias: finalAlias,
           error: error instanceof Error ? error.message : String(error),
         });
       }
       await context.logger.info("session.shortcut.created", "created new logical session from shortcut", {
-        alias,
+        alias: finalAlias,
         workspace: workspace.name,
         agent,
         workspaceReused: workspace.reused,
@@ -117,11 +124,11 @@ export async function handleSessionShortcutCommand(
 
       return {
         text: [
-          t().shortcut.createdHeader(display),
+          t().shortcut.createdHeader(finalDisplay),
           workspace.reused
             ? t().shortcut.createdReusedWorkspace(workspace.name)
             : t().shortcut.createdNewWorkspace(workspace.name, workspace.cwd),
-          t().shortcut.createdNewSession(display),
+          t().shortcut.createdNewSession(finalDisplay),
         ].join("\n"),
       };
     } finally {

--- a/src/commands/handlers/session-shortcut-handler.ts
+++ b/src/commands/handlers/session-shortcut-handler.ts
@@ -191,23 +191,6 @@ async function resolveShortcutWorkspace(
   };
 }
 
-async function allocateUniqueSessionAlias(
-  context: CommandRouterContext,
-  baseAlias: string,
-  chatKey: string,
-): Promise<string> {
-  if (!(await hasLogicalSession(context, baseAlias, chatKey))) {
-    return baseAlias;
-  }
-
-  let suffix = 2;
-  while (await hasLogicalSession(context, `${baseAlias}-${suffix}`, chatKey)) {
-    suffix += 1;
-  }
-
-  return `${baseAlias}-${suffix}`;
-}
-
 async function hasLogicalSession(context: CommandRouterContext, alias: string, chatKey: string): Promise<boolean> {
   const sessions = await context.sessions.listSessions(chatKey);
   return sessions.some((session) => session.internalAlias === alias);

--- a/src/commands/session-control-service.ts
+++ b/src/commands/session-control-service.ts
@@ -44,7 +44,10 @@ export class SessionControlService {
    * ensure acpx named session → verify → bind logical session → refresh agent
    * command), with no chat reply/progress. Used by the relay control surface so a
    * dashboard-created session is immediately promptable, exactly like `/ss new`.
-   * `internalAlias` must already be channel-scoped (e.g. "relay:demo").
+   * `internalAlias` must already be channel-scoped (e.g. "relay:demo"). When the
+   * desired alias is already taken (by an active OR archived session), a numeric
+   * suffix (`-2`, `-3`, …) is automatically appended; the caller can inspect the
+   * returned session's `alias` field to find the final choice.
    */
   async createSessionWithTransport(
     internalAlias: string,
@@ -52,18 +55,16 @@ export class SessionControlService {
     workspace: string,
     model?: string,
   ): Promise<ResolvedSession> {
-    // Refuse to overwrite an existing alias: silently re-pointing it would either
-    // reuse the old transport session (stale history) or orphan it, and a native
-    // session's agent_session_id would be silently dropped. Mirrors handleSessionNew.
-    const releaseAliasReservation = this.sessions.tryReserveNewSessionAlias(internalAlias);
-    if (!releaseAliasReservation) {
-      throw new Error(`session "${internalAlias}" already exists`);
+    const reserved = this.sessions.tryReserveFreeSessionAlias(internalAlias);
+    if (!reserved) {
+      throw new Error(`session "${internalAlias}" already exists and could not derive a free alias`);
     }
+    const { alias: finalInternalAlias, release: releaseAliasReservation } = reserved;
 
     try {
-      const stableTransportSession = `${workspace}:${internalAlias}`;
+      const stableTransportSession = `${workspace}:${finalInternalAlias}`;
       const session = this.sessions.resolveSession(
-        internalAlias,
+        finalInternalAlias,
         agent,
         workspace,
         this.sessions.buildFreshTransportSession(stableTransportSession),
@@ -86,7 +87,7 @@ export class SessionControlService {
           throw new Error(`transport session "${session.transportSession}" could not be verified`);
         }
         await this.sessions.attachSession(
-          internalAlias,
+          finalInternalAlias,
           agent,
           workspace,
           session.transportSession,
@@ -95,16 +96,16 @@ export class SessionControlService {
           session.agentArgv,
         );
         if (normalizedModel) {
-          await this.sessions.setSessionModel(internalAlias, normalizedModel);
+          await this.sessions.setSessionModel(finalInternalAlias, normalizedModel);
         }
         // Best-effort: a transient refresh failure must not fail a create that has
         // already succeeded, bound, and verified. Mirrors the chat paths' use of
         // refreshSessionTransportAgentCommandBestEffort.
         try {
-          await this.invoker.refreshSessionTransportAgentCommand(internalAlias);
+          await this.invoker.refreshSessionTransportAgentCommand(finalInternalAlias);
         } catch (error) {
           await this.logger.error("session.agent_command_refresh_failed", "failed to refresh session agent command", {
-            alias: internalAlias,
+            alias: finalInternalAlias,
             error: error instanceof Error ? error.message : String(error),
           });
         }
@@ -279,6 +280,9 @@ export class SessionControlService {
    * web counterpart of `/ssn` → select. Mirrors createSessionWithTransport but resumes
    * the given agentSessionId and records the binding as a native ("agent-side")
    * attachment. `internalAlias` must already be channel-scoped (e.g. "relay:demo").
+   * When the desired alias is already taken (by an active OR archived session), a
+   * numeric suffix is automatically appended; inspect the returned session's `alias`
+   * to see the final name.
    */
   async attachNativeSessionWithTransport(
     internalAlias: string,
@@ -290,16 +294,17 @@ export class SessionControlService {
     if (!this.transport.resumeAgentSession) {
       throw new Error("the active transport does not support native sessions");
     }
-    const releaseAliasReservation = this.sessions.tryReserveNewSessionAlias(internalAlias);
-    if (!releaseAliasReservation) {
-      throw new Error(`session "${internalAlias}" already exists`);
+    const reserved = this.sessions.tryReserveFreeSessionAlias(internalAlias);
+    if (!reserved) {
+      throw new Error(`session "${internalAlias}" already exists and could not derive a free alias`);
     }
+    const { alias: finalInternalAlias, release: releaseAliasReservation } = reserved;
     try {
       const session = this.sessions.resolveSession(
-        internalAlias,
+        finalInternalAlias,
         agent,
         workspace,
-        `${workspace}:${internalAlias}`,
+        `${workspace}:${finalInternalAlias}`,
       );
       const release = await this.reserveLogicalTransportSession(session.transportSession);
       try {
@@ -309,7 +314,7 @@ export class SessionControlService {
           throw new Error(`transport session "${session.transportSession}" could not be verified`);
         }
         await this.sessions.attachNativeSession({
-          alias: internalAlias,
+          alias: finalInternalAlias,
           agent,
           workspace,
           transportSession: session.transportSession,
@@ -323,10 +328,10 @@ export class SessionControlService {
         // Best-effort: a transient refresh failure must not fail an attach that already
         // succeeded, resumed, and verified. Mirrors createSessionWithTransport.
         try {
-          await this.invoker.refreshSessionTransportAgentCommand(internalAlias);
+          await this.invoker.refreshSessionTransportAgentCommand(finalInternalAlias);
         } catch (error) {
           await this.logger.error("session.native.agent_command_refresh_failed", "failed to refresh native session agent command", {
-            alias: internalAlias,
+            alias: finalInternalAlias,
             error: error instanceof Error ? error.message : String(error),
           });
         }

--- a/src/commands/session-control-service.ts
+++ b/src/commands/session-control-service.ts
@@ -294,6 +294,12 @@ export class SessionControlService {
     if (!this.transport.resumeAgentSession) {
       throw new Error("the active transport does not support native sessions");
     }
+    // Deliberately skip the transport-uniqueness derivation that the chat-side
+    // /ssn handler performs before atomic reservation: the transport uniqueness
+    // constraint is advisory for native attach and never a correctness barrier.
+    // Using tryReserveFreeSessionAlias directly keeps this path deterministic
+    // and lets us surface the same "suffix auto-derived" semantics as chat-side
+    // creation when the logical alias collides with an archived session.
     const reserved = this.sessions.tryReserveFreeSessionAlias(internalAlias);
     if (!reserved) {
       throw new Error(`session "${internalAlias}" already exists and could not derive a free alias`);

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -677,7 +677,12 @@ export class ControlService {
       : await this.deps.createSessionWithTransport(internalAlias, agent, workspace, model);
     this.deps.events.emit({ type: "sessions-changed" });
     if (nativeHistory.length > 0) {
-      this.deps.events.emit({ type: "session-history", chatKey, sessionAlias: alias, messages: nativeHistory });
+      // The emitted alias must match the ACTUALLY-created session (which may have
+      // a `-2`/`-3` suffix derived from the original request when the desired alias
+      // collided with an archived session). Using the user-supplied `alias` here
+      // would drop the native history seed on a session that was never created.
+      const historyAlias = toDisplaySessionAlias(session.alias);
+      this.deps.events.emit({ type: "session-history", chatKey, sessionAlias: historyAlias, messages: nativeHistory });
     }
     return {
       alias: toDisplaySessionAlias(session.alias),

--- a/src/i18n/messages/en/session.ts
+++ b/src/i18n/messages/en/session.ts
@@ -22,6 +22,8 @@ export const session: SessionMessages = {
       `Session "${alias}" already exists (${agent} @ ${workspace}).`,
       `Switch to it with /use ${alias}, or remove it first with /session rm ${alias}.`,
     ].join("\n"),
+  sessionAliasCollided: (desiredAlias, finalAlias) =>
+    `The requested name "${desiredAlias}" is already in use (by an archived session). Creating the new session as "${finalAlias}" instead.`,
   sessionAttachNotFound: (alias, agent, workspace) =>
     [
       "No existing session found to attach.",

--- a/src/i18n/messages/zh/session.ts
+++ b/src/i18n/messages/zh/session.ts
@@ -21,6 +21,8 @@ export const session: SessionMessages = {
       `会话「${alias}」已存在（${agent} @ ${workspace}）。`,
       `发送 /use ${alias} 切换到它，或先执行 /session rm ${alias} 删除后再创建。`,
     ].join("\n"),
+  sessionAliasCollided: (desiredAlias, finalAlias) =>
+    `你指定的会话名「${desiredAlias}」已被其他会话（含已睡眠/归档）占用，已自动改为「${finalAlias}」创建。`,
   sessionAttachNotFound: (alias, agent, workspace) =>
     [
       "没有找到可绑定的已有会话。",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -18,6 +18,7 @@ export interface SessionMessages {
   // handleSessionNew / handleSessionAttach
   sessionCreated: (alias: string) => string;
   sessionAlreadyExists: (alias: string, agent: string, workspace: string) => string;
+  sessionAliasCollided: (desiredAlias: string, finalAlias: string) => string;
   sessionAttachNotFound: (alias: string, agent: string, workspace: string) => string;
   sessionAttached: (alias: string) => string;
   sessionLifecycleBusy: (alias: string) => string;

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -492,8 +492,17 @@ export class SessionService {
     const sep = desiredAlias.lastIndexOf(":");
     const prefix = sep >= 0 ? desiredAlias.slice(0, sep + 1) : "";
     const base = sep >= 0 ? desiredAlias.slice(sep + 1) : desiredAlias;
-    for (let n = 2; n <= 9999; n += 1) {
-      const candidate = `${prefix}${base}-${n}`;
+    // If the base already carries a numeric suffix (e.g. "demo-2"), start
+    // incrementing from that suffix instead of stacking a new one ("demo-2-2").
+    const suffixMatch = /-(\d+)$/.exec(base);
+    let startN = 2;
+    let stem = base;
+    if (suffixMatch) {
+      startN = Number(suffixMatch[1]) + 1;
+      stem = base.slice(0, -suffixMatch[0].length);
+    }
+    for (let n = startN; n <= 9999; n += 1) {
+      const candidate = `${prefix}${stem}-${n}`;
       if (!takenSet.has(candidate)) return candidate;
     }
     // Extremely defensive fallback — 9999 collisions would require an absurd number

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -477,6 +477,50 @@ export class SessionService {
   }
 
   /**
+   * Derive a free internal alias for a new session. When `desiredAlias` is already
+   * taken (by an active OR archived session), append `-2`, `-3`, … until a free
+   * slot is found.
+   *
+   * The alias may carry a channel prefix (`relay:demo`, `weixin:chat123/demo`); the
+   * numeric suffix is always appended to the last path segment after the rightmost
+   * `:` so prefix semantics are preserved (e.g. `relay:demo-2`, never `relay-2:demo`).
+   */
+  deriveFreeAlias(desiredAlias: string): string {
+    const taken = Object.keys(this.state.sessions);
+    const takenSet = new Set(taken);
+    if (!takenSet.has(desiredAlias)) return desiredAlias;
+    const sep = desiredAlias.lastIndexOf(":");
+    const prefix = sep >= 0 ? desiredAlias.slice(0, sep + 1) : "";
+    const base = sep >= 0 ? desiredAlias.slice(sep + 1) : desiredAlias;
+    for (let n = 2; n <= 9999; n += 1) {
+      const candidate = `${prefix}${base}-${n}`;
+      if (!takenSet.has(candidate)) return candidate;
+    }
+    // Extremely defensive fallback — 9999 collisions would require an absurd number
+    // of sessions sharing the same base alias.
+    throw new Error(`could not derive a free alias for "${desiredAlias}" after 9999 attempts`);
+  }
+
+  /**
+   * Convenience: atomically derive a free alias (see `deriveFreeAlias`) AND
+   * reserve it via `tryReserveNewSessionAlias`. If the derived alias loses the
+   * race between the derive step and the reserve step (extremely rare because
+   * callers typically run this while holding the state mutex), retry up to a
+   * small, bounded number of times.
+   *
+   * Returns the chosen alias together with the reservation release callback, or
+   * `null` if no reservation could be obtained.
+   */
+  tryReserveFreeSessionAlias(desiredAlias: string): { alias: string; release: () => void } | null {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const alias = this.deriveFreeAlias(desiredAlias);
+      const release = this.tryReserveNewSessionAlias(alias);
+      if (release) return { alias, release };
+    }
+    return null;
+  }
+
+  /**
    * Allocate a fresh acpx transport incarnation while preserving a stable logical
    * coordinator identity. Explicit "new session" paths use this; archive/restore
    * deliberately keep the transport already stored on the logical session.

--- a/tests/unit/commands/command-router-session.test.ts
+++ b/tests/unit/commands/command-router-session.test.ts
@@ -211,17 +211,18 @@ test("createSessionWithTransport applies a model override to the session and per
   expect(persisted?.model).toBe("gpt-5.2[high]");
 });
 
-test("createSessionWithTransport refuses to overwrite an existing logical alias", async () => {
+test("createSessionWithTransport auto-derives a free alias when the desired alias collides", async () => {
   const { router, transport, sessions, config } = buildRouter();
   config.workspaces.home = { cwd: "/tmp/home" };
   await sessions.attachSession("relay:demo", "codex", "home", "home:relay:demo");
-  const ensureCalls = (transport.ensureSession as ReturnType<typeof mock>).mock.calls.length;
 
-  await expect(router.createSessionWithTransport("relay:demo", "codex", "home")).rejects.toThrow(
-    /already exists/,
-  );
-  // The refused create must not touch the transport.
-  expect((transport.ensureSession as ReturnType<typeof mock>).mock.calls.length).toBe(ensureCalls);
+  // A colliding alias should NOT fail — the backend derives `relay:demo-2`.
+  const result = await router.createSessionWithTransport("relay:demo", "codex", "home");
+  expect(result.alias).toBe("relay:demo-2");
+  // The new session must be distinct from the original.
+  expect(await sessions.getSession("relay:demo-2")).toBeDefined();
+  // The original session must be untouched.
+  expect(await sessions.getSession("relay:demo")).toMatchObject({ agent: "codex", workspace: "home" });
 });
 
 test("concurrent same-alias creates claim the logical alias before transport side effects", async () => {
@@ -364,7 +365,7 @@ test("a remove cannot delete an alias while reset is replacing its transport", a
   expect(await sessions.getSession("main")).not.toBeNull();
 });
 
-test("/session new refuses an alias that already exists", async () => {
+test("/session new auto-derives a free alias when the desired alias already exists", async () => {
   const config = createConfig();
   config.agents.opencode = { driver: "opencode" };
   config.workspaces.frontend = { cwd: "/tmp/frontend" };
@@ -373,18 +374,21 @@ test("/session new refuses an alias that already exists", async () => {
   const router = new CommandRouter(sessions, transport, config);
 
   await router.handle("wx:user", "/session new api-fix --agent codex --ws backend");
-  const ensureCalls = (transport.ensureSession as ReturnType<typeof mock>).mock.calls.length;
 
+  // A colliding alias should auto-derive `api-fix-2` and succeed.
   const reply = await router.handle("wx:user", "/session new api-fix --agent opencode --ws frontend");
 
-  expect(reply.text).toBe(t().session.sessionAlreadyExists("api-fix", "codex", "backend"));
-  // The refused command must not touch the transport or the stored session.
-  expect((transport.ensureSession as ReturnType<typeof mock>).mock.calls.length).toBe(ensureCalls);
+  expect(reply.text).toBe(
+    [t().session.sessionAliasCollided("api-fix", "api-fix-2"), t().session.sessionCreated("api-fix-2")].join("\n"),
+  );
+  // The new session is switched to.
   await expect(sessions.getCurrentSession("wx:user")).resolves.toMatchObject({
-    alias: "api-fix",
-    agent: "codex",
-    workspace: "backend",
+    alias: "api-fix-2",
+    agent: "opencode",
+    workspace: "frontend",
   });
+  // The original session is untouched.
+  expect(await sessions.getSession("api-fix")).toMatchObject({ agent: "codex", workspace: "backend" });
 });
 
 test("/session attach still rebinds an existing alias", async () => {
@@ -1801,10 +1805,10 @@ test("attachNativeSessionWithTransport resumes the agent session and records a n
   expect(stored?.agentSessionId).toBe("ses_42");
 });
 
-test("attachNativeSessionWithTransport refuses to overwrite an existing alias", async () => {
+test("attachNativeSessionWithTransport auto-derives a free alias when the desired alias collides", async () => {
   const { router } = buildRouter();
   await router.attachNativeSessionWithTransport("relay:dup", "codex", "backend", "ses_1");
-  await expect(
-    router.attachNativeSessionWithTransport("relay:dup", "codex", "backend", "ses_2"),
-  ).rejects.toThrow(/already exists/);
+  // A colliding alias should NOT fail — the backend derives `relay:dup-2`.
+  const result = await router.attachNativeSessionWithTransport("relay:dup", "codex", "backend", "ses_2");
+  expect(result.alias).toBe("relay:dup-2");
 });

--- a/tests/unit/commands/golden/fixtures/attach-native-normal.json
+++ b/tests/unit/commands/golden/fixtures/attach-native-normal.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "sessions.tryReserveNewSessionAlias(\"relay:demo\")",
+    "sessions.tryReserveFreeSessionAlias(\"relay:demo\")",
     "sessions.resolveSession(\"relay:demo\", \"codex\", \"backend\", \"backend:relay:demo\")",
     "orchestration.reserveLogicalTransportSession(\"backend:relay:demo\")",
     "transport.resumeAgentSession(session(relay:demo/backend:relay:demo), \"sess-1\")",

--- a/tests/unit/commands/golden/fixtures/create-alias-exists.json
+++ b/tests/unit/commands/golden/fixtures/create-alias-exists.json
@@ -1,8 +1,34 @@
 {
   "record": [
-    "sessions.tryReserveNewSessionAlias(\"relay:demo\")"
+    "sessions.tryReserveFreeSessionAlias(\"relay:demo\")",
+    "sessions.buildFreshTransportSession(\"backend:relay:demo-2\")",
+    "sessions.resolveSession(\"relay:demo-2\", \"codex\", \"backend\", \"backend:relay:demo-2:reset-<n>\")",
+    "orchestration.reserveLogicalTransportSession(\"backend:relay:demo-2\")",
+    "transport.ensureSession(session(relay:demo-2/backend:relay:demo-2:reset-<n>), fn)",
+    "logger.info(transport.ensure_session)",
+    "transport.hasSession(session(relay:demo-2/backend:relay:demo-2:reset-<n>))",
+    "logger.info(transport.has_session)",
+    "sessions.attachSession(\"relay:demo-2\", \"codex\", \"backend\", \"backend:relay:demo-2:reset-<n>\", \"npx -y --registry=https://registry.npmjs…\", \"xacpx-managed-codex-f4349e35c3c8\", {…})",
+    "sessions.getSession(\"relay:demo-2\")"
   ],
   "outcome": {
-    "threw": "session \"relay:demo\" already exists"
+    "ok": {
+      "alias": "relay:demo-2",
+      "agent": "codex",
+      "driver": "codex",
+      "agentCommand": "npx -y --registry=https://registry.npmjs.org --@agentclientprotocol:registry=https://registry.npmjs.org @agentclientprotocol/codex-acp@1.1.9",
+      "acpxAgent": "xacpx-managed-codex-f4349e35c3c8",
+      "agentArgv": [
+        "npx",
+        "-y",
+        "--registry=https://registry.npmjs.org",
+        "--@agentclientprotocol:registry=https://registry.npmjs.org",
+        "@agentclientprotocol/codex-acp@1.1.9"
+      ],
+      "workspace": "backend",
+      "transportSession": "backend:relay:demo-2:reset-<n>",
+      "cwd": "/tmp/backend",
+      "archived": false
+    }
   }
 }

--- a/tests/unit/commands/golden/fixtures/create-normal.json
+++ b/tests/unit/commands/golden/fixtures/create-normal.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "sessions.tryReserveNewSessionAlias(\"relay:demo\")",
+    "sessions.tryReserveFreeSessionAlias(\"relay:demo\")",
     "sessions.buildFreshTransportSession(\"backend:relay:demo\")",
     "sessions.resolveSession(\"relay:demo\", \"codex\", \"backend\", \"backend:relay:demo:reset-<n>\")",
     "orchestration.reserveLogicalTransportSession(\"backend:relay:demo\")",

--- a/tests/unit/commands/golden/fixtures/create-refresh-fails.json
+++ b/tests/unit/commands/golden/fixtures/create-refresh-fails.json
@@ -1,6 +1,6 @@
 {
   "record": [
-    "sessions.tryReserveNewSessionAlias(\"relay:demo\")",
+    "sessions.tryReserveFreeSessionAlias(\"relay:demo\")",
     "sessions.buildFreshTransportSession(\"backend:relay:demo\")",
     "sessions.resolveSession(\"relay:demo\", \"codex\", \"backend\", \"backend:relay:demo:reset-<n>\")",
     "orchestration.reserveLogicalTransportSession(\"backend:relay:demo\")",

--- a/tests/unit/commands/golden/fixtures/handle-ensure-autoinstall.json
+++ b/tests/unit/commands/golden/fixtures/handle-ensure-autoinstall.json
@@ -1,8 +1,7 @@
 {
   "record": [
     "logger.debug(command.parsed)",
-    "sessions.getResolvedSessionByInternalAlias(\"demo\")",
-    "sessions.tryReserveNewSessionAlias(\"demo\")",
+    "sessions.tryReserveFreeSessionAlias(\"demo\")",
     "sessions.buildFreshTransportSession(\"backend:demo\")",
     "sessions.resolveSession(\"demo\", \"codex\", \"backend\", \"backend:demo:reset-<n>\")",
     "orchestration.reserveLogicalTransportSession(\"backend:demo\")",

--- a/tests/unit/commands/golden/fixtures/handle-session-new.json
+++ b/tests/unit/commands/golden/fixtures/handle-session-new.json
@@ -1,26 +1,16 @@
 {
   "record": [
     "logger.debug(command.parsed)",
-    "sessions.getResolvedSessionByInternalAlias(\"demo\")",
-    "sessions.tryReserveNewSessionAlias(\"demo\")",
+    "sessions.tryReserveFreeSessionAlias(\"demo\")",
     "sessions.buildFreshTransportSession(\"backend:demo\")",
     "sessions.resolveSession(\"demo\", \"codex\", \"backend\", \"backend:demo:reset-<n>\")",
     "orchestration.reserveLogicalTransportSession(\"backend:demo\")",
     "transport.ensureSession(session(demo/backend:demo:reset-<n>), fn)",
     "reply(\"🚀 Starting `codex`…\")",
-    "reply(\"⏳ `codex` is still starting up… (waited …\")",
-    "logger.info(transport.ensure_session)",
-    "transport.hasSession(session(demo/backend:demo:reset-<n>))",
-    "logger.info(transport.has_session)",
-    "sessions.attachSession(\"demo\", \"codex\", \"backend\", \"backend:demo:reset-<n>\", \"npx -y --registry=https://registry.npmjs…\", \"xacpx-managed-codex-f4349e35c3c8\", {…})",
-    "sessions.useSession(\"wx:user\", \"demo\")",
-    "sessions.getSession(\"demo\")",
-    "logger.info(session.created)",
-    "logger.info(command.completed)"
+    "logger.error(transport.ensure_session.failed)",
+    "logger.error(command.failed)"
   ],
   "outcome": {
-    "ok": {
-      "text": "Session \"demo\" created and switched."
-    }
+    "threw": "jest.advanceTimersByTime is not a function. (In 'jest.advanceTimersByTime(30000)', 'jest.advanceTimersByTime' is undefined)"
   }
 }

--- a/tests/unit/commands/golden/fixtures/handle-session-new.json
+++ b/tests/unit/commands/golden/fixtures/handle-session-new.json
@@ -7,10 +7,19 @@
     "orchestration.reserveLogicalTransportSession(\"backend:demo\")",
     "transport.ensureSession(session(demo/backend:demo:reset-<n>), fn)",
     "reply(\"🚀 Starting `codex`…\")",
-    "logger.error(transport.ensure_session.failed)",
-    "logger.error(command.failed)"
+    "reply(\"⏳ `codex` is still starting up… (waited …\")",
+    "logger.info(transport.ensure_session)",
+    "transport.hasSession(session(demo/backend:demo:reset-<n>))",
+    "logger.info(transport.has_session)",
+    "sessions.attachSession(\"demo\", \"codex\", \"backend\", \"backend:demo:reset-<n>\", \"npx -y --registry=https://registry.npmjs…\", \"xacpx-managed-codex-f4349e35c3c8\", {…})",
+    "sessions.useSession(\"wx:user\", \"demo\")",
+    "sessions.getSession(\"demo\")",
+    "logger.info(session.created)",
+    "logger.info(command.completed)"
   ],
   "outcome": {
-    "threw": "jest.advanceTimersByTime is not a function. (In 'jest.advanceTimersByTime(30000)', 'jest.advanceTimersByTime' is undefined)"
+    "ok": {
+      "text": "Session \"demo\" created and switched."
+    }
   }
 }

--- a/tests/unit/sessions/session-service.test.ts
+++ b/tests/unit/sessions/session-service.test.ts
@@ -1314,3 +1314,65 @@ test("command refresh preserves recorded structured launch fields", async () => 
   expect(after?.acpxAgent).toBe("xacpx-managed-custom-aaaabbbbcccc");
   expect(after?.agentArgv).toEqual(["C:\\Program Files\\agent-a.exe", "--acp"]);
 });
+
+test("deriveFreeAlias returns the desired alias when it is free", () => {
+  const service = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  expect(service.deriveFreeAlias("new-session")).toBe("new-session");
+  expect(service.deriveFreeAlias("relay:new-session")).toBe("relay:new-session");
+});
+
+test("deriveFreeAlias appends -2 when the desired alias already exists", async () => {
+  const service = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  await service.attachNativeSession({
+    alias: "demo", agent: "codex", workspace: "backend", transportSession: "backend:demo", agentSessionId: "a",
+  });
+  expect(service.deriveFreeAlias("demo")).toBe("demo-2");
+});
+
+test("deriveFreeAlias keeps appending suffixes until a free slot is found", async () => {
+  const service = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  await service.attachNativeSession({
+    alias: "demo", agent: "codex", workspace: "backend", transportSession: "backend:demo", agentSessionId: "a1",
+  });
+  await service.attachNativeSession({
+    alias: "demo-2", agent: "codex", workspace: "backend", transportSession: "backend:demo-2", agentSessionId: "a2",
+  });
+  await service.attachNativeSession({
+    alias: "demo-3", agent: "codex", workspace: "backend", transportSession: "backend:demo-3", agentSessionId: "a3",
+  });
+  expect(service.deriveFreeAlias("demo")).toBe("demo-4");
+});
+
+test("deriveFreeAlias preserves a channel prefix when appending the suffix", async () => {
+  const service = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  await service.attachNativeSession({
+    alias: "relay:demo", agent: "codex", workspace: "backend", transportSession: "backend:relay-demo", agentSessionId: "a",
+  });
+  expect(service.deriveFreeAlias("relay:demo")).toBe("relay:demo-2");
+});
+
+test("deriveFreeAlias increments an existing numeric suffix instead of stacking a new one", async () => {
+  const service = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  await service.attachNativeSession({
+    alias: "demo-2", agent: "codex", workspace: "backend", transportSession: "backend:demo-2", agentSessionId: "a",
+  });
+  expect(service.deriveFreeAlias("demo-2")).toBe("demo-3");
+});
+
+test("deriveFreeAlias increments an existing numeric suffix when a channel prefix is present", async () => {
+  const service = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  await service.attachNativeSession({
+    alias: "relay:demo-5", agent: "codex", workspace: "backend", transportSession: "backend:relay-demo-5", agentSessionId: "a",
+  });
+  expect(service.deriveFreeAlias("relay:demo-5")).toBe("relay:demo-6");
+});
+
+test("deriveFreeAlias treats archived sessions as taken (collisions still suffix)", async () => {
+  const service = new SessionService(createConfig(), new MemoryStateStore(), createEmptyState());
+  await service.attachNativeSession({
+    alias: "demo", agent: "codex", workspace: "backend", transportSession: "backend:demo", agentSessionId: "a",
+  });
+  await service.setArchived("demo", true);
+  expect(service.deriveFreeAlias("demo")).toBe("demo-2");
+});
+


### PR DESCRIPTION
## Summary

When a user creates a new session with an alias that already exists (including archived/sleeping sessions), the system previously failed outright with a "session already exists" error. This PR changes that behavior to automatically derive a free alias by appending a numeric suffix (`-2`, `-3`, …) and transparently proceed with session creation.

## Root Cause

Session alias allocation only checked active sessions via `tryReserveNewSessionAlias`. Archived sessions were not considered during uniqueness checks, causing collisions when a user tried to reuse a name that belonged to an archived session. The hard-fail behavior blocked legitimate session creation in the common case of auto-generated/default aliases.

## Changes

- **`SessionService`**: Added `deriveFreeAlias()` and `tryReserveFreeSessionAlias()` — a centralized mechanism that considers ALL sessions (active + archived) when deriving a unique alias, with atomic reservation and bounded retry for race safety.
- **`session-handler.ts`** (`/ss new`): Replaced hard-fail reservation with auto-derive; notifies the user when the alias was adjusted.
- **`session-shortcut-handler.ts`**: Removed redundant pre-derivation, relying on `tryReserveFreeSessionAlias` as the single source of suffix derivation.
- **`native-session-handler.ts`** (`/ssn` attach): Added bounded retry loop with TOCTOU-safe atomic reservation and logical-only fallback.
- **`session-control-service.ts`** (relay control): Updated `createSessionWithTransport` and `attachNativeSessionWithTransport` to auto-derive free aliases.
- **`control-service.ts`**: Fixed `session-history` event to emit the actually-created session's alias instead of the user-supplied alias.
- **`relay-web/instances.ts`**: Patched optimistic session row to the backend-chosen alias before reloading to prevent stale "name not found" errors.
- **i18n**: Added `sessionAliasCollided` message in EN and ZH.

## Impact

Users can now create sessions with aliases that collide with archived sessions without manual intervention. The system transparently picks a free name and informs the user of the adjustment.