### PR TITLE
fix(relay-web): left-align anchored sent card with tool steps

### DIFF
--- a/packages/relay-web/src/__tests__/agentmessagecard.test.ts
+++ b/packages/relay-web/src/__tests__/agentmessagecard.test.ts
@@ -207,4 +207,44 @@ describe("AgentMessageCard", () => {
     });
     expect(cancelled.find('[data-test="msg-status-cancelled"]').text()).toContain("Cancelled");
   });
+
+  it("standalone sent card keeps chat-bubble alignment and accent skin", () => {
+    const base = {
+      kind: "agent_message" as const,
+      direction: "sent" as const,
+      conversationId: "conv",
+      peer: { handle: "agent:n:e", displayName: "Peer", agent: "codex" },
+      content: "x",
+      createdAt: 1771234567890,
+      status: "sent" as const,
+      messageId: "msg_s",
+    };
+    const wrapper = mount(AgentMessageCard, { props: { message: base } });
+    const cls = wrapper.find('[data-test="agent-message-card"]').classes();
+    expect(cls).toContain("mx-auto");
+    expect(cls).not.toContain("ml-auto");
+    expect(cls).toContain("border-accent/25");
+    expect(cls).toContain("bg-accent/5");
+    expect(cls).not.toContain("shadow-sm");
+  });
+
+  it("anchored sent card left-aligns but keeps accent skin", () => {
+    const base = {
+      kind: "agent_message" as const,
+      direction: "sent" as const,
+      conversationId: "conv",
+      peer: { handle: "agent:n:e", displayName: "Peer", agent: "codex" },
+      content: "x",
+      createdAt: 1771234567890,
+      status: "sent" as const,
+    };
+    const wrapper = mount(AgentMessageCard, { props: { message: { ...base, messageId: "msg_a" }, anchored: true } });
+    const cls = wrapper.find('[data-test="agent-message-card"]').classes();
+    expect(cls).toContain("mr-auto");
+    expect(cls).not.toContain("ml-auto");
+    expect(cls).not.toContain("mx-auto");
+    expect(cls).toContain("border-accent/25");
+    expect(cls).toContain("bg-accent/5");
+    expect(cls).not.toContain("shadow-sm");
+  });
 });

--- a/packages/relay-web/src/components/AgentMessageCard.vue
+++ b/packages/relay-web/src/components/AgentMessageCard.vue
@@ -7,9 +7,15 @@ import AgentIcon from "./AgentIcon.vue";
 import { fmtTime } from "../lib/format";
 import { ArrowRight, ArrowLeft, Folder, AlertCircle, CheckCircle2, Send, Clock3 } from "lucide-vue-next";
 
-const props = defineProps<{
-  message: PeerMessageHistoryEntry;
-}>();
+const props = withDefaults(
+  defineProps<{
+    message: PeerMessageHistoryEntry;
+    /** Anchored inside an assistant turn's timeline: left-align with the tool
+     *  steps instead of the standalone chat-bubble right alignment. */
+    anchored?: boolean;
+  }>(),
+  { anchored: false },
+);
 
 const isSent = computed(() => props.message.direction === "sent");
 const peerName = computed(() => props.message.peer.displayName || props.message.peer.handle);
