### PR TITLE
feat(relay-web): fullscreen image lightbox for message images

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -585,17 +585,35 @@ relay hub 并持久化到 `attachments` 列，用于历史重显。非图片文�
 ### 渲染
 
 - **`MessageAttachments.vue`**：
-  - 图片（`kind: "image"`）显示缩略图（来自持久化的 `previewUrl`，点击可放大）。
+  - 图片（`kind: "image"`）显示缩略图（来自持久化的 `previewUrl`）。
   - 非图片文件（`kind: "file"`）显示文件卡片（文件名 + 大小）。
 - **`MessageList.vue`**：每条消息若含 `attachments`，在气泡下方插入 `<MessageAttachments>`。
 - **历史重显**：页面刷新后，附件从服务端持久化的 `MessageRecordDto.attachments` 中恢复，
   图片缩略图和文件卡片均可再次显示。
 
+### 图片全屏查看（lightbox）
+
+- **触发**：两类消息图片均可点击进入全屏查看——附件缩略图
+  （`MessageAttachments.vue`，按钮语义 + `cursor-zoom-in`）与 Markdown 正文内嵌的
+  `<img>`（`StreamMarkdown.vue` 在根元素上做一次委托 click 监听，仅放行
+  `http(s)/data/blob:` src，防止 `javascript:` 之类 URL 进入查看器）。
+- **翻页范围 = 单个气泡/渲染段内的全部可看图片**（按出现顺序）：打开的是点击那张，
+  左右箭头按钮 / 键盘 ←→ / 移动端横向滑动手势（≥48px，跟随手指位移）在组内切换上一张、
+  下一张；顶部显示 `n / total` 计数与文件名。到头时箭头隐藏、键盘停住（不循环）。
+- **关闭**：Esc、点击空白遮罩（拖动不误关）、右上角 ✕；打开期间锁定 body 滚动，
+  关闭后恢复焦点与滚动。
+- **实现**：状态是模块级单例 `src/lib/use-image-lightbox.ts`
+  （`openLightbox(images, index)` / `closeLightbox()` / `stepLightbox(±1)`），
+  查看器组件 `ImageLightbox.vue` 全局挂载在 `App.vue`（Teleport 到 body，z-[110]），
+  任何渲染器无需逐层透传 props 即可打开。
+
 ### 相关文件
 
 - `packages/relay-web/src/components/PromptInput.vue` — 上传触发 + chip UI
-- `packages/relay-web/src/components/MessageAttachments.vue` — 附件渲染
+- `packages/relay-web/src/components/MessageAttachments.vue` — 附件渲染 + 缩略图点击
 - `packages/relay-web/src/components/MessageList.vue` — 附件在消息气泡下插入
+- `packages/relay-web/src/components/ImageLightbox.vue` — 全屏图片查看器
+- `packages/relay-web/src/lib/use-image-lightbox.ts` — lightbox 状态单例
 - `packages/relay-web/src/stores/chat.ts` — 发送时调用 upload + 附件随 media 字段传出
 
 ## 阶段范围边界

--- a/packages/relay-web/src/App.vue
+++ b/packages/relay-web/src/App.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import ConfirmDialog from "./components/ConfirmDialog.vue";
+import ImageLightbox from "./components/ImageLightbox.vue";
 </script>
 
 <template>
   <RouterView />
   <ConfirmDialog />
+  <ImageLightbox />
 </template>

--- a/packages/relay-web/src/App.vue
+++ b/packages/relay-web/src/App.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
 import ConfirmDialog from "./components/ConfirmDialog.vue";
 import ImageLightbox from "./components/ImageLightbox.vue";
+import { useImageLightbox } from "./lib/use-image-lightbox";
+
+// Exactly one viewer instance app-wide; v-if on the singleton state makes
+// mount == open, so its scroll-lock/focus/modal-stack side effects only exist
+// while an image set is actually shown.
+const { state: lightboxState } = useImageLightbox();
 </script>
 
 <template>
   <RouterView />
   <ConfirmDialog />
-  <ImageLightbox />
+  <ImageLightbox v-if="lightboxState" />
 </template>

--- a/packages/relay-web/src/__tests__/message-attachments.test.ts
+++ b/packages/relay-web/src/__tests__/message-attachments.test.ts
@@ -1,12 +1,12 @@
 import { mount } from "@vue/test-utils";
-import { afterEach, beforeEach, expect, test } from "vitest";
-import { defineComponent, h, nextTick } from "vue";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { defineComponent, h, nextTick, ref } from "vue";
 import type { AttachmentMetadata } from "@ganglion/xacpx-relay-protocol";
 
 import MessageAttachments from "../components/MessageAttachments.vue";
 import ImageLightbox from "../components/ImageLightbox.vue";
 import { closeLightbox, useImageLightbox } from "../lib/use-image-lightbox";
-
+import { useModalA11y } from "../lib/use-modal-a11y";
 import type { VueWrapper } from "@vue/test-utils";
 
 // Track every mount: the singleton lightbox state outlives a single wrapper, and a
@@ -35,21 +35,25 @@ const img = (id: string, previewUrl: string): AttachmentMetadata => ({
   previewUrl,
 });
 
-// The viewer lives in App.vue (singleton state), so the harness pairs the list
-// renderer with one viewer instance the way the real app shell does.
+// Mirrors the real app shell: the viewer mounts only while the singleton state
+// exists (App.vue uses v-if), so mount == open and lifecycle side effects are
+// exercised exactly as in production.
 const Harness = defineComponent(
   (props: { attachments: AttachmentMetadata[] }) => {
+    const { state } = useImageLightbox();
     return () =>
       h("div", [
         h(MessageAttachments, { attachments: props.attachments }),
-        h(ImageLightbox),
+        state.value ? h(ImageLightbox) : null,
       ]);
   },
   { props: { attachments: { type: Array, required: true } } },
 );
 
