### PR TITLE
refactor(relay-web): centralize terminal viewport synchronization

### DIFF
--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
-import { mount, flushPromises } from "@vue/test-utils";
+import { mount, flushPromises, enableAutoUnmount } from "@vue/test-utils";
 import { TerminalRequestError } from "../api/events";
 import { initialRecoveryState } from "../lib/terminal-recovery";
 import type { TerminalAttachmentView } from "../stores/terminal";
+
+// The viewport controller keeps settling timers alive after mount; unmount
+// every wrapper so they are disposed before the next test's mock assertions.
+enableAutoUnmount(afterEach);
 
 const adapter = {
   write: vi.fn(async () => {}),
@@ -440,5 +444,48 @@ describe("TerminalTab", () => {
     expect(adapter.fit.mock.calls.length).toBe(fitCallsBefore);
     expect(adapter.resize.mock.calls.length).toBe(resizesBefore);
     expect(sendResize.mock.calls.length).toBe(sendResizesBefore);
+  });
+
+  it("re-fits when font/canvas metrics settle after open (initial layout settling)", async () => {
+    // The terminal renderer initializes asynchronously (WASM, webfont, canvas
+    // mount, CSS layout). The first measurable geometry can be the fallback
+    // font's; once the webfont lands the same host pixels fit a different
+    // grid, and nothing re-fires ResizeObserver - settling syncs must re-fit.
+    vi.useFakeTimers();
+    try {
+      adapter.fit.mockReturnValueOnce({ cols: 80, rows: 24 }).mockReturnValue({ cols: 150, rows: 45 });
+      mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+      await vi.advanceTimersByTimeAsync(0);
+      // The adapter starts at 80x24, so the first fit is a local no-op - the
+      // backend push is what proves the sync ran.
+      expect(adapter.resize).not.toHaveBeenCalled();
+      expect(sendResize).toHaveBeenCalledWith("i1\0demo", 80, 24);
+
+      await vi.advanceTimersByTimeAsync(1100); // settling window elapses
+      expect(adapter.resize).toHaveBeenLastCalledWith(150, 45);
+      expect(sendResize).toHaveBeenLastCalledWith("i1\0demo", 150, 45);
+    } finally {
+      vi.useRealTimers();
+      adapter.fit.mockReturnValue({ cols: 80, rows: 24 });
+    }
+  });
+
+  it("stops settling syncs once the tab unmounts", async () => {
+    vi.useFakeTimers();
+    try {
+      adapter.fit.mockReturnValue({ cols: 150, rows: 45 });
+      const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+      await vi.advanceTimersByTimeAsync(0);
+      w.unmount();
+      adapter.fit.mockClear();
+      adapter.resize.mockClear();
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(adapter.fit).not.toHaveBeenCalled();
+      expect(adapter.resize).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      adapter.fit.mockReturnValue({ cols: 80, rows: 24 });
+    }
   });
 });

