### PR TITLE
fix(channel-relay): bundle and select dedicated RMUX daemon

### DIFF
--- a/packages/channel-relay/src/terminal/resolve-rmux-binaries.ts
+++ b/packages/channel-relay/src/terminal/resolve-rmux-binaries.ts
@@ -1,15 +1,23 @@
 // Resolve RMUX bridge + daemon binaries for process-owned terminal mode.
 //
 // Bridge order: explicit config absolute path → platform package optional dep → PATH.
-// RMUX order:   explicit config absolute path → beside selected bridge (bundled
-//               platform-package RMUX when the bridge came from a platform
-//               package) → legacy managed helper ~/.local/libexec/rmux → PATH.
+// RMUX order:   explicit config absolute path → dedicated daemon beside selected
+//               bridge (bundled platform-package daemon when applicable) → legacy
+//               managed helper ~/.local/libexec/rmux → PATH.
 //
 // The platform packages bundle a pinned RMUX whose version matches the native
 // bridge's rmux-sdk pin (`RMUX_BUNDLED_VERSION` below), so a machine-local
 // stale RMUX on PATH or in ~/.local/libexec/rmux must never shadow the bundled
 // binary — that was the Windows field bug (PATH WinGet rmux 0.9.0 vs bridge
 // rmux-sdk 0.10.0). Explicit terminal.rmuxCommand always wins.
+//
+// A platform package is stricter than a developer/legacy layout: it must have
+// a dedicated rmux-daemon beside the bridge. Never fall back to the public
+// rmux CLI from a platform package, including from PATH. On Windows the tiny
+// CLI re-execs the full libexec helper without preserving the daemon's hidden-
+// process creation flags, which opens a persistent console window. Missing
+// packaged daemon therefore fails closed into the managed-helper/dedicated-
+// daemon fallback chain instead of launching rmux.exe.
 //
 // Never downloads latest; never path-depends on a workspace `../rmux`.
 
@@ -72,8 +80,11 @@ function which(command: string, pathEnv = process.env.PATH ?? ""): string | unde
   return undefined;
 }
 
