### PR TITLE
fix(relay-web): make terminal open geometry host-authoritative

### DIFF
--- a/packages/channel-relay/native/rmux-bridge/src/actors.rs
+++ b/packages/channel-relay/native/rmux-bridge/src/actors.rs
@@ -5,7 +5,7 @@
 //! 2. `new_window_with().cwd(...)` for the work pane, with the POSIX
 //!    application terminal dialect pinned to `TERM=xterm-256color`
 //! 3. close default window 0
-//! 4. resize + `history-limit` on the stable pane id
+//! 4. resize the work window + set `history-limit` on the stable pane id
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use rmux_sdk::{
     CleanupPolicy, NewWindowBuilder, OwnedSession, PaneId, PaneRecoveryEvent,
-    PaneRecoveryRebaseReason, Rmux, SessionName, TerminalSizeSpec,
+    PaneRecoveryRebaseReason, Rmux, SessionName,
 };
 use tokio::sync::{mpsc, Mutex};
 
@@ -49,6 +49,7 @@ struct SessionActor {
     owned: OwnedSession,
     session_id: String,
     pane_id: String,
+    window_index: u32,
     name: String,
     tags: Vec<String>,
     recover_abort: Option<tokio::task::JoinHandle<()>>,
@@ -110,8 +111,18 @@ impl BridgeState {
                 return Err(format!("new_window failed: {e}"));
             }
         };
+        let work_window_index = work.target().window_index;
 
         let _ = owned.window(0).close().await;
+
+        // Pane::resize changes a pane inside the current window layout; it
+        // cannot grow a single-pane window beyond the window's own geometry.
+        // relay-web needs the PTY/window itself to match the browser viewport,
+        // so use the SDK's authoritative ResizeWindow request instead.
+        if let Err(e) = work.resize(Some(cols), Some(rows)).await {
+            let _ = owned.cleanup().await;
+            return Err(format!("window resize failed: {e}"));
+        }
 
         let panes = match work.panes().await {
             Ok(p) => p,
@@ -135,11 +146,6 @@ impl BridgeState {
                 return Err(format!("pane_by_id failed: {e}"));
             }
         };
-
-        if let Err(e) = pane.resize(TerminalSizeSpec::new(cols, rows)).await {
-            let _ = owned.cleanup().await;
-            return Err(format!("resize failed: {e}"));
-        }
         let _ = pane
             .set_option("history-limit", history_limit.to_string())
             .await;
@@ -152,6 +158,7 @@ impl BridgeState {
             owned,
             session_id: session_id.clone(),
             pane_id: pane_id_str.clone(),
+            window_index: work_window_index,
             name: name.clone(),
             tags: tags.clone(),
             recover_abort: None,
@@ -262,7 +269,6 @@ impl BridgeState {
     }
 
     pub async fn resize(&self, pane_id: &str, cols: u16, rows: u16) -> Result<(), String> {
-        let pane_id_parsed = parse_pane_id(pane_id)?;
         let session_id = self
             .panes
             .lock()
@@ -274,14 +280,12 @@ impl BridgeState {
         let actor = sessions
             .get(&session_id)
             .ok_or_else(|| format!("session not found: {session_id}"))?;
-        let pane = actor
+        actor
             .owned
-            .pane_by_id(pane_id_parsed)
+            .window(actor.window_index)
+            .resize(Some(cols), Some(rows))
             .await
-            .map_err(|e| format!("pane_by_id failed: {e}"))?;
-        pane.resize(TerminalSizeSpec::new(cols, rows))
-            .await
-            .map_err(|e| format!("resize failed: {e}"))?;
+            .map_err(|e| format!("window resize failed: {e}"))?;
         Ok(())
     }
 

--- a/packages/channel-relay/src/terminal-bridge.ts
+++ b/packages/channel-relay/src/terminal-bridge.ts
@@ -247,6 +247,13 @@ export async function handleTerminalRequest(
           cols: p.cols,
           rows: p.rows,
         });
+        // Once the request deadline has fired, this browser no longer owns an
+        // unpublished open. Compensation may detach/clean it up, but it must
+        // not mutate shared terminal state (notably geometry) after timeout.
+        if (timedOut) {
+          void runtime.compensateTimedOutOpen(result).catch(() => {});
+          return true;
+        }
         // A create already passes the requested geometry into driver.create().
         // A resume used to ignore it completely and relied on a later browser
         // fire-and-forget resize, so a stale 80x24 pane could survive a refresh
@@ -263,10 +270,6 @@ export async function handleTerminalRequest(
             runtime.detach(result.attachmentId);
             throw err;
           }
-        }
-        if (timedOut) {
-          void runtime.compensateTimedOutOpen(result).catch(() => {});
-          return true;
         }
         respondOnce(toTerminalOpenWireResult(result));
         return true;

--- a/packages/channel-relay/src/terminal-bridge.ts
+++ b/packages/channel-relay/src/terminal-bridge.ts
@@ -254,6 +254,13 @@ export async function handleTerminalRequest(
           void runtime.compensateTimedOutOpen(result).catch(() => {});
           return true;
         }
+        // Commit phase: once openOrResume succeeds in time, disarm the request
+        // timer so the connector does not declare a timeout mid-resize after
+        // committing to the attachment and authoritative geometry convergence.
+        if (timer !== undefined) {
+          clearTimeoutFn(timer);
+          timer = undefined;
+        }
         // A create already passes the requested geometry into driver.create().
         // A resume used to ignore it completely and relied on a later browser
         // fire-and-forget resize, so a stale 80x24 pane could survive a refresh

--- a/packages/channel-relay/src/terminal-bridge.ts
+++ b/packages/channel-relay/src/terminal-bridge.ts
@@ -247,6 +247,23 @@ export async function handleTerminalRequest(
           cols: p.cols,
           rows: p.rows,
         });
