### PR TITLE
test(relay-web): add Chromium desktop and mobile terminal E2E

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,38 @@ jobs:
       - name: Build (all packages)
         run: bun run build:packages
 
+  relay-web-e2e:
+    name: Relay Web terminal E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: packages/relay-web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        working-directory: .
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run Chromium desktop + mobile E2E
+        run: bun run test:e2e
+
   rmux-bridge:
     # On PRs, only when the native sidecar (or this workflow) changed.
     # Always runs on push to main so the default branch compiles the bridge.

--- a/bun.lock
+++ b/bun.lock
@@ -138,6 +138,7 @@
         "vue-router": "^4.4.0",
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@types/markdown-it": "^14.1.2",
         "@vitejs/plugin-vue": "^5.1.0",
         "@vue/test-utils": "^2.4.6",
@@ -592,6 +593,8 @@
     "@one-ini/wasm": ["@one-ini/wasm@0.1.1", "", {}, ""],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, ""],
+
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, ""],
 
@@ -1579,6 +1582,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, ""],
 
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, ""],
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, ""],
@@ -2058,6 +2065,8 @@
     "parse5/entities": ["entities@6.0.1", "", {}, ""],
 
     "pinia/@vue/devtools-api": ["@vue/devtools-api@6.6.4", "", {}, ""],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "source-map/whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, ""],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2886,6 +2886,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "license": "BSD-3-Clause"
@@ -8274,6 +8290,53 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
       "license": "MIT"
@@ -11767,6 +11830,7 @@
         "vue-router": "^4.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@types/markdown-it": "^14.1.2",
         "@vitejs/plugin-vue": "^5.1.0",
         "@vue/test-utils": "^2.4.6",

--- a/packages/relay-web/.gitignore
+++ b/packages/relay-web/.gitignore
@@ -1,3 +1,7 @@
 dist
 dev-dist
 node_modules
+test-results
+playwright-report
+blob-report
+e2e/.auth