-/** Release-layout + PATH names the RMUX SDK looks for as the daemon helper. */
-const DAEMON_NAMES = ["rmux-daemon.exe", "rmux.exe", "rmux-daemon", "rmux"] as const;
+/** Dedicated daemon names shipped in official RMUX release packages. */
+const DAEMON_BINARY_NAMES = ["rmux-daemon.exe", "rmux-daemon"] as const;
+/** Legacy/SDK fallback names accepted outside the managed platform package. */
+const RMUX_FALLBACK_NAMES = ["rmux.exe", "rmux"] as const;
+const DAEMON_NAMES = [...DAEMON_BINARY_NAMES, ...RMUX_FALLBACK_NAMES] as const;
 
 function firstExecutable(paths: readonly string[]): string | undefined {
   for (const candidate of paths) {
@@ -87,12 +98,16 @@ function resolveDaemonHelper(homeDir: string): string | undefined {
   return firstExecutable(DAEMON_NAMES.map((name) => join(dir, name)));
 }
 
-function resolveDaemonBesideBridge(bridgeCommand: string): string | undefined {
-  return firstExecutable(DAEMON_NAMES.map((name) => join(dirname(bridgeCommand), name)));
+function resolveDaemonBesideBridge(
+  bridgeCommand: string,
+  allowCliFallback: boolean,
+): string | undefined {
+  const names = allowCliFallback ? DAEMON_NAMES : DAEMON_BINARY_NAMES;
+  return firstExecutable(names.map((name) => join(dirname(bridgeCommand), name)));
 }
 
-function resolveDaemonOnPath(pathEnv: string): string | undefined {
-  return which("rmux-daemon", pathEnv) ?? which("rmux", pathEnv);
+function resolveDaemonOnPath(pathEnv: string, allowCliFallback: boolean): string | undefined {
+  return which("rmux-daemon", pathEnv) ?? (allowCliFallback ? which("rmux", pathEnv) : undefined);
 }
 
 function platformPackageName(): string {
@@ -170,14 +185,18 @@ export function resolveRmuxBinaries(input: {
     rmuxCommand = input.rmuxCommand;
     rmuxSource = "config";
   } else {
-    // Bundled RMUX beside the selected bridge is the production default: the
-    // platform package ships `bin/rmux[.exe]` pinned to RMUX_BUNDLED_VERSION.
-    // Only fall back to the legacy managed helper, then PATH, when no bundled
-    // RMUX exists — so a stale ~/.local/libexec/rmux or PATH RMUX never
-    // shadows an up-to-date platform package.
-    const beside = resolveDaemonBesideBridge(bridgeCommand);
+    // Bundled dedicated daemon beside the selected bridge is the production
+    // default. A managed platform package must not silently fall back to its
+    // public rmux CLI (beside the bridge or on PATH). The managed libexec
+    // helper remains a safe compatibility fallback because the SDK applies
+    // hidden-daemon creation flags directly to that helper process.
+    const allowCliFallback = bridgeSource !== "platform-package";
+    const beside = resolveDaemonBesideBridge(bridgeCommand, allowCliFallback);
     const helper = resolveDaemonHelper(input.homeDir ?? homedir());
-    const onPath = resolveDaemonOnPath(input.pathEnv ?? process.env.PATH ?? "");
+    const onPath = resolveDaemonOnPath(
+      input.pathEnv ?? process.env.PATH ?? "",
+      allowCliFallback,
+    );
     rmuxCommand = beside ?? helper ?? onPath;
     if (rmuxCommand) {
       rmuxSource = beside

--- a/packages/channel-relay/src/terminal/resolve-rmux-binaries.ts
+++ b/packages/channel-relay/src/terminal/resolve-rmux-binaries.ts
@@ -1,9 +1,9 @@
 // Resolve RMUX bridge + daemon binaries for process-owned terminal mode.
 //
 // Bridge order: explicit config absolute path → platform package optional dep → PATH.
-// RMUX order:   explicit config absolute path → dedicated daemon beside selected
-//               bridge (bundled platform-package daemon when applicable) → legacy
-//               managed helper ~/.local/libexec/rmux → PATH.
+// RMUX order:   explicit config absolute path → if the bridge came from the managed
+//               platform package, require its bundled dedicated daemon; otherwise
+//               use beside-bridge → legacy managed helper ~/.local/libexec/rmux → PATH.
 //
 // The platform packages bundle a pinned RMUX whose version matches the native
 // bridge's rmux-sdk pin (`RMUX_BUNDLED_VERSION` below), so a machine-local
@@ -12,12 +12,11 @@
 // rmux-sdk 0.10.0). Explicit terminal.rmuxCommand always wins.
 //
 // A platform package is stricter than a developer/legacy layout: it must have
-// a dedicated rmux-daemon beside the bridge. Never fall back to the public
-// rmux CLI from a platform package, including from PATH. On Windows the tiny
-// CLI re-execs the full libexec helper without preserving the daemon's hidden-
-// process creation flags, which opens a persistent console window. Missing
-// packaged daemon therefore fails closed into the managed-helper/dedicated-
-// daemon fallback chain instead of launching rmux.exe.
+// a dedicated rmux-daemon beside the bridge. Never fall back from an incomplete
+// managed package to ~/.local, PATH, or the SDK's implicit candidates. On Windows
+// the public tiny CLI re-execs the full libexec helper without preserving the
+// daemon's hidden-process creation flags, which opens a persistent console window.
+// Missing packaged daemon therefore fails closed before the bridge can start.
 //
 // Never downloads latest; never path-depends on a workspace `../rmux`.
 
@@ -184,25 +183,33 @@ export function resolveRmuxBinaries(input: {
     }
     rmuxCommand = input.rmuxCommand;
     rmuxSource = "config";
+  } else if (bridgeSource === "platform-package") {
+    // Production packages are self-contained. If their dedicated daemon is
+    // missing, do not let the SDK rediscover machine-local rmux/rmux-daemon:
+    // that would reintroduce version skew and the Windows public-CLI handoff.
+    const bundledDaemon = resolveDaemonBesideBridge(bridgeCommand, false);
+    if (!bundledDaemon) {
+      throw new RmuxBinaryUnavailableError(
+        `platform RMUX package is incomplete: dedicated rmux-daemon is missing beside ${bridgeCommand}; reinstall @ganglion/xacpx-channel-relay and its platform optional dependency`,
+      );
+    }
+    rmuxCommand = bundledDaemon;
+    rmuxSource = "platform-package";
   } else {
-    // Bundled dedicated daemon beside the selected bridge is the production
-    // default. A managed platform package must not silently fall back to its
-    // public rmux CLI (beside the bridge or on PATH). The managed libexec
-    // helper remains a safe compatibility fallback because the SDK applies
-    // hidden-daemon creation flags directly to that helper process.
-    const allowCliFallback = bridgeSource !== "platform-package";
-    const beside = resolveDaemonBesideBridge(bridgeCommand, allowCliFallback);
+    // Explicit/PATH bridge layouts are legacy/developer surfaces. Keep their
+    // compatibility chain: beside-bridge, managed helper, then PATH; if none
+    // resolve, leave rmuxCommand undefined and let the SDK emit its native
+    // actionable discovery error during handshake.
+    const beside = resolveDaemonBesideBridge(bridgeCommand, true);
     const helper = resolveDaemonHelper(input.homeDir ?? homedir());
     const onPath = resolveDaemonOnPath(
       input.pathEnv ?? process.env.PATH ?? "",
-      allowCliFallback,
+      true,
     );
     rmuxCommand = beside ?? helper ?? onPath;
     if (rmuxCommand) {
       rmuxSource = beside
-        ? bridgeSource === "platform-package"
-          ? "platform-package"
-          : "beside-bridge"
+        ? "beside-bridge"
         : helper
           ? "managed-helper"
           : "path";

--- a/packages/channel-relay/src/terminal/terminal-registry-store.ts
+++ b/packages/channel-relay/src/terminal/terminal-registry-store.ts
@@ -15,13 +15,22 @@ const OWNER_FILE = "terminal-owner.json";
 const REGISTRY_FILE = "terminals.json";
 const LOCK_FILE = "terminals.lock";
 const FILE_MODE = 0o600;
+
+export type TerminalRegistryLockRetries = number | {
+  retries: number;
+  factor?: number;
+  minTimeout?: number;
+  maxTimeout?: number;
+  randomize?: boolean;
+};
+
 const require = createRequire(import.meta.url);
 const properLockfile = require("proper-lockfile") as {
   lock: (
     resource: string,
     options: {
       lockfilePath: string;
-      retries: number;
+      retries: TerminalRegistryLockRetries;
       stale: number;
       update?: number;
       realpath: boolean;
@@ -31,6 +40,28 @@ const properLockfile = require("proper-lockfile") as {
 
 const WRITER_LOCK_STALE_MS = 30_000;
 const WRITER_LOCK_UPDATE_MS = 10_000;
+const WINDOWS_WRITER_LOCK_RETRY_MS = 1_000;
+const WINDOWS_WRITER_LOCK_RETRY_COUNT = 35;
+
+/**
+ * Windows `xacpx stop/restart` can terminate the daemon tree before channel
+ * cleanup reaches registry.close(), leaving proper-lockfile's directory behind
+ * until its 30s stale lease expires. Retry only on Windows long enough to cross
+ * that lease boundary; POSIX keeps the historical fail-fast behavior because
+ * graceful shutdown normally releases the lock in-process.
+ */
+export function terminalRegistryWriterLockRetries(
+  platform: NodeJS.Platform = process.platform,
+): TerminalRegistryLockRetries {
+  if (platform !== "win32") return 0;
+  return {
+    retries: WINDOWS_WRITER_LOCK_RETRY_COUNT,
+    factor: 1,
+    minTimeout: WINDOWS_WRITER_LOCK_RETRY_MS,
+    maxTimeout: WINDOWS_WRITER_LOCK_RETRY_MS,
+    randomize: false,
+  };
+}
 
 export class TerminalRegistryRevisionMismatchError extends Error {
   constructor(expected: number, actual: number) {
@@ -105,7 +136,7 @@ export interface TerminalRegistryFsDeps {
     resource: string,
     options: {
       lockfilePath: string;
-      retries: number;
+      retries: TerminalRegistryLockRetries;
       stale: number;
       update?: number;
       realpath: boolean;
@@ -124,6 +155,8 @@ export interface TerminalRegistryStoreOptions {
    * without a lock.
    */
   exclusiveWriter?: boolean;
+  /** Override the platform retry policy for the exclusive writer lock (tests/ops). */
+  writerLockRetries?: TerminalRegistryLockRetries;
 }
 
 type LoadedState = {
@@ -228,6 +261,7 @@ export class TerminalRegistryStore {
   private readonly dir: string;
   private readonly deps: Required<TerminalRegistryFsDeps>;
   private readonly exclusiveWriter: boolean;
+  private readonly writerLockRetries: TerminalRegistryLockRetries;
   private state: LoadedState | null = null;
   private chain: Promise<unknown> = Promise.resolve();
   private releaseLock: (() => Promise<void>) | null = null;
@@ -235,6 +269,7 @@ export class TerminalRegistryStore {
   constructor(options: TerminalRegistryStoreOptions) {
     this.dir = options.dir;
     this.exclusiveWriter = options.exclusiveWriter === true;
+    this.writerLockRetries = options.writerLockRetries ?? terminalRegistryWriterLockRetries();
     const d = options.deps ?? {};
     this.deps = {
       mkdir: d.mkdir ?? ((p, o) => mkdir(p, o)),
@@ -567,7 +602,7 @@ export class TerminalRegistryStore {
     try {
       this.releaseLock = await this.deps.lock(this.dir, {
         lockfilePath: join(this.dir, LOCK_FILE),
-        retries: 0,
+        retries: this.writerLockRetries,
         stale: WRITER_LOCK_STALE_MS,
         update: WRITER_LOCK_UPDATE_MS,
         realpath: false,

--- a/platform-packages/xacpx-rmux-bridge-darwin-arm64/.gitignore
+++ b/platform-packages/xacpx-rmux-bridge-darwin-arm64/.gitignore
@@ -3,4 +3,6 @@ bin/xacpx-rmux-bridge
 bin/xacpx-rmux-bridge.exe
 bin/rmux
 bin/rmux.exe
+bin/rmux-daemon
+bin/rmux-daemon.exe
 libexec/

--- a/platform-packages/xacpx-rmux-bridge-darwin-arm64/README.md
+++ b/platform-packages/xacpx-rmux-bridge-darwin-arm64/README.md
@@ -7,9 +7,12 @@ Do not depend on this package directly from application code. Install
 `@ganglion/xacpx-channel-relay` and let npm/bun select the matching optional
 dependency for the current OS/CPU.
 
-Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`, and
-`libexec/rmux/rmux[.exe]`. The bundled RMUX is the pinned 0.10.0 official
-release (fixed URL + SHA-256) matching the bridge's `rmux-sdk = "=0.10.0"`
-pin (no `../rmux` path dependency), so the terminal works offline and machine
--local RMUX on PATH can never shadow it. `checksums.json` records the SHA-256
-of every artifact; the package verifies and installs without network access.
+Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`,
+`bin/rmux-daemon[.exe]`, and `libexec/rmux/rmux[.exe]`. The bundled RMUX is
+the pinned 0.10.0 official release (fixed URL + SHA-256) matching the bridge's
+`rmux-sdk = "=0.10.0"` pin (no `../rmux` path dependency), so the terminal
+works offline and machine-local RMUX on PATH can never shadow it. The bridge
+uses the dedicated daemon binary rather than routing daemon startup through the
+public CLI; on Windows this also keeps the daemon hidden instead of opening a
+persistent console window. `checksums.json` records the SHA-256 of every
+artifact; the package verifies and installs without network access.

--- a/platform-packages/xacpx-rmux-bridge-darwin-arm64/checksums.json
+++ b/platform-packages/xacpx-rmux-bridge-darwin-arm64/checksums.json
@@ -16,6 +16,10 @@
       "path": "bin/rmux",
       "sha256": null
     },
+    "rmuxDaemon": {
+      "path": "bin/rmux-daemon",
+      "sha256": null
+    },
     "rmuxHelper": {
       "path": "libexec/rmux/rmux",
       "sha256": null

--- a/platform-packages/xacpx-rmux-bridge-darwin-x64/.gitignore
+++ b/platform-packages/xacpx-rmux-bridge-darwin-x64/.gitignore
@@ -3,4 +3,6 @@ bin/xacpx-rmux-bridge
 bin/xacpx-rmux-bridge.exe
 bin/rmux
 bin/rmux.exe
+bin/rmux-daemon
+bin/rmux-daemon.exe
 libexec/

--- a/platform-packages/xacpx-rmux-bridge-darwin-x64/README.md
+++ b/platform-packages/xacpx-rmux-bridge-darwin-x64/README.md
@@ -7,9 +7,12 @@ Do not depend on this package directly from application code. Install
 `@ganglion/xacpx-channel-relay` and let npm/bun select the matching optional
 dependency for the current OS/CPU.
 
-Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`, and
-`libexec/rmux/rmux[.exe]`. The bundled RMUX is the pinned 0.10.0 official
-release (fixed URL + SHA-256) matching the bridge's `rmux-sdk = "=0.10.0"`
-pin (no `../rmux` path dependency), so the terminal works offline and machine
--local RMUX on PATH can never shadow it. `checksums.json` records the SHA-256
-of every artifact; the package verifies and installs without network access.
+Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`,
+`bin/rmux-daemon[.exe]`, and `libexec/rmux/rmux[.exe]`. The bundled RMUX is
+the pinned 0.10.0 official release (fixed URL + SHA-256) matching the bridge's
+`rmux-sdk = "=0.10.0"` pin (no `../rmux` path dependency), so the terminal
+works offline and machine-local RMUX on PATH can never shadow it. The bridge
+uses the dedicated daemon binary rather than routing daemon startup through the
+public CLI; on Windows this also keeps the daemon hidden instead of opening a
+persistent console window. `checksums.json` records the SHA-256 of every
+artifact; the package verifies and installs without network access.

--- a/platform-packages/xacpx-rmux-bridge-darwin-x64/checksums.json
+++ b/platform-packages/xacpx-rmux-bridge-darwin-x64/checksums.json
@@ -16,6 +16,10 @@
       "path": "bin/rmux",
       "sha256": null
     },
+    "rmuxDaemon": {
+      "path": "bin/rmux-daemon",
+      "sha256": null
+    },
     "rmuxHelper": {
       "path": "libexec/rmux/rmux",
       "sha256": null

--- a/platform-packages/xacpx-rmux-bridge-linux-arm64/.gitignore
+++ b/platform-packages/xacpx-rmux-bridge-linux-arm64/.gitignore
@@ -3,4 +3,6 @@ bin/xacpx-rmux-bridge
 bin/xacpx-rmux-bridge.exe
 bin/rmux
 bin/rmux.exe
+bin/rmux-daemon
+bin/rmux-daemon.exe
 libexec/

--- a/platform-packages/xacpx-rmux-bridge-linux-arm64/README.md
+++ b/platform-packages/xacpx-rmux-bridge-linux-arm64/README.md
@@ -7,9 +7,12 @@ Do not depend on this package directly from application code. Install
 `@ganglion/xacpx-channel-relay` and let npm/bun select the matching optional
 dependency for the current OS/CPU.
 
-Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`, and
-`libexec/rmux/rmux[.exe]`. The bundled RMUX is the pinned 0.10.0 official
-release (fixed URL + SHA-256) matching the bridge's `rmux-sdk = "=0.10.0"`
-pin (no `../rmux` path dependency), so the terminal works offline and machine
--local RMUX on PATH can never shadow it. `checksums.json` records the SHA-256
-of every artifact; the package verifies and installs without network access.
+Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`,
+`bin/rmux-daemon[.exe]`, and `libexec/rmux/rmux[.exe]`. The bundled RMUX is
+the pinned 0.10.0 official release (fixed URL + SHA-256) matching the bridge's
+`rmux-sdk = "=0.10.0"` pin (no `../rmux` path dependency), so the terminal
+works offline and machine-local RMUX on PATH can never shadow it. The bridge
+uses the dedicated daemon binary rather than routing daemon startup through the
+public CLI; on Windows this also keeps the daemon hidden instead of opening a
+persistent console window. `checksums.json` records the SHA-256 of every
+artifact; the package verifies and installs without network access.

--- a/platform-packages/xacpx-rmux-bridge-linux-arm64/checksums.json
+++ b/platform-packages/xacpx-rmux-bridge-linux-arm64/checksums.json
@@ -16,6 +16,10 @@
       "path": "bin/rmux",
       "sha256": null
     },
+    "rmuxDaemon": {
+      "path": "bin/rmux-daemon",
+      "sha256": null
+    },
     "rmuxHelper": {
       "path": "libexec/rmux/rmux",
       "sha256": null

--- a/platform-packages/xacpx-rmux-bridge-linux-x64/.gitignore
+++ b/platform-packages/xacpx-rmux-bridge-linux-x64/.gitignore
@@ -3,4 +3,6 @@ bin/xacpx-rmux-bridge
 bin/xacpx-rmux-bridge.exe
 bin/rmux
 bin/rmux.exe
+bin/rmux-daemon
+bin/rmux-daemon.exe
 libexec/

--- a/platform-packages/xacpx-rmux-bridge-linux-x64/README.md
+++ b/platform-packages/xacpx-rmux-bridge-linux-x64/README.md
@@ -7,9 +7,12 @@ Do not depend on this package directly from application code. Install
 `@ganglion/xacpx-channel-relay` and let npm/bun select the matching optional
 dependency for the current OS/CPU.
 
-Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`, and
-`libexec/rmux/rmux[.exe]`. The bundled RMUX is the pinned 0.10.0 official
-release (fixed URL + SHA-256) matching the bridge's `rmux-sdk = "=0.10.0"`
-pin (no `../rmux` path dependency), so the terminal works offline and machine
--local RMUX on PATH can never shadow it. `checksums.json` records the SHA-256
-of every artifact; the package verifies and installs without network access.
+Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`,
+`bin/rmux-daemon[.exe]`, and `libexec/rmux/rmux[.exe]`. The bundled RMUX is
+the pinned 0.10.0 official release (fixed URL + SHA-256) matching the bridge's
+`rmux-sdk = "=0.10.0"` pin (no `../rmux` path dependency), so the terminal
+works offline and machine-local RMUX on PATH can never shadow it. The bridge
+uses the dedicated daemon binary rather than routing daemon startup through the
+public CLI; on Windows this also keeps the daemon hidden instead of opening a
+persistent console window. `checksums.json` records the SHA-256 of every
+artifact; the package verifies and installs without network access.

--- a/platform-packages/xacpx-rmux-bridge-linux-x64/checksums.json
+++ b/platform-packages/xacpx-rmux-bridge-linux-x64/checksums.json
@@ -16,6 +16,10 @@
       "path": "bin/rmux",
       "sha256": null
     },
+    "rmuxDaemon": {
+      "path": "bin/rmux-daemon",
+      "sha256": null
+    },
     "rmuxHelper": {
       "path": "libexec/rmux/rmux",
       "sha256": null

--- a/platform-packages/xacpx-rmux-bridge-win32-x64/.gitignore
+++ b/platform-packages/xacpx-rmux-bridge-win32-x64/.gitignore
@@ -3,4 +3,6 @@ bin/xacpx-rmux-bridge
 bin/xacpx-rmux-bridge.exe
 bin/rmux
 bin/rmux.exe
+bin/rmux-daemon
+bin/rmux-daemon.exe
 libexec/

--- a/platform-packages/xacpx-rmux-bridge-win32-x64/README.md
+++ b/platform-packages/xacpx-rmux-bridge-win32-x64/README.md
@@ -7,9 +7,12 @@ Do not depend on this package directly from application code. Install
 `@ganglion/xacpx-channel-relay` and let npm/bun select the matching optional
 dependency for the current OS/CPU.
 
-Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`, and
-`libexec/rmux/rmux[.exe]`. The bundled RMUX is the pinned 0.10.0 official
-release (fixed URL + SHA-256) matching the bridge's `rmux-sdk = "=0.10.0"`
-pin (no `../rmux` path dependency), so the terminal works offline and machine
--local RMUX on PATH can never shadow it. `checksums.json` records the SHA-256
-of every artifact; the package verifies and installs without network access.
+Self-contained: ships `bin/xacpx-rmux-bridge[.exe]`, `bin/rmux[.exe]`,
+`bin/rmux-daemon[.exe]`, and `libexec/rmux/rmux[.exe]`. The bundled RMUX is
+the pinned 0.10.0 official release (fixed URL + SHA-256) matching the bridge's
+`rmux-sdk = "=0.10.0"` pin (no `../rmux` path dependency), so the terminal
+works offline and machine-local RMUX on PATH can never shadow it. The bridge
+uses the dedicated daemon binary rather than routing daemon startup through the
+public CLI; on Windows this also keeps the daemon hidden instead of opening a
+persistent console window. `checksums.json` records the SHA-256 of every
+artifact; the package verifies and installs without network access.

--- a/platform-packages/xacpx-rmux-bridge-win32-x64/checksums.json
+++ b/platform-packages/xacpx-rmux-bridge-win32-x64/checksums.json
@@ -16,6 +16,10 @@
       "path": "bin/rmux.exe",
       "sha256": null
     },
+    "rmuxDaemon": {
+      "path": "bin/rmux-daemon.exe",
+      "sha256": null
+    },
     "rmuxHelper": {
       "path": "libexec/rmux/rmux.exe",
       "sha256": null

--- a/scripts/pack-rmux-bridge-platform.mjs
+++ b/scripts/pack-rmux-bridge-platform.mjs
@@ -4,11 +4,17 @@
  * matching platform npm package and write checksums.json. Does not
  * cross-compile — run on (or with a binary for) each target OS/arch.
  *
- * The RMUX binary comes from the pinned official release (scripts/rmux-release.mjs,
+ * The RMUX binaries come from the pinned official release (scripts/rmux-release.mjs,
  * fixed version + URL + SHA-256) so the platform package is self-contained and
  * offline-installable: users never need a machine-local RMUX, and a stale
  * PATH/~/.local RMUX can never shadow the bundled one (Windows field bug:
  * WinGet rmux 0.9.0 vs bridge rmux-sdk 0.10.0).
+ *
+ * The package includes all three upstream runtime pieces: the tiny public CLI,
+ * the dedicated hidden daemon, and the private full helper. The bridge resolver
+ * intentionally selects rmux-daemon first. On Windows this is required to keep
+ * daemon startup on RMUX's CREATE_NO_WINDOW/DETACHED_PROCESS path instead of
+ * falling through rmux.exe -> libexec/rmux/rmux.exe and opening a console.
  *
  * Usage:
  *   node scripts/pack-rmux-bridge-platform.mjs \
@@ -16,7 +22,8 @@
  *     --binary packages/channel-relay/native/rmux-bridge/target/release/xacpx-rmux-bridge
  *
  * Optional overrides (normally the pinned release is fetched automatically):
- *   --rmux-binary <path>   pre-fetched bin/rmux[.exe] from the pinned release
+ *   --rmux-binary <path>   pre-fetched public bin/rmux[.exe]
+ *   --rmux-daemon <path>   pre-fetched bin/rmux-daemon[.exe] (defaults beside --rmux-binary)
  *   --rmux-helper <path>   pre-fetched libexec/rmux/rmux[.exe] (defaults to
  *                          ../libexec/rmux/rmux relative to --rmux-binary)
  *   --rmux-archive-cache <dir>  where downloaded RMUX archives are reused
@@ -34,7 +41,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import { extractRmuxRelease, fetchRmuxReleaseArchive, RMUX_VERSION } from "./rmux-release.mjs";
 
@@ -55,6 +62,7 @@ const bridge = resolve(
   ),
 );
 const rmuxBinaryArg = arg("rmux-binary", null);
+const rmuxDaemonArg = arg("rmux-daemon", null);
 const rmuxHelperArg = arg("rmux-helper", null);
 const archiveCache = resolve(arg("rmux-archive-cache", join(root, ".rmux-release-cache")));
 const skipVersionCheck = process.argv.includes("--skip-version-check");
@@ -64,6 +72,7 @@ const packagesRoot = resolve(arg("packages-dir", join(root, "platform-packages")
 const pkgDir = join(packagesRoot, `xacpx-rmux-bridge-${key}`);
 const bridgeBinName = platform === "win32" ? "xacpx-rmux-bridge.exe" : "xacpx-rmux-bridge";
 const rmuxBinName = platform === "win32" ? "rmux.exe" : "rmux";
+const rmuxDaemonName = platform === "win32" ? "rmux-daemon.exe" : "rmux-daemon";
 
 if (!existsSync(pkgDir)) {
   console.error(`unknown platform package: ${pkgDir}`);
@@ -74,13 +83,23 @@ if (!existsSync(bridge)) {
   process.exit(1);
 }
 
-// --- Resolve the pinned RMUX CLI + hidden-daemon helper ----------------------
+// --- Resolve the pinned RMUX CLI + dedicated daemon + private helper ---------
 let rmuxSource;
+let rmuxDaemon;
 let rmuxHelper;
 if (rmuxBinaryArg) {
   rmuxSource = resolve(rmuxBinaryArg);
   if (!existsSync(rmuxSource)) {
     console.error(`--rmux-binary not found: ${rmuxSource}`);
+    process.exit(1);
+  }
+  rmuxDaemon = rmuxDaemonArg
+    ? resolve(rmuxDaemonArg)
+    : join(dirname(rmuxSource), rmuxDaemonName);
+  if (!existsSync(rmuxDaemon)) {
+    console.error(
+      `rmux daemon not found: ${rmuxDaemon} (pass --rmux-daemon, or drop --rmux-binary to fetch the pinned release)`,
+    );
     process.exit(1);
   }
   rmuxHelper = rmuxHelperArg
@@ -93,11 +112,12 @@ if (rmuxBinaryArg) {
     process.exit(1);
   }
 } else {
-  // Pin + SHA-verify the official release, then extract the CLI + helper.
+  // Pin + SHA-verify the official release, then extract all runtime binaries.
   const archive = fetchRmuxReleaseArchive({ platform, arch, cacheDir: archiveCache });
   const tmpExtract = join(archiveCache, `extract-${key}`);
   const extracted = extractRmuxRelease({ archive, platform, destDir: tmpExtract });
   rmuxSource = extracted.cli;
+  rmuxDaemon = extracted.daemon;
   rmuxHelper = extracted.helper;
 }
 
@@ -108,14 +128,17 @@ mkdirSync(libexecRmuxDir, { recursive: true });
 
 const bridgeDest = join(binDir, bridgeBinName);
 const rmuxDest = join(binDir, rmuxBinName);
+const rmuxDaemonDest = join(binDir, rmuxDaemonName);
 const rmuxHelperDest = join(libexecRmuxDir, rmuxBinName);
 
 copyFileSync(bridge, bridgeDest);
 copyFileSync(rmuxSource, rmuxDest);
+copyFileSync(rmuxDaemon, rmuxDaemonDest);
 copyFileSync(rmuxHelper, rmuxHelperDest);
 if (platform !== "win32") {
   chmodSync(bridgeDest, 0o755);
   chmodSync(rmuxDest, 0o755);
+  chmodSync(rmuxDaemonDest, 0o755);
   chmodSync(rmuxHelperDest, 0o755);
 }
 
@@ -137,6 +160,7 @@ const sha256Of = (path) => createHash("sha256").update(readFileSync(path)).diges
 
 const bridgeSha = sha256Of(bridgeDest);
 const rmuxSha = sha256Of(rmuxDest);
+const rmuxDaemonSha = sha256Of(rmuxDaemonDest);
 const rmuxHelperSha = sha256Of(rmuxHelperDest);
 
 const channelRelayVersion = JSON.parse(
@@ -173,6 +197,10 @@ const checksums = {
       path: `bin/${rmuxBinName}`,
       sha256: rmuxSha,
     },
+    rmuxDaemon: {
+      path: `bin/${rmuxDaemonName}`,
+      sha256: rmuxDaemonSha,
+    },
     rmuxHelper: {
       path: `libexec/rmux/${rmuxBinName}`,
       sha256: rmuxHelperSha,
@@ -182,5 +210,7 @@ const checksums = {
 };
 writeFileSync(join(pkgDir, "checksums.json"), `${JSON.stringify(checksums, null, 2)}\n`);
 console.log(
-  `packed ${pkgJson.name}@${channelRelayVersion} bridge=${bridgeSha.slice(0, 12)} rmux=${rmuxSha.slice(0, 12)} (v${RMUX_VERSION}) helper=${rmuxHelperSha.slice(0, 12)}`,
+  `packed ${pkgJson.name}@${channelRelayVersion} bridge=${bridgeSha.slice(0, 12)} ` +
+    `rmux=${rmuxSha.slice(0, 12)} daemon=${rmuxDaemonSha.slice(0, 12)} ` +
+    `(v${RMUX_VERSION}) helper=${rmuxHelperSha.slice(0, 12)}`,
 );

--- a/scripts/rmux-release.mjs
+++ b/scripts/rmux-release.mjs
@@ -27,11 +27,16 @@ export const RMUX_RELEASE_REPO = "Helvesec/rmux";
 
 /**
  * Official release asset per platform/arch with its pinned SHA-256.
- * Release layout (rmux-package-v2): `bin/rmux[.exe]` (connect-or-start CLI)
- * + `libexec/rmux/rmux[.exe]` (hidden-daemon helper the CLI re-execs). The
- * bridge only needs the CLI; the helper must ride along in the same package
- * because `rmux` refuses to daemonize without it ("private rmux helper not
- * found under libexec/rmux").
+ * Release layout (rmux-package-v2):
+ *   - public connect-or-start CLI: bin/rmux[.exe] (Windows: package-root rmux.exe)
+ *   - dedicated hidden daemon: bin/rmux-daemon[.exe] (Windows: package-root rmux-daemon.exe)
+ *   - private full helper: libexec/rmux/rmux[.exe]
+ *
+ * xacpx must bundle all three. In particular the bridge SDK should launch the
+ * dedicated rmux-daemon directly; pointing RMUX_SDK_DAEMON_BINARY at the tiny
+ * public rmux.exe makes Windows fall back to the full helper without the
+ * daemon's CREATE_NO_WINDOW/DETACHED_PROCESS launch flags, which opens a
+ * persistent console window.
  */
 export const RMUX_RELEASE_ASSETS = {
   "darwin-arm64": {
@@ -76,18 +81,24 @@ export function rmuxReleaseUrl(platform, arch) {
 export function rmuxBinariesForExtractedRelease(extractRoot, platform) {
   const exe = platform === "win32" ? ".exe" : "";
   const cliName = `rmux${exe}`;
-  const helperName = `${cliName}`;
-  // Two official layouts exist (package_layout rmux-package-v2):
-  //   unix tarballs: bin/rmux + libexec/rmux/rmux
-  //   windows zip:   rmux.exe + libexec/rmux/rmux.exe at the package root
+  const daemonName = `rmux-daemon${exe}`;
+  const helperName = cliName;
+  // Official v0.10.0 layouts:
+  //   unix tarballs: bin/rmux + bin/rmux-daemon + libexec/rmux/rmux
+  //   windows zip:   rmux.exe + rmux-daemon.exe + libexec/rmux/rmux.exe
   const cliCandidates = [join(extractRoot, "bin", cliName), join(extractRoot, cliName)];
+  const daemonCandidates = [
+    join(extractRoot, "bin", daemonName),
+    join(extractRoot, daemonName),
+  ];
   const helperCandidates = [
     join(extractRoot, "libexec", "rmux", helperName),
     join(extractRoot, "bin", "..", "libexec", "rmux", helperName),
   ];
   const cli = cliCandidates.find((candidate) => existsSync(candidate));
+  const daemon = daemonCandidates.find((candidate) => existsSync(candidate));
   const helper = helperCandidates.find((candidate) => existsSync(candidate));
-  return { cli, helper };
+  return { cli, daemon, helper };
 }
 
 /**
@@ -116,8 +127,8 @@ export function fetchRmuxReleaseArchive({ platform, arch, cacheDir }) {
 }
 
 /**
- * Extract a fetched RMUX release archive into destDir and return the
- * connect-or-start CLI + hidden-daemon helper paths.
+ * Extract a fetched RMUX release archive into destDir and return the public
+ * CLI, dedicated daemon, and private helper paths.
  */
 export function extractRmuxRelease({ archive, platform, destDir }) {
   mkdirSync(destDir, { recursive: true });
@@ -144,14 +155,15 @@ export function extractRmuxRelease({ archive, platform, destDir }) {
   const entries = readdirSync(destDir, { withFileTypes: true });
   const topLevel =
     entries.length === 1 && entries[0].isDirectory() ? join(destDir, entries[0].name) : destDir;
-  const { cli, helper } = rmuxBinariesForExtractedRelease(topLevel, platform);
-  if (!existsSync(cli) || !existsSync(helper)) {
+  const { cli, daemon, helper } = rmuxBinariesForExtractedRelease(topLevel, platform);
+  if (!cli || !daemon || !helper || !existsSync(cli) || !existsSync(daemon) || !existsSync(helper)) {
     throw new Error(
-      `unexpected RMUX ${platform} release layout: missing ${cli} or ${helper}; ` +
+      `unexpected RMUX ${platform} release layout: missing CLI (${cli ?? "not found"}), ` +
+        `daemon (${daemon ?? "not found"}), or helper (${helper ?? "not found"}); ` +
         `update scripts/rmux-release.mjs to the current layout`,
     );
   }
-  return { cli, helper };
+  return { cli, daemon, helper };
 }
 
 function sha256OfFile(path) {

--- a/scripts/verify-publish.mjs
+++ b/scripts/verify-publish.mjs
@@ -107,7 +107,7 @@ export async function collectPublishVerificationFailures(input = {}) {
  * Platform packages bundle a pinned RMUX next to the bridge. Verify:
  *   - the three version pins agree (release manifest ↔ TS resolver constant ↔
  *     Cargo.toml rmux-sdk), so the packaged RMUX provably matches the bridge
- *   - every packed package contains bridge + rmux + libexec helper binaries
+ *   - every packed package contains bridge + rmux + rmux-daemon + libexec helper
  *   - checksums.json artifacts match the actual file bytes
  * Unpacked (post-checkout placeholder) packages pass as long as their
  * checksums are null; a non-null checksum must always match its file.
@@ -179,9 +179,14 @@ export async function verifyPlatformPackages(repoRoot, failures = []) {
       );
     }
     const artifacts = checksums.artifacts;
-    if (!artifacts?.bridge?.path || !artifacts?.rmux?.path || !artifacts?.rmuxHelper?.path) {
+    if (
+      !artifacts?.bridge?.path
+      || !artifacts?.rmux?.path
+      || !artifacts?.rmuxDaemon?.path
+      || !artifacts?.rmuxHelper?.path
+    ) {
       failures.push(
-        `${dir}: checksums.artifacts must list bridge + rmux + rmuxHelper paths`,
+        `${dir}: checksums.artifacts must list bridge + rmux + rmuxDaemon + rmuxHelper paths`,
       );
       continue;
     }
@@ -192,9 +197,10 @@ export async function verifyPlatformPackages(repoRoot, failures = []) {
     );
     if (anyArtifactPresent) {
       // Packed (or partially packed) state: every artifact must exist and
-      // match its recorded SHA-256 — including the bundled RMUX + helper.
+      // match its recorded SHA-256 — including the bundled RMUX daemon/helper.
       await verifyArtifactBytes(dir, artifacts.bridge, pkgRoot, checksums, failures);
       await verifyArtifactBytes(dir, artifacts.rmux, pkgRoot, checksums, failures);
+      await verifyArtifactBytes(dir, artifacts.rmuxDaemon, pkgRoot, checksums, failures);
       await verifyArtifactBytes(dir, artifacts.rmuxHelper, pkgRoot, checksums, failures);
       // Legacy single-artifact fields must stay the bridge entry.
       if (checksums.artifact !== artifacts.bridge.path) {

--- a/tests/smoke/relay-rmux-platform-package.test.ts
+++ b/tests/smoke/relay-rmux-platform-package.test.ts
@@ -9,12 +9,13 @@
  *   node_modules/@ganglion/xacpx-rmux-bridge-<os>-<arch>
  * so the production resolver finds it via require.resolve. No explicit
  * terminal.rmuxCommand / bridgeCommand may be set — the point is to exercise
- * production resolution (bundled RMUX wins over PATH/helper).
+ * production resolution (bundled RMUX wins over PATH/helper and resolves the
+ * dedicated rmux-daemon, never the public rmux CLI).
  */
 import { afterEach, expect, setDefaultTimeout, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, join } from "node:path";
+import { basename, delimiter, join } from "node:path";
 
 import { parseRelayTerminalConfig } from "../../packages/channel-relay/src/config";
 import {
@@ -100,7 +101,7 @@ function collectUntil(
   })();
 }
 
-test.skipIf(!enabled)("bundled RMUX is resolved over a hostile PATH fake; live lifecycle works and the fake is never executed", async () => {
+test.skipIf(!enabled)("bundled RMUX daemon is resolved over a hostile PATH fake; live lifecycle works and the fake is never executed", async () => {
   // --- Hostile environment: fake rmux 0.9-ish at the FRONT of PATH -----------
   const hostileDir = tempDir("rmux-hostile-");
   const marker = join(hostileDir, "fake-ran.marker");
@@ -121,19 +122,27 @@ test.skipIf(!enabled)("bundled RMUX is resolved over a hostile PATH fake; live l
   const oldPath = process.env.PATH;
   process.env.PATH = hostilePath;
   try {
-    // --- Production resolution must pick the bundled platform-package RMUX ---
+    // --- Production resolution must pick the bundled platform-package daemon -
     const resolved = resolveRmuxBinaries({
       pathEnv: process.env.PATH,
       platformPackageResolver: undefined,
     });
     expect(resolved.source.bridge).toBe("platform-package");
-    expect(resolved.rmuxCommand, "bundled RMUX must exist next to the platform bridge").toBeDefined();
+    expect(resolved.rmuxCommand, "bundled RMUX daemon must exist next to the platform bridge").toBeDefined();
     expect(resolved.source.rmux).toBe("platform-package");
+    expect(basename(resolved.rmuxCommand!)).toBe(
+      process.platform === "win32" ? "rmux-daemon.exe" : "rmux-daemon",
+    );
     expect(resolved.rmuxCommand).not.toBe(fakeRmux);
     expect(resolved.rmuxCommand).not.toBe(fakeDaemon);
 
-    // The bundled binary must be the pinned version (proves it is not the fake).
-    const probe = Bun.spawnSync([resolved.rmuxCommand!, "-V"], { encoding: "utf8" });
+    // The public bundled CLI remains the version probe authority. Resolve its
+    // path beside the dedicated daemon instead of executing the daemon itself.
+    const bundledCli = join(
+      resolved.rmuxCommand!.slice(0, -basename(resolved.rmuxCommand!).length),
+      process.platform === "win32" ? "rmux.exe" : "rmux",
+    );
+    const probe = Bun.spawnSync([bundledCli, "-V"], { encoding: "utf8" });
     expect(probe.exitCode).toBe(0);
     expect(`${probe.stdout}${probe.stderr}`).toContain(`rmux ${RMUX_BUNDLED_VERSION}`);
 

--- a/tests/unit/packages/channel-relay/resolve-rmux-binaries-strict.test.ts
+++ b/tests/unit/packages/channel-relay/resolve-rmux-binaries-strict.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  resolveRmuxBinaries,
+  RmuxBinaryUnavailableError,
+} from "../../../../packages/channel-relay/src/terminal/resolve-rmux-binaries";
+
+function touchExecutable(path: string): string {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, "#!/bin/sh\nexit 0\n");
+  chmodSync(path, 0o755);
+  return path;
+}
+
+test("incomplete platform package fails closed even when HOME and PATH contain RMUX fallbacks", () => {
+  const dir = mkdtempSync(join(tmpdir(), "rmux-platform-strict-"));
+  try {
+    const pkgBin = join(dir, "pkg", "bin");
+    const bridge = touchExecutable(join(pkgBin, "xacpx-rmux-bridge.exe"));
+    touchExecutable(join(pkgBin, "rmux.exe"));
+
+    const homeDir = join(dir, "home");
+    touchExecutable(join(homeDir, ".local", "libexec", "rmux", "rmux.exe"));
+    touchExecutable(join(homeDir, ".local", "libexec", "rmux", "rmux-daemon.exe"));
+
+    const pathDir = join(dir, "path");
+    touchExecutable(join(pathDir, "rmux.exe"));
+    touchExecutable(join(pathDir, "rmux-daemon.exe"));
+
+    expect(() =>
+      resolveRmuxBinaries({
+        platformPackageResolver: () => bridge,
+        homeDir,
+        pathEnv: pathDir,
+      }),
+    ).toThrow(RmuxBinaryUnavailableError);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/packages/channel-relay/resolve-rmux-binaries.test.ts
+++ b/tests/unit/packages/channel-relay/resolve-rmux-binaries.test.ts
@@ -26,13 +26,14 @@ function homeWithManagedHelper(dir: string): string {
   return helperDir;
 }
 
-test("bundled RMUX beside a platform-package bridge wins over PATH", () => {
+test("bundled RMUX daemon beside a platform-package bridge wins over PATH", () => {
   const dir = mkdtempSync(join(tmpdir(), "rmux-bundled-path-"));
   try {
     const pkgBin = join(dir, "pkg", "bin");
     mkdirSync(pkgBin, { recursive: true });
     const bridge = touchExecutable(join(pkgBin, "xacpx-rmux-bridge.exe"));
-    const bundled = touchExecutable(join(pkgBin, "rmux.exe"));
+    touchExecutable(join(pkgBin, "rmux.exe"));
+    const bundled = touchExecutable(join(pkgBin, "rmux-daemon.exe"));
 
     // Hostile PATH: a stale rmux (e.g. WinGet 0.9.0) that must never win.
     const staleDir = join(dir, "stale-path");
@@ -54,13 +55,14 @@ test("bundled RMUX beside a platform-package bridge wins over PATH", () => {
   }
 });
 
-test("bundled RMUX wins over a stale managed helper in ~/.local/libexec/rmux", () => {
+test("bundled RMUX daemon wins over a stale managed helper in ~/.local/libexec/rmux", () => {
   const dir = mkdtempSync(join(tmpdir(), "rmux-bundled-helper-"));
   try {
     const pkgBin = join(dir, "pkg", "bin");
     mkdirSync(pkgBin, { recursive: true });
     const bridge = touchExecutable(join(pkgBin, "xacpx-rmux-bridge.exe"));
-    const bundled = touchExecutable(join(pkgBin, "rmux.exe"));
+    touchExecutable(join(pkgBin, "rmux.exe"));
+    const bundled = touchExecutable(join(pkgBin, "rmux-daemon.exe"));
     const helperDir = homeWithManagedHelper(dir);
 
     const resolved = resolveRmuxBinaries({
@@ -76,13 +78,35 @@ test("bundled RMUX wins over a stale managed helper in ~/.local/libexec/rmux", (
   }
 });
 
+test("platform package never falls back to its public rmux CLI when the daemon is missing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "rmux-bundled-missing-daemon-"));
+  try {
+    const pkgBin = join(dir, "pkg", "bin");
+    mkdirSync(pkgBin, { recursive: true });
+    const bridge = touchExecutable(join(pkgBin, "xacpx-rmux-bridge.exe"));
+    const publicCli = touchExecutable(join(pkgBin, "rmux.exe"));
+
+    const resolved = resolveRmuxBinaries({
+      platformPackageResolver: () => bridge,
+      pathEnv: "",
+      homeDir: join(dir, "empty-home"),
+    });
+    expect(resolved.source.bridge).toBe("platform-package");
+    expect(resolved.rmuxCommand).toBeUndefined();
+    expect(resolved.source.rmux).toBeUndefined();
+    expect(resolved.rmuxCommand).not.toBe(publicCli);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("explicit terminal.rmuxCommand always wins over bundled RMUX", () => {
   const dir = mkdtempSync(join(tmpdir(), "rmux-explicit-"));
   try {
     const pkgBin = join(dir, "pkg", "bin");
     mkdirSync(pkgBin, { recursive: true });
     const bridge = touchExecutable(join(pkgBin, "xacpx-rmux-bridge.exe"));
-    touchExecutable(join(pkgBin, "rmux.exe"));
+    touchExecutable(join(pkgBin, "rmux-daemon.exe"));
     const customDir = join(dir, "custom");
     mkdirSync(customDir, { recursive: true });
     const custom = touchExecutable(join(customDir, "rmux.exe"));
@@ -224,7 +248,7 @@ test("resolveRmuxBinaries rejects missing config rmuxCommand even with bundled R
   const dir = mkdtempSync(join(tmpdir(), "rmux-bin-"));
   try {
     const bridge = touchExecutable(join(dir, "xacpx-rmux-bridge"));
-    touchExecutable(join(dir, "rmux"));
+    touchExecutable(join(dir, "rmux-daemon"));
     expect(() =>
       resolveRmuxBinaries({
         bridgeCommand: bridge,

--- a/tests/unit/packages/channel-relay/resolve-rmux-binaries.test.ts
+++ b/tests/unit/packages/channel-relay/resolve-rmux-binaries.test.ts
@@ -84,17 +84,15 @@ test("platform package never falls back to its public rmux CLI when the daemon i
     const pkgBin = join(dir, "pkg", "bin");
     mkdirSync(pkgBin, { recursive: true });
     const bridge = touchExecutable(join(pkgBin, "xacpx-rmux-bridge.exe"));
-    const publicCli = touchExecutable(join(pkgBin, "rmux.exe"));
+    touchExecutable(join(pkgBin, "rmux.exe"));
 
-    const resolved = resolveRmuxBinaries({
-      platformPackageResolver: () => bridge,
-      pathEnv: "",
-      homeDir: join(dir, "empty-home"),
-    });
-    expect(resolved.source.bridge).toBe("platform-package");
-    expect(resolved.rmuxCommand).toBeUndefined();
-    expect(resolved.source.rmux).toBeUndefined();
-    expect(resolved.rmuxCommand).not.toBe(publicCli);
+    expect(() =>
+      resolveRmuxBinaries({
+        platformPackageResolver: () => bridge,
+        pathEnv: "",
+        homeDir: join(dir, "empty-home"),
+      }),
+    ).toThrow(RmuxBinaryUnavailableError);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/unit/packages/channel-relay/terminal-registry-lock-recovery.test.ts
+++ b/tests/unit/packages/channel-relay/terminal-registry-lock-recovery.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  TerminalRegistryStore,
+  terminalRegistryWriterLockRetries,
+  type TerminalRegistryLockRetries,
+} from "../../../../packages/channel-relay/src/terminal/terminal-registry-store";
+
+test("Windows writer-lock retry policy spans the 30s stale lease without changing POSIX fail-fast", () => {
+  expect(terminalRegistryWriterLockRetries("linux")).toBe(0);
+  expect(terminalRegistryWriterLockRetries("darwin")).toBe(0);
+  expect(terminalRegistryWriterLockRetries("win32")).toEqual({
+    retries: 35,
+    factor: 1,
+    minTimeout: 1_000,
+    maxTimeout: 1_000,
+    randomize: false,
+  });
+});
+
+test("exclusive writer forwards the configured retry policy to proper-lockfile", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "term-registry-retry-"));
+  const retryPolicy: TerminalRegistryLockRetries = {
+    retries: 3,
+    factor: 1,
+    minTimeout: 25,
+    maxTimeout: 25,
+    randomize: false,
+  };
+  let observed: TerminalRegistryLockRetries | undefined;
+  const store = new TerminalRegistryStore({
+    dir,
+    exclusiveWriter: true,
+    writerLockRetries: retryPolicy,
+    deps: {
+      lock: async (_resource, options) => {
+        observed = options.retries;
+        return async () => {};
+      },
+    },
+  });
+  try {
+    await store.load();
+    expect(observed).toEqual(retryPolicy);
+  } finally {
+    await store.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/scripts/pack-rmux-bridge-platform.test.ts
+++ b/tests/unit/scripts/pack-rmux-bridge-platform.test.ts
@@ -68,12 +68,14 @@ function createFakePlatformPackage(packagesRoot: string, platform: string): stri
   return pkgDir;
 }
 
-test("pack script bundles bridge + rmux + helper and writes the new checksums schema", () => {
+test("pack script bundles bridge + rmux + daemon + helper and writes the new checksums schema", () => {
   const packagesRoot = tempDir("pack-pkgs-");
   const pkgDir = createFakePlatformPackage(packagesRoot, "darwin-x64");
 
   const bridge = writeExecutable(join(tempDir("pack-src-"), "xacpx-rmux-bridge"), "bridge-binary");
-  const rmux = writeExecutable(join(tempDir("pack-rmux-"), "rmux"), "rmux-binary");
+  const rmuxDir = tempDir("pack-rmux-");
+  const rmux = writeExecutable(join(rmuxDir, "rmux"), "rmux-binary");
+  const daemon = writeExecutable(join(rmuxDir, "rmux-daemon"), "rmux-daemon-binary");
   const helper = writeExecutable(
     join(tempDir("pack-helper-"), "rmux"),
     "rmux-helper-binary",
@@ -91,6 +93,8 @@ test("pack script bundles bridge + rmux + helper and writes the new checksums sc
       bridge,
       "--rmux-binary",
       rmux,
+      "--rmux-daemon",
+      daemon,
       "--rmux-helper",
       helper,
       "--packages-dir",
@@ -102,12 +106,14 @@ test("pack script bundles bridge + rmux + helper and writes the new checksums sc
 
   expect(run.status, run.stderr).toBe(0);
 
-  // Layout: bridge + rmux in bin/, helper under libexec/rmux/.
+  // Layout: bridge + rmux + daemon in bin/, helper under libexec/rmux/.
   const bridgeDest = join(pkgDir, "bin", "xacpx-rmux-bridge");
   const rmuxDest = join(pkgDir, "bin", "rmux");
+  const daemonDest = join(pkgDir, "bin", "rmux-daemon");
   const helperDest = join(pkgDir, "libexec", "rmux", "rmux");
   expect(readFileSync(bridgeDest, "utf8")).toBe("bridge-binary");
   expect(readFileSync(rmuxDest, "utf8")).toBe("rmux-binary");
+  expect(readFileSync(daemonDest, "utf8")).toBe("rmux-daemon-binary");
   expect(readFileSync(helperDest, "utf8")).toBe("rmux-helper-binary");
 
   // Redistributed-RMUX license + notice must ride along in the packaged dir
@@ -131,19 +137,24 @@ test("pack script bundles bridge + rmux + helper and writes the new checksums sc
     path: "bin/rmux",
     sha256: sha256Of(rmuxDest),
   });
+  expect(checksums.artifacts.rmuxDaemon).toEqual({
+    path: "bin/rmux-daemon",
+    sha256: sha256Of(daemonDest),
+  });
   expect(checksums.artifacts.rmuxHelper).toEqual({
     path: "libexec/rmux/rmux",
     sha256: sha256Of(helperDest),
   });
 });
 
-test("pack script derives the helper from ../libexec/rmux next to --rmux-binary", () => {
+test("pack script derives the daemon and helper from the official layout around --rmux-binary", () => {
   const packagesRoot = tempDir("pack-pkgs-");
   const pkgDir = createFakePlatformPackage(packagesRoot, "linux-x64");
 
   const srcRoot = tempDir("pack-rel-");
   const bridge = writeExecutable(join(srcRoot, "bin", "xacpx-rmux-bridge"), "bridge");
   const rmux = writeExecutable(join(srcRoot, "bin", "rmux"), "rmux");
+  writeExecutable(join(srcRoot, "bin", "rmux-daemon"), "daemon");
   const helper = writeExecutable(join(srcRoot, "libexec", "rmux", "rmux"), "helper");
 
   const run = spawnSync(
@@ -166,6 +177,7 @@ test("pack script derives the helper from ../libexec/rmux next to --rmux-binary"
   );
 
   expect(run.status, run.stderr).toBe(0);
+  expect(readFileSync(join(pkgDir, "bin", "rmux-daemon"), "utf8")).toBe("daemon");
   expect(readFileSync(join(pkgDir, "libexec", "rmux", "rmux"), "utf8")).toBe("helper");
 });
 
@@ -235,6 +247,7 @@ function writePackedPackage(repoRoot: string, tamperRmuxSha = false): void {
   writeLicenseFiles(pkgDir);
   const bridge = writeExecutable(join(pkgDir, "bin", "xacpx-rmux-bridge"), "bridge");
   const rmux = writeExecutable(join(pkgDir, "bin", "rmux"), "rmux");
+  const daemon = writeExecutable(join(pkgDir, "bin", "rmux-daemon"), "daemon");
   const helper = writeExecutable(join(pkgDir, "libexec", "rmux", "rmux"), "helper");
 
   const checksums = {
@@ -252,6 +265,7 @@ function writePackedPackage(repoRoot: string, tamperRmuxSha = false): void {
         path: "bin/rmux",
         sha256: tamperRmuxSha ? "deadbeef".repeat(8) : sha256Of(rmux),
       },
+      rmuxDaemon: { path: "bin/rmux-daemon", sha256: sha256Of(daemon) },
       rmuxHelper: { path: "libexec/rmux/rmux", sha256: sha256Of(helper) },
     },
   };
@@ -302,6 +316,7 @@ test("verifyRepo accepts the unpacked placeholder state (null checksums, no bina
         artifacts: {
           bridge: { path: "bin/xacpx-rmux-bridge.exe", sha256: null },
           rmux: { path: "bin/rmux.exe", sha256: null },
+          rmuxDaemon: { path: "bin/rmux-daemon.exe", sha256: null },
           rmuxHelper: { path: "libexec/rmux/rmux.exe", sha256: null },
         },
       },
@@ -334,6 +349,7 @@ test("verifyRepo rejects drift between the resolver constant and the release man
     failures.some((f) => f.includes("RMUX_BUNDLED_VERSION=0.9.0 != rmux-release.mjs")),
   ).toBe(true);
 });
+
 test("verifyRepo rejects a platform package that lacks the redistributed-RMUX license", async () => {
   const repoRoot = createVerifyRepo();
   const pkgDir = join(repoRoot, "platform-packages", "xacpx-rmux-bridge-linux-x64");
@@ -341,6 +357,7 @@ test("verifyRepo rejects a platform package that lacks the redistributed-RMUX li
   mkdirSync(join(pkgDir, "libexec", "rmux"), { recursive: true });
   writeExecutable(join(pkgDir, "bin", "xacpx-rmux-bridge"), "bridge");
   writeExecutable(join(pkgDir, "bin", "rmux"), "rmux");
+  writeExecutable(join(pkgDir, "bin", "rmux-daemon"), "daemon");
   writeExecutable(join(pkgDir, "libexec", "rmux", "rmux"), "helper");
   writeFileSync(
     join(pkgDir, "checksums.json"),
@@ -352,7 +369,21 @@ test("verifyRepo rejects a platform package that lacks the redistributed-RMUX li
       platform: "linux-x64",
       artifact: "bin/xacpx-rmux-bridge",
       sha256: sha256Of(join(pkgDir, "bin", "xacpx-rmux-bridge")),
-      artifacts: { bridge: { path: "bin/xacpx-rmux-bridge", sha256: sha256Of(join(pkgDir, "bin", "xacpx-rmux-bridge")) } },
+      artifacts: {
+        bridge: {
+          path: "bin/xacpx-rmux-bridge",
+          sha256: sha256Of(join(pkgDir, "bin", "xacpx-rmux-bridge")),
+        },
+        rmux: { path: "bin/rmux", sha256: sha256Of(join(pkgDir, "bin", "rmux")) },
+        rmuxDaemon: {
+          path: "bin/rmux-daemon",
+          sha256: sha256Of(join(pkgDir, "bin", "rmux-daemon")),
+        },
+        rmuxHelper: {
+          path: "libexec/rmux/rmux",
+          sha256: sha256Of(join(pkgDir, "libexec", "rmux", "rmux")),
+        },
+      },
     }, null, 2)}\n`,
   );
   const failures = await collectPublishVerificationFailures({

--- a/tests/unit/scripts/rmux-daemon-package.test.ts
+++ b/tests/unit/scripts/rmux-daemon-package.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+import { rmuxBinariesForExtractedRelease } from "../../../scripts/rmux-release.mjs";
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const packScript = join(repoRoot, "scripts/pack-rmux-bridge-platform.mjs");
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function writeExecutable(path: string, content: string): string {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function sha256Of(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function createFakePackage(packagesRoot: string): string {
+  const pkgDir = join(packagesRoot, "xacpx-rmux-bridge-win32-x64");
+  mkdirSync(join(pkgDir, "bin"), { recursive: true });
+  mkdirSync(join(pkgDir, "libexec", "rmux"), { recursive: true });
+  writeFileSync(
+    join(pkgDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "@ganglion/xacpx-rmux-bridge-win32-x64",
+        version: "0.0.0-test",
+        files: ["bin", "libexec", "checksums.json"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return pkgDir;
+}
+
+test("release layout discovery includes the dedicated daemon on Unix and Windows", () => {
+  const unixRoot = tempDir("rmux-release-unix-");
+  const unixCli = writeExecutable(join(unixRoot, "bin", "rmux"), "cli");
+  const unixDaemon = writeExecutable(join(unixRoot, "bin", "rmux-daemon"), "daemon");
+  const unixHelper = writeExecutable(join(unixRoot, "libexec", "rmux", "rmux"), "helper");
+  expect(rmuxBinariesForExtractedRelease(unixRoot, "linux")).toEqual({
+    cli: unixCli,
+    daemon: unixDaemon,
+    helper: unixHelper,
+  });
+
+  const windowsRoot = tempDir("rmux-release-windows-");
+  const windowsCli = writeExecutable(join(windowsRoot, "rmux.exe"), "cli");
+  const windowsDaemon = writeExecutable(join(windowsRoot, "rmux-daemon.exe"), "daemon");
+  const windowsHelper = writeExecutable(
+    join(windowsRoot, "libexec", "rmux", "rmux.exe"),
+    "helper",
+  );
+  expect(rmuxBinariesForExtractedRelease(windowsRoot, "win32")).toEqual({
+    cli: windowsCli,
+    daemon: windowsDaemon,
+    helper: windowsHelper,
+  });
+});
+
+test("pack script ships rmux-daemon.exe and records its checksum", () => {
+  const packagesRoot = tempDir("rmux-daemon-packages-");
+  const pkgDir = createFakePackage(packagesRoot);
+  const sourceRoot = tempDir("rmux-daemon-source-");
+  const bridge = writeExecutable(join(sourceRoot, "xacpx-rmux-bridge.exe"), "bridge");
+  const rmux = writeExecutable(join(sourceRoot, "rmux.exe"), "cli");
+  const daemon = writeExecutable(join(sourceRoot, "rmux-daemon.exe"), "daemon");
+  const helper = writeExecutable(join(sourceRoot, "helper", "rmux.exe"), "helper");
+
+  const run = spawnSync(
+    "node",
+    [
+      packScript,
+      "--platform",
+      "win32",
+      "--arch",
+      "x64",
+      "--binary",
+      bridge,
+      "--rmux-binary",
+      rmux,
+      "--rmux-daemon",
+      daemon,
+      "--rmux-helper",
+      helper,
+      "--packages-dir",
+      packagesRoot,
+      "--skip-version-check",
+    ],
+    { encoding: "utf8" },
+  );
+
+  expect(run.status, run.stderr).toBe(0);
+  const daemonDest = join(pkgDir, "bin", "rmux-daemon.exe");
+  expect(readFileSync(daemonDest, "utf8")).toBe("daemon");
+
+  const checksums = JSON.parse(readFileSync(join(pkgDir, "checksums.json"), "utf8"));
+  expect(checksums.artifacts.rmuxDaemon).toEqual({
+    path: "bin/rmux-daemon.exe",
+    sha256: sha256Of(daemonDest),
+  });
+});
+
+test("pack script fails closed instead of falling back to rmux.exe when the daemon is missing", () => {
+  const packagesRoot = tempDir("rmux-daemon-missing-packages-");
+  createFakePackage(packagesRoot);
+  const sourceRoot = tempDir("rmux-daemon-missing-source-");
+  const bridge = writeExecutable(join(sourceRoot, "xacpx-rmux-bridge.exe"), "bridge");
+  const rmux = writeExecutable(join(sourceRoot, "rmux.exe"), "cli");
+  const helper = writeExecutable(join(sourceRoot, "helper", "rmux.exe"), "helper");
+
+  const run = spawnSync(
+    "node",
+    [
+      packScript,
+      "--platform",
+      "win32",
+      "--arch",
+      "x64",
+      "--binary",
+      bridge,
+      "--rmux-binary",
+      rmux,
+      "--rmux-helper",
+      helper,
+      "--packages-dir",
+      packagesRoot,
+      "--skip-version-check",
+    ],
+    { encoding: "utf8" },
+  );
+
+  expect(run.status).not.toBe(0);
+  expect(run.stderr).toContain("rmux daemon not found");
+});

--- a/tests/unit/scripts/verify-rmux-daemon-publish.test.ts
+++ b/tests/unit/scripts/verify-rmux-daemon-publish.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { collectPublishVerificationFailures } from "../../../scripts/verify-publish.mjs";
+import { RMUX_VERSION } from "../../../scripts/rmux-release.mjs";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function fixtureRoot(): { root: string; pkgDir: string } {
+  const root = mkdtempSync(join(tmpdir(), "verify-rmux-daemon-"));
+  roots.push(root);
+  const pkgDir = join(root, "platform-packages", "xacpx-rmux-bridge-linux-x64");
+  mkdirSync(join(pkgDir, "bin"), { recursive: true });
+  mkdirSync(join(pkgDir, "libexec", "rmux"), { recursive: true });
+  mkdirSync(join(pkgDir, "THIRD_PARTY_LICENSES"), { recursive: true });
+  writeFileSync(join(pkgDir, "THIRD_PARTY_NOTICES.md"), "RMUX 0.10.0 - The RMUX Authors\n");
+  writeFileSync(
+    join(pkgDir, "THIRD_PARTY_LICENSES", "RMUX-LICENSE-MIT.txt"),
+    "MIT License\nThe RMUX Authors\n",
+  );
+  return { root, pkgDir };
+}
+
+function write(path: string, content: string): string {
+  writeFileSync(path, content);
+  return path;
+}
+
+function sha256(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function baseChecksums(pkgDir: string) {
+  const bridge = write(join(pkgDir, "bin", "xacpx-rmux-bridge"), "bridge");
+  const rmux = write(join(pkgDir, "bin", "rmux"), "rmux");
+  const helper = write(join(pkgDir, "libexec", "rmux", "rmux"), "helper");
+  return {
+    package: "@ganglion/xacpx-rmux-bridge-linux-x64",
+    version: "0.0.0-test",
+    rmuxSdk: RMUX_VERSION,
+    rmuxVersion: RMUX_VERSION,
+    platform: "linux-x64",
+    artifact: "bin/xacpx-rmux-bridge",
+    sha256: sha256(bridge),
+    artifacts: {
+      bridge: { path: "bin/xacpx-rmux-bridge", sha256: sha256(bridge) },
+      rmux: { path: "bin/rmux", sha256: sha256(rmux) },
+      rmuxHelper: { path: "libexec/rmux/rmux", sha256: sha256(helper) },
+    },
+  };
+}
+
+async function verify(root: string): Promise<string[]> {
+  return await collectPublishVerificationFailures({
+    repoRoot: root,
+    packages: [],
+    scanPaths: [],
+    runDryRun: false,
+  });
+}
+
+test("publish verification requires checksums.artifacts.rmuxDaemon", async () => {
+  const { root, pkgDir } = fixtureRoot();
+  const checksums = baseChecksums(pkgDir);
+  writeFileSync(join(pkgDir, "checksums.json"), `${JSON.stringify(checksums, null, 2)}\n`);
+
+  const failures = await verify(root);
+  expect(failures.some((failure) =>
+    failure.includes("checksums.artifacts must list bridge + rmux + rmuxDaemon + rmuxHelper paths")
+  )).toBe(true);
+});
+
+test("publish verification rejects a declared rmuxDaemon whose binary is missing", async () => {
+  const { root, pkgDir } = fixtureRoot();
+  const checksums = baseChecksums(pkgDir);
+  const withDaemon = {
+    ...checksums,
+    artifacts: {
+      ...checksums.artifacts,
+      rmuxDaemon: { path: "bin/rmux-daemon", sha256: "0".repeat(64) },
+    },
+  };
+  writeFileSync(join(pkgDir, "checksums.json"), `${JSON.stringify(withDaemon, null, 2)}\n`);
+
+  const failures = await verify(root);
+  expect(failures.some((failure) =>
+    failure.includes("checksums artifact missing on disk: bin/rmux-daemon")
+  )).toBe(true);
+});


### PR DESCRIPTION
## Root cause

The platform packages bundled `rmux[.exe]` plus the private `libexec/rmux/rmux[.exe]` helper, but omitted the official `rmux-daemon[.exe]` binary that is also present in RMUX 0.10.0 release packages.

On Windows the bridge therefore set `RMUX_SDK_DAEMON_BINARY` to the public tiny `rmux.exe`. The SDK starts that process hidden, but the tiny CLI then falls through to the private full helper using a normal child spawn. That second hop loses RMUX's `CREATE_NO_WINDOW` / `DETACHED_PROCESS` daemon launch flags, so Windows Terminal opens a persistent console for `libexec\rmux\rmux.exe`.

Because relay startup waits for terminal bootstrap before starting the relay client, an unsafe/missing RMUX daemon path can also keep the instance unavailable until bootstrap fails.

## What changed

- Extract the dedicated `rmux-daemon[.exe]` from every pinned RMUX 0.10.0 release archive.
- Pack all three upstream runtime pieces into every platform package:
  - `bin/rmux[.exe]`
  - `bin/rmux-daemon[.exe]`
  - `libexec/rmux/rmux[.exe]`
- Record `artifacts.rmuxDaemon` in `checksums.json` and keep the packed daemon ignored in source checkouts.
- Make platform-package resolution require the dedicated daemon beside the bridge. It will no longer silently use the public `rmux` CLI from the package or PATH; this prevents the Windows console-window fallback and makes incomplete packages fail closed into the existing managed-helper/dedicated-daemon fallback path.
- Keep explicit `terminal.rmuxCommand` and non-platform developer/legacy CLI fallback behavior unchanged.
- Update platform-package docs for the self-contained four-file layout.

## Regression coverage

- Release-layout tests cover both Unix and Windows `rmux-daemon` locations.
- Packer tests require and checksum the daemon, and fail closed when it is missing.
- Resolver tests require `rmux-daemon` for a platform package and reject fallback to its public CLI.
- The real production-package hostile-PATH smoke now asserts the resolved command basename is `rmux-daemon[.exe]` before running create/input/recover/kill. This runs in the existing Windows production-package CI gate and publish smokes, so a future package that omits the daemon fails before publish.

## Expected Windows acceptance

After installing a build containing this change, starting xacpx with relay terminal enabled should no longer open the persistent `libexec\rmux\rmux.exe` Windows Terminal window. The production resolver should report the platform-package RMUX command as `bin\rmux-daemon.exe`; if that daemon is missing, terminal capability fails closed rather than launching the public CLI fallback.