### PR TITLE
refactor(relay-web): harden mobile terminal input lifecycle

### DIFF
--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -19,6 +19,8 @@ const adapter = {
   scrollLines: vi.fn(),
   resetAndReplay: vi.fn(async () => {}),
   fit: vi.fn((): { cols: number; rows: number } | null => ({ cols: 80, rows: 24 })),
+  localGeometry: vi.fn(() => null),
+  syncInputAnchor: vi.fn(),
   cols: () => 80,
   rows: () => 24,
 };

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -470,6 +470,106 @@ describe("TerminalTab", () => {
     }
   });
 
+  it("keyboard inset lifts locally and compensates the remote fit height", async () => {
+    // Soft keyboard is local occlusion: the visible surface lifts by the inset
+    // while the viewport controller adds it back into the fit height, so the
+    // remote grid stays keyboard-independent.
+    const realMM = window.matchMedia;
+    const vvListeners = new Set<() => void>();
+    const fakeVV = {
+      height: 800, offsetTop: 0, scale: 1,
+      addEventListener(type: string, cb: () => void) { if (type === "resize") vvListeners.add(cb); },
+      removeEventListener(type: string, cb: () => void) { if (type === "resize") vvListeners.delete(cb); },
+    };
+    Object.defineProperty(window, "visualViewport", { value: fakeVV, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 800, configurable: true });
+    window.matchMedia = ((q: string) => ({
+      matches: q.includes("coarse"),
+      media: q, onchange: null,
+      addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+    try {
+      const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+      document.body.appendChild(w.element); // focus tracking needs document attachment
+      await flushPromises();
+      const host = w.find('[data-test="terminal-host"]').element as HTMLElement;
+      const ta = document.createElement("textarea");
+      host.appendChild(ta);
+      ta.focus();
+      expect(document.activeElement).toBe(ta);
+
+      fakeVV.height = 500; // keyboard opens
+      for (const cb of vvListeners) cb();
+      await flushPromises();
+
+      // The keyboard-inset sync coalesces into the pending settling frame;
+      // poll until it lands (no fixed sleeps).
+      await vi.waitFor(() => expect(adapter.fit).toHaveBeenLastCalledWith(300));
+      const center = w.find('[data-test="terminal-center"]').element as HTMLElement;
+      expect(center.style.paddingBottom).toBe("300px");
+    } finally {
+      window.matchMedia = realMM;
+      delete (window as { visualViewport?: unknown }).visualViewport;
+    }
+  });
+
+  it("toolbar keys do not focus the terminal on touch; Enter and Paste do", async () => {
+    const realMM = window.matchMedia;
+    window.matchMedia = ((q: string) => ({
+      matches: q.includes("coarse"),
+      media: q, onchange: null,
+      addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+    try {
+      const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+      await flushPromises();
+      const keybar = w.find('[data-test="keybar"]');
+      expect(keybar.exists()).toBe(true); // mobile default
+
+      adapter.focus.mockClear();
+      await w.find('[data-test="key-esc"]').trigger("click");
+      expect(sendInput).toHaveBeenCalledWith("i1\0demo", "\u001b");
+      expect(adapter.focus).not.toHaveBeenCalled();
+
+      await w.find('[data-test="key-enter"]').trigger("click");
+      expect(adapter.focus).toHaveBeenCalledTimes(1);
+    } finally {
+      window.matchMedia = realMM;
+    }
+  });
+
+  it("desktop keybar keeps terminal focus after sending a key", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await flushPromises();
+    if (!w.find('[data-test="keybar"]').exists()) {
+      await w.find('[data-test="toggle-keybar"]').trigger("click");
+    }
+    adapter.focus.mockClear();
+    await w.find('[data-test="key-esc"]').trigger("click");
+    expect(adapter.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("copy prefers the native selection and ignores clipboard denial", async () => {
+    const w = mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
+    await flushPromises();
+    if (!w.find('[data-test="keybar"]').exists()) {
+      await w.find('[data-test="toggle-keybar"]').trigger("click");
+    }
+    const getSelection = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "native-selection",
+    } as unknown as Selection);
+    adapter.getSelection.mockReturnValue("adapter-selection");
+    // navigator.clipboard is undefined in jsdom -> writeText is skipped, and the
+    // failure must not detach the terminal or throw.
+    await w.find('[data-test="key-copy"]').trigger("click");
+    await flushPromises();
+    expect(getSelection).toHaveBeenCalled();
+    getSelection.mockRestore();
+    expect(detach).not.toHaveBeenCalled();
+  });
+
   it("stops settling syncs once the tab unmounts", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/relay-web/src/__tests__/terminal-touch.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-touch.test.ts
@@ -1,0 +1,90 @@
+// Terminal touch scroll state machine: pending (browser owns the gesture,
+// long-press stays native) -> scrolling (threshold crossed, preventDefault,
+// whole-line terminal scroll).
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { bindTerminalTouchScroll } from "../lib/terminal-touch";
+
+function touchPoint(x: number, y: number) {
+  return { clientX: x, clientY: y };
+}
+
+/** jsdom has no TouchEvent; an Event with expando touches is enough here. */
+function touchEvent(type: "touchstart" | "touchmove" | "touchend", point: { clientX: number; clientY: number }) {
+  const e = new Event(type, { cancelable: true });
+  Object.assign(e, { touches: [touchPoint(point.clientX, point.clientY)] });
+  return e;
+}
+
+function setupHost(rows = 24, hostHeight = 600) {
+  const host = document.createElement("div");
+  Object.defineProperty(host, "clientHeight", { value: hostHeight, configurable: true });
+  document.body.appendChild(host);
+  const scrollLines = vi.fn();
+  const dispose = bindTerminalTouchScroll({ host, rows: () => rows, scrollLines });
+  return { host, scrollLines, dispose };
+}
+
+describe("bindTerminalTouchScroll", () => {
+  let cleanup: Array<() => void> = [];
+  beforeEach(() => { document.body.replaceChildren(); cleanup = []; });
+  afterEach(() => { cleanup.forEach((d) => d()); });
+
+  it("sub-threshold moves stay native: no scroll, no preventDefault", () => {
+    const { host, scrollLines } = setupHost();
+    host.dispatchEvent(touchEvent("touchstart", { clientX: 100, clientY: 300 }));
+    const small = touchEvent("touchmove", { clientX: 102, clientY: 304 });
+    host.dispatchEvent(small);
+    expect(scrollLines).not.toHaveBeenCalled();
+    expect(small.defaultPrevented).toBe(false);
+  });
+
+  it("dragging past the threshold scrolls by whole lines and cancels the gesture", () => {
+    const { host, scrollLines } = setupHost();
+    host.dispatchEvent(touchEvent("touchstart", { clientX: 100, clientY: 300 }));
+    const move = touchEvent("touchmove", { clientX: 100, clientY: 325 }); // 25px, cell = 25
+    host.dispatchEvent(move);
+    expect(move.defaultPrevented).toBe(true);
+    expect(scrollLines).toHaveBeenCalledWith(-1);
+  });
+
+  it("accumulates the pixel remainder across moves", () => {
+    const { host, scrollLines } = setupHost();
+    host.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 0 }));
+    host.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 8 }));  // crosses threshold
+    host.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 20 })); // +12 residual
+    expect(scrollLines).not.toHaveBeenCalled();
+    host.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 40 })); // +20 -> 40px residual
+    expect(scrollLines).toHaveBeenCalledWith(-1); // 1 full line of 25px
+  });
+
+  it("touchend after a scroll is cancelled; a new gesture starts pending", () => {
+    const { host, scrollLines } = setupHost();
+    host.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 0 }));
+    host.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 30 }));
+    expect(scrollLines).toHaveBeenCalledTimes(1);
+    const end = touchEvent("touchend", { clientX: 0, clientY: 30 });
+    host.dispatchEvent(end);
+    expect(end.defaultPrevented).toBe(true);
+
+    host.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 0 }));
+    host.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 5 }));
+    expect(scrollLines).toHaveBeenCalledTimes(1); // still pending, no scroll
+  });
+
+  it("multi-touch resets to idle", () => {
+    const { host, scrollLines } = setupHost();
+    const twoFinger = new Event("touchstart", { cancelable: true });
+    Object.assign(twoFinger, { touches: [touchPoint(0, 0), touchPoint(10, 10)] });
+    host.dispatchEvent(twoFinger);
+    host.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 30 }));
+    expect(scrollLines).not.toHaveBeenCalled();
+  });
+
+  it("dispose removes the listeners", () => {
+    const { host, scrollLines, dispose } = setupHost();
+    dispose();
+    host.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 0 }));
+    host.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 60 }));
+    expect(scrollLines).not.toHaveBeenCalled();
+  });
+});

