### PR TITLE
fix(relay): carry session driver on SessionDto — sleeping sessions keep their brand icon

### DIFF
--- a/packages/relay-protocol/dist/dtos.d.ts
+++ b/packages/relay-protocol/dist/dtos.d.ts
@@ -2,6 +2,11 @@
 export interface SessionDto {
     alias: string;
     agent: string;
+    /** The acpx driver backing `agent` (codex/claude/…), resolved from the instance's
+     *  agent config. Lets the web render the brand icon without a second agents lookup
+     *  — critical for sleeping (archived) sessions, whose rows can live outside the
+     *  active session list. Omitted by old instances; web falls back to its agents map. */
+    driver?: string;
     workspace: string;
     transportSession: string;
     running: boolean;

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -2,6 +2,11 @@
 export interface SessionDto {
   alias: string;
   agent: string;
+  /** The acpx driver backing `agent` (codex/claude/…), resolved from the instance's
+   *  agent config. Lets the web render the brand icon without a second agents lookup
+   *  — critical for sleeping (archived) sessions, whose rows can live outside the
+   *  active session list. Omitted by old instances; web falls back to its agents map. */
+  driver?: string;
   workspace: string;
   transportSession: string;
   running: boolean;

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -9,6 +9,7 @@ vi.mock("../api/client", () => ({
 }));
 
 import ChatPane from "../components/ChatPane.vue";
+import { api } from "../api/client";
 import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
 import { useFilesStore } from "../stores/files";
@@ -117,13 +118,20 @@ it("stacks status, plan, and composer as document-flow layers (status → plan �
   expect(kids.indexOf(planEl)).toBeLessThan(kids.indexOf(composerEl!));
 });
 
-it("renders the brand icon for a sleeping (archived) session from the row's driver, without an agents map", async () => {
-  // Sleeping rows can be absent from inst.sessions (grouped sidebar keeps them in
-  // groupArchived) and inst.agents may not be loaded — only SessionDto.driver works.
+it("grouped sidebar: sleeping row lives only in groupArchived — avatar still shows its driver", async () => {
+  // Production shape (grouped sidebar): archived rows are paged into
+  // inst.groupArchived[*].sessions and stay OUT of inst.sessions. inst.agents is
+  // not loaded. Only the row's own SessionDto.driver can drive the icon.
   const instances = useInstancesStore();
   instances.instances.push({
     id: "i1", name: "prod-box", online: true, lastSeenAt: null,
-    sessions: [{ alias: "sleepy", agent: "my-kimi", driver: "kimi", workspace: "ws", archived: true }],
+    sessions: [{ alias: "active", agent: "codex", workspace: "ws" }],
+    groupArchived: {
+      "workspace:ws": {
+        sessions: [{ alias: "sleepy", agent: "my-kimi", driver: "kimi", workspace: "ws", archived: true }],
+        loaded: true, hasMore: false, nextOffset: 1,
+      },
+    },
     agents: [], workspaces: [], agentCatalog: [],
   } as never);
   const chat = useChatStore();
@@ -133,6 +141,45 @@ it("renders the brand icon for a sleeping (archived) session from the row's driv
     instanceId: "i1", sessionAlias: "sleepy", direction: "out",
     text: "hello", createdAt: new Date().toISOString(),
   } as never);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  const icon = w.find('[data-test="agent-icon"]');
+  expect(icon.exists()).toBe(true);
+  expect(icon.attributes("data-driver")).toBe("kimi");
+});
+
+it("flat sidebar: archiving the selected session keeps the avatar driver across a refresh that drops the row", async () => {
+  // Production shape: archive → sessions-changed → loadSessions replace; without
+  // a loaded full snapshot the active-only page no longer contains the just-slept
+  // row. The open chat must keep resolving its driver.
+  const instances = useInstancesStore();
+  instances.instances.push({
+    id: "i1", name: "prod-box", online: true, lastSeenAt: null,
+    sessions: [{ alias: "main", agent: "my-kimi", driver: "kimi", workspace: "ws", archived: true }],
+    agents: [], workspaces: [], agentCatalog: [],
+  } as never);
+  const chat = useChatStore();
+  chat.select("i1", "main");
+  chat.messages.push({
+    instanceId: "i1", sessionAlias: "main", direction: "out",
+    text: "hello", createdAt: new Date().toISOString(),
+  } as never);
+  // The post-archive replace: an active-only page WITHOUT the selected (now
+  // sleeping) row. Both the sessions page and the agents side-call must resolve.
+  const rpc = vi.spyOn(api, "rpc").mockImplementation(async (_id: string, type: string) => {
+    if (type === "control.agents.list") return { agents: [] };
+    return {
+      sessions: [{ alias: "other", agent: "codex", workspace: "ws2", transportSession: "t2", running: false, archived: false }],
+      hasMore: false,
+    };
+  });
+  await instances.loadSessions("i1");
+  rpc.mockRestore();
+  // The replace KEEPS the selected archived row (fetchSessionsPage retain rule), so
+  // the open chat's header/driver survive until a full snapshot re-homes the row.
+  const kept = instances.byId("i1")!.sessions.find((s) => s.alias === "main");
+  expect(kept?.archived).toBe(true);
+
   const w = mount(ChatPane);
   await w.vm.$nextTick();
   const icon = w.find('[data-test="agent-icon"]');

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -117,6 +117,29 @@ it("stacks status, plan, and composer as document-flow layers (status → plan �
   expect(kids.indexOf(planEl)).toBeLessThan(kids.indexOf(composerEl!));
 });
 
+it("renders the brand icon for a sleeping (archived) session from the row's driver, without an agents map", async () => {
+  // Sleeping rows can be absent from inst.sessions (grouped sidebar keeps them in
+  // groupArchived) and inst.agents may not be loaded — only SessionDto.driver works.
+  const instances = useInstancesStore();
+  instances.instances.push({
+    id: "i1", name: "prod-box", online: true, lastSeenAt: null,
+    sessions: [{ alias: "sleepy", agent: "my-kimi", driver: "kimi", workspace: "ws", archived: true }],
+    agents: [], workspaces: [], agentCatalog: [],
+  } as never);
+  const chat = useChatStore();
+  chat.select("i1", "sleepy");
+  // The avatar rides the assistant bubble row — seed one so it renders.
+  chat.messages.push({
+    instanceId: "i1", sessionAlias: "sleepy", direction: "out",
+    text: "hello", createdAt: new Date().toISOString(),
+  } as never);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+  const icon = w.find('[data-test="agent-icon"]');
+  expect(icon.exists()).toBe(true);
+  expect(icon.attributes("data-driver")).toBe("kimi");
+});
+
 it("localizes the empty-state prompt when locale is zh-CN", () => {
   i18n.global.locale.value = "zh-CN";
   const w = mount(ChatPane); // no session selected → empty state

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -148,14 +148,15 @@ it("grouped sidebar: sleeping row lives only in groupArchived — avatar still s
   expect(icon.attributes("data-driver")).toBe("kimi");
 });
 
-it("flat sidebar: archiving the selected session keeps the avatar driver across a refresh that drops the row", async () => {
-  // Production shape: archive → sessions-changed → loadSessions replace; without
-  // a loaded full snapshot the active-only page no longer contains the just-slept
-  // row. The open chat must keep resolving its driver.
+it("flat sidebar: archiving the SELECTED session keeps the avatar driver through the real transition", async () => {
+  // The full production sequence: row starts ACTIVE (archived:false) →
+  // archiveSession RPC → optimistic archived flag → loadSessions replace whose
+  // active-only page no longer contains the row → keep-rule retains it →
+  // findSessionRow still resolves the open chat's driver.
   const instances = useInstancesStore();
   instances.instances.push({
     id: "i1", name: "prod-box", online: true, lastSeenAt: null,
-    sessions: [{ alias: "main", agent: "my-kimi", driver: "kimi", workspace: "ws", archived: true }],
+    sessions: [{ alias: "main", agent: "my-kimi", driver: "kimi", workspace: "ws", transportSession: "t1", running: false, archived: false }],
     agents: [], workspaces: [], agentCatalog: [],
   } as never);
   const chat = useChatStore();
@@ -164,27 +165,48 @@ it("flat sidebar: archiving the selected session keeps the avatar driver across 
     instanceId: "i1", sessionAlias: "main", direction: "out",
     text: "hello", createdAt: new Date().toISOString(),
   } as never);
-  // The post-archive replace: an active-only page WITHOUT the selected (now
-  // sleeping) row. Both the sessions page and the agents side-call must resolve.
+
   const rpc = vi.spyOn(api, "rpc").mockImplementation(async (_id: string, type: string) => {
+    if (type === "control.sessions.archive") return {}; // connector returns {} — no row back
     if (type === "control.agents.list") return { agents: [] };
+    // Post-archive refresh: active-only page WITHOUT the just-slept row.
     return {
       sessions: [{ alias: "other", agent: "codex", workspace: "ws2", transportSession: "t2", running: false, archived: false }],
       hasMore: false,
     };
   });
-  await instances.loadSessions("i1");
+  await instances.archiveSession("i1", "main");
   rpc.mockRestore();
-  // The replace KEEPS the selected archived row (fetchSessionsPage retain rule), so
-  // the open chat's header/driver survive until a full snapshot re-homes the row.
+
+  // The optimistic flag + retain rule kept the selected row across the refresh…
   const kept = instances.byId("i1")!.sessions.find((s) => s.alias === "main");
   expect(kept?.archived).toBe(true);
+  // …and findSessionRow (what ChatPane resolves with) still yields the driver.
+  expect(instances.findSessionRow("i1", "main")?.driver).toBe("kimi");
 
   const w = mount(ChatPane);
   await w.vm.$nextTick();
   const icon = w.find('[data-test="agent-icon"]');
   expect(icon.exists()).toBe(true);
   expect(icon.attributes("data-driver")).toBe("kimi");
+});
+
+it("flat sidebar: a failed archive rolls the optimistic archived flag back", async () => {
+  const instances = useInstancesStore();
+  instances.instances.push({
+    id: "i1", name: "prod-box", online: true, lastSeenAt: null,
+    sessions: [{ alias: "main", agent: "my-kimi", driver: "kimi", workspace: "ws", transportSession: "t1", running: false, archived: false }],
+    agents: [], workspaces: [], agentCatalog: [],
+  } as never);
+  const rpc = vi.spyOn(api, "rpc").mockImplementation(async (_id: string, type: string) => {
+    if (type === "control.sessions.archive") throw new Error("archive failed");
+    if (type === "control.agents.list") return { agents: [] };
+    return { sessions: [], hasMore: false };
+  });
+  await expect(instances.archiveSession("i1", "main")).rejects.toThrow("archive failed");
+  rpc.mockRestore();
+  // Rollback: the row stays active-looking so the sidebar doesn't grey a live session.
+  expect(instances.byId("i1")!.sessions.find((s) => s.alias === "main")?.archived).toBe(false);
 });
 
 it("localizes the empty-state prompt when locale is zh-CN", () => {

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -54,8 +54,14 @@ watch(
 // instance name. Branch comes from the read-only git summary (undefined until the
 // backend ever adds it to the diff result).
 const instance = computed(() => (chat.instanceId ? instances.byId(chat.instanceId) : undefined));
+// Resolve the selected row across every list the dashboard keeps it in — NOT just
+// inst.sessions. Sleeping rows deliberately live outside that list (grouped sidebar
+// pages them into groupArchived; flat-mode archive can drop the selected row until a
+// full snapshot loads), and the chat pane must keep its header/driver while one is open.
 const currentSession = computed(() =>
-  instance.value?.sessions.find((s) => s.alias === chat.sessionAlias),
+  chat.instanceId && chat.sessionAlias
+    ? instances.findSessionRow(chat.instanceId, chat.sessionAlias)
+    : undefined,
 );
 // The session's acpx driver (codex/claude/…), driving the assistant avatar glyph.
 // Prefer the driver carried on the session row itself (resolved server-side) — the

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -57,11 +57,15 @@ const instance = computed(() => (chat.instanceId ? instances.byId(chat.instanceI
 const currentSession = computed(() =>
   instance.value?.sessions.find((s) => s.alias === chat.sessionAlias),
 );
-// The session's acpx driver (codex/claude/…), resolved from the instance's configured
-// agents (session carries the agent NAME; AgentDto maps name→driver). Drives the
-// assistant avatar glyph. Undefined until agents load → AgentIcon shows its fallback.
-const currentDriver = computed(() =>
-  instance.value?.agents.find((a) => a.name === currentSession.value?.agent)?.driver,
+// The session's acpx driver (codex/claude/…), driving the assistant avatar glyph.
+// Prefer the driver carried on the session row itself (resolved server-side) — the
+// agents-map fallback fails exactly when a sleeping (archived) row is selected from
+// the sidebar without its group/section being in the active list. Undefined until
+// either source loads → AgentIcon shows its fallback.
+const currentDriver = computed(
+  () =>
+    currentSession.value?.driver
+    ?? instance.value?.agents.find((a) => a.name === currentSession.value?.agent)?.driver,
 );
 
 // Booting state: an optimistic session whose create RPC is still cold-starting the agent.

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -28,9 +28,14 @@ const centerTabs = useCenterTabsStore();
 const terminals = useTerminalStore();
 const { t } = useI18n();
 
-// A session row carries the agent NAME; the brand glyph keys on its driver. Resolve via the
-// instance's configured agents (AgentDto maps name→driver). Undefined → AgentIcon falls back.
-function driverFor(inst: InstanceView, agentName: string): string | undefined {
+// A session row carries the agent NAME; the brand glyph keys on its driver. Prefer the
+// driver carried on the row itself (server-resolved; sleeping rows live outside the
+// active list, so the agents map below is only a fallback for old instances).
+function driverFor(inst: InstanceView, s: Pick<InstanceView["sessions"][number], "agent" | "driver">): string | undefined {
+  return s.driver ?? inst.agents.find((a) => a.name === s.agent)?.driver;
+}
+// Agent-mode group headers key on the agent NAME (no row) — agents map only.
+function driverForAgentName(inst: InstanceView, agentName: string): string | undefined {
   return inst.agents.find((a) => a.name === agentName)?.driver;
 }
 const emit = defineEmits<{ select: [instanceId: string, alias: string] }>();
@@ -418,7 +423,7 @@ const rowSwipes = computed(() => {
               <ChevronDown v-if="!isGroupCollapsed(inst, grp.key)" :size="11" class="shrink-0 text-fg-muted" />
               <ChevronRight v-else :size="11" class="shrink-0 text-fg-muted" />
               <Folder v-if="groupModeOf(inst) === 'workspace'" :size="12" class="shrink-0 text-fg-muted" />
-              <AgentIcon v-else :driver="driverFor(inst, grp.key)" :title="grp.key" :size="13" />
+              <AgentIcon v-else :driver="driverForAgentName(inst, grp.key)" :title="grp.key" :size="13" />
               <span data-test="group-name" class="min-w-0 truncate text-[11.5px] font-semibold text-fg-muted">{{ grp.key }}</span>
               <span data-test="group-count" class="shrink-0 font-mono text-[10px] tabular-nums text-fg-muted">{{ grp.sessions.length }}</span>
             </button>
@@ -464,7 +469,7 @@ const rowSwipes = computed(() => {
                   <!-- Agent brand glyph (driver icon) BEFORE the name, in place of a text badge —
                        saves horizontal space; the agent name stays available on hover. Redundant
                        inside an agent-mode group (the group header already carries it) → dropped. -->
-                  <AgentIcon v-if="groupModeOf(inst) !== 'agent'" :driver="driverFor(inst, s.agent)" :title="s.agent" :size="14"
+                  <AgentIcon v-if="groupModeOf(inst) !== 'agent'" :driver="driverFor(inst, s)" :title="s.agent" :size="14"
                              :class="s.archived ? 'opacity-60' : ''" />
                   <input v-if="renamingFor === `${inst.id}:${s.alias}`" data-test="rename-input"
                          v-model="renameDraft" :maxlength="60" :placeholder="$t('instance.sessionRenamePlaceholder')"

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -704,7 +704,21 @@ export const useInstancesStore = defineStore("instances", () => {
   }
 
   async function archiveSession(instanceId: string, alias: string): Promise<void> {
-    await api.rpc(instanceId, "control.sessions.archive", { alias });
+    // Optimistic archived flag: the connector's archive RPC returns {} without the
+    // updated row, and core's `sessions-changed` only triggers a refetch — nothing
+    // else flips the local row. Marking it here (rolling back on failure, mirroring
+    // chat.send's warm/archived optimistic clear) lets the post-archive
+    // loadSessions replace recognize the selected row as archived and retain it,
+    // instead of dropping it from the active list mid-transition.
+    const sessionRow = byId(instanceId)?.sessions.find((s) => s.alias === alias);
+    const prevArchived = sessionRow?.archived === true;
+    if (sessionRow) sessionRow.archived = true;
+    try {
+      await api.rpc(instanceId, "control.sessions.archive", { alias });
+    } catch (error) {
+      if (sessionRow && !prevArchived) sessionRow.archived = false;
+      throw error;
+    }
     // No cache purge: a sleeping session stays resumable, and its cached tail
     // lets waking it paint instantly.
     await loadSessions(instanceId);

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -445,7 +445,7 @@ export const useInstancesStore = defineStore("instances", () => {
         const rows = sessions.map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest));
         const archived = replace && inst.archivedSessionsLoaded ? inst.sessions.filter((session) => session.archived) : [];
         if (replace) {
-          // A replace snapshot is authoritative for the rows it contains, but two
+          // A replace snapshot is authoritative for the rows it contains, but these
           // kinds of local row must survive it:
           //  - an optimistic create still booting (RPC in flight, or a 504 whose
           //    session arrives later via sessions-changed) — dropping it would
@@ -455,11 +455,18 @@ export const useInstancesStore = defineStore("instances", () => {
           //    with more actives than one page the new one sits past the boundary.
           //    Kept only while hasMore — a COMPLETE list omitting the alias is the
           //    server saying the session is gone.
+          //  - the SELECTED session if it just went archived: archive → sessions-changed
+          //    → this replace runs before any full archived snapshot loads, and the
+          //    active-only page no longer contains the row. Dropping it would blank the
+          //    open chat's header/driver. Kept until a full snapshot (loadArchivedSessions)
+          //    re-homes it authoritatively.
           // Mirrors loadArchivedSessions' transient handling.
+          const chat = useChatStore();
           const keep = inst.sessions.filter((row) =>
             row.creating
             || row.createError
             || (row.justCreated === true && hasMore && !rows.some((r) => r.alias === row.alias))
+            || (row.archived === true && instanceId === chat.instanceId && row.alias === chat.sessionAlias),
           );
           for (const row of keep) {
             if (!rows.some((r) => r.alias === row.alias)) {
@@ -813,6 +820,23 @@ export const useInstancesStore = defineStore("instances", () => {
   function byId(id: string): InstanceView | undefined {
     return instances.value.find((i) => i.id === id);
   }
+  /** Resolve a session row by alias across EVERY list the dashboard keeps it in:
+   *  the active list AND per-group sleeping pages. Sleeping rows deliberately live
+   *  outside `sessions` (grouped sidebar), and flat-mode archive can drop the
+   *  selected row entirely until a full snapshot loads — consumers that must keep
+   *  working while a sleeping session is selected (chat header/avatar, driver)
+   *  resolve through here instead of `inst.sessions.find`. */
+  function findSessionRow(instanceId: string, alias: string): SessionRow | undefined {
+    const inst = byId(instanceId);
+    if (!inst) return undefined;
+    const active = inst.sessions.find((s) => s.alias === alias);
+    if (active) return active;
+    for (const state of Object.values(inst.groupArchived ?? {})) {
+      const row = state.sessions.find((s) => s.alias === alias);
+      if (row) return row;
+    }
+    return undefined;
+  }
 
-  return { agentDirectory, loadAgentDirectory, instances, groupModes, groupModeFor, setGroupMode, loadInstances, loadSessions, loadMoreSessions, loadSessionsForOnlineInstances, loadArchivedSessions, loadGroupArchivedSessions, refreshLoadedGroupArchivedSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, beginSessionCreation, cancelSessionCreation, listNativeSessions, listModelSuggestions, removeSession, archiveSession, unarchiveSession, renameSession, renameInstance, applyEvent, byId };
+  return { agentDirectory, loadAgentDirectory, instances, groupModes, groupModeFor, setGroupMode, loadInstances, loadSessions, loadMoreSessions, loadSessionsForOnlineInstances, loadArchivedSessions, loadGroupArchivedSessions, refreshLoadedGroupArchivedSessions, loadWorkspaces, loadFormOptions, loadAgentCatalog, createWorkspace, createAgent, removeAgent, removeWorkspace, createSession, beginSessionCreation, cancelSessionCreation, listNativeSessions, listModelSuggestions, removeSession, archiveSession, unarchiveSession, renameSession, renameInstance, applyEvent, byId, findSessionRow };
 });

--- a/src/control/control-service.ts
+++ b/src/control/control-service.ts
@@ -92,6 +92,12 @@ export interface ModelSetRequestOptions {
 export interface ControlSessionInfo {
   alias: string;
   agent: string;
+  /** The acpx driver backing `agent`, resolved from the agent's config at listing
+   *  time. Lets the web render the brand icon without an agents-map lookup — which
+   *  fails for sleeping sessions whose rows live outside the active session list.
+   *  Optional: mirrors ResolvedSession.driver (custom agents always resolve one,
+   *  but the type stays tolerant). */
+  driver?: string;
   workspace: string;
   transportSession: string;
   running: boolean;
@@ -944,6 +950,7 @@ export class ControlService {
         return {
           alias: toDisplaySessionAlias(session.alias),
           agent: session.agent,
+          driver: session.driver,
           workspace: session.workspace,
           transportSession: session.transportSession,
           running,

--- a/tests/unit/control/control-archive.test.ts
+++ b/tests/unit/control/control-archive.test.ts
@@ -19,6 +19,7 @@ function makeDeps() {
   const session = {
     alias: "relay:backend",
     agent: "claude",
+    driver: "claude",
     workspace: "/ws/backend",
     transportSession: "xacpx-backend",
     archived: true,
@@ -115,10 +116,13 @@ test("removeSession routes through removeSessionWithTransport (real delete), not
   expect(seen).toContainEqual({ type: "sessions-changed" });
 });
 
-test("listSessions includes the archived flag on each session", () => {
+test("listSessions includes the archived flag and the resolved driver on each session", () => {
   const { deps } = makeDeps();
   const control = new ControlService(deps as never);
   const sessions = control.listSessions("relay:acct");
   expect(sessions).toHaveLength(1);
   expect(sessions[0]?.archived).toBe(true);
+  // Sleeping sessions render their brand icon from this field — the web cannot
+  // re-derive it from an agents map once the row leaves the active list.
+  expect(sessions[0]?.driver).toBe("claude");
 });


### PR DESCRIPTION
## Problem

选择睡眠（archived）会话后，消息气泡的 agent 头像和侧栏行图标都退化为通用 Bot 图标，而不是该会话 agent 的品牌图标。

## Root cause

Web 解析图标 driver 是两跳：会话行的 `agent` 名 → `inst.agents` 映射查 driver。睡眠会话恰好破坏第一跳：

- **分组侧栏模式**：睡眠行按设计存在 `inst.groupArchived[*].sessions`，**不进** `inst.sessions`。选中后 `ChatPane.currentSession` 找不到行，driver 为 undefined；
- **平铺模式**：睡眠动作触发 `sessions-changed` → `loadSessions` 替换列表，归档行被移出 `inst.sessions`（仅当完整快照加载过才保留），同样丢行。

两条路都让 AgentIcon 拿不到 driver，回退通用图标。

## Fix

在源头解决：服务端 `ResolvedSession.driver` 本来就已解析（来自 agent 配置），现在 `ControlService.listSessions` 把它映射到每行 —— 新增可选字段 `SessionDto.driver`（旧实例不发送，向后兼容）。

Web 侧优先使用行内 `driver`，`inst.agents` 查找仅作为老实例回退。顺带修掉“agents 未加载时全部显示默认图标”这一整类脆弱性（原实现依赖 agents 表先于图标渲染加载）。

## Test plan

- [x] core: `control-archive.test.ts` 断言归档会话的 `listSessions` 行携带 `driver`
- [x] web 回归：ChatPane 在 archived 行 + 空 agents map 下渲染气泡头像，断言 `data-driver="kimi"`（修复前为 fallback Bot）
- [x] 全量 control 单测 335 pass；relay-web vitest 1126 pass；core/web typecheck 干净；`build:relay-web` 通过