### PR TITLE
fix(relay-web): idempotent terminal resize — dedupe on backend-synced geometry

### DIFF
--- a/packages/relay-web/src/__tests__/terminal-store.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-store.test.ts
@@ -518,6 +518,68 @@ describe("terminal store", () => {
     ]);
   });
 
+  it("same-role viewerCount churn keeps the synced belief (join)", async () => {
+    connectEvents((e) => { void useTerminalStore().applyEvent(e); });
+    const ws = FakeWS.instances[0];
+    ws.onopen?.();
+    const store = useTerminalStore();
+    const key = terminalLocalKey("i1", "demo");
+    await openAttached(store, key, ws, { role: "controller" });
+    store.sendResize(key, 70, 40);
+    expect(resizeFrames(ws)).toHaveLength(1);
+
+    // A spectator attaches: the registry broadcasts role-changed to EVERY
+    // attachment, but this one's role did not change — only viewerCount did.
+    await store.applyEvent({
+      kind: "terminal-role-changed", instanceId: "i1", attachmentId: "a1",
+      terminalId: "t1", role: "controller", viewerCount: 2,
+    });
+
+    // A duplicate applyFit at the same geometry must still be deduped.
+    store.sendResize(key, 70, 40);
+    expect(resizeFrames(ws)).toEqual([{ cols: 70, rows: 40 }]);
+    expect(store.get(key)?.syncedResize).toEqual({ cols: 70, rows: 40 });
+  });
+
+  it("same-role viewerCount churn keeps the synced belief (leave)", async () => {
+    connectEvents((e) => { void useTerminalStore().applyEvent(e); });
+    const ws = FakeWS.instances[0];
+    ws.onopen?.();
+    const store = useTerminalStore();
+    const key = terminalLocalKey("i1", "demo");
+    await openAttached(store, key, ws, { role: "controller", viewerCount: 2 });
+    store.sendResize(key, 70, 40);
+
+    // The other spectator detaches: viewerCount 2→1, role unchanged.
+    await store.applyEvent({
+      kind: "terminal-role-changed", instanceId: "i1", attachmentId: "a1",
+      terminalId: "t1", role: "controller", viewerCount: 1,
+    });
+
+    store.sendResize(key, 70, 40);
+    expect(resizeFrames(ws)).toEqual([{ cols: 70, rows: 40 }]);
+    expect(store.get(key)?.syncedResize).toEqual({ cols: 70, rows: 40 });
+  });
+
+  it("same-role spectator churn never arms a belief", async () => {
+    connectEvents((e) => { void useTerminalStore().applyEvent(e); });
+    const ws = FakeWS.instances[0];
+    ws.onopen?.();
+    const store = useTerminalStore();
+    const key = terminalLocalKey("i1", "demo");
+    await openAttached(store, key, ws, { role: "spectator", viewerCount: 2 });
+
+    await store.applyEvent({
+      kind: "terminal-role-changed", instanceId: "i1", attachmentId: "a1",
+      terminalId: "t1", role: "spectator", viewerCount: 3,
+    });
+    store.sendResize(key, 70, 40);
+
+    expect(resizeFrames(ws)).toEqual([]);
+    expect(store.get(key)?.syncedResize).toBeUndefined();
+    expect(store.get(key)?.role).toBe("spectator");
+  });
+
   it("take-control re-syncs geometry that was already pushed before demotion", async () => {
     connectEvents((e) => { void useTerminalStore().applyEvent(e); });
     const ws = FakeWS.instances[0];

--- a/packages/relay-web/src/__tests__/terminal-store.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-store.test.ts
@@ -31,6 +31,17 @@ function sentMessages(ws: FakeWS): unknown[] {
   });
 }
 