+// attachTo: focus() must move document.activeElement, which jsdom only does for
+// nodes in the document (a detached wrapper subtree won't take focus).
 function mountHarness(attachments: AttachmentMetadata[]) {
-  const wrapper = mount(Harness, { props: { attachments } });
+  const wrapper = mount(Harness, { props: { attachments }, attachTo: document.body });
   wrappers.push(wrapper);
   return wrapper;
 }
@@ -107,4 +111,79 @@ test("viewer pages prev/next within the bubble's image set and stops at the ends
   (document.querySelector<HTMLButtonElement>('[data-test="lightbox-close"]')!).click();
   await nextTick();
   expect(useImageLightbox().state.value).toBeNull();
+});
+
+test("closed viewer leaves body scroll untouched; open locks and close restores it without unmount", async () => {
+  document.body.style.overflow = "auto";
+  const wrapper = mountHarness([img("a", "data:image/png;base64,AA")]);
+  await nextTick();
+  // Never opened: no scroll lock, no overlay.
+  expect(document.body.style.overflow).toBe("auto");
+  expect(document.querySelector('[data-test="image-lightbox"]')).toBeNull();
+
+  await wrapper.find('[data-test="att-image"]').trigger("click");
+  await nextTick();
+  expect(document.body.style.overflow).toBe("hidden");
+
+  (document.querySelector<HTMLButtonElement>('[data-test="lightbox-close"]')!).click();
+  await nextTick();
+  expect(useImageLightbox().state.value).toBeNull();
+  expect(document.querySelector('[data-test="image-lightbox"]')).toBeNull();
+  // Restored WITHOUT unmounting the harness.
+  expect(document.body.style.overflow).toBe("auto");
+  document.body.style.overflow = "";
+});
+
+test("focus moves into the viewer while open and returns to the trigger on close", async () => {
+  const wrapper = mountHarness([img("a", "data:image/png;base64,AA"), img("b", "data:image/png;base64,BB")]);
+  const thumbEl = wrapper.findAll('[data-test="att-image"]')[1]!.element as HTMLElement;
+  thumbEl.focus();
+  expect(document.activeElement).toBe(thumbEl);
+
+  await wrapper.findAll('[data-test="att-image"]')[1]!.trigger("click");
+  await nextTick();
+  // useModalA11y focuses the first focusable (the ✕ button) on mount; the key
+  // invariant is that focus LIVES INSIDE the overlay while open.
+  const overlay = document.querySelector<HTMLElement>('[data-test="image-lightbox"]')!;
+  expect(overlay).not.toBeNull();
+  expect(overlay.contains(document.activeElement)).toBe(true);
+
+  (document.querySelector<HTMLButtonElement>('[data-test="lightbox-close"]')!).click();
+  await nextTick();
+  expect(document.activeElement).toBe(thumbEl);
+});
+
+test("Escape closes only the lightbox, not an underlying modal-stack dialog", async () => {
+  const events: string[] = [];
+  // A stand-in for SubagentTraceDialog: registered in the same shared stack.
+  const underDialogClose = vi.fn(() => events.push("under"));
+  const Under = defineComponent({
+    setup() {
+      const el = ref<HTMLElement | null>(null);
+      useModalA11y(el, underDialogClose);
+      return () =>
+        h(
+          "div",
+          { ref: el, tabindex: "-1", role: "dialog", "aria-modal": "true", "data-test": "under-dialog" },
+          [h(MessageAttachments, { attachments: [img("a", "data:image/png;base64,AA")] }), h(ImageLightboxGate)],
+        );
+    },
+  });
+  // Lightbox must be mounted AFTER the underlying dialog so it sits on top of the stack.
+  const ImageLightboxGate = defineComponent({
+    setup() {
+      const { state } = useImageLightbox();
+      return () => (state.value ? h(ImageLightbox) : null);
+    },
+  });
+  const wrapper = mount(Under);
+  wrappers.push(wrapper);
+  await wrapper.find('[data-test="att-image"]').trigger("click");
+  await nextTick();
+
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+  await nextTick();
+  expect(events).toEqual([]); // lightbox handled it first
+  expect(useImageLightbox().state.value).toBeNull(); // lightbox closed…
+  expect(underDialogClose).not.toHaveBeenCalled(); // …underlying dialog did NOT
 });

--- a/packages/relay-web/src/__tests__/message-attachments.test.ts
+++ b/packages/relay-web/src/__tests__/message-attachments.test.ts
@@ -1,15 +1,66 @@
 import { mount } from "@vue/test-utils";