--- a/packages/relay-web/src/__tests__/terminal-touch.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-touch.test.ts
@@ -15,12 +15,12 @@ function touchEvent(type: "touchstart" | "touchmove" | "touchend", point: { clie
   return e;
 }
 
-function setupHost(rows = 24, hostHeight = 600) {
+function setupHost(cellHeight = 25, hostHeight = 600) {
   const host = document.createElement("div");
   Object.defineProperty(host, "clientHeight", { value: hostHeight, configurable: true });
   document.body.appendChild(host);
   const scrollLines = vi.fn();
-  const dispose = bindTerminalTouchScroll({ host, rows: () => rows, scrollLines });
+  const dispose = bindTerminalTouchScroll({ host, lineHeight: () => cellHeight, scrollLines });
   return { host, scrollLines, dispose };
 }
 
@@ -69,6 +69,17 @@ describe("bindTerminalTouchScroll", () => {
     host.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 0 }));
     host.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 5 }));
     expect(scrollLines).toHaveBeenCalledTimes(1); // still pending, no scroll
+  });
+
+  it("scrolls by the renderer cell height, independent of the host height (keyboard-open)", () => {
+    // A 40-row terminal at 20px cells is an 800px canvas. The open keyboard
+    // shrinks the HOST to 500px without shrinking rows; host-derived math
+    // (500/40 = 12.5px) would over-count lines. The lineHeight callback reads
+    // the real rendered cell height, so a 40px drag is exactly 2 lines.
+    const { host, scrollLines } = setupHost(20, 500);
+    host.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 0 }));
+    host.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 40 }));
+    expect(scrollLines).toHaveBeenCalledWith(-2);
   });
 
   it("multi-touch resets to idle", () => {

--- a/packages/relay-web/src/__tests__/terminal-viewport-insets.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-viewport-insets.test.ts
@@ -1,0 +1,210 @@
+// Soft-keyboard viewport inset measurement + tracker.
+//
+// The keyboard/browser-chrome classification is behavioral: a shrink only
+// counts as the keyboard while an editable inside the terminal host holds
+// focus AND the shrink is keyboard-sized. The tracker commits opens/grows
+// immediately and debounces closes with a fresh re-measure at fire time.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  measureTerminalViewportInsets,
+  bindTerminalKeyboardInset,
+  KEYBOARD_INSET_CLOSE_DELAY_MS,
+  type TerminalViewportLike,
+} from "../lib/terminal-viewport-insets";
+
+type VvEvent = "resize" | "scroll";
+
+function installVisualViewport(height: number, offsetTop = 0, scale = 1) {
+  const listeners = new Map<VvEvent, Set<() => void>>([["resize", new Set()], ["scroll", new Set()]]);
+  const vv: TerminalViewportLike & EventTarget = {
+    height, offsetTop, scale,
+    addEventListener: (type: string, cb: EventListenerOrEventListenerObject) => {
+      listeners.get(type as VvEvent)?.add(cb as () => void);
+    },
+    removeEventListener: (type: string, cb: EventListenerOrEventListenerObject) => {
+      listeners.get(type as VvEvent)?.delete(cb as () => void);
+    },
+    dispatchEvent: () => true,
+  } as unknown as TerminalViewportLike & EventTarget;
+  Object.defineProperty(window, "visualViewport", { value: vv, configurable: true });
+  return {
+    set(height: number, offsetTop = 0) {
+      (vv as { height: number }).height = height;
+      (vv as { offsetTop: number }).offsetTop = offsetTop;
+      for (const cb of listeners.get("resize") ?? []) cb();
+    },
+    poke: () => { for (const cb of listeners.get("resize") ?? []) cb(); },
+  };
+}
+
+function focusedHostWithTextarea(): { host: HTMLElement; ta: HTMLTextAreaElement } {
+  const host = document.createElement("div");
+  const ta = document.createElement("textarea");
+  host.appendChild(ta);
+  document.body.appendChild(host);
+  ta.focus();
+  return { host, ta };
+}
+
+describe("measureTerminalViewportInsets", () => {
+  let host: HTMLElement;
+  let ta: HTMLTextAreaElement;
+  beforeEach(() => {
+    document.body.replaceChildren();
+    ({ host, ta } = focusedHostWithTextarea());
+    Object.defineProperty(window, "innerHeight", { value: 800, configurable: true });
+  });
+
+  it("desktop never reports insets", () => {
+    const r = measureTerminalViewportInsets({
+      visualViewport: { height: 400, offsetTop: 0, scale: 1 },
+      windowHeight: 800, terminalHost: host, activeElement: ta,
+      connected: true, mobile: false,
+    });
+    expect(r).toEqual({ keyboardInset: 0, viewportTopInset: 0, viewportBottomInset: 0 });
+  });
+
+  it("keyboard-sized shrink with terminal editable focus lifts as keyboard", () => {
+    const r = measureTerminalViewportInsets({
+      visualViewport: { height: 500, offsetTop: 0, scale: 1 },
+      windowHeight: 800, terminalHost: host, activeElement: ta,
+      connected: true, mobile: true,
+    });
+    expect(r).toEqual({ keyboardInset: 300, viewportTopInset: 0, viewportBottomInset: 0 });
+  });
+
+  it("sub-threshold shrink is chrome, not keyboard", () => {
+    const r = measureTerminalViewportInsets({
+      visualViewport: { height: 750, offsetTop: 10, scale: 1 },
+      windowHeight: 800, terminalHost: host, activeElement: ta,
+      connected: true, mobile: true,
+    });
+    expect(r.keyboardInset).toBe(0);
+    expect(r.viewportTopInset).toBe(10);
+    expect(r.viewportBottomInset).toBe(40);
+  });
+
+  it("non-editable focus inside the host is not a keyboard claim", () => {
+    const canvas = document.createElement("canvas");
+    host.appendChild(canvas);
+    canvas.focus?.();
+    const r = measureTerminalViewportInsets({
+      visualViewport: { height: 500, offsetTop: 0, scale: 1 },
+      windowHeight: 800, terminalHost: host, activeElement: canvas,
+      connected: true, mobile: true,
+    });
+    expect(r.keyboardInset).toBe(0);
+    expect(r.viewportBottomInset).toBe(300);
+  });
+
+  it("focus outside the terminal host is browser chrome, not keyboard", () => {
+    const r = measureTerminalViewportInsets({
+      visualViewport: { height: 500, offsetTop: 0, scale: 1 },
+      windowHeight: 800, terminalHost: host, activeElement: document.body,
+      connected: true, mobile: true,
+    });
+    expect(r.keyboardInset).toBe(0);
+  });
+
+  it("disconnected attachments never claim a keyboard", () => {
+    const r = measureTerminalViewportInsets({
+      visualViewport: { height: 500, offsetTop: 0, scale: 1 },
+      windowHeight: 800, terminalHost: host, activeElement: ta,
+      connected: false, mobile: true,
+    });
+    expect(r.keyboardInset).toBe(0);
+  });
+
+  it("pinch zoom disables insets entirely", () => {
+    const r = measureTerminalViewportInsets({
+      visualViewport: { height: 500, offsetTop: 0, scale: 1.5 },
+      windowHeight: 800, terminalHost: host, activeElement: ta,
+      connected: true, mobile: true,
+    });
+    expect(r).toEqual({ keyboardInset: 0, viewportTopInset: 0, viewportBottomInset: 0 });
+  });
+
+  it("a null visualViewport reports zeros", () => {
+    const r = measureTerminalViewportInsets({
+      visualViewport: null,
+      windowHeight: 800, terminalHost: host, activeElement: ta,
+      connected: true, mobile: true,
+    });
+    expect(r).toEqual({ keyboardInset: 0, viewportTopInset: 0, viewportBottomInset: 0 });
+  });
+});
+
+describe("bindTerminalKeyboardInset", () => {
+  let host: HTMLElement;
+  let ta: HTMLTextAreaElement;
+  let vv: ReturnType<typeof installVisualViewport>;
+  let onInset: ReturnType<typeof vi.fn>;
+  let dispose: (() => void) | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.replaceChildren();
+    ({ host, ta } = focusedHostWithTextarea());
+    Object.defineProperty(window, "innerHeight", { value: 800, configurable: true });
+    vv = installVisualViewport(800);
+    onInset = vi.fn();
+  });
+  afterEach(() => {
+    dispose?.();
+    dispose = null;
+    vi.useRealTimers();
+    delete (window as { visualViewport?: unknown }).visualViewport;
+  });
+
+  function bind() {
+    dispose = bindTerminalKeyboardInset({
+      host,
+      isMobile: () => true,
+      isConnected: () => true,
+      onKeyboardInset: onInset,
+    });
+  }
+
+  it("keyboard open commits immediately", () => {
+    bind();
+    vv.set(500);
+    expect(onInset).toHaveBeenCalledWith(300);
+  });
+
+  it("per-keystroke shrink transient never drops the inset", async () => {
+    bind();
+    vv.set(500); // keyboard open: 300
+    vv.set(560); // transient shrink: measured 240 < current 300 -> deferred
+    vv.set(500); // recovered: cancels the close, still 300
+    await vi.advanceTimersByTimeAsync(KEYBOARD_INSET_CLOSE_DELAY_MS * 2);
+    expect(onInset).toHaveBeenCalledTimes(1);
+    expect(onInset).toHaveBeenLastCalledWith(300);
+  });
+
+  it("real close commits zero after the debounce, re-measuring fresh", async () => {
+    bind();
+    vv.set(500);
+    expect(onInset).toHaveBeenLastCalledWith(300);
+
+    vv.set(800); // keyboard closed: measured 0 -> deferred close
+    // Reopened before the timer fires: the fire-time re-measure must see the
+    // keyboard still open at the same inset (never commits a stale zero).
+    vv.set(500);
+    await vi.advanceTimersByTimeAsync(KEYBOARD_INSET_CLOSE_DELAY_MS * 2);
+    expect(onInset).toHaveBeenCalledTimes(1);
+
+    vv.set(800); // and now a sustained close
+    await vi.advanceTimersByTimeAsync(KEYBOARD_INSET_CLOSE_DELAY_MS + 10);
+    expect(onInset).toHaveBeenLastCalledWith(0);
+    expect(onInset).toHaveBeenCalledTimes(2);
+  });
+
+  it("dispose stops the close timer and removes listeners", async () => {
+    bind();
+    vv.set(500);
+    dispose?.();
+    vv.set(800);
+    await vi.advanceTimersByTimeAsync(KEYBOARD_INSET_CLOSE_DELAY_MS * 2);
+    expect(onInset).toHaveBeenCalledTimes(1); // only the open commit
+  });
+});