+function resizeFrames(ws: FakeWS): Array<{ cols: number; rows: number }> {
+  const frames: Array<{ cols: number; rows: number }> = [];
+  for (const m of sentMessages(ws)) {
+    if (typeof m !== "object" || m === null || !("kind" in m) || m.kind !== "terminal-resize") continue;
+    if ("cols" in m && "rows" in m && typeof m.cols === "number" && typeof m.rows === "number") {
+      frames.push({ cols: m.cols, rows: m.rows });
+    }
+  }
+  return frames;
+}
+
 async function openAttached(
   store: ReturnType<typeof useTerminalStore>,
   key: string,
@@ -455,5 +466,120 @@ describe("terminal store", () => {
     } finally {
       if (desc) Object.defineProperty(globalThis, "Buffer", desc);
     }
+  });
+
+  it("sendResize dedupes identical geometry and sends once per change", async () => {
+    connectEvents((e) => { void useTerminalStore().applyEvent(e); });
+    const ws = FakeWS.instances[0];
+    ws.onopen?.();
+    const store = useTerminalStore();
+    const key = terminalLocalKey("i1", "demo");
+    await openAttached(store, key, ws, { role: "controller" });
+
+    // Initial fit + duplicate ResizeObserver callbacks at the same geometry.
+    store.sendResize(key, 70, 40);
+    store.sendResize(key, 70, 40);
+    store.sendResize(key, 70, 40);
+    // Actual geometry change must still go through exactly once.
+    store.sendResize(key, 71, 40);
+    store.sendResize(key, 71, 40);
+
+    expect(resizeFrames(ws)).toEqual([
+      { cols: 70, rows: 40 },
+      { cols: 71, rows: 40 },
+    ]);
+    expect(store.get(key)?.syncedResize).toEqual({ cols: 71, rows: 40 });
+  });
+
+  it("role-changed back to controller re-allows the same geometry", async () => {
+    connectEvents((e) => { void useTerminalStore().applyEvent(e); });
+    const ws = FakeWS.instances[0];
+    ws.onopen?.();
+    const store = useTerminalStore();
+    const key = terminalLocalKey("i1", "demo");
+    await openAttached(store, key, ws, { role: "controller" });
+    store.sendResize(key, 70, 40);
+    expect(resizeFrames(ws)).toHaveLength(1);
+
+    // Another viewer takes control, may resize the pane, then hands it back.
+    await store.applyEvent({
+      kind: "terminal-role-changed", instanceId: "i1", attachmentId: "a1",
+      terminalId: "t1", role: "spectator", viewerCount: 2,
+    });
+    await store.applyEvent({
+      kind: "terminal-role-changed", instanceId: "i1", attachmentId: "a1",
+      terminalId: "t1", role: "controller", viewerCount: 1,
+    });
+
+    store.sendResize(key, 70, 40);
+    expect(resizeFrames(ws)).toEqual([
+      { cols: 70, rows: 40 },
+      { cols: 70, rows: 40 },
+    ]);
+  });
+
+  it("take-control re-syncs geometry that was already pushed before demotion", async () => {
+    connectEvents((e) => { void useTerminalStore().applyEvent(e); });
+    const ws = FakeWS.instances[0];
+    ws.onopen?.();
+    const store = useTerminalStore();
+    const key = terminalLocalKey("i1", "demo");
+    await openAttached(store, key, ws, { role: "controller" });
+    store.sendResize(key, 70, 40);
+
+    await store.applyEvent({
+      kind: "terminal-role-changed", instanceId: "i1", attachmentId: "a1",
+      terminalId: "t1", role: "spectator", viewerCount: 2,
+    });
+    const takePromise = store.takeControl(key);
+    const takeDecoded = decodeEnvelope(ws.send.mock.calls.at(-1)![0] as string);
+    if (!takeDecoded.ok) throw new Error("decode");
+    const takeMsg = parseWebClientMessage(takeDecoded.envelope) as { requestId: string };
+    pushEvent(ws, {
+      kind: "terminal-opened", requestId: takeMsg.requestId, instanceId: "i1",
+      terminalId: "t1", generation: "g1", attachmentId: "a1",
+      role: "controller", viewerCount: 2,
+    });
+    await takePromise;
+
+    store.sendResize(key, 70, 40);
+    expect(resizeFrames(ws)).toEqual([
+      { cols: 70, rows: 40 },
+      { cols: 70, rows: 40 },
+    ]);
+  });
+
+  it("reopen resets the synced belief so a resumed pane re-syncs its geometry", async () => {
+    connectEvents((e) => { void useTerminalStore().applyEvent(e); });
+    const ws = FakeWS.instances[0];
+    ws.onopen?.();
+    const store = useTerminalStore();
+    const key = terminalLocalKey("i1", "demo");
+    await openAttached(store, key, ws, { role: "controller" });
+    store.sendResize(key, 70, 40);
+    expect(resizeFrames(ws)).toHaveLength(1);
+
+    // Detach + reopen (e.g. reconnect/rebind): the existing pane kept its own
+    // size, so the same fit must be pushed again instead of being deduped.
+    await openAttached(store, key, ws, { role: "controller" });
+    store.sendResize(key, 70, 40);
+    expect(resizeFrames(ws)).toEqual([
+      { cols: 70, rows: 40 },
+      { cols: 70, rows: 40 },
+    ]);
+  });
+
+  it("spectator fits never push a backend resize", async () => {
+    connectEvents((e) => { void useTerminalStore().applyEvent(e); });
+    const ws = FakeWS.instances[0];
+    ws.onopen?.();
+    const store = useTerminalStore();
+    const key = terminalLocalKey("i1", "demo");
+    await openAttached(store, key, ws, { role: "spectator", viewerCount: 2 });
+
+    store.sendResize(key, 70, 40);
+    store.sendResize(key, 90, 30);
+    expect(resizeFrames(ws)).toEqual([]);
+    expect(store.get(key)?.syncedResize).toBeUndefined();
   });
 });

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -210,6 +210,54 @@ describe("TerminalTab", () => {
     expect(sendInput).toHaveBeenCalledWith("i1\0demo", "\r");
   });
 