+        // A create already passes the requested geometry into driver.create().
+        // A resume used to ignore it completely and relied on a later browser
+        // fire-and-forget resize, so a stale 80x24 pane could survive a refresh
+        // indefinitely. The controller open is authoritative: converge the
+        // durable pane before acknowledging terminal-open. Spectators never
+        // resize the shared pane.
+        if (result.openKind === "resumed" && result.role === "controller") {
+          try {
+            await runtime.resize(result.attachmentId, result.generation, p.cols, p.rows);
+          } catch (err) {
+            // The Hub has not seen this attachment yet. Roll it back so a
+            // failed authoritative resize cannot leave a phantom viewer bound
+            // to a terminal-open request that returns an error.
+            runtime.detach(result.attachmentId);
+            throw err;
+          }
+        }
         if (timedOut) {
           void runtime.compensateTimedOutOpen(result).catch(() => {});
           return true;

--- a/packages/channel-relay/src/terminal-bridge.ts
+++ b/packages/channel-relay/src/terminal-bridge.ts
@@ -247,10 +247,17 @@ export async function handleTerminalRequest(
           cols: p.cols,
           rows: p.rows,
         });
-        // Once the request deadline has fired, this browser no longer owns an
-        // unpublished open. Compensation may detach/clean it up, but it must
-        // not mutate shared terminal state (notably geometry) after timeout.
-        if (timedOut) {
+        const deadlineMissed =
+          timedOut ||
+          (deadlineAt !== undefined && now() >= deadlineAt);
+        if (deadlineMissed) {
+          if (!timedOut) {
+            timedOut = true;
+            respondOnce(errorPayload(
+              "timeout",
+              `rpc ${envelope.type} exceeded request deadline`,
+            ));
+          }
           void runtime.compensateTimedOutOpen(result).catch(() => {});
           return true;
         }
@@ -288,7 +295,7 @@ export async function handleTerminalRequest(
           return true;
         }
         const result = await runtime.takeControl(p.attachmentId, p.generation);
-        if (timedOut) return true;
+        if (timedOut || (deadlineAt !== undefined && now() >= deadlineAt)) return true;
         respondOnce(result);
         return true;
       }
@@ -299,7 +306,7 @@ export async function handleTerminalRequest(
           return true;
         }
         await runtime.resync(p.attachmentId, p.generation);
-        if (timedOut) return true;
+        if (timedOut || (deadlineAt !== undefined && now() >= deadlineAt)) return true;
         respondOnce({ ok: true });
         return true;
       }
@@ -316,7 +323,7 @@ export async function handleTerminalRequest(
         });
         // Late terminate after Hub timeout is still useful cleanup; respond if
         // the Hub is still waiting, otherwise leave the side effect alone.
-        if (timedOut) return true;
+        if (timedOut || (deadlineAt !== undefined && now() >= deadlineAt)) return true;
         respondOnce(result);
         return true;
       }

--- a/packages/relay-web/e2e/mock-hub.ts
+++ b/packages/relay-web/e2e/mock-hub.ts
@@ -243,11 +243,11 @@ export async function startMockHub(): Promise<MockHub> {
         role,
         viewerCount: role === "spectator" ? 2 : 1,
       });