--- a/packages/relay-web/e2e/fixtures.ts
+++ b/packages/relay-web/e2e/fixtures.ts
@@ -1,0 +1,120 @@
+import { test as base, expect, type Page } from "@playwright/test";
+import { startMockHub, type MockHub } from "./mock-hub";
+
+export { expect };
+
+export const test = base.extend<{ hub: MockHub; page: Page }>({
+  hub: async ({}, use) => {
+    const hub = await startMockHub();
+    await use(hub);
+    await hub.close();
+  },
+  page: async ({ page, hub }, use) => {
+    // Only the Hub REST prefix — never Vite modules under /src/api/.
+    await page.route((url) => {
+      const path = new URL(url).pathname;
+      return path === "/api" || path.startsWith("/api/");
+    }, async (route) => {
+      const req = route.request();
+      const url = new URL(req.url());
+      const headers: Record<string, string> = { "content-type": "application/json" };
+      const init: RequestInit = { method: req.method(), headers };
+      if (req.method() !== "GET" && req.method() !== "HEAD") {
+        init.body = req.postData() ?? undefined;
+      }
+      const res = await fetch(`http://127.0.0.1:${hub.port}${url.pathname}${url.search}`, init);
+      await route.fulfill({
+        status: res.status,
+        headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+        body: await res.text(),
+      });
+    });
+    // Vite's /ws proxy is not used in E2E: rewrite the browser WebSocket to the
+    // mock hub so we control rebase / resize / role without a real connector.
+    await page.addInitScript((port: number) => {
+      const Orig = window.WebSocket;
+      class HubWS extends Orig {
+        constructor(url: string | URL, protocols?: string | string[]) {
+          const u = String(url);
+          // Only the Hub events socket. Vite HMR also uses a /ws path.
+          // Hub events socket is exactly /ws. Vite HMR uses /?token=... or /vite-hmr.
+          const parsed = new URL(u, "http://127.0.0.1");
+          if (parsed.pathname === "/ws") {
+            super(`ws://127.0.0.1:${port}/ws`, protocols);
+            return;
+          }
+          super(url, protocols);
+        }
+      }
+      window.WebSocket = HubWS as unknown as typeof WebSocket;
+    }, hub.port);
+    await use(page);
+  },
+});
+
+export async function loginAndOpenTerminal(page: Page): Promise<void> {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  // /api/me is stubbed as authenticated, so the login page is usually skipped.
+  const token = page.getByTestId("token-input");
+  if (await token.isVisible().catch(() => false)) {
+    await token.fill("e2e-token");
+    await page.getByTestId("signin").click();
+  }
+  const termBtn = page.getByTestId("toggle-terminal");
+  await expect(termBtn).toBeVisible({ timeout: 30_000 });
+  const sessionRow = page.getByTestId("session-row");
+  if (!(await sessionRow.isVisible().catch(() => false))) {
+    const open = page.getByTestId("open-instances");
+    if (await open.isVisible().catch(() => false)) await open.click();
+  }
+  await expect(sessionRow).toBeVisible({ timeout: 20_000 });
+  await sessionRow.getByTestId("session-name").evaluate((el) => (el as HTMLElement).click());
+  const closeInstances = page.getByTestId("close-instances");
+  if (await closeInstances.isVisible().catch(() => false)) {
+    await closeInstances.evaluate((el) => (el as HTMLElement).click());
+  }
+  await expect(termBtn).toBeEnabled({ timeout: 10_000 });
+  await termBtn.evaluate((el) => (el as HTMLElement).click());
+  await expect(page.getByTestId("terminal-host")).toBeVisible();
+}
+
+/** Wait until the terminal renderer has a measurable canvas (WASM + font). */
+export async function waitForTerminalCanvas(page: Page) {
+  const canvas = page.locator('[data-test="terminal-host"] canvas').first();
+  await expect(canvas).toBeVisible({ timeout: 20_000 });
+  await expect.poll(async () => {
+    return canvas.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      return r.width > 40 && r.height > 40;
+    });
+  }).toBe(true);
+  return canvas;
+}
+
+export async function readTerminalGrid(page: Page): Promise<{
+  cols: number;
+  rows: number;
+  canvasWidth: number;
+  hostWidth: number;
+  remainder: number;
+}> {
+  await expect.poll(async () => {
+    return page.locator('[data-test="terminal-host"]').getAttribute("data-cols");
+  }).not.toBeNull();
+  return page.locator('[data-test="terminal-host"]').evaluate((host) => {
+    const canvas = host.querySelector("canvas");
+    if (!canvas) throw new Error("no canvas");
+    const canvasRect = canvas.getBoundingClientRect();
+    const hostRect = host.getBoundingClientRect();
+    const cols = Number(host.dataset.cols ?? 0);
+    const rows = Number(host.dataset.rows ?? 0);
+    const cellW = cols > 0 ? canvasRect.width / cols : 0;
+    return {
+      cols,
+      rows,
+      canvasWidth: canvasRect.width,
+      hostWidth: hostRect.width,
+      remainder: cellW > 0 ? hostRect.width - canvasRect.width : hostRect.width,
+    };
+  });
+}