--- a/packages/relay-web/src/__tests__/terminal-viewport.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-viewport.test.ts
@@ -33,7 +33,8 @@ function manualFrames() {
 function fakeAdapter() {
   let cols = 80;
   let rows = 24;
-  const fit = vi.fn((): { cols: number; rows: number } | null => ({ cols: 150, rows: 45 }));
+  const fit = vi.fn((_extraHeightPx = 0): { cols: number; rows: number } | null => ({ cols: 150, rows: 45 }));
+  const localGeometry = vi.fn((): { cellHeight: number; canvasHeight: number; cursorY: number } | null => null);
   const adapter: TerminalAdapter = {
     write: vi.fn(),
     resize: vi.fn((c: number, r: number) => { cols = c; rows = r; }),
@@ -45,10 +46,12 @@ function fakeAdapter() {
     scrollLines: vi.fn(),
     ready: vi.fn(async () => {}),
     fit,
+    localGeometry,
+    syncInputAnchor: vi.fn(),
     cols: () => cols,
     rows: () => rows,
   };
-  return { adapter, fit };
+  return { adapter, fit, localGeometry };
 }
 
 function host(width = 800, height = 600) {
@@ -60,7 +63,7 @@ function host(width = 800, height = 600) {
 
 function setup(opts?: Partial<Parameters<typeof createTerminalViewportController>[0]>) {
   const frames = manualFrames();
-  const { adapter, fit } = fakeAdapter();
+  const { adapter, fit, localGeometry } = fakeAdapter();
   const canResizeRemote = opts?.canResizeRemote ?? vi.fn(() => true);
   const sendRemoteResize = opts?.sendRemoteResize ?? vi.fn();
   const el = host();
@@ -71,7 +74,7 @@ function setup(opts?: Partial<Parameters<typeof createTerminalViewportController
     sendRemoteResize,
     requestFrame: frames.requestFrame,
   });
-  return { controller, adapter, fit, el, frames, canResizeRemote, sendRemoteResize };
+  return { controller, adapter, fit, localGeometry, el, frames, canResizeRemote, sendRemoteResize };
 }
 
 describe("terminal viewport controller", () => {
@@ -248,6 +251,125 @@ describe("terminal viewport controller", () => {
     expect(fit).toHaveBeenLastCalledWith(300);
     expect(adapter.resize).toHaveBeenLastCalledWith(150, 45);
     controller.dispose();
+  });
+
+  describe("keyboard-open local cursor-follow", () => {
+    it("scrolls the host so the cursor row stays visible without resizing the grid", async () => {
+      // 40 rows × 20px = 800px canvas; keyboard shrinks the host to 500px.
+      const frames = manualFrames();
+      const { adapter, fit, localGeometry } = fakeAdapter();
+      const el = host(800, 500);
+      const controller = createTerminalViewportController({
+        host: el,
+        adapter,
+        canResizeRemote: () => true,
+        sendRemoteResize: vi.fn(),
+        requestFrame: frames.requestFrame,
+      });
+      fit.mockReturnValue({ cols: 150, rows: 40 });
+      localGeometry.mockReturnValue({ cellHeight: 20, canvasHeight: 800, cursorY: 39 });
+      controller.start();
+      frames.flushAll();
+
+      controller.setKeyboardInset(300);
+      frames.flushAll();
+
+      // Cursor row 39 bottom = 40*20 = 800px; visible is 500px -> scroll 300px.
+      expect(el.style.alignItems).toBe("flex-start");
+      expect(el.scrollTop).toBe(300);
+      // The scroll moved the canvas under a stationary IME anchor: re-anchor.
+      expect(adapter.syncInputAnchor).toHaveBeenCalled();
+      // Remote grid stayed at the fit rows — never shrunk for the keyboard.
+      expect(adapter.resize).toHaveBeenLastCalledWith(150, 40);
+    });
+
+    it("clears the local follow when the keyboard closes", async () => {
+      const frames = manualFrames();
+      const { adapter, fit, localGeometry } = fakeAdapter();
+      const el = host(800, 500);
+      const controller = createTerminalViewportController({
+        host: el,
+        adapter,
+        canResizeRemote: () => true,
+        sendRemoteResize: vi.fn(),
+        requestFrame: frames.requestFrame,
+      });
+      fit.mockReturnValue({ cols: 150, rows: 40 });
+      localGeometry.mockReturnValue({ cellHeight: 20, canvasHeight: 800, cursorY: 39 });
+      controller.start();
+      frames.flushAll();
+      controller.setKeyboardInset(300);
+      frames.flushAll();
+      expect(el.scrollTop).toBe(300);
+
+      controller.setKeyboardInset(0);
+      frames.flushAll();
+      expect(el.style.alignItems).toBe("");
+      expect(el.scrollTop).toBe(0);
+    });
+
+    it("revealCursor re-scrolls on live output without a fit or remote push", async () => {
+      const frames = manualFrames();
+      const { adapter, fit, localGeometry } = fakeAdapter();
+      const sendRemoteResize = vi.fn();
+      const el = host(800, 500);
+      const controller = createTerminalViewportController({
+        host: el,
+        adapter,
+        canResizeRemote: () => true,
+        sendRemoteResize,
+        requestFrame: frames.requestFrame,
+      });
+      fit.mockReturnValue({ cols: 150, rows: 40 });
+      controller.start();
+      frames.flushAll();
+      controller.setKeyboardInset(300);
+      localGeometry.mockReturnValue({ cellHeight: 20, canvasHeight: 800, cursorY: 30 });
+      frames.flushAll();
+      expect(el.scrollTop).toBe(120); // (30+1)*20 - 500
+
+      // Cursor moves down on output; revealCursor must follow without re-fitting.
+      const fitCalls = fit.mock.calls.length;
+      const resizeCalls = sendRemoteResize.mock.calls.length;
+      localGeometry.mockReturnValue({ cellHeight: 20, canvasHeight: 800, cursorY: 39 });
+      controller.revealCursor();
+      expect(el.scrollTop).toBe(300);
+      expect(fit.mock.calls.length).toBe(fitCalls);
+      expect(sendRemoteResize.mock.calls.length).toBe(resizeCalls);
+    });
+  });
+
+  it("honors a keyboard inset set before start() on the very first fit (re-attach while keyboard open)", () => {
+    // Re-attach with the keyboard already up: the keyboardInset is remembered,
+    // so setKeyboardInset() runs BEFORE start(). The first forceSync must then
+    // fit the full (pre-keyboard) grid, never the shrunken host — otherwise the
+    // remote grid would temporarily collapse 40→25 rows and reflow back to 40.
+    const frames = manualFrames();
+    const { adapter, fit, localGeometry } = fakeAdapter();
+    const sendRemoteResize = vi.fn();
+    const el = host(800, 500); // keyboard-shrunk visible host
+    const controller = createTerminalViewportController({
+      host: el,
+      adapter,
+      canResizeRemote: () => true,
+      sendRemoteResize,
+      requestFrame: frames.requestFrame,
+    });
+    fit.mockImplementation((extraHeightPx = 0) => ({
+      cols: 150,
+      rows: Math.floor((500 + extraHeightPx) / 20),
+    }));
+    localGeometry.mockReturnValue({ cellHeight: 20, canvasHeight: 800, cursorY: 39 });
+
+    controller.setKeyboardInset(300);
+    controller.start();
+    frames.flushAll();
+
+    // The first fit already carried the inset; no fit(0) ever happened.
+    expect(fit.mock.calls[0][0]).toBe(300);
+    const rowsSeen = fit.mock.calls.map((c) => Math.floor((500 + (c[0] ?? 0)) / 20));
+    expect(rowsSeen).not.toContain(25);
+    expect(sendRemoteResize).toHaveBeenCalledWith(150, 40);
   });
 
   it("start() syncs immediately and re-syncs on window resize", () => {

--- a/packages/relay-web/src/__tests__/terminal-viewport.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-viewport.test.ts
@@ -69,7 +69,6 @@ function setup(opts?: Partial<Parameters<typeof createTerminalViewportController
     adapter,
     canResizeRemote: canResizeRemote,
     sendRemoteResize,
-    getKeyboardInset: opts?.getKeyboardInset ?? vi.fn(() => 0),
     requestFrame: frames.requestFrame,
   });
   return { controller, adapter, fit, el, frames, canResizeRemote, sendRemoteResize };
@@ -176,7 +175,6 @@ describe("terminal viewport controller", () => {
         adapter,
         canResizeRemote: () => true,
         sendRemoteResize,
-        getKeyboardInset: () => 0,
         requestFrame: (cb) => {
           const t = setTimeout(() => cb(), 0);
           return () => clearTimeout(t);
@@ -206,7 +204,6 @@ describe("terminal viewport controller", () => {
         adapter,
         canResizeRemote: () => true,
         sendRemoteResize,
-        getKeyboardInset: () => 0,
         requestFrame: (cb) => {
           const t = setTimeout(() => cb(), 0);
           return () => clearTimeout(t);
@@ -229,13 +226,11 @@ describe("terminal viewport controller", () => {
     const frames = manualFrames();
     const { adapter, fit } = fakeAdapter();
     const sendRemoteResize = vi.fn();
-    let inset = 0;
     const controller = createTerminalViewportController({
       host: host(),
       adapter,
       canResizeRemote: () => true,
       sendRemoteResize,
-      getKeyboardInset: () => inset,
       requestFrame: frames.requestFrame,
     });
     // Simulate the adapter's inset-aware fit: 600px host, 20px cells, inset added back.
@@ -290,7 +285,6 @@ describe("terminal viewport controller", () => {
         adapter,
         canResizeRemote: () => true,
         sendRemoteResize: vi.fn(),
-        getKeyboardInset: () => 0,
         requestFrame: frames.requestFrame,
       });
       controller.start();

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -246,6 +246,9 @@ async function openAttachment(): Promise<void> {
   offBytes = terminals.onBytes(async (key, data) => {
     if (key !== localKey.value || myEpoch !== epoch) return;
     await currentAdapter.write(data);
+    // Live output moves the cursor without a geometry change; keep the prompt
+    // visible under the open keyboard (no fit / no remote push).
+    viewport?.revealCursor();
   });
   offMeta = terminals.onMeta((key, view) => {
     if (key !== localKey.value || myEpoch !== epoch) return;
@@ -282,9 +285,13 @@ async function openAttachment(): Promise<void> {
       canResizeRemote: () => canType.value,
       sendRemoteResize: (cols, rows) => terminals.sendResize(localKey.value, cols, rows),
     });
-    viewport.start();
-    // A soft keyboard opened before this (re)attach must keep compensating.
+    // Set the inset BEFORE start(): start() force-syncs immediately, and it
+    // must carry the keyboard height on the very first fit. Ordering this the
+    // other way (start, then setKeyboardInset) fits the shrunken host once —
+    // e.g. 40→25 rows — then re-fits back to 40, a spurious remote reflow on
+    // every re-attach while the keyboard is open.
     if (keyboardInset.value > 0) viewport.setKeyboardInset(keyboardInset.value);
+    viewport.start();
     currentAdapter.focus();
   } catch (e) {
     if (myEpoch !== epoch) return;
@@ -339,7 +346,9 @@ function attachInputLifecycles() {
   if (!el) return;
   offTouchScroll = bindTerminalTouchScroll({
     host: el,
-    rows: () => adapter?.rows() ?? 24,
+    // Real rendered cell height — the keyboard shrinks the host without
+    // shrinking rows, so host.clientHeight/rows under-reports the cell height.
+    lineHeight: () => adapter?.localGeometry()?.cellHeight ?? null,
     scrollLines: (n) => adapter?.scrollLines(n),
   });
   offKeyboardInset = bindTerminalKeyboardInset({

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -6,6 +6,8 @@ import {
   createTerminalViewportController,
   type TerminalViewportController,
 } from "../lib/terminal-viewport";
+import { bindTerminalKeyboardInset } from "../lib/terminal-viewport-insets";
+import { bindTerminalTouchScroll } from "../lib/terminal-touch";
 import { useTerminalStore, terminalLocalKey, isFatalTerminalRecoveryCode, type TerminalAttachmentView } from "../stores/terminal";
 import { useThemeStore } from "../stores/theme";
 import { useConnectionStore } from "../stores/connection";
@@ -126,27 +128,33 @@ function applyMods(seq: string): string {
   return seq;
 }
 
-function sendKey(seq: string) {
+function sendKey(seq: string, opts?: { refocus?: boolean }) {
   if (!canType.value) return;
   const out = applyMods(seq);
   if (anyModArmed()) disarmMods();
   terminals.sendInput(localKey.value, out);
-  adapter?.focus();
+  // Toolbar keys must not pop the soft keyboard on touch devices - only
+  // keyboard-requiring actions (Paste, Enter) and the terminal surface tap
+  // re-focus the IME anchor there. Desktop always keeps focus after the keybar.
+  if (opts?.refocus || !isCoarsePointer()) adapter?.focus();
 }
 
 async function pasteClipboard() {
   if (!canType.value) return;
   try {
     const text = await navigator.clipboard?.readText();
-    if (text) sendKey(text);
+    // Clipboard failures are browser-policy dependent: ignore this action
+    // only - never detach the terminal or trip recovery.
+    if (text) sendKey(text, { refocus: true });
   } catch { /* clipboard blocked/unavailable — ignore */ }
 }
 
 async function copySelection() {
-  const sel = adapter?.getSelection() ?? "";
+  // Prefer a native long-press selection (mobile) over the renderer's own.
+  const sel = window.getSelection()?.toString() || adapter?.getSelection() || "";
   if (!sel) return;
   try { await navigator.clipboard?.writeText(sel); } catch { /* clipboard blocked — ignore */ }
-  adapter?.focus();
+  if (!isCoarsePointer()) adapter?.focus();
 }
 
 function pageLines(): number {
@@ -155,39 +163,17 @@ function pageLines(): number {
 function pageUp() { adapter?.scrollLines(-pageLines()); }
 function pageDown() { adapter?.scrollLines(pageLines()); }
 
-const KEYBOARD_MIN_INSET = 120;
-const hostFocused = ref(false);
+function isCoarsePointer(): boolean {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    && window.matchMedia("(pointer: coarse)").matches;
+}
+// Soft-keyboard occlusion px (mobile). Local-only: it lifts the visible
+// surface via paddingBottom AND is added back to the fit height through the
+// viewport controller, so the remote grid never churns as the keyboard
+// opens/closes. Fed by bindTerminalKeyboardInset (debounced measurement).
 const keyboardInset = ref(0);
-function updateKeyboardInset() {
-  const vv = typeof window !== "undefined" ? window.visualViewport : null;
-  if (!vv || !hostFocused.value) { keyboardInset.value = 0; return; }
-  const raw = Math.round(window.innerHeight - vv.height - vv.offsetTop);
-  keyboardInset.value = raw > KEYBOARD_MIN_INSET ? raw : 0;
-}
 
-let touchStartY = 0, touchStartX = 0, touchLastY = 0, touchResidual = 0, touchMoved = false;
-function onTouchStart(e: TouchEvent) {
-  if (e.touches.length !== 1) return;
-  const t = e.touches[0];
-  touchStartY = touchLastY = t.clientY; touchStartX = t.clientX;
-  touchResidual = 0; touchMoved = false;
-}
-function onTouchMove(e: TouchEvent) {
-  if (e.touches.length !== 1 || !adapter || !host.value) return;
-  const t = e.touches[0];
-  if (!touchMoved && Math.hypot(t.clientX - touchStartX, t.clientY - touchStartY) < 8) return;
-  touchMoved = true;
-  e.preventDefault(); e.stopPropagation();
-  const lineH = host.value.clientHeight / Math.max(1, adapter.rows());
-  if (!(lineH > 0)) return;
-  touchResidual += t.clientY - touchLastY;
-  touchLastY = t.clientY;
-  const lines = Math.trunc(touchResidual / lineH);
-  if (lines !== 0) { adapter.scrollLines(-lines); touchResidual -= lines * lineH; }
-}
-function onTouchEnd(e: TouchEvent) {
-  if (touchMoved) { e.preventDefault(); e.stopPropagation(); }
-}
+
 
 function mapErrorCode(code: string): string {
   switch (code) {
@@ -295,9 +281,10 @@ async function openAttachment(): Promise<void> {
       adapter: currentAdapter,
       canResizeRemote: () => canType.value,
       sendRemoteResize: (cols, rows) => terminals.sendResize(localKey.value, cols, rows),
-      getKeyboardInset: () => 0,
     });
     viewport.start();
+    // A soft keyboard opened before this (re)attach must keep compensating.
+    if (keyboardInset.value > 0) viewport.setKeyboardInset(keyboardInset.value);
     currentAdapter.focus();
   } catch (e) {
     if (myEpoch !== epoch) return;
@@ -337,8 +324,6 @@ async function takeControl(): Promise<void> {
   }
 }
 
-function onHostFocusIn() { hostFocused.value = true; updateKeyboardInset(); }
-function onHostFocusOut() { hostFocused.value = false; keyboardInset.value = 0; }
 function onHostMouseDown() {
   if (canTakeControl.value) {
     void takeControl();
@@ -347,23 +332,29 @@ function onHostMouseDown() {
   if (isController()) adapter?.focus();
 }
 
-function attachTouch() {
+let offTouchScroll: (() => void) | null = null;
+let offKeyboardInset: (() => void) | null = null;
+function attachInputLifecycles() {
   const el = host.value;
   if (!el) return;
-  el.addEventListener("touchstart", onTouchStart, { capture: true, passive: true });
-  el.addEventListener("touchmove", onTouchMove, { capture: true, passive: false });
-  el.addEventListener("touchend", onTouchEnd, { capture: true });
-  el.addEventListener("focusin", onHostFocusIn);
-  el.addEventListener("focusout", onHostFocusOut);
+  offTouchScroll = bindTerminalTouchScroll({
+    host: el,
+    rows: () => adapter?.rows() ?? 24,
+    scrollLines: (n) => adapter?.scrollLines(n),
+  });
+  offKeyboardInset = bindTerminalKeyboardInset({
+    host: el,
+    isMobile: isCoarsePointer,
+    isConnected: () => status.value === "open" && attached.value,
+    onKeyboardInset: (px) => {
+      keyboardInset.value = px;
+      viewport?.setKeyboardInset(px);
+    },
+  });
 }
-function detachTouch() {
-  const el = host.value;
-  if (!el) return;
-  el.removeEventListener("touchstart", onTouchStart, { capture: true });
-  el.removeEventListener("touchmove", onTouchMove, { capture: true });
-  el.removeEventListener("touchend", onTouchEnd, { capture: true });
-  el.removeEventListener("focusin", onHostFocusIn);
-  el.removeEventListener("focusout", onHostFocusOut);
+function detachInputLifecycles() {
+  offTouchScroll?.(); offTouchScroll = null;
+  offKeyboardInset?.(); offKeyboardInset = null;
 }
 
 function onPageHide() {
@@ -373,9 +364,7 @@ function onPageHide() {
 
 onMounted(() => {
   void openAttachment();
-  attachTouch();
-  window.visualViewport?.addEventListener("resize", updateKeyboardInset);
-  window.visualViewport?.addEventListener("scroll", updateKeyboardInset);
+  attachInputLifecycles();
   window.addEventListener("pagehide", onPageHide);
 });
 watch(() => [props.instanceId, props.sessionAlias], () => { void openAttachment(); });
@@ -394,9 +383,7 @@ watch(() => instances.byId(props.instanceId)?.online, (online) => {
 });
 onBeforeUnmount(() => {
   if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
-  detachTouch();
-  window.visualViewport?.removeEventListener("resize", updateKeyboardInset);
-  window.visualViewport?.removeEventListener("scroll", updateKeyboardInset);
+  detachInputLifecycles();
   window.removeEventListener("pagehide", onPageHide);
   releaseFrontend(true);
 });
@@ -476,7 +463,7 @@ onBeforeUnmount(() => {
       <button data-test="key-pageup" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="pageUp">PgUp</button>
       <button data-test="key-pagedown" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="pageDown">PgDn</button>
       <button data-test="key-insert" :disabled="!canType" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg disabled:opacity-40" @click="sendKey(KEYS.insert)">Ins</button>
-      <button data-test="key-enter" :disabled="!canType" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg disabled:opacity-40" @click="sendKey(KEYS.enter)">Enter</button>
+      <button data-test="key-enter" :disabled="!canType" class="shrink-0 rounded-md border border-border bg-bg px-2.5 py-1 font-mono text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg disabled:opacity-40" @click="sendKey(KEYS.enter, { refocus: true })">Enter</button>
       <span class="h-4 w-px shrink-0 bg-border" aria-hidden="true" />
       <button data-test="key-copy" class="ml-auto flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 py-1 text-[12px] text-fg-muted transition-colors hover:bg-raised hover:text-fg" @click="copySelection">
         <Copy :size="14" />{{ $t("terminal.keybar.copy") }}

--- a/packages/relay-web/src/lib/terminal-adapter.ts
+++ b/packages/relay-web/src/lib/terminal-adapter.ts
@@ -45,6 +45,18 @@ export interface GhosttyTerminalLike {
   rows: number;
 }
 
+/** Local rendered-canvas geometry used for keyboard-open cursor-follow. Distinct from
+ *  the remote grid: the soft keyboard shrinks the HOST without shrinking rows, so a
+ *  taller canvas must be scrolled to keep the cursor row visible locally. */
+export interface TerminalLocalGeometry {
+  /** Rendered canvas cell height in px. */
+  cellHeight: number;
+  /** Rendered canvas total height in px (= rows × cellHeight). */
+  canvasHeight: number;
+  /** Active-screen cursor row (0-indexed, absolute viewport). */
+  cursorY: number;
+}
+
 export interface TerminalAdapter {
   /** Resolves once the underlying terminal is open and wired. Rejects if construction fails
    *  or the adapter is disposed before that happens — never hangs forever either way. */
@@ -71,6 +83,13 @@ export interface TerminalAdapter {
    *  height the host visually lost to local occlusion (soft keyboard) so the
    *  grid stays keyboard-independent - see TerminalViewportController. */
   fit(extraHeightPx?: number): { cols: number; rows: number } | null;
+  /** Local cursor/canvas metrics (cell height, canvas height, cursor row) for
+   *  keyboard-open cursor-follow. Null until the canvas is measurable. */
+  localGeometry(): TerminalLocalGeometry | null;
+  /** Re-anchor the IME helper textarea at the cursor using the CURRENT canvas
+   *  rect. The host can be scrolled (keyboard cursor-follow) without the canvas
+   *  resizing, so the anchor must re-measure after any such scroll. */
+  syncInputAnchor(): void;
   cols(): number;
   rows(): number;
 }
@@ -245,6 +264,21 @@ export function createTerminalAdapter(el: HTMLElement, opts: TerminalAdapterOpti
         cols: Math.max(2, Math.floor(el.clientWidth / cellW)),
         rows: Math.max(1, Math.floor((el.clientHeight + extraHeightPx) / cellH)),
       };
+    },
+    localGeometry: () => {
+      if (!live?.element || !live.rows) return null;
+      const canvas = live.element.querySelector("canvas");
+      if (!canvas) return null;
+      const rect = canvas.getBoundingClientRect();
+      if (!(rect.height > 0)) return null;
+      return {
+        cellHeight: rect.height / live.rows,
+        canvasHeight: rect.height,
+        cursorY: live.buffer?.active?.cursorY ?? 0,
+      };
+    },
+    syncInputAnchor: () => {
+      if (live) syncGhosttyInputAnchor(el, live);
     },
     cols: () => live?.cols ?? opts.cols,
     rows: () => live?.rows ?? opts.rows,

--- a/packages/relay-web/src/lib/terminal-touch.ts
+++ b/packages/relay-web/src/lib/terminal-touch.ts
@@ -8,16 +8,18 @@
 //   touchend/pointercancel         back to idle
 //
 // Sub-threshold moves never preventDefault, so long-press selection stays
-// native. Scrolling converts pixel deltas to lines using the live cell height
-// (host height / current rows), with a per-gesture pixel remainder.
+// native. Scrolling converts pixel deltas to lines using the RENDERED cell
+// height — never host.clientHeight / rows: the on-screen keyboard shrinks the
+// host without shrinking the grid, so the host-derived ratio under-reports the
+// real cell height the more the keyboard occludes.
 
 /** Drag distance before a touch becomes a terminal scroll. */
 const TOUCH_SCROLL_THRESHOLD_PX = 8;
 
 export interface TerminalTouchScrollOptions {
   host: HTMLElement;
-  /** Current terminal rows; used to derive the cell height. */
-  rows(): number;
+  /** Rendered canvas cell height in px; null until the canvas is measurable. */
+  lineHeight(): number | null;
   scrollLines(amount: number): void;
 }
 
@@ -28,14 +30,8 @@ type TouchState =
 
 /** Binds touch scroll listeners on the host (capture phase). Returns dispose. */
 export function bindTerminalTouchScroll(opts: TerminalTouchScrollOptions): () => void {
-  const { host, rows, scrollLines } = opts;
+  const { host, lineHeight, scrollLines } = opts;
   let state: TouchState = { kind: "idle" };
-
-  function lineHeight(): number {
-    const rowsNow = Math.max(1, rows());
-    const h = host.clientHeight / rowsNow;
-    return h > 0 ? h : 0;
-  }
 
   function onTouchStart(e: TouchEvent) {
     if (e.touches.length !== 1) {
@@ -59,7 +55,7 @@ export function bindTerminalTouchScroll(opts: TerminalTouchScrollOptions): () =>
     e.preventDefault();
     e.stopPropagation();
     const lineH = lineHeight();
-    if (!(lineH > 0)) return;
+    if (!lineH || !(lineH > 0)) return;
     state.residual += t.clientY - state.lastY;
     state.lastY = t.clientY;
     const lines = Math.trunc(state.residual / lineH);

--- a/packages/relay-web/src/lib/terminal-touch.ts
+++ b/packages/relay-web/src/lib/terminal-touch.ts
@@ -1,0 +1,91 @@
+// Terminal touch scroll - a small explicit state machine so terminal dragging
+// and native long-press behavior (text selection, context menu) coexist.
+//
+//   idle -> pending (touchstart)   no preventDefault: a stationary touch is
+//                                  left to the browser for long-press
+//   pending -> scrolling (>=8px)   preventDefault + capture: the drag scrolls
+//                                  the terminal viewport by whole lines
+//   touchend/pointercancel         back to idle
+//
+// Sub-threshold moves never preventDefault, so long-press selection stays
+// native. Scrolling converts pixel deltas to lines using the live cell height
+// (host height / current rows), with a per-gesture pixel remainder.
+
+/** Drag distance before a touch becomes a terminal scroll. */
+const TOUCH_SCROLL_THRESHOLD_PX = 8;
+
+export interface TerminalTouchScrollOptions {
+  host: HTMLElement;
+  /** Current terminal rows; used to derive the cell height. */
+  rows(): number;
+  scrollLines(amount: number): void;
+}
+
+type TouchState =
+  | { kind: "idle" }
+  | { kind: "pending"; startX: number; startY: number; lastY: number; residual: number }
+  | { kind: "scrolling"; lastY: number; residual: number };
+
+/** Binds touch scroll listeners on the host (capture phase). Returns dispose. */
+export function bindTerminalTouchScroll(opts: TerminalTouchScrollOptions): () => void {
+  const { host, rows, scrollLines } = opts;
+  let state: TouchState = { kind: "idle" };
+
+  function lineHeight(): number {
+    const rowsNow = Math.max(1, rows());
+    const h = host.clientHeight / rowsNow;
+    return h > 0 ? h : 0;
+  }
+
+  function onTouchStart(e: TouchEvent) {
+    if (e.touches.length !== 1) {
+      state = { kind: "idle" };
+      return;
+    }
+    const t = e.touches[0];
+    state = { kind: "pending", startX: t.clientX, startY: t.clientY, lastY: t.clientY, residual: 0 };
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    if (e.touches.length !== 1) return;
+    const t = e.touches[0];
+    if (state.kind === "pending") {
+      // Below threshold the browser still owns the gesture (long-press
+      // selection); never preventDefault in the pending phase.
+      if (Math.hypot(t.clientX - state.startX, t.clientY - state.startY) < TOUCH_SCROLL_THRESHOLD_PX) return;
+      state = { kind: "scrolling", lastY: state.lastY, residual: state.residual };
+    }
+    if (state.kind !== "scrolling") return;
+    e.preventDefault();
+    e.stopPropagation();
+    const lineH = lineHeight();
+    if (!(lineH > 0)) return;
+    state.residual += t.clientY - state.lastY;
+    state.lastY = t.clientY;
+    const lines = Math.trunc(state.residual / lineH);
+    if (lines !== 0) {
+      scrollLines(-lines);
+      state.residual -= lines * lineH;
+    }
+  }
+
+  function onTouchEnd(e: TouchEvent) {
+    if (state.kind === "scrolling") {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    state = { kind: "idle" };
+  }
+
+  host.addEventListener("touchstart", onTouchStart, { capture: true, passive: true });
+  host.addEventListener("touchmove", onTouchMove, { capture: true, passive: false });
+  host.addEventListener("touchend", onTouchEnd, { capture: true });
+  host.addEventListener("touchcancel", onTouchEnd, { capture: true });
+  return () => {
+    host.removeEventListener("touchstart", onTouchStart, { capture: true });
+    host.removeEventListener("touchmove", onTouchMove, { capture: true });
+    host.removeEventListener("touchend", onTouchEnd, { capture: true });
+    host.removeEventListener("touchcancel", onTouchEnd, { capture: true });
+    state = { kind: "idle" };
+  };
+}

--- a/packages/relay-web/src/lib/terminal-viewport-insets.ts
+++ b/packages/relay-web/src/lib/terminal-viewport-insets.ts
@@ -1,0 +1,171 @@
+// Soft-keyboard viewport insets - mobile browser lifecycle, modeled on
+// rmux-web-share's viewport-insets design (measurement semantics only).
+//
+// Both the on-screen keyboard and collapsible browser chrome shrink
+// visualViewport; the distinction is behavioral, not browser-specific:
+//   keyboard  = an editable INSIDE the terminal host holds focus AND the
+//               viewport lost a large chunk of height (keyboard-sized)
+//   chrome    = anything else (address bar, safe area, viewport scroll)
+//
+// The keyboard inset is LOCAL occlusion only. The terminal grid must never
+// shrink because a keyboard opened: TerminalViewportController adds the inset
+// back to the host height when fitting (keyboard-independent remote geometry),
+// and the app layout lifts the visible surface by the same amount.
+
+/** Below this shrink the viewport change is not keyboard-sized (chrome/bars). */
+export const MIN_KEYBOARD_INSET_PX = 120;
+/** Pinch zoom disables inset compensation entirely. */
+const MAX_VIEWPORT_SCALE_FOR_INSETS = 1.01;
+
+export interface TerminalViewportLike {
+  height: number;
+  offsetTop: number;
+  scale: number;
+}
+
+export interface TerminalViewportInsetInput {
+  visualViewport: TerminalViewportLike | null;
+  windowHeight: number;
+  terminalHost: HTMLElement;
+  activeElement: Element | null;
+  /** Attachment open - a disconnected tab never claims a keyboard. */
+  connected: boolean;
+  /** Touch viewport gate; desktop never reports insets. */
+  mobile: boolean;
+}
+
+export interface TerminalViewportInsets {
+  keyboardInset: number;
+  viewportTopInset: number;
+  viewportBottomInset: number;
+}
+
+function zeroInsets(): TerminalViewportInsets {
+  return { keyboardInset: 0, viewportTopInset: 0, viewportBottomInset: 0 };
+}
+
+function positiveRound(value: number): number {
+  return Math.max(0, Math.round(value));
+}
+
+function hostHasEditableFocus(host: HTMLElement, active: Element | null): boolean {
+  if (!(active instanceof HTMLElement) || !host.contains(active)) return false;
+  return active instanceof HTMLTextAreaElement
+    || active instanceof HTMLInputElement
+    || active.isContentEditable;
+}
+
+/** Pure measurement: classify the current viewport shrink as keyboard vs
+ *  browser chrome. No listeners, no timers - fully deterministic. */
+export function measureTerminalViewportInsets(input: TerminalViewportInsetInput): TerminalViewportInsets {
+  const vv = input.visualViewport;
+  if (!input.mobile || !vv || vv.scale > MAX_VIEWPORT_SCALE_FOR_INSETS) {
+    return zeroInsets();
+  }
+
+  const top = positiveRound(vv.offsetTop);
+  const bottom = positiveRound(input.windowHeight - vv.offsetTop - vv.height);
+  const keyboard = positiveRound(input.windowHeight - vv.height);
+  const keyboardCanLift =
+    input.connected
+    && hostHasEditableFocus(input.terminalHost, input.activeElement)
+    && keyboard > MIN_KEYBOARD_INSET_PX
+    && bottom > MIN_KEYBOARD_INSET_PX;
+
+  if (keyboardCanLift) {
+    // While typing, the whole shrink is the keyboard; browser chrome is
+    // absorbed into the lift so the input line stays visible.
+    return { keyboardInset: keyboard, viewportTopInset: 0, viewportBottomInset: 0 };
+  }
+  return { keyboardInset: 0, viewportTopInset: top, viewportBottomInset: bottom };
+}
+
+/** A real keyboard close is sustained; a per-keystroke viewport transient
+ *  recovers within a frame or two. Defer shrinking the inset by this long so
+ *  the transient cannot collapse the local lift mid-typing. */
+export const KEYBOARD_INSET_CLOSE_DELAY_MS = 300;
+
+export interface TerminalKeyboardInsetOptions {
+  host: HTMLElement;
+  isMobile(): boolean;
+  isConnected(): boolean;
+  /** Keyboard-inset commit (local lift + fit compensation). */
+  onKeyboardInset(px: number): void;
+  closeDelayMs?: number;
+}
+
+/**
+ * Tracks visualViewport and commits keyboard insets with close-debounce.
+ *
+ * Opening/growing commits immediately (the lift must track the keyboard with
+ * no lag); shrinking/closing defers a single re-measure - the timer re-measures
+ * at fire time (never commits a stale value), and a grow event cancels it.
+ * Returns a dispose function; safe to call once.
+ */
+export function bindTerminalKeyboardInset(
+  opts: TerminalKeyboardInsetOptions,
+): () => void {
+  const vv = typeof window !== "undefined" ? window.visualViewport : null;
+  if (!vv) return () => {};
+  const closeDelay = opts.closeDelayMs ?? KEYBOARD_INSET_CLOSE_DELAY_MS;
+
+  let current = 0;
+  let closeTimer: ReturnType<typeof setTimeout> | null = null;
+  let disposed = false;
+
+  function measure(): TerminalViewportInsets {
+    return measureTerminalViewportInsets({
+      visualViewport: vv,
+      windowHeight: window.innerHeight,
+      terminalHost: opts.host,
+      activeElement: document.activeElement,
+      connected: opts.isConnected(),
+      mobile: opts.isMobile(),
+    });
+  }
+
+  function commit(px: number): void {
+    if (px === current) return;
+    current = px;
+    opts.onKeyboardInset(px);
+  }
+
+  function clearCloseTimer(): void {
+    if (closeTimer !== null) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
+  }
+
+  function apply(): void {
+    if (disposed) return;
+    const measured = measure();
+    if (measured.keyboardInset >= current || current === 0) {
+      // Opening/growing, or a hard close from zero (desktop, disconnected):
+      // apply immediately so the lift tracks the keyboard with no lag.
+      clearCloseTimer();
+      commit(measured.keyboardInset);
+      return;
+    }
+    // Shrinking or closing while the keyboard is up: defer one re-measure. A
+    // genuine close is sustained and still lands; a transient recovers (a grow
+    // commits immediately and cancels this, or the re-measure holds the inset).
+    if (closeTimer === null) {
+      closeTimer = setTimeout(() => {
+        closeTimer = null;
+        if (disposed) return;
+        commit(measure().keyboardInset);
+      }, closeDelay);
+    }
+  }
+
+  vv.addEventListener("resize", apply);
+  vv.addEventListener("scroll", apply);
+  apply();
+  return () => {
+    disposed = true;
+    clearCloseTimer();
+    vv.removeEventListener("resize", apply);
+    vv.removeEventListener("scroll", apply);
+  };
+}

--- a/packages/relay-web/src/lib/terminal-viewport.ts
+++ b/packages/relay-web/src/lib/terminal-viewport.ts
@@ -32,9 +32,6 @@ export interface TerminalViewportControllerOptions {
   canResizeRemote(): boolean;
   /** Backend resize forwarder (terminal store owns the syncedResize dedupe). */
   sendRemoteResize(cols: number, rows: number): void;
-  /** Soft-keyboard occlusion px to add back to the host height when fitting,
-   *  so the remote grid is keyboard-independent (local occlusion only). */
-  getKeyboardInset(): number;
   /** Test seam: frame scheduler. Defaults to requestAnimationFrame. */
   requestFrame?(cb: () => void): () => void;
 }

--- a/packages/relay-web/src/lib/terminal-viewport.ts
+++ b/packages/relay-web/src/lib/terminal-viewport.ts
@@ -44,6 +44,10 @@ export interface TerminalViewportController {
   scheduleSync(reason?: string): void;
   /** Immediate sync: runs now and replaces any pending frame. */
   forceSync(reason?: string): void;
+  /** Re-run local cursor-follow only (no fit / no remote push) — the cursor row
+   *  can move on live output without any geometry change, so a write must keep
+   *  the prompt visible while the keyboard is open. */
+  revealCursor(): void;
   setKeyboardInset(px: number): void;
 }
 
@@ -83,7 +87,10 @@ export function createTerminalViewportController(
   function runSync(reason?: string): void {
     if (disposed) return;
     const dim = fitLocal();
-    if (dim) syncRemote(dim);
+    if (dim) {
+      applyLocalCursorFollow();
+      syncRemote(dim);
+    }
   }
 
   /** Reflow the local emulator to the host; returns the applied geometry.
@@ -114,6 +121,37 @@ export function createTerminalViewportController(
     sendRemoteResize(dim.cols, dim.rows);
   }
 
+  /** Keep the cursor row visible while the soft keyboard occludes the host. The
+   *  grid is keyboard-independent — rows stay put, so the canvas is taller than
+   *  the shrunken host and flex-center would clip BOTH edges (the prompt at the
+   *  bottom out of view). Top-align the canvas and scroll it so the cursor row
+   *  sits at the visible bottom. Never shrinks the Ghostty grid. */
+  function applyLocalCursorFollow(): void {
+    if (keyboardInset <= 0) {
+      clearLocalFollow();
+      return;
+    }
+    const vis = host.clientHeight;
+    const geo = adapter.localGeometry();
+    if (!geo || geo.canvasHeight <= vis) {
+      clearLocalFollow();
+      return;
+    }
+    host.style.alignItems = "flex-start";
+    const cursorBottom = Math.min(geo.canvasHeight, (geo.cursorY + 1) * geo.cellHeight);
+    host.scrollTop = Math.max(0, cursorBottom - vis);
+    // The scroll moved the canvas under a stationary IME anchor; re-measure it.
+    adapter.syncInputAnchor();
+  }
+
+  /** Restore the neutral (flex-centered) layout when the keyboard is closed. */
+  function clearLocalFollow(): void {
+    const changed = host.style.alignItems !== "" || host.scrollTop !== 0;
+    if (host.style.alignItems) host.style.alignItems = "";
+    if (host.scrollTop !== 0) host.scrollTop = 0;
+    if (changed) adapter.syncInputAnchor();
+  }
+
   return {
     start(): void {
       if (started || disposed) return;
@@ -142,6 +180,10 @@ export function createTerminalViewportController(
     },
     scheduleSync,
     forceSync,
+    revealCursor(): void {
+      if (disposed) return;
+      applyLocalCursorFollow();
+    },
     setKeyboardInset(px: number): void {
       const next = Math.max(0, Math.round(px));
       if (next === keyboardInset) return;


### PR DESCRIPTION
## Summary

- Soft keyboard is **local occlusion**, not a remote resize. `measureTerminalViewportInsets` only claims a keyboard when an editable inside the terminal host is focused **and** the visualViewport shrink is keyboard-sized; anything else is browser chrome.
- `bindTerminalKeyboardInset` commits opens/grows immediately and debounces closes (~300ms) with a fresh re-measure at fire time, so per-keystroke jitter never collapses the lift or the remote grid.
- The tracker feeds `viewport.setKeyboardInset()`. The controller adds that inset back into `fit()` height, so opening/closing the keyboard no longer churns RMUX rows ±1. The visible surface still lifts via `paddingBottom`.
- `terminal-touch.ts`: idle → pending → scrolling. Moves under 8px never `preventDefault` (native long-press selection survives); past the threshold the gesture is captured and scrolls whole lines.
- Toolbar keys no longer focus the IME textarea on coarse-pointer devices (Esc/Ctrl/Copy will not pop the OSK). Only Paste, Enter, and a terminal-surface tap re-focus. Desktop keybar still refocuses.
- Copy prefers `window.getSelection()` over `adapter.getSelection()`. Clipboard denial ignores the action only — never detaches or trips recovery.

## Borrowed design, not protocol

Behavior model from rmux-web-share (`viewport-insets`, keyboard close debounce, touch threshold, capture-phase focus suppression). **Not** adopted: Web Share socket, session-view / split UI, E2EE/PIN, 2-cell hysteresis, VT clear stripping.

Spectator/take-control invariants are unchanged.

## Test plan

- [x] Unit: insets classification + close debounce; touch pending vs scrolling; TerminalTab keyboard-inset compensation / toolbar focus / native copy
- [ ] Manual iPhone Safari / Android Chrome: keyboard open keeps prompt visible and does not resize the pane; 20-char input without jump; long-press selects; swipe scrolls; toolbar does not pop the OSK

Stacked on **PR A** (#277). Playwright coverage is the follow-up PR (`test/relay-web-terminal-e2e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)