### PR TITLE
fix(presentation): omp seam — machine identity from xd-device metadata, receipt from rawOutput.content

### DIFF
--- a/packages/channel-relay/src/tool-presentation.ts
+++ b/packages/channel-relay/src/tool-presentation.ts
@@ -162,6 +162,15 @@ function extractAgentMessageId(event: ToolUseEvent): string | undefined {
     const found = receiptFromText(tb.text);
     if (found) return found;
   }
+  // omp (Oh My Pi) wraps the xd-device MCP result as rawOutput.content blocks
+  // next to its details.xdev execution metadata (verified against captured
+  // production frames) — same structured rules.
+  for (const block of blocksOf(output.content)) {
+    const tb = textBlockOf(block);
+    if (!tb) continue;
+    const found = receiptFromText(tb.text);
+    if (found) return found;
+  }
   // Adapter kept no content blocks but passed the MCP text through as a bare
   // rawOutput string (or an output/text field) — same versioned marker scan.
   const rawText =

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -527,6 +527,9 @@ function buildToolUseEvent(
     (driver === "qoder" ? update._meta?.qoder?.toolName?.trim() : "") ||
     (driver === "codex" ? codexMcpMachineToolName(update.rawInput) : "") ||
     (driver === "cursor" ? machineToolNameFromCursorInput(update.rawInput) : "") ||
+    (driver === "omp"
+      ? ompXdevMachineToolName(update.rawInput, update.rawOutput)
+      : "") ||
     undefined;
   const parentToolCallId = claudeMeta?.parentToolUseId?.trim() || update.parentToolCallId?.trim();
   const isSubagent = (claudeMeta?.toolName === "Agent")
@@ -565,6 +568,34 @@ function codexMcpMachineToolName(rawInput: unknown): string {
   if (typeof server !== "string" || server.trim().length === 0) return "";
   if (typeof tool !== "string" || tool.trim().length === 0) return "";
   return tool.trim();
+}
+
+/** omp (Oh My Pi) executes MCP tools through xd:// device writes, and its ACP
+ *  display title is the MODEL'S INTENT (e.g. "Request beta release from …") —
+ *  never the tool name. The stable machine identity rides elsewhere (both
+ *  verified against captured production frames):
+ *  - start frame:     rawInput.path === "xd://<machineToolName>"
+ *  - terminal frame:  rawOutput.details.xdev.tool === "<machineToolName>"
+ */
+function ompXdevMachineToolName(rawInput: unknown, rawOutput: unknown): string {
+  const details = isRecord(rawOutput) ? rec2(rawOutput.details) : undefined;
+  const xdev = details ? rec2(details.xdev) : undefined;
+  if (typeof xdev?.tool === "string" && xdev.tool.trim().length > 0) {
+    return xdev.tool.trim();
+  }
+  const path =
+    isRecord(rawInput) && typeof rawInput.path === "string"
+      ? rawInput.path.trim()
+      : "";
+  if (path.toLowerCase().startsWith("xd://")) {
+    const name = path.slice(5).split(/[/?#]/)[0] ?? "";
+    if (name.length > 0) return name;
+  }
+  return "";
+}
+
+function rec2(v: unknown): Record<string, unknown> | undefined {
+  return isRecord(v) ? v : undefined;
 }
 
 /** Cursor's stable machine tool name, when the rawInput marker carries one. */

--- a/tests/unit/packages/channel-relay/agent-send-anchoring-seam.test.ts
+++ b/tests/unit/packages/channel-relay/agent-send-anchoring-seam.test.ts
@@ -285,6 +285,72 @@ test("late-join regression: running frame (no receipt) → sparse terminal frame
   expect(terminalStep.agentMessageId).toBe(RECEIPT.messageId);
 });
 
+test("omp seam (captured production frames): intent display title + xd:// write — machine identity from rawInput.path and details.xdev, receipt from rawOutput.content marker", async () => {
+  const result = await callRealAgentSend();
+  // Frames below are the ACTUAL captured production emission for my own
+  // agent_send call (xacpx session stream, driver "omp"): the display title
+  // is the MODEL INTENT, the tool identity rides rawInput.path (start) and
+  // rawOutput.details.xdev.tool (terminal), and the MCP result text (with the
+  // versioned marker) sits in rawOutput.content.
+  const events = streamAcpFrames("omp", [
+    {
+      sessionUpdate: "tool_call",
+      toolCallId: "call_cd61dee8f0404322b7dc960d",
+      title: "Send comm test to 发版 agent",
+      kind: "other",
+      rawInput: {
+        path: "xd://mcp__xacpx_agent_send",
+        content: JSON.stringify({ to: "agent:node_dfeca37e-158e-470f-9d44-0a52ce7a21a2:042495af-2662-439a-8979-0e12f15af05c", message: "通讯测试", completion: "result" }),
+      },
+      status: "pending",
+    },
+    {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call_cd61dee8f0404322b7dc960d",
+      status: "completed",
+      rawOutput: {
+        content: [{ type: "text", text: result.text }],
+        details: {
+          xdev: {
+            tool: "mcp__xacpx_agent_send",
+            mode: "execute",
+            args: { to: "agent:node_dfeca37e-158e-470f-9d44-0a52ce7a21a2:042495af-2662-439a-8979-0e12f15af05c" },
+          },
+        },
+      },
+    },
+  ]);
+
+  const runningIdx = events.findIndex((e) => e.status === "running");
+  expect(runningIdx).toBe(0);
+  // Running frame: identity already resolvable from rawInput.path.
+  expect(events[0]!.machineToolName).toBe("mcp__xacpx_agent_send");
+  expect(events[0]!.toolName).toBe("Send comm test to 发版 agent");
+  expect(toolUseEventToStepDto(events[0]!).agentMessageId).toBeUndefined();
+
+  const terminal = events.at(-1)!;
+  // Terminal frame: identity re-confirmed from details.xdev; display stays intent.
+  expect(terminal.machineToolName).toBe("mcp__xacpx_agent_send");
+  expect(terminal.toolName).toBe("Send comm test to 发版 agent");
+  expect(terminal.status).toBe("success");
+
+  const step = toolUseEventToStepDto(terminal);
+  expect(step.agentMessageId).toBe(RECEIPT.messageId);
+});
+
+test("omp seam: intent-only title with NO machine identity never correlates (negative)", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "t",
+    toolName: "Request beta release from 发版 agent",
+    kind: "other",
+    status: "success",
+    rawOutput: {
+      content: [{ type: "text", text: `Peer message msg_${"a".repeat(8)} accepted with status=queued.\nxacpx-agent-send-receipt:v1 ${JSON.stringify({ messageId: `msg_${"a".repeat(8)}`, status: "queued" })}` }],
+    },
+  });
+  expect(step.agentMessageId).toBeUndefined();
+});
+
 test("a display title that merely MENTIONS agent_send never correlates when the machine name says otherwise", () => {
   const step = toolUseEventToStepDto({
     toolCallId: "t",

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -520,6 +520,59 @@ test("qoder and cursor machine tool names are extracted from their metadata name
   ).toBeUndefined();
 });
 
+test("omp xdev machine identity: rawInput xd:// path (start) and rawOutput.details.xdev.tool (terminal) override the intent display title", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, { driver: "omp", onToolEvent: (e) => { events.push(e); } });
+  const send = (update: Record<string, unknown>) =>
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+
+  send({
+    sessionUpdate: "tool_call",
+    toolCallId: "xd-1",
+    kind: "other",
+    title: "Request beta release from 发版 agent",
+    rawInput: { path: "xd://mcp__xacpx_agent_send", content: "{}" },
+    status: "pending",
+  });
+  send({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "xd-1",
+    status: "completed",
+    rawOutput: {
+      content: [{ type: "text", text: "ok" }],
+      details: { xdev: { tool: "mcp__xacpx_agent_send", mode: "execute" } },
+    },
+  });
+
+  expect(events.at(-1)).toMatchObject({
+    toolCallId: "xd-1",
+    toolName: "Request beta release from 发版 agent",
+    machineToolName: "mcp__xacpx_agent_send",
+    status: "success",
+  });
+});
+
+test("omp machine identity is driver-gated: non-omp drivers ignore xdev metadata and xd:// paths", () => {
+  const collect = (driver: string | undefined, update: Record<string, unknown>): ToolUseEvent | undefined => {
+    const events: ToolUseEvent[] = [];
+    const state = createStreamingPromptState(false, { driver, onToolEvent: (e) => { events.push(e); } });
+    parseStreamingChunks(state, JSON.stringify({ method: "session/update", params: { update } }));
+    return events[0];
+  };
+  const frame = {
+    sessionUpdate: "tool_call",
+    toolCallId: "xd-g",
+    kind: "other",
+    title: "Send message",
+    rawInput: { path: "xd://mcp__xacpx_agent_send", content: "{}" },
+    rawOutput: { details: { xdev: { tool: "mcp__xacpx_agent_send" } } },
+    status: "pending",
+  };
+  expect((collect("claude", frame) as Partial<ToolUseEvent>).machineToolName).toBeUndefined();
+  expect((collect(undefined, frame) as Partial<ToolUseEvent>).machineToolName).toBeUndefined();
+  expect((collect("omp", frame) as Partial<ToolUseEvent>).machineToolName).toBe("mcp__xacpx_agent_send");
+});
+
 test("Claude Agent and its nested tools preserve subagent hierarchy across sparse updates", () => {
   const events: ToolUseEvent[] = [];
   const state = createStreamingPromptState(false, (event) => events.push(event));


### PR DESCRIPTION
## Production follow-up to #299

After beta.4 the sent card STILL anchored standalone for omp-driven sessions (the agent type that hosts the main v0.3 working sessions). Root cause found in the **actual captured ACP frames** (`~/.acpx/sessions/<id>.stream.ndjson`), not in reproduction guesses:

```jsonc
// tool_call (start)
{ "title": "Request beta release from 发版 agent",     // ← the MODEL'S INTENT
  "rawInput": { "path": "xd://mcp__xacpx_agent_send", "content": "…" } }
// tool_call_update (terminal)
{ "status": "completed",
  "rawOutput": {
    "content": [{ "type": "text", "text": "Peer message msg_… accepted…\nxacpx-agent-send-receipt:v1 {…}" }],
    "details": { "xdev": { "tool": "mcp__xacpx_agent_send", "mode": "execute" } } } }
```

omp executes MCP tools through **xd:// device writes** and uses the model's intent as the ACP display title — the `machineToolName ?? toolName` display fallback from #299 can never match an intent phrase. Meanwhile the stable identity and the receipt both exist, just in omp-specific places: `rawInput.path` (start), `rawOutput.details.xdev.tool` (terminal), and the marker inside `rawOutput.content` blocks.

## Fix

1. **streaming-prompt**: `ompXdevMachineToolName` for `driver === "omp"` — terminal `rawOutput.details.xdev.tool`, else start `rawInput.path` `xd://<name>`; driver-gated like the claude/qoder/codex/cursor identities.
2. **tool-presentation**: extractor scans `rawOutput.content` text blocks with the same structured rules (whole-block JSON, then the versioned marker) — still only after machine-identity confirmation.
3. **Gates replay the captured production frames verbatim**: intent title + xd:// start → running step already carries `machineToolName`, no `agentMessageId`; terminal frame with `details.xdev` + marker in `rawOutput.content` → `step.agentMessageId === receipt.messageId`. Negative gate: intent-only title with no machine identity never correlates even with a marker-shaped output. Core gates: identity extraction start/terminal + driver-gating (claude/undefined ignore xdev).

## Verification
- seam suite 9/9 (incl. captured-frame replay) ✓ · transport tool-events 27/27 ✓ · mcp 88/88 ✓ · both `tsc` ✓ · **official unit 1244/1244 all green** ✓ · `build:packages` ✓