### PR TITLE
fix(transport): skip effort reapply on a warm queue owner

### DIFF
--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -18,7 +18,7 @@ import { createStreamingPromptState, parseStreamingDataChunk } from "../transpor
 import { parseMissingOptionalDep } from "./parse-missing-optional-dep";
 import { isModelNotAdvertisedError } from "../transport/model-not-advertised";
 import { deriveParentPackageName } from "../recovery/discover-parent-package-paths";
-import { AcpxQueueOwnerLauncher, readQueueOwnerPid, terminateAcpxQueueOwner, terminateAcpxQueueOwnerVerified, type QueueOwnerAdapterContext } from "../transport/acpx-queue-owner-launcher";
+import { AcpxQueueOwnerLauncher, readQueueOwnerPid, terminateAcpxQueueOwner, terminateAcpxQueueOwnerVerified, type LaunchQueueOwnerInput, type QueueOwnerAdapterContext } from "../transport/acpx-queue-owner-launcher";
 import { classifyPreinstalledAdapterCommandShape } from "../adapters/adapter-catalog";
 import { migrateSessionArgvFile } from "../transport/acpx-session-argv-migration";
 import { renderAgentArgvIdentity } from "../config/agent-launch";
@@ -161,12 +161,18 @@ interface BridgeRuntimeOptions {
   now?: () => number;
   /** Test seam for filtered per-agent process environments. */
   resolveSpawnEnvironment?: (input: ClaudeExecutionSettings) => NodeJS.ProcessEnv | undefined;
+  /** Test seam: cool a live queue owner before `acpx set` releases exclusive leases. */
+  terminateQueueOwner?: (acpxRecordId: string) => Promise<void>;
   createAdapterContext?: (input: {
     id: "codex" | "claude";
     sessionKey: string;
     agentCommand: string;
   }) => QueueOwnerAdapterContext;
 }