--- a/packages/relay-web/e2e/mock-hub.ts
+++ b/packages/relay-web/e2e/mock-hub.ts
@@ -1,0 +1,281 @@
+// In-process mock of the XACPX Hub used by Playwright E2E.
+//
+// Serves the REST surface the dashboard needs to boot (login / me / instances /
+// control RPC) and a /ws that speaks the real relay-protocol envelope. Terminal
+// recovery is driven here: open → opened → rebase-start/end, late rebase,
+// spectator vs controller resize, take-control, and WS drop/reconnect.
+//
+// This is NOT a Web Share socket. It stays on the XACPX Hub protocol so the
+// browser under test exercises the same TerminalTab / store / adapter path as
+// production.
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { WebSocketServer, type WebSocket } from "ws";
+import {
+  decodeEnvelope,
+  encodeEnvelope,
+  parseWebClientMessage,
+  webEventEnvelope,
+  type WebClientMessage,
+  type WebServerEvent,
+} from "@ganglion/xacpx-relay-protocol";
+
+export const INSTANCE_ID = "i1";
+export const SESSION_ALIAS = "demo";
+export const TERMINAL_ID = "term-e2e";
+export const GENERATION = "gen-e2e";
+export const ATTACHMENT_ID = "att-e2e";
+
+const CAPS = ["terminal.rmux.recovery.v1", "terminal.multi-view.v1"];
+
+export interface MockHub {
+  port: number;
+  url: string;
+  resizes: Array<{ cols: number; rows: number }>;
+  inputs: string[];
+  lastOpen: { cols: number; rows: number; requestId: string } | null;
+  lastTakeControl: { requestId: string } | null;
+  sockets: WebSocket[];
+  role: "controller" | "spectator";
+  send(event: WebServerEvent): void;
+  sendRebase(cols: number, rows: number, keyframe?: string, epoch?: number): void;
+  closeSockets(): void;
+  setRole(role: "controller" | "spectator"): void;
+  close(): Promise<void>;
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+    "access-control-allow-origin": "*",
+    "access-control-allow-credentials": "true",
+  });
+  res.end(payload);
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c as Buffer));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function canonicalBase64(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
+export async function startMockHub(): Promise<MockHub> {
+  const sockets: WebSocket[] = [];
+  const resizes: Array<{ cols: number; rows: number }> = [];
+  const inputs: string[] = [];
+  let lastOpen: MockHub["lastOpen"] = null;
+  let lastTakeControl: MockHub["lastTakeControl"] = null;
+  let role: "controller" | "spectator" = "controller";
+  let rebaseEpoch = 1;
+
+  const http = createServer(async (req, res) => {
+    const url = req.url ?? "/";
+    const path = url.split("?")[0];
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, {
+        "access-control-allow-origin": "*",
+        "access-control-allow-credentials": "true",
+        "access-control-allow-headers": "content-type",
+        "access-control-allow-methods": "GET,POST,PATCH,DELETE,OPTIONS",
+      });
+      res.end();
+      return;
+    }
+    if (req.method === "POST" && path === "/api/login") {
+      json(res, 200, { username: "e2e" });
+      return;
+    }
+    if (req.method === "GET" && path === "/api/me") {
+      json(res, 200, { username: "e2e" });
+      return;
+    }
+    if (req.method === "GET" && path === "/api/instances") {
+      json(res, 200, {
+        instances: [{
+          id: INSTANCE_ID,
+          name: "e2e-pc",
+          online: true,
+          lastSeenAt: null,
+          capabilities: CAPS,
+        }],
+      });
+      return;
+    }
+    if (req.method === "POST" && path === `/api/instances/${INSTANCE_ID}/rpc`) {
+      const raw = await readBody(req);
+      let type = "";
+      try { type = (JSON.parse(raw) as { type?: string }).type ?? ""; } catch { /* ignore */ }
+      if (type === "control.sessions.list") {
+        json(res, 200, {
+          result: {
+            sessions: [{
+              alias: SESSION_ALIAS,
+              agent: "codex",
+              workspace: "/w",
+              transportSession: "t1",
+              running: true,
+              archived: false,
+            }],
+            hasMore: false,
+            nextOffset: 1,
+          },
+        });
+        return;
+      }
+      if (type === "control.agents.list") {
+        json(res, 200, { result: { agents: [{ name: "codex", driver: "codex" }] } });
+        return;
+      }
+      json(res, 200, { result: {} });
+      return;
+    }
+    json(res, 404, { error: "not-found" });
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+  http.on("upgrade", (req, socket, head) => {
+    if ((req.url ?? "").split("?")[0] !== "/ws") {
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => wss.emit("connection", ws, req));
+  });
+
+  function send(event: WebServerEvent): void {
+    const line = encodeEnvelope(webEventEnvelope(event));
+    for (const ws of sockets) {
+      if (ws.readyState === ws.OPEN) ws.send(line);
+    }
+  }
+
+  function sendRebase(cols: number, rows: number, keyframe = "", epoch = rebaseEpoch++): void {
+    const dataBase64 = canonicalBase64(keyframe);
+    const totalBytes = Buffer.from(dataBase64, "base64").byteLength;
+    send({
+      kind: "terminal-rebase-start",
+      instanceId: INSTANCE_ID,
+      attachmentId: ATTACHMENT_ID,
+      generation: GENERATION,
+      epoch,
+      nextSequence: 0,
+      cols,
+      rows,
+      alternate: false,
+      totalBytes,
+      chunkCount: totalBytes === 0 ? 0 : 1,
+    });
+    if (totalBytes > 0) {
+      send({
+        kind: "terminal-rebase-chunk",
+        instanceId: INSTANCE_ID,
+        attachmentId: ATTACHMENT_ID,
+        generation: GENERATION,
+        epoch,
+        index: 0,
+        dataBase64,
+      });
+    }
+    send({
+      kind: "terminal-rebase-end",
+      instanceId: INSTANCE_ID,
+      attachmentId: ATTACHMENT_ID,
+      generation: GENERATION,
+      epoch,
+    });
+  }
+
+  wss.on("connection", (ws) => {
+    sockets.push(ws);
+    ws.on("message", (data) => {
+      const decoded = decodeEnvelope(String(data));
+      if (!decoded.ok) return;
+      const msg = parseWebClientMessage(decoded.envelope);
+      if (!msg) return;
+      handleClient(msg);
+    });
+    ws.on("close", () => {
+      const i = sockets.indexOf(ws);
+      if (i >= 0) sockets.splice(i, 1);
+    });
+  });
+
+  function handleClient(msg: WebClientMessage): void {
+    if (msg.kind === "terminal-open") {
+      lastOpen = { cols: msg.cols, rows: msg.rows, requestId: msg.requestId };
+      send({
+        kind: "terminal-opened",
+        requestId: msg.requestId,
+        instanceId: INSTANCE_ID,
+        terminalId: TERMINAL_ID,
+        generation: GENERATION,
+        attachmentId: ATTACHMENT_ID,
+        role,
+        viewerCount: role === "spectator" ? 2 : 1,
+      });
+      // Authoritative recovery geometry first; the browser must then re-fit
+      // the host (the late-rebase / initial-viewport invariant).
+      sendRebase(80, 24);
+      return;
+    }
+    if (msg.kind === "terminal-take-control") {
+      lastTakeControl = { requestId: msg.requestId };
+      role = "controller";
+      send({
+        kind: "terminal-opened",
+        requestId: msg.requestId,
+        instanceId: INSTANCE_ID,
+        terminalId: TERMINAL_ID,
+        generation: GENERATION,
+        attachmentId: ATTACHMENT_ID,
+        role: "controller",
+        viewerCount: 1,
+      });
+      return;
+    }
+    if (msg.kind === "terminal-resize" && "attachmentId" in msg) {
+      resizes.push({ cols: msg.cols, rows: msg.rows });
+      return;
+    }
+    if (msg.kind === "terminal-input" && "dataBase64" in msg) {
+      inputs.push(Buffer.from(msg.dataBase64, "base64").toString("utf8"));
+    }
+  }
+
+  await new Promise<void>((resolve) => http.listen(0, "127.0.0.1", resolve));
+  const addr = http.address();
+  if (!addr || typeof addr === "string") throw new Error("mock hub failed to bind");
+  const port = addr.port;
+
+  return {
+    port,
+    url: `http://127.0.0.1:${port}`,
+    resizes,
+    inputs,
+    get lastOpen() { return lastOpen; },
+    get lastTakeControl() { return lastTakeControl; },
+    sockets,
+    get role() { return role; },
+    send,
+    sendRebase,
+    closeSockets() {
+      for (const ws of [...sockets]) ws.close();
+    },
+    setRole(next) { role = next; },
+    close() {
+      return new Promise((resolve) => {
+        for (const ws of [...sockets]) ws.close();
+        wss.close();
+        http.close(() => resolve());
+      });
+    },
+  };
+}

--- a/packages/relay-web/e2e/terminal-input.spec.ts
+++ b/packages/relay-web/e2e/terminal-input.spec.ts
@@ -84,6 +84,23 @@ test.describe("terminal input lifecycle", () => {
     const center = page.getByTestId("terminal-center");
     await expect.poll(async () => center.evaluate((el) => (el as HTMLElement).style.paddingBottom)).not.toBe("");
     await expect.poll(() => hub.resizes.length).toBe(resizesBefore);
+
+    // The IME anchor (one-cell textarea at the cursor) must still sit inside
+    // the visible host rect once the keyboard is up. The remote grid didn't
+    // resize, so the taller canvas has to be scrolled to keep it in view.
+    const anchor = await page.locator('[data-test="terminal-host"]').evaluate((host) => {
+      const ta = host.querySelector("textarea");
+      if (!ta) return null;
+      const h = host.getBoundingClientRect();
+      const t = ta.getBoundingClientRect();
+      return {
+        visible: t.bottom <= h.bottom + 1 && t.top >= h.top - 1,
+        hostHeight: h.height,
+        scrollTop: (host as HTMLElement).scrollTop,
+      };
+    });
+    expect(anchor).not.toBeNull();
+    expect(anchor!.visible).toBe(true);
   });
 
   test("touch: 2px stay pending, 20px scroll the terminal", async ({ page }, testInfo) => {

--- a/packages/relay-web/e2e/terminal-input.spec.ts
+++ b/packages/relay-web/e2e/terminal-input.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, loginAndOpenTerminal, waitForTerminalCanvas } from "./fixtures";
+
+test.describe("terminal input lifecycle", () => {
+  test("IME composition commits once; intermediate pinyin never reaches the PTY", async ({ page, hub }) => {
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+
+    const host = page.getByTestId("terminal-host");
+    await host.click();
+    const ta = host.locator("textarea");
+    await expect(ta).toHaveCount(1);
+    await ta.focus();
+
+    const inputsBefore = hub.inputs.length;
+    await ta.evaluate((el) => {
+      const fire = (type: string, data?: string) => {
+        el.dispatchEvent(new CompositionEvent(type, { bubbles: true, data }));
+      };
+      fire("compositionstart");
+      fire("compositionupdate", "ni");
+      fire("compositionupdate", "nihao");
+      fire("compositionend", "你好");
+    });
+
+    await expect.poll(() => hub.inputs.slice(inputsBefore).join("")).toBe("你好");
+    const added = hub.inputs.slice(inputsBefore);
+    expect(added.join("")).not.toMatch(/n|i|h|a|o/i);
+    expect(added).toHaveLength(1);
+  });
+
+  test("IME textarea is a one-cell cursor anchor, not a fullscreen overlay", async ({ page }) => {
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+    const host = page.getByTestId("terminal-host");
+    await host.click();
+
+    const geo = await host.evaluate((el) => {
+      const ta = el.querySelector("textarea");
+      if (!ta) throw new Error("no textarea");
+      const cs = getComputedStyle(ta);
+      const hostRect = el.getBoundingClientRect();
+      return {
+        width: parseFloat(ta.style.width),
+        height: parseFloat(ta.style.height),
+        left: parseFloat(ta.style.left),
+        top: parseFloat(ta.style.top),
+        inset: ta.style.inset || cs.inset,
+        display: cs.display,
+        visibility: cs.visibility,
+        pointerEvents: ta.style.pointerEvents || cs.pointerEvents,
+        opacity: ta.style.opacity,
+        hostW: hostRect.width,
+        hostH: hostRect.height,
+      };
+    });
+    expect(geo.display).not.toBe("none");
+    expect(geo.visibility).not.toBe("hidden");
+    expect(geo.pointerEvents).toBe("none");
+    expect(geo.width).toBeGreaterThan(0);
+    expect(geo.height).toBeGreaterThan(0);
+    expect(geo.width).toBeLessThan(geo.hostW / 2);
+    expect(geo.height).toBeLessThan(geo.hostH / 2);
+    expect(geo.left).toBeGreaterThan(-1);
+    expect(geo.top).toBeGreaterThan(-1);
+  });
+
+  test("mobile keyboard inset is local: remote resize count does not grow", async ({ page, hub }, testInfo) => {
+    test.skip(testInfo.project.name !== "chromium-mobile", "keyboard inset is a mobile viewport concern");
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+    const resizesBefore = hub.resizes.length;
+
+    await page.evaluate(() => {
+      const host = document.querySelector('[data-test="terminal-host"]') as HTMLElement;
+      const ta = host?.querySelector("textarea");
+      ta?.focus();
+      const vv = window.visualViewport;
+      if (!vv) return;
+      Object.defineProperty(vv, "height", { configurable: true, get: () => window.innerHeight - 320 });
+      Object.defineProperty(vv, "offsetTop", { configurable: true, get: () => 0 });
+      vv.dispatchEvent(new Event("resize"));
+    });
+
+    const center = page.getByTestId("terminal-center");
+    await expect.poll(async () => center.evaluate((el) => (el as HTMLElement).style.paddingBottom)).not.toBe("");
+    await expect.poll(() => hub.resizes.length).toBe(resizesBefore);
+  });
+
+  test("touch: 2px stay pending, 20px scroll the terminal", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "chromium-mobile", "touch gesture is a mobile concern");
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+    const host = page.getByTestId("terminal-host");
+    const box = await host.boundingBox();
+    if (!box) throw new Error("no host box");
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+
+    // Sub-threshold: browser still owns the gesture (no preventDefault).
+    await page.evaluate(({ x, y }) => {
+      const el = document.querySelector('[data-test="terminal-host"]')!;
+      const fire = (type: string, cx: number, cy: number) => {
+        const t = new Touch({ identifier: 1, target: el, clientX: cx, clientY: cy });
+        el.dispatchEvent(new TouchEvent(type, {
+          bubbles: true, cancelable: true, touches: type === "touchend" ? [] : [t],
+          changedTouches: [t],
+        }));
+      };
+      fire("touchstart", x, y);
+      fire("touchmove", x, y + 2);
+      fire("touchend", x, y + 2);
+    }, { x, y });
+
+    // Above-threshold drag: the state machine must preventDefault (captured).
+    const prevented = await page.evaluate(({ x, y }) => {
+      const el = document.querySelector('[data-test="terminal-host"]')!;
+      let sawPrevent = false;
+      const t0 = new Touch({ identifier: 2, target: el, clientX: x, clientY: y });
+      el.dispatchEvent(new TouchEvent("touchstart", {
+        bubbles: true, cancelable: true, touches: [t0], changedTouches: [t0],
+      }));
+      const t1 = new Touch({ identifier: 2, target: el, clientX: x, clientY: y + 20 });
+      const move = new TouchEvent("touchmove", {
+        bubbles: true, cancelable: true, touches: [t1], changedTouches: [t1],
+      });
+      el.dispatchEvent(move);
+      sawPrevent = move.defaultPrevented;
+      el.dispatchEvent(new TouchEvent("touchend", {
+        bubbles: true, cancelable: true, touches: [], changedTouches: [t1],
+      }));
+      return sawPrevent;
+    }, { x, y });
+    expect(prevented).toBe(true);
+  });
+});

