### PR TITLE
fix(relay-web): stable sidebar on create, stay on new session, sleep-time sort

### DIFF
--- a/packages/relay-protocol/dist/dtos.d.ts
+++ b/packages/relay-protocol/dist/dtos.d.ts
@@ -6,6 +6,8 @@ export interface SessionDto {
     transportSession: string;
     running: boolean;
     archived: boolean;
+    /** ISO timestamp when the session was archived. */
+    archivedAt?: string;
     /** Whether the session's agent process is currently alive (next prompt responds without
      *  a cold start). Drives the web cold-session indicator, shown only when `warm === false`.
      *  Omitted when unknown — old instances that don't report warmth, or a session not yet

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -6,6 +6,8 @@ export interface SessionDto {
   transportSession: string;
   running: boolean;
   archived: boolean;
+  /** ISO timestamp when the session was archived. */
+  archivedAt?: string;
   /** Whether the session's agent process is currently alive (next prompt responds without
    *  a cold start). Drives the web cold-session indicator, shown only when `warm === false`.
    *  Omitted when unknown — old instances that don't report warmth, or a session not yet

--- a/packages/relay-web/src/__tests__/instances-optimistic-create.test.ts
+++ b/packages/relay-web/src/__tests__/instances-optimistic-create.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { flushPromises } from "@vue/test-utils";
 import { useInstancesStore } from "../stores/instances";
+import { useChatStore } from "../stores/chat";
 import { api, ApiError } from "../api/client";
+
 
 const inst = (sessions: unknown[] = []) => ({
   id: "i1", name: "pc", online: true, lastSeenAt: null,
@@ -113,6 +115,89 @@ describe("optimistic session creation", () => {
     const creatingRows = store.byId("i1")!.sessions.filter((s) => s.creating);
     expect(creatingRows).toHaveLength(1);
     expect(rpc).toHaveBeenCalled();
+  });
+
+  it("appends the optimistic row after existing active rows — sidebar order never jumps on create", () => {
+    const store = useInstancesStore();
+    store.instances = [inst([
+      { alias: "a", agent: "codex", workspace: "home", transportSession: "t1", running: false, archived: false },
+      { alias: "z-sleeping", agent: "codex", workspace: "home", transportSession: "t2", running: false, archived: true },
+    ])] as never;
+    vi.spyOn(api, "rpc").mockReturnValue(Promise.withResolvers<never>().promise as never);
+    store.beginSessionCreation("i1", "new", "codex", "home");
+    // The server list appends new sessions last, so the optimistic row must sit at
+    // the same position the real row will land: end of the ACTIVE rows, before any
+    // archived tail. Prepending it would visibly reorder the sidebar on completion.
+    expect(store.byId("i1")!.sessions.map((s) => s.alias)).toEqual(["a", "new", "z-sleeping"]);
+  });
+
+  it("keeps an in-flight optimistic row across a sessions-changed list replace", async () => {
+    const store = useInstancesStore();
+    store.instances = [inst([
+      { alias: "a", agent: "codex", workspace: "home", transportSession: "t1", running: false, archived: false },
+    ])] as never;
+    // Create RPC still pending; a sessions-changed refetch lands mid-boot.
+    vi.spyOn(api, "rpc").mockImplementation(async (_id: string, type: string) => {
+      if (type === "control.sessions.create") return Promise.withResolvers<never>().promise as never;
+      if (type === "control.sessions.list") {
+        // Server does not know the new session yet (cold agent start).
+        return { sessions: [{ alias: "a", agent: "codex", workspace: "home", transportSession: "t1", running: false, archived: false }] } as never;
+      }
+      return { agents: [] } as never;
+    });
+    store.beginSessionCreation("i1", "booting", "codex", "home");
+    await store.loadSessions("i1");
+    const aliases = store.byId("i1")!.sessions.map((s) => s.alias);
+    expect(aliases).toEqual(["a", "booting"]);
+    expect(store.byId("i1")!.sessions.find((s) => s.alias === "booting")!.creating).toBe(true);
+});
+  it("materialises the row from the create RPC and keeps it while pagination may hide it", async () => {
+    // >20 actives: the server appends new sessions last, so the refreshed page-1
+    // (hasMore) cannot contain the fresh session — the materialised row must
+    // survive that replace instead of blanking the session the user is on.
+    const store = useInstancesStore();
+    store.instances = [inst()] as never;
+    vi.spyOn(api, "rpc")
+      .mockResolvedValueOnce({ alias: "backend", agent: "codex", workspace: "home", transportSession: "t", running: false, archived: false } as never)
+      .mockResolvedValueOnce({ sessions: [], hasMore: true, nextOffset: 0 } as never) // page-1 list omits the new session
+      .mockResolvedValue({ agents: [] } as never);
+    store.beginSessionCreation("i1", "backend", "codex", "home");
+    await flushPromises();
+    // The merged row keeps the server identity and stops spinning.
+    const row = store.byId("i1")!.sessions.find((s) => s.alias === "backend");
+    expect(row).toMatchObject({ alias: "backend", transportSession: "t" });
+    expect(row!.creating).toBeUndefined();
+  });
+
+  it("drops a just-created row once a COMPLETE list omits it (real removal converges)", async () => {
+    const store = useInstancesStore();
+    store.instances = [inst()] as never;
+    vi.spyOn(api, "rpc")
+      .mockResolvedValueOnce({ alias: "backend", agent: "codex", workspace: "home", transportSession: "t", running: false, archived: false } as never)
+      .mockResolvedValueOnce({ sessions: [{ alias: "other", agent: "codex", workspace: "home", transportSession: "t2", running: false, archived: false }], hasMore: false } as never)
+      .mockResolvedValue({ agents: [] } as never);
+    store.beginSessionCreation("i1", "backend", "codex", "home");
+    await flushPromises();
+    // hasMore=false means the list is complete and authoritative: an absent alias
+    // was deleted server-side, so the local row must not linger.
+    expect(store.byId("i1")!.sessions.map((s) => s.alias)).toEqual(["other"]);
+  });
+
+  it("follows the chat selection to the backend-derived alias when it differs", async () => {
+    const store = useInstancesStore();
+    store.instances = [inst()] as never;
+    const chat = useChatStore();
+    vi.spyOn(api, "rpc")
+      .mockResolvedValueOnce({ alias: "backend-2", agent: "codex", workspace: "home", transportSession: "t", running: false, archived: false } as never)
+      .mockResolvedValueOnce({ sessions: [{ alias: "backend-2", agent: "codex", workspace: "home", transportSession: "t", running: false, archived: false }] } as never)
+      .mockResolvedValue({ agents: [] } as never);
+    store.beginSessionCreation("i1", "backend", "codex", "home");
+    chat.select("i1", "backend");
+    await flushPromises();
+    // The user created "backend"; the backend named it "backend-2" — the view must
+    // end up ON the created session, not stranded on the requested-but-uncreated name.
+    expect(chat.instanceId).toBe("i1");
+    expect(chat.sessionAlias).toBe("backend-2");
   });
 
   it("cancelSessionCreation drops a booting/failed row but spares a materialised one", () => {

--- a/packages/relay-web/src/__tests__/sidebar-group-mode.test.ts
+++ b/packages/relay-web/src/__tests__/sidebar-group-mode.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { loadGroupMode, saveGroupMode, groupSessions, dedupedSessionName } from "../lib/sidebar-group-mode";
+import { loadGroupMode, saveGroupMode, groupSessions, dedupedSessionName, archivedLast } from "../lib/sidebar-group-mode";
 
 const KEY = "xacpx.sidebar.groupMode.i1";
 
@@ -53,6 +53,20 @@ describe("groupSessions", () => {
       "workspace",
     );
     expect(groups[0]!.sessions.map((x) => x.alias)).toEqual(["live1", "live2", "arch1", "arch2"]);
+  });
+
+  it("orders archived sessions by sleep time, most recently slept first", () => {
+    const arch = (alias: string, archivedAt?: string) => ({ ...s(alias, "web", "claude", true), ...(archivedAt ? { archivedAt } : {}) });
+    const sorted = archivedLast([
+      s("live", "web", "claude"),
+      arch("old-sleep", "2026-08-01T00:00:00Z"),
+      arch("fresh-sleep", "2026-08-17T00:00:00Z"),
+      arch("legacy-sleep"), // old connector: no timestamp
+      arch("mid-sleep", "2026-08-09T00:00:00Z"),
+    ]);
+    // Actives keep incoming order; archived sink below, newest sleep on top so a
+    // user expanding the sleeping list finds the latest sessions without paging.
+    expect(sorted.map((x) => x.alias)).toEqual(["live", "fresh-sleep", "mid-sleep", "old-sleep", "legacy-sleep"]);
   });
 
   it("returns no groups for no sessions", () => {

--- a/packages/relay-web/src/lib/sidebar-group-mode.ts
+++ b/packages/relay-web/src/lib/sidebar-group-mode.ts
@@ -34,20 +34,27 @@ export interface SessionGroup<T> {
 }
 
 /**
- * Archived sessions sink below active ones (stable: both halves keep their
- * incoming order) — shared by the flat list and every group.
+ * Archived sessions sink below active ones — shared by the flat list and every
+ * group. Actives keep their incoming order; among the archived, the most
+ * recently slept session comes first (sorted by archivedAt descending, stable
+ * for rows without a timestamp — old connectors or ties).
  */
-export function archivedLast<T extends { archived?: boolean }>(sessions: T[]): T[] {
-  return [...sessions].sort((a, b) => Number(a.archived ?? false) - Number(b.archived ?? false));
+export function archivedLast<T extends { archived?: boolean; archivedAt?: string }>(sessions: T[]): T[] {
+  const active = sessions.filter((s) => !s.archived);
+  const archived = sessions.filter((s) => s.archived).sort((a, b) => {
+    const aTime = a.archivedAt ? new Date(a.archivedAt).getTime() : 0;
+    const bTime = b.archivedAt ? new Date(b.archivedAt).getTime() : 0;
+    return bTime - aTime;
+  });
+  return [...active, ...archived];
 }
-
 /**
  * Derive second-level groups from the sessions themselves (never from the
  * workspaces/agents catalogs — no empty groups, and the catalogs may not be
  * loaded when sessions arrive). Groups appear in first-appearance (server)
  * order; within a group actives keep server order and archived sink last.
  */
-export function groupSessions<T extends { workspace: string; agent: string; archived?: boolean }>(
+export function groupSessions<T extends { workspace: string; agent: string; archived?: boolean; archivedAt?: string }>(
   sessions: T[],
   mode: "workspace" | "agent",
 ): Array<SessionGroup<T>> {

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -44,6 +44,11 @@ export type SessionRow = SessionDto & {
   creatingSince?: number;
   /** Background creation failed; message surfaced in the booting pane. */
   createError?: string;
+  /** Materialised from the create RPC response but not yet seen in a list
+   *  snapshot. Survives page-1 replaces while `sessionsHasMore` may hide it
+   *  (the server appends new sessions last); cleared once a snapshot contains
+   *  the alias, or dropped when a complete list (hasMore false) omits it. */
+  justCreated?: boolean;
 };
 
 export interface InstanceView {
@@ -425,6 +430,29 @@ export const useInstancesStore = defineStore("instances", () => {
       if (inst) {
         const rows = sessions.map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest));
         const archived = replace && inst.archivedSessionsLoaded ? inst.sessions.filter((session) => session.archived) : [];
+        if (replace) {
+          // A replace snapshot is authoritative for the rows it contains, but two
+          // kinds of local row must survive it:
+          //  - an optimistic create still booting (RPC in flight, or a 504 whose
+          //    session arrives later via sessions-changed) — dropping it would
+          //    blank the selected session's pane mid-boot;
+          //  - a row materialised from the create RPC response that this page-1
+          //    snapshot cannot contain: the server appends new sessions last, so
+          //    with more actives than one page the new one sits past the boundary.
+          //    Kept only while hasMore — a COMPLETE list omitting the alias is the
+          //    server saying the session is gone.
+          // Mirrors loadArchivedSessions' transient handling.
+          const keep = inst.sessions.filter((row) =>
+            row.creating
+            || row.createError
+            || (row.justCreated === true && hasMore && !rows.some((r) => r.alias === row.alias))
+          );
+          for (const row of keep) {
+            if (!rows.some((r) => r.alias === row.alias)) {
+              rows.push(row);
+            }
+          }
+        }
         inst.sessions = replace
           ? [...rows, ...archived.filter((old) => !rows.some((row) => row.alias === old.alias))]
           : [...inst.sessions, ...rows.filter((row) => !inst.sessions.some((old) => old.alias === row.alias))];
@@ -504,10 +532,11 @@ export const useInstancesStore = defineStore("instances", () => {
   //
   // The RPC returns the ACTUAL alias chosen by the backend, which may differ from
   // the request alias when the desired name collides with an existing archived
-  // session (the backend derives `<alias>-2`, `<alias>-3`, …). When that happens
-  // we patch the optimistic row to the final alias BEFORE reloading the session
-  // list, so `loadSessions` can match the real row against the corrected one and
-  // the user never sees a stale "name not found" error card.
+  // session (the backend derives `<alias>-2`, `<alias>-3`, …). On success the
+  // optimistic row is materialised from the response (final alias, real transport
+  // session, boot state cleared) BEFORE the list reload, and when the alias changed
+  // the chat selection follows it — so `loadSessions` matches the real row against
+  // the corrected one and the user never lands on a stale name.
   async function createSession(instanceId: string, alias: string, agent: string, workspace: string, agentSessionId?: string, model?: string): Promise<{ pending: boolean }> {
     let result: SessionDto | undefined;
     try {
@@ -520,14 +549,25 @@ export const useInstancesStore = defineStore("instances", () => {
       if (e instanceof ApiError && (e.status === 504 || e.code === "timeout")) return { pending: true };
       throw e;
     }
-    if (result && result.alias !== alias) {
+    if (result) {
       const inst = byId(instanceId);
-      if (inst) {
-        const idx = inst.sessions.findIndex((s) => s.alias === alias && !!s.creating);
-        if (idx >= 0) {
-          // Preserve any in-flight optimistic fields (creating, creatingSince, native)
-          // while retargeting the row to the server-chosen alias.
-          inst.sessions.splice(idx, 1, { ...inst.sessions[idx]!, alias: result.alias });
+      const idx = inst?.sessions.findIndex((s) => s.alias === alias && !!s.creating) ?? -1;
+      if (idx >= 0 && inst) {
+        // Materialise the row from the server response: adopt the final alias (the
+        // backend derives `<alias>-2`, … on a collision), real transportSession and
+        // flags, and clear the optimistic boot state. `justCreated` lets the row
+        // survive the page-1 reload below when the instance has more actives than
+        // one page — the server appends new sessions last, so the snapshot cannot
+        // contain it yet and a dropped row would blank the session the user is on.
+        inst.sessions.splice(idx, 1, { ...inst.sessions[idx]!, ...result, creating: undefined, creatingSince: undefined, createError: undefined, justCreated: true });
+      }
+      if (typeof result.alias === "string" && result.alias !== alias) {
+        // The backend derived a different alias — the view (and persisted selection)
+        // must follow the session the user just created, not stay pointed at a name
+        // that never materialised.
+        const chat = useChatStore();
+        if (chat.instanceId === instanceId && chat.sessionAlias === alias) {
+          chat.select(instanceId, result.alias);
         }
       }
     }
@@ -539,9 +579,15 @@ export const useInstancesStore = defineStore("instances", () => {
   // the (slow) create RPC in the background. A cold agent start blocks `createSession`
   // for 10–40s; awaiting it before closing the dialog traps the user in a frozen modal.
   // Instead the booting row lets them watch progress (or navigate away) while it spins
-  // up. On success `loadSessions` (inside createSession) swaps in the real row; on a
-  // 504 the optimistic row simply persists until `sessions-changed` lands; a hard
-  // failure flips the row to an error the booting pane shows.
+  // up. On success `createSession` materialises the row from the RPC response and
+  // `loadSessions` swaps in the list row; on a 504 the optimistic row simply persists
+  // until `sessions-changed` lands; a hard failure flips the row to an error the
+  // booting pane shows.
+  //
+  // The row is appended at the END of the active rows, not prepended: the server list
+  // appends new sessions last (creation order), so the optimistic row sits exactly
+  // where the real row will land — the sidebar order never jumps when creation
+  // completes.
   // Returns false WITHOUT starting creation when the alias is already taken (or the
   // instance is gone): firing the create RPC anyway would only get rejected as a
   // duplicate, and that rejection would land on the pre-existing row (creating=false)
@@ -550,12 +596,20 @@ export const useInstancesStore = defineStore("instances", () => {
   function beginSessionCreation(instanceId: string, alias: string, agent: string, workspace: string, agentSessionId?: string, model?: string): boolean {
     const inst = byId(instanceId);
     if (!inst || inst.sessions.some((s) => s.alias === alias && !s.archived)) return false;
-    inst.sessions = [
-      // A native attach (agentSessionId set) yields a native session — badge the optimistic
-      // row immediately so the marker doesn't pop in only once the server row lands.
-      { alias, agent, workspace, transportSession: "", running: false, archived: false, creating: true, creatingSince: Date.now(), ...(agentSessionId ? { native: true } : {}) },
-      ...inst.sessions,
-    ];
+    const active = inst.sessions.filter((s) => !s.archived);
+    const archived = inst.sessions.filter((s) => s.archived);
+    const optimisticRow: SessionRow = {
+      alias,
+      agent,
+      workspace,
+      transportSession: "",
+      running: false,
+      archived: false,
+      creating: true,
+      creatingSince: Date.now(),
+      ...(agentSessionId ? { native: true } : {}),
+    };
+    inst.sessions = [...active, optimisticRow, ...archived];
     void createSession(instanceId, alias, agent, workspace, agentSessionId, model).catch((e) => {
       const row = byId(instanceId)?.sessions.find((s) => s.alias === alias);
       if (row?.creating) {

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -66,6 +66,8 @@ export interface ControlSessionInfo {
   transportSession: string;
   running: boolean;
   archived: boolean;
+  /** ISO timestamp when the session was archived. */
+  archivedAt?: string;
   /** Whether the session's agent process is currently alive (next prompt responds
    *  without a cold start). Omitted when unknown — e.g. the transport can't observe
    *  liveness or the warmth tracker hasn't sampled this session yet. */
@@ -597,6 +599,7 @@ export class ControlService {
           transportSession: session.transportSession,
           running,
           archived: session.archived === true,
+          ...(session.archivedAt ? { archivedAt: session.archivedAt } : {}),
           ...(warm !== undefined ? { warm } : {}),
           ...(session.source === "agent-side" ? { native: true } : {}),
           ...(session.agentCommand ? { agentCommand: session.agentCommand } : {}),
@@ -623,6 +626,16 @@ export class ControlService {
       if (filters?.agent !== undefined && (session.agent ?? "") !== filters.agent) return false;
       return true;
     });
+    if (filters?.archivedOnly) {
+      all.sort((a, b) => {
+        const aTime = a.archivedAt ? new Date(a.archivedAt).getTime() : 0;
+        const bTime = b.archivedAt ? new Date(b.archivedAt).getTime() : 0;
+        if (aTime !== bTime) {
+          return bTime - aTime;
+        }
+        return 0;
+      });
+    }
     const safeOffset = Math.max(0, Math.floor(offset));
     const safeLimit = Math.min(100, Math.max(1, Math.floor(limit)));
     const sessions = all.slice(safeOffset, safeOffset + safeLimit);

--- a/src/sessions/session-service.ts
+++ b/src/sessions/session-service.ts
@@ -916,6 +916,7 @@ export class SessionService {
       effectiveReplyMode,
       cwd: workspaceConfig.cwd,
       archived: session.archived === true,
+      archivedAt: session.archived_at,
     };
   }
 

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -118,6 +118,8 @@ export interface ResolvedSession {
    * web dashboard). Surfaced to the control/web path via ControlSessionInfo.
    */
   archived?: boolean;
+  /** ISO timestamp when the session was archived. */
+  archivedAt?: string;
 }
 
 export interface AgentSession {

--- a/tests/unit/control/control-service-sessions.test.ts
+++ b/tests/unit/control/control-service-sessions.test.ts
@@ -95,6 +95,38 @@ test("listSessionsPage filters sleeping sessions and returns a server cursor", (
   expect(control.listSessionsPage("relay:acct", 0, 2, true).sessions.map((session) => session.alias)).toEqual(["s0", "s1"]);
 });
 
+test("listSessionsPage archivedOnly orders sleeping sessions newest-sleep-first", () => {
+  const { deps } = makeDeps();
+  deps.sessions.listAllResolvedSessions = () => [
+    { alias: "oldest", agent: "claude", workspace: "/ws", transportSession: "t1", archived: true, archivedAt: "2026-08-01T00:00:00Z" },
+    { alias: "fresh", agent: "claude", workspace: "/ws", transportSession: "t2", archived: true, archivedAt: "2026-08-17T00:00:00Z" },
+    { alias: "mid", agent: "claude", workspace: "/ws", transportSession: "t3", archived: true, archivedAt: "2026-08-09T00:00:00Z" },
+    { alias: "live", agent: "claude", workspace: "/ws", transportSession: "t4" },
+  ];
+  const control = new ControlService(deps as never);
+
+  const page = control.listSessionsPage("relay:acct", 0, 10, false, { archivedOnly: true });
+  expect(page.sessions.map((s) => s.alias)).toEqual(["fresh", "mid", "oldest"]);
+  // Cursor math runs on the sorted set: paging yields the same order.
+  expect(control.listSessionsPage("relay:acct", 0, 2, false, { archivedOnly: true }))
+    .toMatchObject({ sessions: [expect.objectContaining({ alias: "fresh" }), expect.objectContaining({ alias: "mid" })], hasMore: true, nextOffset: 2 });
+});
+
+test("listSessions surfaces archivedAt for sleeping sessions and omits it otherwise", () => {
+  const { deps } = makeDeps();
+  deps.sessions.listAllResolvedSessions = () => [
+    { alias: "slept", agent: "claude", workspace: "/ws", transportSession: "t1", archived: true, archivedAt: "2026-08-17T00:00:00Z" },
+    { alias: "legacy", agent: "claude", workspace: "/ws", transportSession: "t2", archived: true },
+    { alias: "awake", agent: "claude", workspace: "/ws", transportSession: "t3" },
+  ];
+  const control = new ControlService(deps as never);
+  const byAlias = new Map(control.listSessions("relay:acct").map((s) => [s.alias, s]));
+  expect(byAlias.get("slept")!.archivedAt).toBe("2026-08-17T00:00:00Z");
+  // Old records without archived_at keep the field omitted (wire stays minimal).
+  expect("archivedAt" in byAlias.get("legacy")!).toBe(false);
+  expect("archivedAt" in byAlias.get("awake")!).toBe(false);
+});
+
 test("listSessionsPage supports archivedOnly, workspace and agent filters", () => {
   const { deps } = makeDeps();
   deps.sessions.listAllResolvedSessions = () => [


### PR DESCRIPTION
## Summary

Three relay-web dashboard fixes around session creation and the sleeping-session list:

### 1. Sidebar order no longer jumps on session create
`beginSessionCreation` unshifted the optimistic "creating" row to the top of the list, but the server appends new sessions last — the post-create `loadSessions` replace reordered the list under the user. The optimistic row now inserts at the **end of active rows** (before the archived tail), exactly where the real row will land.

### 2. The view stays on the newly created session
Two independent defects fixed in `createSession` / `fetchSessionsPage` (`packages/relay-web/src/stores/instances.ts`):

- **Alias retarget**: when the backend auto-derives a different alias (`backend` → `backend-2` after an archived-name collision), the chat selection (and persisted selection) now follows the final alias instead of stranding on a name that never materialised. Guarded so it never yanks a user who already navigated elsewhere mid-RPC.
- **Mid-boot row survival**: a `loadSessions` replace no longer drops the optimistic row while its create RPC is still in flight (cold agent start, 10–40s) — rows that are `creating`/`createError` survive the replace, mirroring `loadArchivedSessions`' transient handling.
- **Materialise on success**: the row is materialised from the create RPC response (final alias, real `transportSession`, boot state cleared) and marked `justCreated`, so it survives page-1 replaces while the instance has more actives than one page (the server appends new sessions last, so the snapshot cannot contain it yet). A **complete** list (`hasMore=false`) omitting the alias drops it — real removal converges.

### 3. Sleeping sessions sort newest-sleep-first
New `archivedAt` flows end-to-end: `LogicalSession.archived_at` → `ResolvedSession` → `ControlSessionInfo` → `SessionDto` (optional field, omitted when unset — old connectors and old web builds stay wire-compatible).

- `listSessionsPage` with `archivedOnly` sorts by `archivedAt` descending.
- Web `archivedLast` sinks archived rows below actives (active order untouched) but orders the archived half newest-sleep-first, so expanding the sleeping list finds recent sessions without paging. Legacy rows without a timestamp sort stably last.

## Review

Reviewed by an independent reviewer agent across the race surface (504-pending path, selection retarget guard, `justCreated` lifecycle, sort stability for active rows, in-place sort safety, wire compat): verdict **ship, zero defects**.

## Test plan

- [x] 5 new optimistic-create contract tests: insert position, mid-boot replace survival, materialise-then-keep while paginated, complete-list convergence, selection follows derived alias
- [x] `archivedLast` sleep-order test (sidebar-group-mode)
- [x] `listSessionsPage` archivedOnly sort + `archivedAt` passthrough tests (core, bun test)
- [x] Full core unit suite: 4761 pass / 0 fail
- [x] Full relay-web vitest suite: 117 files, 1136 tests pass
- [x] `tsc` / `vue-tsc` / relay-protocol `tsc` clean
- [x] `bun run build` + `bun run build:relay` succeed