+
+type QueueOwnerLaunchPort = Pick<AcpxQueueOwnerLauncher, "launch"> & {
+  wouldReuse?(input: LaunchQueueOwnerInput): Promise<boolean>;
+};
 
 export class BridgeRuntime {
   // undefined = not yet probed; true/false = probed result.
@@ -182,7 +188,7 @@ export class BridgeRuntime {
     private readonly options: BridgeRuntimeOptions = {},
     private readonly runPromptCommand: PromptRunner = defaultPromptRunner,
     private readonly repairSessionIndex: RepairSessionIndexFn = tryRepairAcpxSessionIndex,
-    private readonly queueOwnerLauncher: Pick<AcpxQueueOwnerLauncher, "launch"> = new AcpxQueueOwnerLauncher({
+    private readonly queueOwnerLauncher: QueueOwnerLaunchPort = new AcpxQueueOwnerLauncher({
       acpxCommand: command,
       // Coordinator sessions pre-spawn the queue owner here (before `acpx prompt`),
       // so the owner's warm window must be set at launch — the prompt's `--ttl`
@@ -547,13 +553,7 @@ export class BridgeRuntime {
   }
 
   async prompt(input: BridgeSessionInput & { text: string }, onEvent?: (event: BridgePromptStreamEvent) => void): Promise<{ text: string }> {
-    const effort = await sessionEffortToReapply(
-      input.effort,
-      async () => (await this.isSessionWarm(input)).warm,
-    );
-    if (effort) {
-      await this.reapplySessionEffort(input, effort);
-    }
+    await this.syncPersistedSessionEffort(input);
     await this.launchMcpQueueOwnerIfNeeded(input);
     const structuredPrompt = await createStructuredPromptFile(input.text, input.media);
     const spawnSpec = resolveSpawnCommand(this.command, this.buildPromptArgs(input, [
@@ -596,26 +596,7 @@ export class BridgeRuntime {
       return;
     }
     const record = await this.readSessionRecord(input);
-    const env = this.spawnEnvironment(input);
-    const adapterId = classifyPreinstalledAdapterCommandShape(input.agentCommand);
-    const adapterContext = adapterId && input.agentCommand
-      ? this.options.createAdapterContext?.({
-          id: adapterId,
-          sessionKey: input.sessionKey ?? input.name,
-          agentCommand: input.agentCommand,
-        })
-      : undefined;
-    const prepared = await this.queueOwnerLauncher.launch({
-      acpxRecordId: record.acpxRecordId,
-      coordinatorSession: input.mcpCoordinatorSession,
-      ...(input.mcpSourceHandle ? { sourceHandle: input.mcpSourceHandle } : {}),
-      permissionMode: this.options.permissionMode ?? "approve-all",
-      nonInteractivePermissions: this.options.nonInteractivePermissions ?? "deny",
-      ...(input.model?.trim() ? { sessionOptions: { model: input.model.trim() } } : {}),
-      ...(adapterId && input.agentCommand ? { agentCommand: input.agentCommand } : {}),
-      ...(adapterContext ? { adapterContext } : {}),
-      ...(env ? { env } : {}),
-    });
+    const prepared = await this.queueOwnerLauncher.launch(this.queueOwnerLaunchInput(input, record.acpxRecordId));
     if (prepared?.agentCommand) input.agentCommand = prepared.agentCommand;
   }
 
@@ -841,13 +822,58 @@ export class BridgeRuntime {
     return {};
   }
 
-  private async reapplySessionEffort(input: BridgeSessionInput, effort: string): Promise<void> {
+  private async syncPersistedSessionEffort(input: BridgeSessionInput): Promise<void> {
+    const persisted = input.effort?.trim();
+    if (!persisted) return;
     const record = await this.readRawSessionRecord(input, "get-session-effort", "json");
     const observed = parseSessionEffortRecord(record);
-    if (!observed?.available.includes(effort)) {
-      return;
-    }
+    const acpxRecordId = parseAcpxSessionRecordId(record)?.acpxRecordId;
+    const effort = sessionEffortToReapply({
+      persisted,
+      observedCurrent: observed?.current,
+      advertised: observed?.available,
+      ownerWillBeReplaced: await this.queueOwnerWillBeReplaced(input, acpxRecordId),
+    });
+    if (!effort) return;
+    if (acpxRecordId) await this.terminateQueueOwner(acpxRecordId);
     await this.applyAdvertisedSessionEffort(input, effort, record);
+  }
+
+  private async queueOwnerWillBeReplaced(
+    input: BridgeSessionInput,
+    acpxRecordId: string | undefined,
+  ): Promise<boolean> {
+    if (!input.mcpCoordinatorSession || !acpxRecordId) return false;
+    const wouldReuse = this.queueOwnerLauncher.wouldReuse?.bind(this.queueOwnerLauncher);
+    if (!wouldReuse) return true;
+    return !(await wouldReuse(this.queueOwnerLaunchInput(input, acpxRecordId)));
+  }
+
+  private queueOwnerLaunchInput(input: BridgeSessionInput, acpxRecordId: string): LaunchQueueOwnerInput {
+    const env = this.spawnEnvironment(input);
+    const adapterId = classifyPreinstalledAdapterCommandShape(input.agentCommand);
+    const adapterContext = adapterId && input.agentCommand
+      ? this.options.createAdapterContext?.({
+          id: adapterId,
+          sessionKey: input.sessionKey ?? input.name,
+          agentCommand: input.agentCommand,
+        })
+      : undefined;
+    return {
+      acpxRecordId,
+      coordinatorSession: input.mcpCoordinatorSession!,
+      ...(input.mcpSourceHandle ? { sourceHandle: input.mcpSourceHandle } : {}),
+      permissionMode: this.options.permissionMode ?? "approve-all",
+      nonInteractivePermissions: this.options.nonInteractivePermissions ?? "deny",
+      ...(input.model?.trim() ? { sessionOptions: { model: input.model.trim() } } : {}),
+      ...(adapterId && input.agentCommand ? { agentCommand: input.agentCommand } : {}),
+      ...(adapterContext ? { adapterContext } : {}),
+      ...(env ? { env } : {}),
+    };
+  }
+
+  private terminateQueueOwner(acpxRecordId: string): Promise<void> {
+    return (this.options.terminateQueueOwner ?? terminateAcpxQueueOwner)(acpxRecordId);
   }
 
   private async applyAdvertisedSessionEffort(

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -547,7 +547,9 @@ export class BridgeRuntime {
   }
 
   async prompt(input: BridgeSessionInput & { text: string }, onEvent?: (event: BridgePromptStreamEvent) => void): Promise<{ text: string }> {
-    if (input.effort?.trim()) {
+    // Same cold-only rule as AcpxCliTransport.prompt: a live queue owner
+    // already holds the effort, and `acpx set` would race a second ACP process.
+    if (input.effort?.trim() && !(await this.isSessionWarm(input)).warm) {
       await this.reapplySessionEffort(input, input.effort.trim());
     }
     await this.launchMcpQueueOwnerIfNeeded(input);

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -49,7 +49,7 @@ import {
   DEFAULT_PERMISSION_MODE,
   DEFAULT_NON_INTERACTIVE,
 } from "../transport/acpx-command-builder";
-import { parseSessionEffortRecord, requireAdvertisedSessionEffort } from "../transport/session-effort";
+import { parseSessionEffortRecord, requireAdvertisedSessionEffort, sessionEffortToReapply } from "../transport/session-effort";
 
 type BridgePromptStreamEvent =
   | { type: "prompt.segment"; text: string }
@@ -547,10 +547,12 @@ export class BridgeRuntime {
   }
 
   async prompt(input: BridgeSessionInput & { text: string }, onEvent?: (event: BridgePromptStreamEvent) => void): Promise<{ text: string }> {
-    // Same cold-only rule as AcpxCliTransport.prompt: a live queue owner
-    // already holds the effort, and `acpx set` would race a second ACP process.
-    if (input.effort?.trim() && !(await this.isSessionWarm(input)).warm) {
-      await this.reapplySessionEffort(input, input.effort.trim());
+    const effort = await sessionEffortToReapply(
+      input.effort,
+      async () => (await this.isSessionWarm(input)).warm,
+    );
+    if (effort) {
+      await this.reapplySessionEffort(input, effort);
     }
     await this.launchMcpQueueOwnerIfNeeded(input);
     const structuredPrompt = await createStructuredPromptFile(input.text, input.media);

--- a/src/bridge/bridge-runtime.ts
+++ b/src/bridge/bridge-runtime.ts
@@ -161,8 +161,6 @@ interface BridgeRuntimeOptions {
   now?: () => number;
   /** Test seam for filtered per-agent process environments. */
   resolveSpawnEnvironment?: (input: ClaudeExecutionSettings) => NodeJS.ProcessEnv | undefined;
-  /** Test seam: cool a live queue owner before `acpx set` releases exclusive leases. */
-  terminateQueueOwner?: (acpxRecordId: string) => Promise<void>;
   createAdapterContext?: (input: {
     id: "codex" | "claude";
     sessionKey: string;
@@ -172,6 +170,7 @@ interface BridgeRuntimeOptions {
 
 type QueueOwnerLaunchPort = Pick<AcpxQueueOwnerLauncher, "launch"> & {
   wouldReuse?(input: LaunchQueueOwnerInput): Promise<boolean>;
+  cool?(acpxRecordId: string): Promise<void>;
 };
 
 export class BridgeRuntime {
@@ -835,8 +834,16 @@ export class BridgeRuntime {
       ownerWillBeReplaced: await this.queueOwnerWillBeReplaced(input, acpxRecordId),
     });
     if (!effort) return;
-    if (acpxRecordId) await this.terminateQueueOwner(acpxRecordId);
+    if (acpxRecordId) await this.coolQueueOwner(acpxRecordId);
     await this.applyAdvertisedSessionEffort(input, effort, record);
+  }
+
+  private async coolQueueOwner(acpxRecordId: string): Promise<void> {
+    if (this.queueOwnerLauncher.cool) {
+      await this.queueOwnerLauncher.cool(acpxRecordId);
+      return;
+    }
+    await terminateAcpxQueueOwnerVerified(acpxRecordId);
   }
 
   private async queueOwnerWillBeReplaced(
@@ -870,10 +877,6 @@ export class BridgeRuntime {
       ...(adapterContext ? { adapterContext } : {}),
       ...(env ? { env } : {}),
     };
-  }
-
-  private terminateQueueOwner(acpxRecordId: string): Promise<void> {
-    return (this.options.terminateQueueOwner ?? terminateAcpxQueueOwner)(acpxRecordId);
   }
 
   private async applyAdvertisedSessionEffort(

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -35,7 +35,7 @@ import {
 } from "../quota-gated-reply-sink";
 import { ensureNodePtyHelperExecutable, resolveNodePtyHelperPath } from "./node-pty-helper";
 import { terminateProcessTree } from "../../process/terminate-process-tree";
-import { AcpxQueueOwnerLauncher, readQueueOwnerPid, terminateAcpxQueueOwner, terminateAcpxQueueOwnerVerified, type QueueOwnerAdapterContext } from "../acpx-queue-owner-launcher";
+import { AcpxQueueOwnerLauncher, readQueueOwnerPid, terminateAcpxQueueOwner, terminateAcpxQueueOwnerVerified, type LaunchQueueOwnerInput, type QueueOwnerAdapterContext } from "../acpx-queue-owner-launcher";
 import { classifyPreinstalledAdapterCommandShape } from "../../adapters/adapter-catalog";
 import { migrateSessionArgvFile } from "../acpx-session-argv-migration";
 import { renderAgentArgvIdentity } from "../../config/agent-launch";
@@ -77,6 +77,8 @@ interface AcpxCliTransportOptions {
   queueOwnerTtlSeconds?: number;
   /** Test seam for filtered per-agent process environments. */
   resolveSpawnEnvironment?: (input: ClaudeExecutionSettings) => NodeJS.ProcessEnv | undefined;
+  /** Test seam: cool a live queue owner before `acpx set` releases exclusive leases. */
+  terminateQueueOwner?: (acpxRecordId: string) => Promise<void>;
   createAdapterContext?: (input: {
     id: "codex" | "claude";
     sessionKey: string;
@@ -219,6 +221,10 @@ async function defaultPtyRunner(command: string, args: string[], options?: RunOp
   });
 }
 
+type QueueOwnerLaunchPort = Pick<AcpxQueueOwnerLauncher, "launch"> & {
+  wouldReuse?(input: LaunchQueueOwnerInput): Promise<boolean>;
+};
+
 export class AcpxCliTransport implements SessionTransport {
   private readonly command: string;
   private readonly sessionInitTimeoutMs: number;
@@ -229,16 +235,17 @@ export class AcpxCliTransport implements SessionTransport {
   private readonly queueOwnerTtlSeconds: number | undefined;
   private readonly runCommand: CommandRunner;
   private readonly runPtyCommand: PtyRunner;
-  private readonly queueOwnerLauncher: Pick<AcpxQueueOwnerLauncher, "launch">;
+  private readonly queueOwnerLauncher: QueueOwnerLaunchPort;
   private readonly streamingHooks: StreamingPromptHooks;
   private readonly resolveSpawnEnvironment: (input: ClaudeExecutionSettings) => NodeJS.ProcessEnv | undefined;
   private readonly createAdapterContext?: AcpxCliTransportOptions["createAdapterContext"];
+  private readonly terminateQueueOwner: (acpxRecordId: string) => Promise<void>;
 
   constructor(
     options: AcpxCliTransportOptions,
     runCommand: CommandRunner = defaultRunner,
     runPtyCommand: PtyRunner = defaultPtyRunner,
-    queueOwnerLauncher?: Pick<AcpxQueueOwnerLauncher, "launch">,
+    queueOwnerLauncher?: QueueOwnerLaunchPort,
     streamingHooks: StreamingPromptHooks = {},
   ) {
     this.command = options.command ?? "acpx";
@@ -262,6 +269,7 @@ export class AcpxCliTransport implements SessionTransport {
     this.streamingHooks = streamingHooks;
     this.resolveSpawnEnvironment = options.resolveSpawnEnvironment ?? resolveClaudeSpawnEnvironment;
     this.createAdapterContext = options.createAdapterContext;
+    this.terminateQueueOwner = options.terminateQueueOwner ?? terminateAcpxQueueOwner;
   }
 
   // acpx-cli transport does not stream stderr back to the caller, so "note" progress
@@ -397,10 +405,7 @@ export class AcpxCliTransport implements SessionTransport {
     replyContext?: ReplyQuotaContext,
     options?: PromptOptions,
   ): Promise<{ text: string }> {
-    const effort = await sessionEffortToReapply(session.effort, () => this.isSessionWarm(session));
-    if (effort) {
-      await this.reapplySessionEffort(session, effort);
-    }
+    await this.syncPersistedSessionEffort(session);
     await this.launchMcpQueueOwnerIfNeeded(session);
     const structuredPrompt = await createStructuredPromptFile(text, options?.media);
     const args = this.buildPromptArgs(session, text, structuredPrompt?.filePath);
@@ -540,13 +545,50 @@ export class AcpxCliTransport implements SessionTransport {
     await this.applyAdvertisedSessionEffort(session, effort, record);
   }
 
-  private async reapplySessionEffort(session: ResolvedSession, effort: string): Promise<void> {
+  private async syncPersistedSessionEffort(session: ResolvedSession): Promise<void> {
+    const persisted = session.effort?.trim();
+    if (!persisted) return;
     const record = await this.readSessionEffortRecord(session);
     const observed = parseSessionEffortRecord(record);
-    if (!observed?.available.includes(effort)) {
-      return;
-    }
+    const acpxRecordId = parseAcpxSessionRecordId(record)?.acpxRecordId;
+    const effort = sessionEffortToReapply({
+      persisted,
+      observedCurrent: observed?.current,
+      advertised: observed?.available,
+      ownerWillBeReplaced: await this.queueOwnerWillBeReplaced(session, acpxRecordId),
+    });
+    if (!effort) return;
+    if (acpxRecordId) await this.terminateQueueOwner(acpxRecordId);
     await this.applyAdvertisedSessionEffort(session, effort, record);
+  }
+
+  private async queueOwnerWillBeReplaced(
+    session: ResolvedSession,
+    acpxRecordId: string | undefined,
+  ): Promise<boolean> {
+    if (!session.mcpCoordinatorSession || !acpxRecordId) return false;
+    const wouldReuse = this.queueOwnerLauncher.wouldReuse?.bind(this.queueOwnerLauncher);
+    if (!wouldReuse) return true;
+    return !(await wouldReuse(this.queueOwnerLaunchInput(session, acpxRecordId)));
+  }
+
+  private queueOwnerLaunchInput(session: ResolvedSession, acpxRecordId: string): LaunchQueueOwnerInput {
+    const env = this.spawnEnvironment(session);
+    const adapterId = classifyPreinstalledAdapterCommandShape(session.agentCommand);
+    const adapterContext = adapterId && session.agentCommand
+      ? this.createAdapterContext?.({ id: adapterId, sessionKey: session.alias, agentCommand: session.agentCommand })
+      : undefined;
+    return {
+      acpxRecordId,
+      coordinatorSession: session.mcpCoordinatorSession!,
+      ...(session.mcpSourceHandle ? { sourceHandle: session.mcpSourceHandle } : {}),
+      permissionMode: this.permissionMode,
+      nonInteractivePermissions: this.nonInteractivePermissions,
+      ...(adapterId && session.agentCommand ? { agentCommand: session.agentCommand } : {}),
+      ...(adapterContext ? { adapterContext } : {}),
+      ...(session.model?.trim() ? { sessionOptions: { model: session.model.trim() } } : {}),
+      ...(env ? { env } : {}),
+    };
   }
 
   private async readSessionEffortRecord(session: ResolvedSession): Promise<string> {
@@ -719,22 +761,7 @@ export class AcpxCliTransport implements SessionTransport {
       return;
     }
     const record = await this.readSessionRecord(session);
-    const env = this.spawnEnvironment(session);
-    const adapterId = classifyPreinstalledAdapterCommandShape(session.agentCommand);
-    const adapterContext = adapterId && session.agentCommand
-      ? this.createAdapterContext?.({ id: adapterId, sessionKey: session.alias, agentCommand: session.agentCommand })
-      : undefined;
-    const prepared = await this.queueOwnerLauncher.launch({
-      acpxRecordId: record.acpxRecordId,
-      coordinatorSession: session.mcpCoordinatorSession,
-      ...(session.mcpSourceHandle ? { sourceHandle: session.mcpSourceHandle } : {}),
-      permissionMode: this.permissionMode,
-      nonInteractivePermissions: this.nonInteractivePermissions,
-      ...(adapterId && session.agentCommand ? { agentCommand: session.agentCommand } : {}),
-      ...(adapterContext ? { adapterContext } : {}),
-      ...(session.model?.trim() ? { sessionOptions: { model: session.model.trim() } } : {}),
-      ...(env ? { env } : {}),
-    });
+    const prepared = await this.queueOwnerLauncher.launch(this.queueOwnerLaunchInput(session, record.acpxRecordId));
     if (prepared?.agentCommand) session.agentCommand = prepared.agentCommand;
   }
 

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -44,7 +44,7 @@ import { resolveToolEventMode, type ToolEventMode } from "../tool-event-mode.js"
 import { runAgentSessionList } from "../agent-session-list";
 import { CODEX_AGENT_NAME, codexSubagentPredicate } from "../codex-subagent-filter";
 import { deleteAcpxSessionFiles } from "../acpx-session-files";
-import { parseSessionEffortRecord, requireAdvertisedSessionEffort } from "../session-effort";
+import { parseSessionEffortRecord, requireAdvertisedSessionEffort, sessionEffortToReapply } from "../session-effort";
 import {
   CommandTimeoutError,
   DEFAULT_MANAGEMENT_COMMAND_TIMEOUT_MS,
@@ -397,12 +397,9 @@ export class AcpxCliTransport implements SessionTransport {
     replyContext?: ReplyQuotaContext,
     options?: PromptOptions,
   ): Promise<{ text: string }> {
-    // Reapply only on a cold owner: `acpx set` against a live queue owner
-    // falls back to spawning a second ACP process and `session/resume`. Agents
-    // with exclusive session leases (Reasonix) reject that as "in use by
-    // another process" — the warm owner already holds the configured effort.
-    if (session.effort?.trim() && !(await this.isSessionWarm(session))) {
-      await this.reapplySessionEffort(session, session.effort.trim());
+    const effort = await sessionEffortToReapply(session.effort, () => this.isSessionWarm(session));
+    if (effort) {
+      await this.reapplySessionEffort(session, effort);
     }
     await this.launchMcpQueueOwnerIfNeeded(session);
     const structuredPrompt = await createStructuredPromptFile(text, options?.media);

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -397,7 +397,11 @@ export class AcpxCliTransport implements SessionTransport {
     replyContext?: ReplyQuotaContext,
     options?: PromptOptions,
   ): Promise<{ text: string }> {
-    if (session.effort?.trim()) {
+    // Reapply only on a cold owner: `acpx set` against a live queue owner
+    // falls back to spawning a second ACP process and `session/resume`. Agents
+    // with exclusive session leases (Reasonix) reject that as "in use by
+    // another process" — the warm owner already holds the configured effort.
+    if (session.effort?.trim() && !(await this.isSessionWarm(session))) {
       await this.reapplySessionEffort(session, session.effort.trim());
     }
     await this.launchMcpQueueOwnerIfNeeded(session);

--- a/src/transport/acpx-cli/acpx-cli-transport.ts
+++ b/src/transport/acpx-cli/acpx-cli-transport.ts
@@ -77,8 +77,6 @@ interface AcpxCliTransportOptions {
   queueOwnerTtlSeconds?: number;
   /** Test seam for filtered per-agent process environments. */
   resolveSpawnEnvironment?: (input: ClaudeExecutionSettings) => NodeJS.ProcessEnv | undefined;
-  /** Test seam: cool a live queue owner before `acpx set` releases exclusive leases. */
-  terminateQueueOwner?: (acpxRecordId: string) => Promise<void>;
   createAdapterContext?: (input: {
     id: "codex" | "claude";
     sessionKey: string;
@@ -223,6 +221,7 @@ async function defaultPtyRunner(command: string, args: string[], options?: RunOp
 
 type QueueOwnerLaunchPort = Pick<AcpxQueueOwnerLauncher, "launch"> & {
   wouldReuse?(input: LaunchQueueOwnerInput): Promise<boolean>;
+  cool?(acpxRecordId: string): Promise<void>;
 };
 
 export class AcpxCliTransport implements SessionTransport {
@@ -239,7 +238,6 @@ export class AcpxCliTransport implements SessionTransport {
   private readonly streamingHooks: StreamingPromptHooks;
   private readonly resolveSpawnEnvironment: (input: ClaudeExecutionSettings) => NodeJS.ProcessEnv | undefined;
   private readonly createAdapterContext?: AcpxCliTransportOptions["createAdapterContext"];
-  private readonly terminateQueueOwner: (acpxRecordId: string) => Promise<void>;
 
   constructor(
     options: AcpxCliTransportOptions,
@@ -269,7 +267,6 @@ export class AcpxCliTransport implements SessionTransport {
     this.streamingHooks = streamingHooks;
     this.resolveSpawnEnvironment = options.resolveSpawnEnvironment ?? resolveClaudeSpawnEnvironment;
     this.createAdapterContext = options.createAdapterContext;
-    this.terminateQueueOwner = options.terminateQueueOwner ?? terminateAcpxQueueOwner;
   }
 
   // acpx-cli transport does not stream stderr back to the caller, so "note" progress
@@ -558,8 +555,16 @@ export class AcpxCliTransport implements SessionTransport {
       ownerWillBeReplaced: await this.queueOwnerWillBeReplaced(session, acpxRecordId),
     });
     if (!effort) return;
-    if (acpxRecordId) await this.terminateQueueOwner(acpxRecordId);
+    if (acpxRecordId) await this.coolQueueOwner(acpxRecordId);
     await this.applyAdvertisedSessionEffort(session, effort, record);
+  }
+
+  private async coolQueueOwner(acpxRecordId: string): Promise<void> {
+    if (this.queueOwnerLauncher.cool) {
+      await this.queueOwnerLauncher.cool(acpxRecordId);
+      return;
+    }
+    await terminateAcpxQueueOwnerVerified(acpxRecordId);
   }
 
   private async queueOwnerWillBeReplaced(

--- a/src/transport/acpx-queue-owner-launcher.ts
+++ b/src/transport/acpx-queue-owner-launcher.ts
@@ -203,6 +203,13 @@ export class AcpxQueueOwnerLauncher {
     this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   }
 
+  async wouldReuse(input: LaunchQueueOwnerInput): Promise<boolean> {
+    const childEnv = input.env ?? this.baseEnv;
+    const fingerprint = launchFingerprint(input, childEnv);
+    return await this.isOwnerAlive(input.acpxRecordId)
+      && this.lastLaunchFingerprint.get(input.acpxRecordId) === fingerprint;
+  }
+
   async launch(input: LaunchQueueOwnerInput): Promise<{ agentCommand?: string }> {
     const key = input.acpxRecordId;
     const previous = this.launchLocks.get(key) ?? Promise.resolve();
@@ -227,14 +234,10 @@ export class AcpxQueueOwnerLauncher {
     // model options, and the agent command are all baked into the owner's
     // payload at spawn time. Reusing it under changed parameters would keep an
     // old permission/MCP/model/command profile alive (forever with ttl=0).
-    const childEnv = input.env ?? this.baseEnv;
-    const fingerprint = launchFingerprint(input, childEnv);
-    if (
-      await this.isOwnerAlive(input.acpxRecordId)
-      && this.lastLaunchFingerprint.get(input.acpxRecordId) === fingerprint
-    ) {
+    if (await this.wouldReuse(input)) {
       return { agentCommand: input.agentCommand };
     }
+    const childEnv = input.env ?? this.baseEnv;
     await this.terminateOwner(input.acpxRecordId);
     if (await this.isOwnerAlive(input.acpxRecordId)) {
       throw new Error(

--- a/src/transport/acpx-queue-owner-launcher.ts
+++ b/src/transport/acpx-queue-owner-launcher.ts
@@ -203,6 +203,34 @@ export class AcpxQueueOwnerLauncher {
     this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   }
 
+  async cool(acpxRecordId: string): Promise<void> {
+    const key = acpxRecordId;
+    const previous = this.launchLocks.get(key) ?? Promise.resolve();
+    const next = previous.then(
+      () => this.doCool(acpxRecordId),
+      () => this.doCool(acpxRecordId),
+    );
+    const tracked = next.then(() => ({}), () => ({}));
+    this.launchLocks.set(key, tracked);
+    void tracked.finally(() => {
+      if (this.launchLocks.get(key) === tracked) {
+        this.launchLocks.delete(key);
+      }
+    });
+    await next;
+  }
+
+  private async doCool(acpxRecordId: string): Promise<void> {
+    await this.terminateOwner(acpxRecordId);
+    if (await this.isOwnerAlive(acpxRecordId)) {
+      throw new Error(
+        `queue owner for session ${acpxRecordId} is still live after termination; ` +
+          "refusing to apply session effort while the owner may still be running",
+      );
+    }
+    this.lastLaunchFingerprint.delete(acpxRecordId);
+  }
+
   async wouldReuse(input: LaunchQueueOwnerInput): Promise<boolean> {
     const childEnv = input.env ?? this.baseEnv;
     const fingerprint = launchFingerprint(input, childEnv);

--- a/src/transport/session-effort.ts
+++ b/src/transport/session-effort.ts
@@ -9,6 +9,24 @@ const EFFORT_CONFIG_IDS = new Set([
 
 type EffortConfigOption = SessionEffortState & { configId: string };
 
+/**
+ * Reapply persisted effort only on a cold queue owner. `acpx set` against a
+ * live owner falls back to spawning a second ACP process and `session/resume`.
+ * Agents with exclusive session leases (Reasonix) reject that as "in use by
+ * another process" — the warm owner already holds the configured effort.
+ *
+ * Skip the warmth probe when there is no effort: `isSessionWarm` is a
+ * management command and must not run on every prompt.
+ */
+export async function sessionEffortToReapply(
+  effort: string | undefined,
+  isWarm: () => Promise<boolean>,
+): Promise<string | undefined> {
+  const value = effort?.trim();
+  if (!value) return undefined;
+  return (await isWarm()) ? undefined : value;
+}
+
 export function requireAdvertisedSessionEffort(raw: string, value: string): EffortConfigOption {
   const advertised = parseSessionEffortRecord(raw);
   if (!advertised) {

--- a/src/transport/session-effort.ts
+++ b/src/transport/session-effort.ts
@@ -9,22 +9,32 @@ const EFFORT_CONFIG_IDS = new Set([
 
 type EffortConfigOption = SessionEffortState & { configId: string };
 
+export interface SessionEffortReapplyInput {
+  persisted?: string;
+  observedCurrent?: string;
+  advertised?: string[];
+  /**
+   * True when the next queue-owner launch will kill and respawn (fingerprint
+   * change or no reusable owner). A replacement adapter can reset effort even
+   * when the current record still matches, so write desired effort while cold.
+   */
+  ownerWillBeReplaced: boolean;
+}
+
 /**
- * Reapply persisted effort only on a cold queue owner. `acpx set` against a
- * live owner falls back to spawning a second ACP process and `session/resume`.
- * Agents with exclusive session leases (Reasonix) reject that as "in use by
- * another process" — the warm owner already holds the configured effort.
- *
- * Skip the warmth probe when there is no effort: `isSessionWarm` is a
- * management command and must not run on every prompt.
+ * Persisted `session.effort` is the user's desired value and can differ from
+ * the adapter's advertised current — ControlService prefers persisted when it
+ * is still advertised. Skip `acpx set` only when the live record already
+ * matches AND the current owner will be reused. Otherwise return the value to
+ * apply after cooling the owner: `acpx set` against a live owner can spawn a
+ * second ACP process and break exclusive session leases (Reasonix).
  */
-export async function sessionEffortToReapply(
-  effort: string | undefined,
-  isWarm: () => Promise<boolean>,
-): Promise<string | undefined> {
-  const value = effort?.trim();
-  if (!value) return undefined;
-  return (await isWarm()) ? undefined : value;
+export function sessionEffortToReapply(input: SessionEffortReapplyInput): string | undefined {
+  const effort = input.persisted?.trim();
+  if (!effort) return undefined;
+  if (!input.advertised?.includes(effort)) return undefined;
+  if (input.observedCurrent === effort && !input.ownerWillBeReplaced) return undefined;
+  return effort;
 }
 
 export function requireAdvertisedSessionEffort(raw: string, value: string): EffortConfigOption {

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -888,12 +888,7 @@ test("a model change cools the owner and reapplies persisted effort before repla
     events.push("prompt");
     return { code: 0, stdout: "worker response", stderr: "" };
   };
-  const runtime = new BridgeRuntime("acpx", run, undefined, {
-    terminateQueueOwner: async () => {
-      events.push("cool");
-      alive = false;
-    },
-  }, undefined, undefined, queueOwnerLauncher);
+  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
   const baseInput = {
     agent: "codex",
     cwd: "/repo",
@@ -907,8 +902,8 @@ test("a model change cools the owner and reapplies persisted effort before repla
   await runtime.prompt({ ...baseInput, model: "model-b" });
 
   expect(events).toEqual([
-    "cool", "set:high", "replace", "spawn", "prompt",
-    "cool", "set:high", "replace", "spawn", "prompt",
+    "replace", "set:high", "replace", "spawn", "prompt",
+    "replace", "set:high", "replace", "spawn", "prompt",
   ]);
   expect(payloads.map((payload) => payload.sessionOptions?.model)).toEqual(["model-a", "model-b"]);
 });
@@ -928,6 +923,9 @@ test("prompt persists effort before launching the queue owner so reconnect repla
   });
   const queueOwnerLauncher = {
     wouldReuse: async () => false,
+    cool: async () => {
+      events.push("cool");
+    },
     launch: async () => {
       events.push("launch");
     },
@@ -943,11 +941,7 @@ test("prompt persists effort before launching the queue owner so reconnect repla
     events.push("prompt");
     return { code: 0, stdout: "worker response", stderr: "" };
   };
-  const runtime = new BridgeRuntime("acpx", run, undefined, {
-    terminateQueueOwner: async () => {
-      events.push("cool");
-    },
-  }, undefined, undefined, queueOwnerLauncher);
+  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
 
   await runtime.prompt({
     agent: "codex",
@@ -965,6 +959,9 @@ test("prompt skips effort reapply when a reusable owner already holds the persis
   const events: string[] = [];
   const queueOwnerLauncher = {
     wouldReuse: async () => true,
+    cool: async () => {
+      events.push("cool");
+    },
     launch: async () => {
       events.push("launch");
     },
@@ -991,11 +988,7 @@ test("prompt skips effort reapply when a reusable owner already holds the persis
     events.push(args.includes("prompt") ? "prompt" : "other");
     return { code: 0, stdout: "worker response", stderr: "" };
   };
-  const runtime = new BridgeRuntime("acpx", run, undefined, {
-    terminateQueueOwner: async () => {
-      events.push("cool");
-    },
-  }, undefined, undefined, queueOwnerLauncher);
+  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
 
   await runtime.prompt({
     agent: "codex",
@@ -1013,6 +1006,9 @@ test("prompt cools a reusable owner and reapplies persisted effort when adapter 
   const events: string[] = [];
   const queueOwnerLauncher = {
     wouldReuse: async () => true,
+    cool: async () => {
+      events.push("cool");
+    },
     launch: async () => {
       events.push("launch");
     },
@@ -1042,11 +1038,7 @@ test("prompt cools a reusable owner and reapplies persisted effort when adapter 
     events.push("prompt");
     return { code: 0, stdout: "worker response", stderr: "" };
   };
-  const runtime = new BridgeRuntime("acpx", run, undefined, {
-    terminateQueueOwner: async () => {
-      events.push("cool");
-    },
-  }, undefined, undefined, queueOwnerLauncher);
+  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
 
   await runtime.prompt({
     agent: "codex",
@@ -1058,6 +1050,56 @@ test("prompt cools a reusable owner and reapplies persisted effort when adapter 
   });
 
   expect(events).toEqual(["cool", "set:high", "launch", "prompt"]);
+});
+
+test("prompt does not acpx set when the queue owner cannot be cooled", async () => {
+  const events: string[] = [];
+  const queueOwnerLauncher = {
+    wouldReuse: async () => true,
+    cool: async () => {
+      events.push("cool");
+      throw new Error(
+        "queue owner for session acpx-record-1 is still live after termination; " +
+          "refusing to apply session effort while the owner may still be running",
+      );
+    },
+    launch: async () => {
+      events.push("launch");
+    },
+  };
+  const run = async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "medium",
+              options: [{ value: "medium" }, { value: "high" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("set")) events.push("set");
+    events.push(args.includes("prompt") ? "prompt" : "other");
+    return { code: 0, stdout: "worker response", stderr: "" };
+  };
+  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
+
+  await expect(runtime.prompt({
+    agent: "codex",
+    cwd: "/repo",
+    name: "worker",
+    text: "hello",
+    effort: "high",
+    mcpCoordinatorSession: "backend:main",
+  })).rejects.toThrow(/still live after termination/);
+  expect(events).toEqual(["cool"]);
 });
 
 test("prompt continues when the persisted effort is no longer advertised", async () => {

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -845,6 +845,74 @@ test("prompt replaces a bridge queue owner when the resolved model changes", asy
   expect(payloads.map((payload) => payload.sessionOptions?.model)).toEqual(["model-a", "model-b"]);
 });
 
+test("a model change cools the owner and reapplies persisted effort before replacing it", async () => {
+  const events: string[] = [];
+  const payloads: Array<{ sessionOptions?: { model?: string } }> = [];
+  let alive = false;
+  const queueOwnerLauncher = new AcpxQueueOwnerLauncher({
+    acpxCommand: "acpx",
+    spawnOwner: async (_command, _args, options) => {
+      alive = true;
+      events.push("spawn");
+      payloads.push(JSON.parse(options.env.ACPX_QUEUE_OWNER_PAYLOAD));
+      return 100 + payloads.length;
+    },
+    terminateOwner: async () => {
+      events.push("replace");
+      alive = false;
+    },
+    isOwnerAlive: async () => alive,
+  });
+  const run = async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "medium",
+              options: [{ value: "low" }, { value: "medium" }, { value: "high" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("set")) {
+      events.push("set:high");
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    events.push("prompt");
+    return { code: 0, stdout: "worker response", stderr: "" };
+  };
+  const runtime = new BridgeRuntime("acpx", run, undefined, {
+    terminateQueueOwner: async () => {
+      events.push("cool");
+      alive = false;
+    },
+  }, undefined, undefined, queueOwnerLauncher);
+  const baseInput = {
+    agent: "codex",
+    cwd: "/repo",
+    name: "worker",
+    text: "hello",
+    effort: "high",
+    mcpCoordinatorSession: "backend:main",
+  };
+
+  await runtime.prompt({ ...baseInput, model: "model-a" });
+  await runtime.prompt({ ...baseInput, model: "model-b" });
+
+  expect(events).toEqual([
+    "cool", "set:high", "replace", "spawn", "prompt",
+    "cool", "set:high", "replace", "spawn", "prompt",
+  ]);
+  expect(payloads.map((payload) => payload.sessionOptions?.model)).toEqual(["model-a", "model-b"]);
+});
+
 test("prompt persists effort before launching the queue owner so reconnect replays it", async () => {
   const events: string[] = [];
   const effortRecord = JSON.stringify({
@@ -859,10 +927,11 @@ test("prompt persists effort before launching the queue owner so reconnect repla
     },
   });
   const queueOwnerLauncher = {
+    wouldReuse: async () => false,
     launch: async () => {
       events.push("launch");
     },
-  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  };
   const run = async (_command: string, args: string[]) => {
     if (args.includes("show")) {
       return { code: 0, stdout: effortRecord, stderr: "" };
@@ -874,8 +943,11 @@ test("prompt persists effort before launching the queue owner so reconnect repla
     events.push("prompt");
     return { code: 0, stdout: "worker response", stderr: "" };
   };
-  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
-  spyOn(runtime, "isSessionWarm").mockResolvedValue({ warm: false });
+  const runtime = new BridgeRuntime("acpx", run, undefined, {
+    terminateQueueOwner: async () => {
+      events.push("cool");
+    },
+  }, undefined, undefined, queueOwnerLauncher);
 
   await runtime.prompt({
     agent: "codex",
@@ -886,26 +958,44 @@ test("prompt persists effort before launching the queue owner so reconnect repla
     mcpCoordinatorSession: "backend:main",
   });
 
-  expect(events).toEqual(["set:high", "launch", "prompt"]);
+  expect(events).toEqual(["cool", "set:high", "launch", "prompt"]);
 });
 
-test("prompt skips effort reapply when the queue owner is already warm", async () => {
+test("prompt skips effort reapply when a reusable owner already holds the persisted value", async () => {
   const events: string[] = [];
   const queueOwnerLauncher = {
+    wouldReuse: async () => true,
     launch: async () => {
       events.push("launch");
     },
-  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  };
   const run = async (_command: string, args: string[]) => {
     if (args.includes("set")) events.push("set");
     if (args.includes("show")) {
-      return { code: 0, stdout: JSON.stringify({ acpxRecordId: "acpx-record-1" }), stderr: "" };
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "max",
+              options: [{ value: "medium" }, { value: "max" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
     }
     events.push(args.includes("prompt") ? "prompt" : "other");
     return { code: 0, stdout: "worker response", stderr: "" };
   };
-  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
-  spyOn(runtime, "isSessionWarm").mockResolvedValue({ warm: true });
+  const runtime = new BridgeRuntime("acpx", run, undefined, {
+    terminateQueueOwner: async () => {
+      events.push("cool");
+    },
+  }, undefined, undefined, queueOwnerLauncher);
 
   await runtime.prompt({
     agent: "codex",
@@ -917,6 +1007,57 @@ test("prompt skips effort reapply when the queue owner is already warm", async (
   });
 
   expect(events).toEqual(["launch", "prompt"]);
+});
+
+test("prompt cools a reusable owner and reapplies persisted effort when adapter current drifted", async () => {
+  const events: string[] = [];
+  const queueOwnerLauncher = {
+    wouldReuse: async () => true,
+    launch: async () => {
+      events.push("launch");
+    },
+  };
+  const run = async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "medium",
+              options: [{ value: "low" }, { value: "medium" }, { value: "high" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("set")) {
+      events.push("set:high");
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    events.push("prompt");
+    return { code: 0, stdout: "worker response", stderr: "" };
+  };
+  const runtime = new BridgeRuntime("acpx", run, undefined, {
+    terminateQueueOwner: async () => {
+      events.push("cool");
+    },
+  }, undefined, undefined, queueOwnerLauncher);
+
+  await runtime.prompt({
+    agent: "codex",
+    cwd: "/repo",
+    name: "worker",
+    text: "hello",
+    effort: "high",
+    mcpCoordinatorSession: "backend:main",
+  });
+
+  expect(events).toEqual(["cool", "set:high", "launch", "prompt"]);
 });
 
 test("prompt continues when the persisted effort is no longer advertised", async () => {

--- a/tests/unit/bridge/bridge-runtime.test.ts
+++ b/tests/unit/bridge/bridge-runtime.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 
 import {
   BridgeRuntime,
@@ -875,6 +875,7 @@ test("prompt persists effort before launching the queue owner so reconnect repla
     return { code: 0, stdout: "worker response", stderr: "" };
   };
   const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
+  spyOn(runtime, "isSessionWarm").mockResolvedValue({ warm: false });
 
   await runtime.prompt({
     agent: "codex",
@@ -886,6 +887,36 @@ test("prompt persists effort before launching the queue owner so reconnect repla
   });
 
   expect(events).toEqual(["set:high", "launch", "prompt"]);
+});
+
+test("prompt skips effort reapply when the queue owner is already warm", async () => {
+  const events: string[] = [];
+  const queueOwnerLauncher = {
+    launch: async () => {
+      events.push("launch");
+    },
+  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  const run = async (_command: string, args: string[]) => {
+    if (args.includes("set")) events.push("set");
+    if (args.includes("show")) {
+      return { code: 0, stdout: JSON.stringify({ acpxRecordId: "acpx-record-1" }), stderr: "" };
+    }
+    events.push(args.includes("prompt") ? "prompt" : "other");
+    return { code: 0, stdout: "worker response", stderr: "" };
+  };
+  const runtime = new BridgeRuntime("acpx", run, undefined, {}, undefined, undefined, queueOwnerLauncher);
+  spyOn(runtime, "isSessionWarm").mockResolvedValue({ warm: true });
+
+  await runtime.prompt({
+    agent: "codex",
+    cwd: "/repo",
+    name: "worker",
+    text: "hello",
+    effort: "max",
+    mcpCoordinatorSession: "backend:main",
+  });
+
+  expect(events).toEqual(["launch", "prompt"]);
 });
 
 test("prompt continues when the persisted effort is no longer advertised", async () => {

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -1,4 +1,4 @@
-import { expect, mock, test } from "bun:test";
+import { expect, mock, spyOn, test } from "bun:test";
 import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1435,10 +1435,44 @@ test("persists effort before launching the queue owner so reconnect replays it",
     undefined,
     queueOwnerLauncher,
   );
+  spyOn(transport, "isSessionWarm").mockResolvedValue(false);
 
   await transport.prompt(effortSession, "hello");
 
   expect(events).toEqual(["set:high", "launch", "prompt"]);
+});
+
+test("skips effort reapply when the queue owner is already warm", async () => {
+  const events: string[] = [];
+  const effortSession: ResolvedSession = {
+    ...session,
+    effort: "max",
+    mcpCoordinatorSession: "backend:main",
+  };
+  const run = mock(async (_command: string, args: string[]) => {
+    if (args.includes("set")) events.push("set");
+    if (args.includes("show")) {
+      return { code: 0, stdout: JSON.stringify({ acpxRecordId: "acpx-record-1" }), stderr: "" };
+    }
+    events.push(args.includes("prompt") ? "prompt" : "other");
+    return { code: 0, stdout: "ok", stderr: "" };
+  });
+  const queueOwnerLauncher = {
+    launch: async () => {
+      events.push("launch");
+    },
+  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    run,
+    undefined,
+    queueOwnerLauncher,
+  );
+  spyOn(transport, "isSessionWarm").mockResolvedValue(true);
+
+  await transport.prompt(effortSession, "hello");
+
+  expect(events).toEqual(["launch", "prompt"]);
 });
 
 test("does not block a prompt when the persisted effort is no longer advertised", async () => {
@@ -1481,6 +1515,7 @@ test("does not block a prompt when the persisted effort is no longer advertised"
     undefined,
     queueOwnerLauncher,
   );
+  spyOn(transport, "isSessionWarm").mockResolvedValue(false);
 
   await expect(transport.prompt(staleSession, "hello")).resolves.toEqual({ text: "worker response" });
   expect(events).toEqual(["launch", "prompt"]);

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -1425,24 +1425,29 @@ test("persists effort before launching the queue owner so reconnect replays it",
     return { code: 0, stdout: "worker response", stderr: "" };
   });
   const queueOwnerLauncher = {
+    wouldReuse: async () => false,
     launch: async () => {
       events.push("launch");
     },
-  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  };
   const transport = new AcpxCliTransport(
-    { command: "acpx" },
+    {
+      command: "acpx",
+      terminateQueueOwner: async () => {
+        events.push("cool");
+      },
+    },
     run,
     undefined,
     queueOwnerLauncher,
   );
-  spyOn(transport, "isSessionWarm").mockResolvedValue(false);
 
   await transport.prompt(effortSession, "hello");
 
-  expect(events).toEqual(["set:high", "launch", "prompt"]);
+  expect(events).toEqual(["cool", "set:high", "launch", "prompt"]);
 });
 
-test("skips effort reapply when the queue owner is already warm", async () => {
+test("skips effort reapply when a reusable owner already holds the persisted value", async () => {
   const events: string[] = [];
   const effortSession: ResolvedSession = {
     ...session,
@@ -1452,27 +1457,157 @@ test("skips effort reapply when the queue owner is already warm", async () => {
   const run = mock(async (_command: string, args: string[]) => {
     if (args.includes("set")) events.push("set");
     if (args.includes("show")) {
-      return { code: 0, stdout: JSON.stringify({ acpxRecordId: "acpx-record-1" }), stderr: "" };
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "max",
+              options: [{ value: "medium" }, { value: "max" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
     }
     events.push(args.includes("prompt") ? "prompt" : "other");
     return { code: 0, stdout: "ok", stderr: "" };
   });
   const queueOwnerLauncher = {
+    wouldReuse: async () => true,
     launch: async () => {
       events.push("launch");
     },
-  } as Pick<AcpxQueueOwnerLauncher, "launch">;
+  };
   const transport = new AcpxCliTransport(
-    { command: "acpx" },
+    {
+      command: "acpx",
+      terminateQueueOwner: async () => {
+        events.push("cool");
+      },
+    },
     run,
     undefined,
     queueOwnerLauncher,
   );
-  spyOn(transport, "isSessionWarm").mockResolvedValue(true);
 
   await transport.prompt(effortSession, "hello");
 
   expect(events).toEqual(["launch", "prompt"]);
+});
+
+test("cools a reusable owner and reapplies persisted effort when adapter current drifted", async () => {
+  const events: string[] = [];
+  const effortSession: ResolvedSession = {
+    ...session,
+    effort: "high",
+    mcpCoordinatorSession: "backend:main",
+  };
+  const run = mock(async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "medium",
+              options: [{ value: "low" }, { value: "medium" }, { value: "high" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("set")) {
+      events.push("set:high");
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    events.push("prompt");
+    return { code: 0, stdout: "worker response", stderr: "" };
+  });
+  const queueOwnerLauncher = {
+    wouldReuse: async () => true,
+    launch: async () => {
+      events.push("launch");
+    },
+  };
+  const transport = new AcpxCliTransport(
+    {
+      command: "acpx",
+      terminateQueueOwner: async () => {
+        events.push("cool");
+      },
+    },
+    run,
+    undefined,
+    queueOwnerLauncher,
+  );
+
+  await transport.prompt(effortSession, "hello");
+
+  expect(events).toEqual(["cool", "set:high", "launch", "prompt"]);
+});
+
+test("writes persisted effort while cold when the next launch will replace the owner", async () => {
+  const events: string[] = [];
+  const effortSession: ResolvedSession = {
+    ...session,
+    effort: "high",
+    model: "model-b",
+    mcpCoordinatorSession: "backend:main",
+  };
+  const run = mock(async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "high",
+              options: [{ value: "medium" }, { value: "high" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("set")) {
+      events.push("set:high");
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    events.push("prompt");
+    return { code: 0, stdout: "ok", stderr: "" };
+  });
+  const queueOwnerLauncher = {
+    wouldReuse: async () => false,
+    launch: async () => {
+      events.push("launch");
+    },
+  };
+  const transport = new AcpxCliTransport(
+    {
+      command: "acpx",
+      terminateQueueOwner: async () => {
+        events.push("cool");
+      },
+    },
+    run,
+    undefined,
+    queueOwnerLauncher,
+  );
+
+  await transport.prompt(effortSession, "hello");
+
+  expect(events).toEqual(["cool", "set:high", "launch", "prompt"]);
 });
 
 test("does not block a prompt when the persisted effort is no longer advertised", async () => {
@@ -1515,7 +1650,6 @@ test("does not block a prompt when the persisted effort is no longer advertised"
     undefined,
     queueOwnerLauncher,
   );
-  spyOn(transport, "isSessionWarm").mockResolvedValue(false);
 
   await expect(transport.prompt(staleSession, "hello")).resolves.toEqual({ text: "worker response" });
   expect(events).toEqual(["launch", "prompt"]);

--- a/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
+++ b/tests/unit/transport/acpx-cli/acpx-cli-transport.test.ts
@@ -1426,17 +1426,15 @@ test("persists effort before launching the queue owner so reconnect replays it",
   });
   const queueOwnerLauncher = {
     wouldReuse: async () => false,
+    cool: async () => {
+      events.push("cool");
+    },
     launch: async () => {
       events.push("launch");
     },
   };
   const transport = new AcpxCliTransport(
-    {
-      command: "acpx",
-      terminateQueueOwner: async () => {
-        events.push("cool");
-      },
-    },
+    { command: "acpx" },
     run,
     undefined,
     queueOwnerLauncher,
@@ -1478,17 +1476,15 @@ test("skips effort reapply when a reusable owner already holds the persisted val
   });
   const queueOwnerLauncher = {
     wouldReuse: async () => true,
+    cool: async () => {
+      events.push("cool");
+    },
     launch: async () => {
       events.push("launch");
     },
   };
   const transport = new AcpxCliTransport(
-    {
-      command: "acpx",
-      terminateQueueOwner: async () => {
-        events.push("cool");
-      },
-    },
+    { command: "acpx" },
     run,
     undefined,
     queueOwnerLauncher,
@@ -1533,17 +1529,15 @@ test("cools a reusable owner and reapplies persisted effort when adapter current
   });
   const queueOwnerLauncher = {
     wouldReuse: async () => true,
+    cool: async () => {
+      events.push("cool");
+    },
     launch: async () => {
       events.push("launch");
     },
   };
   const transport = new AcpxCliTransport(
-    {
-      command: "acpx",
-      terminateQueueOwner: async () => {
-        events.push("cool");
-      },
-    },
+    { command: "acpx" },
     run,
     undefined,
     queueOwnerLauncher,
@@ -1589,17 +1583,15 @@ test("writes persisted effort while cold when the next launch will replace the o
   });
   const queueOwnerLauncher = {
     wouldReuse: async () => false,
+    cool: async () => {
+      events.push("cool");
+    },
     launch: async () => {
       events.push("launch");
     },
   };
   const transport = new AcpxCliTransport(
-    {
-      command: "acpx",
-      terminateQueueOwner: async () => {
-        events.push("cool");
-      },
-    },
+    { command: "acpx" },
     run,
     undefined,
     queueOwnerLauncher,
@@ -1608,6 +1600,59 @@ test("writes persisted effort while cold when the next launch will replace the o
   await transport.prompt(effortSession, "hello");
 
   expect(events).toEqual(["cool", "set:high", "launch", "prompt"]);
+});
+
+test("does not acpx set when the queue owner cannot be cooled", async () => {
+  const events: string[] = [];
+  const effortSession: ResolvedSession = {
+    ...session,
+    effort: "high",
+    mcpCoordinatorSession: "backend:main",
+  };
+  const run = mock(async (_command: string, args: string[]) => {
+    if (args.includes("show")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          acpxRecordId: "acpx-record-1",
+          acpx: {
+            config_options: [{
+              id: "reasoning_effort",
+              category: "thought_level",
+              currentValue: "medium",
+              options: [{ value: "medium" }, { value: "high" }],
+            }],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("set")) events.push("set");
+    events.push(args.includes("prompt") ? "prompt" : "other");
+    return { code: 0, stdout: "ok", stderr: "" };
+  });
+  const queueOwnerLauncher = {
+    wouldReuse: async () => true,
+    cool: async () => {
+      events.push("cool");
+      throw new Error(
+        "queue owner for session acpx-record-1 is still live after termination; " +
+          "refusing to apply session effort while the owner may still be running",
+      );
+    },
+    launch: async () => {
+      events.push("launch");
+    },
+  };
+  const transport = new AcpxCliTransport(
+    { command: "acpx" },
+    run,
+    undefined,
+    queueOwnerLauncher,
+  );
+
+  await expect(transport.prompt(effortSession, "hello")).rejects.toThrow(/still live after termination/);
+  expect(events).toEqual(["cool"]);
 });
 
 test("does not block a prompt when the persisted effort is no longer advertised", async () => {

--- a/tests/unit/transport/acpx-queue-owner-launcher.test.ts
+++ b/tests/unit/transport/acpx-queue-owner-launcher.test.ts
@@ -346,6 +346,32 @@ test("reuses a live warm owner only when launch parameters are unchanged", async
   expect(spawns).toHaveLength(2);
 });
 
+test("wouldReuse is true only for a live owner with a matching launch fingerprint", async () => {
+  let alive = false;
+  const launcher = new AcpxQueueOwnerLauncher({
+    acpxCommand: "acpx",
+    spawnOwner: async () => {
+      alive = true;
+      return 41;
+    },
+    terminateOwner: async () => {
+      alive = false;
+    },
+    isOwnerAlive: async () => alive,
+  });
+  const input = {
+    acpxRecordId: "acpx-record-1",
+    coordinatorSession: "backend:main",
+    permissionMode: "approve-all" as const,
+    nonInteractivePermissions: "deny" as const,
+  };
+
+  await expect(launcher.wouldReuse(input)).resolves.toBe(false);
+  await launcher.launch(input);
+  await expect(launcher.wouldReuse(input)).resolves.toBe(true);
+  await expect(launcher.wouldReuse({ ...input, sessionOptions: { model: "model-b" } })).resolves.toBe(false);
+});
+
 test("a changed effective environment replaces the warm owner without exposing secrets in the fingerprint", async () => {
   const spawns: Array<Record<string, string>> = [];
   let alive = false;

--- a/tests/unit/transport/acpx-queue-owner-launcher.test.ts
+++ b/tests/unit/transport/acpx-queue-owner-launcher.test.ts
@@ -372,6 +372,39 @@ test("wouldReuse is true only for a live owner with a matching launch fingerprin
   await expect(launcher.wouldReuse({ ...input, sessionOptions: { model: "model-b" } })).resolves.toBe(false);
 });
 
+test("cool fails closed when the owner remains alive after a Windows no-op terminate", async () => {
+  const launcher = new AcpxQueueOwnerLauncher({
+    acpxCommand: "acpx",
+    spawnOwner: async () => 41,
+    terminateOwner: async () => {},
+    isOwnerAlive: async () => true,
+  });
+
+  await expect(launcher.cool("acpx-record-1")).rejects.toThrow(/still live after termination/);
+});
+
+test("cool proves the owner is gone before returning", async () => {
+  let alive = true;
+  const launcher = new AcpxQueueOwnerLauncher({
+    acpxCommand: "acpx",
+    spawnOwner: async () => 41,
+    terminateOwner: async () => {
+      alive = false;
+    },
+    isOwnerAlive: async () => alive,
+  });
+  const input = {
+    acpxRecordId: "acpx-record-1",
+    coordinatorSession: "backend:main",
+    permissionMode: "approve-all" as const,
+    nonInteractivePermissions: "deny" as const,
+  };
+  await launcher.launch(input);
+  alive = true;
+  await launcher.cool("acpx-record-1");
+  await expect(launcher.wouldReuse(input)).resolves.toBe(false);
+});
+
 test("a changed effective environment replaces the warm owner without exposing secrets in the fingerprint", async () => {
   const spawns: Array<Record<string, string>> = [];
   let alive = false;

--- a/tests/unit/transport/session-effort.test.ts
+++ b/tests/unit/transport/session-effort.test.ts
@@ -2,14 +2,46 @@ import { expect, test } from "bun:test";
 
 import { sessionEffortToReapply } from "../../../src/transport/session-effort";
 
-test("sessionEffortToReapply is cold-only and skips the warmth probe without effort", async () => {
-  const mustNotProbe = async (): Promise<boolean> => {
-    throw new Error("should not probe warmth without effort");
-  };
-
-  await expect(sessionEffortToReapply("max", async () => false)).resolves.toBe("max");
-  await expect(sessionEffortToReapply("  high  ", async () => false)).resolves.toBe("high");
-  await expect(sessionEffortToReapply("max", async () => true)).resolves.toBeUndefined();
-  await expect(sessionEffortToReapply(undefined, mustNotProbe)).resolves.toBeUndefined();
-  await expect(sessionEffortToReapply("   ", mustNotProbe)).resolves.toBeUndefined();
+test("sessionEffortToReapply skips only when the live record matches and the owner is reused", () => {
+  expect(sessionEffortToReapply({
+    persisted: "high",
+    observedCurrent: "medium",
+    advertised: ["low", "medium", "high"],
+    ownerWillBeReplaced: false,
+  })).toBe("high");
+  expect(sessionEffortToReapply({
+    persisted: "  high  ",
+    observedCurrent: "medium",
+    advertised: ["high"],
+    ownerWillBeReplaced: false,
+  })).toBe("high");
+  expect(sessionEffortToReapply({
+    persisted: "high",
+    observedCurrent: "high",
+    advertised: ["medium", "high"],
+    ownerWillBeReplaced: false,
+  })).toBeUndefined();
+  expect(sessionEffortToReapply({
+    persisted: "high",
+    observedCurrent: "high",
+    advertised: ["medium", "high"],
+    ownerWillBeReplaced: true,
+  })).toBe("high");
+  expect(sessionEffortToReapply({
+    persisted: "xhigh",
+    observedCurrent: "high",
+    advertised: ["medium", "high"],
+    ownerWillBeReplaced: false,
+  })).toBeUndefined();
+  expect(sessionEffortToReapply({
+    persisted: undefined,
+    observedCurrent: "medium",
+    advertised: ["medium"],
+    ownerWillBeReplaced: true,
+  })).toBeUndefined();
+  expect(sessionEffortToReapply({
+    persisted: "   ",
+    advertised: ["high"],
+    ownerWillBeReplaced: true,
+  })).toBeUndefined();
 });

--- a/tests/unit/transport/session-effort.test.ts
+++ b/tests/unit/transport/session-effort.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+
+import { sessionEffortToReapply } from "../../../src/transport/session-effort";
+
+test("sessionEffortToReapply is cold-only and skips the warmth probe without effort", async () => {
+  const mustNotProbe = async (): Promise<boolean> => {
+    throw new Error("should not probe warmth without effort");
+  };
+
+  await expect(sessionEffortToReapply("max", async () => false)).resolves.toBe("max");
+  await expect(sessionEffortToReapply("  high  ", async () => false)).resolves.toBe("high");
+  await expect(sessionEffortToReapply("max", async () => true)).resolves.toBeUndefined();
+  await expect(sessionEffortToReapply(undefined, mustNotProbe)).resolves.toBeUndefined();
+  await expect(sessionEffortToReapply("   ", mustNotProbe)).resolves.toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- Stop replaying persisted reasoning effort via `acpx set` when the session's queue owner is already live.
- A live owner already holds the configured effort; `acpx set` against it falls back to spawning a second ACP process and `session/resume`.
- Exclusive-lease agents such as Reasonix then fail the second prompt with `QUEUE_CONTROL_REQUEST_FAILED session/resume: this session is in use by another Reasonix process`.
- Cold start (owner dead / TTL expired) still reapplies effort so reconnect restores it. Covered on both acpx-cli and bridge.

## Test plan
- [x] Unit: warm owner skips `acpx set` (`["launch", "prompt"]`) on cli + bridge
- [x] Unit: cold reconnect still `["set:high", "launch", "prompt"]`
- [ ] Local: reasonix session with persisted effort — first prompt succeeds, second prompt on the warm owner succeeds without `session/resume` lease conflict
- [ ] Local: after queue-owner TTL, next prompt still reapplies effort


Made with [Cursor](https://cursor.com)