### PR TITLE
fix(channel-relay): align RMUX shell TERM with xterm renderer

### DIFF
--- a/packages/channel-relay/native/rmux-bridge/src/actors.rs
+++ b/packages/channel-relay/native/rmux-bridge/src/actors.rs
@@ -441,18 +441,21 @@ impl BridgeState {
         (
             BRIDGE_VERSION.to_owned(),
             "0.10.0".to_owned(),
-            bridge_capabilities(),
+            bridge_capabilities(std::env::consts::FAMILY),
         )
     }
 }
 
-fn bridge_capabilities() -> Vec<String> {
-    vec![
+fn bridge_capabilities(family: &str) -> Vec<String> {
+    let mut capabilities = vec![
         "terminal.rmux.recovery.v1".to_owned(),
         "terminal.multi-view.v1".to_owned(),
         "process-owned.v1".to_owned(),
-        POSIX_WEB_TERMINAL_DIALECT_CAPABILITY.to_owned(),
-    ]
+    ];
+    if family == "unix" {
+        capabilities.push(POSIX_WEB_TERMINAL_DIALECT_CAPABILITY.to_owned());
+    }
+    capabilities
 }
 
 /// Process environment overrides for xacpx-created shell work windows.
@@ -632,9 +635,11 @@ mod tests {
     }
 
     #[test]
-    fn bridge_capabilities_publish_versioned_posix_renderer_dialect() {
-        let capabilities = bridge_capabilities();
-        assert!(capabilities
+    fn bridge_capabilities_publish_renderer_dialect_only_on_posix() {
+        assert!(bridge_capabilities("unix")
+            .iter()
+            .any(|value| value == POSIX_WEB_TERMINAL_DIALECT_CAPABILITY));
+        assert!(!bridge_capabilities("windows")
             .iter()
             .any(|value| value == POSIX_WEB_TERMINAL_DIALECT_CAPABILITY));
         assert_eq!(

--- a/packages/channel-relay/native/rmux-bridge/src/actors.rs
+++ b/packages/channel-relay/native/rmux-bridge/src/actors.rs
@@ -2,8 +2,8 @@
 //!
 //! Create path (no rmux patches):
 //! 1. `OwnedSession` with `KillOnOwnerExit` + lease TTL
-//! 2. `new_window_with().cwd(...)` for the work pane, plus a macOS-only
-//!    `TERM=screen-256color` override on that pane (not daemon-global)
+//! 2. `new_window_with().cwd(...)` for the work pane, with the POSIX
+//!    application terminal dialect pinned to `TERM=xterm-256color`
 //! 3. close default window 0
 //! 4. resize + `history-limit` on the stable pane id
 
@@ -28,6 +28,16 @@ use crate::protocol::{
 /// sidecar request timeout (15s). Recover itself is dispatched off the stdin
 /// loop so other panes are not queued behind this wait.
 const INITIAL_REBASE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Terminal dialect advertised to POSIX applications whose RMUX raw recovery
+/// stream is replayed by relay-web's xterm.js renderer.
+///
+/// This is an end-to-end renderer contract, not RMUX's daemon terminal type.
+/// Keeping application output on the xterm dialect prevents screen/tmux-only
+/// control strings from reaching a renderer that does not implement them.
+const POSIX_WEB_TERMINAL_DIALECT: &str = "xterm-256color";
+const POSIX_WEB_TERMINAL_DIALECT_CAPABILITY: &str =
+    "terminal.posix-dialect.xterm-256color.v1";
 
 pub struct BridgeState {
     rmux: Rmux,
@@ -91,7 +101,8 @@ impl BridgeState {
             .new_window_with()
             .name("shell")
             .cwd(PathBuf::from(&cwd));
-        let work_builder = apply_production_work_window_env(work_builder, std::env::consts::OS);
+        let work_builder =
+            apply_production_work_window_env(work_builder, std::env::consts::FAMILY);
         let work = match work_builder.await {
             Ok(w) => w,
             Err(e) => {
@@ -430,38 +441,43 @@ impl BridgeState {
         (
             BRIDGE_VERSION.to_owned(),
             "0.10.0".to_owned(),
-            vec![
-                "terminal.rmux.recovery.v1".to_owned(),
-                "terminal.multi-view.v1".to_owned(),
-                "process-owned.v1".to_owned(),
-            ],
+            bridge_capabilities(),
         )
     }
 }
 
+fn bridge_capabilities() -> Vec<String> {
+    vec![
+        "terminal.rmux.recovery.v1".to_owned(),
+        "terminal.multi-view.v1".to_owned(),
+        "process-owned.v1".to_owned(),
+        POSIX_WEB_TERMINAL_DIALECT_CAPABILITY.to_owned(),
+    ]
+}
+
 /// Process environment overrides for xacpx-created shell work windows.
 ///
-/// `os` is [`std::env::consts::OS`] (`macos`, `linux`, `windows`, ...).
+/// `family` is [`std::env::consts::FAMILY`] (`unix`, `windows`, ...).
 ///
-/// On macOS, inject `TERM=screen-256color`. RMUX's daemon default is
-/// `tmux-256color`, which is a valid terminal type, but the current macOS
-/// system terminfo database has no readable entry for it. Async prompts such
-/// as Powerlevel10k then cannot emit CUU/ED and append a duplicate prompt
-/// after every command. This is a host compatibility fallback, not a claim
-/// that `screen-256color` is a better default than `tmux-256color`. Other
-/// platforms keep the daemon `default-terminal`.
-fn production_work_window_env(os: &str) -> Vec<(&'static str, &'static str)> {
-    match os {
-        "macos" => vec![("TERM", "screen-256color")],
+/// RMUX recovery deliberately forwards the pane's raw terminal bytes to
+/// relay-web, so the shell application and the browser renderer must agree on
+/// one terminal dialect. relay-web uses xterm.js; therefore POSIX work panes
+/// advertise `xterm-256color` rather than inheriting RMUX's `tmux-256color` or
+/// using the previous macOS-only `screen-256color` fallback. That keeps title
+/// integration and other terminal-control choices on xterm-compatible
+/// sequences end to end. Windows does not use the POSIX TERM contract.
+fn production_work_window_env(family: &str) -> Vec<(&'static str, &'static str)> {
+    match family {
+        "unix" => vec![("TERM", POSIX_WEB_TERMINAL_DIALECT)],
         _ => Vec::new(),
     }
 }
 
 fn apply_production_work_window_env<'a>(
     mut builder: NewWindowBuilder<'a>,
-    os: &str,
+    family: &str,
 ) -> NewWindowBuilder<'a> {
-    for (key, value) in production_work_window_env(os) {
+    for (key, value) in production_work_window_env(family) {
         builder = builder.env(key, value);
     }
     builder
@@ -583,40 +599,48 @@ mod tests {
     use rmux_sdk::PaneStreamEndReason;
 
     #[test]
-    fn macos_work_window_injects_screen_256color_term() {
+    fn unix_work_window_uses_xterm_renderer_dialect() {
         assert_eq!(
-            production_work_window_env("macos"),
-            vec![("TERM", "screen-256color")]
+            production_work_window_env("unix"),
+            vec![("TERM", "xterm-256color")]
         );
     }
 
     #[test]
-    fn macos_work_window_does_not_prefer_xterm_256color() {
-        assert!(
-            !production_work_window_env("macos")
-                .iter()
-                .any(|(key, value)| *key == "TERM" && *value == "xterm-256color"),
-            "macOS fallback must be screen-256color, not xterm-256color"
-        );
+    fn unix_work_window_does_not_advertise_screen_or_tmux_dialect() {
+        let term = production_work_window_env("unix")
+            .into_iter()
+            .find_map(|(key, value)| (key == "TERM").then_some(value))
+            .expect("unix work window must set TERM");
+        assert!(!term.starts_with("screen"));
+        assert!(!term.starts_with("tmux"));
+        assert!(term.starts_with("xterm"));
     }
 
     #[test]
-    fn linux_work_window_keeps_daemon_default_term() {
-        assert!(production_work_window_env("linux").is_empty());
-    }
-
-    #[test]
-    fn windows_work_window_keeps_daemon_default_term() {
+    fn windows_work_window_does_not_inject_posix_term() {
         assert!(production_work_window_env("windows").is_empty());
     }
 
     #[test]
-    fn host_work_window_env_matches_production_helper() {
-        let env = production_work_window_env(std::env::consts::OS);
-        #[cfg(target_os = "macos")]
-        assert_eq!(env, vec![("TERM", "screen-256color")]);
-        #[cfg(not(target_os = "macos"))]
+    fn host_work_window_env_matches_renderer_contract() {
+        let env = production_work_window_env(std::env::consts::FAMILY);
+        #[cfg(unix)]
+        assert_eq!(env, vec![("TERM", POSIX_WEB_TERMINAL_DIALECT)]);
+        #[cfg(windows)]
         assert!(env.is_empty());
+    }
+
+    #[test]
+    fn bridge_capabilities_publish_versioned_posix_renderer_dialect() {
+        let capabilities = bridge_capabilities();
+        assert!(capabilities
+            .iter()
+            .any(|value| value == POSIX_WEB_TERMINAL_DIALECT_CAPABILITY));
+        assert_eq!(
+            POSIX_WEB_TERMINAL_DIALECT_CAPABILITY,
+            "terminal.posix-dialect.xterm-256color.v1"
+        );
     }
 
     #[test]

--- a/packages/channel-relay/src/channel.ts
+++ b/packages/channel-relay/src/channel.ts
@@ -40,7 +40,10 @@ import {
   SupervisedRmuxDriver,
   createProductionTerminalDriver,
 } from "./terminal/rmux-sidecar-supervisor.js";
-import type { RmuxTerminalDriver } from "./terminal/rmux-driver.js";
+import {
+  missingRequiredRmuxBridgeCapabilities,
+  type RmuxTerminalDriver,
+} from "./terminal/rmux-driver.js";
 import { TerminalRegistryStore } from "./terminal/terminal-registry-store.js";
 import {
   DefaultRelayTerminalRuntime,
@@ -527,6 +530,20 @@ export class RelayChannel implements MessageChannelRuntime {
         this.terminalSupervisor = supervisor;
         driver = new SupervisedRmuxDriver(supervisor);
         await supervisor.start();
+      }
+
+      // The bridge handshake may succeed across mixed package versions, so the
+      // renderer dialect must be validated explicitly before reconciliation or
+      // Hub capability publication. On POSIX this includes the xterm-256color
+      // dialect proof; Windows deliberately has no POSIX TERM requirement.
+      const bridgeDiagnostics = await driver.diagnostics();
+      const missingBridgeCapabilities = missingRequiredRmuxBridgeCapabilities(
+        bridgeDiagnostics.capabilities,
+      );
+      if (missingBridgeCapabilities.length > 0) {
+        throw new Error(
+          `RMUX bridge is missing required terminal capabilities: ${missingBridgeCapabilities.join(", ")}`,
+        );
       }
 
       const runtime = new DefaultRelayTerminalRuntime({

--- a/packages/channel-relay/src/terminal/in-memory-rmux-driver.ts
+++ b/packages/channel-relay/src/terminal/in-memory-rmux-driver.ts
@@ -360,12 +360,6 @@ export class InMemoryRmuxDriver implements RmuxTerminalDriver {
     this.inventoryOverride = [];
   }
 
-  restoreDriver(): void {
-    this.crashed = false;
-    this.crashError = new RmuxDriverCrashedError();
-    this.inventoryOverride = null;
-  }
-
   private async gate(op: RmuxDriverOp): Promise<void> {
     const delay = this.delays.get(op);
     if (delay !== undefined) await this.deps.sleep(delay);

--- a/packages/channel-relay/src/terminal/in-memory-rmux-driver.ts
+++ b/packages/channel-relay/src/terminal/in-memory-rmux-driver.ts
@@ -3,6 +3,7 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  requiredRmuxBridgeCapabilities,
   RmuxDriverCrashedError,
   RmuxPaneNotFoundError,
   RmuxSessionNameConflictError,
@@ -138,7 +139,7 @@ export class InMemoryRmuxDriver implements RmuxTerminalDriver {
   private diagnosticsValue: RmuxDiagnostics = {
     bridgeVersion: "in-memory-fake-0.0.0",
     rmuxWireVersion: "0.10.0-fake",
-    capabilities: ["terminal.rmux.recovery.v1", "terminal.multi-view.v1"],
+    capabilities: [...requiredRmuxBridgeCapabilities()],
   };
 
   constructor(deps: InMemoryRmuxDriverDeps = {}) {
@@ -357,6 +358,12 @@ export class InMemoryRmuxDriver implements RmuxTerminalDriver {
     }
     this.sessionsById.clear();
     this.inventoryOverride = [];
+  }
+
+  restoreDriver(): void {
+    this.crashed = false;
+    this.crashError = new RmuxDriverCrashedError();
+    this.inventoryOverride = null;
   }
 
   private async gate(op: RmuxDriverOp): Promise<void> {

--- a/packages/channel-relay/src/terminal/rmux-driver.ts
+++ b/packages/channel-relay/src/terminal/rmux-driver.ts
@@ -68,7 +68,38 @@ export type RmuxRecoveryEvent =
   | { type: "exit"; code?: number }
   | { type: "error"; code: string; message: string };
 
-/** Version/capability stub — real driver reports bridge + RMUX wire version. */
+/** Bridge capabilities that must be proven before Relay advertises terminal
+ * capability to the Hub. The POSIX dialect capability is deliberately an
+ * internal bridge→connector contract: browsers only see the generic terminal
+ * capabilities after this preflight succeeds. */
+export const RMUX_BRIDGE_RECOVERY_CAPABILITY = "terminal.rmux.recovery.v1";
+export const RMUX_BRIDGE_MULTI_VIEW_CAPABILITY = "terminal.multi-view.v1";
+export const RMUX_POSIX_XTERM_DIALECT_CAPABILITY =
+  "terminal.posix-dialect.xterm-256color.v1";
+
+export function requiredRmuxBridgeCapabilities(
+  platform: NodeJS.Platform = process.platform,
+): readonly string[] {
+  return platform === "win32"
+    ? [RMUX_BRIDGE_RECOVERY_CAPABILITY, RMUX_BRIDGE_MULTI_VIEW_CAPABILITY]
+    : [
+        RMUX_BRIDGE_RECOVERY_CAPABILITY,
+        RMUX_BRIDGE_MULTI_VIEW_CAPABILITY,
+        RMUX_POSIX_XTERM_DIALECT_CAPABILITY,
+      ];
+}
+
+export function missingRequiredRmuxBridgeCapabilities(
+  capabilities: readonly string[],
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  const advertised = new Set(capabilities);
+  return requiredRmuxBridgeCapabilities(platform).filter(
+    (capability) => !advertised.has(capability),
+  );
+}
+
+/** Version/capability snapshot — real driver reports bridge + RMUX wire version. */
 export interface RmuxDiagnostics {
   bridgeVersion: string;
   rmuxWireVersion: string;

--- a/packages/relay-web/e2e/terminal-dialect.spec.ts
+++ b/packages/relay-web/e2e/terminal-dialect.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect, loginAndOpenTerminal, waitForTerminalScreen } from "./fixtures";
+
+test.describe("terminal dialect contract", () => {
+  test("xterm title metadata stays non-visual while command output renders", async ({ page, hub }) => {
+    await loginAndOpenTerminal(page);
+    await waitForTerminalScreen(page);
+
+    // XACPX POSIX work panes advertise TERM=xterm-256color. Shell integrations
+    // therefore use xterm-family OSC title controls instead of screen/tmux's
+    // ESC k ... ST rename string. The browser renderer must consume the title
+    // metadata without painting its payload into the terminal grid.
+    const titleProbe = "__XACPX_XTERM_TITLE_PROBE__";
+    const outputProbe = "__XACPX_XTERM_OUTPUT_PROBE__";
+    hub.sendBytes(`\u001b]2;${titleProbe}\u0007${outputProbe}\r\n`);
+
+    const rows = page.locator('[data-test="terminal-host"] .xterm-rows');
+    await expect.poll(async () => rows.innerText()).toContain(outputProbe);
+
+    const rendered = await rows.innerText();
+    expect(rendered).not.toContain(titleProbe);
+  });
+});

--- a/tests/smoke/relay-rmux-terminal.test.ts
+++ b/tests/smoke/relay-rmux-terminal.test.ts
@@ -20,6 +20,7 @@ import {
   type RmuxSidecarSupervisor,
 } from "../../packages/channel-relay/src/terminal/rmux-sidecar-supervisor";
 import {
+  RMUX_POSIX_XTERM_DIALECT_CAPABILITY,
   RmuxInvalidUtf8InputError,
   type RmuxRecoveryEvent,
   type RmuxSessionHandle,
@@ -131,6 +132,16 @@ async function collectUntil(
   );
 }
 
+function recoveryText(events: RmuxRecoveryEvent[]): string {
+  const decoder = new TextDecoder();
+  let text = "";
+  for (const event of events) {
+    if (event.type === "rebase") text += decoder.decode(event.keyframe);
+    if (event.type === "bytes") text += decoder.decode(event.data);
+  }
+  return text;
+}
+
 function hasRebase(events: RmuxRecoveryEvent[]): boolean {
   return events.some((e) => e.type === "rebase");
 }
@@ -169,6 +180,36 @@ test.skipIf(!enabled)("real sidecar: create → UTF-8 input → recover rebase �
     driver.input(handle.paneId, new Uint8Array([0xff, 0xfe])),
   ).rejects.toBeInstanceOf(RmuxInvalidUtf8InputError);
 });
+
+test.skipIf(!enabled || process.platform === "win32")(
+  "real sidecar: created POSIX shell advertises xterm-256color through recovery",
+  async () => {
+    const { driver, cwd } = await boot();
+    const diagnostics = await driver.diagnostics();
+    expect(diagnostics.capabilities).toContain(
+      RMUX_POSIX_XTERM_DIALECT_CAPABILITY,
+    );
+
+    const handle = await createShell(driver, cwd, "term-dialect");
+    const expected = "__XACPX_TERM__xterm-256color__";
+    const recoverP = collectUntil(
+      driver.recover(handle.paneId),
+      (events) => recoveryText(events).includes(expected),
+      20_000,
+    );
+    await Bun.sleep(50);
+    await driver.input(
+      handle.paneId,
+      new TextEncoder().encode(
+        "printf '__XACPX_TERM__%s__\\n' \"$TERM\"\n",
+      ),
+    );
+    const events = await recoverP;
+    expect(recoveryText(events)).toContain(expected);
+
+    await driver.kill(handle.sessionId);
+  },
+);
 
 test.skipIf(!enabled)("real sidecar: shutdown kills owned session (process-owned)", async () => {
   const { driver, supervisor, cwd } = await boot();

--- a/tests/smoke/relay-rmux-terminal.test.ts
+++ b/tests/smoke/relay-rmux-terminal.test.ts
@@ -133,24 +133,16 @@ async function collectUntil(
 }
 
 function recoveryText(events: RmuxRecoveryEvent[]): string {
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  for (const event of events) {
-    const bytes =
-      event.type === "rebase"
-        ? event.keyframe
-        : event.type === "bytes"
-          ? event.data
-          : null;
-    if (!bytes) continue;
-    chunks.push(bytes);
-    total += bytes.byteLength;
-  }
+  const bytesEvents = events.filter(
+    (event): event is Extract<RmuxRecoveryEvent, { type: "bytes" }> =>
+      event.type === "bytes",
+  );
+  const total = bytesEvents.reduce((sum, event) => sum + event.data.byteLength, 0);
   const joined = new Uint8Array(total);
   let offset = 0;
-  for (const chunk of chunks) {
-    joined.set(chunk, offset);
-    offset += chunk.byteLength;
+  for (const event of bytesEvents) {
+    joined.set(event.data, offset);
+    offset += event.data.byteLength;
   }
   return new TextDecoder().decode(joined);
 }

--- a/tests/smoke/relay-rmux-terminal.test.ts
+++ b/tests/smoke/relay-rmux-terminal.test.ts
@@ -133,13 +133,26 @@ async function collectUntil(
 }
 
 function recoveryText(events: RmuxRecoveryEvent[]): string {
-  const decoder = new TextDecoder();
-  let text = "";
+  const chunks: Uint8Array[] = [];
+  let total = 0;
   for (const event of events) {
-    if (event.type === "rebase") text += decoder.decode(event.keyframe);
-    if (event.type === "bytes") text += decoder.decode(event.data);
+    const bytes =
+      event.type === "rebase"
+        ? event.keyframe
+        : event.type === "bytes"
+          ? event.data
+          : null;
+    if (!bytes) continue;
+    chunks.push(bytes);
+    total += bytes.byteLength;
   }
-  return text;
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(joined);
 }
 
 function hasRebase(events: RmuxRecoveryEvent[]): boolean {

--- a/tests/unit/packages/channel-relay/channel-terminal-dialect.test.ts
+++ b/tests/unit/packages/channel-relay/channel-terminal-dialect.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { RelayChannel } from "../../../../packages/channel-relay/src/channel";
+import type { RelayCredential } from "../../../../packages/channel-relay/src/credential-store";
+import { InMemoryRmuxDriver } from "../../../../packages/channel-relay/src/terminal/in-memory-rmux-driver";
+import {
+  RMUX_BRIDGE_MULTI_VIEW_CAPABILITY,
+  RMUX_BRIDGE_RECOVERY_CAPABILITY,
+  RMUX_POSIX_XTERM_DIALECT_CAPABILITY,
+  requiredRmuxBridgeCapabilities,
+} from "../../../../packages/channel-relay/src/terminal/rmux-driver";
+import type {
+  SessionResourceCatalog,
+  SessionResourceDescriptor,
+  SessionResourceLifecycleEvent,
+} from "xacpx/plugin-api";
+
+class MemoryCredentialStore {
+  constructor(private value: RelayCredential | null = null) {}
+  load() {
+    return this.value;
+  }
+  save(credential: RelayCredential) {
+    this.value = credential;
+  }
+  clear() {
+    this.value = null;
+  }
+}
+
+class FakeCatalog implements SessionResourceCatalog {
+  private readonly listeners = new Set<
+    (event: SessionResourceLifecycleEvent) => void
+  >();
+  private readonly item: SessionResourceDescriptor = {
+    logicalSessionId: "11111111-1111-4111-8111-111111111111",
+    channelId: "relay",
+    internalAlias: "demo",
+    displayAlias: "demo",
+    workspace: "ws",
+    cwd: "/tmp/ws",
+    archived: false,
+  };
+
+  async resolve(_channelId: string, alias: string) {
+    return alias === this.item.displayAlias ? this.item : null;
+  }
+
+  async list(channelId: string) {
+    return channelId === this.item.channelId ? [this.item] : [];
+  }
+
+  subscribe(listener: (event: SessionResourceLifecycleEvent) => void) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+}
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length > 0) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+async function waitUntil(
+  pred: () => boolean,
+  label: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!pred() && Date.now() < deadline) {
+    await Bun.sleep(5);
+  }
+  if (!pred()) throw new Error(`timed out waiting for ${label}`);
+}
+
+test("bridge capability contract requires xterm dialect on POSIX but not Windows", () => {
+  expect(requiredRmuxBridgeCapabilities("linux")).toContain(
+    RMUX_POSIX_XTERM_DIALECT_CAPABILITY,
+  );
+  expect(requiredRmuxBridgeCapabilities("darwin")).toContain(
+    RMUX_POSIX_XTERM_DIALECT_CAPABILITY,
+  );
+  expect(requiredRmuxBridgeCapabilities("win32")).not.toContain(
+    RMUX_POSIX_XTERM_DIALECT_CAPABILITY,
+  );
+  expect(requiredRmuxBridgeCapabilities("win32")).toEqual([
+    RMUX_BRIDGE_RECOVERY_CAPABILITY,
+    RMUX_BRIDGE_MULTI_VIEW_CAPABILITY,
+  ]);
+});
+
+test("in-memory driver advertises the host bridge contract by default", async () => {
+  const diagnostics = await new InMemoryRmuxDriver().diagnostics();
+  expect(diagnostics.capabilities).toEqual(requiredRmuxBridgeCapabilities());
+});
+
+test.skipIf(process.platform === "win32")(
+  "old bridge without POSIX dialect fails closed before reconcile or Hub capability publication",
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), "relay-term-dialect-"));
+    dirs.push(dir);
+
+    const driver = new InMemoryRmuxDriver();
+    driver.setDiagnostics({
+      bridgeVersion: "0.1.0-old",
+      capabilities: [
+        RMUX_BRIDGE_RECOVERY_CAPABILITY,
+        RMUX_BRIDGE_MULTI_VIEW_CAPABILITY,
+      ],
+    });
+
+    let listCalls = 0;
+    const originalList = driver.list.bind(driver);
+    driver.list = async () => {
+      listCalls += 1;
+      return originalList();
+    };
+
+    let capturedCaps: string[] | undefined;
+    const errors: string[] = [];
+    const channel = new RelayChannel(
+      {
+        url: "ws://h:1",
+        pairingToken: "t",
+        terminal: { enabled: true },
+      },
+      {
+        credentialStore: new MemoryCredentialStore(),
+        terminalRegistryDir: dir,
+        createTerminalDriver: () => driver,
+        createClient: (options) => {
+          capturedCaps = options.capabilities;
+          return {
+            start: () => {},
+            stop: () => {},
+            sendEvent: () => {},
+          } as never;
+        },
+      },
+    );
+
+    const controller = new AbortController();
+    const started = channel.start({
+      agent: { chat: async () => ({ text: "" }) },
+      abortSignal: controller.signal,
+      quota: {} as never,
+      logger: {
+        info: async () => {},
+        debug: async () => {},
+        error: async (_id: string, message: string) => {
+          errors.push(message);
+        },
+      },
+      control: {
+        events: { subscribe: () => () => {} },
+        listSessions: () => [],
+      },
+      coreVersion: "0.17.0",
+      sessionResources: new FakeCatalog(),
+    } as never);
+
+    await waitUntil(() => capturedCaps !== undefined, "client capability capture");
+    expect(capturedCaps).toEqual([]);
+    expect(channel.getTerminalRuntimeForTests()).toBeNull();
+    expect(listCalls).toBe(0);
+    expect(
+      errors.some((message) =>
+        message.includes(RMUX_POSIX_XTERM_DIALECT_CAPABILITY),
+      ),
+    ).toBe(true);
+
+    controller.abort();
+    await started;
+  },
+);


### PR DESCRIPTION
## Summary

Fix relay-web terminal output incorrectly prefixing command names (for example `pwd/Users/...` and `echoscreen-256color`) after the xterm.js renderer migration.

The bug is not duplicate input and is intentionally **not** fixed with a browser-side escape-sequence filter. RMUX recovery forwards raw pane bytes to relay-web, so the application `$TERM` is part of the end-to-end renderer contract. `screen-256color` / `tmux-256color` cause shell integrations such as Oh My Zsh to emit screen/tmux-specific title sequences (`ESC k ... ST`). RMUX understands those sequences, but xterm.js does not consume that string form, so its payload is rendered as ordinary text.

This change makes the contract explicit and fail-closed:

- pin POSIX xacpx-created work panes to `TERM=xterm-256color`, matching relay-web's xterm.js renderer instead of inheriting RMUX `tmux-256color` or using the previous macOS-only `screen-256color` fallback;
- leave Windows outside the POSIX `TERM` contract;
- publish `terminal.posix-dialect.xterm-256color.v1` from the native bridge on POSIX;
- **consume bridge diagnostics before runtime reconciliation / readiness / Hub capability publication**: POSIX connectors require the xterm dialect capability (plus recovery + multi-view), while Windows requires only the two generic bridge capabilities;
- mixed-version new connector + old bridge therefore fails closed and advertises no terminal capabilities instead of opening a renderer-incompatible terminal;
- keep RMUX raw recovery semantics unchanged and add no output string filtering/deduplication.

## Regression coverage

### Bridge / connector contract

- Native bridge unit tests lock `TERM=xterm-256color` for Unix work panes and prove Windows receives no POSIX `TERM` override.
- Shared connector-side capability helpers define the required bridge contract per platform.
- `InMemoryRmuxDriver` advertises the same host contract by default.
- A POSIX channel regression simulates an old bridge that still advertises only `terminal.rmux.recovery.v1` + `terminal.multi-view.v1` and asserts:
  - Relay publishes **no** terminal capabilities to the Hub;
  - terminal runtime never becomes ready;
  - reconciliation is not entered (`driver.list()` is never called);
  - the missing xterm dialect capability is surfaced in bootstrap diagnostics.
- A platform-specific unit assertion proves Windows does not require the POSIX dialect capability.

### Real producer path

The opt-in real RMUX smoke now creates a shell through the release sidecar, starts recovery, executes:

```sh
printf '__XACPX_TERM__%s__\n' "$TERM"
```

and requires `__XACPX_TERM__xterm-256color__` to arrive through live RMUX recovery bytes. This exercises the actual `create -> NewWindowBuilder -> PTY environment -> shell -> recovery` path rather than only testing the Rust env helper. The existing publish `smoke-legacy` job runs this real sidecar/RMUX matrix on Linux.

### Renderer contract

Relay Web keeps a real-browser xterm regression that sends the xterm-family OSC title sequence expected from this dialect and verifies title payload stays non-visual while ordinary output renders. It is a renderer-contract test, not the proof that the producer sets `$TERM`; the real RMUX smoke above provides that producer proof.

Existing recovery ordering/rebase semantics are unchanged.

## Compatibility note

The environment is fixed when the PTY is created, so already-running terminal panes retain their previous `$TERM`. Closing/terminating the old terminal and creating a new one is required to pick up the new dialect.

## Test plan

- [x] Earlier implementation head: repository tests/build, Relay Web terminal E2E, native bridge tests/check, and Windows RMUX platform-package smoke passed (Actions run 32330802868).
- [ ] Latest review-fix head: GitHub Actions rerun in progress; do not merge until it is green.
- [ ] Real sidecar `$TERM` smoke is exercised by the existing channel-relay publish `smoke-legacy` workflow (`XACPX_RMUX_INTEGRATION=1`).