--- a/packages/relay-web/e2e/terminal-viewport.spec.ts
+++ b/packages/relay-web/e2e/terminal-viewport.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, loginAndOpenTerminal, waitForTerminalCanvas, readTerminalGrid } from "./fixtures";
+
+test.describe("terminal viewport", () => {
+  test("initial open fills the host instead of staying at 80x24", async ({ page, hub }) => {
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+    const grid = await readTerminalGrid(page);
+    // Mobile viewports often fit fewer than 80 cols; the bug is staying at the
+    // 80x24 bootstrap size, not "must be wider than 80".
+    expect(grid.cols === 80 && grid.rows === 24).toBe(false);
+    expect(grid.cols).toBeGreaterThan(20);
+    expect(grid.rows).toBeGreaterThan(10);
+    // Sub-cell remainder is expected (items-center); never a whole unused cell.
+    expect(grid.remainder).toBeLessThan(grid.canvasWidth / grid.cols + 1);
+    expect(hub.resizes.length).toBeGreaterThan(0);
+    const last = hub.resizes.at(-1)!;
+    expect(last.cols).toBe(grid.cols);
+    expect(last.rows).toBe(grid.rows);
+  });
+
+  test("late rebase rebuilds at the keyframe size then re-fits the host", async ({ page, hub }) => {
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+    const before = await readTerminalGrid(page);
+    expect(before.cols === 80 && before.rows === 24).toBe(false);
+
+    const resizesBefore = hub.resizes.length;
+    hub.sendRebase(80, 24, "late");
+
+    await expect.poll(async () => (await readTerminalGrid(page)).cols).toBe(before.cols);
+    const after = await readTerminalGrid(page);
+    expect(after.rows).toBe(before.rows);
+    expect(after.cols === 80 && after.rows === 24).toBe(false);
+    // Controller may re-push the host geometry; store dedupe owns exact count.
+    expect(hub.resizes.length).toBeGreaterThanOrEqual(resizesBefore);
+    const last = hub.resizes.at(-1)!;
+    expect(last.cols).toBe(after.cols);
+    expect(last.rows).toBe(after.rows);
+  });
+
+  test("spectator host resize never sends a backend resize", async ({ page, hub }) => {
+    hub.setRole("spectator");
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+    await expect(page.getByTestId("terminal-role")).toContainText(/spectator/i);
+    expect(hub.resizes).toEqual([]);
+
+    const before = await readTerminalGrid(page);
+    await page.setViewportSize({ width: 700, height: 500 });
+    await expect.poll(async () => {
+      const next = await readTerminalGrid(page);
+      return next.cols !== before.cols || next.rows !== before.rows;
+    }).toBe(true);
+    expect(hub.resizes).toEqual([]);
+  });
+
+  test("controller host resize pushes the final geometry", async ({ page, hub }) => {
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+    const before = await readTerminalGrid(page);
+    const countBefore = hub.resizes.length;
+
+    await page.setViewportSize({ width: 1100, height: 720 });
+    await expect.poll(async () => (await readTerminalGrid(page)).cols).not.toBe(before.cols);
+    const after = await readTerminalGrid(page);
+    const pushed = hub.resizes.slice(countBefore);
+    expect(pushed.length).toBeGreaterThan(0);
+    const last = pushed.at(-1)!;
+    expect(last.cols).toBe(after.cols);
+    expect(last.rows).toBe(after.rows);
+  });
+
+  test("take-control syncs the current browser geometry to the backend", async ({ page, hub }) => {
+    hub.setRole("spectator");
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+    expect(hub.resizes).toEqual([]);
+    const grid = await readTerminalGrid(page);
+
+    await page.getByTestId("terminal-take-control").click();
+    await expect.poll(() => hub.lastTakeControl !== null).toBe(true);
+    await expect.poll(() => hub.resizes.length).toBeGreaterThan(0);
+    const last = hub.resizes.at(-1)!;
+    expect(last.cols).toBe(grid.cols);
+    expect(last.rows).toBe(grid.rows);
+  });
+
+  test("reconnect + rebase recovers a filled viewport", async ({ page, hub }) => {
+    await loginAndOpenTerminal(page);
+    await waitForTerminalCanvas(page);
+    const before = await readTerminalGrid(page);
+    expect(before.cols === 80 && before.rows === 24).toBe(false);
+
+    hub.closeSockets();
+    await expect.poll(() => hub.sockets.length).toBeGreaterThan(0);
+    // Reopen re-issues terminal-open; mock replies with 80x24 rebase then the
+    // browser must re-fit just like the first open.
+    await expect.poll(async () => {
+      const grid = await readTerminalGrid(page);
+      return !(grid.cols === 80 && grid.rows === 24) && grid.cols > 20;
+    }).toBe(true);
+    const after = await readTerminalGrid(page);
+    expect(after.cols === 80 && after.rows === 24).toBe(false);
+  });
+});