--- a/packages/relay-web/src/__tests__/terminal-viewport.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-viewport.test.ts
@@ -1,0 +1,309 @@
+// TerminalViewportController regression suite.
+//
+// The controller owns browser-side terminal geometry: every viewport signal
+// (ResizeObserver, window resize, rebase replay, keyboard inset, layout/font
+// settling) funnels through scheduleSync(), which coalesces to one sync per
+// animation frame. Local fit and remote resize are deliberately separate
+// steps - spectators fit locally but never push, and the remote push stays
+// unconditional because the terminal store owns the "last synced" dedupe.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTerminalViewportController } from "../lib/terminal-viewport";
+import type { TerminalAdapter } from "../lib/terminal-adapter";
+
+/** Manual frame queue: frames flush only when the test pumps them. */
+function manualFrames() {
+  const pending: Array<() => void> = [];
+  const requestFrame = (cb: () => void) => {
+    pending.push(cb);
+    return () => {
+      const i = pending.indexOf(cb);
+      if (i >= 0) pending.splice(i, 1);
+    };
+  };
+  const flushOne = () => {
+    const cb = pending.shift();
+    cb?.();
+  };
+  const flushAll = () => {
+    while (pending.length) flushOne();
+  };
+  return { requestFrame, flushOne, flushAll, get pending() { return pending.length; } };
+}
+
+function fakeAdapter() {
+  let cols = 80;
+  let rows = 24;
+  const fit = vi.fn((): { cols: number; rows: number } | null => ({ cols: 150, rows: 45 }));
+  const adapter: TerminalAdapter = {
+    write: vi.fn(),
+    resize: vi.fn((c: number, r: number) => { cols = c; rows = r; }),
+    resetAndReplay: vi.fn(async () => {}),
+    dispose: vi.fn(),
+    focus: vi.fn(),
+    getSelection: vi.fn(() => ""),
+    setTheme: vi.fn(),
+    scrollLines: vi.fn(),
+    ready: vi.fn(async () => {}),
+    fit,
+    cols: () => cols,
+    rows: () => rows,
+  };
+  return { adapter, fit };
+}
+
+function host(width = 800, height = 600) {
+  const el = document.createElement("div");
+  Object.defineProperty(el, "clientWidth", { value: width, configurable: true });
+  Object.defineProperty(el, "clientHeight", { value: height, configurable: true });
+  return el;
+}
+
+function setup(opts?: Partial<Parameters<typeof createTerminalViewportController>[0]>) {
+  const frames = manualFrames();
+  const { adapter, fit } = fakeAdapter();
+  const canResizeRemote = opts?.canResizeRemote ?? vi.fn(() => true);
+  const sendRemoteResize = opts?.sendRemoteResize ?? vi.fn();
+  const el = host();
+  const controller = createTerminalViewportController({
+    host: el,
+    adapter,
+    canResizeRemote: canResizeRemote,
+    sendRemoteResize,
+    getKeyboardInset: opts?.getKeyboardInset ?? vi.fn(() => 0),
+    requestFrame: frames.requestFrame,
+  });
+  return { controller, adapter, fit, el, frames, canResizeRemote, sendRemoteResize };
+}
+
+describe("terminal viewport controller", () => {
+  beforeEach(() => { document.body.replaceChildren(); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("coalesces multiple scheduleSync calls within one frame into a single sync", () => {
+    const { controller, adapter, fit, frames } = setup();
+    controller.start();
+    frames.flushAll(); // start()'s immediate scheduleSync
+    expect(fit).toHaveBeenCalledTimes(1);
+    fit.mockClear();
+
+    controller.scheduleSync("a");
+    controller.scheduleSync("b");
+    controller.scheduleSync("c");
+    expect(fit).not.toHaveBeenCalled(); // nothing runs mid-frame
+
+    frames.flushOne();
+    expect(fit).toHaveBeenCalledTimes(1);
+    frames.flushAll();
+    expect(fit).toHaveBeenCalledTimes(1);
+    controller.dispose();
+  });
+
+  it("forceSync runs immediately and swallows the pending frame", () => {
+    const { controller, adapter, fit, frames } = setup();
+    controller.scheduleSync("pending");
+    controller.forceSync("rebase");
+    expect(fit).toHaveBeenCalledTimes(1); // ran synchronously
+
+    frames.flushAll(); // the cancelled frame must not run a second sync
+    expect(fit).toHaveBeenCalledTimes(1);
+    controller.dispose();
+  });
+
+  it("fitLocal skips redundant local reflow but the remote push stays unconditional", () => {
+    // The store's syncedResize owns dedupe: the local adapter size is NOT
+    // backend truth (spectator fits, pane resume, take-control handoff), so
+    // the controller must forward every successful fit.
+    const { controller, adapter, fit, frames, sendRemoteResize } = setup();
+    fit.mockReturnValue({ cols: 80, rows: 24 }); // == adapter's current size
+    controller.start();
+    frames.flushAll();
+    expect(adapter.resize).not.toHaveBeenCalled();
+    expect(sendRemoteResize).toHaveBeenCalledWith(80, 24);
+    controller.dispose();
+  });
+
+  it("spectators fit locally and never push a backend resize", () => {
+    const { controller, adapter, frames, sendRemoteResize } = setup({ canResizeRemote: () => false });
+    controller.start();
+    frames.flushAll();
+    expect(adapter.resize).toHaveBeenCalledWith(150, 45);
+    expect(sendRemoteResize).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("retries on the next frame while fit() is not yet measurable, then stops", () => {
+    const { controller, adapter, fit, frames } = setup();
+    fit
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null)
+      .mockReturnValue({ cols: 100, rows: 30 });
+    controller.start(); // immediate sync: fit null (#1) -> retry scheduled
+    frames.flushOne(); // retry: still null -> schedules another
+    expect(adapter.resize).not.toHaveBeenCalled();
+
+    frames.flushOne(); // retry: measurable -> fits
+    expect(adapter.resize).toHaveBeenCalledWith(100, 30);
+    expect(frames.pending).toBe(0); // no endless frame loop after success
+    controller.dispose();
+  });
+
+  it("gives up the frame retry while the host has no layout, and refits when it settles", () => {
+    const { controller, adapter, fit, el, frames } = setup();
+    fit.mockReturnValueOnce(null).mockReturnValue({ cols: 120, rows: 40 });
+    Object.defineProperty(el, "clientWidth", { value: 0, configurable: true });
+    controller.start();
+    frames.flushAll(); // host unmeasurable -> no retry scheduled
+    expect(frames.pending).toBe(0);
+    expect(adapter.resize).not.toHaveBeenCalled();
+
+    Object.defineProperty(el, "clientWidth", { value: 800, configurable: true });
+    controller.scheduleSync("layout-settled");
+    frames.flushAll();
+    expect(adapter.resize).toHaveBeenCalledWith(120, 40);
+    controller.dispose();
+  });
+
+  describe("settling", () => {
+    beforeEach(() => { vi.useFakeTimers(); });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it("re-fits as font/WASM metrics settle after start (16/64/250/1000ms)", async () => {
+      const { adapter, fit } = fakeAdapter();
+      const el = host();
+      const sendRemoteResize = vi.fn();
+      const controller = createTerminalViewportController({
+        host: el,
+        adapter,
+        canResizeRemote: () => true,
+        sendRemoteResize,
+        getKeyboardInset: () => 0,
+        requestFrame: (cb) => {
+          const t = setTimeout(() => cb(), 0);
+          return () => clearTimeout(t);
+        },
+      });
+      // First measurable size is the default font; the webfont loads later and
+      // the same host pixels now fit a different grid. (The fake adapter
+      // already starts at 80x24, so the first fit is a no-op local reflow -
+      // observe the remote push instead.)
+      fit.mockReturnValueOnce({ cols: 80, rows: 24 }).mockReturnValue({ cols: 150, rows: 45 });
+      controller.start();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(adapter.resize).not.toHaveBeenCalled();
+      expect(sendRemoteResize).toHaveBeenCalledWith(80, 24);
+
+      await vi.advanceTimersByTimeAsync(1100); // all settling timers fire
+      expect(adapter.resize).toHaveBeenLastCalledWith(150, 45);
+      expect(sendRemoteResize).toHaveBeenLastCalledWith(150, 45);
+      controller.dispose();
+    });
+
+    it("dispose stops the settling timers; double dispose is safe", async () => {
+      const { adapter, fit } = fakeAdapter();
+      const sendRemoteResize = vi.fn();
+      const controller = createTerminalViewportController({
+        host: host(),
+        adapter,
+        canResizeRemote: () => true,
+        sendRemoteResize,
+        getKeyboardInset: () => 0,
+        requestFrame: (cb) => {
+          const t = setTimeout(() => cb(), 0);
+          return () => clearTimeout(t);
+        },
+      });
+      controller.start();
+      await vi.advanceTimersByTimeAsync(0);
+      controller.dispose();
+      controller.dispose();
+
+      fit.mockClear();
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(fit).not.toHaveBeenCalled();
+    });
+  });
+
+  it("keyboard inset feeds the keyboard-independent height into fit()", () => {
+    // Soft keyboard occlusion is local: rows must be derived from the full
+    // (pre-keyboard) height so the remote grid never churns as it opens.
+    const frames = manualFrames();
+    const { adapter, fit } = fakeAdapter();
+    const sendRemoteResize = vi.fn();
+    let inset = 0;
+    const controller = createTerminalViewportController({
+      host: host(),
+      adapter,
+      canResizeRemote: () => true,
+      sendRemoteResize,
+      getKeyboardInset: () => inset,
+      requestFrame: frames.requestFrame,
+    });
+    // Simulate the adapter's inset-aware fit: 600px host, 20px cells, inset added back.
+    fit.mockImplementation((extraHeightPx = 0) => ({
+      cols: 150,
+      rows: Math.floor((600 + extraHeightPx) / 20),
+    }));
+    controller.start();
+    frames.flushAll();
+    expect(fit).toHaveBeenLastCalledWith(0);
+    expect(adapter.resize).toHaveBeenCalledWith(150, 30);
+
+    controller.setKeyboardInset(300);
+    frames.flushAll();
+    expect(fit).toHaveBeenLastCalledWith(300);
+    expect(adapter.resize).toHaveBeenLastCalledWith(150, 45);
+    controller.dispose();
+  });
+
+  it("start() syncs immediately and re-syncs on window resize", () => {
+    const { controller, adapter, fit, frames } = setup();
+    controller.start();
+    expect(fit).toHaveBeenCalledTimes(1); // immediate, no frame wait
+    fit.mockClear();
+
+    window.dispatchEvent(new Event("resize"));
+    expect(frames.pending).toBeGreaterThan(0);
+    frames.flushAll();
+    expect(fit).toHaveBeenCalledTimes(1);
+    controller.dispose();
+
+    window.dispatchEvent(new Event("resize"));
+    frames.flushAll();
+    expect(fit).toHaveBeenCalledTimes(1); // disposed: listener removed
+  });
+
+  it("start() observes the host with ResizeObserver and re-syncs on its callback", () => {
+    const instances: Array<{ cb: () => void }> = [];
+    const RealRO = globalThis.ResizeObserver;
+    class CapturingRO {
+      constructor(cb: () => void) { instances.push({ cb }); }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    globalThis.ResizeObserver = CapturingRO as unknown as typeof ResizeObserver;
+    try {
+      const frames = manualFrames();
+      const { adapter, fit } = fakeAdapter();
+      const controller = createTerminalViewportController({
+        host: host(),
+        adapter,
+        canResizeRemote: () => true,
+        sendRemoteResize: vi.fn(),
+        getKeyboardInset: () => 0,
+        requestFrame: frames.requestFrame,
+      });
+      controller.start();
+      frames.flushAll();
+      expect(instances.length).toBe(1);
+      fit.mockClear();
+
+      instances[0].cb();
+      frames.flushAll();
+      expect(fit).toHaveBeenCalledTimes(1);
+      controller.dispose();
+    } finally {
+      globalThis.ResizeObserver = RealRO;
+    }
+  });
+});

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -2,6 +2,10 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import { Keyboard, ClipboardPaste, Copy, ChevronUp, ChevronDown, ChevronLeft, ChevronRight } from "lucide-vue-next";
 import { createTerminalAdapter, type TerminalAdapter, type TerminalTheme } from "../lib/terminal-adapter";
+import {
+  createTerminalViewportController,
+  type TerminalViewportController,
+} from "../lib/terminal-viewport";
 import { useTerminalStore, terminalLocalKey, isFatalTerminalRecoveryCode, type TerminalAttachmentView } from "../stores/terminal";
 import { useThemeStore } from "../stores/theme";
 import { useConnectionStore } from "../stores/connection";
@@ -56,11 +60,11 @@ function toggleKeybar() {
 }
 
 let adapter: TerminalAdapter | null = null;
+let viewport: TerminalViewportController | null = null;
 let offRebase: (() => void) | null = null;
 let offBytes: (() => void) | null = null;
 let offMeta: (() => void) | null = null;
 let offExit: (() => void) | null = null;
-let resizeObs: ResizeObserver | null = null;
 let epoch = 0;
 let retryTimer: ReturnType<typeof setTimeout> | null = null;
 let autoRetried = false;
@@ -185,25 +189,6 @@ function onTouchEnd(e: TouchEvent) {
   if (touchMoved) { e.preventDefault(); e.stopPropagation(); }
 }
 
-function applyFit(myEpoch = epoch) {
-  if (myEpoch !== epoch || !attached.value || !adapter) return;
-  const dim = adapter.fit();
-  if (!dim) {
-    if (host.value && host.value.clientWidth > 0) requestAnimationFrame(() => applyFit(myEpoch));
-    return;
-  }
-  // Local emulator: skip redundant reflow when geometry is unchanged. The
-  // backend push below is intentionally unconditional — the local adapter size
-  // is NOT backend truth (spectator fits, resume of an existing pane,
-  // take-control handoff), so the store owns the "last synced" belief and
-  // dedupes. Early-returning here would swallow required syncs.
-  if (dim.cols !== adapter.cols() || dim.rows !== adapter.rows()) {
-    adapter.resize(dim.cols, dim.rows);
-  }
-  // Spectator: local fit only — never push backend resize.
-  if (canType.value) terminals.sendResize(localKey.value, dim.cols, dim.rows);
-}
-
 function mapErrorCode(code: string): string {
   switch (code) {
     case "terminal-disabled": return "terminal.disabled";
@@ -240,7 +225,7 @@ function releaseFrontend(detachBackend: boolean): void {
   offBytes?.(); offBytes = null;
   offMeta?.(); offMeta = null;
   offExit?.(); offExit = null;
-  resizeObs?.disconnect(); resizeObs = null;
+  viewport?.dispose(); viewport = null;
   adapter?.dispose(); adapter = null;
   if (detachBackend && attached.value) {
     terminals.detach(localKey.value);
@@ -270,7 +255,7 @@ async function openAttachment(): Promise<void> {
     // Rebase resizes to the recovery geometry; the host size did not change,
     // so ResizeObserver never re-fires — re-fit or the canvas stays shrunk.
     if (myEpoch !== epoch || adapter !== currentAdapter) return;
-    applyFit(myEpoch);
+    viewport?.forceSync("rebase");
   });
   offBytes = terminals.onBytes(async (key, data) => {
     if (key !== localKey.value || myEpoch !== epoch) return;
@@ -305,9 +290,14 @@ async function openAttachment(): Promise<void> {
     autoRetried = false;
     status.value = "open";
     applyMeta(view);
-    resizeObs = new ResizeObserver(() => applyFit());
-    if (host.value) resizeObs.observe(host.value);
-    applyFit(myEpoch);
+    viewport = createTerminalViewportController({
+      host: host.value!,
+      adapter: currentAdapter,
+      canResizeRemote: () => canType.value,
+      sendRemoteResize: (cols, rows) => terminals.sendResize(localKey.value, cols, rows),
+      getKeyboardInset: () => 0,
+    });
+    viewport.start();
     currentAdapter.focus();
   } catch (e) {
     if (myEpoch !== epoch) return;
@@ -337,7 +327,9 @@ async function takeControl(): Promise<void> {
   try {
     const view = await terminals.takeControl(localKey.value);
     applyMeta(view);
-    applyFit();
+    // New authority: force a sync so the store's syncedResize belief resets
+    // and the backend converges on this browser's geometry.
+    viewport?.forceSync("take-control");
   } catch {
     /* server remains the authority; role-changed will update if another path succeeds */
   } finally {

--- a/packages/relay-web/src/lib/terminal-adapter.ts
+++ b/packages/relay-web/src/lib/terminal-adapter.ts
@@ -67,8 +67,10 @@ export interface TerminalAdapter {
   /** Scroll the viewport by N lines (positive = toward the newest/bottom rows). */
   scrollLines(amount: number): void;
   /** Compute cols/rows that fit the host element, using the rendered canvas cell size.
-   *  Returns null until the canvas has a measurable size. */
-  fit(): { cols: number; rows: number } | null;
+   *  Returns null until the canvas has a measurable size. `extraHeightPx` adds
+   *  height the host visually lost to local occlusion (soft keyboard) so the
+   *  grid stays keyboard-independent - see TerminalViewportController. */
+  fit(extraHeightPx?: number): { cols: number; rows: number } | null;
   cols(): number;
   rows(): number;
 }
@@ -231,7 +233,7 @@ export function createTerminalAdapter(el: HTMLElement, opts: TerminalAdapterOpti
       else t.renderer?.setTheme?.(theme);
     }); },
     scrollLines: (n) => live?.scrollLines?.(n),
-    fit: () => {
+    fit: (extraHeightPx = 0) => {
       if (!live?.element || !live.cols || !live.rows) return null;
       const canvas = live.element.querySelector("canvas");
       if (!canvas) return null;
@@ -241,7 +243,7 @@ export function createTerminalAdapter(el: HTMLElement, opts: TerminalAdapterOpti
       if (!(cellW > 0) || !(cellH > 0)) return null;
       return {
         cols: Math.max(2, Math.floor(el.clientWidth / cellW)),
-        rows: Math.max(1, Math.floor(el.clientHeight / cellH)),
+        rows: Math.max(1, Math.floor((el.clientHeight + extraHeightPx) / cellH)),
       };
     },
     cols: () => live?.cols ?? opts.cols,

--- a/packages/relay-web/src/lib/terminal-viewport.ts
+++ b/packages/relay-web/src/lib/terminal-viewport.ts
@@ -1,0 +1,155 @@
+// Terminal viewport controller - owns browser-side terminal geometry.
+//
+// Every viewport signal (host ResizeObserver, window resize, rebase replay,
+// keyboard inset changes, initial font/WASM settling) funnels through
+// scheduleSync(), which coalesces to a single sync per animation frame - a
+// burst of resize events never produces a burst of fits. A sync is two
+// deliberately separate steps:
+//
+//   fitLocal()  - reflow the local emulator to whatever fits the host
+//   syncRemote() - forward the geometry to the backend (controller role only)
+//
+// The remote push is unconditional on every successful fit: the local adapter
+// size is NOT backend truth (spectator fits, pane resume, take-control
+// handoff), so the terminal store's syncedResize owns the dedupe. Spectators
+// never push - their local fit must not change backend geometry.
+//
+// Layout settlement: the terminal renderer initializes across several frames
+// (WASM, webfont, canvas mount, CSS layout), and a font swap changes cell
+// metrics without changing host pixels - ResizeObserver stays silent. start()
+// therefore re-syncs on a short settling ladder (immediate + 16/64/250/1000ms)
+// so the grid always converges to the final metrics.
+
+import type { TerminalAdapter } from "./terminal-adapter";
+
+/** Syncs re-issued after start() to absorb renderer/font/CSS settling. */
+const SETTLING_SYNC_DELAYS_MS = [16, 64, 250, 1000];
+
+export interface TerminalViewportControllerOptions {
+  host: HTMLElement;
+  adapter: TerminalAdapter;
+  /** Controller-role gate; spectators fit locally but never push a resize. */
+  canResizeRemote(): boolean;
+  /** Backend resize forwarder (terminal store owns the syncedResize dedupe). */
+  sendRemoteResize(cols: number, rows: number): void;
+  /** Soft-keyboard occlusion px to add back to the host height when fitting,
+   *  so the remote grid is keyboard-independent (local occlusion only). */
+  getKeyboardInset(): number;
+  /** Test seam: frame scheduler. Defaults to requestAnimationFrame. */
+  requestFrame?(cb: () => void): () => void;
+}
+
+export interface TerminalViewportController {
+  start(): void;
+  /** Idempotent; stops the frame, settling timers, and observers. */
+  dispose(): void;
+  /** Coalesced sync: runs at most one sync per animation frame. */
+  scheduleSync(reason?: string): void;
+  /** Immediate sync: runs now and replaces any pending frame. */
+  forceSync(reason?: string): void;
+  setKeyboardInset(px: number): void;
+}
+
+export function createTerminalViewportController(
+  opts: TerminalViewportControllerOptions,
+): TerminalViewportController {
+  const { host, adapter, canResizeRemote, sendRemoteResize } = opts;
+  const requestFrame = opts.requestFrame
+    ?? ((cb: () => void) => {
+      const id = requestAnimationFrame(() => cb());
+      return () => cancelAnimationFrame(id);
+    });
+
+  let started = false;
+  let disposed = false;
+  let keyboardInset = 0;
+  let cancelFrame: (() => void) | null = null;
+  let resizeObserver: ResizeObserver | null = null;
+  const settlingTimers: ReturnType<typeof setTimeout>[] = [];
+  const onWindowResize = () => scheduleSync("window-resize");
+
+  function scheduleSync(reason?: string): void {
+    if (disposed || cancelFrame) return;
+    cancelFrame = requestFrame(() => {
+      cancelFrame = null;
+      runSync(reason);
+    });
+  }
+
+  function forceSync(reason?: string): void {
+    if (disposed) return;
+    cancelFrame?.();
+    cancelFrame = null;
+    runSync(reason);
+  }
+
+  function runSync(reason?: string): void {
+    if (disposed) return;
+    const dim = fitLocal();
+    if (dim) syncRemote(dim);
+  }
+
+  /** Reflow the local emulator to the host; returns the applied geometry.
+   *  Null while the renderer is not yet measurable. */
+  function fitLocal(): { cols: number; rows: number } | null {
+    // The keyboard inset is added back: the remote grid must be sized for the
+    // full (pre-keyboard) host height so opening/closing the soft keyboard
+    // never churns the backend pane layout - it only occludes locally.
+    const dim = adapter.fit(keyboardInset);
+    if (!dim) {
+      // Renderer not measurable yet (WASM/font/canvas). Retry next frame while
+      // the host has layout; once measurable the retries stop on their own.
+      if (host.clientWidth > 0) scheduleSync("fit-retry");
+      return null;
+    }
+    if (dim.cols !== adapter.cols() || dim.rows !== adapter.rows()) {
+      adapter.resize(dim.cols, dim.rows);
+    }
+    return dim;
+  }
+
+  /** Forward the fit geometry to the backend. The adapter's own cols/rows are
+   *  NOT used here: adapter.resize() is queued, so its reported size can still
+   *  be stale in this task - the fit result is the truth being pushed. Dedupe
+   *  stays the store's job (syncedResize). */
+  function syncRemote(dim: { cols: number; rows: number }): void {
+    if (!canResizeRemote()) return;
+    sendRemoteResize(dim.cols, dim.rows);
+  }
+
+  return {
+    start(): void {
+      if (started || disposed) return;
+      started = true;
+      if (typeof ResizeObserver !== "undefined") {
+        resizeObserver = new ResizeObserver(() => scheduleSync("host-resize"));
+        resizeObserver.observe(host);
+      }
+      window.addEventListener("resize", onWindowResize, { passive: true });
+      // Immediate sync (not scheduled): the first fit must land in the same
+      // task as the attachment becoming ready, before any frame wait.
+      forceSync("start");
+      for (const delay of SETTLING_SYNC_DELAYS_MS) {
+        settlingTimers.push(setTimeout(() => scheduleSync(`settle-${delay}`), delay));
+      }
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      cancelFrame?.();
+      cancelFrame = null;
+      for (const t of settlingTimers.splice(0)) clearTimeout(t);
+      resizeObserver?.disconnect();
+      resizeObserver = null;
+      window.removeEventListener("resize", onWindowResize);
+    },
+    scheduleSync,
+    forceSync,
+    setKeyboardInset(px: number): void {
+      const next = Math.max(0, Math.round(px));
+      if (next === keyboardInset) return;
+      keyboardInset = next;
+      scheduleSync("keyboard-inset");
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Extract `TerminalViewportController` so every browser geometry signal (host `ResizeObserver`, window resize, rebase replay, layout/font settling) funnels through one RAF-coalesced `scheduleSync()` / `forceSync()`.
- Late recovery rebase still rebuilds at the **authoritative** RMUX keyframe cols/rows, then `forceSync("rebase")` re-fits the host under epoch/adapter/disposed guards — the canvas no longer stays shrunk when ResizeObserver does not re-fire.
- Local fit and remote resize are separate steps. Spectators fit locally and never push. The controller push stays unconditional; `syncedResize` in the terminal store remains the sole backend dedupe authority.
- `adapter.fit()` accepts optional `extraHeightPx` so a later PR can size the remote grid against the pre-keyboard host height. This PR still passes 0.

## Borrowed design, not protocol

Modeled on rmux-web-share's viewport lifecycle (`scheduleTerminalViewportSync`, settling timers 16/64/250/1000ms). **Not** adopted:

- rmux-web-share WebSocket / E2EE / PIN / session-view protocol
- 2-cell resize hysteresis (XACPX pane recovery + exact `syncedResize` is safer)
- VT `ESC[2J`/`ESC[3J` stripping
- xterm.js swap

Rebase authoritative geometry and spectator/backend resize invariants are unchanged.

## Test plan

- [x] `packages/relay-web` unit tests (viewport controller + TerminalTab late-rebase / settle / stale-replay)
- [x] `vue-tsc` / root `tsc` / `git diff --check`
- [ ] Manual: desktop open fills the host; refresh 5× never sticks at 80x24; browser resize follows

Stacked: this is **PR A**. Mobile keyboard/touch is PR C (`refactor/relay-web-mobile-input-lifecycle`). Playwright is PR E2E (`test/relay-web-terminal-e2e`). IME cursor anchor already landed in #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)