-import { expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { defineComponent, h, nextTick } from "vue";
+import type { AttachmentMetadata } from "@ganglion/xacpx-relay-protocol";
 
 import MessageAttachments from "../components/MessageAttachments.vue";
+import ImageLightbox from "../components/ImageLightbox.vue";
+import { closeLightbox, useImageLightbox } from "../lib/use-image-lightbox";
+
+import type { VueWrapper } from "@vue/test-utils";
+
+// Track every mount: the singleton lightbox state outlives a single wrapper, and a
+// stale wrapper left open across tests re-patches its (cleared) teleported DOM.
+const wrappers: VueWrapper[] = [];
+
+beforeEach(() => {
+  closeLightbox();
+});
+
+afterEach(async () => {
+  while (wrappers.length) void wrappers.pop()!.unmount();
+  // Flush the close/unmount patches WHILE the teleported nodes are still attached,
+  // then reset the body between tests.
+  closeLightbox();
+  await nextTick();
+  document.body.innerHTML = "";
+  document.body.style.overflow = "";
+});
+const img = (id: string, previewUrl: string): AttachmentMetadata => ({
+  id,
+  filename: `${id}.png`,
+  mimeType: "image/png",
+  size: 10,
+  kind: "image",
+  previewUrl,
+});
+
+// The viewer lives in App.vue (singleton state), so the harness pairs the list
+// renderer with one viewer instance the way the real app shell does.
+const Harness = defineComponent(
+  (props: { attachments: AttachmentMetadata[] }) => {
+    return () =>
+      h("div", [
+        h(MessageAttachments, { attachments: props.attachments }),
+        h(ImageLightbox),
+      ]);
+  },
+  { props: { attachments: { type: Array, required: true } } },
+);
+
+function mountHarness(attachments: AttachmentMetadata[]) {
+  const wrapper = mount(Harness, { props: { attachments } });
+  wrappers.push(wrapper);
+  return wrapper;
+}
 
 test("renders an image attachment as a thumbnail using previewUrl", () => {
   const wrapper = mount(MessageAttachments, {
-    props: { attachments: [{ id: "1", filename: "a.png", mimeType: "image/png", size: 10, kind: "image", previewUrl: "data:image/png;base64,AA" }] },
+    props: { attachments: [img("a", "data:image/png;base64,AA")] },
   });
-  const img = wrapper.find('[data-test="att-image"]');
-  expect(img.exists()).toBe(true);
-  expect(img.attributes("src")).toBe("data:image/png;base64,AA");
+  const thumb = wrapper.find('[data-test="att-image"]');
+  expect(thumb.exists()).toBe(true);
+  expect(thumb.find("img").attributes("src")).toBe("data:image/png;base64,AA");
 });
 
 test("renders a non-image attachment as a file card with name + size", () => {
@@ -18,4 +69,42 @@ test("renders a non-image attachment as a file card with name + size", () => {
   });
   expect(wrapper.find('[data-test="att-file"]').exists()).toBe(true);
   expect(wrapper.text()).toContain("report.pdf");
+});
+
+test("clicking a thumbnail opens the fullscreen viewer on that image", async () => {
+  const wrapper = mountHarness([img("a", "data:image/png;base64,AA"), img("b", "data:image/png;base64,BB")]);
+  await wrapper.findAll('[data-test="att-image"]')[1]!.trigger("click");
+  await nextTick();
+
+  expect(document.querySelector('[data-test="image-lightbox"]')).not.toBeNull();
+  expect(document.querySelector('[data-test="lightbox-counter"]')?.textContent).toContain("2 / 2");
+  const shown = document.querySelector<HTMLImageElement>('[data-test="lightbox-image"]');
+  expect(shown?.getAttribute("src")).toBe("data:image/png;base64,BB");
+});
+
+test("viewer pages prev/next within the bubble's image set and stops at the ends", async () => {
+  const wrapper = mountHarness([
+    img("a", "data:image/png;base64,AA"),
+    img("b", "data:image/png;base64,BB"),
+    img("c", "data:image/png;base64,CC"),
+  ]);
+  await wrapper.findAll('[data-test="att-image"]')[0]!.trigger("click");
+  await nextTick();
+
+  // Opened on the first image: no prev arrow (start of set), next available.
+  expect(document.querySelector('[data-test="lightbox-prev"]')).toBeNull();
+  expect(document.querySelector('[data-test="lightbox-next"]')).not.toBeNull();
+
+  (document.querySelector<HTMLButtonElement>('[data-test="lightbox-next"]')!).click();
+  await nextTick();
+  expect(document.querySelector('[data-test="lightbox-counter"]')?.textContent).toContain("2 / 3");
+
+  (document.querySelector<HTMLButtonElement>('[data-test="lightbox-prev"]')!).click();
+  await nextTick();
+  expect(document.querySelector('[data-test="lightbox-counter"]')?.textContent).toContain("1 / 3");
+
+  // Close restores state.
+  (document.querySelector<HTMLButtonElement>('[data-test="lightbox-close"]')!).click();
+  await nextTick();
+  expect(useImageLightbox().state.value).toBeNull();
 });

--- a/packages/relay-web/src/__tests__/streammarkdown.test.ts
+++ b/packages/relay-web/src/__tests__/streammarkdown.test.ts
@@ -3,6 +3,7 @@ import { mount, flushPromises, type VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { createPinia, setActivePinia } from "pinia";
 import StreamMarkdown from "../components/StreamMarkdown.vue";
+import ImageLightbox from "../components/ImageLightbox.vue";
 import MermaidViewer from "../components/MermaidViewer.vue";
 import { renderMarkdown } from "../lib/render-markdown";
 import { useThemeStore } from "../stores/theme";
@@ -419,5 +420,26 @@ describe("StreamMarkdown image lightbox delegation", () => {
     imgEl.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     await nextTick();
     expect(useImageLightbox().state.value).toBeNull();
+  });
+
+  test("duplicate srcs: clicking the second occurrence pages at its own position", async () => {
+    renderSpy.mockImplementationOnce(
+      (_text: string) =>
+        '<p><img src="data:image/png;base64,AA" alt="a"> <img src="data:image/png;base64,BB" alt="b"> <img src="data:image/png;base64,AA" alt="a-again"></p>',
+    );
+    const wrapper = mountWith("ignored");
+    const imgs = wrapper.element.querySelectorAll("img");
+    expect(imgs.length).toBe(3);
+    // Same src as the FIRST image, but element identity must win.
+    (imgs[2]!).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+    expect(useImageLightbox().state.value).toMatchObject({ index: 2 });
+    expect(useImageLightbox().state.value!.images).toHaveLength(3);
+    expect(useImageLightbox().counter.value).toBe("3 / 3");
+  });
+
+  test("StreamMarkdown renders no viewer of its own (App shell owns the single instance)", () => {
+    const wrapper = mountWith("plain **text**, no images");
+    expect(wrapper.findComponent(ImageLightbox).exists()).toBe(false);
   });
 });

