### PR TITLE
feat(relay-web): refine @agent autocomplete UX with human-readable identity and sessionAlias discovery

### DIFF
--- a/packages/relay-protocol/dist/dtos.d.ts
+++ b/packages/relay-protocol/dist/dtos.d.ts
@@ -308,6 +308,7 @@ export interface PublishedAgentEndpointDto {
     nodeId: string;
     endpointId: string;
     displayName?: string;
+    sessionAlias?: string;
     agent: string;
     workspace?: string;
     state: "idle" | "running";

--- a/packages/relay-protocol/dist/web-dtos.d.ts
+++ b/packages/relay-protocol/dist/web-dtos.d.ts
@@ -96,6 +96,10 @@ export interface InstanceSummaryDto {
     /** Last known connector capabilities; missing/undefined → treat as []. */
     capabilities?: string[];
 }
+/** Web-enriched agent directory DTO tagging each published endpoint with its owning Relay instanceId. */
+export interface WebAgentDirectoryEndpointDto extends PublishedAgentEndpointDto {
+    instanceId: string;
+}
 /** Server→web push payloads (tagged with the originating instance). */
 export type WebServerEvent = {
     kind: "instance-status";
@@ -114,7 +118,7 @@ export type WebServerEvent = {
     notice: InstanceNoticePayload;
 } | {
     kind: "agent-directory";
-    endpoints: PublishedAgentEndpointDto[];
+    endpoints: WebAgentDirectoryEndpointDto[];
 } | {
     kind: "terminal-opened";
     requestId: string;

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -335,6 +335,7 @@ export interface PublishedAgentEndpointDto {
   nodeId: string;
   endpointId: string;
   displayName?: string;
+  sessionAlias?: string;
   agent: string;
   workspace?: string;
   state: "idle" | "running";

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -118,6 +118,10 @@ export interface InstanceSummaryDto {
   /** Last known connector capabilities; missing/undefined → treat as []. */
   capabilities?: string[];
 }
+/** Web-enriched agent directory DTO tagging each published endpoint with its owning Relay instanceId. */
+export interface WebAgentDirectoryEndpointDto extends PublishedAgentEndpointDto {
+  instanceId: string;
+}
 
 /** Server→web push payloads (tagged with the originating instance). */
 export type WebServerEvent =
@@ -125,7 +129,7 @@ export type WebServerEvent =
   | { kind: "control-event"; instanceId: string; event: ControlEventDto }
   | ({ kind: "state-snapshot"; instanceId: string } & InstanceStateSnapshotDto)
   | { kind: "notice"; instanceId: string; notice: InstanceNoticePayload }
-  | { kind: "agent-directory"; endpoints: PublishedAgentEndpointDto[] }
+  | { kind: "agent-directory"; endpoints: WebAgentDirectoryEndpointDto[] }
   | {
       kind: "terminal-opened";
       requestId: string;

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -56,17 +56,28 @@ describe("PromptInput composer", () => {
     await w.setProps({ draftKey: "k2" }); // switch session → draft stashed, k2 empty
     expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("");
     await w.setProps({ draftKey: "k1" }); // back → restored
-    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("half-typed");
+    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe(
+      "half-typed",
+    );
   });
 
   it("typing / shows agent-command autocomplete and Enter completes without sending", async () => {
     const { useChatStore } = await import("../stores/chat");
     const chat = useChatStore();
     chat.select("i1", "backend");
-    chat.applyEvent({ kind: "control-event", instanceId: "i1", event: {
-      type: "agent-commands", chatKey: "relay:a1", sessionAlias: "backend",
-      commands: [{ name: "compact", description: "Compact the conversation" }, { name: "clear" }],
-    } } as never);
+    chat.applyEvent({
+      kind: "control-event",
+      instanceId: "i1",
+      event: {
+        type: "agent-commands",
+        chatKey: "relay:a1",
+        sessionAlias: "backend",
+        commands: [
+          { name: "compact", description: "Compact the conversation" },
+          { name: "clear" },
+        ],
+      },
+    } as never);
     const w = mount(PromptInput);
     const ta = w.find("textarea");
     await ta.setValue("/co");
@@ -85,10 +96,16 @@ describe("PromptInput composer", () => {
     const { useChatStore } = await import("../stores/chat");
     const chat = useChatStore();
     chat.select("i1", "backend");
-    chat.applyEvent({ kind: "control-event", instanceId: "i1", event: {
-      type: "agent-commands", chatKey: "relay:a1", sessionAlias: "backend",
-      commands: [{ name: "compact" }],
-    } } as never);
+    chat.applyEvent({
+      kind: "control-event",
+      instanceId: "i1",
+      event: {
+        type: "agent-commands",
+        chatKey: "relay:a1",
+        sessionAlias: "backend",
+        commands: [{ name: "compact" }],
+      },
+    } as never);
     const w = mount(PromptInput);
     const ta = w.find("textarea");
     await ta.setValue("/co");
@@ -107,10 +124,16 @@ describe("PromptInput composer", () => {
     const composer = useComposerStore();
     const w = mount(PromptInput);
     await w.find("textarea").setValue("ready to go"); // would normally enable Send
-    expect((w.get('[data-test="composer-send"]').element as HTMLButtonElement).disabled).toBe(false);
+    expect(
+      (w.get('[data-test="composer-send"]').element as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
     composer.uploading = true;
     await w.vm.$nextTick();
-    expect((w.get('[data-test="composer-send"]').element as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      (w.get('[data-test="composer-send"]').element as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
   });
 
   it("inserts text from a composer store request targeting this session", async () => {
@@ -119,11 +142,15 @@ describe("PromptInput composer", () => {
     const w = mount(PromptInput, { props: { draftKey: "ins-key" } });
     composer.requestInsert("ins-key", "/status");
     await w.vm.$nextTick();
-    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("/status");
+    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe(
+      "/status",
+    );
     // a request for a different session is ignored
     composer.requestInsert("other", "/help");
     await w.vm.$nextTick();
-    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe("/status");
+    expect((w.find("textarea").element as HTMLTextAreaElement).value).toBe(
+      "/status",
+    );
   });
 
   it("typing @ displays agent mention autocomplete from canonical directory and emits structured agentMentions", async () => {
@@ -137,7 +164,13 @@ describe("PromptInput composer", () => {
         agent: "codex",
         workspace: "project",
         state: "idle",
-        capabilities: { receive: true, steer: false, queue: true, interrupt: false, conversation: true },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
         updatedAt: Date.now(),
       },
     ];
@@ -157,7 +190,9 @@ describe("PromptInput composer", () => {
     await ta.trigger("keydown", { key: "Enter" });
     await w.vm.$nextTick();
 
-    expect((ta.element as HTMLTextAreaElement).value).toBe("Please check with @Backend ");
+    expect((ta.element as HTMLTextAreaElement).value).toBe(
+      "Please check with @Backend ",
+    );
     expect(w.find('[data-test="mention-menu"]').exists()).toBe(false);
 
     // Submit
@@ -185,7 +220,13 @@ describe("PromptInput composer", () => {
         agent: "codex",
         workspace: "project",
         state: "idle",
-        capabilities: { receive: true, steer: false, queue: true, interrupt: false, conversation: true },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
         updatedAt: Date.now(),
       },
     ];
@@ -217,7 +258,13 @@ describe("PromptInput composer", () => {
         agent: "codex",
         workspace: "backend-api",
         state: "idle",
-        capabilities: { receive: true, steer: false, queue: true, interrupt: false, conversation: true },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
         updatedAt: Date.now(),
       },
       {
@@ -227,7 +274,13 @@ describe("PromptInput composer", () => {
         agent: "claude",
         workspace: "billing-service",
         state: "idle",
-        capabilities: { receive: true, steer: false, queue: true, interrupt: false, conversation: true },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
         updatedAt: Date.now(),
       },
     ];
@@ -258,5 +311,293 @@ describe("PromptInput composer", () => {
         },
       ],
     ]);
+  });
+
+  it("Test A: custom display name renders primary @displayName and secondary sessionAlias · workspace · agent", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.agentDirectory = [
+      {
+        nodeId: "node-12345",
+        endpointId: "ep-1",
+        displayName: "发布机器人",
+        sessionAlias: "omp-2",
+        agent: "codex",
+        workspace: "weacpx-github",
+        state: "running",
+        activity: { status: "working", summary: "Building release" },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ask @发布");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    expect(w.find('[data-test="mention-menu"]').exists()).toBe(true);
+    const item = w.find('[data-test="mention-item"]');
+    expect(item.find('[data-test="mention-primary"]').text()).toBe(
+      "@发布机器人",
+    );
+    expect(item.find('[data-test="mention-secondary"]').text()).toBe(
+      "omp-2 · weacpx-github · codex",
+    );
+    expect(item.find('[data-test="mention-activity"]').text()).toBe("Working");
+
+    // Selecting binds canonical handle
+    await ta.trigger("keydown", { key: "Enter" });
+    await w.vm.$nextTick();
+    await ta.trigger("keydown", { key: "Enter" });
+
+    expect(w.emitted("send")?.[0]).toEqual([
+      "Ask @发布机器人",
+      [],
+      [
+        {
+          range: [4, 10],
+          handle: "agent:node-12345:ep-1",
+        },
+      ],
+    ]);
+  });
+
+  it("Test B: no custom display name (displayName === sessionAlias) does not duplicate alias", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.agentDirectory = [
+      {
+        nodeId: "node-12345",
+        endpointId: "ep-1",
+        displayName: "omp-2",
+        sessionAlias: "omp-2",
+        agent: "codex",
+        workspace: "weacpx-github",
+        state: "idle",
+        activity: { status: "idle" },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ask @omp");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const item = w.find('[data-test="mention-item"]');
+    expect(item.find('[data-test="mention-primary"]').text()).toBe("@omp-2");
+    expect(item.find('[data-test="mention-secondary"]').text()).toBe(
+      "weacpx-github · codex",
+    );
+    expect(item.find('[data-test="mention-secondary"]').text()).not.toContain(
+      "omp-2 · omp-2",
+    );
+    expect(item.find('[data-test="mention-activity"]').text()).toBe("Idle");
+  });
+
+  it("Test C: search by sessionAlias finds agent with custom displayName", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.agentDirectory = [
+      {
+        nodeId: "node-1",
+        endpointId: "ep-1",
+        displayName: "发布机器人",
+        sessionAlias: "omp-2",
+        agent: "codex",
+        workspace: "weacpx-github",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    // Type @omp which matches sessionAlias 'omp-2' even though displayName is '发布机器人'
+    await ta.setValue("Ask @omp");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    expect(w.find('[data-test="mention-menu"]').exists()).toBe(true);
+    const item = w.find('[data-test="mention-item"]');
+    expect(item.find('[data-test="mention-primary"]').text()).toBe(
+      "@发布机器人",
+    );
+    expect(item.find('[data-test="mention-secondary"]').text()).toBe(
+      "omp-2 · weacpx-github · codex",
+    );
+  });
+
+  it("Test D & E: duplicate displayNames render distinct human metadata and no normal nodeId exposure", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.agentDirectory = [
+      {
+        nodeId: "node_4c860598-e4ba-4205-ad59-08f0fb683dbc",
+        endpointId: "ep_789123456_a",
+        displayName: "Backend",
+        sessionAlias: "backend-api",
+        agent: "claude",
+        workspace: "xacpx",
+        state: "running",
+        activity: { status: "working" },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        nodeId: "node_99887766-aaaa-bbbb-cccc-112233445566",
+        endpointId: "ep_789123456_b",
+        displayName: "Backend",
+        sessionAlias: "billing-service",
+        agent: "codex",
+        workspace: "billing",
+        state: "idle",
+        activity: { status: "idle" },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ping @Back");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+
+    expect(items[0].find('[data-test="mention-primary"]').text()).toBe(
+      "@Backend",
+    );
+    expect(items[0].find('[data-test="mention-secondary"]').text()).toBe(
+      "backend-api · xacpx · claude",
+    );
+    // Test E: assert full nodeId/endpointId is NOT in normal row text
+    expect(items[0].text()).not.toContain(
+      "node_4c860598-e4ba-4205-ad59-08f0fb683dbc",
+    );
+    expect(items[0].text()).not.toContain("ep_789123456_a");
+
+    expect(items[1].find('[data-test="mention-primary"]').text()).toBe(
+      "@Backend",
+    );
+    expect(items[1].find('[data-test="mention-secondary"]').text()).toBe(
+      "billing-service · billing · codex",
+    );
+    expect(items[1].text()).not.toContain(
+      "node_99887766-aaaa-bbbb-cccc-112233445566",
+    );
+    expect(items[1].text()).not.toContain("ep_789123456_b");
+
+    // Select second item
+    await ta.trigger("keydown", { key: "ArrowDown" });
+    await ta.trigger("keydown", { key: "Enter" });
+    await w.vm.$nextTick();
+    await ta.trigger("keydown", { key: "Enter" });
+
+    expect(w.emitted("send")?.[0]).toEqual([
+      "Ping @Backend",
+      [],
+      [
+        {
+          range: [5, 13],
+          handle:
+            "agent:node_99887766-aaaa-bbbb-cccc-112233445566:ep_789123456_b",
+        },
+      ],
+    ]);
+  });
+
+  it("Test F: Session Tree consistency and deterministic ranking", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.agentDirectory = [
+      {
+        nodeId: "node-1",
+        endpointId: "ep-1",
+        displayName: "发布机器人",
+        sessionAlias: "omp-2",
+        agent: "codex",
+        workspace: "weacpx-github",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        nodeId: "node-1",
+        endpointId: "ep-2",
+        displayName: "omp-builder",
+        sessionAlias: "omp-builder",
+        agent: "codex",
+        workspace: "weacpx-github",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("@omp");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+    // omp-builder has displayName prefix match (rank 3), while 发布机器人 has sessionAlias prefix match (rank 4)
+    expect(items[0].find('[data-test="mention-primary"]').text()).toBe(
+      "@omp-builder",
+    );
+    expect(items[1].find('[data-test="mention-primary"]').text()).toBe(
+      "@发布机器人",
+    );
   });
 });

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -555,7 +555,8 @@ describe("PromptInput composer", () => {
 
   it("Test F: Session Tree consistency under workspace grouped mode", async () => {
     const { useInstancesStore } = await import("../stores/instances");
-    const { sessionPresentationName } = await import("../lib/sidebar-group-mode");
+    const { sessionPresentationName } =
+      await import("../lib/sidebar-group-mode");
     const instances = useInstancesStore();
     instances.instances = [
       { id: "inst-1", name: "MacBook Air", online: true, sessionsLoaded: true },
@@ -742,6 +743,323 @@ describe("PromptInput composer", () => {
 
     expect(items[1].find('[data-test="mention-primary"]').text()).toBe(
       "@发布机器人",
+    );
+    expect(items[1].find('[data-test="mention-activity"]').text()).toBe(
+      "Working",
+    );
+  });
+
+  it("Test I: same instance duplicate endpoints disambiguate with endpointId suffix", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.instances = [
+      { id: "inst-1", name: "MacBook Air", online: true },
+    ] as never;
+
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep_worker_1234a",
+        displayName: "Reviewer",
+        agent: "claude",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep_worker_5678b",
+        displayName: "Reviewer",
+        agent: "claude",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ask @Rev");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+
+    // Both are on the SAME instance with the same human metadata.
+    // They MUST append endpointId technical suffix to guarantee unique distinction!
+    expect(items[0].find('[data-test="mention-secondary"]').text()).toBe(
+      "project · claude · MacBook Air · …1234a",
+    );
+    expect(items[1].find('[data-test="mention-secondary"]').text()).toBe(
+      "project · claude · MacBook Air · …5678b",
+    );
+
+    // Selecting the second binds the second endpoint
+    await ta.trigger("keydown", { key: "ArrowDown" });
+    await ta.trigger("keydown", { key: "Enter" });
+    await w.vm.$nextTick();
+    await ta.trigger("keydown", { key: "Enter" });
+
+    expect(w.emitted("send")?.[0]).toEqual([
+      "Ask @Reviewer",
+      [],
+      [
+        {
+          range: [4, 13],
+          handle: "agent:node-1:ep_worker_5678b",
+        },
+      ],
+    ]);
+  });
+
+  it("Test J: instances with duplicate name disambiguate using endpointId suffix", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    // Two different instances legally sharing the same name "Dev Server"
+    instances.instances = [
+      { id: "inst-1", name: "Dev Server", online: true },
+      { id: "inst-2", name: "Dev Server", online: true },
+    ] as never;
+
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep_aaaa_11111",
+        displayName: "Backend",
+        sessionAlias: "backend",
+        agent: "codex",
+        workspace: "xacpx",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-2",
+        nodeId: "node-2",
+        endpointId: "ep_bbbb_22222",
+        displayName: "Backend",
+        sessionAlias: "backend",
+        agent: "codex",
+        workspace: "xacpx",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ping @Back");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+
+    expect(items[0].find('[data-test="mention-secondary"]').text()).toBe(
+      "backend · xacpx · codex · Dev Server · …11111",
+    );
+    expect(items[1].find('[data-test="mention-secondary"]').text()).toBe(
+      "backend · xacpx · codex · Dev Server · …22222",
+    );
+  });
+
+  it("Test K: full-field ranking ensures exact matches on workspace/agent beat prefix matches on displayName", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep-1",
+        displayName: "codex-helper",
+        sessionAlias: "codex-helper",
+        agent: "claude",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep-2",
+        displayName: "Helper",
+        sessionAlias: "helper",
+        agent: "codex",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep-3",
+        displayName: "xacpx-runner",
+        sessionAlias: "xacpx-runner",
+        agent: "claude",
+        workspace: "other",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep-4",
+        displayName: "Runner",
+        sessionAlias: "runner",
+        agent: "claude",
+        workspace: "xacpx",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+
+    // 1. Query @codex: exact match on agent (ep-2: Helper) MUST beat prefix match on displayName (ep-1: codex-helper)
+    await ta.setValue("@codex");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    let items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+    expect(items[0].find('[data-test="mention-primary"]').text()).toBe(
+      "@Helper",
+    );
+    expect(items[1].find('[data-test="mention-primary"]').text()).toBe(
+      "@codex-helper",
+    );
+
+    // 2. Query @xacpx: exact match on workspace (ep-4: Runner) MUST beat prefix match on displayName (ep-3: xacpx-runner)
+    await ta.setValue("@xacpx");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+    expect(items[0].find('[data-test="mention-primary"]').text()).toBe(
+      "@Runner",
+    );
+    expect(items[1].find('[data-test="mention-primary"]').text()).toBe(
+      "@xacpx-runner",
+    );
+  });
+
+  it("Test L: activity fallback normalizes from state when activity field is omitted", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep-1",
+        displayName: "RunningBot",
+        agent: "codex",
+        workspace: "project",
+        state: "running",
+        // activity omitted (e.g. older connector or state-only publish)
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep-2",
+        displayName: "IdleBot",
+        agent: "codex",
+        workspace: "project",
+        state: "idle",
+        // activity omitted
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("@Bot");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+    expect(items[0].find('[data-test="mention-primary"]').text()).toBe(
+      "@IdleBot",
+    );
+    expect(items[0].find('[data-test="mention-activity"]').text()).toBe("Idle");
+    expect(items[1].find('[data-test="mention-primary"]').text()).toBe(
+      "@RunningBot",
     );
     expect(items[1].find('[data-test="mention-activity"]').text()).toBe(
       "Working",

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -1329,4 +1329,79 @@ describe("PromptInput composer", () => {
       "@omp-2-helper",
     );
   });
+
+  it("Test Q: collision key aligns with visible secondary parts when one endpoint has custom displayName and another does not", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.instances = [
+      { id: "inst-1", name: "MacBook Air", online: true },
+    ] as never;
+    instances.setGroupMode("inst-1", "workspace");
+
+    // Endpoint A: custom displayName "review", raw sessionAlias "project-review" (folds to "review" under workspace mode)
+    // Endpoint B: no custom displayName, raw sessionAlias "review" (folds to "review" under workspace mode)
+    // Both render primary: @review
+    // Both render initial secondary: project · codex
+    // Level-3 routing suffix MUST trigger to disambiguate!
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep_aaaa_1",
+        displayName: "review",
+        sessionAlias: "project-review",
+        agent: "codex",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep_bbbb_2",
+        sessionAlias: "review",
+        agent: "codex",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ask @rev");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+
+    expect(items[0].find('[data-test="mention-primary"]').text()).toBe(
+      "@review",
+    );
+    expect(items[0].find('[data-test="mention-secondary"]').text()).toBe(
+      "project · codex · MacBook Air · …aaa_1",
+    );
+
+    expect(items[1].find('[data-test="mention-primary"]').text()).toBe(
+      "@review",
+    );
+    expect(items[1].find('[data-test="mention-secondary"]').text()).toBe(
+      "project · codex · MacBook Air · …bbb_2",
+    );
+  });
 });

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -1192,4 +1192,141 @@ describe("PromptInput composer", () => {
       "project · codex · Dev Server · …ta:endpoint_worker_default",
     );
   });
+
+  it("Test O: group mode folding different raw aliases into same presentation alias correctly triggers Level-3 disambiguation", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.instances = [
+      { id: "inst-1", name: "MacBook Air", online: true },
+    ] as never;
+    instances.setGroupMode("inst-1", "workspace");
+
+    // Two endpoints on the same instance:
+    // raw alias "project-review" folds to "review" under workspace mode
+    // raw alias "review" is already "review"
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep_aaaa_1",
+        displayName: "Reviewer",
+        sessionAlias: "project-review",
+        agent: "codex",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep_bbbb_2",
+        displayName: "Reviewer",
+        sessionAlias: "review",
+        agent: "codex",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ask @Rev");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+
+    // Both display @Reviewer with visible presentation alias "review", "project", "codex", "MacBook Air".
+    // Because the VISIBLE Level-1 metadata and nodeLabel collide, Level-3 routing suffix MUST trigger!
+    expect(items[0].find('[data-test="mention-secondary"]').text()).toBe(
+      "review · project · codex · MacBook Air · …aaa_1",
+    );
+    expect(items[1].find('[data-test="mention-secondary"]').text()).toBe(
+      "review · project · codex · MacBook Air · …bbb_2",
+    );
+  });
+
+  it("Test P: search ranking matches visible presentation alias as exact match over displayName prefix match", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.instances = [
+      { id: "inst-1", name: "MacBook Air", online: true },
+    ] as never;
+    instances.setGroupMode("inst-1", "workspace");
+
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep-1",
+        displayName: "发布机器人",
+        sessionAlias: "weacpx-github-omp-2", // folds to visible presentation alias "omp-2"
+        agent: "codex",
+        workspace: "weacpx-github",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep-2",
+        displayName: "omp-2-helper",
+        sessionAlias: "omp-2-helper",
+        agent: "claude",
+        workspace: "weacpx-github",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    // User types @omp-2:
+    // ep-1 has visible presentation alias "omp-2" (Exact match, Rank 12)
+    // ep-2 has displayName "omp-2-helper" (Prefix match, Rank 21)
+    await ta.setValue("@omp-2");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+
+    // Exact match on visible presentation alias MUST rank #1!
+    expect(items[0].find('[data-test="mention-primary"]').text()).toBe(
+      "@发布机器人",
+    );
+    expect(items[1].find('[data-test="mention-primary"]').text()).toBe(
+      "@omp-2-helper",
+    );
+  });
 });

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -158,6 +158,7 @@ describe("PromptInput composer", () => {
     const instances = useInstancesStore();
     instances.agentDirectory = [
       {
+        instanceId: "inst-1",
         nodeId: "node-1",
         endpointId: "ep-backend",
         displayName: "Backend",
@@ -214,6 +215,7 @@ describe("PromptInput composer", () => {
     const instances = useInstancesStore();
     instances.agentDirectory = [
       {
+        instanceId: "inst-1",
         nodeId: "node-1",
         endpointId: "ep-backend",
         displayName: "Backend",
@@ -252,6 +254,7 @@ describe("PromptInput composer", () => {
     const instances = useInstancesStore();
     instances.agentDirectory = [
       {
+        instanceId: "inst-1",
         nodeId: "node-1",
         endpointId: "ep-backend-1",
         displayName: "Backend",
@@ -268,6 +271,7 @@ describe("PromptInput composer", () => {
         updatedAt: Date.now(),
       },
       {
+        instanceId: "inst-2",
         nodeId: "node-2",
         endpointId: "ep-backend-2",
         displayName: "Backend",
@@ -318,6 +322,7 @@ describe("PromptInput composer", () => {
     const instances = useInstancesStore();
     instances.agentDirectory = [
       {
+        instanceId: "inst-1",
         nodeId: "node-12345",
         endpointId: "ep-1",
         displayName: "发布机器人",
@@ -375,6 +380,7 @@ describe("PromptInput composer", () => {
     const instances = useInstancesStore();
     instances.agentDirectory = [
       {
+        instanceId: "inst-1",
         nodeId: "node-12345",
         endpointId: "ep-1",
         displayName: "omp-2",
@@ -416,6 +422,7 @@ describe("PromptInput composer", () => {
     const instances = useInstancesStore();
     instances.agentDirectory = [
       {
+        instanceId: "inst-1",
         nodeId: "node-1",
         endpointId: "ep-1",
         displayName: "发布机器人",
@@ -456,6 +463,7 @@ describe("PromptInput composer", () => {
     const instances = useInstancesStore();
     instances.agentDirectory = [
       {
+        instanceId: "inst-1",
         nodeId: "node_4c860598-e4ba-4205-ad59-08f0fb683dbc",
         endpointId: "ep_789123456_a",
         displayName: "Backend",
@@ -474,6 +482,7 @@ describe("PromptInput composer", () => {
         updatedAt: Date.now(),
       },
       {
+        instanceId: "inst-2",
         nodeId: "node_99887766-aaaa-bbbb-cccc-112233445566",
         endpointId: "ep_789123456_b",
         displayName: "Backend",
@@ -544,17 +553,37 @@ describe("PromptInput composer", () => {
     ]);
   });
 
-  it("Test F: Session Tree consistency and deterministic ranking", async () => {
+  it("Test F: Session Tree consistency under workspace grouped mode", async () => {
     const { useInstancesStore } = await import("../stores/instances");
+    const { sessionPresentationName } = await import("../lib/sidebar-group-mode");
     const instances = useInstancesStore();
+    instances.instances = [
+      { id: "inst-1", name: "MacBook Air", online: true, sessionsLoaded: true },
+    ] as never;
+    instances.setGroupMode("inst-1", "workspace");
+
+    // Session in workspace "weacpx-github" with alias "weacpx-github-omp-2"
+    const sessionAlias = "weacpx-github-omp-2";
+    const workspace = "weacpx-github";
+
+    // 1. Shared helper (also used by InstanceTree.vue rowName) returns "omp-2"
+    const treeRowName = sessionPresentationName({
+      alias: sessionAlias,
+      workspace,
+      agent: "codex",
+      groupMode: instances.groupModeFor("inst-1"),
+    });
+    expect(treeRowName).toBe("omp-2");
+
+    // 2. PromptInput autocomplete directory item from inst-1
     instances.agentDirectory = [
       {
+        instanceId: "inst-1",
         nodeId: "node-1",
         endpointId: "ep-1",
-        displayName: "发布机器人",
-        sessionAlias: "omp-2",
+        sessionAlias,
         agent: "codex",
-        workspace: "weacpx-github",
+        workspace,
         state: "idle",
         capabilities: {
           receive: true,
@@ -565,7 +594,118 @@ describe("PromptInput composer", () => {
         },
         updatedAt: Date.now(),
       },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ask @omp");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const item = w.find('[data-test="mention-item"]');
+    // The primary name MUST match the Session Tree grouped presentation ("omp-2"), NOT "weacpx-github-omp-2"
+    expect(item.find('[data-test="mention-primary"]').text()).toBe("@omp-2");
+    expect(item.find('[data-test="mention-secondary"]').text()).toBe(
+      "weacpx-github · codex",
+    );
+  });
+
+  it("Test G: duplicate displayNames across Relay instances disambiguate using instance name, not technical nodeId", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.instances = [
+      { id: "inst-mac", name: "MacBook Air", online: true },
+      { id: "inst-dev", name: "Dev Server", online: true },
+    ] as never;
+
+    instances.agentDirectory = [
       {
+        instanceId: "inst-mac",
+        nodeId: "node_4c860598-e4ba-4205-ad59-08f0fb683dbc",
+        endpointId: "ep_1",
+        displayName: "Backend",
+        sessionAlias: "backend",
+        agent: "codex",
+        workspace: "xacpx",
+        state: "running",
+        activity: { status: "working" },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-dev",
+        nodeId: "node_99887766-aaaa-bbbb-cccc-112233445566",
+        endpointId: "ep_2",
+        displayName: "Backend",
+        sessionAlias: "backend",
+        agent: "codex",
+        workspace: "xacpx",
+        state: "idle",
+        activity: { status: "idle" },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ping @Back");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+
+    // Both have exact same (displayName, sessionAlias, workspace, agent).
+    // They MUST disambiguate via Relay instance names (MacBook Air / Dev Server)
+    expect(items[0].find('[data-test="mention-secondary"]').text()).toBe(
+      "backend · xacpx · codex · MacBook Air",
+    );
+    expect(items[1].find('[data-test="mention-secondary"]').text()).toBe(
+      "backend · xacpx · codex · Dev Server",
+    );
+
+    // Must NOT contain technical nodeId suffix
+    expect(items[0].text()).not.toContain("…83dbc");
+    expect(items[1].text()).not.toContain("…45566");
+  });
+  it("Test H: activity badges display localized strings and deterministic ranking", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "ep-1",
+        displayName: "发布机器人",
+        sessionAlias: "omp-2",
+        agent: "codex",
+        workspace: "weacpx-github",
+        state: "running",
+        activity: { status: "working" },
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
         nodeId: "node-1",
         endpointId: "ep-2",
         displayName: "omp-builder",
@@ -573,6 +713,7 @@ describe("PromptInput composer", () => {
         agent: "codex",
         workspace: "weacpx-github",
         state: "idle",
+        activity: { status: "waiting" },
         capabilities: {
           receive: true,
           steer: false,
@@ -589,15 +730,21 @@ describe("PromptInput composer", () => {
     await ta.setValue("@omp");
     await ta.trigger("input");
     await w.vm.$nextTick();
-
     const items = w.findAll('[data-test="mention-item"]');
     expect(items.length).toBe(2);
     // omp-builder has displayName prefix match (rank 3), while 发布机器人 has sessionAlias prefix match (rank 4)
     expect(items[0].find('[data-test="mention-primary"]').text()).toBe(
       "@omp-builder",
     );
+    expect(items[0].find('[data-test="mention-activity"]').text()).toBe(
+      "Waiting",
+    );
+
     expect(items[1].find('[data-test="mention-primary"]').text()).toBe(
       "@发布机器人",
+    );
+    expect(items[1].find('[data-test="mention-activity"]').text()).toBe(
+      "Working",
     );
   });
 });

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -1065,4 +1065,131 @@ describe("PromptInput composer", () => {
       "Working",
     );
   });
+
+  it("Test M: shortest unique suffix dynamically expands when last 5 characters of endpointId collide", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.instances = [
+      { id: "inst-1", name: "MacBook Air", online: true },
+    ] as never;
+
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "endpoint_worker_A12345",
+        displayName: "Reviewer",
+        agent: "claude",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-1",
+        nodeId: "node-1",
+        endpointId: "endpoint_worker_B12345",
+        displayName: "Reviewer",
+        agent: "claude",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ask @Rev");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+
+    // Both end with "12345" (5 chars collision).
+    // The suffix MUST dynamically expand to 6 characters ("…A12345" vs "…B12345") to guarantee uniqueness!
+    expect(items[0].find('[data-test="mention-secondary"]').text()).toBe(
+      "project · claude · MacBook Air · …A12345",
+    );
+    expect(items[1].find('[data-test="mention-secondary"]').text()).toBe(
+      "project · claude · MacBook Air · …B12345",
+    );
+  });
+
+  it("Test N: cross-node identical endpointIds with duplicate instance names dynamically expand to include node discriminator", async () => {
+    const { useInstancesStore } = await import("../stores/instances");
+    const instances = useInstancesStore();
+    instances.instances = [
+      { id: "inst-1", name: "Dev Server", online: true },
+      { id: "inst-2", name: "Dev Server", online: true },
+    ] as never;
+
+    instances.agentDirectory = [
+      {
+        instanceId: "inst-1",
+        nodeId: "node-alpha",
+        endpointId: "endpoint_worker_default",
+        displayName: "Backend",
+        agent: "codex",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+      {
+        instanceId: "inst-2",
+        nodeId: "node-beta",
+        endpointId: "endpoint_worker_default",
+        displayName: "Backend",
+        agent: "codex",
+        workspace: "project",
+        state: "idle",
+        capabilities: {
+          receive: true,
+          steer: false,
+          queue: true,
+          interrupt: false,
+          conversation: true,
+        },
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const w = mount(PromptInput);
+    const ta = w.find("textarea");
+    await ta.setValue("Ask @Back");
+    await ta.trigger("input");
+    await w.vm.$nextTick();
+
+    const items = w.findAll('[data-test="mention-item"]');
+    expect(items.length).toBe(2);
+
+    // endpointId is identical across two nodes ("endpoint_worker_default").
+    // The suffix MUST dynamically expand until the node discriminator is included!
+    expect(items[0].find('[data-test="mention-secondary"]').text()).toBe(
+      "project · codex · Dev Server · …ha:endpoint_worker_default",
+    );
+    expect(items[1].find('[data-test="mention-secondary"]').text()).toBe(
+      "project · codex · Dev Server · …ta:endpoint_worker_default",
+    );
+  });
 });

--- a/packages/relay-web/src/__tests__/sidebar-group-mode.test.ts
+++ b/packages/relay-web/src/__tests__/sidebar-group-mode.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { loadGroupMode, saveGroupMode, groupSessions, dedupedSessionName, archivedLast } from "../lib/sidebar-group-mode";
+import { loadGroupMode, saveGroupMode, groupSessions, dedupedSessionName, sessionPresentationName, archivedLast } from "../lib/sidebar-group-mode";
 
 const KEY = "xacpx.sidebar.groupMode.i1";
 
@@ -91,5 +91,25 @@ describe("dedupedSessionName", () => {
   it("never dedups down to an empty name", () => {
     expect(dedupedSessionName("web-", "web", "workspace")).toBe("web-");
     expect(dedupedSessionName("-claude", "claude", "agent")).toBe("-claude");
+  });
+});
+
+describe("sessionPresentationName", () => {
+  it("uses custom displayName when present under any mode", () => {
+    expect(sessionPresentationName({ displayName: "发布机器人", alias: "weacpx-github-omp-2", workspace: "weacpx-github", groupMode: "workspace" })).toBe("发布机器人");
+    expect(sessionPresentationName({ displayName: "发布机器人", alias: "omp-2", groupMode: "instance" })).toBe("发布机器人");
+  });
+
+  it("dedups alias in workspace mode by stripping leading <workspace>-", () => {
+    expect(sessionPresentationName({ alias: "weacpx-github-omp-2", workspace: "weacpx-github", groupMode: "workspace" })).toBe("omp-2");
+  });
+
+  it("dedups alias in agent mode by stripping trailing -<agent>", () => {
+    expect(sessionPresentationName({ alias: "omp-2-codex", agent: "codex", groupMode: "agent" })).toBe("omp-2");
+  });
+
+  it("preserves alias unchanged in flat instance mode or when no group key matches", () => {
+    expect(sessionPresentationName({ alias: "weacpx-github-omp-2", workspace: "weacpx-github", groupMode: "instance" })).toBe("weacpx-github-omp-2");
+    expect(sessionPresentationName({ alias: "custom-alias", workspace: "weacpx-github", groupMode: "workspace" })).toBe("custom-alias");
   });
 });

--- a/packages/relay-web/src/__tests__/sidebar-group-mode.test.ts
+++ b/packages/relay-web/src/__tests__/sidebar-group-mode.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { loadGroupMode, saveGroupMode, groupSessions, dedupedSessionName, sessionPresentationName, archivedLast } from "../lib/sidebar-group-mode";
+import {
+  loadGroupMode,
+  saveGroupMode,
+  groupSessions,
+  dedupedSessionName,
+  sessionPresentationName,
+  shortestUniqueSuffix,
+  archivedLast,
+} from "../lib/sidebar-group-mode";
 
 const KEY = "xacpx.sidebar.groupMode.i1";
 
@@ -31,32 +39,60 @@ describe("group mode persistence", () => {
   });
 });
 
-const s = (alias: string, workspace: string, agent: string, archived = false) => ({ alias, workspace, agent, archived });
+const s = (
+  alias: string,
+  workspace: string,
+  agent: string,
+  archived = false,
+) => ({ alias, workspace, agent, archived });
 
 describe("groupSessions", () => {
   it("groups by workspace in first-appearance order, derived from sessions only", () => {
-    const groups = groupSessions([s("a", "web", "claude"), s("b", "api", "codex"), s("c", "web", "codex")], "workspace");
+    const groups = groupSessions(
+      [s("a", "web", "claude"), s("b", "api", "codex"), s("c", "web", "codex")],
+      "workspace",
+    );
     expect(groups.map((g) => g.key)).toEqual(["web", "api"]);
     expect(groups[0]!.sessions.map((x) => x.alias)).toEqual(["a", "c"]);
     expect(groups[1]!.sessions.map((x) => x.alias)).toEqual(["b"]);
   });
 
   it("groups by agent", () => {
-    const groups = groupSessions([s("a", "web", "claude"), s("b", "api", "codex"), s("c", "web", "claude")], "agent");
+    const groups = groupSessions(
+      [
+        s("a", "web", "claude"),
+        s("b", "api", "codex"),
+        s("c", "web", "claude"),
+      ],
+      "agent",
+    );
     expect(groups.map((g) => g.key)).toEqual(["claude", "codex"]);
     expect(groups[0]!.sessions.map((x) => x.alias)).toEqual(["a", "c"]);
   });
 
   it("sinks archived sessions to the bottom of their group (stable)", () => {
     const groups = groupSessions(
-      [s("arch1", "web", "claude", true), s("live1", "web", "claude"), s("arch2", "web", "codex", true), s("live2", "web", "codex")],
+      [
+        s("arch1", "web", "claude", true),
+        s("live1", "web", "claude"),
+        s("arch2", "web", "codex", true),
+        s("live2", "web", "codex"),
+      ],
       "workspace",
     );
-    expect(groups[0]!.sessions.map((x) => x.alias)).toEqual(["live1", "live2", "arch1", "arch2"]);
+    expect(groups[0]!.sessions.map((x) => x.alias)).toEqual([
+      "live1",
+      "live2",
+      "arch1",
+      "arch2",
+    ]);
   });
 
   it("orders archived sessions by sleep time, most recently slept first", () => {
-    const arch = (alias: string, archivedAt?: string) => ({ ...s(alias, "web", "claude", true), ...(archivedAt ? { archivedAt } : {}) });
+    const arch = (alias: string, archivedAt?: string) => ({
+      ...s(alias, "web", "claude", true),
+      ...(archivedAt ? { archivedAt } : {}),
+    });
     const sorted = archivedLast([
       s("live", "web", "claude"),
       arch("old-sleep", "2026-08-01T00:00:00Z"),
@@ -66,7 +102,13 @@ describe("groupSessions", () => {
     ]);
     // Actives keep incoming order; archived sink below, newest sleep on top so a
     // user expanding the sleeping list finds the latest sessions without paging.
-    expect(sorted.map((x) => x.alias)).toEqual(["live", "fresh-sleep", "mid-sleep", "old-sleep", "legacy-sleep"]);
+    expect(sorted.map((x) => x.alias)).toEqual([
+      "live",
+      "fresh-sleep",
+      "mid-sleep",
+      "old-sleep",
+      "legacy-sleep",
+    ]);
   });
 
   it("returns no groups for no sessions", () => {
@@ -84,8 +126,12 @@ describe("dedupedSessionName", () => {
   });
 
   it("leaves non-matching names untouched", () => {
-    expect(dedupedSessionName("my-session", "web", "workspace")).toBe("my-session");
-    expect(dedupedSessionName("my-session", "claude", "agent")).toBe("my-session");
+    expect(dedupedSessionName("my-session", "web", "workspace")).toBe(
+      "my-session",
+    );
+    expect(dedupedSessionName("my-session", "claude", "agent")).toBe(
+      "my-session",
+    );
   });
 
   it("never dedups down to an empty name", () => {
@@ -96,20 +142,86 @@ describe("dedupedSessionName", () => {
 
 describe("sessionPresentationName", () => {
   it("uses custom displayName when present under any mode", () => {
-    expect(sessionPresentationName({ displayName: "发布机器人", alias: "weacpx-github-omp-2", workspace: "weacpx-github", groupMode: "workspace" })).toBe("发布机器人");
-    expect(sessionPresentationName({ displayName: "发布机器人", alias: "omp-2", groupMode: "instance" })).toBe("发布机器人");
+    expect(
+      sessionPresentationName({
+        displayName: "发布机器人",
+        alias: "weacpx-github-omp-2",
+        workspace: "weacpx-github",
+        groupMode: "workspace",
+      }),
+    ).toBe("发布机器人");
+    expect(
+      sessionPresentationName({
+        displayName: "发布机器人",
+        alias: "omp-2",
+        groupMode: "instance",
+      }),
+    ).toBe("发布机器人");
   });
 
   it("dedups alias in workspace mode by stripping leading <workspace>-", () => {
-    expect(sessionPresentationName({ alias: "weacpx-github-omp-2", workspace: "weacpx-github", groupMode: "workspace" })).toBe("omp-2");
+    expect(
+      sessionPresentationName({
+        alias: "weacpx-github-omp-2",
+        workspace: "weacpx-github",
+        groupMode: "workspace",
+      }),
+    ).toBe("omp-2");
   });
 
   it("dedups alias in agent mode by stripping trailing -<agent>", () => {
-    expect(sessionPresentationName({ alias: "omp-2-codex", agent: "codex", groupMode: "agent" })).toBe("omp-2");
+    expect(
+      sessionPresentationName({
+        alias: "omp-2-codex",
+        agent: "codex",
+        groupMode: "agent",
+      }),
+    ).toBe("omp-2");
   });
 
   it("preserves alias unchanged in flat instance mode or when no group key matches", () => {
-    expect(sessionPresentationName({ alias: "weacpx-github-omp-2", workspace: "weacpx-github", groupMode: "instance" })).toBe("weacpx-github-omp-2");
-    expect(sessionPresentationName({ alias: "custom-alias", workspace: "weacpx-github", groupMode: "workspace" })).toBe("custom-alias");
+    expect(
+      sessionPresentationName({
+        alias: "weacpx-github-omp-2",
+        workspace: "weacpx-github",
+        groupMode: "instance",
+      }),
+    ).toBe("weacpx-github-omp-2");
+    expect(
+      sessionPresentationName({
+        alias: "custom-alias",
+        workspace: "weacpx-github",
+        groupMode: "workspace",
+      }),
+    ).toBe("custom-alias");
+  });
+});
+
+describe("shortestUniqueSuffix", () => {
+  it("returns 5-char tail when 5-char tails are unique", () => {
+    const k1 = "node-1:endpoint_worker_1234a";
+    const k2 = "node-1:endpoint_worker_5678b";
+    expect(shortestUniqueSuffix(k1, [k1, k2], 5)).toBe("…1234a");
+    expect(shortestUniqueSuffix(k2, [k1, k2], 5)).toBe("…5678b");
+  });
+
+  it("expands suffix dynamically when 5-char tails collide", () => {
+    const k1 = "node-1:endpoint_worker_A12345";
+    const k2 = "node-1:endpoint_worker_B12345";
+    // 5 chars "12345" collide -> expands to 6 chars "A12345" vs "B12345"
+    expect(shortestUniqueSuffix(k1, [k1, k2], 5)).toBe("…A12345");
+    expect(shortestUniqueSuffix(k2, [k1, k2], 5)).toBe("…B12345");
+  });
+
+  it("expands to include node discriminator when endpointIds are completely identical across nodes", () => {
+    const k1 = "node-alpha:endpoint_worker_default";
+    const k2 = "node-beta:endpoint_worker_default";
+    // "endpoint_worker_default" is identical -> expands until node difference is included
+    expect(shortestUniqueSuffix(k1, [k1, k2], 5)).toBe(
+      "…ha:endpoint_worker_default",
+    );
+    expect(shortestUniqueSuffix(k2, [k1, k2], 5)).toBe(
+      "…ta:endpoint_worker_default",
+    );
   });
 });

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -11,7 +11,7 @@ import { confirm } from "../lib/use-confirm";
 import { showActionToast } from "../lib/use-action-toast";
 import { pushToast } from "../lib/use-toasts";
 import { useSwipeActions } from "../lib/use-swipe-actions";
-import { groupSessions, dedupedSessionName, archivedLast } from "../lib/sidebar-group-mode";
+import { groupSessions, dedupedSessionName, sessionPresentationName, archivedLast } from "../lib/sidebar-group-mode";
 import NewSessionDialog from "./NewSessionDialog.vue";
 import ManageInstanceDialog from "./ManageInstanceDialog.vue";
 import AgentIcon from "./AgentIcon.vue";
@@ -205,11 +205,15 @@ function toggleGroup(inst: InstanceView, key: string): void {
 
 // Display-only dedup of the `<workspace>-<agent>` auto-alias inside a group; the
 // row's hover title always carries the full name.
-function rowName(inst: InstanceView, s: { alias: string; displayName?: string }, sectionKey: string | null): string {
-  const name = s.displayName || s.alias;
+function rowName(inst: InstanceView, s: { alias: string; displayName?: string; workspace?: string; agent?: string }, sectionKey: string | null): string {
   const mode = groupModeOf(inst);
-  if (sectionKey === null || mode === "instance") return name;
-  return dedupedSessionName(name, sectionKey, mode);
+  return sessionPresentationName({
+    displayName: s.displayName,
+    alias: s.alias,
+    workspace: s.workspace ?? (mode === "workspace" ? sectionKey ?? undefined : undefined),
+    agent: s.agent ?? (mode === "agent" ? sectionKey ?? undefined : undefined),
+    groupMode: mode,
+  });
 }
 
 // Group-header ＋: open the create dialog with the group's own value prefilled.

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -27,7 +27,10 @@ import { useSessionControlsStore } from "../stores/session-controls";
 import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
 import { formatModelLabel } from "../lib/model-label";
+import { sessionPresentationName } from "../lib/sidebar-group-mode";
+import { useI18n } from "vue-i18n";
 
+const { t } = useI18n();
 const props = defineProps<{
   busy?: boolean;
   draftKey?: string;
@@ -216,9 +219,12 @@ interface AgentMentionItem {
   handle: string;
   displayName: string;
   sessionAlias?: string;
+  hasCustomDisplayName: boolean;
   agent: string;
   workspace?: string;
+  groupMode?: "instance" | "workspace" | "agent";
   nodeLabel?: string;
+  instanceId?: string;
   nodeId: string;
   endpointId: string;
   activity?: {
@@ -229,16 +235,36 @@ interface AgentMentionItem {
 
 const availableAgents = computed<AgentMentionItem[]>(() => {
   return instancesStore.agentDirectory.map((ep) => {
-    const inst = instancesStore.instances.find((i) => i.id === ep.nodeId);
+    const inst = ep.instanceId
+      ? instancesStore.instances.find((i) => i.id === ep.instanceId)
+      : undefined;
     const nodeLabel = inst?.name;
-    const primaryName = ep.displayName || ep.sessionAlias || ep.agent;
+    const groupMode = ep.instanceId
+      ? instancesStore.groupModeFor(ep.instanceId)
+      : undefined;
+    const baseAlias = ep.sessionAlias || ep.agent;
+    const primaryName = sessionPresentationName({
+      displayName: ep.displayName,
+      alias: baseAlias,
+      workspace: ep.workspace,
+      agent: ep.agent,
+      groupMode,
+    });
+    const hasCustomDisplayName = Boolean(
+      ep.displayName &&
+        ep.sessionAlias &&
+        ep.displayName !== ep.sessionAlias,
+    );
     return {
       handle: `agent:${ep.nodeId}:${ep.endpointId}`,
       displayName: primaryName,
       sessionAlias: ep.sessionAlias,
+      hasCustomDisplayName,
       agent: ep.agent,
       workspace: ep.workspace,
+      groupMode,
       nodeLabel,
+      instanceId: ep.instanceId,
       nodeId: ep.nodeId,
       endpointId: ep.endpointId,
       activity: ep.activity,
@@ -252,9 +278,18 @@ function formatSecondaryLine(
 ): string {
   const parts: string[] = [];
 
-  if (item.sessionAlias && item.sessionAlias !== item.displayName) {
-    parts.push(item.sessionAlias);
+  if (item.hasCustomDisplayName && item.sessionAlias) {
+    const displayAlias = sessionPresentationName({
+      alias: item.sessionAlias,
+      workspace: item.workspace,
+      agent: item.agent,
+      groupMode: item.groupMode,
+    });
+    if (displayAlias && displayAlias !== item.displayName) {
+      parts.push(displayAlias);
+    }
   }
+
   if (item.workspace) {
     parts.push(item.workspace);
   }
@@ -264,19 +299,23 @@ function formatSecondaryLine(
 
   const duplicates = allItems.filter(
     (other) =>
-      other.displayName === item.displayName && other.handle !== item.handle,
+      other.displayName === item.displayName &&
+      other.handle !== item.handle,
   );
 
   if (duplicates.length > 0) {
     const myBaseKey = [
-      item.sessionAlias ?? "",
+      item.hasCustomDisplayName ? item.sessionAlias ?? "" : "",
       item.workspace ?? "",
       item.agent ?? "",
     ].join("::");
     const sameBaseDuplicates = duplicates.filter(
       (d) =>
-        [d.sessionAlias ?? "", d.workspace ?? "", d.agent ?? ""].join("::") ===
-        myBaseKey,
+        [
+          d.hasCustomDisplayName ? d.sessionAlias ?? "" : "",
+          d.workspace ?? "",
+          d.agent ?? "",
+        ].join("::") === myBaseKey,
     );
 
     if (sameBaseDuplicates.length > 0) {
@@ -300,16 +339,15 @@ function activityLabel(activity?: {
   if (!activity?.status) return "";
   switch (activity.status) {
     case "working":
-      return "Working";
+      return t("chat.mentionActivity.working");
     case "waiting":
-      return "Waiting";
+      return t("chat.mentionActivity.waiting");
     case "idle":
-      return "Idle";
+      return t("chat.mentionActivity.idle");
     default:
       return "";
   }
 }
-
 function activityClass(status?: "idle" | "working" | "waiting"): string {
   switch (status) {
     case "working":

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -222,6 +222,7 @@ interface AgentMentionItem {
   handle: string;
   displayName: string;
   sessionAlias?: string;
+  presentationSessionAlias?: string;
   hasCustomDisplayName: boolean;
   agent: string;
   workspace?: string;
@@ -256,6 +257,14 @@ const availableAgents = computed<AgentMentionItem[]>(() => {
     const hasCustomDisplayName = Boolean(
       ep.displayName && ep.sessionAlias && ep.displayName !== ep.sessionAlias,
     );
+    const presentationSessionAlias = ep.sessionAlias
+      ? sessionPresentationName({
+          alias: ep.sessionAlias,
+          workspace: ep.workspace,
+          agent: ep.agent,
+          groupMode,
+        })
+      : undefined;
     const normalizedActivity = ep.activity ?? {
       status: ep.state === "running" ? "working" : "idle",
     };
@@ -263,6 +272,7 @@ const availableAgents = computed<AgentMentionItem[]>(() => {
       handle: `agent:${ep.nodeId}:${ep.endpointId}`,
       displayName: primaryName,
       sessionAlias: ep.sessionAlias,
+      presentationSessionAlias,
       hasCustomDisplayName,
       agent: ep.agent,
       workspace: ep.workspace,
@@ -282,16 +292,12 @@ function formatSecondaryLine(
 ): string {
   const parts: string[] = [];
 
-  if (item.hasCustomDisplayName && item.sessionAlias) {
-    const displayAlias = sessionPresentationName({
-      alias: item.sessionAlias,
-      workspace: item.workspace,
-      agent: item.agent,
-      groupMode: item.groupMode,
-    });
-    if (displayAlias && displayAlias !== item.displayName) {
-      parts.push(displayAlias);
-    }
+  if (
+    item.hasCustomDisplayName &&
+    item.presentationSessionAlias &&
+    item.presentationSessionAlias !== item.displayName
+  ) {
+    parts.push(item.presentationSessionAlias);
   }
 
   if (item.workspace) {
@@ -307,14 +313,14 @@ function formatSecondaryLine(
 
   if (duplicates.length > 0) {
     const baseKey = [
-      item.hasCustomDisplayName ? (item.sessionAlias ?? "") : "",
+      item.hasCustomDisplayName ? (item.presentationSessionAlias ?? "") : "",
       item.workspace ?? "",
       item.agent ?? "",
     ].join("::");
     const sameBaseDuplicates = duplicates.filter(
       (d) =>
         [
-          d.hasCustomDisplayName ? (d.sessionAlias ?? "") : "",
+          d.hasCustomDisplayName ? (d.presentationSessionAlias ?? "") : "",
           d.workspace ?? "",
           d.agent ?? "",
         ].join("::") === baseKey,
@@ -423,27 +429,31 @@ function updateMentionState() {
 function computeRank(item: AgentMentionItem, q: string): number {
   if (!q) return 0;
   const dn = item.displayName.toLowerCase();
-  const sa = (item.sessionAlias ?? "").toLowerCase();
+  const psa = (item.presentationSessionAlias ?? "").toLowerCase();
+  const rawSa = (item.sessionAlias ?? "").toLowerCase();
   const ws = (item.workspace ?? "").toLowerCase();
   const ag = item.agent.toLowerCase();
 
-  // Tier 1: Exact matches (11..14)
+  // Tier 1: Exact matches (11..15)
   if (dn === q) return 11;
-  if (sa && sa === q) return 12;
+  if (psa && psa === q) return 12;
   if (ws && ws === q) return 13;
   if (ag === q) return 14;
+  if (rawSa && rawSa !== psa && rawSa === q) return 15;
 
-  // Tier 2: Prefix matches (21..24)
+  // Tier 2: Prefix matches (21..25)
   if (dn.startsWith(q)) return 21;
-  if (sa && sa.startsWith(q)) return 22;
+  if (psa && psa.startsWith(q)) return 22;
   if (ws && ws.startsWith(q)) return 23;
   if (ag.startsWith(q)) return 24;
+  if (rawSa && rawSa !== psa && rawSa.startsWith(q)) return 25;
 
-  // Tier 3: Contains matches (31..34)
+  // Tier 3: Contains matches (31..35)
   if (dn.includes(q)) return 31;
-  if (sa && sa.includes(q)) return 32;
+  if (psa && psa.includes(q)) return 32;
   if (ws && ws.includes(q)) return 33;
   if (ag.includes(q)) return 34;
+  if (rawSa && rawSa !== psa && rawSa.includes(q)) return 35;
 
   return -1;
 }
@@ -467,10 +477,10 @@ const mentionMatches = computed(() => {
     }
     const dnCmp = a.item.displayName.localeCompare(b.item.displayName);
     if (dnCmp !== 0) return dnCmp;
-    const saCmp = (a.item.sessionAlias ?? "").localeCompare(
-      b.item.sessionAlias ?? "",
+    const psaCmp = (a.item.presentationSessionAlias ?? "").localeCompare(
+      b.item.presentationSessionAlias ?? "",
     );
-    if (saCmp !== 0) return saCmp;
+    if (psaCmp !== 0) return psaCmp;
     const wsCmp = (a.item.workspace ?? "").localeCompare(
       b.item.workspace ?? "",
     );

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -27,7 +27,10 @@ import { useSessionControlsStore } from "../stores/session-controls";
 import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
 import { formatModelLabel } from "../lib/model-label";
-import { sessionPresentationName } from "../lib/sidebar-group-mode";
+import {
+  sessionPresentationName,
+  shortestUniqueSuffix,
+} from "../lib/sidebar-group-mode";
 import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
@@ -327,15 +330,19 @@ function formatSecondaryLine(
       );
 
       if (sameInstanceDuplicates.length > 0) {
-        const suffix =
-          item.endpointId.length > 5
-            ? `…${item.endpointId.slice(-5)}`
-            : item.endpointId;
+        const allCollidingRoutingKeys = [item, ...sameInstanceDuplicates].map(
+          (i) => `${i.nodeId}:${i.endpointId}`,
+        );
+        const targetRoutingKey = `${item.nodeId}:${item.endpointId}`;
+        const suffix = shortestUniqueSuffix(
+          targetRoutingKey,
+          allCollidingRoutingKeys,
+          5,
+        );
         parts.push(suffix);
       }
     }
   }
-
   return parts.join(" · ");
 }
 

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -286,10 +286,7 @@ const availableAgents = computed<AgentMentionItem[]>(() => {
   });
 });
 
-function formatSecondaryLine(
-  item: AgentMentionItem,
-  allItems: AgentMentionItem[],
-): string {
+function secondaryIdentityParts(item: AgentMentionItem): string[] {
   const parts: string[] = [];
 
   if (
@@ -306,24 +303,25 @@ function formatSecondaryLine(
   if (item.agent && item.agent !== item.displayName) {
     parts.push(item.agent);
   }
+
+  return parts;
+}
+
+function formatSecondaryLine(
+  item: AgentMentionItem,
+  allItems: AgentMentionItem[],
+): string {
+  const parts = secondaryIdentityParts(item);
+
   const duplicates = allItems.filter(
     (other) =>
       other.displayName === item.displayName && other.handle !== item.handle,
   );
 
   if (duplicates.length > 0) {
-    const baseKey = [
-      item.hasCustomDisplayName ? (item.presentationSessionAlias ?? "") : "",
-      item.workspace ?? "",
-      item.agent ?? "",
-    ].join("::");
+    const baseKey = secondaryIdentityParts(item).join("::");
     const sameBaseDuplicates = duplicates.filter(
-      (d) =>
-        [
-          d.hasCustomDisplayName ? (d.presentationSessionAlias ?? "") : "",
-          d.workspace ?? "",
-          d.agent ?? "",
-        ].join("::") === baseKey,
+      (d) => secondaryIdentityParts(d).join("::") === baseKey,
     );
 
     if (sameBaseDuplicates.length > 0) {

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -251,10 +251,11 @@ const availableAgents = computed<AgentMentionItem[]>(() => {
       groupMode,
     });
     const hasCustomDisplayName = Boolean(
-      ep.displayName &&
-        ep.sessionAlias &&
-        ep.displayName !== ep.sessionAlias,
+      ep.displayName && ep.sessionAlias && ep.displayName !== ep.sessionAlias,
     );
+    const normalizedActivity = ep.activity ?? {
+      status: ep.state === "running" ? "working" : "idle",
+    };
     return {
       handle: `agent:${ep.nodeId}:${ep.endpointId}`,
       displayName: primaryName,
@@ -267,7 +268,7 @@ const availableAgents = computed<AgentMentionItem[]>(() => {
       instanceId: ep.instanceId,
       nodeId: ep.nodeId,
       endpointId: ep.endpointId,
-      activity: ep.activity,
+      activity: normalizedActivity,
     };
   });
 });
@@ -296,34 +297,40 @@ function formatSecondaryLine(
   if (item.agent && item.agent !== item.displayName) {
     parts.push(item.agent);
   }
-
   const duplicates = allItems.filter(
     (other) =>
-      other.displayName === item.displayName &&
-      other.handle !== item.handle,
+      other.displayName === item.displayName && other.handle !== item.handle,
   );
 
   if (duplicates.length > 0) {
-    const myBaseKey = [
-      item.hasCustomDisplayName ? item.sessionAlias ?? "" : "",
+    const baseKey = [
+      item.hasCustomDisplayName ? (item.sessionAlias ?? "") : "",
       item.workspace ?? "",
       item.agent ?? "",
     ].join("::");
     const sameBaseDuplicates = duplicates.filter(
       (d) =>
         [
-          d.hasCustomDisplayName ? d.sessionAlias ?? "" : "",
+          d.hasCustomDisplayName ? (d.sessionAlias ?? "") : "",
           d.workspace ?? "",
           d.agent ?? "",
-        ].join("::") === myBaseKey,
+        ].join("::") === baseKey,
     );
 
     if (sameBaseDuplicates.length > 0) {
       if (item.nodeLabel) {
         parts.push(item.nodeLabel);
-      } else {
+      }
+
+      const sameInstanceDuplicates = sameBaseDuplicates.filter(
+        (d) => (d.nodeLabel ?? "") === (item.nodeLabel ?? ""),
+      );
+
+      if (sameInstanceDuplicates.length > 0) {
         const suffix =
-          item.nodeId.length > 5 ? `…${item.nodeId.slice(-5)}` : item.nodeId;
+          item.endpointId.length > 5
+            ? `…${item.endpointId.slice(-5)}`
+            : item.endpointId;
         parts.push(suffix);
       }
     }
@@ -413,16 +420,23 @@ function computeRank(item: AgentMentionItem, q: string): number {
   const ws = (item.workspace ?? "").toLowerCase();
   const ag = item.agent.toLowerCase();
 
-  if (dn === q) return 1;
-  if (sa && sa === q) return 2;
-  if (dn.startsWith(q)) return 3;
-  if (sa && sa.startsWith(q)) return 4;
-  if (dn.includes(q)) return 5;
-  if (sa && sa.includes(q)) return 6;
-  if (ws && ws.startsWith(q)) return 7;
-  if (ws && ws.includes(q)) return 8;
-  if (ag.startsWith(q)) return 9;
-  if (ag.includes(q)) return 10;
+  // Tier 1: Exact matches (11..14)
+  if (dn === q) return 11;
+  if (sa && sa === q) return 12;
+  if (ws && ws === q) return 13;
+  if (ag === q) return 14;
+
+  // Tier 2: Prefix matches (21..24)
+  if (dn.startsWith(q)) return 21;
+  if (sa && sa.startsWith(q)) return 22;
+  if (ws && ws.startsWith(q)) return 23;
+  if (ag.startsWith(q)) return 24;
+
+  // Tier 3: Contains matches (31..34)
+  if (dn.includes(q)) return 31;
+  if (sa && sa.includes(q)) return 32;
+  if (ws && ws.includes(q)) return 33;
+  if (ag.includes(q)) return 34;
 
   return -1;
 }
@@ -450,6 +464,12 @@ const mentionMatches = computed(() => {
       b.item.sessionAlias ?? "",
     );
     if (saCmp !== 0) return saCmp;
+    const wsCmp = (a.item.workspace ?? "").localeCompare(
+      b.item.workspace ?? "",
+    );
+    if (wsCmp !== 0) return wsCmp;
+    const agCmp = a.item.agent.localeCompare(b.item.agent);
+    if (agCmp !== 0) return agCmp;
     return a.item.handle.localeCompare(b.item.handle);
   });
 

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -1,6 +1,22 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
-import { Brain, Check, ChevronDown, Gauge, Paperclip, Send, SlidersHorizontal, X } from "lucide-vue-next";
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+} from "vue";
+import {
+  Brain,
+  Check,
+  ChevronDown,
+  Gauge,
+  Paperclip,
+  Send,
+  SlidersHorizontal,
+  X,
+} from "lucide-vue-next";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
 import { createDebouncedFlush } from "../lib/debounce-flush";
@@ -12,7 +28,12 @@ import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
 import { formatModelLabel } from "../lib/model-label";
 
-const props = defineProps<{ busy?: boolean; draftKey?: string; instanceId?: string | null; sessionAlias?: string | null }>();
+const props = defineProps<{
+  busy?: boolean;
+  draftKey?: string;
+  instanceId?: string | null;
+  sessionAlias?: string | null;
+}>();
 const emit = defineEmits<{
   send: [
     text: string,
@@ -27,7 +48,6 @@ const controls = useSessionControlsStore();
 const chat = useChatStore();
 const instancesStore = useInstancesStore();
 
-
 // Context-usage meter (ACP usage_update) for the current session. Null when the agent
 // doesn't report it (e.g. codex) or the window is unknown — the chip then hides.
 const context = computed(() => {
@@ -35,15 +55,32 @@ const context = computed(() => {
   if (!u || u.size <= 0) return null;
   const pct = Math.min(100, Math.round((u.used / u.size) * 100));
   const tone = pct >= 90 ? "danger" : pct >= 75 ? "warn" : "accent";
-  return { used: u.used, size: u.size, pct, tone, cost: u.cost, breakdown: u.breakdown };
+  return {
+    used: u.used,
+    size: u.size,
+    pct,
+    tone,
+    cost: u.cost,
+    breakdown: u.breakdown,
+  };
 });
 
 // Click the meter to open a popover with the cost & per-turn token breakdown.
 const usageOpen = ref(false);
-const usageAnchor = ref<{ top: number; left: number; width: number; height: number } | null>(null);
+const usageAnchor = ref<{
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+} | null>(null);
 function toggleUsage(e: MouseEvent) {
   const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
-  usageAnchor.value = { top: r.top, left: r.left, width: r.width, height: r.height };
+  usageAnchor.value = {
+    top: r.top,
+    left: r.left,
+    width: r.width,
+    height: r.height,
+  };
   usageOpen.value = !usageOpen.value;
 }
 
@@ -98,20 +135,32 @@ const HEIGHT_VIEWPORT_FRACTION = 0.5;
 // `matchMedia` is absent in some test/embedded runtimes; treat its absence as
 // "not desktop" so the resize handle and inline height simply don't engage.
 function queryDesktop(): boolean {
-  return typeof window !== "undefined" && typeof window.matchMedia === "function"
-    && window.matchMedia("(min-width: 1024px)").matches;
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(min-width: 1024px)").matches
+  );
 }
 const isDesktop = ref(queryDesktop());
-const composerHeight = ref(clampPanelWidth(
-  Number(localStorage.getItem("xacpx.composerHeight")) || HEIGHT_DEFAULT,
-  HEIGHT_MIN, HEIGHT_MAX,
-  typeof window !== "undefined" ? window.innerHeight : undefined, HEIGHT_VIEWPORT_FRACTION));
+const composerHeight = ref(
+  clampPanelWidth(
+    Number(localStorage.getItem("xacpx.composerHeight")) || HEIGHT_DEFAULT,
+    HEIGHT_MIN,
+    HEIGHT_MAX,
+    typeof window !== "undefined" ? window.innerHeight : undefined,
+    HEIGHT_VIEWPORT_FRACTION,
+  ),
+);
 const heightDragging = ref(false);
-watch(composerHeight, (v) => localStorage.setItem("xacpx.composerHeight", String(v)));
+watch(composerHeight, (v) =>
+  localStorage.setItem("xacpx.composerHeight", String(v)),
+);
 
 const heightResize = createBottomPanelResize({
   getHeight: () => composerHeight.value,
-  setHeight: (h) => { composerHeight.value = h; },
+  setHeight: (h) => {
+    composerHeight.value = h;
+  },
   min: HEIGHT_MIN,
   max: HEIGHT_MAX,
   maxViewportFraction: HEIGHT_VIEWPORT_FRACTION,
@@ -142,15 +191,21 @@ const cmdMenuOpen = ref(false);
 const cmdActiveIdx = ref(0);
 const cmdQuery = computed(() => {
   const v = text.value;
-  if (!v.startsWith("/") || v.includes("\n") || v.slice(1).includes(" ")) return null;
+  if (!v.startsWith("/") || v.includes("\n") || v.slice(1).includes(" "))
+    return null;
   return v.slice(1).toLowerCase();
 });
 const cmdMatches = computed(() => {
   const q = cmdQuery.value;
   if (q === null) return [];
-  return chat.sessionCommands.filter((c) => c.name.toLowerCase().startsWith(q)).slice(0, 8);
+  return chat.sessionCommands
+    .filter((c) => c.name.toLowerCase().startsWith(q))
+    .slice(0, 8);
 });
-watch(cmdMatches, (m) => { cmdMenuOpen.value = m.length > 0; cmdActiveIdx.value = 0; });
+watch(cmdMatches, (m) => {
+  cmdMenuOpen.value = m.length > 0;
+  cmdActiveIdx.value = 0;
+});
 function pickCommand(name: string) {
   text.value = `/${name} `;
   cmdMenuOpen.value = false;
@@ -160,22 +215,113 @@ function pickCommand(name: string) {
 interface AgentMentionItem {
   handle: string;
   displayName: string;
+  sessionAlias?: string;
   agent: string;
   workspace?: string;
+  nodeLabel?: string;
   nodeId: string;
   endpointId: string;
+  activity?: {
+    status: "idle" | "working" | "waiting";
+    summary?: string;
+  };
 }
 
 const availableAgents = computed<AgentMentionItem[]>(() => {
-  return instancesStore.agentDirectory.map((ep) => ({
-    handle: `agent:${ep.nodeId}:${ep.endpointId}`,
-    displayName: ep.displayName || ep.agent,
-    agent: ep.agent,
-    workspace: ep.workspace,
-    nodeId: ep.nodeId,
-    endpointId: ep.endpointId,
-  }));
+  return instancesStore.agentDirectory.map((ep) => {
+    const inst = instancesStore.instances.find((i) => i.id === ep.nodeId);
+    const nodeLabel = inst?.name;
+    const primaryName = ep.displayName || ep.sessionAlias || ep.agent;
+    return {
+      handle: `agent:${ep.nodeId}:${ep.endpointId}`,
+      displayName: primaryName,
+      sessionAlias: ep.sessionAlias,
+      agent: ep.agent,
+      workspace: ep.workspace,
+      nodeLabel,
+      nodeId: ep.nodeId,
+      endpointId: ep.endpointId,
+      activity: ep.activity,
+    };
+  });
 });
+
+function formatSecondaryLine(
+  item: AgentMentionItem,
+  allItems: AgentMentionItem[],
+): string {
+  const parts: string[] = [];
+
+  if (item.sessionAlias && item.sessionAlias !== item.displayName) {
+    parts.push(item.sessionAlias);
+  }
+  if (item.workspace) {
+    parts.push(item.workspace);
+  }
+  if (item.agent && item.agent !== item.displayName) {
+    parts.push(item.agent);
+  }
+
+  const duplicates = allItems.filter(
+    (other) =>
+      other.displayName === item.displayName && other.handle !== item.handle,
+  );
+
+  if (duplicates.length > 0) {
+    const myBaseKey = [
+      item.sessionAlias ?? "",
+      item.workspace ?? "",
+      item.agent ?? "",
+    ].join("::");
+    const sameBaseDuplicates = duplicates.filter(
+      (d) =>
+        [d.sessionAlias ?? "", d.workspace ?? "", d.agent ?? ""].join("::") ===
+        myBaseKey,
+    );
+
+    if (sameBaseDuplicates.length > 0) {
+      if (item.nodeLabel) {
+        parts.push(item.nodeLabel);
+      } else {
+        const suffix =
+          item.nodeId.length > 5 ? `…${item.nodeId.slice(-5)}` : item.nodeId;
+        parts.push(suffix);
+      }
+    }
+  }
+
+  return parts.join(" · ");
+}
+
+function activityLabel(activity?: {
+  status: "idle" | "working" | "waiting";
+  summary?: string;
+}): string {
+  if (!activity?.status) return "";
+  switch (activity.status) {
+    case "working":
+      return "Working";
+    case "waiting":
+      return "Waiting";
+    case "idle":
+      return "Idle";
+    default:
+      return "";
+  }
+}
+
+function activityClass(status?: "idle" | "working" | "waiting"): string {
+  switch (status) {
+    case "working":
+      return "text-run-bright";
+    case "waiting":
+      return "text-warn";
+    case "idle":
+      return "text-fg-muted";
+    default:
+      return "text-fg-muted";
+  }
+}
 
 const mentionMenuOpen = ref(false);
 const mentionActiveIdx = ref(0);
@@ -222,18 +368,54 @@ function updateMentionState() {
   mentionQuery.value = query.toLowerCase();
 }
 
+function computeRank(item: AgentMentionItem, q: string): number {
+  if (!q) return 0;
+  const dn = item.displayName.toLowerCase();
+  const sa = (item.sessionAlias ?? "").toLowerCase();
+  const ws = (item.workspace ?? "").toLowerCase();
+  const ag = item.agent.toLowerCase();
+
+  if (dn === q) return 1;
+  if (sa && sa === q) return 2;
+  if (dn.startsWith(q)) return 3;
+  if (sa && sa.startsWith(q)) return 4;
+  if (dn.includes(q)) return 5;
+  if (sa && sa.includes(q)) return 6;
+  if (ws && ws.startsWith(q)) return 7;
+  if (ws && ws.includes(q)) return 8;
+  if (ag.startsWith(q)) return 9;
+  if (ag.includes(q)) return 10;
+
+  return -1;
+}
+
 const mentionMatches = computed(() => {
   if (mentionQuery.value === null) return [];
-  const q = mentionQuery.value;
-  return availableAgents.value
-    .filter((a) => {
-      return (
-        a.displayName.toLowerCase().includes(q) ||
-        a.agent.toLowerCase().includes(q) ||
-        (a.workspace && a.workspace.toLowerCase().includes(q))
-      );
-    })
-    .slice(0, 8);
+  const q = mentionQuery.value.trim().toLowerCase();
+  const all = availableAgents.value;
+
+  const scored: Array<{ item: AgentMentionItem; rank: number }> = [];
+  for (const item of all) {
+    const rank = computeRank(item, q);
+    if (rank !== -1) {
+      scored.push({ item, rank });
+    }
+  }
+
+  scored.sort((a, b) => {
+    if (a.rank !== b.rank) {
+      return a.rank - b.rank;
+    }
+    const dnCmp = a.item.displayName.localeCompare(b.item.displayName);
+    if (dnCmp !== 0) return dnCmp;
+    const saCmp = (a.item.sessionAlias ?? "").localeCompare(
+      b.item.sessionAlias ?? "",
+    );
+    if (saCmp !== 0) return saCmp;
+    return a.item.handle.localeCompare(b.item.handle);
+  });
+
+  return scored.map((s) => s.item).slice(0, 8);
 });
 
 watch(mentionMatches, (m) => {
@@ -339,7 +521,9 @@ watch(
   () => composer.insertRequest,
   (req) => {
     if (!req || req.key !== (props.draftKey ?? "")) return;
-    text.value = text.value.trim() ? `${text.value.trimEnd()} ${req.text}` : req.text;
+    text.value = text.value.trim()
+      ? `${text.value.trimEnd()} ${req.text}`
+      : req.text;
     void nextTick(() => textarea.value?.focus());
   },
 );
@@ -369,7 +553,9 @@ function submit() {
 
   for (const item of recordedMentions.value) {
     const targetToken = `@${item.displayName}`;
-    if (rawText.slice(item.start, item.start + targetToken.length) === targetToken) {
+    if (
+      rawText.slice(item.start, item.start + targetToken.length) === targetToken
+    ) {
       const key = `${item.start}:${item.handle}`;
       if (!seenRanges.has(key)) {
         seenRanges.add(key);
@@ -390,7 +576,8 @@ function submit() {
   }
   composer.clearAttachments();
   recordedMentions.value = [];
-  if (value && history.value[history.value.length - 1] !== value) history.value.push(value);
+  if (value && history.value[history.value.length - 1] !== value)
+    history.value.push(value);
   historyIdx = -1;
   text.value = "";
   mentionMenuOpen.value = false;
@@ -400,11 +587,18 @@ function submit() {
 function recallHistory(dir: -1 | 1) {
   if (history.value.length === 0) return;
   if (dir === -1) {
-    historyIdx = historyIdx === -1 ? history.value.length - 1 : Math.max(0, historyIdx - 1);
+    historyIdx =
+      historyIdx === -1
+        ? history.value.length - 1
+        : Math.max(0, historyIdx - 1);
   } else {
     if (historyIdx === -1) return;
     historyIdx = historyIdx + 1;
-    if (historyIdx >= history.value.length) { historyIdx = -1; text.value = ""; return; }
+    if (historyIdx >= history.value.length) {
+      historyIdx = -1;
+      text.value = "";
+      return;
+    }
   }
   text.value = history.value[historyIdx];
 }
@@ -416,12 +610,15 @@ function onKeydown(e: KeyboardEvent) {
   // Mention autocomplete takes keys while menu is open
   if (mentionMenuOpen.value && mentionMatches.value.length > 0) {
     if (e.key === "ArrowDown") {
-      mentionActiveIdx.value = (mentionActiveIdx.value + 1) % mentionMatches.value.length;
+      mentionActiveIdx.value =
+        (mentionActiveIdx.value + 1) % mentionMatches.value.length;
       e.preventDefault();
       return;
     }
     if (e.key === "ArrowUp") {
-      mentionActiveIdx.value = (mentionActiveIdx.value - 1 + mentionMatches.value.length) % mentionMatches.value.length;
+      mentionActiveIdx.value =
+        (mentionActiveIdx.value - 1 + mentionMatches.value.length) %
+        mentionMatches.value.length;
       e.preventDefault();
       return;
     }
@@ -439,21 +636,57 @@ function onKeydown(e: KeyboardEvent) {
   }
   // Command autocomplete takes the arrow/enter/tab/esc keys while its menu is open.
   if (cmdMenuOpen.value && cmdMatches.value.length > 0) {
-    if (e.key === "ArrowDown") { cmdActiveIdx.value = (cmdActiveIdx.value + 1) % cmdMatches.value.length; e.preventDefault(); return; }
-    if (e.key === "ArrowUp") { cmdActiveIdx.value = (cmdActiveIdx.value - 1 + cmdMatches.value.length) % cmdMatches.value.length; e.preventDefault(); return; }
-    if (e.key === "Enter" || e.key === "Tab") { const c = cmdMatches.value[cmdActiveIdx.value]; if (c) pickCommand(c.name); e.preventDefault(); return; }
-    if (e.key === "Escape") { cmdMenuOpen.value = false; e.preventDefault(); return; }
+    if (e.key === "ArrowDown") {
+      cmdActiveIdx.value = (cmdActiveIdx.value + 1) % cmdMatches.value.length;
+      e.preventDefault();
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      cmdActiveIdx.value =
+        (cmdActiveIdx.value - 1 + cmdMatches.value.length) %
+        cmdMatches.value.length;
+      e.preventDefault();
+      return;
+    }
+    if (e.key === "Enter" || e.key === "Tab") {
+      const c = cmdMatches.value[cmdActiveIdx.value];
+      if (c) pickCommand(c.name);
+      e.preventDefault();
+      return;
+    }
+    if (e.key === "Escape") {
+      cmdMenuOpen.value = false;
+      e.preventDefault();
+      return;
+    }
   }
   if (e.key === "Escape") {
-    if (props.busy) { emit("cancel"); e.preventDefault(); }
+    if (props.busy) {
+      emit("cancel");
+      e.preventDefault();
+    }
     return;
   }
   // Plain Enter submits; Shift+Enter inserts a newline (default behavior).
-  if (e.key === "Enter" && !e.shiftKey) { submit(); e.preventDefault(); return; }
+  if (e.key === "Enter" && !e.shiftKey) {
+    submit();
+    e.preventDefault();
+    return;
+  }
   // History recall only when the caret sits at the very start of the input.
-  const caretAtStart = (textarea.value?.selectionStart ?? 0) === 0 && (textarea.value?.selectionEnd ?? 0) === 0;
-  if (e.key === "ArrowUp" && caretAtStart) { recallHistory(-1); e.preventDefault(); return; }
-  if (e.key === "ArrowDown" && historyIdx !== -1 && caretAtStart) { recallHistory(1); e.preventDefault(); return; }
+  const caretAtStart =
+    (textarea.value?.selectionStart ?? 0) === 0 &&
+    (textarea.value?.selectionEnd ?? 0) === 0;
+  if (e.key === "ArrowUp" && caretAtStart) {
+    recallHistory(-1);
+    e.preventDefault();
+    return;
+  }
+  if (e.key === "ArrowDown" && historyIdx !== -1 && caretAtStart) {
+    recallHistory(1);
+    e.preventDefault();
+    return;
+  }
 }
 
 function onInput() {
@@ -469,163 +702,345 @@ function onInput() {
   <!-- No form-level border-t / top padding: ChatPane stacks status/plan against this
        form's top edge, which must be the message card's top border — not a resize-handle
        gutter above it. Separation comes from the card border + ChatPane stack shadows. -->
-  <form class="relative px-0" @submit.prevent="submit"
-        @drop.prevent="onDrop" @dragover.prevent>
+  <form
+    class="relative px-0"
+    @submit.prevent="submit"
+    @drop.prevent="onDrop"
+    @dragover.prevent
+  >
     <!-- hidden file picker -->
-    <input ref="fileInput" type="file" multiple class="hidden" data-test="attach-input" @change="onFilesPicked" />
+    <input
+      ref="fileInput"
+      type="file"
+      multiple
+      class="hidden"
+      data-test="attach-input"
+      @change="onFilesPicked"
+    />
     <!-- COMPOSER — single elevated card: textarea on top, controls row below.
          `relative` so the slash-command menu can float above the card (bottom-full)
          instead of pushing the textarea down. -->
-    <div class="relative rounded-lg border border-border bg-surface shadow-e2 focus-within:border-accent/50 transition-colors">
+    <div
+      class="relative rounded-lg border border-border bg-surface shadow-e2 focus-within:border-accent/50 transition-colors"
+    >
       <!-- Resize handle: thin grab strip on the card's top edge (desktop only). Anchored
            inside the card so status/plan stack layers baseline to the real message-box
            top, not a gutter/handle above it. touch-none keeps a touch from scrolling;
            aria-hidden (pointer-only over rows="2"); title gives a hover hint. -->
-      <div data-test="composer-resize" aria-hidden="true" :title='$t("chat.resizeComposer")'
-           class="absolute inset-x-0 top-0 z-10 hidden h-2 cursor-row-resize touch-none select-none rounded-t-lg transition-colors lg:block"
-           :class="heightDragging ? 'bg-accent/50' : 'hover:bg-accent/30'"
-           @pointerdown.prevent="heightResize.onPointerDown" />
+      <div
+        data-test="composer-resize"
+        aria-hidden="true"
+        :title="$t('chat.resizeComposer')"
+        class="absolute inset-x-0 top-0 z-10 hidden h-2 cursor-row-resize touch-none select-none rounded-t-lg transition-colors lg:block"
+        :class="heightDragging ? 'bg-accent/50' : 'hover:bg-accent/30'"
+        @pointerdown.prevent="heightResize.onPointerDown"
+      />
       <!-- Pending attachment chips -->
-      <div v-if="composer.pending.length" class="flex flex-wrap gap-2 px-2.5 pt-2.5 pb-1">
-        <div v-for="p in composer.pending" :key="p.id"
-             class="flex items-center gap-1.5 rounded-md border border-border bg-raised px-2 py-1 text-[12px]">
-          <img v-if="p.previewUrl" :src="p.previewUrl" class="h-6 w-6 rounded object-cover" :alt="p.filename" />
+      <div
+        v-if="composer.pending.length"
+        class="flex flex-wrap gap-2 px-2.5 pt-2.5 pb-1"
+      >
+        <div
+          v-for="p in composer.pending"
+          :key="p.id"
+          class="flex items-center gap-1.5 rounded-md border border-border bg-raised px-2 py-1 text-[12px]"
+        >
+          <img
+            v-if="p.previewUrl"
+            :src="p.previewUrl"
+            class="h-6 w-6 rounded object-cover"
+            :alt="p.filename"
+          />
           <span class="max-w-[120px] truncate text-fg">{{ p.filename }}</span>
           <span v-if="p.status === 'uploading'" class="text-fg-muted">…</span>
-          <span v-else-if="p.status === 'error'" class="text-danger font-semibold">!</span>
-          <button type="button" :title="$t('chat.attach.remove')" class="text-fg-muted hover:text-fg transition-colors"
-                  @click="composer.removeAttachment(p.id)"><X :size="12" /></button>
+          <span
+            v-else-if="p.status === 'error'"
+            class="text-danger font-semibold"
+            >!</span
+          >
+          <button
+            type="button"
+            :title="$t('chat.attach.remove')"
+            class="text-fg-muted hover:text-fg transition-colors"
+            @click="composer.removeAttachment(p.id)"
+          >
+            <X :size="12" />
+          </button>
         </div>
       </div>
       <!-- Inline feedback when an attachment is rejected (cap or size limit). -->
-      <span v-if="composer.rejection" data-test="attach-rejected" class="block px-3 pt-2 text-xs text-danger">
-        {{ composer.rejection.reason === 'too-many' ? $t('chat.attach.tooMany') : $t('chat.attach.tooLarge', { name: composer.rejection.filename }) }}
+      <span
+        v-if="composer.rejection"
+        data-test="attach-rejected"
+        class="block px-3 pt-2 text-xs text-danger"
+      >
+        {{
+          composer.rejection.reason === "too-many"
+            ? $t("chat.attach.tooMany")
+            : $t("chat.attach.tooLarge", { name: composer.rejection.filename })
+        }}
       </span>
       <!-- Agent slash-command autocomplete: floats above the composer card (bottom-full)
            so it never grows the input box; pinned to the card's horizontal edges. -->
       <!-- Agent slash-command autocomplete -->
-      <ul v-if="cmdMenuOpen && cmdMatches.length" data-test="cmd-menu" role="listbox"
-          class="absolute bottom-full inset-x-2.5 z-20 mb-2 max-h-56 overflow-auto rounded-md border border-border bg-raised py-1 shadow-e2">
-        <li v-for="(c, i) in cmdMatches" :key="c.name"
-            data-test="cmd-item" role="option" :aria-selected="i === cmdActiveIdx"
-            class="flex cursor-pointer items-baseline gap-2 px-3 py-1.5 text-[13px]"
-            :class="i === cmdActiveIdx ? 'bg-accent/10' : ''"
-            @mousedown.prevent="pickCommand(c.name)"
-            @mouseenter="cmdActiveIdx = i">
+      <ul
+        v-if="cmdMenuOpen && cmdMatches.length"
+        data-test="cmd-menu"
+        role="listbox"
+        class="absolute bottom-full inset-x-2.5 z-20 mb-2 max-h-56 overflow-auto rounded-md border border-border bg-raised py-1 shadow-e2"
+      >
+        <li
+          v-for="(c, i) in cmdMatches"
+          :key="c.name"
+          data-test="cmd-item"
+          role="option"
+          :aria-selected="i === cmdActiveIdx"
+          class="flex cursor-pointer items-baseline gap-2 px-3 py-1.5 text-[13px]"
+          :class="i === cmdActiveIdx ? 'bg-accent/10' : ''"
+          @mousedown.prevent="pickCommand(c.name)"
+          @mouseenter="cmdActiveIdx = i"
+        >
           <span class="shrink-0 font-medium text-fg">/{{ c.name }}</span>
-          <span v-if="c.description" class="truncate text-fg-muted">{{ c.description }}</span>
+          <span v-if="c.description" class="truncate text-fg-muted">{{
+            c.description
+          }}</span>
         </li>
       </ul>
       <!-- Agent @ mention autocomplete: floats above the composer card -->
-      <ul v-if="mentionMenuOpen && mentionMatches.length" data-test="mention-menu" role="listbox"
-          class="absolute bottom-full inset-x-2.5 z-20 mb-2 max-h-56 overflow-auto rounded-md border border-border bg-raised py-1 shadow-e2">
-        <li v-for="(agentItem, i) in mentionMatches" :key="agentItem.handle"
-            data-test="mention-item" role="option" :aria-selected="i === mentionActiveIdx"
-            class="flex cursor-pointer items-center justify-between gap-2 px-3 py-1.5 text-[13px]"
-            :class="i === mentionActiveIdx ? 'bg-accent/10' : ''"
-            @mousedown.prevent="pickMention(agentItem)"
-            @mouseenter="mentionActiveIdx = i">
-          <div class="flex min-w-0 items-center gap-2">
-            <span class="font-semibold text-accent">@{{ agentItem.displayName }}</span>
-            <span class="inline-flex items-center gap-1 rounded border border-border bg-surface px-1.5 py-0.5 text-[11px] text-fg-muted">
-              {{ agentItem.agent }}
-            </span>
-            <span v-if="agentItem.workspace" class="truncate text-[11px] text-fg-muted">
-              {{ agentItem.workspace }}
-            </span>
+      <ul
+        v-if="mentionMenuOpen && mentionMatches.length"
+        data-test="mention-menu"
+        role="listbox"
+        class="absolute bottom-full inset-x-2.5 z-20 mb-2 max-h-56 overflow-auto rounded-md border border-border bg-raised py-1 shadow-e2"
+      >
+        <li
+          v-for="(agentItem, i) in mentionMatches"
+          :key="agentItem.handle"
+          data-test="mention-item"
+          role="option"
+          :aria-selected="i === mentionActiveIdx"
+          class="flex cursor-pointer items-center justify-between gap-2 px-3 py-1.5 text-[13px]"
+          :class="i === mentionActiveIdx ? 'bg-accent/10' : ''"
+          @mousedown.prevent="pickMention(agentItem)"
+          @mouseenter="mentionActiveIdx = i"
+        >
+          <div class="flex min-w-0 flex-1 flex-col">
+            <div class="flex min-w-0 items-center justify-between gap-2">
+              <span
+                class="font-semibold text-accent truncate"
+                data-test="mention-primary"
+                >@{{ agentItem.displayName }}</span
+              >
+              <span
+                v-if="activityLabel(agentItem.activity)"
+                data-test="mention-activity"
+                :data-status="agentItem.activity?.status"
+                class="shrink-0 text-[11px] font-medium"
+                :class="activityClass(agentItem.activity?.status)"
+              >
+                {{ activityLabel(agentItem.activity) }}
+              </span>
+            </div>
+            <div
+              v-if="formatSecondaryLine(agentItem, availableAgents)"
+              data-test="mention-secondary"
+              class="truncate text-[11px] text-fg-muted"
+            >
+              {{ formatSecondaryLine(agentItem, availableAgents) }}
+            </div>
           </div>
-          <span v-if="agentItem.nodeId" class="shrink-0 text-[11px] text-fg-muted">
-            {{ agentItem.nodeId }}
-          </span>
         </li>
       </ul>
       <!-- Stays enabled while busy: sending here queues server-side (no client-side
            blocking) and Esc still cancels the in-flight turn. -->
-      <textarea ref="textarea" v-model="text" rows="2"
-                class="w-full resize-none bg-transparent px-3.5 pt-2.5 pb-1 text-[16px] lg:text-[14px] leading-relaxed text-fg placeholder:text-fg-muted focus:outline-none"
-                :style="isDesktop ? { height: composerHeight + 'px' } : undefined"
-                :placeholder='busy ? $t("chat.working") : $t("chat.message")'
-                @input="onInput"
-                @click="updateMentionState"
-                @keyup="updateMentionState"
-                @keydown="onKeydown"
-                @paste="onPaste" />
+      <textarea
+        ref="textarea"
+        v-model="text"
+        rows="2"
+        class="w-full resize-none bg-transparent px-3.5 pt-2.5 pb-1 text-[16px] lg:text-[14px] leading-relaxed text-fg placeholder:text-fg-muted focus:outline-none"
+        :style="isDesktop ? { height: composerHeight + 'px' } : undefined"
+        :placeholder="busy ? $t('chat.working') : $t('chat.message')"
+        @input="onInput"
+        @click="updateMentionState"
+        @keyup="updateMentionState"
+        @keydown="onKeydown"
+        @paste="onPaste"
+      />
       <div class="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-0.5">
         <!-- model chip (left) -->
-        <div v-if="instanceId && sessionAlias" class="relative flex min-w-0 flex-1 items-center gap-2">
-          <button type="button" data-test="model-chip"
-                  class="flex min-w-0 items-center gap-1.5 px-1.5 py-1 rounded-md text-fg-muted hover:bg-raised transition-colors disabled:opacity-60"
-                  :disabled="!controls.modelAvailable.length"
-                  @click="toggleModelMenu">
+        <div
+          v-if="instanceId && sessionAlias"
+          class="relative flex min-w-0 flex-1 items-center gap-2"
+        >
+          <button
+            type="button"
+            data-test="model-chip"
+            class="flex min-w-0 items-center gap-1.5 px-1.5 py-1 rounded-md text-fg-muted hover:bg-raised transition-colors disabled:opacity-60"
+            :disabled="!controls.modelAvailable.length"
+            @click="toggleModelMenu"
+          >
             <Brain :size="14" class="shrink-0 text-accent" />
-            <span class="min-w-0 truncate font-mono text-[11.5px] font-medium text-fg">{{ controls.modelCurrent ? formatModelLabel(controls.modelCurrent) : $t("chat.model") }}</span>
-            <ChevronDown v-if="controls.modelAvailable.length" :size="13" class="shrink-0" />
+            <span
+              class="min-w-0 truncate font-mono text-[11.5px] font-medium text-fg"
+              >{{
+                controls.modelCurrent
+                  ? formatModelLabel(controls.modelCurrent)
+                  : $t("chat.model")
+              }}</span
+            >
+            <ChevronDown
+              v-if="controls.modelAvailable.length"
+              :size="13"
+              class="shrink-0"
+            />
           </button>
-          <ul v-if="modelMenuOpen && controls.modelAvailable.length" data-test="model-menu"
-              class="absolute bottom-full left-0 z-10 mb-1 max-h-48 min-w-40 overflow-y-auto rounded-lg border border-border bg-raised shadow-lg">
+          <ul
+            v-if="modelMenuOpen && controls.modelAvailable.length"
+            data-test="model-menu"
+            class="absolute bottom-full left-0 z-10 mb-1 max-h-48 min-w-40 overflow-y-auto rounded-lg border border-border bg-raised shadow-lg"
+          >
             <li v-for="m in controls.modelAvailable" :key="m">
-              <button type="button" data-test="model-option"
-                      class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
-                      :class="m === controls.modelCurrent ? 'bg-accent/10 text-accent' : 'hover:bg-fg/10 text-fg-muted'"
-                      @click="pickModel(m)">
+              <button
+                type="button"
+                data-test="model-option"
+                class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
+                :class="
+                  m === controls.modelCurrent
+                    ? 'bg-accent/10 text-accent'
+                    : 'hover:bg-fg/10 text-fg-muted'
+                "
+                @click="pickModel(m)"
+              >
                 <span class="font-mono">{{ formatModelLabel(m) }}</span>
-                <Check v-if="m === controls.modelCurrent" :size="14" class="ml-auto" />
+                <Check
+                  v-if="m === controls.modelCurrent"
+                  :size="14"
+                  class="ml-auto"
+                />
               </button>
             </li>
           </ul>
           <div v-if="controls.effortAvailable.length" class="relative shrink-0">
-            <button type="button" data-test="effort-chip"
-                    class="flex items-center gap-1.5 rounded-md px-1.5 py-1 text-fg-muted transition-colors hover:bg-raised"
-                    :title="$t('chat.effort')"
-                    @click="toggleEffortMenu">
+            <button
+              type="button"
+              data-test="effort-chip"
+              class="flex items-center gap-1.5 rounded-md px-1.5 py-1 text-fg-muted transition-colors hover:bg-raised"
+              :title="$t('chat.effort')"
+              @click="toggleEffortMenu"
+            >
               <SlidersHorizontal :size="14" class="text-accent" />
-              <span class="font-mono text-[11.5px] font-medium text-fg">{{ controls.effortCurrent ?? $t("chat.effort") }}</span>
+              <span class="font-mono text-[11.5px] font-medium text-fg">{{
+                controls.effortCurrent ?? $t("chat.effort")
+              }}</span>
               <ChevronDown :size="13" />
             </button>
-            <ul v-if="effortMenuOpen" data-test="effort-menu"
-                class="absolute bottom-full left-0 z-10 mb-1 max-h-48 min-w-32 overflow-y-auto rounded-lg border border-border bg-raised shadow-lg">
+            <ul
+              v-if="effortMenuOpen"
+              data-test="effort-menu"
+              class="absolute bottom-full left-0 z-10 mb-1 max-h-48 min-w-32 overflow-y-auto rounded-lg border border-border bg-raised shadow-lg"
+            >
               <li v-for="effort in controls.effortAvailable" :key="effort">
-                <button type="button" data-test="effort-option"
-                        class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
-                        :class="effort === controls.effortCurrent ? 'bg-accent/10 text-accent' : 'hover:bg-fg/10 text-fg-muted'"
-                        @click="pickEffort(effort)">
+                <button
+                  type="button"
+                  data-test="effort-option"
+                  class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
+                  :class="
+                    effort === controls.effortCurrent
+                      ? 'bg-accent/10 text-accent'
+                      : 'hover:bg-fg/10 text-fg-muted'
+                  "
+                  @click="pickEffort(effort)"
+                >
                   <span class="font-mono">{{ effort }}</span>
-                  <Check v-if="effort === controls.effortCurrent" :size="14" class="ml-auto" />
+                  <Check
+                    v-if="effort === controls.effortCurrent"
+                    :size="14"
+                    class="ml-auto"
+                  />
                 </button>
               </li>
             </ul>
           </div>
           <!-- context-usage meter: click to open the cost / token-breakdown popover -->
-          <button v-if="context" type="button" data-test="context-meter"
-                  class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded pl-0.5 hover:opacity-80"
-                  :title="$t('chat.contextUsage', { used: context.used.toLocaleString(), size: context.size.toLocaleString() })"
-                  @click="toggleUsage">
-            <Gauge :size="13" class="shrink-0"
-                   :class="context.tone === 'danger' ? 'text-danger' : context.tone === 'warn' ? 'text-warn' : 'text-accent'" />
-            <span class="relative h-1 w-8 shrink-0 overflow-hidden rounded-full bg-border">
-              <span class="absolute inset-y-0 left-0 rounded-full"
-                    :class="context.tone === 'danger' ? 'bg-danger' : context.tone === 'warn' ? 'bg-warn' : 'bg-accent'"
-                    :style="{ width: context.pct + '%' }" />
+          <button
+            v-if="context"
+            type="button"
+            data-test="context-meter"
+            class="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded pl-0.5 hover:opacity-80"
+            :title="
+              $t('chat.contextUsage', {
+                used: context.used.toLocaleString(),
+                size: context.size.toLocaleString(),
+              })
+            "
+            @click="toggleUsage"
+          >
+            <Gauge
+              :size="13"
+              class="shrink-0"
+              :class="
+                context.tone === 'danger'
+                  ? 'text-danger'
+                  : context.tone === 'warn'
+                    ? 'text-warn'
+                    : 'text-accent'
+              "
+            />
+            <span
+              class="relative h-1 w-8 shrink-0 overflow-hidden rounded-full bg-border"
+            >
+              <span
+                class="absolute inset-y-0 left-0 rounded-full"
+                :class="
+                  context.tone === 'danger'
+                    ? 'bg-danger'
+                    : context.tone === 'warn'
+                      ? 'bg-warn'
+                      : 'bg-accent'
+                "
+                :style="{ width: context.pct + '%' }"
+              />
             </span>
-            <span class="shrink-0 text-[11.5px] font-medium tabular-nums text-fg-muted">{{ context.pct }}%</span>
+            <span
+              class="shrink-0 text-[11.5px] font-medium tabular-nums text-fg-muted"
+              >{{ context.pct }}%</span
+            >
           </button>
-          <UsagePopover v-if="context && usageOpen"
-                        :used="context.used" :size="context.size" :pct="context.pct"
-                        :cost="context.cost" :breakdown="context.breakdown" :anchor="usageAnchor"
-                        @dismiss="usageOpen = false" />
+          <UsagePopover
+            v-if="context && usageOpen"
+            :used="context.used"
+            :size="context.size"
+            :pct="context.pct"
+            :cost="context.cost"
+            :breakdown="context.breakdown"
+            :anchor="usageAnchor"
+            @dismiss="usageOpen = false"
+          />
         </div>
         <span v-else />
 
         <!-- send / stop (right) -->
         <div class="flex shrink-0 items-center gap-1.5">
           <!-- attach button -->
-          <button type="button" data-test="attach-btn" :title="$t('chat.attach.add')"
-                  class="flex items-center gap-1.5 px-1.5 py-1 rounded-md text-fg-muted hover:bg-raised transition-colors"
-                  @click="openPicker">
+          <button
+            type="button"
+            data-test="attach-btn"
+            :title="$t('chat.attach.add')"
+            class="flex items-center gap-1.5 px-1.5 py-1 rounded-md text-fg-muted hover:bg-raised transition-colors"
+            @click="openPicker"
+          >
             <Paperclip :size="15" />
           </button>
-          <button type="submit" data-test="composer-send" :disabled="composer.uploading || (!text.trim() && !composer.pending.filter(p => p.status === 'ready').length)"
-                  class="flex items-center gap-1.5 whitespace-nowrap pl-3 pr-2.5 py-1.5 rounded-md bg-accent text-white text-[12.5px] font-semibold shadow-e1 hover:bg-accent-hover hover:shadow-e2 transition-all disabled:bg-fg/10 disabled:text-fg-muted disabled:shadow-none">
+          <button
+            type="submit"
+            data-test="composer-send"
+            :disabled="
+              composer.uploading ||
+              (!text.trim() &&
+                !composer.pending.filter((p) => p.status === 'ready').length)
+            "
+            class="flex items-center gap-1.5 whitespace-nowrap pl-3 pr-2.5 py-1.5 rounded-md bg-accent text-white text-[12.5px] font-semibold shadow-e1 hover:bg-accent-hover hover:shadow-e2 transition-all disabled:bg-fg/10 disabled:text-fg-muted disabled:shadow-none"
+          >
             {{ $t("chat.send") }}
             <Send :size="14" />
           </button>

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -85,6 +85,11 @@ export default {
     effort: "effort",
     effortSetFailed: "Failed to switch effort. Try again.",
     working: "Agent is working… (Esc to stop)",
+    mentionActivity: {
+      working: "Working",
+      waiting: "Waiting",
+      idle: "Idle",
+    },
     message: "Message",
     mermaidError: "Diagram failed to render",
     mermaidZoomOut: "Zoom out",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -83,6 +83,11 @@ export default {
     effort: "推理强度",
     effortSetFailed: "切换推理强度失败，请重试。",
     working: "Agent 正在工作…（按 Esc 停止）",
+    mentionActivity: {
+      working: "执行中",
+      waiting: "等待中",
+      idle: "空闲",
+    },
     message: "消息",
     mermaidError: "图表渲染失败",
     mermaidZoomOut: "缩小",

--- a/packages/relay-web/src/lib/sidebar-group-mode.ts
+++ b/packages/relay-web/src/lib/sidebar-group-mode.ts
@@ -85,3 +85,27 @@ export function dedupedSessionName(name: string, groupKey: string, mode: "worksp
   }
   return name;
 }
+
+/**
+ * Shared presentation helper for deriving a human-facing session name, matching
+ * the name displayed in the left-side Session Tree under any groupMode (instance,
+ * workspace, or agent).
+ */
+export function sessionPresentationName(params: {
+  displayName?: string;
+  alias: string;
+  workspace?: string;
+  agent?: string;
+  groupMode?: "instance" | "workspace" | "agent";
+}): string {
+  const name = params.displayName || params.alias;
+  const mode = params.groupMode;
+  if (!mode || mode === "instance") {
+    return name;
+  }
+  const sectionKey = mode === "workspace" ? params.workspace : params.agent;
+  if (!sectionKey) {
+    return name;
+  }
+  return dedupedSessionName(name, sectionKey, mode);
+}

--- a/packages/relay-web/src/lib/sidebar-group-mode.ts
+++ b/packages/relay-web/src/lib/sidebar-group-mode.ts
@@ -11,14 +11,18 @@ const MODES: readonly SidebarGroupMode[] = ["instance", "workspace", "agent"];
 export function loadGroupMode(instanceId: string): SidebarGroupMode {
   try {
     const raw = localStorage.getItem(KEY_PREFIX + instanceId);
-    if (raw && (MODES as readonly string[]).includes(raw)) return raw as SidebarGroupMode;
+    if (raw && (MODES as readonly string[]).includes(raw))
+      return raw as SidebarGroupMode;
   } catch {
     // localStorage unavailable (private mode) → fall through to default
   }
   return "instance";
 }
 
-export function saveGroupMode(instanceId: string, mode: SidebarGroupMode): void {
+export function saveGroupMode(
+  instanceId: string,
+  mode: SidebarGroupMode,
+): void {
   try {
     if (mode === "instance") localStorage.removeItem(KEY_PREFIX + instanceId);
     else localStorage.setItem(KEY_PREFIX + instanceId, mode);
@@ -39,13 +43,17 @@ export interface SessionGroup<T> {
  * recently slept session comes first (sorted by archivedAt descending, stable
  * for rows without a timestamp — old connectors or ties).
  */
-export function archivedLast<T extends { archived?: boolean; archivedAt?: string }>(sessions: T[]): T[] {
+export function archivedLast<
+  T extends { archived?: boolean; archivedAt?: string },
+>(sessions: T[]): T[] {
   const active = sessions.filter((s) => !s.archived);
-  const archived = sessions.filter((s) => s.archived).sort((a, b) => {
-    const aTime = a.archivedAt ? new Date(a.archivedAt).getTime() : 0;
-    const bTime = b.archivedAt ? new Date(b.archivedAt).getTime() : 0;
-    return bTime - aTime;
-  });
+  const archived = sessions
+    .filter((s) => s.archived)
+    .sort((a, b) => {
+      const aTime = a.archivedAt ? new Date(a.archivedAt).getTime() : 0;
+      const bTime = b.archivedAt ? new Date(b.archivedAt).getTime() : 0;
+      return bTime - aTime;
+    });
   return [...active, ...archived];
 }
 /**
@@ -54,10 +62,14 @@ export function archivedLast<T extends { archived?: boolean; archivedAt?: string
  * loaded when sessions arrive). Groups appear in first-appearance (server)
  * order; within a group actives keep server order and archived sink last.
  */
-export function groupSessions<T extends { workspace: string; agent: string; archived?: boolean; archivedAt?: string }>(
-  sessions: T[],
-  mode: "workspace" | "agent",
-): Array<SessionGroup<T>> {
+export function groupSessions<
+  T extends {
+    workspace: string;
+    agent: string;
+    archived?: boolean;
+    archivedAt?: string;
+  },
+>(sessions: T[], mode: "workspace" | "agent"): Array<SessionGroup<T>> {
   const byKey = new Map<string, T[]>();
   for (const s of sessions) {
     const key = mode === "workspace" ? s.workspace : s.agent;
@@ -65,7 +77,10 @@ export function groupSessions<T extends { workspace: string; agent: string; arch
     if (bucket) bucket.push(s);
     else byKey.set(key, [s]);
   }
-  return [...byKey.entries()].map(([key, list]) => ({ key, sessions: archivedLast(list) }));
+  return [...byKey.entries()].map(([key, list]) => ({
+    key,
+    sessions: archivedLast(list),
+  }));
 }
 
 /**
@@ -74,7 +89,11 @@ export function groupSessions<T extends { workspace: string; agent: string; arch
  * trailing "-<group>". Only when a non-empty remainder is left; the real alias
  * is untouched (hover title always shows the full name).
  */
-export function dedupedSessionName(name: string, groupKey: string, mode: "workspace" | "agent"): string {
+export function dedupedSessionName(
+  name: string,
+  groupKey: string,
+  mode: "workspace" | "agent",
+): string {
   if (mode === "workspace" && name.startsWith(`${groupKey}-`)) {
     const rest = name.slice(groupKey.length + 1);
     if (rest) return rest;
@@ -108,4 +127,33 @@ export function sessionPresentationName(params: {
     return name;
   }
   return dedupedSessionName(name, sectionKey, mode);
+}
+
+/**
+ * Computes the shortest unique suffix for targetKey among collisionKeys, starting
+ * from minLength up to full length. If targetKey.length > len, prefixes with "…".
+ */
+export function shortestUniqueSuffix(
+  targetKey: string,
+  collisionKeys: string[],
+  minLength = 5,
+): string {
+  if (collisionKeys.length <= 1) {
+    return targetKey.length > minLength
+      ? `…${targetKey.slice(-minLength)}`
+      : targetKey;
+  }
+
+  const otherKeys = collisionKeys.filter((k) => k !== targetKey);
+  const maxLen = targetKey.length;
+
+  for (let len = minLength; len <= maxLen; len++) {
+    const candidate = targetKey.slice(-len);
+    const hasCollision = otherKeys.some((other) => other.endsWith(candidate));
+    if (!hasCollision) {
+      return len < maxLen ? `…${candidate}` : targetKey;
+    }
+  }
+
+  return targetKey;
 }

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -9,6 +9,7 @@ import {
   type PublishedAgentEndpointDto,
   type SessionDto,
   type SessionModelResult,
+  type WebAgentDirectoryEndpointDto,
   type WebServerEvent,
   type WorkspaceDto,
 } from "@ganglion/xacpx-relay-protocol";
@@ -116,11 +117,11 @@ export function parseGroupArchivedKey(key: string): { mode: GroupArchivedMode; g
 }
 
 export const useInstancesStore = defineStore("instances", () => {
-  const agentDirectory = ref<PublishedAgentEndpointDto[]>([]);
+  const agentDirectory = ref<WebAgentDirectoryEndpointDto[]>([]);
 
   async function loadAgentDirectory(): Promise<void> {
     try {
-      const res = await api.get<{ endpoints: PublishedAgentEndpointDto[] }>("/api/agent-directory");
+      const res = await api.get<{ endpoints: WebAgentDirectoryEndpointDto[] }>("/api/agent-directory");
       agentDirectory.value = res.endpoints ?? [];
     } catch {
       /* best effort */

--- a/packages/relay/src/gateway/instance-gateway.ts
+++ b/packages/relay/src/gateway/instance-gateway.ts
@@ -13,6 +13,7 @@ import {
   type InstanceRegisterPayload,
   type PublishedAgentEndpointDto,
   type RelayEnvelope,
+  type WebAgentDirectoryEndpointDto,
 } from "@ganglion/xacpx-relay-protocol";
 import type { AccountStore } from "../stores/accounts.js";
 import type { InstanceStore } from "../stores/instances.js";
@@ -75,7 +76,7 @@ export interface InstanceGatewayDeps {
   ) => boolean;
   onDirectoryChange?: (
     accountId: string,
-    endpoints: PublishedAgentEndpointDto[],
+    endpoints: WebAgentDirectoryEndpointDto[],
   ) => void;
   logger?: RelayLogger;
 }
@@ -692,9 +693,26 @@ export class InstanceGateway {
     return result;
   }
 
+  getWebPublishedEndpoints(accountId: string): WebAgentDirectoryEndpointDto[] {
+    const result: WebAgentDirectoryEndpointDto[] = [];
+    for (const [instId, conn] of this.connections) {
+      if (conn.accountId === accountId) {
+        const endpoints = this.endpointsByInstance.get(instId) ?? [];
+        for (const ep of endpoints) {
+          result.push({
+            ...ep,
+            instanceId: instId,
+          });
+        }
+      }
+    }
+    return result;
+  }
+
   private broadcastDirectorySnapshot(accountId: string): void {
     const endpoints = this.getPublishedEndpoints(accountId);
-    this.deps.onDirectoryChange?.(accountId, endpoints);
+    const webEndpoints = this.getWebPublishedEndpoints(accountId);
+    this.deps.onDirectoryChange?.(accountId, webEndpoints);
     for (const [instId, conn] of this.connections) {
       if (conn.accountId === accountId) {
         this.sendEvent(instId, MSG.agentDirectorySnapshot, { endpoints });

--- a/packages/relay/src/gateway/web-inbound.ts
+++ b/packages/relay/src/gateway/web-inbound.ts
@@ -11,6 +11,7 @@ import {
   type TerminalRoleResult,
   type TerminalTerminateResult,
   type TerminalViewerEventPayload,
+  type WebAgentDirectoryEndpointDto,
   type WebServerEvent,
 } from "@ganglion/xacpx-relay-protocol";
 
@@ -32,6 +33,7 @@ export interface WebClientDeps {
     ): Promise<unknown>;
     isOnline(instanceId: string): boolean;
     getPublishedEndpoints?(accountId: string): PublishedAgentEndpointDto[];
+    getWebPublishedEndpoints?(accountId: string): WebAgentDirectoryEndpointDto[];
   };
   webGateway: Pick<
     WebGateway,
@@ -130,10 +132,15 @@ async function handleWebClientMessageAsync(
     const ownedIds = new Set(deps.instances.listByAccount(accountId).map((instance) => instance.id));
     const instanceIds = [...new Set(msg.instanceIds)].filter((id) => ownedIds.has(id));
     deps.webGateway.setSubscription(socket, instanceIds);
-    if (typeof deps.gateway.getPublishedEndpoints === "function") {
+    if (typeof deps.gateway.getWebPublishedEndpoints === "function") {
       deps.webGateway.send(socket, {
         kind: "agent-directory",
-        endpoints: deps.gateway.getPublishedEndpoints(accountId),
+        endpoints: deps.gateway.getWebPublishedEndpoints(accountId),
+      });
+    } else if (typeof deps.gateway.getPublishedEndpoints === "function") {
+      deps.webGateway.send(socket, {
+        kind: "agent-directory",
+        endpoints: deps.gateway.getPublishedEndpoints(accountId) as never,
       });
     }
     for (const instanceId of instanceIds) {

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -11,6 +11,7 @@ import {
   type PublishedAgentEndpointDto,
   type SessionCommandsSnapshotDto,
   type SessionUsageSnapshotDto,
+  type WebAgentDirectoryEndpointDto,
 } from "@ganglion/xacpx-relay-protocol";
 
 import type { AccountRow, AccountStore } from "../stores/accounts.js";
@@ -25,6 +26,7 @@ export interface GatewayForApp {
   isOnline(instanceId: string): boolean;
   sendRequest(instanceId: string, type: string, payload: unknown): Promise<unknown>;
   getPublishedEndpoints(accountId: string): PublishedAgentEndpointDto[];
+  getWebPublishedEndpoints?(accountId: string): WebAgentDirectoryEndpointDto[];
 }
 
 export interface AppDeps {
@@ -442,7 +444,9 @@ export function createApp(deps: AppDeps): Hono<Vars> {
   });
   app.get("/api/agent-directory", (c) => {
     const account = c.get("account");
-    const endpoints = deps.gateway.getPublishedEndpoints(account.id);
+    const endpoints = deps.gateway.getWebPublishedEndpoints
+      ? deps.gateway.getWebPublishedEndpoints(account.id)
+      : deps.gateway.getPublishedEndpoints(account.id);
     return c.json({ endpoints });
   });
 

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -250,7 +250,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
       webGateway.broadcast(accountId, { kind: "instance-status", instanceId, online });
       webGateway.broadcast(accountId, {
         kind: "agent-directory",
-        endpoints: gateway.getPublishedEndpoints(accountId),
+        endpoints: gateway.getWebPublishedEndpoints(accountId),
       });
     },
     onEvent: (instanceId, accountId, envelope: RelayEnvelope) => {

--- a/src/orchestration/agent-endpoint-registry.ts
+++ b/src/orchestration/agent-endpoint-registry.ts
@@ -75,6 +75,7 @@ export class AgentEndpointRegistry {
       nodeId: string;
       endpointId: string;
       displayName?: string;
+      sessionAlias?: string;
       agent: string;
       workspace?: string;
       state: "idle" | "running";
@@ -103,6 +104,7 @@ export class AgentEndpointRegistry {
           }),
           node: ep.displayName ?? ep.nodeId,
           displayName: ep.displayName,
+          sessionAlias: ep.sessionAlias,
           agent: ep.agent,
           workspace: ep.workspace,
           state: ep.state,
@@ -128,6 +130,7 @@ export class AgentEndpointRegistry {
       nodeId: string;
       endpointId: string;
       displayName?: string;
+      sessionAlias?: string;
       agent: string;
       workspace?: string;
       state: "idle" | "running";
@@ -159,6 +162,9 @@ export class AgentEndpointRegistry {
         capabilities: candidate.endpoint.capabilities,
         ...(candidate.endpoint.displayName
           ? { displayName: candidate.endpoint.displayName }
+          : {}),
+        ...(candidate.endpoint.sessionAlias
+          ? { sessionAlias: candidate.endpoint.sessionAlias }
           : {}),
         updatedAt: Date.now(),
       }));
@@ -230,15 +236,15 @@ export class AgentEndpointRegistry {
     const external =
       state.orchestration.externalCoordinators[coordinatorSession];
     if (external) {
-        return {
-          address: {
-            nodeId: this.deps.nodeId,
-            endpointId: requireEndpointId(external.agentEndpointId),
-          },
-          coordinatorSession,
-          receive: false,
-          sessionAlias: coordinatorSession,
-        };
+      return {
+        address: {
+          nodeId: this.deps.nodeId,
+          endpointId: requireEndpointId(external.agentEndpointId),
+        },
+        coordinatorSession,
+        receive: false,
+        sessionAlias: coordinatorSession,
+      };
     }
 
     throw new AgentMessagingError(
@@ -340,9 +346,7 @@ export class AgentEndpointRegistry {
     selector: AgentTargetSelector,
   ): Promise<ResolvedAgentEndpoint> {
     const senderIdentity =
-      "address" in sender
-        ? sender
-        : await this.resolveSender(sender);
+      "address" in sender ? sender : await this.resolveSender(sender);
 
     const state = await this.deps.loadState();
     const localCandidates = this.listCandidates(
@@ -383,9 +387,10 @@ export class AgentEndpointRegistry {
           ?.trim()
           .toLowerCase();
         const candAlias =
-          candidate.runtime.kind === "logical"
+          candidate.endpoint.sessionAlias?.trim().toLowerCase() ??
+          (candidate.runtime.kind === "logical"
             ? candidate.runtime.alias?.trim().toLowerCase()
-            : undefined;
+            : undefined);
         if (
           candDisplayName !== displayNameFilter &&
           candAlias !== displayNameFilter
@@ -523,8 +528,8 @@ export class AgentEndpointRegistry {
       nodeId: this.deps.nodeId,
       endpointId: session.logical_session_id,
     };
-    const displayName =
-      session.display_name || toDisplaySessionAlias(session.alias);
+    const sessionAlias = toDisplaySessionAlias(session.alias);
+    const displayName = session.display_name || sessionAlias;
     const isRunning = this.deps.isSessionActive?.(session.alias) ?? false;
     return {
       address,
@@ -533,6 +538,7 @@ export class AgentEndpointRegistry {
       agent: session.agent,
       workspace: session.workspace,
       displayName,
+      sessionAlias,
       state: isRunning ? "running" : "idle",
       activity: {
         status: isRunning ? "working" : "idle",

--- a/src/orchestration/agent-messaging-types.ts
+++ b/src/orchestration/agent-messaging-types.ts
@@ -31,6 +31,7 @@ export interface AgentEndpointView {
   agent: string;
   workspace?: string;
   displayName?: string;
+  sessionAlias?: string;
   state: "idle" | "running" | "unreachable";
   activity: AgentActivityView;
   capabilities: AgentCapabilities;

--- a/tests/unit/orchestration/agent-endpoint-registry.test.ts
+++ b/tests/unit/orchestration/agent-endpoint-registry.test.ts
@@ -181,7 +181,9 @@ test("derives worker activity status and summary from orchestration task state",
     coordinatorSession: "coordinator",
     sourceHandle: "workerB",
   });
-  const workerAIdle = endpoints.find((e) => e.address.endpointId === "endpoint_worker-a");
+  const workerAIdle = endpoints.find(
+    (e) => e.address.endpointId === "endpoint_worker-a",
+  );
   expect(workerAIdle?.activity.status).toBe("idle");
   expect(workerAIdle?.activity.summary).toBe("Idle (worker-a-role)");
   expect(workerAIdle?.displayName).toBe("worker-a-role");
@@ -209,9 +211,13 @@ test("derives worker activity status and summary from orchestration task state",
     coordinatorSession: "coordinator",
     sourceHandle: "workerB",
   });
-  const workerARunning = endpoints.find((e) => e.address.endpointId === "endpoint_worker-a");
+  const workerARunning = endpoints.find(
+    (e) => e.address.endpointId === "endpoint_worker-a",
+  );
   expect(workerARunning?.activity.status).toBe("working");
-  expect(workerARunning?.activity.summary).toBe("Implementing User OAuth Migration");
+  expect(workerARunning?.activity.summary).toBe(
+    "Implementing User OAuth Migration",
+  );
   // Must NEVER expose the raw prompt text
   expect(JSON.stringify(workerARunning)).not.toContain("Secret raw prompt");
 
@@ -221,7 +227,9 @@ test("derives worker activity status and summary from orchestration task state",
     coordinatorSession: "coordinator",
     sourceHandle: "workerB",
   });
-  const workerAWaiting = endpoints.find((e) => e.address.endpointId === "endpoint_worker-a");
+  const workerAWaiting = endpoints.find(
+    (e) => e.address.endpointId === "endpoint_worker-a",
+  );
   expect(workerAWaiting?.activity.status).toBe("waiting");
   expect(workerAWaiting?.activity.summary).toBe("Waiting for confirmation");
 });
@@ -281,11 +289,21 @@ test("archived sessions are excluded from candidates, reachable list, and target
     coordinatorSession: "coordinator",
     sourceHandle: "workerA",
   });
-  expect(reachable.some((e) => e.address.endpointId === "33333333-3333-4333-8333-333333333333")).toBe(false);
-  expect(reachable.some((e) => e.displayName === "Archived Specialist")).toBe(false);
+  expect(
+    reachable.some(
+      (e) => e.address.endpointId === "33333333-3333-4333-8333-333333333333",
+    ),
+  ).toBe(false);
+  expect(reachable.some((e) => e.displayName === "Archived Specialist")).toBe(
+    false,
+  );
 
   const published = await registry.getPublishedEndpoints();
-  expect(published.some((e) => e.endpointId === "33333333-3333-4333-8333-333333333333")).toBe(false);
+  expect(
+    published.some(
+      (e) => e.endpointId === "33333333-3333-4333-8333-333333333333",
+    ),
+  ).toBe(false);
 
   const sender = await registry.resolveSender({
     coordinatorSession: "coordinator",
@@ -295,7 +313,9 @@ test("archived sessions are excluded from candidates, reachable list, and target
     nodeId,
     endpointId: "33333333-3333-4333-8333-333333333333",
   });
-  await expect(registry.resolveTarget(sender, archivedHandle)).rejects.toMatchObject<Partial<AgentMessagingError>>({
+  await expect(
+    registry.resolveTarget(sender, archivedHandle),
+  ).rejects.toMatchObject<Partial<AgentMessagingError>>({
     code: "TARGET_NOT_REACHABLE",
   });
 
@@ -312,12 +332,18 @@ test("resolveSelector resolves a unique match by displayName, workspace, or agen
   const sender = { coordinatorSession: "coordinator", sourceHandle: "workerA" };
 
   // Match by displayName (case-insensitive with trimming)
-  const byName = await registry.resolveSelector(sender, { displayName: "  reviewer  " });
+  const byName = await registry.resolveSelector(sender, {
+    displayName: "  reviewer  ",
+  });
   expect(byName.endpoint.address.endpointId).toBe("endpoint_worker-b");
 
   // Match by logical session alias
-  const byAlias = await registry.resolveSelector(sender, { displayName: "main" });
-  expect(byAlias.endpoint.address.endpointId).toBe("22222222-2222-4222-8222-222222222222");
+  const byAlias = await registry.resolveSelector(sender, {
+    displayName: "main",
+  });
+  expect(byAlias.endpoint.address.endpointId).toBe(
+    "22222222-2222-4222-8222-222222222222",
+  );
 
   // Match by agent
   const byAgent = await registry.resolveSelector(sender, { agent: "gemini" });
@@ -452,10 +478,61 @@ test("logical session endpoint reflects active status when isSessionActive retur
     isSessionActive: (alias) => alias === "backend",
   });
   const endpoints = await activeRegistry.getPublishedEndpoints();
-  const ep = endpoints.find((e) => e.endpointId === "33333333-3333-4333-8333-333333333333");
+  const ep = endpoints.find(
+    (e) => e.endpointId === "33333333-3333-4333-8333-333333333333",
+  );
   expect(ep).toBeDefined();
   expect(ep!.state).toBe("running");
   expect(ep!.activity).toEqual({ status: "working" });
+});
+test("getPublishedEndpoints publishes sessionAlias and displayName separately for logical sessions", async () => {
+  const state = createEmptyState();
+  state.sessions.withCustomName = {
+    alias: "weixin:omp-2",
+    display_name: "发布机器人",
+    agent: "codex",
+    workspace: "weacpx-github",
+    transport_session: "coordinator",
+    logical_session_id: "44444444-4444-4444-4444-444444444444",
+    created_at: "2026-08-18T00:00:00.000Z",
+    last_used_at: "2026-08-18T00:00:00.000Z",
+  };
+  state.sessions.plain = {
+    alias: "omp-3",
+    agent: "claude",
+    workspace: "weacpx-github",
+    transport_session: "coordinator",
+    logical_session_id: "55555555-5555-5555-5555-555555555555",
+    created_at: "2026-08-18T00:00:00.000Z",
+    last_used_at: "2026-08-18T00:00:00.000Z",
+  };
+
+  const reg = new AgentEndpointRegistry({
+    nodeId,
+    loadState: async () => state,
+  });
+
+  const endpoints = await reg.getPublishedEndpoints();
+  const customEp = endpoints.find(
+    (e) => e.endpointId === "44444444-4444-4444-4444-444444444444",
+  );
+  const plainEp = endpoints.find(
+    (e) => e.endpointId === "55555555-5555-5555-5555-555555555555",
+  );
+
+  expect(customEp).toMatchObject({
+    displayName: "发布机器人",
+    sessionAlias: "omp-2",
+    agent: "codex",
+    workspace: "weacpx-github",
+  });
+
+  expect(plainEp).toMatchObject({
+    displayName: "omp-3",
+    sessionAlias: "omp-3",
+    agent: "claude",
+    workspace: "weacpx-github",
+  });
 });
 
 test("resolveSelector throws TARGET_NOT_FOUND when selector is empty object", async () => {


### PR DESCRIPTION
## Summary
Refines the Relay Web `@Agent` autocomplete UX and discovery metadata according to the **Relay Web `@Agent` Autocomplete UX Refinement Spec**:

- **Directory DTO Extension**: Added `sessionAlias?: string` to `PublishedAgentEndpointDto` and `AgentEndpointView`. Logical sessions publish `displayName` (`session.display_name || sessionAlias`) and `sessionAlias` (`toDisplaySessionAlias(session.alias)`) separately.
- **Session Tree Alignment**: Primary autocomplete label is derived from `displayName ?? sessionAlias ?? agent`, matching the exact name shown in the Session Tree.
- **Secondary Metadata Presentation**: Compact human-readable format (`sessionAlias · workspace · agent`) omitting duplicate aliases when `displayName === sessionAlias`.
- **Node ID Removal**: Removed raw `nodeId` UUIDs from normal presentation.
- **Duplicate Name Disambiguation**: Disambiguates progressively using human metadata (`sessionAlias + workspace + agent`), then Relay instance label (`nodeLabel`), with a short technical suffix as final fallback.
- **Search & Ranking**: `sessionAlias` participates in search with deterministic relevance ranking (exact match -> prefix match -> contains for displayName, sessionAlias, workspace, agent) and stable tie-breaking.
- **Activity Badges**: Compact activity indicator (`Working`, `Waiting`, `Idle`) on autocomplete rows.
- **Test Coverage**: Added comprehensive test cases (Tests A-G) in `packages/relay-web/src/__tests__/promptinput.test.ts` and updated orchestration registry unit tests.