-      // Authoritative recovery geometry first; the browser must then re-fit
-      // the host (the late-rebase / initial-viewport invariant). The keyframe
-      // carries a prompt + a cursor move so the rendered grid actually places
-      // the cursor off home (xterm sizes/anchors its IME textarea on cursor move).
-      sendRebase(80, 24, "xacpx demo shell\r\n$ \x1b[1;3H");
+      // Authoritative recovery geometry matching the controller-converged open.
+      // The keyframe carries a prompt + a cursor move so the rendered grid
+      // actually places the cursor off home (xterm sizes/anchors its IME
+      // textarea on cursor move).
+      sendRebase(msg.cols, msg.rows, "xacpx demo shell\r\n$ \x1b[1;3H");
       return;
     }
     if (msg.kind === "terminal-take-control") {

--- a/packages/relay-web/e2e/terminal-viewport.spec.ts
+++ b/packages/relay-web/e2e/terminal-viewport.spec.ts
@@ -10,6 +10,12 @@ test.describe("terminal viewport", () => {
     expect(grid.cols === 80 && grid.rows === 24).toBe(false);
     expect(grid.cols).toBeGreaterThan(20);
     expect(grid.rows).toBeGreaterThan(10);
+    // The backend terminal-open must be born at the measured browser grid.
+    // A later resize is no longer allowed to repair an 80x24 bootstrap PTY.
+    expect(hub.lastOpen).not.toBeNull();
+    expect(hub.lastOpen!.cols).toBe(grid.cols);
+    expect(hub.lastOpen!.rows).toBe(grid.rows);
+    expect(hub.lastOpen!.cols === 80 && hub.lastOpen!.rows === 24).toBe(false);
     // Sub-cell remainder is expected (items-center); never a whole unused cell.
     expect(grid.remainder).toBeLessThan(grid.screenWidth / grid.cols + 1);
     expect(hub.resizes.length).toBeGreaterThan(0);

--- a/packages/relay-web/e2e/terminal-viewport.spec.ts
+++ b/packages/relay-web/e2e/terminal-viewport.spec.ts
@@ -41,6 +41,7 @@ test.describe("terminal viewport", () => {
     // Authoritative rebase (80x24) updates syncedResize belief, so the
     // subsequent forceSync sends a corrective resize back to host dimensions.
     expect(hub.resizes.length).toBeGreaterThan(resizesBefore);
+    const last = hub.resizes.at(-1)!;
     expect(last.cols).toBe(after.cols);
     expect(last.rows).toBe(after.rows);
   });

--- a/packages/relay-web/e2e/terminal-viewport.spec.ts
+++ b/packages/relay-web/e2e/terminal-viewport.spec.ts
@@ -18,10 +18,11 @@ test.describe("terminal viewport", () => {
     expect(hub.lastOpen!.cols === 80 && hub.lastOpen!.rows === 24).toBe(false);
     // Sub-cell remainder is expected (items-center); never a whole unused cell.
     expect(grid.remainder).toBeLessThan(grid.screenWidth / grid.cols + 1);
-    expect(hub.resizes.length).toBeGreaterThan(0);
-    const last = hub.resizes.at(-1)!;
-    expect(last.cols).toBe(grid.cols);
-    expect(last.rows).toBe(grid.rows);
+    if (hub.resizes.length > 0) {
+      const last = hub.resizes.at(-1)!;
+      expect(last.cols).toBe(grid.cols);
+      expect(last.rows).toBe(grid.rows);
+    }
   });
 
   test("late rebase rebuilds at the keyframe size then re-fits the host", async ({ page, hub }) => {
@@ -37,9 +38,9 @@ test.describe("terminal viewport", () => {
     const after = await readTerminalGrid(page);
     expect(after.rows).toBe(before.rows);
     expect(after.cols === 80 && after.rows === 24).toBe(false);
-    // Controller may re-push the host geometry; store dedupe owns exact count.
-    expect(hub.resizes.length).toBeGreaterThanOrEqual(resizesBefore);
-    const last = hub.resizes.at(-1)!;
+    // Authoritative rebase (80x24) updates syncedResize belief, so the
+    // subsequent forceSync sends a corrective resize back to host dimensions.
+    expect(hub.resizes.length).toBeGreaterThan(resizesBefore);
     expect(last.cols).toBe(after.cols);
     expect(last.rows).toBe(after.rows);
   });

--- a/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/dashboard-center-tabs.test.ts
@@ -366,3 +366,34 @@ test("clicking the tab strip's own X button terminates after confirm", async () 
 
   expect(terminateSpy).toHaveBeenCalledWith(localKey);
 });
+
+test("background terminal tab receives active=false, becomes active=true when switched to", async () => {
+  const termStub = {
+    name: "TerminalTab",
+    props: ["active", "instanceId", "sessionAlias"],
+    template: '<div data-test="stub-term" :data-active="active" />',
+    emits: ["close"],
+  };
+  const wrapper = mount(DashboardView, { global: { stubs: { ...stubs, TerminalTab: termStub } } });
+  await flushPromises();
+  const key = selectSession();
+  await flushPromises();
+
+  const centerTabs = useCenterTabsStore();
+  centerTabs.openTerminal(key);
+  await flushPromises();
+  // Open file to put terminal in background
+  centerTabs.openFile(key, "README.md");
+  await flushPromises();
+
+  const term = wrapper.findComponent(termStub);
+  expect(term.exists()).toBe(true);
+  expect(term.props("active")).toBe(false);
+
+  // Switch back to terminal
+  const termTabId = centerTabs.tabsFor(key).find((t) => t.kind === "terminal")!.id;
+  centerTabs.setActive(key, termTabId);
+  await flushPromises();
+
+  expect(term.props("active")).toBe(true);
+});

--- a/packages/relay-web/src/__tests__/terminal-store.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-store.test.ts
@@ -534,6 +534,42 @@ describe("terminal store", () => {
     ]);
   });
 
+  it("authoritative rebase-start updates syncedResize and allows corrective resize", async () => {
+    connectEvents((e) => { void useTerminalStore().applyEvent(e); });
+    const ws = FakeWS.instances[0];
+    ws.onopen?.();
+    const store = useTerminalStore();
+    const key = terminalLocalKey("i1", "demo");
+    await openAttached(store, key, ws, { role: "controller" });
+    store.sendResize(key, 132, 47);
+    expect(resizeFrames(ws)).toEqual([{ cols: 132, rows: 47 }]);
+    expect(store.get(key)?.syncedResize).toEqual({ cols: 132, rows: 47 });
+
+    // Late recovery arrives carrying backend authoritative 80x24 geometry.
+    await store.applyEvent({
+      kind: "terminal-rebase-start",
+      instanceId: "i1",
+      attachmentId: "a1",
+      generation: "g1",
+      epoch: 2,
+      nextSequence: 0,
+      cols: 80,
+      rows: 24,
+      alternate: false,
+      totalBytes: 0,
+      chunkCount: 0,
+    });
+    expect(store.get(key)?.syncedResize).toEqual({ cols: 80, rows: 24 });
+
+    // Viewport forceSync re-fits to local 132x47 and must NOT be swallowed.
+    store.sendResize(key, 132, 47);
+    expect(resizeFrames(ws)).toEqual([
+      { cols: 132, rows: 47 },
+      { cols: 132, rows: 47 },
+    ]);
+    expect(store.get(key)?.syncedResize).toEqual({ cols: 132, rows: 47 });
+  });
+
   it("same-role viewerCount churn keeps the synced belief (join)", async () => {
     connectEvents((e) => { void useTerminalStore().applyEvent(e); });
     const ws = FakeWS.instances[0];

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -593,4 +593,36 @@ describe("TerminalTab", () => {
       adapter.fit.mockReturnValue({ cols: 80, rows: 24 });
     }
   });
+
+  it("does not open attachment on mount when active is false, opens when activated", async () => {
+    const w = mount(TerminalTab, {
+      props: { instanceId: "i1", sessionAlias: "demo", active: false },
+      global: globalOpts,
+    });
+    await flushPromises();
+    expect(openOrResume).not.toHaveBeenCalled();
+    expect(createTerminalAdapter).not.toHaveBeenCalled();
+
+    // Activating opens with fitted geometry
+    adapter.fit.mockReturnValue({ cols: 120, rows: 35 });
+    try {
+      await w.setProps({ active: true });
+      await flushPromises();
+      expect(openOrResume).toHaveBeenCalledWith("i1\0demo", expect.objectContaining({ cols: 120, rows: 35 }));
+      expect(createTerminalAdapter).toHaveBeenCalled();
+
+      // Deactivating keeps the attachment warm (no detach)
+      await w.setProps({ active: false });
+      await flushPromises();
+      expect(detach).not.toHaveBeenCalled();
+
+      // Reactivating does not reopen, stays attached
+      openOrResume.mockClear();
+      await w.setProps({ active: true });
+      await flushPromises();
+      expect(openOrResume).not.toHaveBeenCalled();
+    } finally {
+      adapter.fit.mockReturnValue({ cols: 80, rows: 24 });
+    }
+  });
 });

--- a/packages/relay-web/src/__tests__/terminal-tab.test.ts
+++ b/packages/relay-web/src/__tests__/terminal-tab.test.ts
@@ -10,6 +10,7 @@ import type { TerminalAttachmentView } from "../stores/terminal";
 enableAutoUnmount(afterEach);
 
 const adapter = {
+  ready: vi.fn(async () => {}),
   write: vi.fn(async () => {}),
   resize: vi.fn(),
   dispose: vi.fn(),
@@ -454,7 +455,10 @@ describe("TerminalTab", () => {
     // grid, and nothing re-fires ResizeObserver - settling syncs must re-fit.
     vi.useFakeTimers();
     try {
-      adapter.fit.mockReturnValueOnce({ cols: 80, rows: 24 }).mockReturnValue({ cols: 150, rows: 45 });
+      adapter.fit
+        .mockReturnValueOnce({ cols: 80, rows: 24 })
+        .mockReturnValueOnce({ cols: 80, rows: 24 })
+        .mockReturnValue({ cols: 150, rows: 45 });
       mount(TerminalTab, { props: { instanceId: "i1", sessionAlias: "demo" }, global: globalOpts });
       await vi.advanceTimersByTimeAsync(0);
       // The adapter starts at 80x24, so the first fit is a local no-op - the

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -180,7 +180,46 @@ function isCoarsePointer(): boolean {
 // opens/closes. Fed by bindTerminalKeyboardInset (debounced measurement).
 const keyboardInset = ref(0);
 
+async function nextLayoutFrame(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
 
+/**
+ * terminal-open creates (or resumes) the backend PTY at the supplied geometry.
+ * Do not send the adapter's 80x24 construction bootstrap: xterm.js loads its
+ * CSS/font asynchronously, so first wait until it is open, then derive the
+ * actual host-fit grid. A few layout-frame retries cover the rare case where
+ * the xterm screen is mounted but has not received measurable layout yet.
+ */
+async function fitBeforeTerminalOpen(
+  currentAdapter: TerminalAdapter,
+  myEpoch: number,
+): Promise<{ cols: number; rows: number }> {
+  await currentAdapter.ready();
+  for (let attempt = 0; attempt < 8; attempt++) {
+    if (myEpoch !== epoch || adapter !== currentAdapter) {
+      throw new Error("terminal adapter superseded");
+    }
+    const dim = currentAdapter.fit(keyboardInset.value);
+    if (dim) {
+      if (dim.cols !== currentAdapter.cols() || dim.rows !== currentAdapter.rows()) {
+        currentAdapter.resize(dim.cols, dim.rows);
+      }
+      return dim;
+    }
+    await nextLayoutFrame();
+  }
+  // Extremely defensive fallback for a renderer that remains unmeasurable.
+  // Normal browser opens never take this path; the settling viewport controller
+  // still converges locally afterward.
+  return { cols: currentAdapter.cols(), rows: currentAdapter.rows() };
+}
 
 function mapErrorCode(code: string): string {
   switch (code) {
@@ -271,8 +310,7 @@ async function openAttachment(): Promise<void> {
   });
 
   try {
-    const cols = currentAdapter.cols();
-    const rows = currentAdapter.rows();
+    const { cols, rows } = await fitBeforeTerminalOpen(currentAdapter, myEpoch);
     const view = await terminals.openOrResume(localKey.value, {
       instanceId: props.instanceId,
       sessionAlias: props.sessionAlias,

--- a/packages/relay-web/src/components/TerminalTab.vue
+++ b/packages/relay-web/src/components/TerminalTab.vue
@@ -14,7 +14,10 @@ import { useConnectionStore } from "../stores/connection";
 import { useInstancesStore } from "../stores/instances";
 import { TerminalRequestError, isRetryableTerminalError } from "../api/events";
 
-const props = defineProps<{ instanceId: string; sessionAlias: string }>();
+const props = withDefaults(
+  defineProps<{ instanceId: string; sessionAlias: string; active?: boolean }>(),
+  { active: true },
+);
 // Close is owned by the center tab strip → Dashboard requestCloseTerminal (global terminate).
 defineEmits<{ close: [] }>();
 
@@ -202,7 +205,7 @@ async function fitBeforeTerminalOpen(
   myEpoch: number,
 ): Promise<{ cols: number; rows: number }> {
   await currentAdapter.ready();
-  for (let attempt = 0; attempt < 8; attempt++) {
+  for (let attempt = 0; attempt < 30; attempt++) {
     if (myEpoch !== epoch || adapter !== currentAdapter) {
       throw new Error("terminal adapter superseded");
     }
@@ -215,10 +218,7 @@ async function fitBeforeTerminalOpen(
     }
     await nextLayoutFrame();
   }
-  // Extremely defensive fallback for a renderer that remains unmeasurable.
-  // Normal browser opens never take this path; the settling viewport controller
-  // still converges locally afterward.
-  return { cols: currentAdapter.cols(), rows: currentAdapter.rows() };
+  throw new Error("terminal host layout unmeasurable");
 }
 
 function mapErrorCode(code: string): string {
@@ -267,6 +267,7 @@ function releaseFrontend(detachBackend: boolean): void {
 }
 
 async function openAttachment(): Promise<void> {
+  if (!props.active) return;
   releaseFrontend(true);
   const myEpoch = epoch;
   if (!props.sessionAlias || !host.value) { status.value = "idle"; return; }
@@ -425,20 +426,39 @@ function onPageHide() {
 }
 
 onMounted(() => {
-  void openAttachment();
+  if (props.active) {
+    void openAttachment();
+  }
   attachInputLifecycles();
   window.addEventListener("pagehide", onPageHide);
 });
-watch(() => [props.instanceId, props.sessionAlias], () => { void openAttachment(); });
+watch(() => props.active, (active) => {
+  if (active) {
+    if (!attached.value && status.value !== "connecting") {
+      void openAttachment();
+    } else if (attached.value) {
+      viewport?.forceSync("tab-activated");
+      if (isController()) adapter?.focus();
+    }
+  }
+});
+watch(() => [props.instanceId, props.sessionAlias], () => {
+  if (props.active) {
+    void openAttachment();
+  } else {
+    releaseFrontend(true);
+    status.value = "idle";
+  }
+});
 watch(() => theme.mode, () => adapter?.setTheme(currentTheme()));
 watch(() => conn.online, (online) => {
-  if (online && status.value === "error") {
+  if (online && status.value === "error" && props.active) {
     autoRetried = false;
     void openAttachment();
   }
 });
 watch(() => instances.byId(props.instanceId)?.online, (online) => {
-  if (online && status.value === "error") {
+  if (online && status.value === "error" && props.active) {
     autoRetried = false;
     void openAttachment();
   }

--- a/packages/relay-web/src/stores/terminal.ts
+++ b/packages/relay-web/src/stores/terminal.ts
@@ -265,9 +265,8 @@ export const useTerminalStore = defineStore("terminal", () => {
         viewerCount: opened.viewerCount,
         recovery: initialRecoveryState(opened.generation),
         lastErrorCode: undefined,
-        // Resume of an existing pane does NOT resize it to the browser's fit —
-        // the new binding carries no "backend already at this size" guarantee.
-        syncedResize: undefined,
+        // Controller open authoritatively converges backend geometry to requested opts.
+        syncedResize: opened.role === "controller" ? { cols: opts.cols, rows: opts.rows } : undefined,
       };
       put(view);
       // Spec §14.5: stream starts only after opened metadata is applied locally.
@@ -558,6 +557,13 @@ export const useTerminalStore = defineStore("terminal", () => {
     ) {
       const view = findByAttachmentId(event.attachmentId);
       if (!view) return;
+      let syncedResize = view.syncedResize;
+      if (event.kind === "terminal-rebase-start") {
+        // Authoritative rebase carries backend geometry — update belief so
+        // subsequent viewport.forceSync() can send a corrective resize if host
+        // dimensions differ.
+        syncedResize = { cols: event.cols, rows: event.rows };
+      }
       const inbound =
         event.kind === "terminal-rebase-start"
           ? {
@@ -596,7 +602,7 @@ export const useTerminalStore = defineStore("terminal", () => {
       if (stepped.state.phase !== "waiting") {
         waitingStreamStartInFlight.delete(view.localKey);
       }
-      put({ ...view, recovery: stepped.state });
+      put({ ...view, recovery: stepped.state, syncedResize });
       await applyRecoveryAction(view.localKey, stepped.action);
     }
   }

--- a/packages/relay-web/src/views/DashboardView.vue
+++ b/packages/relay-web/src/views/DashboardView.vue
@@ -488,6 +488,7 @@ onUnmounted(() => {
                         @close="requestCloseTab(key, tab.id)" />
             <TerminalTab v-else-if="tab.kind === 'terminal'" class="absolute inset-0 z-20"
                          v-show="key === currentKey && centerTabs.activeFor(key) === tab.id"
+                         :active="key === currentKey && centerTabs.activeFor(key) === tab.id"
                          :instance-id="keyInstance(key)" :session-alias="keyAlias(key)"
                          @close="requestCloseTab(key, tab.id)" />
           </template>

--- a/tests/smoke/relay-rmux-platform-package.test.ts
+++ b/tests/smoke/relay-rmux-platform-package.test.ts
@@ -156,8 +156,8 @@ test.skipIf(!enabled)("bundled RMUX daemon is resolved over a hostile PATH fake;
     const handle = await prod.driver.create({
       name,
       cwd,
-      cols: 80,
-      rows: 24,
+      cols: 132,
+      rows: 47,
       historyLimit: 2000,
       tags: ["xacpx:relay", "smoke:platform-package"],
       ownerLeaseTtlSeconds: 30,
@@ -170,13 +170,18 @@ test.skipIf(!enabled)("bundled RMUX daemon is resolved over a hostile PATH fake;
     await Bun.sleep(200);
     await prod.driver.input(handle.paneId, new TextEncoder().encode("echo pkg-smoke-ok\n"));
     const events = await recoveryP;
-    expect(events[0]?.type).toBe("rebase");
+    const initialRebase = events.find(
+      (event): event is Extract<RmuxRecoveryEvent, { type: "rebase" }> => event.type === "rebase",
+    );
+    expect(initialRebase).toBeDefined();
+    expect(initialRebase!.cols).toBe(132);
+    expect(initialRebase!.rows).toBe(47);
 
-    // The exact production package must also prove that a browser-sized resize
+    // The exact production package must also prove that a subsequent resize
     // reaches the native RMUX pane. Starting a fresh recovery after resize gives
     // us an authoritative rebase geometry instead of merely checking that the
     // resize RPC returned.
-    await prod.driver.resize(handle.paneId, 132, 47);
+    await prod.driver.resize(handle.paneId, 111, 39);
     const resized = await collectUntil(
       prod.driver.recover(handle.paneId),
       (next) => next.some((event) => event.type === "rebase"),
@@ -185,9 +190,8 @@ test.skipIf(!enabled)("bundled RMUX daemon is resolved over a hostile PATH fake;
       (event): event is Extract<RmuxRecoveryEvent, { type: "rebase" }> => event.type === "rebase",
     );
     expect(resizedRebase).toBeDefined();
-    expect(resizedRebase!.cols).toBe(132);
-    expect(resizedRebase!.rows).toBe(47);
-
+    expect(resizedRebase!.cols).toBe(111);
+    expect(resizedRebase!.rows).toBe(39);
     await prod.driver.kill(handle.sessionId);
     expect((await prod.driver.list()).every((e) => e.name !== name)).toBe(true);
 

--- a/tests/smoke/relay-rmux-platform-package.test.ts
+++ b/tests/smoke/relay-rmux-platform-package.test.ts
@@ -1,7 +1,7 @@
 /**
  * Production-platform-package smoke: resolve the bridge + bundled RMUX from
- * the real npm layout, then run a live create → input → recover → kill cycle
- * with a HOSTILE fake RMUX on PATH that must never be executed.
+ * the real npm layout, then run a live create → input → recover → resize → kill
+ * cycle with a HOSTILE fake RMUX on PATH that must never be executed.
  *
  * Requires (publish workflow / Windows CI only, never default CI):
  *   XACPX_RMUX_PLATFORM_PACKAGE=1
@@ -171,6 +171,22 @@ test.skipIf(!enabled)("bundled RMUX daemon is resolved over a hostile PATH fake;
     await prod.driver.input(handle.paneId, new TextEncoder().encode("echo pkg-smoke-ok\n"));
     const events = await recoveryP;
     expect(events[0]?.type).toBe("rebase");
+
+    // The exact production package must also prove that a browser-sized resize
+    // reaches the native RMUX pane. Starting a fresh recovery after resize gives
+    // us an authoritative rebase geometry instead of merely checking that the
+    // resize RPC returned.
+    await prod.driver.resize(handle.paneId, 132, 47);
+    const resized = await collectUntil(
+      prod.driver.recover(handle.paneId),
+      (next) => next.some((event) => event.type === "rebase"),
+    );
+    const resizedRebase = resized.find(
+      (event): event is Extract<RmuxRecoveryEvent, { type: "rebase" }> => event.type === "rebase",
+    );
+    expect(resizedRebase).toBeDefined();
+    expect(resizedRebase!.cols).toBe(132);
+    expect(resizedRebase!.rows).toBe(47);
 
     await prod.driver.kill(handle.sessionId);
     expect((await prod.driver.list()).every((e) => e.name !== name)).toBe(true);

--- a/tests/unit/packages/channel-relay/terminal-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/terminal-bridge.test.ts
@@ -167,6 +167,133 @@ test("late timed-out open strips openKind from successful wire responses", async
   expect((responses[0] as { openKind?: string }).openKind).toBeUndefined();
 });
 
+test("resumed controller is resized to requested geometry before terminal-open succeeds", async () => {
+  const order: string[] = [];
+  const resize = mock(async () => { order.push("resize"); });
+  const detach = mock(() => { order.push("detach"); });
+  const runtime = {
+    openOrResume: mock(async () => {
+      order.push("open");
+      return {
+        terminalId: "term-1",
+        generation: "g1",
+        attachmentId: "att-1",
+        role: "controller" as const,
+        viewerCount: 1,
+        openKind: "resumed" as const,
+      };
+    }),
+    resize,
+    detach,
+  };
+  const responses: unknown[] = [];
+  await handleTerminalRequest(
+    runtime as never,
+    {
+      protocolVersion: RELAY_PROTOCOL_VERSION,
+      kind: "req",
+      id: "t-resume",
+      type: MSG.terminalOpen,
+      payload: {
+        chatKey: "relay:u1",
+        sessionAlias: "demo",
+        viewerId: "v1",
+        cols: 132,
+        rows: 47,
+      },
+    },
+    (payload) => responses.push(payload),
+  );
+
+  expect(order).toEqual(["open", "resize"]);
+  expect(resize).toHaveBeenCalledWith("att-1", "g1", 132, 47);
+  expect(detach).not.toHaveBeenCalled();
+  expect(responses[0]).toEqual({
+    terminalId: "term-1",
+    generation: "g1",
+    attachmentId: "att-1",
+    role: "controller",
+    viewerCount: 1,
+  });
+});
+
+test("resumed spectator never resizes the shared pane", async () => {
+  const resize = mock(async () => {});
+  const runtime = {
+    openOrResume: mock(async () => ({
+      terminalId: "term-1",
+      generation: "g1",
+      attachmentId: "att-2",
+      role: "spectator" as const,
+      viewerCount: 2,
+      openKind: "resumed" as const,
+    })),
+    resize,
+  };
+  const responses: unknown[] = [];
+  await handleTerminalRequest(
+    runtime as never,
+    {
+      protocolVersion: RELAY_PROTOCOL_VERSION,
+      kind: "req",
+      id: "t-spectator",
+      type: MSG.terminalOpen,
+      payload: {
+        chatKey: "relay:u1",
+        sessionAlias: "demo",
+        viewerId: "v2",
+        cols: 150,
+        rows: 50,
+      },
+    },
+    (payload) => responses.push(payload),
+  );
+
+  expect(resize).not.toHaveBeenCalled();
+  expect(responses).toHaveLength(1);
+});
+
+test("resumed controller resize failure rolls back the unpublished attachment", async () => {
+  const detach = mock(() => {});
+  const runtime = {
+    openOrResume: mock(async () => ({
+      terminalId: "term-1",
+      generation: "g1",
+      attachmentId: "att-1",
+      role: "controller" as const,
+      viewerCount: 1,
+      openKind: "resumed" as const,
+    })),
+    resize: mock(async () => {
+      throw new Error("resize failed");
+    }),
+    detach,
+  };
+  const responses: unknown[] = [];
+  await handleTerminalRequest(
+    runtime as never,
+    {
+      protocolVersion: RELAY_PROTOCOL_VERSION,
+      kind: "req",
+      id: "t-resume-fail",
+      type: MSG.terminalOpen,
+      payload: {
+        chatKey: "relay:u1",
+        sessionAlias: "demo",
+        viewerId: "v1",
+        cols: 132,
+        rows: 47,
+      },
+    },
+    (payload) => responses.push(payload),
+  );
+
+  expect(detach).toHaveBeenCalledWith("att-1");
+  expect(responses).toEqual([
+    { error: { code: "terminal-rmux-unavailable", message: "resize failed" } },
+  ]);
+});
+
 test("malformed terminal-open payload returns invalid-payload and does not call runtime", async () => {
   const runtime = {
     openOrResume: mock(async () => {

--- a/tests/unit/packages/channel-relay/terminal-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/terminal-bridge.test.ts
@@ -207,6 +207,85 @@ test("late timed-out resumed controller is compensated without resizing shared p
   expect(responses).toHaveLength(1);
 });
 
+test("authoritative resume resize enters commit phase and disarms deadline timer", async () => {
+  let releaseResize!: () => void;
+  const resizeGate = new Promise<void>((resolve) => {
+    releaseResize = resolve;
+  });
+  const compensateTimedOutOpen = mock(async () => {});
+  const detach = mock(() => {});
+  const clearedTimers: unknown[] = [];
+  const runtime = {
+    openOrResume: mock(async () => ({
+      terminalId: "term-1",
+      generation: "g1",
+      attachmentId: "att-commit",
+      role: "controller" as const,
+      viewerCount: 1,
+      openKind: "resumed" as const,
+    })),
+    compensateTimedOutOpen,
+    resize: mock(async () => resizeGate),
+    detach,
+  };
+
+  const responses: unknown[] = [];
+  const timers: Array<{ fn: () => void; ms: number }> = [];
+  const done = handleTerminalRequest(
+    runtime as never,
+    {
+      protocolVersion: RELAY_PROTOCOL_VERSION,
+      kind: "req",
+      id: "t-open-commit",
+      type: MSG.terminalOpen,
+      payload: {
+        chatKey: "relay:u1",
+        sessionAlias: "demo",
+        viewerId: "v1",
+        cols: 132,
+        rows: 47,
+      },
+      requestDeadlineAt: 1_050,
+      requestBudgetMs: 50,
+    },
+    (payload) => responses.push(payload),
+    {
+      now: () => 1_000,
+      setTimeoutFn: (fn, ms) => {
+        timers.push({ fn, ms });
+        return timers.length;
+      },
+      clearTimeoutFn: (timer) => {
+        clearedTimers.push(timer);
+      },
+    },
+  );
+
+  // Wait for openOrResume to settle and enter the commit phase.
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // openOrResume resolved before deadline -> commit phase disarmed the timer.
+  expect(clearedTimers).toEqual([1]);
+  expect(responses).toHaveLength(0);
+  // Complete resize
+  releaseResize();
+  await done;
+
+  expect(runtime.resize).toHaveBeenCalledWith("att-commit", "g1", 132, 47);
+  expect(compensateTimedOutOpen).not.toHaveBeenCalled();
+  expect(detach).not.toHaveBeenCalled();
+  expect(responses).toEqual([
+    {
+      terminalId: "term-1",
+      generation: "g1",
+      attachmentId: "att-commit",
+      role: "controller",
+      viewerCount: 1,
+    },
+  ]);
+});
+
 test("late timed-out open strips openKind from successful wire responses", async () => {
   const runtime = {
     openOrResume: mock(async () => ({

--- a/tests/unit/packages/channel-relay/terminal-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/terminal-bridge.test.ts
@@ -286,6 +286,67 @@ test("authoritative resume resize enters commit phase and disarms deadline timer
   ]);
 });
 
+test("openOrResume resolving after deadlineAt but before timer callback is fenced from commit", async () => {
+  const openGate = Promise.withResolvers<unknown>();
+  const compensateTimedOutOpen = mock(async () => {});
+  const resize = mock(async () => {});
+  const runtime = {
+    openOrResume: mock(async () => openGate.promise),
+    compensateTimedOutOpen,
+    resize,
+    detach: mock(() => {}),
+  };
+  let currentTime = 1_000;
+  const timers: Array<{ fn: () => void; ms: number }> = [];
+  const responses: unknown[] = [];
+
+  const done = handleTerminalRequest(
+    runtime as never,
+    {
+      protocolVersion: RELAY_PROTOCOL_VERSION,
+      kind: "req",
+      id: "t-open-deadline-fence",
+      type: MSG.terminalOpen,
+      payload: {
+        chatKey: "relay:u1",
+        sessionAlias: "demo",
+        viewerId: "v1",
+        cols: 132,
+        rows: 47,
+      },
+      requestDeadlineAt: 1_050,
+      requestBudgetMs: 50,
+    },
+    (payload) => responses.push(payload),
+    {
+      now: () => currentTime,
+      setTimeoutFn: (fn, ms) => {
+        timers.push({ fn, ms });
+        return timers.length;
+      },
+    },
+  );
+
+  // Advance clock past deadline (1051 > 1050) WITHOUT firing the timer callback
+  currentTime = 1_051;
+  const result = {
+    terminalId: "term-1",
+    generation: "g1",
+    attachmentId: "att-late",
+    role: "controller" as const,
+    viewerCount: 1,
+    openKind: "resumed" as const,
+  };
+  openGate.resolve(result);
+  await done;
+
+  expect(resize).not.toHaveBeenCalled();
+  expect(compensateTimedOutOpen).toHaveBeenCalledWith(result);
+  expect(responses).toEqual([
+    { error: { code: "timeout", message: `rpc ${MSG.terminalOpen} exceeded request deadline` } },
+  ]);
+});
+
 test("late timed-out open strips openKind from successful wire responses", async () => {
   const runtime = {
     openOrResume: mock(async () => ({

--- a/tests/unit/packages/channel-relay/terminal-bridge.test.ts
+++ b/tests/unit/packages/channel-relay/terminal-bridge.test.ts
@@ -127,6 +127,86 @@ test("late timed-out create compensates via compensateTimedOutOpen", async () =>
   expect(responses).toHaveLength(1);
 });
 
+test("late timed-out resumed controller is compensated without resizing shared pane", async () => {
+  let release!: (value: {
+    terminalId: string;
+    generation: string;
+    attachmentId: string;
+    role: "controller";
+    viewerCount: number;
+    openKind: "resumed";
+  }) => void;
+  const openGate = new Promise<{
+    terminalId: string;
+    generation: string;
+    attachmentId: string;
+    role: "controller";
+    viewerCount: number;
+    openKind: "resumed";
+  }>((resolve) => {
+    release = resolve;
+  });
+  const compensateTimedOutOpen = mock(async () => {});
+  const resize = mock(async () => {});
+  const runtime = {
+    openOrResume: mock(async () => openGate),
+    compensateTimedOutOpen,
+    resize,
+    detach: mock(() => {}),
+  };
+
+  const responses: unknown[] = [];
+  const timers: Array<{ fn: () => void; ms: number }> = [];
+  const done = handleTerminalRequest(
+    runtime as never,
+    {
+      protocolVersion: RELAY_PROTOCOL_VERSION,
+      kind: "req",
+      id: "t-open-late-resume",
+      type: MSG.terminalOpen,
+      payload: {
+        chatKey: "relay:u1",
+        sessionAlias: "demo",
+        viewerId: "v1",
+        cols: 132,
+        rows: 47,
+      },
+      requestDeadlineAt: 1_050,
+      requestBudgetMs: 50,
+    },
+    (payload) => responses.push(payload),
+    {
+      now: () => 1_000,
+      setTimeoutFn: (fn, ms) => {
+        timers.push({ fn, ms });
+        return timers.length;
+      },
+      clearTimeoutFn: () => {},
+    },
+  );
+
+  expect(timers).toHaveLength(1);
+  timers[0]!.fn();
+  expect(responses).toEqual([
+    expect.objectContaining({ error: expect.objectContaining({ code: "timeout" }) }),
+  ]);
+
+  const result = {
+    terminalId: "term-1",
+    generation: "g1",
+    attachmentId: "att-late",
+    role: "controller" as const,
+    viewerCount: 1,
+    openKind: "resumed" as const,
+  };
+  release(result);
+  await done;
+
+  expect(resize).not.toHaveBeenCalled();
+  expect(compensateTimedOutOpen).toHaveBeenCalledWith(result);
+  expect(responses).toHaveLength(1);
+});
+
 test("late timed-out open strips openKind from successful wire responses", async () => {
   const runtime = {
     openOrResume: mock(async () => ({


### PR DESCRIPTION
## Summary

Fix relay-web terminals whose TUI only occupies the upper-left portion of a large browser terminal because the backend RMUX/PTY can remain at the xterm bootstrap size (`80x24`).

The root problem is geometry ownership, not CSS. `TerminalTab` constructed xterm at `80x24` and immediately sent `currentAdapter.cols()/rows()` in `terminal-open` before xterm.js, its stylesheet, and the terminal font were ready. The browser later fit its local xterm grid to the host, but the real PTY had already been created at `80x24`; a later fire-and-forget resize was the only repair path. Resume was worse: the existing-pane path ignored the browser's requested geometry entirely.

This change makes browser geometry authoritative at the open boundary:

- wait for the xterm adapter to be ready and derive the real host-fit grid before sending `terminal-open`;
- gate `TerminalTab` initial open on `active` state so background or restored tabs in `DashboardView` do not open at `80x24` when unmeasurable (host-fit open is deferred until the tab becomes visible);
- create new RMUX panes at that measured browser geometry instead of the `80x24` renderer bootstrap size;
- when reopening an existing pane, a controller attachment synchronously resizes the durable RMUX pane to the requested geometry **before** `terminal-open` succeeds;
- if that authoritative resume resize fails, roll back the unpublished attachment and fail the open instead of returning a terminal whose local and backend geometries disagree;
- fence late `terminal-open` with real clock check (`deadlineAt`) before committing authoritative resize or publish;
- track authoritative `terminal-rebase-start` geometry in `syncedResize` so late rebases reset belief and allow host-fit corrective resizes;
- spectators never resize the shared pane;
- keep the existing post-open viewport settling and live-resize behavior unchanged.

## Why this fixes the reported Windows symptom

Previously the browser could display a large xterm surface while the PTY/TUI still believed it was roughly `80x24`, so full-screen apps and prompts only redrew a small region. The new create path gives the PTY the fitted browser size from birth, and the resume path converges an existing controller pane before the browser is told the open succeeded.

## Regression coverage

- **Initial open geometry**: Relay Web Playwright asserts the initial `terminal-open` dimensions equal the final fitted xterm grid and are not the `80x24` bootstrap size.
- **Active tab gating**: `terminal-tab.test.ts` & `dashboard-center-tabs.test.ts` prove hidden/restored tabs with `active=false` do not open at `80x24`, open on activation with real host geometry, and stay warm across tab switches.
- **Authoritative open & fence**: Connector request tests prove:
  - resumed controllers resize to the requested geometry before the open response;
  - resumed spectators do not resize the shared pane;
  - `openOrResume` resolving after `deadlineAt` is fenced from committing resize/publish;
  - a failed authoritative resume resize detaches the unpublished attachment and fails the request.
- **Authoritative rebase belief**: `terminal-store.test.ts` & `terminal-viewport.spec.ts` prove `terminal-rebase-start` updates `syncedResize` so subsequent `forceSync` re-sends host geometry without dedupe suppression.
- **Platform smoke**: The production platform-package RMUX smoke creates at `132x47` (asserting initial recovery rebase is `132x47`), then resizes to `111x39` (asserting fresh recovery rebase is `111x39`), under a hostile PATH environment. Used by both Linux and Windows CI.

## Scope

This PR fixes the initial/create and resume geometry contract so correctness no longer depends on a later resize event repairing an incorrectly sized PTY. It intentionally does not redesign the existing live post-open resize event into a request/ack protocol; that path remains useful for subsequent browser window changes, but initial correctness no longer relies on it.

## Test plan

- [x] Repository/unit/build CI (`test` job passed)
- [x] Relay Web Chromium desktop + mobile terminal E2E (`Relay Web terminal E2E` passed)
- [x] Windows terminal/RMUX CI (`terminal-windows` + `terminal-rmux-windows` passed)
- [x] Production platform-package real RMUX create + resize smoke on release workflow (`rmux-bridge` passed)