--- a/packages/relay-web/package.json
+++ b/packages/relay-web/package.json
@@ -8,7 +8,10 @@
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
     "generate-pwa-icons": "node scripts/generate-pwa-icons.mjs",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:desktop": "playwright test --project=chromium-desktop",
+    "test:e2e:mobile": "playwright test --project=chromium-mobile"
   },
   "dependencies": {
     "@codemirror/commands": "^6.0.0",
@@ -44,6 +47,7 @@
     "vue-router": "^4.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@types/markdown-it": "^14.1.2",
     "@vitejs/plugin-vue": "^5.1.0",
     "@vue/test-utils": "^2.4.6",

--- a/packages/relay-web/playwright.config.ts
+++ b/packages/relay-web/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Local macOS 13 cannot install Playwright's bundled Chromium. Prefer the
+// system Google Chrome channel; CI (Ubuntu) still uses bundled Chromium.
+const useSystemChrome = process.platform === "darwin";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    testIdAttribute: "data-test",
+    trace: "retain-on-failure",
+    ...(useSystemChrome ? { channel: "chrome" } : {}),
+  },
+  webServer: {
+    command: "bunx vite --port 4173 --strictPort --host 127.0.0.1",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium-desktop",
+      use: {
+        viewport: { width: 1440, height: 900 },
+        isMobile: false,
+        hasTouch: false,
+        ...(useSystemChrome ? { channel: "chrome" } : { ...devices["Desktop Chrome"] }),
+      },
+    },
+    {
+      name: "chromium-mobile",
+      use: {
+        ...devices["Pixel 7"],
+        hasTouch: true,
+        isMobile: true,
+        ...(useSystemChrome ? { channel: "chrome" } : {}),
+      },
+    },
+  ],
+});

