### PR TITLE
fix(channel-relay): inject TERM=screen-256color on macOS work windows

### DIFF
--- a/packages/channel-relay/native/rmux-bridge/src/actors.rs
+++ b/packages/channel-relay/native/rmux-bridge/src/actors.rs
@@ -2,7 +2,8 @@
 //!
 //! Create path (no rmux patches):
 //! 1. `OwnedSession` with `KillOnOwnerExit` + lease TTL
-//! 2. `new_window_with().cwd(...)` for the work pane
+//! 2. `new_window_with().cwd(...)` for the work pane, plus a macOS-only
+//!    `TERM=screen-256color` override on that pane (not daemon-global)
 //! 3. close default window 0
 //! 4. resize + `history-limit` on the stable pane id
 
@@ -12,8 +13,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rmux_sdk::{
-    CleanupPolicy, OwnedSession, PaneId, PaneRecoveryEvent, PaneRecoveryRebaseReason, Rmux,
-    SessionName, TerminalSizeSpec,
+    CleanupPolicy, NewWindowBuilder, OwnedSession, PaneId, PaneRecoveryEvent,
+    PaneRecoveryRebaseReason, Rmux, SessionName, TerminalSizeSpec,
 };
 use tokio::sync::{mpsc, Mutex};
 
@@ -86,7 +87,12 @@ impl BridgeState {
             .await
             .map_err(|e| format!("owned_session create failed: {e}"))?;
 
-        let work = match owned.new_window_with().name("shell").cwd(PathBuf::from(&cwd)).await {
+        let work_builder = owned
+            .new_window_with()
+            .name("shell")
+            .cwd(PathBuf::from(&cwd));
+        let work_builder = apply_production_work_window_env(work_builder, std::env::consts::OS);
+        let work = match work_builder.await {
             Ok(w) => w,
             Err(e) => {
                 let _ = owned.cleanup().await;
@@ -433,6 +439,34 @@ impl BridgeState {
     }
 }
 
+/// Process environment overrides for xacpx-created shell work windows.
+///
+/// `os` is [`std::env::consts::OS`] (`macos`, `linux`, `windows`, ...).
+///
+/// On macOS, inject `TERM=screen-256color`. RMUX's daemon default is
+/// `tmux-256color`, which is a valid terminal type, but the current macOS
+/// system terminfo database has no readable entry for it. Async prompts such
+/// as Powerlevel10k then cannot emit CUU/ED and append a duplicate prompt
+/// after every command. This is a host compatibility fallback, not a claim
+/// that `screen-256color` is a better default than `tmux-256color`. Other
+/// platforms keep the daemon `default-terminal`.
+fn production_work_window_env(os: &str) -> Vec<(&'static str, &'static str)> {
+    match os {
+        "macos" => vec![("TERM", "screen-256color")],
+        _ => Vec::new(),
+    }
+}
+
+fn apply_production_work_window_env<'a>(
+    mut builder: NewWindowBuilder<'a>,
+    os: &str,
+) -> NewWindowBuilder<'a> {
+    for (key, value) in production_work_window_env(os) {
+        builder = builder.env(key, value);
+    }
+    builder
+}
+
 fn parse_pane_id(raw: &str) -> Result<PaneId, String> {
     let trimmed = raw.trim().trim_start_matches('%');
     let n: u32 = trimmed
@@ -547,6 +581,43 @@ async fn with_initial_rebase_deadline<T>(
 mod tests {
     use super::*;
     use rmux_sdk::PaneStreamEndReason;
+
+    #[test]
+    fn macos_work_window_injects_screen_256color_term() {
+        assert_eq!(
+            production_work_window_env("macos"),
+            vec![("TERM", "screen-256color")]
+        );
+    }
+
+    #[test]
+    fn macos_work_window_does_not_prefer_xterm_256color() {
+        assert!(
+            !production_work_window_env("macos")
+                .iter()
+                .any(|(key, value)| *key == "TERM" && *value == "xterm-256color"),
+            "macOS fallback must be screen-256color, not xterm-256color"
+        );
+    }
+
+    #[test]
+    fn linux_work_window_keeps_daemon_default_term() {
+        assert!(production_work_window_env("linux").is_empty());
+    }
+
+    #[test]
+    fn windows_work_window_keeps_daemon_default_term() {
+        assert!(production_work_window_env("windows").is_empty());
+    }
+
+    #[test]
+    fn host_work_window_env_matches_production_helper() {
+        let env = production_work_window_env(std::env::consts::OS);
+        #[cfg(target_os = "macos")]
+        assert_eq!(env, vec![("TERM", "screen-256color")]);
+        #[cfg(not(target_os = "macos"))]
+        assert!(env.is_empty());
+    }
 
     #[test]
     fn startup_rejects_bytes_before_rebase() {


### PR DESCRIPTION
## Summary

- Duplicate Powerlevel10k prompts in RMUX `capture-pane` came from the pane `$TERM`, not from the VT/scrollback/reflow parser and not from a Web rendering bug. xacpx-created shell work windows inherit RMUX's daemon `default-terminal` (`tmux-256color`). **`tmux-256color` itself is not an error**; the problem is that the current macOS system terminfo database has no readable entry for it. zsh/p10k then see empty `terminfo[cuu1]` / `ed` / `el`, so gitstatus/transient `zle reset-prompt` appends `\r\n` + a new prompt instead of CUU+ED overwrite.
- This PR injects `TERM=screen-256color` **only on the xacpx-created shell work window** via RMUX SDK `NewWindowBuilder.env()`. It does **not** change RMUX daemon `default-terminal`, does **not** patch RMUX VT / scrollback / reflow, and does **not** string-dedupe prompts. `screen-256color` is a macOS compatibility fallback, **not** a claim that it is a better default than `tmux-256color`. `xterm-256color` is not used as the preferred fallback.
- Production pane env is a pure helper (`production_work_window_env`) so the macOS `TERM=screen-256color` contract is unit-tested without mocking the SDK request. Linux/Windows keep the daemon default.

## Test plan

- [x] Native bridge: `cargo check` / `cargo test` on `packages/channel-relay/native/rmux-bridge` (includes new tests locking macOS work-window env to `TERM=screen-256color`, and that it is not `xterm-256color`)
- [x] Existing channel-relay unit tests (`tests/unit/packages/channel-relay`)
- [x] Existing relay-web terminal tests
- [x] `bun run build` and `bun run build:channel-relay`
- [x] **New pane only** (old PTYs keep the previous TERM). macOS live verification:
  - `echo $TERM` → `screen-256color`
  - `infocmp screen-256color` exists
  - in-pane: `CUU1=$'\033'M`, `ED=$'\033'[J`, `EL=$'\033'[K`
  - `tput cuu1 | od -An -tx1` / `tput ed | od -An -tx1` (host `tput -T screen-256color cuu1` → `1b 4d`)
  - Powerlevel10k: Enter / `echo XACPX_PROMPT_TEST` / Enter — `capture-pane` leaves only the final prompt after each command, no second full async prompt
- [x] RMUX VT regressions (unchanged parser; recorded so this is not “fixed” by masking in the terminal state machine):
  - `cargo test -p rmux-core --lib async_prompt_redraw` — 5 passed (`cuu_then_ed_replaces_two_line_prompt_in_place`, `p10k_transient_accept_line_overwrite_does_not_duplicate`, `missing_terminfo_append_redraw_keeps_both_prompts`, …)
  - `cargo test -p rmux-core --lib erase_` — 11 passed (existing erase/reflow tests)


Made with [Cursor](https://cursor.com)