### PR TITLE
fix(presentation): anchor sent agent-message cards via machine tool identity + versioned receipt marker

### DIFF
--- a/packages/channel-relay/src/tool-presentation.ts
+++ b/packages/channel-relay/src/tool-presentation.ts
@@ -124,11 +124,18 @@ function agentReceiptMessageId(v: unknown): string | undefined {
   return typeof r.status === "string" && AGENT_RECEIPT_STATUSES[r.status] === true ? messageId : undefined;
 }
 
+/** Versioned machine-readable receipt marker appended to agent_send's text
+ *  result (see src/mcp/xacpx-mcp-tools.ts). Parsed ONLY after the tool has been
+ *  identified as agent_send via its machine tool identity — never regex-scraped
+ *  out of arbitrary display text. */
+const AGENT_SEND_RECEIPT_MARKER_RE = /xacpx-agent-send-receipt:v1 (\{[^\n]*\})/;
+
 /** Extract the Agent Messaging receipt messageId from an agent_send tool event.
  * Structured shapes only: MCP structuredContent, a receipt-shaped rawOutput, a
- * JSON-RPC result envelope, or a single content text block that JSON-parses to
- * a receipt. The human display line ("Peer message msg_… accepted…") is never
- * parsed. Pure and total: malformed input yields undefined, never an exception. */
+ * JSON-RPC result envelope, a single content text block that JSON-parses to a
+ * receipt, or the versioned xacpx receipt marker inside a text block. The human
+ * display line ("Peer message msg_… accepted…") is never parsed. Pure and
+ * total: malformed input yields undefined, never an exception. */
 function extractAgentMessageId(event: ToolUseEvent): string | undefined {
   const output = rec(event.rawOutput);
   // Host preserved the MCP tool result's structured output.
@@ -138,14 +145,40 @@ function extractAgentMessageId(event: ToolUseEvent): string | undefined {
   const result = rec(output.result);
   const enveloped = agentReceiptMessageId(result.structuredContent) ?? agentReceiptMessageId(result);
   if (enveloped) return enveloped;
-  // Host stringified the MCP result into a single text block.
+  // Host stringified the MCP result into text blocks: whole-block JSON first,
+  // then the versioned marker line (adapters that keep the human line + marker
+  // in one block, or drop structuredContent entirely).
   const blocks = blocksOf(event.content);
   const block = blocks[0];
   if (block && block.type === "text" && typeof block.text === "string") {
     try {
       return agentReceiptMessageId(JSON.parse(block.text));
     } catch {
-      // not JSON (e.g. the human display line) — nothing structured to read
+      // not JSON — fall through to the marker scan
+    }
+    const marker = block.text.match(AGENT_SEND_RECEIPT_MARKER_RE);
+    if (marker?.[1]) {
+      try {
+        return agentReceiptMessageId(JSON.parse(marker[1]));
+      } catch {
+        // malformed marker payload — nothing structured to read
+      }
+    }
+  }
+  // Adapter kept no content blocks but passed the MCP text through as a bare
+  // rawOutput string (or an output/text field) — same versioned marker scan.
+  const rawText =
+    typeof event.rawOutput === "string"
+      ? event.rawOutput
+      : (asString(output.output) ?? asString(output.text));
+  if (rawText !== undefined) {
+    const marker = rawText.match(AGENT_SEND_RECEIPT_MARKER_RE);
+    if (marker?.[1]) {
+      try {
+        return agentReceiptMessageId(JSON.parse(marker[1]));
+      } catch {
+        // malformed marker payload — nothing structured to read
+      }
     }
   }
   return undefined;
@@ -176,8 +209,13 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
   // Agent Messaging correlation: only the agent_send tool (bare or MCP-qualified
   // as mcp__xacpx__agent_send — tight suffix match, no fuzzy contains) and only
   // a valid structured receipt may anchor a messageId to the step.
+  // Protocol identity is the MACHINE tool name when the driver exposed one
+  // (Claude `_meta.claudeCode.toolName`, Qoder, Cursor `_toolName`); the ACP
+  // display title in `toolName` is a human phrase ("Send peer message…") and is
+  // only consulted as a fallback for drivers without machine names (Codex).
+  const toolIdentity = event.machineToolName ?? event.toolName;
   const agentMessageId =
-    event.toolName === "agent_send" || /__?agent_send$/.test(event.toolName)
+    toolIdentity === "agent_send" || /__?agent_send$/.test(toolIdentity)
       ? extractAgentMessageId(event)
       : undefined;
   const base: Omit<ToolStepDto, "title" | "detail"> = {

--- a/packages/channel-relay/src/tool-presentation.ts
+++ b/packages/channel-relay/src/tool-presentation.ts
@@ -148,22 +148,19 @@ function extractAgentMessageId(event: ToolUseEvent): string | undefined {
   // Host stringified the MCP result into text blocks: whole-block JSON first,
   // then the versioned marker line (adapters that keep the human line + marker
   // in one block, or drop structuredContent entirely).
-  const blocks = blocksOf(event.content);
-  const block = blocks[0];
-  if (block && block.type === "text" && typeof block.text === "string") {
-    try {
-      return agentReceiptMessageId(JSON.parse(block.text));
-    } catch {
-      // not JSON — fall through to the marker scan
-    }
-    const marker = block.text.match(AGENT_SEND_RECEIPT_MARKER_RE);
-    if (marker?.[1]) {
-      try {
-        return agentReceiptMessageId(JSON.parse(marker[1]));
-      } catch {
-        // malformed marker payload — nothing structured to read
-      }
-    }
+  const blockReceipt = textBlockOf(blocksOf(event.content)[0] ?? {});
+  if (blockReceipt) {
+    const found = receiptFromText(blockReceipt.text);
+    if (found) return found;
+  }
+  // codex-acp wraps the MCP CallToolResult as rawOutput.result and keeps the
+  // text blocks (with the versioned marker) inside result.content — scanned
+  // with the same structured-shape rules, never display-text scraping.
+  for (const block of blocksOf(result.content)) {
+    const tb = textBlockOf(block);
+    if (!tb) continue;
+    const found = receiptFromText(tb.text);
+    if (found) return found;
   }
   // Adapter kept no content blocks but passed the MCP text through as a bare
   // rawOutput string (or an output/text field) — same versioned marker scan.
@@ -172,13 +169,36 @@ function extractAgentMessageId(event: ToolUseEvent): string | undefined {
       ? event.rawOutput
       : (asString(output.output) ?? asString(output.text));
   if (rawText !== undefined) {
-    const marker = rawText.match(AGENT_SEND_RECEIPT_MARKER_RE);
-    if (marker?.[1]) {
-      try {
-        return agentReceiptMessageId(JSON.parse(marker[1]));
-      } catch {
-        // malformed marker payload — nothing structured to read
-      }
+    const found = receiptFromText(rawText);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/** A text content block that can be probed for a structured receipt. */
+function textBlockOf(
+  block: Record<string, unknown>,
+): { text: string } | undefined {
+  return block && block.type === "text" && typeof block.text === "string"
+    ? { text: block.text }
+    : undefined;
+}
+
+/** Receipt from one text surface: whole-block JSON, else the versioned marker
+ *  line. Returns undefined for anything else (incl. the human display line). */
+function receiptFromText(text: string): string | undefined {
+  try {
+    const direct = agentReceiptMessageId(JSON.parse(text));
+    if (direct) return direct;
+  } catch {
+    // not JSON — fall through to the marker scan
+  }
+  const marker = text.match(AGENT_SEND_RECEIPT_MARKER_RE);
+  if (marker?.[1]) {
+    try {
+      return agentReceiptMessageId(JSON.parse(marker[1]));
+    } catch {
+      // malformed marker payload — nothing structured to read
     }
   }
   return undefined;

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -519,6 +519,37 @@ describe("MessageList", () => {
     expect(anchored.element.compareDocumentPosition(mds[2]!.element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it("late-joins the anchored card when the terminal step arrives after the standalone row (running → receipt update, same toolCallId)", async () => {
+    // The transport seam reality: while the MCP agent_send call is in flight the
+    // step is running with NO agentMessageId, so the sent card renders standalone.
+    const runningStep = { ...sendStep("send-late"), status: "running" as const, agentMessageId: undefined };
+    const runningTurn = msg({
+      direction: "out",
+      text: "running",
+      status: "streaming",
+      structured: { parts: [{ type: "tool", step: runningStep }] },
+    });
+    const wrapper = mount(MessageList, {
+      props: { messages: [runningTurn, sentCard("m1")], liveTurn: null },
+    });
+    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
+    // Standalone row is visible BEFORE correlation exists.
+    expect(wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]').exists()).toBe(false);
+
+    // The sparse terminal update replaces the running step with one carrying
+    // agentMessageId (upsertTool semantics) — the standalone row must be
+    // suppressed and the card re-anchored after the exact toolCallId.
+    await wrapper.setProps({
+      messages: [turnWithSend("m1"), sentCard("m1")],
+    });
+    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
+    const anchored = wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]');
+    expect(anchored.exists()).toBe(true);
+    const tool = wrapper.find('[data-test="tool-step-card"]');
+    expect(tool.exists()).toBe(true);
+    expect(tool.element.compareDocumentPosition(anchored.element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it("keeps a received card standalone even when a turn step references its message id (Gate B)", () => {
     const wrapper = mount(MessageList, {
       props: {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -254,8 +254,17 @@ export interface ToolUseEvent {
   parentToolCallId?: string;
   /** This tool call represents a delegated subagent task rather than an ordinary tool. */
   isSubagent?: boolean;
-  /** Free-form tool name from the agent (e.g. "Read File", "Bash"). */
+  /** Free-form tool name from the agent (e.g. "Read File", "Bash"). This is the
+   *  ACP DISPLAY title — a human phrase, not a stable protocol identity, and may
+   *  differ from the underlying machine tool name on every driver. Presentation
+   *  only; NEVER use for protocol/tool-identity decisions (see machineToolName). */
   toolName: string;
+  /** Stable machine tool name extracted from provider metadata (Claude
+   *  `_meta.claudeCode.toolName`, Qoder `_meta.qoder.toolName`, Cursor
+   *  `rawInput._toolName`). Absent when the driver exposes none (e.g. Codex).
+   *  This is the ONLY field protocol-level tool identification (agent_send
+   *  correlation) may match on when present. */
+  machineToolName?: string;
   /** Coarse classifier produced by the transport from the agent's tool kind; channels use it to pick an icon. */
   kind: ToolUseKind;
   /** Best-effort one-line summary derived from `rawInput`. */

--- a/src/mcp/xacpx-mcp-tools.ts
+++ b/src/mcp/xacpx-mcp-tools.ts
@@ -584,8 +584,17 @@ export function buildXacpxMcpToolRegistry(input: {
             completionHint =
               " xacpx will return the peer's final result to this session when it completes. Do not poll or send acknowledgement messages.";
           }
+          // Machine-readable receipt marker (v0.3 presentation correlation):
+          // some ACP adapters drop MCP structuredContent and only forward text,
+          // so the human line alone is not a durable correlation source. The
+          // marker is versioned JSON and parsed ONLY by hosts that have already
+          // identified the tool as agent_send via its machine tool name.
+          const receiptMarker = `xacpx-agent-send-receipt:v1 ${JSON.stringify({
+            messageId: receipt.messageId,
+            status: receipt.status,
+          })}`;
           return createSuccessResult(
-            `Peer message ${receipt.messageId} accepted with status=${receipt.status}${receipt.modeUsed ? ` via ${receipt.modeUsed}` : ""}.${completionHint}`,
+            `Peer message ${receipt.messageId} accepted with status=${receipt.status}${receipt.modeUsed ? ` via ${receipt.modeUsed}` : ""}.${completionHint}\n${receiptMarker}`,
             receipt,
           );
         }),

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -525,7 +525,8 @@ function buildToolUseEvent(
   const machineToolName =
     (isClaudeDriver ? update._meta?.claudeCode?.toolName?.trim() : "") ||
     (driver === "qoder" ? update._meta?.qoder?.toolName?.trim() : "") ||
-    machineToolNameFromCursorInput(update.rawInput) ||
+    (driver === "codex" ? codexMcpMachineToolName(update.rawInput) : "") ||
+    (driver === "cursor" ? machineToolNameFromCursorInput(update.rawInput) : "") ||
     undefined;
   const parentToolCallId = claudeMeta?.parentToolUseId?.trim() || update.parentToolCallId?.trim();
   const isSubagent = (claudeMeta?.toolName === "Agent")
@@ -551,6 +552,20 @@ function buildToolUseEvent(
 
 /** Internal marker cursor-agent injects into `rawInput` to name the tool. */
 export const CURSOR_TOOL_NAME_KEY = "_toolName";
+
+/** Codex-acp reports MCP calls as `title: mcp.<server>.<tool>` with
+ *  `rawInput: {server, tool, arguments}` — the stable machine identity is the
+ *  tool field, NOT the dotted display title (see @agentclientprotocol/codex-acp
+ *  createMcpToolCallUpdate). Returns "" for non-MCP codex calls (their title is
+ *  already the machine name and needs no separate identity). */
+function codexMcpMachineToolName(rawInput: unknown): string {
+  if (!isRecord(rawInput)) return "";
+  const server = rawInput.server;
+  const tool = rawInput.tool;
+  if (typeof server !== "string" || server.trim().length === 0) return "";
+  if (typeof tool !== "string" || tool.trim().length === 0) return "";
+  return tool.trim();
+}
 
 /** Cursor's stable machine tool name, when the rawInput marker carries one. */
 function machineToolNameFromCursorInput(rawInput: unknown): string | undefined {

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -517,6 +517,16 @@ function buildToolUseEvent(
   const content = update.content;
   const rawOutput = update.rawOutput ?? claudeToolResponse;
   const locations = update.locations;
+  // Stable machine tool identity for protocol decisions (agent_send correlation):
+  // the ACP `title` is a DISPLAY phrase ("Send peer message…"), not the tool name.
+  // Providers stamp the real machine name in their own metadata namespaces:
+  // Claude Code `_meta.claudeCode.toolName` (e.g. "mcp__xacpx__agent_send"),
+  // Qoder `_meta.qoder.toolName`, Cursor a `_toolName` marker in rawInput.
+  const machineToolName =
+    (isClaudeDriver ? update._meta?.claudeCode?.toolName?.trim() : "") ||
+    (driver === "qoder" ? update._meta?.qoder?.toolName?.trim() : "") ||
+    machineToolNameFromCursorInput(update.rawInput) ||
+    undefined;
   const parentToolCallId = claudeMeta?.parentToolUseId?.trim() || update.parentToolCallId?.trim();
   const isSubagent = (claudeMeta?.toolName === "Agent")
     || (driver === "qoder" && update._meta?.qoder?.toolName === "Agent")
@@ -528,6 +538,7 @@ function buildToolUseEvent(
     ...(parentToolCallId ? { parentToolCallId } : {}),
     ...(isSubagent ? { isSubagent: true } : {}),
     toolName,
+    ...(machineToolName ? { machineToolName } : {}),
     kind,
     ...(summary ? { summary } : {}),
     ...(rawInput !== undefined ? { rawInput } : {}),
@@ -540,6 +551,15 @@ function buildToolUseEvent(
 
 /** Internal marker cursor-agent injects into `rawInput` to name the tool. */
 export const CURSOR_TOOL_NAME_KEY = "_toolName";
+
+/** Cursor's stable machine tool name, when the rawInput marker carries one. */
+function machineToolNameFromCursorInput(rawInput: unknown): string | undefined {
+  if (!isRecord(rawInput)) return undefined;
+  const declared = rawInput[CURSOR_TOOL_NAME_KEY];
+  if (typeof declared !== "string") return undefined;
+  const trimmed = declared.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
 
 const CURSOR_PLAN_TOOL_NAMES = new Set([
   "todowrite", "createplan", "updateplan", "plan", "updatetodos", "todoread",

--- a/tests/unit/mcp/xacpx-mcp-tools.test.ts
+++ b/tests/unit/mcp/xacpx-mcp-tools.test.ts
@@ -1347,6 +1347,7 @@ test("agent_send returns tailored success text for none, notify, and result comp
     coordinatorSession: "backend:main",
   });
   const sendTool = registry.find((tool) => tool.name === "agent_send");
+  const marker = `\nxacpx-agent-send-receipt:v1 ${JSON.stringify({ messageId: receipt.messageId, status: receipt.status })}`;
 
   // none / unset
   const resNone = await sendTool?.handler({
@@ -1354,7 +1355,7 @@ test("agent_send returns tailored success text for none, notify, and result comp
     message: "msg",
   });
   expect(resNone && "content" in resNone ? resNone.content[0]?.text : "").toBe(
-    "Peer message msg-123 accepted with status=queued.",
+    `Peer message msg-123 accepted with status=queued.${marker}`,
   );
 
   // notify
@@ -1364,7 +1365,7 @@ test("agent_send returns tailored success text for none, notify, and result comp
     completion: "notify",
   });
   expect(resNotify && "content" in resNotify ? resNotify.content[0]?.text : "").toBe(
-    "Peer message msg-123 accepted with status=queued. xacpx will notify this session when the peer turn completes. Do not poll or send acknowledgement messages.",
+    `Peer message msg-123 accepted with status=queued. xacpx will notify this session when the peer turn completes. Do not poll or send acknowledgement messages.${marker}`,
   );
 
   // result
@@ -1374,6 +1375,6 @@ test("agent_send returns tailored success text for none, notify, and result comp
     completion: "result",
   });
   expect(resResult && "content" in resResult ? resResult.content[0]?.text : "").toBe(
-    "Peer message msg-123 accepted with status=queued. xacpx will return the peer's final result to this session when it completes. Do not poll or send acknowledgement messages.",
+    `Peer message msg-123 accepted with status=queued. xacpx will return the peer's final result to this session when it completes. Do not poll or send acknowledgement messages.${marker}`,
   );
 });

--- a/tests/unit/packages/channel-relay/agent-send-anchoring-seam.test.ts
+++ b/tests/unit/packages/channel-relay/agent-send-anchoring-seam.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Real-seam anchoring gate for Agent Messaging v0.3 presentation correlation.
+ *
+ * Regression: in production the sent agent-message card rendered as a standalone
+ * row at the TOP of the transcript because the correlation join never fired —
+ * ToolUseEvent.toolName carries the ACP DISPLAY title (e.g. "Send peer message
+ * to Worker B"), not the MCP machine tool name, so the agent_send branch in
+ * tool-presentation never executed. The prior unit tests hand-forged
+ * toolName:"agent_send" and bypassed the transport seam entirely.
+ *
+ * This gate chains the REAL components:
+ *
+ *   real xacpx MCP server (InMemoryTransport) → agent_send CallToolResult
+ *   → representative ACP tool_call / tool_call_update frames per driver
+ *   → createStreamingPromptState → ToolUseEvent
+ *   → toolUseEventToStepDto → step.agentMessageId === receipt.messageId
+ *
+ * Drivers covered: Claude (machine name in _meta.claudeCode.toolName, receipt in
+ * toolResponse) and Codex (no machine name; title carries the tool name; the
+ * adapter dropped structuredContent and only forwarded text — recovered via the
+ * versioned receipt marker).
+ */
+import { expect, test } from "bun:test";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import {
+  createStreamingPromptState,
+  parseStreamingChunks,
+} from "../../../../src/transport/streaming-prompt";
+import type { ToolUseEvent } from "../../../../src/channels/types";
+import { createXacpxMcpServer } from "../../../../src/mcp/xacpx-mcp-server";
+import { createMemoryTransport } from "../../../../src/mcp/xacpx-mcp-transport";
+import { toolUseEventToStepDto } from "../../../../packages/channel-relay/src/tool-presentation";
+
+const RECEIPT = {
+  messageId: "msg_seam_1",
+  status: "queued" as const,
+  modeUsed: "queue" as const,
+  route: "local" as const,
+};
+
+/** Real MCP agent_send result through the actual server + SDK client. */
+async function callRealAgentSend(): Promise<{
+  structuredContent: unknown;
+  text: string;
+}> {
+  const server = createXacpxMcpServer({
+    transport: createMemoryTransport(async () => null, {
+      sendAgentMessage: async () => RECEIPT,
+    }),
+    coordinatorSession: "backend:main",
+  });
+  const client = new Client({ name: "seam-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const result = (await client.callTool({
+      name: "agent_send",
+      arguments: { to: "agent:node-local:endpoint-peer", message: "ping" },
+    })) as unknown as {
+      structuredContent?: unknown;
+      content?: Array<{ type: string; text?: string }>;
+    };
+    return {
+      structuredContent: result.structuredContent,
+      text: result.content?.find((b) => b.type === "text")?.text ?? "",
+    };
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+/** Drive ACP session/update frames through the real streaming-prompt state. */
+function streamAcpFrames(
+  driver: string | undefined,
+  frames: Array<Record<string, unknown>>,
+): ToolUseEvent[] {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, {
+    driver,
+    onToolEvent: (e) => {
+      events.push(e);
+    },
+  });
+  for (const update of frames) {
+    parseStreamingChunks(
+      state,
+      JSON.stringify({ method: "session/update", params: { update } }),
+    );
+  }
+  return events;
+}
+
+test("real MCP agent_send result carries structuredContent AND the versioned text marker", async () => {
+  const result = await callRealAgentSend();
+  expect(result.structuredContent).toEqual(RECEIPT);
+  const marker = result.text.match(/xacpx-agent-send-receipt:v1 (\{[^\n]*\})/);
+  expect(marker?.[1]).toBeDefined();
+  expect(JSON.parse(marker![1]!)).toEqual({
+    messageId: RECEIPT.messageId,
+    status: RECEIPT.status,
+  });
+});
+
+test("Claude seam: display title ≠ agent_send, machine name in _meta.claudeCode.toolName — step still anchors", async () => {
+  const result = await callRealAgentSend();
+  const events = streamAcpFrames(undefined, [
+    {
+      sessionUpdate: "tool_call",
+      toolCallId: "toolu_as_1",
+      kind: "other",
+      // Display title is a human phrase — this is what broke production.
+      title: "Send peer message to Worker B",
+      rawInput: { to: "agent:node-local:endpoint-peer", message: "ping" },
+      status: "pending",
+      _meta: { claudeCode: { toolName: "mcp__xacpx__agent_send" } },
+    },
+    {
+      // Sparse terminal frame: claude-agent-acp delivers the MCP result via
+      // toolResponse with status omitted.
+      sessionUpdate: "tool_call_update",
+      toolCallId: "toolu_as_1",
+      _meta: {
+        claudeCode: {
+          toolName: "mcp__xacpx__agent_send",
+          toolResponse: result.structuredContent,
+        },
+      },
+    },
+  ]);
+
+  const terminal = events.at(-1)!;
+  expect(terminal.toolName).toBe("Send peer message to Worker B"); // display stays display
+  expect(terminal.machineToolName).toBe("mcp__xacpx__agent_send");
+  expect(terminal.status).toBe("success");
+
+  const step = toolUseEventToStepDto(terminal);
+  expect(step.agentMessageId).toBe(RECEIPT.messageId);
+});
+
+test("Codex seam: no machine name, structuredContent dropped — display title + versioned text marker still anchors", async () => {
+  const result = await callRealAgentSend();
+  const events = streamAcpFrames("codex", [
+    {
+      sessionUpdate: "tool_call",
+      toolCallId: "call_as_1",
+      kind: "other",
+      // Codex presents the MCP tool BY NAME in the title and forwards only the
+      // text content (structuredContent lost across the adapter).
+      title: "agent_send",
+      rawInput: { to: "agent:node-local:endpoint-peer", message: "ping" },
+      status: "pending",
+    },
+    {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call_as_1",
+      status: "completed",
+      rawOutput: result.text,
+    },
+  ]);
+
+  const terminal = events.at(-1)!;
+  expect(terminal.machineToolName).toBeUndefined();
+  expect(terminal.status).toBe("success");
+
+  const step = toolUseEventToStepDto(terminal);
+  expect(step.agentMessageId).toBe(RECEIPT.messageId);
+});
+
+test("late-join regression: running frame (no receipt) → sparse terminal frame (receipt) gains agentMessageId on the same toolCallId", async () => {
+  const result = await callRealAgentSend();
+  // ONE state across both frames — the turn is running when the receipt lands.
+  const collected: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, {
+    driver: undefined,
+    onToolEvent: (e) => {
+      collected.push(e);
+    },
+  });
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(
+      state,
+      JSON.stringify({ method: "session/update", params: { update } }),
+    );
+
+  send({
+    sessionUpdate: "tool_call",
+    toolCallId: "toolu_as_late",
+    kind: "other",
+    title: "Send peer message to Worker B",
+    rawInput: { to: "agent:node-local:endpoint-peer", message: "ping" },
+    status: "pending",
+    _meta: { claudeCode: { toolName: "mcp__xacpx__agent_send" } },
+  });
+  // While the MCP call is in flight there is no receipt yet.
+  const running = toolUseEventToStepDto(collected.at(-1)!);
+  expect(running.status).toBe("running");
+  expect(running.agentMessageId).toBeUndefined();
+
+  // The sparse terminal update lands with the receipt — the SAME toolCallId
+  // replaces the running step and must now carry agentMessageId.
+  send({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "toolu_as_late",
+    _meta: {
+      claudeCode: {
+        toolName: "mcp__xacpx__agent_send",
+        toolResponse: result.structuredContent,
+      },
+    },
+  });
+  const terminalStep = toolUseEventToStepDto(collected.at(-1)!);
+  expect(terminalStep.toolCallId).toBe("toolu_as_late");
+  expect(terminalStep.agentMessageId).toBe(RECEIPT.messageId);
+});
+
+test("a display title that merely MENTIONS agent_send never correlates when the machine name says otherwise", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "t",
+    toolName: "Call agent_send for updates",
+    machineToolName: "WebSearch",
+    kind: "other",
+    status: "success",
+    rawOutput: {
+      structuredContent: { messageId: RECEIPT.messageId, status: "queued" },
+    },
+  });
+  expect(step.agentMessageId).toBeUndefined();
+});

--- a/tests/unit/packages/channel-relay/agent-send-anchoring-seam.test.ts
+++ b/tests/unit/packages/channel-relay/agent-send-anchoring-seam.test.ts
@@ -142,32 +142,99 @@ test("Claude seam: display title ≠ agent_send, machine name in _meta.claudeCod
   expect(step.agentMessageId).toBe(RECEIPT.messageId);
 });
 
-test("Codex seam: no machine name, structuredContent dropped — display title + versioned text marker still anchors", async () => {
+test("Codex seam (real codex-acp shape): title mcp.server.tool, rawInput {server,tool}, receipt under rawOutput.result — anchors via structuredContent", async () => {
   const result = await callRealAgentSend();
+  // Exact codex-acp createMcpToolCallUpdate frame shape (verified against
+  // @agentclientprotocol/codex-acp): title `mcp.${server}.${tool}`,
+  // rawInput {server, tool, arguments}, rawOutput {result, error},
+  // _meta {is_mcp_tool_call: true}.
   const events = streamAcpFrames("codex", [
     {
       sessionUpdate: "tool_call",
       toolCallId: "call_as_1",
       kind: "other",
-      // Codex presents the MCP tool BY NAME in the title and forwards only the
-      // text content (structuredContent lost across the adapter).
-      title: "agent_send",
-      rawInput: { to: "agent:node-local:endpoint-peer", message: "ping" },
+      title: "mcp.xacpx.agent_send",
+      rawInput: {
+        server: "xacpx",
+        tool: "agent_send",
+        arguments: { to: "agent:node-local:endpoint-peer", message: "ping" },
+      },
       status: "pending",
+      _meta: { is_mcp_tool_call: true },
     },
     {
       sessionUpdate: "tool_call_update",
       toolCallId: "call_as_1",
       status: "completed",
-      rawOutput: result.text,
+      rawOutput: {
+        result: {
+          content: [{ type: "text", text: result.text }],
+          structuredContent: result.structuredContent,
+        },
+        error: null,
+      },
+      _meta: { is_mcp_tool_call: true },
     },
   ]);
 
   const terminal = events.at(-1)!;
-  expect(terminal.machineToolName).toBeUndefined();
+  // Display title is the dotted mcp.server.tool phrase — it must NOT match the
+  // agent_send correlation on its own.
+  expect(terminal.toolName).toBe("mcp.xacpx.agent_send");
+  // The stable identity comes from rawInput.tool.
+  expect(terminal.machineToolName).toBe("agent_send");
   expect(terminal.status).toBe("success");
 
   const step = toolUseEventToStepDto(terminal);
+  expect(step.agentMessageId).toBe(RECEIPT.messageId);
+});
+
+test("Codex seam, structuredContent dropped: the versioned marker under rawOutput.result.content anchors", async () => {
+  const result = await callRealAgentSend();
+  const events = streamAcpFrames("codex", [
+    {
+      sessionUpdate: "tool_call",
+      toolCallId: "call_as_2",
+      kind: "other",
+      title: "mcp.xacpx.agent_send",
+      rawInput: { server: "xacpx", tool: "agent_send", arguments: { to: "agent:node-local:endpoint-peer", message: "ping" } },
+      status: "pending",
+      _meta: { is_mcp_tool_call: true },
+    },
+    {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call_as_2",
+      status: "completed",
+      // Adapter variant that drops structuredContent: only the text content
+      // survives inside result.content, carrying the versioned marker.
+      rawOutput: {
+        result: { content: [{ type: "text", text: result.text }] },
+        error: null,
+      },
+      _meta: { is_mcp_tool_call: true },
+    },
+  ]);
+
+  const step = toolUseEventToStepDto(events.at(-1)!);
+  expect(step.agentMessageId).toBe(RECEIPT.messageId);
+});
+
+test("Codex non-MCP tools (title is the machine name) keep bare-name correlation", async () => {
+  const result = await callRealAgentSend();
+  const events = streamAcpFrames("codex", [
+    {
+      sessionUpdate: "tool_call",
+      toolCallId: "call_as_3",
+      kind: "other",
+      // Dynamic (non-MCP) codex tools report the bare tool name as title and
+      // no {server,tool} rawInput — display fallback stays valid.
+      title: "agent_send",
+      rawInput: { arguments: { to: "agent:node-local:endpoint-peer", message: "ping" } },
+      status: "completed",
+      rawOutput: { result: { content: [{ type: "text", text: result.text }] }, error: null },
+    },
+  ]);
+  const step = toolUseEventToStepDto(events.at(-1)!);
   expect(step.agentMessageId).toBe(RECEIPT.messageId);
 });
 

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -459,6 +459,45 @@ test("qoder and cursor machine tool names are extracted from their metadata name
     }),
   ).toMatchObject({ machineToolName: "mcp__xacpx__agent_send" });
 
+  // The `_toolName` rawInput marker is a cursor-agent convention — it must not
+  // be trusted from other drivers.
+  expect(
+    (collect("codex", {
+      sessionUpdate: "tool_call",
+      toolCallId: "c2",
+      kind: "other",
+      title: "Send message",
+      rawInput: { _toolName: "mcp__xacpx__agent_send", to: "agent:node_2:endpoint_b" },
+      status: "pending",
+    }) as Partial<ToolUseEvent>).machineToolName,
+  ).toBeUndefined();
+
+  // codex MCP calls: title is `mcp.<server>.<tool>` (display), rawInput
+  // {server, tool, arguments} carries the stable identity.
+  expect(
+    collect("codex", {
+      sessionUpdate: "tool_call",
+      toolCallId: "cx1",
+      kind: "other",
+      title: "mcp.xacpx.agent_send",
+      rawInput: { server: "xacpx", tool: "agent_send", arguments: { to: "agent:node_2:endpoint_b" } },
+      status: "pending",
+      _meta: { is_mcp_tool_call: true },
+    }),
+  ).toMatchObject({ machineToolName: "agent_send", toolName: "mcp.xacpx.agent_send" });
+
+  // codex non-MCP calls (no {server,tool} rawInput) expose no machine name.
+  expect(
+    (collect("codex", {
+      sessionUpdate: "tool_call",
+      toolCallId: "cx2",
+      kind: "other",
+      title: "agent_send",
+      rawInput: { arguments: { to: "agent:node_2:endpoint_b" } },
+      status: "pending",
+    }) as Partial<ToolUseEvent>).machineToolName,
+  ).toBeUndefined();
+
   // No provider metadata → no machine name (display title alone must not be
   // mistaken for one).
   expect(

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -392,6 +392,95 @@ test("Claude sparse toolResponse update is terminal even when status is omitted"
   });
 });
 
+test("machine tool identity survives Claude display titles and sparse updates (agent_send correlation seam)", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, { onToolEvent: (e) => { events.push(e); } });
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+
+  send({
+    sessionUpdate: "tool_call",
+    toolCallId: "as-1",
+    kind: "other",
+    title: "Send peer message to Worker B",
+    rawInput: { to: "agent:node_2:endpoint_b", message: "ping" },
+    status: "pending",
+    _meta: { claudeCode: { toolName: "mcp__xacpx__agent_send" } },
+  });
+  send({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "as-1",
+    _meta: {
+      claudeCode: {
+        toolName: "mcp__xacpx__agent_send",
+        toolResponse: { messageId: "msg_1", status: "queued" },
+      },
+    },
+  });
+
+  expect(events.at(-1)).toMatchObject({
+    toolCallId: "as-1",
+    // Display title stays a display title — presentation only.
+    toolName: "Send peer message to Worker B",
+    // The stable machine identity is carried separately.
+    machineToolName: "mcp__xacpx__agent_send",
+    status: "success",
+    rawOutput: { messageId: "msg_1", status: "queued" },
+  });
+});
+
+test("qoder and cursor machine tool names are extracted from their metadata namespaces", () => {
+  const collect = (driver: string | undefined, update: Record<string, unknown>): ToolUseEvent | undefined => {
+    const events: ToolUseEvent[] = [];
+    const state = createStreamingPromptState(false, { driver, onToolEvent: (e) => { events.push(e); } });
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+    return events[0];
+  };
+
+  expect(
+    collect("qoder", {
+      sessionUpdate: "tool_call",
+      toolCallId: "q1",
+      kind: "other",
+      title: "发送同伴消息",
+      status: "pending",
+      _meta: { qoder: { toolName: "mcp__xacpx__agent_send" } },
+    }),
+  ).toMatchObject({ machineToolName: "mcp__xacpx__agent_send", toolName: "发送同伴消息" });
+
+  expect(
+    collect("cursor", {
+      sessionUpdate: "tool_call",
+      toolCallId: "c1",
+      kind: "other",
+      title: "Send message",
+      rawInput: { _toolName: "mcp__xacpx__agent_send", to: "agent:node_2:endpoint_b" },
+      status: "pending",
+    }),
+  ).toMatchObject({ machineToolName: "mcp__xacpx__agent_send" });
+
+  // No provider metadata → no machine name (display title alone must not be
+  // mistaken for one).
+  expect(
+    collect("codex", {
+      sessionUpdate: "tool_call",
+      toolCallId: "x1",
+      kind: "other",
+      title: "agent_send",
+      status: "pending",
+    }),
+  ).toMatchObject({ toolName: "agent_send" });
+  expect(
+    (collect("codex", {
+      sessionUpdate: "tool_call",
+      toolCallId: "x1",
+      kind: "other",
+      title: "agent_send",
+      status: "pending",
+    }) as Partial<ToolUseEvent>).machineToolName,
+  ).toBeUndefined();
+});
+
 test("Claude Agent and its nested tools preserve subagent hierarchy across sparse updates", () => {
   const events: ToolUseEvent[] = [];
   const state = createStreamingPromptState(false, (event) => events.push(event));
@@ -480,6 +569,8 @@ test("Qoder Agent metadata produces a subagent event across a sparse terminal up
     toolCallId: "qoder-agent-1",
     isSubagent: true,
     toolName: "Agent",
+    // qoder metadata names the machine tool — carried as stable identity.
+    machineToolName: "Agent",
     kind: "think",
     summary: "general-purpose: Pick a random number 1-100",
     rawInput: {


### PR DESCRIPTION
## Regression

After beta.3, sent agent-message cards still rendered as standalone rows at the TOP of the sender's transcript. Root cause is NOT Relay Web ordering and NOT compact history — it is the presentation correlation seam: `ToolUseEvent.toolName` carries the ACP **display title** (`update.title || "Tool"`, e.g. "Send peer message to Worker B"), not the MCP machine tool name, so the `agent_send` correlation branch in `tool-presentation` never executed for real transports. Existing tests hand-forged `toolName: "agent_send"` and bypassed the seam entirely, which is why CI was green while production fell back to standalone.

## Fix (correlation source only — no MessageList heuristics, no timestamp/order guessing, no completion-state changes)

1. **Machine tool identity on `ToolUseEvent`** — new optional `machineToolName`, extracted in `buildToolUseEvent` from provider metadata: Claude `_meta.claudeCode.toolName` (driver-gated, consistent with the other claude-meta gates), Qoder `_meta.qoder.toolName`, Cursor `rawInput._toolName`. `toolName` stays the display phrase, presentation-only.

2. **tool-presentation correlates on machine identity** — `const toolIdentity = event.machineToolName ?? event.toolName`. Display-title matching remains only as the fallback for drivers that expose no machine name (Codex). A display title that merely *mentions* `agent_send` never correlates when the machine name says otherwise (gate included).

3. **Durable MCP receipt fallback** — `agent_send` success results append a versioned marker next to the human line:

   ```
   xacpx-agent-send-receipt:v1 {"messageId":"msg_…","status":"queued"}
   ```

   The extractor parses it ONLY after machine-identity confirmation, from content blocks, bare `rawOutput` strings, or `output`/`text` fields — covering adapters that drop `structuredContent`. No return to display-text regex scraping (the display-line negative test stays green).

4. **Gates that would have caught this** — new real-seam suite chains the actual components: real xacpx MCP server (InMemoryTransport) → `agent_send` CallToolResult → representative ACP `tool_call` / sparse `tool_call_update` frames → `createStreamingPromptState` → `toolUseEventToStepDto`, asserting `step.agentMessageId === receipt.messageId`:
   - **Claude**: display title ≠ tool name, machine name in `_meta.claudeCode.toolName`, receipt via sparse `toolResponse` — anchors.
   - **Codex**: no machine name, structuredContent dropped, text-only result — anchors via display-name fallback + marker.
   - **Late-join regression**: running frame (no receipt) → sparse terminal frame (receipt) on the same `toolCallId` → `agentMessageId` appears (upsertTool replace semantics).
   - **Web late-join gate**: standalone row visible while the step is running, then suppressed with the card re-anchored after the exact `toolCallId` once the step carries the id.
   - **Core extraction gates**: per-driver machine-name extraction + wrong-driver claude meta ignored (existing driver-gating intent preserved).

## Verification
- `npx tsc --noEmit` ✓ · channel-relay `tsc` ✓ · relay-web `vue-tsc` ✓
- New seam suite 5/5 ✓ · transport tool-events 25/25 ✓ · mcp 88/88 ✓ · messagelist 58/58 ✓
- Official unit suite **1244/1244 all green** ✓ · `build:packages` ✓
- (The transport-directory batch-mode queue-owner failures reproduce identically on the pre-change tree — pre-existing, pass in isolation and under the official runner.)