+  it("initial fit skips local resize but still forwards the backend resize", async () => {
+    // fit() agrees with the adapter's current geometry (80x24 default) — the
+    // local emulator must not reflow, but the backend push is unconditional:
+    // the store owns "last synced" semantics, not the adapter size.
+    mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await flushPromises();
+    expect(adapter.resize).not.toHaveBeenCalled();
+    expect(sendResize).toHaveBeenCalledTimes(1);
+    expect(sendResize).toHaveBeenCalledWith("i1\0demo", 80, 24);
+  });
+
+  it("fit-driven local resize changes forward exactly one backend resize", async () => {
+    adapter.fit.mockReturnValue({ cols: 70, rows: 40 });
+    try {
+      mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+      await flushPromises();
+      expect(adapter.resize).toHaveBeenCalledWith(70, 40);
+      expect(sendResize).toHaveBeenCalledTimes(1);
+      expect(sendResize).toHaveBeenCalledWith("i1\0demo", 70, 40);
+    } finally {
+      // clearAllMocks does not reset mockReturnValue — restore the shared default.
+      adapter.fit.mockReturnValue({ cols: 80, rows: 24 });
+    }
+  });
+
+  it("spectator fits stay local; take-control re-syncs backend geometry even when unchanged", async () => {
+    adapter.fit.mockReturnValue({ cols: 80, rows: 24 });
+    openOrResume.mockImplementation(async (key: string, opts: { sessionAlias: string }) =>
+      openedView({ localKey: key, sessionAlias: opts.sessionAlias, role: "spectator", viewerCount: 2 }),
+    );
+    takeControl.mockResolvedValue(openedView({ role: "controller", viewerCount: 2 }));
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await flushPromises();
+
+    // Spectator: adapter fitted locally (fit() returns 80x24 == adapter) but
+    // no backend resize is ever pushed.
+    expect(sendResize).not.toHaveBeenCalled();
+
+    // Take control: even though the adapter is already at the target geometry,
+    // applyFit must still forward the resize — the pane may be at another size.
+    await w.find('[data-test="terminal-take-control"]').trigger("click");
+    await flushPromises();
+    expect(takeControl).toHaveBeenCalledWith("i1\0demo");
+    expect(adapter.resize).not.toHaveBeenCalled();
+    expect(sendResize).toHaveBeenCalledTimes(1);
+    expect(sendResize).toHaveBeenCalledWith("i1\0demo", 80, 24);
+  });
+
   it("host is keyboard-focusable", async () => {
     const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
     await flushPromises();

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -192,8 +192,14 @@ function applyFit(myEpoch = epoch) {
     if (host.value && host.value.clientWidth > 0) requestAnimationFrame(() => applyFit(myEpoch));
     return;
   }
-  if (dim.cols === adapter.cols() && dim.rows === adapter.rows()) return;
-  adapter.resize(dim.cols, dim.rows);
+  // Local emulator: skip redundant reflow when geometry is unchanged. The
+  // backend push below is intentionally unconditional — the local adapter size
+  // is NOT backend truth (spectator fits, resume of an existing pane,
+  // take-control handoff), so the store owns the "last synced" belief and
+  // dedupes. Early-returning here would swallow required syncs.
+  if (dim.cols !== adapter.cols() || dim.rows !== adapter.rows()) {
+    adapter.resize(dim.cols, dim.rows);
+  }
   // Spectator: local fit only — never push backend resize.
   if (canType.value) terminals.sendResize(localKey.value, dim.cols, dim.rows);
 }

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -192,6 +192,7 @@ function applyFit(myEpoch = epoch) {
     if (host.value && host.value.clientWidth > 0) requestAnimationFrame(() => applyFit(myEpoch));
     return;
   }
+  if (dim.cols === adapter.cols() && dim.rows === adapter.rows()) return;
   adapter.resize(dim.cols, dim.rows);
   // Spectator: local fit only — never push backend resize.
   if (canType.value) terminals.sendResize(localKey.value, dim.cols, dim.rows);

--- a/packages/relay-web/src/stores/terminal.ts
+++ b/packages/relay-web/src/stores/terminal.ts
@@ -394,6 +394,7 @@ export const useTerminalStore = defineStore("terminal", () => {
   function sendResize(localKey: string, cols: number, rows: number): void {
     const view = get(localKey);
     if (!view?.attachmentId || !view.generation || view.role !== "controller") return;
+    if (view.cols === cols && view.rows === rows) return;
     put({ ...view, cols, rows });
     sendWebClientMessage({
       kind: "terminal-resize",

--- a/packages/relay-web/src/stores/terminal.ts
+++ b/packages/relay-web/src/stores/terminal.ts
@@ -39,9 +39,11 @@ export interface TerminalAttachmentView {
   exitCode?: number;
   /** Geometry last pushed to the backend on the current attachment binding.
    *  Undefined until this controller has synced once — and after any rebinding
-   *  (reopen, take-control, role-changed) that breaks the "backend is at this
-   *  size" guarantee. Drives sendResize dedupe; NOT the same as cols/rows
-   *  (those are the local tab's latest fit, which spectators update too). */
+   *  or authority transition (reopen, take-control, role change) that breaks
+   *  the "backend is at this size" guarantee; pure viewerCount churn keeps it.
+   *  Drives sendResize dedupe. Distinct from cols/rows: those record the last
+   *  controller push only (spectator fits never touch the store), and the
+   *  local emulator's live size lives in the adapter, not here at all. */
   syncedResize?: { cols: number; rows: number };
 }
 
@@ -484,14 +486,19 @@ export const useTerminalStore = defineStore("terminal", () => {
     if (event.kind === "terminal-role-changed") {
       const view = findByAttachmentId(event.attachmentId);
       if (!view) return;
+      // role-changed is a broadcast to EVERY attachment on the terminal —
+      // attach/detach/takeControl/TTL expiry all recompute and fan it out even
+      // when this attachment's own role is unchanged. Only an actual authority
+      // transition breaks the "backend is at this size" guarantee (the pane
+      // may have been resized under a different controller); pure viewerCount
+      // churn must keep the belief or duplicate resizes reopen.
+      const authorityChanged = view.role !== event.role;
       put({
         ...view,
         role: event.role,
         viewerCount: event.viewerCount,
         terminalId: event.terminalId,
-        // Control authority moved; the pane may have been resized under the
-        // other controller, so drop the synced-geometry belief.
-        syncedResize: undefined,
+        syncedResize: authorityChanged ? undefined : view.syncedResize,
       });
       return;
     }

--- a/packages/relay-web/src/stores/terminal.ts
+++ b/packages/relay-web/src/stores/terminal.ts
@@ -37,6 +37,12 @@ export interface TerminalAttachmentView {
   lastErrorCode?: string;
   exitReason?: string;
   exitCode?: number;
+  /** Geometry last pushed to the backend on the current attachment binding.
+   *  Undefined until this controller has synced once — and after any rebinding
+   *  (reopen, take-control, role-changed) that breaks the "backend is at this
+   *  size" guarantee. Drives sendResize dedupe; NOT the same as cols/rows
+   *  (those are the local tab's latest fit, which spectators update too). */
+  syncedResize?: { cols: number; rows: number };
 }
 
 type RebaseCb = (localKey: string, keyframe: Uint8Array, cols: number, rows: number) => void | Promise<void>;
@@ -252,6 +258,9 @@ export const useTerminalStore = defineStore("terminal", () => {
         viewerCount: opened.viewerCount,
         recovery: initialRecoveryState(opened.generation),
         lastErrorCode: undefined,
+        // Resume of an existing pane does NOT resize it to the browser's fit —
+        // the new binding carries no "backend already at this size" guarantee.
+        syncedResize: undefined,
       };
       put(view);
       // Spec §14.5: stream starts only after opened metadata is applied locally.
@@ -390,12 +399,13 @@ export const useTerminalStore = defineStore("terminal", () => {
     ensureOutputStreamIfWaiting(view);
   }
 
-  /** RMUX path: controller-only resize for a local tab attachment. */
+  /** RMUX path: controller-only resize for a local tab attachment. Dedupes on
+   *  syncedResize so identical geometry never re-sends, while role/rebind
+   *  transitions reset the belief so required syncs are never swallowed. */
   function sendResize(localKey: string, cols: number, rows: number): void {
     const view = get(localKey);
     if (!view?.attachmentId || !view.generation || view.role !== "controller") return;
-    if (view.cols === cols && view.rows === rows) return;
-    put({ ...view, cols, rows });
+    if (view.syncedResize?.cols === cols && view.syncedResize.rows === rows) return;
     sendWebClientMessage({
       kind: "terminal-resize",
       instanceId: view.instanceId,
@@ -404,6 +414,7 @@ export const useTerminalStore = defineStore("terminal", () => {
       cols,
       rows,
     });
+    put({ ...view, cols, rows, syncedResize: { cols, rows } });
   }
 
   async function takeControl(localKey: string): Promise<TerminalAttachmentView> {
@@ -428,6 +439,7 @@ export const useTerminalStore = defineStore("terminal", () => {
       attachmentId: opened.attachmentId,
       role: opened.role,
       viewerCount: opened.viewerCount,
+      syncedResize: undefined,
     };
     put(next);
     // Open already sent stream-start; take-control does not. If recover never
@@ -477,6 +489,9 @@ export const useTerminalStore = defineStore("terminal", () => {
         role: event.role,
         viewerCount: event.viewerCount,
         terminalId: event.terminalId,
+        // Control authority moved; the pane may have been resized under the
+        // other controller, so drop the synced-geometry belief.
+        syncedResize: undefined,
       });
       return;
     }


### PR DESCRIPTION
## Root cause

Relay Web terminal 开启后连续向同一 RMUX pane 发送重复 `terminal-resize`(HAR: open 80x24 → resize 70x40 → resize 70x40,后两帧仅隔十几毫秒)。根因是 `applyFit()`(open 成功后的手动 fit + ResizeObserver 首次回调)每次都无条件调用 `adapter.resize` + `terminals.sendResize`,而 store 对相同 geometry 也无条件转发。

深层问题:系统中有**三个不同的 geometry 状态**被混用了 —

1. 本地模拟器尺寸(`adapter.cols()/rows()`)— 纯浏览器渲染态
2. 后端 RMUX pane 实际尺寸 — 只有 backend 知道
3. 浏览器对 (2) 的信念("我最后一次告知后端的尺寸")— 此前不存在

去重 key 必须是 (3),不能用 (1) 冒充(spectator→take-control、resume 已有 pane 会吞掉必要的同步),也不能绑定在 attachment 生命周期之外。

## Fix

**`stores/terminal.ts`** — `TerminalAttachmentView` 新增 `syncedResize?: { cols, rows }`,语义为 *当前 attachment binding 上最后推送到 backend 的 geometry*:

- `sendResize()` 在 `sendWebClientMessage()` 之后才记录信念;guard 比对 `syncedResize`,相同 geometry 直接 return
- 信念在三种"保证被破坏"的情形显式置 `undefined`:
  - `openOrResume` 绑定成功(resume 已有 pane 不会按浏览器 fit 改尺寸)
  - `takeControl` 成功(权限移交,pane 可能已被其他 controller 改过)
  - `terminal-role-changed` **实际 role 转换**(`view.role !== event.role`)。纯 viewerCount 变化保留信念 — registry 对 attach/detach/takeControl/TTL 都会向所有 attachment 广播 role-changed,即使自身 role 没变;无条件清除会让 viewer join/leave 重新打开 duplicate 窗口

**`components/TerminalTab.vue`** — `applyFit()` 拆开两个责任:本地 emulator 仅在 geometry 变化时 reflow;backend 转发保持无条件(store 拥有"last synced"语义)。组件层 early-return 会吞掉必要同步。

## Tests

Store 层(`terminal-store.test.ts`,FakeWS + 真 store):
- 同尺寸连续 sendResize → 恰好一帧;`70x40 → 71x40` 恰好再一帧
- role-changed demote→promote 往返后,同尺寸重发一次
- take-control 后,曾被推送过的 geometry 重发一次
- reopen(resume)后,同尺寸重发一次
- spectator 任何 fit 永不发 backend resize
- **同 role viewerCount churn(join 1→2 / leave 2→1)保留信念,仍只一帧**;spectator churn 不会武装信念

组件层(`terminal-tab.test.ts`):
- 初始 fit 与 adapter 尺寸一致 → 本地不 reflow,backend 仍转发一次
- `fit → 70x40` → 本地 resize 一次 + backend 恰好一帧
- spectator 本地 fit 不发 backend;take-control 后即使 adapter 尺寸未变也重同步

反向验证(临时恢复被否决的旧实现,确认回归测试失败):
- v1 组件层 early-return → take-control 重同步测试失败(expected 1, got 0)
- 无条件清除 role-changed 信念 → join/leave churn 测试均失败(duplicate resize 出现)

## 验证

- relay-web 全量:`114 files / 1082 tests passed`
- `vue-tsc --noEmit` ✅ · `vite build` ✅ · `git diff --check` ✅
- CI `test` job SUCCESS(rmux-bridge / Windows 路径过滤 skipped,符合纯 Relay Web PR 预期)

## 已知非阻塞项

`sendWebClientMessage()` 在 events socket 未 open 时是静默 no-op,严格说返回成功 ≠ 帧真正入网。当前 reconnect 路径会重新 `openOrResume` 并清空 `syncedResize`,窗口可恢复。长期方向:让 `sendWebClientMessage(): boolean`,offline 返回 false,`sendResize` 仅在 true 时记录信念。

## Before / after resize frame 序列

Before:`open 80x24 → resize 70x40 → resize 70x40(重复)`
After:`open 80x24 → resize 70x40`(同尺寸不再重复;真实 geometry 变化、权限移交、rebind 后的必要同步均保留)

Async prompt duplicate:超出本 PR 范围(未改动 RMUX bridge / prompt 内容)。