--- a/packages/relay-web/src/__tests__/streammarkdown.test.ts
+++ b/packages/relay-web/src/__tests__/streammarkdown.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
-import { mount, flushPromises } from "@vue/test-utils";
+import { mount, flushPromises, type VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { createPinia, setActivePinia } from "pinia";
 import StreamMarkdown from "../components/StreamMarkdown.vue";
 import MermaidViewer from "../components/MermaidViewer.vue";
 import { renderMarkdown } from "../lib/render-markdown";
 import { useThemeStore } from "../stores/theme";
+import { closeLightbox, useImageLightbox } from "../lib/use-image-lightbox";
+
+// Stale wrappers keep reactive effects alive across tests; the singleton lightbox
+// state would make them re-patch cleared DOM. Unmount everything in afterEach.
+const wrappers: VueWrapper[] = [];
 
 // Count parses without paying for the real pipeline (healing + markdown-it + DOMPurify).
 vi.mock("../lib/render-markdown", () => ({
@@ -59,7 +64,10 @@ beforeEach(() => {
   detachCalls.length = 0;
   enhanceSeq = 0;
 });
+
 afterEach(() => {
+  while (wrappers.length) void wrappers.pop()!.unmount();
+  closeLightbox();
   vi.useRealTimers();
 });
 
@@ -368,5 +376,48 @@ describe("StreamMarkdown mermaid hydration", () => {
     expect(viewer.props("svg")).toContain('data-test="d"');
     hydrate.mockImplementation(async () => {});
     wrapper.unmount();
+  });
+});
+
+describe("StreamMarkdown image lightbox delegation", () => {
+  afterEach(() => {
+    closeLightbox();
+  });
+
+  function mountWith(text: string) {
+    const wrapper = mount(StreamMarkdown, {
+      props: { text, streaming: false },
+      global: { stubs: { MermaidViewer: true } },
+    });
+    wrappers.push(wrapper);
+    return wrapper;
+  }
+
+  test("a delegated img click opens the fullscreen viewer on the clicked image", async () => {
+    // The suite mocks renderMarkdown, so inject real <img> markup the way the
+    // real pipeline emits for ![alt](data:...) — via the mocked renderer itself.
+    renderSpy.mockImplementationOnce(
+      (_text: string) =>
+        '<p><img src="data:image/png;base64,AA" alt="one"> and <img src="data:image/png;base64,BB" alt="two"></p>',
+    );
+    const wrapper = mountWith("ignored");
+    const imgs = wrapper.element.querySelectorAll("img");
+    expect(imgs.length).toBe(2);
+    (imgs[1]!).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+    expect(useImageLightbox().state.value).toMatchObject({ index: 1 });
+    expect(useImageLightbox().state.value!.images).toHaveLength(2);
+    expect(useImageLightbox().current.value?.src).toBe("data:image/png;base64,BB");
+  });
+
+  test("non-viewable srcs never open the viewer", async () => {
+    // A relative src resolves to an absolute http URL on .src; the raw-attribute
+    // check must still reject it.
+    renderSpy.mockImplementationOnce((_text: string) => '<p><img src="relative.png" alt="x"></p>');
+    const wrapper = mountWith("ignored");
+    const imgEl = wrapper.element.querySelector("img")!;
+    imgEl.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+    expect(useImageLightbox().state.value).toBeNull();
   });
 });

--- a/packages/relay-web/src/components/ImageLightbox.vue
+++ b/packages/relay-web/src/components/ImageLightbox.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import { ChevronLeft, ChevronRight, X } from "lucide-vue-next";
+import { closeLightbox, stepLightbox, useImageLightbox } from "../lib/use-image-lightbox";
+
+// Fullscreen image viewer for message images (attachment thumbnails and
+// markdown-embedded images). Rendered only while a set is open (parent v-if /
+// internal state): mount == open. Esc / tap-on-empty-black / ✕ close; arrow keys,
+// buttons and horizontal swipe move within the bubble's image list.
+const { state, current, counter, hasPrev, hasNext } = useImageLightbox();
+
+// Swipe: one active pointer; a clearly-horizontal drag ≥48px flips pages and the
+// image follows the finger live. Dragging past an end does nothing.
+let pointerId: number | null = null;
+let startX = 0;
+let startY = 0;
+let dragging = false;
+const dragDx = ref(0);
+
+function onPointerDown(e: PointerEvent): void {
+  if (pointerId !== null) return;
+  pointerId = e.pointerId;
+  startX = e.clientX;
+  startY = e.clientY;
+  dragging = false;
+}
+
+function onPointerMove(e: PointerEvent): void {
+  if (e.pointerId !== pointerId || !state.value) return;
+  const dx = e.clientX - startX;
+  const dy = e.clientY - startY;
+  // Only once clearly horizontal, so vertical touch scrolling never hijacks.
+  if (!dragging && Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 8) dragging = true;
+  if (!dragging) return;
+  if ((dx > 0 && !hasPrev.value) || (dx < 0 && !hasNext.value)) return;
+  dragDx.value = dx;
+}
+
+function onPointerUp(e: PointerEvent): void {
+  if (e.pointerId !== pointerId) return;
+  const wasDragging = dragging;
+  const dx = dragDx.value;
+  pointerId = null;
+  dragging = false;
+  dragDx.value = 0;
+  if (wasDragging) {
+    if (dx <= -48) stepLightbox(1);
+    else if (dx >= 48) stepLightbox(-1);
+    return;
+  }
+  // A still pointer released on the empty backdrop (the stage itself, not the
+  // image or a button) closes the viewer.
+  if (e.target === e.currentTarget) closeLightbox();
+}
+
+function onPointerCancel(): void {
+  pointerId = null;
+  dragging = false;
+  dragDx.value = 0;
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === "Escape") {
+    e.preventDefault();
+    closeLightbox();
+  } else if (e.key === "ArrowLeft" && hasPrev.value) {
+    stepLightbox(-1);
+  } else if (e.key === "ArrowRight" && hasNext.value) {
+    stepLightbox(1);
+  }
+}
+
+// Light focus + scroll-lock treatment (MermaidViewer-style): lock body overflow
+// while open and restore both scroll and focus on unmount.
+let prevOverflow = "";
+let previouslyFocused: HTMLElement | null = null;
+onMounted(() => {
+  previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  prevOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+  document.addEventListener("keydown", onKeydown);
+});
+onBeforeUnmount(() => {
+  document.removeEventListener("keydown", onKeydown);
+  document.body.style.overflow = prevOverflow;
+  previouslyFocused?.focus?.();
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="state"
+      class="fixed inset-0 z-[110] select-none bg-black/90 backdrop-blur-sm"
+      data-test="image-lightbox"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="current?.alt || $t('chat.lightboxLabel')"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerCancel"
+    >
+      <!-- Top bar: position counter + filename, then close. -->
+      <div class="pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center gap-3 p-3 text-white/90">
+        <span v-if="counter" data-test="lightbox-counter" class="rounded-full bg-white/10 px-2.5 py-1 font-mono text-[11px] tabular-nums">
+          {{ counter }}
+        </span>
+        <span v-if="current?.alt" class="min-w-0 flex-1 truncate text-[12px] text-white/70">{{ current.alt }}</span>
+        <button
+          type="button"
+          data-test="lightbox-close"
+          class="pointer-events-auto grid h-9 w-9 shrink-0 place-items-center rounded-full text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+          :aria-label="$t('common.dismiss')"
+          @click="closeLightbox()"
+        >
+          <X :size="18" />
+        </button>
+      </div>
+
+      <!-- The image itself: centered, contain-fit, follows the swipe finger. -->
+      <img
+        v-if="current"
+        data-test="lightbox-image"
+        :src="current.src"
+        :alt="current.alt ?? ''"
+        draggable="false"
+        class="absolute inset-0 m-auto max-h-full max-w-full object-contain shadow-2xl"
+        :style="{ transform: `translateX(${dragDx}px)`, transition: dragging ? 'none' : 'transform 150ms ease-out' }"
+      />
+
+      <!-- Prev/next hidden at the ends (not merely disabled) so mobile users get an
+           honest affordance; keyboard stops at the same bounds. -->
+      <button
+        v-if="hasPrev"
+        type="button"
+        data-test="lightbox-prev"
+        class="absolute left-2 top-1/2 z-20 grid h-11 w-11 -translate-y-1/2 place-items-center rounded-full bg-black/40 text-white/85 backdrop-blur transition-colors hover:bg-black/60 hover:text-white sm:left-4"
+        :aria-label="$t('chat.lightboxPrev')"
+        @click="stepLightbox(-1)"
+      >
+        <ChevronLeft :size="22" />
+      </button>
+      <button
+        v-if="hasNext"
+        type="button"
+        data-test="lightbox-next"
+        class="absolute right-2 top-1/2 z-20 grid h-11 w-11 -translate-y-1/2 place-items-center rounded-full bg-black/40 text-white/85 backdrop-blur transition-colors hover:bg-black/60 hover:text-white sm:right-4"
+        :aria-label="$t('chat.lightboxNext')"
+        @click="stepLightbox(1)"
+      >
+        <ChevronRight :size="22" />
+      </button>
+    </div>
+  </Teleport>
+</template>

--- a/packages/relay-web/src/components/ImageLightbox.vue
+++ b/packages/relay-web/src/components/ImageLightbox.vue
@@ -2,12 +2,30 @@
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import { ChevronLeft, ChevronRight, X } from "lucide-vue-next";
 import { closeLightbox, stepLightbox, useImageLightbox } from "../lib/use-image-lightbox";
+import { useModalA11y } from "../lib/use-modal-a11y";
 
 // Fullscreen image viewer for message images (attachment thumbnails and
-// markdown-embedded images). Rendered only while a set is open (parent v-if /
-// internal state): mount == open. Esc / tap-on-empty-black / ✕ close; arrow keys,
-// buttons and horizontal swipe move within the bubble's image list.
+// markdown-embedded images). The parent gates this component with v-if on the
+// singleton state (App.vue), so mount == open and every side effect below
+// (scroll lock, focus, key handling) is installed/torn down exactly once per
+// open/close cycle. Esc + focus trap/restore come from the shared modal stack
+// (useModalA11y), so a lightbox opened above another dialog closes alone.
 const { state, current, counter, hasPrev, hasNext } = useImageLightbox();
+
+const dialogEl = ref<HTMLElement | null>(null);
+useModalA11y(dialogEl, closeLightbox);
+
+// Scroll lock for the open duration. Safe to do in mount/unmount ONLY because the
+// parent gates this component with v-if on the singleton state (mount == open);
+// a permanently-mounted instance would lock scrolling for the whole app session.
+let prevOverflow = "";
+onMounted(() => {
+  prevOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+});
+onBeforeUnmount(() => {
+  document.body.style.overflow = prevOverflow;
+});
 
 // Swipe: one active pointer; a clearly-horizontal drag ≥48px flips pages and the
 // image follows the finger live. Dragging past an end does nothing.
@@ -58,48 +76,24 @@ function onPointerCancel(): void {
   dragging = false;
   dragDx.value = 0;
 }
-
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === "Escape") {
-    e.preventDefault();
-    closeLightbox();
-  } else if (e.key === "ArrowLeft" && hasPrev.value) {
-    stepLightbox(-1);
-  } else if (e.key === "ArrowRight" && hasNext.value) {
-    stepLightbox(1);
-  }
-}
-
-// Light focus + scroll-lock treatment (MermaidViewer-style): lock body overflow
-// while open and restore both scroll and focus on unmount.
-let prevOverflow = "";
-let previouslyFocused: HTMLElement | null = null;
-onMounted(() => {
-  previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-  prevOverflow = document.body.style.overflow;
-  document.body.style.overflow = "hidden";
-  document.addEventListener("keydown", onKeydown);
-});
-onBeforeUnmount(() => {
-  document.removeEventListener("keydown", onKeydown);
-  document.body.style.overflow = prevOverflow;
-  previouslyFocused?.focus?.();
-});
 </script>
 
 <template>
   <Teleport to="body">
     <div
-      v-if="state"
-      class="fixed inset-0 z-[110] select-none bg-black/90 backdrop-blur-sm"
+      ref="dialogEl"
+      class="fixed inset-0 z-[110] select-none bg-black/90 outline-none backdrop-blur-sm"
       data-test="image-lightbox"
       role="dialog"
       aria-modal="true"
+      tabindex="-1"
       :aria-label="current?.alt || $t('chat.lightboxLabel')"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"
       @pointercancel="onPointerCancel"
+      @keydown.left.prevent="hasPrev && stepLightbox(-1)"
+      @keydown.right.prevent="hasNext && stepLightbox(1)"
     >
       <!-- Top bar: position counter + filename, then close. -->
       <div class="pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center gap-3 p-3 text-white/90">

--- a/packages/relay-web/src/components/MessageAttachments.vue
+++ b/packages/relay-web/src/components/MessageAttachments.vue
@@ -1,26 +1,54 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { FileText } from "lucide-vue-next";
 import type { AttachmentMetadata } from "@ganglion/xacpx-relay-protocol";
+import { openLightbox } from "../lib/use-image-lightbox";
 
-defineProps<{ attachments: AttachmentMetadata[] }>();
+const props = defineProps<{ attachments: AttachmentMetadata[] }>();
 
 function fmtSize(n: number): string {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
   return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
-</script>
 
+// The lightbox pages within THIS bubble's images, in attachment order. The
+// viewer index of attachment i is its rank among the preceding viewable images.
+const imageRank = computed(() => {
+  const ranks = new Map<number, number>();
+  let n = 0;
+  props.attachments.forEach((a, i) => {
+    if (a.kind === "image" && a.previewUrl) ranks.set(i, n++);
+  });
+  return ranks;
+});
+
+function openAt(attachmentIndex: number): void {
+  const images = props.attachments
+    .filter((a) => a.kind === "image" && a.previewUrl)
+    .map((a) => ({ src: a.previewUrl!, alt: a.filename }));
+  openLightbox(images, imageRank.value.get(attachmentIndex) ?? 0);
+}
+</script>
 <template>
   <div class="mt-1 flex flex-wrap gap-2">
-    <template v-for="a in attachments" :key="a.id">
-      <img
+    <template v-for="(a, i) in attachments" :key="a.id">
+      <button
         v-if="a.kind === 'image' && a.previewUrl"
+        type="button"
         data-test="att-image"
-        :src="a.previewUrl"
-        :alt="a.filename"
-        class="max-h-40 max-w-[200px] rounded-lg border border-border object-cover"
-      />
+        class="cursor-zoom-in overflow-hidden rounded-lg border border-border transition-opacity hover:opacity-85"
+        :aria-label="`${$t('chat.lightboxOpen')}: ${a.filename}`"
+        :title="$t('chat.lightboxOpen')"
+        @click="openAt(i)"
+      >
+        <img
+          :src="a.previewUrl"
+          :alt="a.filename"
+          class="block max-h-40 max-w-[200px] object-cover"
+          loading="lazy"
+        />
+      </button>
       <div
         v-else
         data-test="att-file"

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -5,7 +5,9 @@ import { renderMarkdown } from "../lib/render-markdown";
 import { hydrateMermaidBlocks, resetMermaidBlocks } from "../lib/render-mermaid";
 import { enhanceMermaidBlock } from "../lib/inline-mermaid";
 import MermaidViewer from "./MermaidViewer.vue";
+import ImageLightbox from "./ImageLightbox.vue";
 import { useThemeStore } from "../stores/theme";
+import { openLightbox, type LightboxImage } from "../lib/use-image-lightbox";
 
 defineOptions({ inheritAttrs: false });
 
@@ -31,6 +33,36 @@ function cancelTimer(): void {
     clearTimeout(timer);
     timer = null;
   }
+}
+
+// Message images embedded in markdown (agent output like ![alt](data:...) or a
+// workspace URL) open fullscreen in the lightbox. One delegated click listener on
+// the root handles every re-render without rebinding per <img>; the swipeable set
+// is the ordered images of this rendered segment, so a bubble with several inline
+// images can be paged through. Only http(s)/data/blob srcs are viewable.
+function onViewableImg(img: HTMLImageElement): boolean {
+  // Use the RAW attribute: the DOM-resolved .src turns relative paths into
+  // absolute http(s) URLs, which would admit broken relative links.
+  const src = (img.getAttribute("src") ?? "").trim().toLowerCase();
+  return /^(https?:)?\/\//.test(src) || src.startsWith("data:") || src.startsWith("blob:");
+}
+function segmentImages(): LightboxImage[] {
+  const root = rootEl.value;
+  if (!root) return [];
+  return Array.from(root.querySelectorAll<HTMLImageElement>("img"))
+    .filter(onViewableImg)
+    .map((img) => ({ src: img.getAttribute("src") ?? "", alt: img.alt || undefined }));
+}
+function onRootClick(e: MouseEvent): void {
+  const target = e.target as HTMLElement | null;
+  if (!target || target.tagName !== "IMG") return;
+  const img = target as HTMLImageElement;
+  if (!onViewableImg(img)) return;
+  e.preventDefault();
+  // Match on the raw attribute (see onViewableImg) — the resolved .src differs.
+  const clicked = img.getAttribute("src") ?? "";
+  const images = segmentImages();
+  openLightbox(images, Math.max(0, images.findIndex((candidate) => candidate.src === clicked)));
 }
 
 // Mermaid blocks are hydrated only when NOT streaming: a mid-stream fence (auto-closed by
@@ -131,7 +163,10 @@ function render(): void {
 }
 
 render(); // initial synchronous render (also seeds the throttle clock)
-onMounted(() => scheduleHydrate(false)); // rootEl exists only after mount
+onMounted(() => {
+  scheduleHydrate(false); // rootEl exists only after mount
+  rootEl.value?.addEventListener("click", onRootClick);
+});
 
 watch(
   () => props.text,
@@ -177,6 +212,7 @@ onBeforeUnmount(() => {
   disposed = true;
   cancelTimer();
   detachEnhancers();
+  rootEl.value?.removeEventListener("click", onRootClick);
 });
 </script>
 
@@ -184,6 +220,7 @@ onBeforeUnmount(() => {
   <!-- eslint-disable-next-line vue/no-v-html -- input is sanitized by renderMarkdown (DOMPurify) -->
   <div ref="rootEl" class="stream-md text-sm" v-bind="$attrs" v-html="html" />
   <MermaidViewer v-if="viewerSvg" :svg="viewerSvg" @close="viewerSvg = null" />
+  <ImageLightbox />
 </template>
 
 <style>

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -5,7 +5,6 @@ import { renderMarkdown } from "../lib/render-markdown";
 import { hydrateMermaidBlocks, resetMermaidBlocks } from "../lib/render-mermaid";
 import { enhanceMermaidBlock } from "../lib/inline-mermaid";
 import MermaidViewer from "./MermaidViewer.vue";
-import ImageLightbox from "./ImageLightbox.vue";
 import { useThemeStore } from "../stores/theme";
 import { openLightbox, type LightboxImage } from "../lib/use-image-lightbox";
 
@@ -46,12 +45,10 @@ function onViewableImg(img: HTMLImageElement): boolean {
   const src = (img.getAttribute("src") ?? "").trim().toLowerCase();
   return /^(https?:)?\/\//.test(src) || src.startsWith("data:") || src.startsWith("blob:");
 }
-function segmentImages(): LightboxImage[] {
+function segmentImageEls(): HTMLImageElement[] {
   const root = rootEl.value;
   if (!root) return [];
-  return Array.from(root.querySelectorAll<HTMLImageElement>("img"))
-    .filter(onViewableImg)
-    .map((img) => ({ src: img.getAttribute("src") ?? "", alt: img.alt || undefined }));
+  return Array.from(root.querySelectorAll<HTMLImageElement>("img")).filter(onViewableImg);
 }
 function onRootClick(e: MouseEvent): void {
   const target = e.target as HTMLElement | null;
@@ -59,10 +56,12 @@ function onRootClick(e: MouseEvent): void {
   const img = target as HTMLImageElement;
   if (!onViewableImg(img)) return;
   e.preventDefault();
-  // Match on the raw attribute (see onViewableImg) — the resolved .src differs.
-  const clicked = img.getAttribute("src") ?? "";
-  const images = segmentImages();
-  openLightbox(images, Math.max(0, images.findIndex((candidate) => candidate.src === clicked)));
+  // Element identity, not src matching: the same image can appear twice in one
+  // segment and each occurrence must page at its own position.
+  const els = segmentImageEls();
+  const index = Math.max(0, els.indexOf(img));
+  const images: LightboxImage[] = els.map((el) => ({ src: el.getAttribute("src") ?? "", alt: el.alt || undefined }));
+  openLightbox(images, index);
 }
 
 // Mermaid blocks are hydrated only when NOT streaming: a mid-stream fence (auto-closed by
@@ -220,7 +219,6 @@ onBeforeUnmount(() => {
   <!-- eslint-disable-next-line vue/no-v-html -- input is sanitized by renderMarkdown (DOMPurify) -->
   <div ref="rootEl" class="stream-md text-sm" v-bind="$attrs" v-html="html" />
   <MermaidViewer v-if="viewerSvg" :svg="viewerSvg" @close="viewerSvg = null" />
-  <ImageLightbox />
 </template>
 
 <style>

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -121,6 +121,10 @@ export default {
       cumulative: "Cumulative",
     },
     attach: { add: "Attach file", remove: "Remove", tooMany: "Up to 5 files per message", tooLarge: "{name} is too large (max 10MB)" },
+    lightboxLabel: "Image viewer",
+    lightboxOpen: "View fullscreen",
+    lightboxPrev: "Previous image",
+    lightboxNext: "Next image",
   },
   session: {
     newSession: "New session",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -119,6 +119,10 @@ export default {
       cumulative: "累计",
     },
     attach: { add: "添加附件", remove: "移除", tooMany: "每条消息最多 5 个文件", tooLarge: "{name} 太大（最大 10MB）" },
+    lightboxLabel: "图片查看器",
+    lightboxOpen: "全屏查看",
+    lightboxPrev: "上一张",
+    lightboxNext: "下一张",
   },
   session: {
     newSession: "新建会话",

--- a/packages/relay-web/src/lib/use-image-lightbox.ts
+++ b/packages/relay-web/src/lib/use-image-lightbox.ts
@@ -1,0 +1,50 @@
+import { computed, ref } from "vue";
+
+// Global fullscreen image viewer state (module singleton, same pattern as
+// use-toasts) so any renderer — MessageAttachments thumbnails, StreamMarkdown's
+// delegated img clicks — can open it without prop drilling through the chat pane.
+// The opener hands in the FULL ordered image list of its bubble/segment plus the
+// clicked index; the viewer then swipes prev/next within that list.
+export interface LightboxImage {
+  src: string;
+  alt?: string;
+}
+
+interface LightboxState {
+  images: LightboxImage[];
+  index: number;
+}
+
+const state = ref<LightboxState | null>(null);
+
+/** Open the viewer on `images` at `index` (clamped). No-op on an empty list. */
+export function openLightbox(images: LightboxImage[], index = 0): void {
+  if (images.length === 0) return;
+  state.value = { images, index: Math.min(Math.max(index, 0), images.length - 1) };
+}
+
+export function closeLightbox(): void {
+  state.value = null;
+}
+
+export function stepLightbox(delta: number): void {
+  const s = state.value;
+  if (!s) return;
+  const next = s.index + delta;
+  if (next < 0 || next >= s.images.length) return;
+  s.index = next;
+}
+
+export function useImageLightbox() {
+  const current = computed<LightboxImage | null>(() => {
+    const s = state.value;
+    return s ? (s.images[s.index] ?? null) : null;
+  });
+  const counter = computed(() => {
+    const s = state.value;
+    return s ? `${s.index + 1} / ${s.images.length}` : "";
+  });
+  const hasPrev = computed(() => !!state.value && state.value.index > 0);
+  const hasNext = computed(() => !!state.value && state.value.index < state.value.images.length - 1);
+  return { state, current, counter, hasPrev, hasNext };
+}


### PR DESCRIPTION
## Summary

Message images in relay-web are now viewable fullscreen. Clicking any message image opens a lightbox; when the bubble contains multiple images, users can page through them.

- **Two image sources wired**: attachment thumbnails (`MessageAttachments.vue`) and markdown-embedded `<img>` (`StreamMarkdown.vue`, one delegated click listener on the root — no per-render rebinding)
- **Paging scope = one bubble/segment**: the swipeable set is all viewable images of the clicked bubble in reading order; prev/next arrow buttons, ←/→ keys, and horizontal swipe (image follows the finger, ≥48px threshold) move within the set; ends clamp — arrows hide, no wrap
- **Header**: `n / total` counter + filename
- **Close**: Esc, tap on empty backdrop (drag-safe), ✕ button; body scroll locked while open, focus restored on close
- **Safety**: only raw `http(s)/data/blob:` `src` attributes admitted — checking the raw attribute (not DOM-resolved `.src`) matters because relative paths resolve to absolute http URLs and would otherwise slip through; click index resolved by element identity so repeated identical images page at their own position
- **Single app-gated viewer**: module-singleton state (`lib/use-image-lightbox.ts`) + one `ImageLightbox` instance in `App.vue`, gated by `v-if` on the state (mount == open) — scroll-lock/focus side effects exist only while a set is shown. Esc/focus handling rides the shared modal stack (`useModalA11y`), so a lightbox above another dialog closes alone
- i18n keys mirrored in en + zh-CN (parity test green)

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] Full web suite: 1255 tests pass across 121 files, including 10 new tests: attachment click opens at correct index, prev/next clamp at both ends, delegated click locates clicked image, non-viewable srcs never open the viewer, closed state never locks body scroll / close restores it without unmount, focus moves into the overlay and back to the trigger, Esc above another modal-stack dialog closes only the lightbox, duplicate-src second occurrence pages at its own position, StreamMarkdown renders no own viewer
- [x] `vite build` production build passes
- [x] Headless-browser smoke: open from thumbnail + markdown image, independent grouping per bubble, swipe finger-follow + flip, backdrop-tap close vs drag stays open, end-clamp, ✕/Esc close

## Review fixes (81a06ee9)

Addressed 2×P1 (viewer permanently mounted with open-time side effects → gated via App-shell `v-if`; duplicate viewer instance inside every StreamMarkdown → removed), 1×P2 (Escape moved onto shared `useModalA11y` nested-dialog stack), 1×minor (element-identity index for duplicate srcs). Details in the review-reply comment.