@@ -51,17 +57,18 @@ const completionChip = computed<CompletionChip | null>(() => {
     class="cv-row my-2 w-full max-w-2xl rounded-xl border transition-all"
     :class="[
       isSent
-        ? 'ml-auto border-accent/25 bg-accent/5'
-        : 'mr-auto border-border bg-surface shadow-sm',
+        ? 'border-accent/25 bg-accent/5'
+        : 'border-border bg-surface shadow-sm',
+      anchored ? 'mr-auto' : 'mx-auto',
     ]"
     :data-direction="message.direction"
   >
     <!-- Header -->
     <div
-      class="flex items-center justify-between gap-2 border-b px-3.5 py-2 text-[12px]"
+      class="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 border-b px-3.5 py-2 text-[12px]"
       :class="isSent ? 'border-accent/15 text-accent' : 'border-border text-fg-muted'"
     >
-      <div class="flex min-w-0 items-center gap-1.5 font-medium">
+      <div class="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 font-medium">
         <span v-if="isSent" data-test="direction-sent" class="inline-flex items-center gap-1 font-semibold text-accent">
           <ArrowRight :size="13" class="shrink-0" />
           <span>{{ $t("chat.sentTo") || "Sent to" }}</span>
@@ -73,28 +80,33 @@ const completionChip = computed<CompletionChip | null>(() => {
 
         <span data-test="peer-name" class="truncate font-semibold text-fg">{{ peerName }}</span>
 
-        <!-- Agent badge -->
+        <!-- Peer meta badges travel as ONE wrap unit: on narrow screens the pair
+             drops to its own line together instead of fragmenting row-by-row. -->
         <span
-          v-if="message.peer.agent"
-          data-test="peer-agent"
-          class="inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-surface px-1.5 py-0.5 text-[11px] text-fg-muted"
+          v-if="message.peer.agent || message.peer.workspace"
+          class="inline-flex min-w-0 flex-wrap items-center gap-1"
         >
-          <AgentIcon :driver="message.peer.agent" :size="11" />
-          <span>{{ message.peer.agent }}</span>
-        </span>
+          <span
+            v-if="message.peer.agent"
+            data-test="peer-agent"
+            class="inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-surface px-1.5 py-0.5 text-[11px] text-fg-muted"
+          >
+            <AgentIcon :driver="message.peer.agent" :size="11" />
+            <span>{{ message.peer.agent }}</span>
+          </span>
 
-        <!-- Workspace badge -->
-        <span
-          v-if="message.peer.workspace"
-          data-test="peer-workspace"
-          class="inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-surface px-1.5 py-0.5 text-[11px] text-fg-muted"
-        >
-          <Folder :size="10" class="text-warn" />
-          <span>{{ message.peer.workspace }}</span>
+          <span
+            v-if="message.peer.workspace"
+            data-test="peer-workspace"
+            class="inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-surface px-1.5 py-0.5 text-[11px] text-fg-muted"
+          >
+            <Folder :size="10" class="text-warn" />
+            <span>{{ message.peer.workspace }}</span>
+          </span>
         </span>
       </div>
 
-      <div class="flex shrink-0 items-center gap-2 text-[11px] text-fg-muted">
+      <div class="ml-auto flex shrink-0 items-center gap-2 text-[11px] text-fg-muted">
         <span
           v-if="completionChip"
           :data-test="completionChip.test"

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -38,9 +38,9 @@ const presentation = computed(() =>
                       :default-open="false" />
       <ToolStepCard v-else-if="item.type === 'tool'" :step="item.step" :ensure-full="ensureFull" />
       <!-- Sent peer-message card joined to the agent_send step right above it;
-           indented to read as nested inside the turn, not a standalone row. -->
-      <div v-else-if="item.type === 'agent-message'" data-test="turn-agent-message" class="pl-2">
-        <AgentMessageCard :message="item.message" />
+           left-aligned flush with the tool steps (no chat-bubble right shift). -->
+      <div v-else-if="item.type === 'agent-message'" data-test="turn-agent-message">
+        <AgentMessageCard :message="item.message" anchored />
       </div>
       <SubagentStepCard v-else :step="item.step" :children="item.children" :ensure-full="ensureFull" />
     </template>


### PR DESCRIPTION
## Visual follow-up to #300 (verified working in beta.5)

The anchoring itself now works — the sent card renders inside the assistant turn right after its `agent_send` step. But its **left margin** was off: the card kept the standalone chat-bubble alignment (`ml-auto` right shift for sent cards) **plus** a `pl-2` wrapper indent from TurnParts — so inside the turn its left edge sat noticeably right of the tool steps and narrative text.

## Fix

- `AgentMessageCard` gains an `anchored` prop: when set, sent cards use `mr-auto` (left-aligned, flush with tool steps) instead of the standalone right shift.
- Anchoring changes **alignment only**: sent cards keep the accent skin (`border-accent/25` + `bg-accent/5`) whether standalone or anchored — anchoring no longer flips them to the received surface skin. Received cards are untouched.
- **Standalone cards center in the column** (`mx-auto`): the `max-w-2xl` readability cap now leaves balanced whitespace on both sides instead of a one-sided gap (desktop verified: card 672px, equal 304px gutters in a 1280px viewport).
- `TurnParts` passes `anchored` and drops the `pl-2` wrapper — the card's left edge is now flush with the tool steps and narrative in the turn.
- **Mobile header squeeze fixed**: header clusters wrap as units — peer meta badges travel together to a second line; status + time drop to their own right-aligned row when space runs out (`ml-auto`). Desktop single-line header unchanged (40px vs 60px two-line mobile). No horizontal overflow at 390px.
- Class-level regression tests lock both alignment/skin invariants: standalone sent = `mx-auto` + accent skin; anchored sent = `mr-auto` + still accent skin.

## Verification

- relay-web `vue-tsc --noEmit` ✓
- vitest messagelist + turn-presentation + agentmessagecard suites **84/84** ✓ (the anchored-sent regression test fails against the pre-fix component)
- Visual check via headless browser harness at 1280px and 390px viewports: centering gutters measured symmetric; mobile header wraps to exactly 2 rows with no truncation/overflow