--- a/packages/relay-web/playwright.config.ts
+++ b/packages/relay-web/playwright.config.ts
@@ -29,10 +29,13 @@ export default defineConfig({
     {
       name: "chromium-desktop",
       use: {
+        // Spread the device descriptor first so the explicit viewport below
+        // always wins (a spread after it would clobber 1440x900 on CI).
+        ...(useSystemChrome ? {} : devices["Desktop Chrome"]),
+        ...(useSystemChrome ? { channel: "chrome" } : {}),
         viewport: { width: 1440, height: 900 },
         isMobile: false,
         hasTouch: false,
-        ...(useSystemChrome ? { channel: "chrome" } : { ...devices["Desktop Chrome"] }),
       },
     },
     {

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -284,6 +284,12 @@ async function openAttachment(): Promise<void> {
       adapter: currentAdapter,
       canResizeRemote: () => canType.value,
       sendRemoteResize: (cols, rows) => terminals.sendResize(localKey.value, cols, rows),
+      onLocalFit: (dim) => {
+        const el = host.value;
+        if (!el) return;
+        el.dataset.cols = String(dim.cols);
+        el.dataset.rows = String(dim.rows);
+      },
     });
     // Set the inset BEFORE start(): start() force-syncs immediately, and it
     // must carry the keyboard height on the very first fit. Ordering this the

--- a/packages/relay-web/src/lib/terminal-viewport.ts
+++ b/packages/relay-web/src/lib/terminal-viewport.ts
@@ -32,6 +32,8 @@ export interface TerminalViewportControllerOptions {
   canResizeRemote(): boolean;
   /** Backend resize forwarder (terminal store owns the syncedResize dedupe). */
   sendRemoteResize(cols: number, rows: number): void;
+  /** Optional: observe the last successful local fit (E2E / diagnostics). */
+  onLocalFit?(dim: { cols: number; rows: number }): void;
   /** Test seam: frame scheduler. Defaults to requestAnimationFrame. */
   requestFrame?(cb: () => void): () => void;
 }
@@ -54,7 +56,7 @@ export interface TerminalViewportController {
 export function createTerminalViewportController(
   opts: TerminalViewportControllerOptions,
 ): TerminalViewportController {
-  const { host, adapter, canResizeRemote, sendRemoteResize } = opts;
+  const { host, adapter, canResizeRemote, sendRemoteResize, onLocalFit } = opts;
   const requestFrame = opts.requestFrame
     ?? ((cb: () => void) => {
       const id = requestAnimationFrame(() => cb());
@@ -109,6 +111,7 @@ export function createTerminalViewportController(
     if (dim.cols !== adapter.cols() || dim.rows !== adapter.rows()) {
       adapter.resize(dim.cols, dim.rows);
     }
+    onLocalFit?.(dim);
     return dim;
   }
 

--- a/packages/relay-web/vite.config.ts
+++ b/packages/relay-web/vite.config.ts
@@ -18,5 +18,9 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/__tests__/setup.ts"],
+    // Playwright specs live in e2e/ and use @playwright/test's own runner; they
+    // must never be collected by vitest (which would fail with "Playwright Test
+    // did not expect test.describe() to be called here").
+    include: ["src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- Playwright gate against an in-process mock Hub (REST + the existing XACPX relay-protocol `/ws` envelope — **not** a Web Share socket).
- Chromium **desktop** and **mobile** projects cover the browser-only bugs this series landed:
  - initial open / late rebase leave a host-fitted grid, not 80×24
  - spectator resize stays local; controller resize and take-control push current geometry
  - reconnect + rebase recovers a filled viewport
  - IME composition commits once; helper textarea is a one-cell cursor anchor
  - mobile keyboard inset is local (no extra remote resize)
  - touch stays pending below 8px and captures past the threshold
- Local macOS 13 cannot install Playwright's bundled Chromium, so the config uses the system Chrome channel there. CI installs bundled Chromium.
- New `relay-web-e2e` job on `.github/workflows/test.yml` runs both projects on every PR.

`onLocalFit` on the viewport controller writes `data-cols` / `data-rows` on the host so E2E can read the fitted grid without poking ghostty internals.

## Test plan

- [x] `bunx playwright test` locally: 18 passed / 2 skipped (desktop skips the two mobile-only cases)
- [ ] CI `relay-web-e2e` green on this PR
- WebKit remains a later nightly/dedicated workflow (not in this PR)

Stacked on **PR C** (`refactor/relay-web-mobile-input-lifecycle`). Retarget to `main` after A (#277) and C merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)