### PR TITLE
feat(relay,relay-web): support Apple Web Push (macOS Safari & iOS Home Screen Web Apps)

### DIFF
--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -118,9 +118,16 @@
 
 ## Web Push（task-completion 桌面通知）
 
-- 用途：实例产生 `notice.kind === "task-completion"` 时，向该账号已订阅的浏览器推系统通知（标签页在后台或已关闭也能收到）；`task-progress` / `coordinator-message` 仅走 WS 广播。设计 spec：docs/superpowers/specs/2026-08-24-web-push-task-completion-design.md。
+- 用途：基于 W3C 标准 Web Push / VAPID 协议，实例产生 `notice.kind === "task-completion"` 时向该账号已订阅的浏览器推送系统通知（标签页在后台或已关闭也能收到）；`task-progress` / `coordinator-message` 仅走 WS 广播。支持浏览器覆盖：
+  - **Chrome / Chromium**
+  - **macOS Safari**（Safari 16.1+ / macOS Ventura+）
+  - **iOS / iPadOS 主屏幕 Web App**（iOS/iPadOS 16.4+，添加到主屏幕并从主屏幕打开）
+  设计 specs：`docs/superpowers/specs/2026-08-24-web-push-task-completion-design.md`、`docs/superpowers/specs/2026-08-25-support-apple-web-push.md`。
+- 网络出站要求：Hub 出站网络需允许连接以下 Push 服务的标准 443 端口：
+  - `fcm.googleapis.com`、`fcm.notifications.google.com`（Chrome / Chromium）
+  - `*.push.apple.com`（Apple Safari / APNs）
 - 配置：`xacpx-relay push-keys generate` 打印 VAPID 密钥对；经环境变量 `XACPX_RELAY_VAPID_SUBJECT` / `XACPX_RELAY_VAPID_PUBLIC_KEY` / `XACPX_RELAY_VAPID_PRIVATE_KEY` 或 start 子命令 `--vapid-subject/--vapid-public-key/--vapid-private-key` 注入。未配置则推送禁用（log warn），WS 通道不受影响。
-- 存储：`push_subscriptions` 表（account_id + endpoint 主键，endpoint 全局唯一索引）。API：`GET /api/web-push/vapid-public-key`、`PUT/DELETE /api/web-push/subscriptions`（authed + requireJson）。
+- 存储：`push_subscriptions` 表（account_id + endpoint 主键，endpoint 全局唯一索引）。API：`GET /api/web-push/vapid-public-key`、`PUT/DELETE /api/web-push/subscriptions`（authed + requireJson，严格校验 endpoint allowlist 防 SSRF）。
 - 发送：server.ts 的 instanceNotice 分支 fire-and-forget fan-out；payload `{title=实例名, body=text 截断200, instanceId, url:"/"}`，TTL 3600；410/404 自动删订阅行。
 - Web 端：SettingsView「桌面通知」开关（五态状态机）；订阅所有权转移属于认证生命周期——login fail-closed 转移（失败撤销 session），fetchMe 认证成功后 best-effort 维护同账号订阅，logout 先解绑再清 session。SW 推送处理器为 public/push-sw.js，经 pwa-options 的 workbox.importScripts 注入。
 

--- a/docs/superpowers/specs/2026-08-25-support-apple-web-push.md
+++ b/docs/superpowers/specs/2026-08-25-support-apple-web-push.md
@@ -1,0 +1,944 @@
+# Safari Web Push Support 实现方案
+
+目标：在现有 PR #305 Web Push 架构上增加 **Safari 支持**，覆盖：
+
+* macOS Safari Web Push
+* iPhone / iPad Home Screen Web App Web Push
+* 保持 Chrome/Chromium 行为不变
+* 不削弱现有 SSRF 防护
+* 不引入 Apple Developer Program、APNs certificate 等额外依赖
+
+Apple 的 Safari 使用标准 Web Push / VAPID。macOS Safari 16.1+ 支持标准 Web Push；iOS/iPadOS 16.4+ 支持添加到主屏幕的 Web App，并且 Apple 明确要求服务端允许 `*.push.apple.com` Push endpoint。([WebKit][1])
+
+## 1. 当前限制
+
+现有实现前端和 Hub 都只允许两个 FCM origin：
+
+```ts
+const ALLOWED_ENDPOINT_ORIGINS = {
+  "https://fcm.googleapis.com": true,
+  "https://fcm.notifications.google.com": true,
+};
+```
+
+因此 Safari 虽然可以成功创建 `PushSubscription`，但 Apple 返回的 endpoint 属于：
+
+```text
+https://<subdomain>.push.apple.com/...
+```
+
+随后会被 xacpx 自己判定为 `push-endpoint-unsupported`。
+
+前端限制位于：
+
+```text
+packages/relay-web/src/lib/web-push.ts
+```
+
+现有代码也明确注明当前只支持 Chrome。
+
+Hub 同样有独立 endpoint validator：
+
+```text
+packages/relay/src/push.ts
+```
+
+所以这次必须 **前后端同时扩展**，不能只改一边。
+
+---
+
+# 2. Endpoint validator
+
+不要把 Apple 写成固定 origin，因为 Apple 官方要求的是：
+
+```text
+*.push.apple.com
+```
+
+也不要简单写这种不安全判断：
+
+```ts
+endpoint.includes("push.apple.com")
+```
+
+或者：
+
+```ts
+hostname.endsWith("push.apple.com")
+```
+
+后者会错误接受：
+
+```text
+evilpush.apple.com
+```
+
+建议前后端统一成这种语义：
+
+```ts
+export function isAllowedPushEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint);
+
+    if (url.protocol !== "https:") return false;
+
+    // Push services should only be reachable over normal HTTPS.
+    // URL.port is "" for implicit 443.
+    if (url.port !== "" && url.port !== "443") return false;
+
+    if (
+      url.hostname === "fcm.googleapis.com" ||
+      url.hostname === "fcm.notifications.google.com"
+    ) {
+      return true;
+    }
+
+    // Apple officially requires allowing any subdomain of push.apple.com.
+    if (url.hostname.endsWith(".push.apple.com")) {
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+```
+
+Apple 官方明确说 Safari Web Push 服务端需要允许 `*.push.apple.com`。([WebKit][1])
+
+### 必须注意
+
+不要接受：
+
+```text
+https://push.apple.com.evil.com/...
+https://evilpush.apple.com/...
+https://push.apple.com@evil.com/...
+http://web.push.apple.com/...
+https://web.push.apple.com:8443/...
+https://example.com/?next=https://web.push.apple.com/
+```
+
+应该接受：
+
+```text
+https://web.push.apple.com/...
+https://foo.push.apple.com/...
+https://foo.bar.push.apple.com/...
+https://web.push.apple.com:443/...
+```
+
+我倾向于**不接受裸的**：
+
+```text
+https://push.apple.com/
+```
+
+因为 Apple 的公开要求是 `*.push.apple.com`，不是 `push.apple.com`。
+
+---
+
+# 3. Hub 改动
+
+修改：
+
+```text
+packages/relay/src/push.ts
+```
+
+现有：
+
+```ts
+const ALLOWED_ENDPOINT_ORIGINS = {
+  "https://fcm.googleapis.com": true,
+  "https://fcm.notifications.google.com": true,
+};
+```
+
+改成支持：
+
+```text
+FCM
++
+*.push.apple.com
+```
+
+继续确保所有客户端提交的 endpoint 都经过这个 validator。
+
+这是一个**安全边界**，不能为了 Safari 改成：
+
+```ts
+url.protocol === "https:"
+```
+
+因为 Hub 会从服务器网络直接 POST 到客户端提交的 endpoint；允许任意 HTTPS 会重新打开 #305 已经修掉的 blind SSRF。
+
+---
+
+# 4. relay-web 改动
+
+修改：
+
+```text
+packages/relay-web/src/lib/web-push.ts
+```
+
+把同样的 Apple endpoint 规则加入：
+
+```ts
+isAllowedPushEndpoint()
+```
+
+现有流程：
+
+```text
+PushManager.subscribe()
+        ↓
+检查 endpoint
+        ↓
+unsupported -> unsubscribe
+        ↓
+PUT Hub
+```
+
+这个顺序保持不变。
+
+Safari subscription 应该现在通过本地 validator，然后正常：
+
+```ts
+await api.put("/api/web-push/subscriptions", sub.toJSON());
+```
+
+不要为 Safari 写特殊 subscription payload。
+
+Safari 使用的仍然是标准：
+
+```ts
+{
+  endpoint,
+  keys: {
+    p256dh,
+    auth
+  }
+}
+```
+
+现有 VAPID public/private key 也继续使用，不需要 Apple 专用 key。
+
+Apple 明确说明这是标准 Web Push，而且**不需要加入 Apple Developer Program**。([WebKit][1])
+
+---
+
+# 5. 不要做 browser detection 来决定是否支持
+
+核心能力判断继续使用：
+
+```ts
+"serviceWorker" in navigator &&
+"PushManager" in window &&
+"Notification" in window
+```
+
+不要这样：
+
+```ts
+if (isSafari) ...
+if (isChrome) ...
+```
+
+Apple 自己也建议标准 Web Push 应该通过 feature detection，而不是排除 Safari 的 browser detection。([WebKit][2])
+
+换句话说：
+
+```text
+Chrome → 标准 Push API
+Safari → 标准 Push API
+未来 Firefox → 也是标准 Push API
+```
+
+provider 差异只应该体现在 **服务器安全 endpoint allowlist**。
+
+---
+
+# 6. macOS Safari
+
+目标至少覆盖：
+
+```text
+Safari 16.1+
+macOS Ventura+
+```
+
+Safari 在 macOS 上不要求安装 PWA。
+
+普通网页：
+
+```text
+打开 relay-web
+→ Settings
+→ Desktop Notifications
+→ 点击 Enable
+→ Safari permission prompt
+→ PushManager.subscribe()
+→ *.push.apple.com endpoint
+→ Hub 保存
+→ task-completion
+→ Apple Push Service
+→ Safari/macOS notification
+```
+
+Safari 甚至没有运行时，也可以由系统投递 Web Push。([WebKit][2])
+
+---
+
+# 7. iPhone / iPad
+
+这里必须明确处理产品语义。
+
+iOS/iPadOS Web Push 的经典要求是：
+
+```text
+iOS/iPadOS 16.4+
++
+网站添加到 Home Screen
++
+以 Home Screen Web App 打开
++
+用户主动点击 Enable
+```
+
+Apple 明确要求 notification permission 必须由用户操作触发，例如点击订阅按钮。([WebKit][1])
+
+现有 Settings 中用户主动点击 Enable 已经满足 user gesture 要求。
+
+## PWA manifest
+
+现有 xacpx 已经有：
+
+```ts
+manifest: {
+  name: "XACPX HUB",
+  short_name: "XACPX",
+  display: "standalone",
+  start_url: "/",
+  scope: "/",
+  ...
+}
+```
+
+所以 PWA 基础已经满足，不需要重新搭 PWA。
+
+Apple 对 iOS Home Screen Web App 的 Web Push 支持就是建立在这套标准能力上的。([WebKit][1])
+
+---
+
+# 8. Settings UX
+
+建议顺便补 Safari/iOS 用户提示，但**不要让 UI browser detection 成为能力安全判断**。
+
+例如增加一个说明：
+
+中文：
+
+```text
+iPhone/iPad 需要先将 XACPX 添加到主屏幕，并从主屏幕打开后才能启用通知。
+```
+
+英文：
+
+```text
+On iPhone and iPad, add XACPX to the Home Screen and open it from there before enabling notifications.
+```
+
+可以一直作为辅助文本显示，不必精准检测 Safari。
+
+或者，仅为了 UX 使用 iOS detection 显示这句也可以，但：
+
+```text
+UA detection only controls hint text
+```
+
+不能控制：
+
+```text
+pushSupported()
+endpoint validation
+subscription behavior
+```
+
+---
+
+# 9. Service Worker
+
+当前：
+
+```text
+packages/relay-web/public/push-sw.js
+```
+
+逻辑本身是标准 API：
+
+```js
+self.addEventListener("push", ...)
+self.registration.showNotification(...)
+self.addEventListener("notificationclick", ...)
+```
+
+没有 Chrome 专用 API，所以**不要为了 Safari 重写 Service Worker**。
+
+现有：
+
+```js
+showNotification(title, {
+  body,
+  tag,
+  icon,
+  data
+})
+```
+
+以及：
+
+```js
+clients.matchAll()
+client.focus()
+clients.openWindow()
+```
+
+应继续保留。
+
+Safari 可能忽略部分 notification presentation option，例如某些 icon/tag 表现，但这不应该影响基础 Push 支持。
+
+本 PR 不需要引入 Apple 2025 年新增的 Declarative Web Push。现有 Service Worker Web Push 在当前 Safari/iOS 上仍然是兼容路径；Declarative Web Push 属于未来优化，不是此 PR 的必要条件。([WebKit][3])
+
+---
+
+# 10. 单元测试：安全矩阵
+
+这是本次最重要的自动化测试。
+
+前端和 Hub 的 `isAllowedPushEndpoint()` 都必须覆盖完全一致的 corpus。
+
+### Accept
+
+```ts
+[
+  "https://fcm.googleapis.com/fcm/send/abc",
+  "https://fcm.notifications.google.com/fcm/send/abc",
+
+  "https://web.push.apple.com/Q...",
+  "https://foo.push.apple.com/abc",
+  "https://foo.bar.push.apple.com/abc",
+  "https://web.push.apple.com:443/abc",
+]
+```
+
+全部：
+
+```ts
+expect(isAllowedPushEndpoint(endpoint)).toBe(true)
+```
+
+### Reject：SSRF
+
+```ts
+[
+  "http://web.push.apple.com/abc",
+  "https://web.push.apple.com:8443/abc",
+
+  "https://push.apple.com.evil.com/abc",
+  "https://evilpush.apple.com/abc",
+  "https://push.apple.com@evil.com/abc",
+
+  "https://evil.com/push.apple.com",
+  "https://127.0.0.1/",
+  "https://localhost/",
+  "https://169.254.169.254/",
+  "https://10.0.0.1/",
+  "https://example.com/",
+  "not-a-url",
+]
+```
+
+全部 reject。
+
+再单独加：
+
+```ts
+expect(
+  isAllowedPushEndpoint(
+    "https://foo.push.apple.com.evil.example/path"
+  )
+).toBe(false);
+```
+
+这是防止错误 suffix matcher 的关键回归测试。
+
+---
+
+# 11. relay-web subscription 测试
+
+现有 `web-push` tests 增加真实 Safari-like subscription。
+
+模拟：
+
+```ts
+const safariSub = {
+  endpoint: "https://web.push.apple.com/Q-xxxxx",
+  options: {
+    applicationServerKey: ...
+  },
+  toJSON() {
+    return {
+      endpoint: this.endpoint,
+      keys: {
+        p256dh: "...",
+        auth: "..."
+      }
+    };
+  }
+};
+```
+
+验证：
+
+```text
+Notification.permission = granted
+PushManager.subscribe() -> Safari endpoint
+```
+
+结果必须：
+
+```text
+不调用 unsubscribe()
+PUT /api/web-push/subscriptions
+成功
+```
+
+关键断言：
+
+```ts
+expect(unsubscribe).not.toHaveBeenCalled();
+expect(put).toHaveBeenCalledWith(
+  "/api/web-push/subscriptions",
+  expect.objectContaining({
+    endpoint: expect.stringContaining(".push.apple.com"),
+  }),
+);
+```
+
+同时保留：
+
+```text
+arbitrary HTTPS endpoint
+→ unsubscribe
+→ push-endpoint-unsupported
+→ no PUT
+```
+
+确保 Safari 支持没有破坏 SSRF fail-closed。
+
+---
+
+# 12. Hub API 测试
+
+对：
+
+```text
+PUT /api/web-push/subscriptions
+```
+
+增加 Safari endpoint。
+
+合法：
+
+```json
+{
+  "endpoint": "https://web.push.apple.com/...",
+  "keys": {
+    "p256dh": "<valid key>",
+    "auth": "<valid auth>"
+  }
+}
+```
+
+预期：
+
+```text
+200
+subscription stored
+```
+
+恶意：
+
+```text
+https://web.push.apple.com.attacker.example/...
+```
+
+预期：
+
+```text
+400
+not stored
+```
+
+同时：
+
+```text
+https://attacker.example/...
+```
+
+必须继续 400。
+
+---
+
+# 13. PushNotifier 测试
+
+增加一条 provider-neutral test。
+
+数据库里放：
+
+```text
+Chrome FCM subscription
+Safari Apple subscription
+```
+
+同一账号收到：
+
+```text
+task-completion
+```
+
+断言 notifier fan-out 对两个 subscription 都调用：
+
+```ts
+sendNotification(...)
+```
+
+不要根据 endpoint provider 写不同发送逻辑。
+
+理想结构：
+
+```text
+Hub
+ ├─ FCM endpoint       → web-push.sendNotification()
+ └─ Apple endpoint     → web-push.sendNotification()
+```
+
+`web-push` library 负责标准协议发送。
+
+如果 Apple endpoint 返回：
+
+```text
+404 / 410
+```
+
+现有 stale subscription cleanup 同样应该删除 Apple subscription。
+
+这个行为也补一条 Safari endpoint 测试。
+
+---
+
+# 14. Auth ownership lifecycle 必须继续 provider-neutral
+
+#305 最复杂的安全逻辑不能因为 Safari support 被绕开。
+
+以下全部必须继续适用于 Safari endpoint：
+
+```text
+login ownership transfer
+logout release
+fetchMe same-account reconcile
+VAPID rotation
+destroyProven()
+```
+
+尤其检查：
+
+```ts
+transferSubscriptionOwnership()
+```
+
+不要有这种 Chrome-only 分支：
+
+```ts
+if (!isFcm(sub.endpoint)) destroy...
+```
+
+扩展 `isAllowedPushEndpoint()` 后 Safari subscription 应与 FCM subscription 走完全相同的 ownership contract。
+
+建议至少增加一条：
+
+```text
+existing Safari PushSubscription
+→ login new account
+→ matching VAPID
+→ PUT succeeds
+→ no unsubscribe
+```
+
+和：
+
+```text
+Safari subscription
+→ logout
+→ Hub DELETE
+→ local unsubscribe
+```
+
+---
+
+# 15. VAPID rotation
+
+Safari 必须复用现有逻辑。
+
+场景：
+
+```text
+Safari subscription 使用 VAPID key A
+Hub 改成 key B
+```
+
+应该：
+
+```text
+subscriptionMatchesKey() == false
+→ destroy old subscription
+→ subscribe(applicationServerKey=B)
+→ Apple 返回新 endpoint
+→ PUT Hub
+```
+
+不要为 Apple 创建独立 VAPID key。
+
+也不要：
+
+```text
+Chrome key
+Safari key
+```
+
+一套 Hub VAPID keypair 就够。
+
+---
+
+# 16. notificationclick 手工验收
+
+macOS Safari：
+
+```text
+1. 打开 XACPX
+2. 开启通知
+3. 关闭 tab
+4. 触发 task-completion
+5. 收到 macOS 通知
+6. 点击
+7. XACPX 打开到 /
+```
+
+还要测试已有 XACPX 窗口：
+
+```text
+收到通知
+→ click
+→ existing window focus
+```
+
+iPhone/iPad：
+
+```text
+1. Safari 打开 XACPX
+2. Add to Home Screen
+3. 从 Home Screen 打开 XACPX
+4. 登录
+5. Settings → Desktop Notifications → Enable
+6. Allow
+7. 完全关闭/切后台 Web App
+8. 从另一个 agent 触发 task-completion
+9. Lock Screen / Notification Center 收到通知
+10. 点击通知
+11. XACPX Home Screen Web App 打开
+```
+
+Apple 明确说明 iOS/iPadOS Web Push 通知可以显示在 Lock Screen、Notification Center，并集成 Focus。([WebKit][1])
+
+---
+
+# 17. HTTPS 是硬要求
+
+实际部署测试必须使用：
+
+```text
+https://relay.example.com
+```
+
+不要拿：
+
+```text
+http://LAN-IP:8787
+```
+
+判断 Safari Web Push 是否正常。
+
+Service Worker / Push 都依赖 secure context。
+
+localhost 只适合开发环境特殊规则，不是部署验收条件。
+
+---
+
+# 18. 不需要的东西
+
+这次明确 **不要**：
+
+```text
+Apple Developer Program
+APNs certificate
+.p8 APNs key
+Bundle ID
+native iOS app
+Safari Push Package
+Website Push ID
+Apple proprietary legacy Safari Push
+```
+
+这是标准 W3C Web Push。
+
+Apple 官方明确说 Safari 标准 Web Push 不需要 Apple Developer Program。([WebKit][1])
+
+也不要引入：
+
+```text
+Firebase SDK
+Apple SDK
+browser-specific push client
+```
+
+---
+
+# 19. 建议改动文件
+
+主要：
+
+```text
+packages/relay/src/push.ts
+
+packages/relay-web/src/lib/web-push.ts
+
+packages/relay-web/src/views/SettingsView.vue
+```
+
+测试按仓库现有位置补：
+
+```text
+tests/unit/packages/relay/...
+packages/relay-web/src/__tests__/...
+```
+
+如当前 endpoint validator tests 已存在，直接扩充，不要新建重复测试体系。
+
+文档：
+
+```text
+docs/relay-module.md
+```
+
+把：
+
+```text
+Chrome desktop notifications
+```
+
+改成：
+
+```text
+standards-based Web Push:
+- Chrome/Chromium
+- Safari on macOS
+- Home Screen web apps on iOS/iPadOS
+```
+
+同时记录：
+
+```text
+Hub outbound network must allow:
+- fcm.googleapis.com
+- fcm.notifications.google.com
+- *.push.apple.com
+```
+
+Apple 特别提醒如果服务器管理 outbound endpoints，需要允许 `*.push.apple.com`。([WebKit][1])
+
+---
+
+# 20. PR 验收 Gate
+
+这个 PR 在以下全部满足之前不要合并：
+
+1. Chrome Web Push 现有测试全部不变通过。
+2. Hub 和 relay-web 都接受 `*.push.apple.com`。
+3. 两边都继续拒绝 arbitrary HTTPS。
+4. `evil.push.apple.com.example.com` 必须 reject。
+5. Safari-like subscription 能完成 PUT。
+6. Safari-like subscription 能进入 `PushNotifier.sendNotification()`。
+7. Apple endpoint 404/410 能清理数据库 subscription。
+8. login/logout/fetchMe ownership lifecycle 对 Safari subscription 不退化。
+9. VAPID rotation 对 Safari subscription 正常。
+10. relay 全量测试通过。
+11. relay-web 全量 Vitest 通过。
+12. TypeScript typecheck 通过。
+13. build 通过。
+14. Chrome E2E 不回归。
+15. 至少完成一次真实 macOS Safari 手工端到端。
+16. 最好再完成一次真实 iOS/iPadOS Home Screen Web App 端到端。
+
+---
+
+## 实现原则
+
+最终架构应该保持：
+
+```text
+                    PushSubscription
+                           │
+              ┌────────────┴────────────┐
+              │                         │
+          Chrome                    Safari
+              │                         │
+             FCM                       APNs
+              │                         │
+ fcm.googleapis.com        *.push.apple.com
+              │                         │
+              └────────────┬────────────┘
+                           │
+                standards-based Web Push
+                           │
+                     web-push library
+                           │
+                       XACPX Hub
+```
+
+**provider 只影响 endpoint allowlist，不影响业务逻辑。**
+
+也就是说，不要在 notifier、auth lifecycle、subscription storage 里逐渐长出：
+
+```ts
+if (chrome) ...
+else if (safari) ...
+```
+
+正确方向是：
+
+```ts
+valid standard PushSubscription
+→ same storage
+→ same ownership model
+→ same VAPID
+→ same notifier
+```
+
+这会让后面加 Firefox/Mozilla Push 时也只需要安全地扩展 endpoint provider，而不用再改一遍整个架构。
+
+[1]: https://webkit.org/blog/13878/web-push-for-web-apps-on-ios-and-ipados/?utm_source=chatgpt.com "Web Push for Web Apps on iOS and iPadOS | WebKit"
+[2]: https://webkit.org/blog/13399/webkit-features-in-safari-16-1/?utm_source=chatgpt.com "WebKit Features in Safari 16.1 | WebKit"
+[3]: https://webkit.org/blog/16535/meet-declarative-web-push/?utm_source=chatgpt.com "Meet Declarative Web Push | WebKit"

--- a/packages/relay-web/src/__tests__/settings-notifications.test.ts
+++ b/packages/relay-web/src/__tests__/settings-notifications.test.ts
@@ -128,4 +128,12 @@ describe("settings notifications section", () => {
     expect(w.text()).toContain("browser site settings");
     vi.unstubAllGlobals();
   });
+
+  it("renders iOS / iPadOS Home Screen notification hint", async () => {
+    const w = mountSettings();
+    await flush();
+    const hint = w.find('[data-test="notif-ios-hint"]');
+    expect(hint.exists()).toBe(true);
+    expect(hint.text()).toContain("Home Screen");
+  });
 });

--- a/packages/relay-web/src/__tests__/settings-notifications.test.ts
+++ b/packages/relay-web/src/__tests__/settings-notifications.test.ts
@@ -8,6 +8,7 @@ const lib = vi.hoisted(() => ({
   enableDesktopNotifications: vi.fn(),
   disableDesktopNotifications: vi.fn(),
   subscriptionMatchesKey: vi.fn(),
+  getExistingSubscription: vi.fn(),
 }));
 
 vi.mock("../lib/web-push", () => lib);
@@ -48,14 +49,10 @@ describe("settings notifications section", () => {
     lib.enableDesktopNotifications.mockResolvedValue(undefined);
     lib.disableDesktopNotifications.mockResolvedValue(undefined);
     lib.subscriptionMatchesKey.mockReturnValue(true);
+    lib.getExistingSubscription.mockResolvedValue(null);
   });
   it("renders 已开启 when a probe subscription exists", async () => {
-    vi.stubGlobal("navigator", {
-      ...navigator,
-      serviceWorker: {
-        ready: Promise.resolve({ pushManager: { getSubscription: vi.fn().mockResolvedValue({ endpoint: "https://push/e1" }) } }),
-      },
-    });
+    lib.getExistingSubscription.mockResolvedValue({ endpoint: "https://push/e1" });
     const w = mountSettings();
     await flush();
     expect(w.find('[data-test="notif-state"]').text()).toBe("On");
@@ -99,12 +96,7 @@ describe("settings notifications section", () => {
   });
 
   it("toggle-off calls disableDesktopNotifications and flips to 未开启", async () => {
-    vi.stubGlobal("navigator", {
-      ...navigator,
-      serviceWorker: {
-        ready: Promise.resolve({ pushManager: { getSubscription: vi.fn().mockResolvedValue({ endpoint: "https://push/e1" }) } }),
-      },
-    });
+    lib.getExistingSubscription.mockResolvedValue({ endpoint: "https://push/e1" });
     const w = mountSettings();
     await flush();
     await w.find('[data-test="notif-toggle"]').trigger("click");
@@ -129,11 +121,20 @@ describe("settings notifications section", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders iOS / iPadOS Home Screen notification hint", async () => {
-    const w = mountSettings();
+  it("renders iOS / iPadOS Home Screen notification hint only on iOS/iPadOS", async () => {
+    // 1. Desktop UA -> hint not rendered
+    vi.stubGlobal("navigator", { ...navigator, userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36", maxTouchPoints: 0 });
+    const wDesktop = mountSettings();
     await flush();
-    const hint = w.find('[data-test="notif-ios-hint"]');
+    expect(wDesktop.find('[data-test="notif-ios-hint"]').exists()).toBe(false);
+
+    // 2. iOS UA -> hint rendered
+    vi.stubGlobal("navigator", { ...navigator, userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)", maxTouchPoints: 5 });
+    const wIos = mountSettings();
+    await flush();
+    const hint = wIos.find('[data-test="notif-ios-hint"]');
     expect(hint.exists()).toBe(true);
     expect(hint.text()).toContain("Home Screen");
+    vi.unstubAllGlobals();
   });
 });

--- a/packages/relay-web/src/__tests__/web-push-lib.test.ts
+++ b/packages/relay-web/src/__tests__/web-push-lib.test.ts
@@ -154,25 +154,24 @@ describe("web-push lib", () => {
     expect(apiMocks.del).not.toHaveBeenCalled();
   });
 
-  it("disableDesktopNotifications rejects when unsubscribe fails and Hub DELETE returns deleted: false", async () => {
+  it("disableDesktopNotifications rejects when local destroy is unproven (even if Hub DELETE returns deleted: true)", async () => {
     const unsubscribe = vi.fn().mockRejectedValue(new Error("unsub failed"));
     const getSubscription = vi.fn().mockResolvedValue({ endpoint: "https://push/e1", unsubscribe });
     const unregister = vi.fn().mockResolvedValue(false); // unproven
-    apiMocks.del.mockResolvedValue({ ok: true, deleted: false }); // hub did not delete
+    apiMocks.del.mockResolvedValue({ ok: true, deleted: true }); // hub confirmed deletion, but local remains
     stubNavigator({ registration: { pushManager: { getSubscription }, unregister } });
 
     await expect(disableDesktopNotifications()).rejects.toThrow("push-subscription-destroy-failed");
   });
 
-  it("disableDesktopNotifications resolves when unsubscribe fails but Hub DELETE returns deleted: true", async () => {
-    const unsubscribe = vi.fn().mockRejectedValue(new Error("unsub failed"));
+  it("disableDesktopNotifications resolves when local destroy is proven even if Hub DELETE fails", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true);
     const getSubscription = vi.fn().mockResolvedValue({ endpoint: "https://push/e1", unsubscribe });
-    const unregister = vi.fn().mockResolvedValue(false);
-    apiMocks.del.mockResolvedValue({ ok: true, deleted: true }); // hub confirmed deletion
-    stubNavigator({ registration: { pushManager: { getSubscription }, unregister } });
+    apiMocks.del.mockRejectedValue(new Error("hub offline"));
+    stubNavigator({ registration: { pushManager: { getSubscription } } });
 
     await expect(disableDesktopNotifications()).resolves.toBeUndefined();
-    expect(apiMocks.del).toHaveBeenCalledWith("/api/web-push/subscriptions", { endpoint: "https://push/e1" });
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
   it("reconcileExistingSubscription PUTs a matching subscription; skips otherwise", async () => {
@@ -776,6 +775,32 @@ describe("Safari / Apple Web Push support", () => {
 
     await expect(releaseSubscriptionOwnership()).resolves.toBeUndefined();
     expect(apiMocks.del).toHaveBeenCalledWith("/api/web-push/subscriptions", { endpoint: "https://web.push.apple.com/Q-origin-dead" });
+
+    delete (window as unknown as Record<string, unknown>).pushManager;
+    delete (window as unknown as Record<string, unknown>).PushManager;
+    delete (window as unknown as Record<string, unknown>).Notification;
+  });
+
+  it("unsubscribe resolves but window.pushManager verification rejects -> destroyProven fails closed (rejects)", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true); // sub says unsubscribed
+    const safariSub = {
+      endpoint: "https://web.push.apple.com/Q-origin-flaky",
+      unsubscribe,
+      toJSON() { return { endpoint: this.endpoint }; },
+    };
+    // 1st getSubscription probe returns safariSub; 2nd inside destroyProven rejects with DOMException/AbortError
+    const winGetSub = vi.fn()
+      .mockResolvedValueOnce(safariSub)
+      .mockRejectedValueOnce(new DOMException("query aborted", "AbortError"))
+      .mockRejectedValue(new DOMException("query aborted", "AbortError"));
+    const winPushManager = { getSubscription: winGetSub };
+    (window as unknown as Record<string, unknown>).pushManager = winPushManager;
+    (window as unknown as Record<string, unknown>).PushManager = function FakePushManager() {};
+    (window as unknown as Record<string, unknown>).Notification = function FakeNotification() {};
+    stubNavigator({ registration: null });
+
+    await expect(releaseSubscriptionOwnership()).rejects.toThrow("push-subscription-destroy-failed");
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
 
     delete (window as unknown as Record<string, unknown>).pushManager;
     delete (window as unknown as Record<string, unknown>).PushManager;

--- a/packages/relay-web/src/__tests__/web-push-lib.test.ts
+++ b/packages/relay-web/src/__tests__/web-push-lib.test.ts
@@ -659,4 +659,104 @@ describe("Safari / Apple Web Push support", () => {
     delete (window as unknown as Record<string, unknown>).PushManager;
     delete (window as unknown as Record<string, unknown>).Notification;
   });
+
+  it("window.pushManager has Safari sub + getRegistration() null -> logout DELETEs + unsubscribes", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true);
+    const safariSub = {
+      endpoint: "https://web.push.apple.com/Q-origin-level",
+      unsubscribe,
+      toJSON() { return { endpoint: this.endpoint }; },
+    };
+    const winPushManager = { getSubscription: vi.fn().mockResolvedValue(safariSub) };
+    (window as unknown as Record<string, unknown>).pushManager = winPushManager;
+    (window as unknown as Record<string, unknown>).PushManager = function FakePushManager() {};
+    (window as unknown as Record<string, unknown>).Notification = function FakeNotification() {};
+    apiMocks.del.mockResolvedValue({ ok: true, deleted: true });
+    stubNavigator({ registration: null }); // No SW registration
+
+    await releaseSubscriptionOwnership();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(apiMocks.del).toHaveBeenCalledWith("/api/web-push/subscriptions", { endpoint: "https://web.push.apple.com/Q-origin-level" });
+
+    delete (window as unknown as Record<string, unknown>).pushManager;
+    delete (window as unknown as Record<string, unknown>).PushManager;
+    delete (window as unknown as Record<string, unknown>).Notification;
+  });
+
+  it("window.pushManager has Safari sub + getRegistration() null -> login transfer PUTs/rebinds", async () => {
+    const safariSub = {
+      endpoint: "https://web.push.apple.com/Q-origin-level-login",
+      options: { applicationServerKey: urlBase64ToUint8Array2("BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U").buffer },
+      unsubscribe: vi.fn().mockResolvedValue(true),
+      toJSON() { return { endpoint: this.endpoint, keys: { p256dh: "k", auth: "a" } }; },
+    };
+    const winPushManager = { getSubscription: vi.fn().mockResolvedValue(safariSub) };
+    (window as unknown as Record<string, unknown>).pushManager = winPushManager;
+    (window as unknown as Record<string, unknown>).PushManager = function FakePushManager() {};
+    (window as unknown as Record<string, unknown>).Notification = function FakeNotification() {};
+    apiMocks.get.mockResolvedValue({ publicKey: "BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U" });
+    apiMocks.put.mockResolvedValue({ ok: true });
+    stubNavigator({ registration: null }); // No SW registration
+
+    await transferSubscriptionOwnership();
+    expect(safariSub.unsubscribe).not.toHaveBeenCalled();
+    expect(apiMocks.put).toHaveBeenCalledWith("/api/web-push/subscriptions", {
+      endpoint: "https://web.push.apple.com/Q-origin-level-login",
+      keys: { p256dh: "k", auth: "a" },
+    });
+
+    delete (window as unknown as Record<string, unknown>).pushManager;
+    delete (window as unknown as Record<string, unknown>).PushManager;
+    delete (window as unknown as Record<string, unknown>).Notification;
+  });
+
+  it("unregister=true and reg.pushManager null but window.pushManager non-null -> destroyProven rejects", async () => {
+    const unsubscribe = vi.fn().mockRejectedValue(new Error("unsub failed"));
+    const safariSub = {
+      endpoint: "https://web.push.apple.com/Q-lingering-origin",
+      unsubscribe,
+      toJSON() { return { endpoint: this.endpoint }; },
+    };
+    const winPushManager = { getSubscription: vi.fn().mockResolvedValue(safariSub) }; // Still non-null!
+    (window as unknown as Record<string, unknown>).pushManager = winPushManager;
+    (window as unknown as Record<string, unknown>).PushManager = function FakePushManager() {};
+    (window as unknown as Record<string, unknown>).Notification = function FakeNotification() {};
+    apiMocks.del.mockResolvedValue({ ok: true });
+
+    const unregisterReg = vi.fn().mockResolvedValue(true);
+    const existingReg = { pushManager: { getSubscription: vi.fn().mockResolvedValue(null) }, unregister: unregisterReg };
+    stubNavigator({ registration: existingReg });
+
+    await expect(releaseSubscriptionOwnership()).rejects.toThrow("push-subscription-destroy-failed");
+
+    delete (window as unknown as Record<string, unknown>).pushManager;
+    delete (window as unknown as Record<string, unknown>).PushManager;
+    delete (window as unknown as Record<string, unknown>).Notification;
+  });
+
+  it("window.pushManager.getSubscription()=null proves origin binding is dead when unsub failed", async () => {
+    const unsubscribe = vi.fn().mockRejectedValue(new Error("unsub failed"));
+    const safariSub = {
+      endpoint: "https://web.push.apple.com/Q-origin-dead",
+      unsubscribe,
+      toJSON() { return { endpoint: this.endpoint }; },
+    };
+    // 1st getSubscription probe returns safariSub; 2nd inside destroyProven returns null (dead)
+    const winGetSub = vi.fn()
+      .mockResolvedValueOnce(safariSub)
+      .mockResolvedValueOnce(null);
+    const winPushManager = { getSubscription: winGetSub };
+    (window as unknown as Record<string, unknown>).pushManager = winPushManager;
+    (window as unknown as Record<string, unknown>).PushManager = function FakePushManager() {};
+    (window as unknown as Record<string, unknown>).Notification = function FakeNotification() {};
+    apiMocks.del.mockResolvedValue({ ok: true, deleted: true });
+    stubNavigator({ registration: null });
+
+    await expect(releaseSubscriptionOwnership()).resolves.toBeUndefined();
+    expect(apiMocks.del).toHaveBeenCalledWith("/api/web-push/subscriptions", { endpoint: "https://web.push.apple.com/Q-origin-dead" });
+
+    delete (window as unknown as Record<string, unknown>).pushManager;
+    delete (window as unknown as Record<string, unknown>).PushManager;
+    delete (window as unknown as Record<string, unknown>).Notification;
+  });
 });

--- a/packages/relay-web/src/__tests__/web-push-lib.test.ts
+++ b/packages/relay-web/src/__tests__/web-push-lib.test.ts
@@ -140,6 +140,7 @@ describe("web-push lib", () => {
   it("disableDesktopNotifications unsubscribes and DELETEs", async () => {
     const unsubscribe = vi.fn().mockResolvedValue(true);
     const getSubscription = vi.fn().mockResolvedValue({ endpoint: "https://push/e1", unsubscribe });
+    apiMocks.del.mockResolvedValue({ ok: true, deleted: true });
     stubNavigator({ registration: { pushManager: { getSubscription } } });
 
     await disableDesktopNotifications();
@@ -151,6 +152,27 @@ describe("web-push lib", () => {
     getSubscription.mockResolvedValue(null);
     await disableDesktopNotifications();
     expect(apiMocks.del).not.toHaveBeenCalled();
+  });
+
+  it("disableDesktopNotifications rejects when unsubscribe fails and Hub DELETE returns deleted: false", async () => {
+    const unsubscribe = vi.fn().mockRejectedValue(new Error("unsub failed"));
+    const getSubscription = vi.fn().mockResolvedValue({ endpoint: "https://push/e1", unsubscribe });
+    const unregister = vi.fn().mockResolvedValue(false); // unproven
+    apiMocks.del.mockResolvedValue({ ok: true, deleted: false }); // hub did not delete
+    stubNavigator({ registration: { pushManager: { getSubscription }, unregister } });
+
+    await expect(disableDesktopNotifications()).rejects.toThrow("push-subscription-destroy-failed");
+  });
+
+  it("disableDesktopNotifications resolves when unsubscribe fails but Hub DELETE returns deleted: true", async () => {
+    const unsubscribe = vi.fn().mockRejectedValue(new Error("unsub failed"));
+    const getSubscription = vi.fn().mockResolvedValue({ endpoint: "https://push/e1", unsubscribe });
+    const unregister = vi.fn().mockResolvedValue(false);
+    apiMocks.del.mockResolvedValue({ ok: true, deleted: true }); // hub confirmed deletion
+    stubNavigator({ registration: { pushManager: { getSubscription }, unregister } });
+
+    await expect(disableDesktopNotifications()).resolves.toBeUndefined();
+    expect(apiMocks.del).toHaveBeenCalledWith("/api/web-push/subscriptions", { endpoint: "https://push/e1" });
   });
 
   it("reconcileExistingSubscription PUTs a matching subscription; skips otherwise", async () => {

--- a/packages/relay-web/src/__tests__/web-push-lib.test.ts
+++ b/packages/relay-web/src/__tests__/web-push-lib.test.ts
@@ -23,6 +23,8 @@ import {
   disableDesktopNotifications,
   reconcileExistingSubscription,
   releaseSubscriptionOwnership,
+  transferSubscriptionOwnership,
+  isAllowedPushEndpoint,
 } from "../lib/web-push";
 
 interface StubSW {
@@ -544,6 +546,116 @@ describe("release ownership (round-5 strict contract)", () => {
 
     await expect(reconcileExistingSubscription()).rejects.toThrow("push-subscription-destroy-failed");
     expect(unregisterReg).toHaveBeenCalledTimes(1);
+    delete (window as unknown as Record<string, unknown>).PushManager;
+    delete (window as unknown as Record<string, unknown>).Notification;
+  });
+});
+
+describe("Safari / Apple Web Push support", () => {
+  beforeEach(() => {
+    apiMocks.get.mockReset().mockResolvedValue({ publicKey: "PK" });
+    apiMocks.put.mockReset().mockResolvedValue({ ok: true });
+    apiMocks.del.mockReset().mockResolvedValue({ ok: true });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("isAllowedPushEndpoint accept and reject matrix", () => {
+    // Accept matrix
+    for (const ep of [
+      "https://fcm.googleapis.com/fcm/send/abc",
+      "https://fcm.notifications.google.com/fcm/send/abc",
+      "https://web.push.apple.com/Q-xxxxx",
+      "https://foo.push.apple.com/abc",
+      "https://foo.bar.push.apple.com/abc",
+      "https://web.push.apple.com:443/abc",
+    ]) {
+      expect(isAllowedPushEndpoint(ep)).toBe(true);
+    }
+
+    // Reject matrix
+    for (const ep of [
+      "http://web.push.apple.com/abc",
+      "https://web.push.apple.com:8443/abc",
+      "https://push.apple.com.evil.com/abc",
+      "https://evilpush.apple.com/abc",
+      "https://push.apple.com@evil.com/abc",
+      "https://push.apple.com/abc",
+      "https://evil.com/push.apple.com",
+      "https://127.0.0.1/",
+      "https://localhost/",
+      "https://169.254.169.254/",
+      "https://10.0.0.1/",
+      "https://example.com/",
+      "not-a-url",
+      "https://foo.push.apple.com.evil.example/path",
+    ]) {
+      expect(isAllowedPushEndpoint(ep)).toBe(false);
+    }
+  });
+
+  it("enableDesktopNotifications succeeds for Safari endpoint without unsubscribe", async () => {
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    vi.stubGlobal("Notification", { permission: "default", requestPermission });
+    const unsubscribe = vi.fn().mockResolvedValue(true);
+    const subscribe = vi.fn().mockResolvedValue({
+      endpoint: "https://web.push.apple.com/Q-safari-12345",
+      keys: { p256dh: "k-safari", auth: "a-safari" },
+      unsubscribe,
+      toJSON() {
+        return { endpoint: this.endpoint, keys: this.keys };
+      },
+    });
+    stubNavigator({ readyPushManager: { subscribe, getSubscription: vi.fn().mockResolvedValue(null) } });
+
+    await enableDesktopNotifications("PK");
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(unsubscribe).not.toHaveBeenCalled();
+    expect(apiMocks.put).toHaveBeenCalledWith("/api/web-push/subscriptions", {
+      endpoint: "https://web.push.apple.com/Q-safari-12345",
+      keys: { p256dh: "k-safari", auth: "a-safari" },
+    });
+  });
+
+  it("transferSubscriptionOwnership transfers an existing Safari subscription", async () => {
+    const safariSub = {
+      endpoint: "https://web.push.apple.com/Q-safari-owned",
+      options: { applicationServerKey: urlBase64ToUint8Array2("BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U").buffer },
+      unsubscribe: vi.fn().mockResolvedValue(true),
+      toJSON() { return { endpoint: this.endpoint, keys: { p256dh: "k", auth: "a" } }; },
+    };
+    (window as unknown as Record<string, unknown>).PushManager = function FakePushManager() {};
+    (window as unknown as Record<string, unknown>).Notification = function FakeNotification() {};
+    apiMocks.get.mockResolvedValue({ publicKey: "BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U" });
+    apiMocks.put.mockResolvedValue({ ok: true });
+    stubNavigator({ registration: { pushManager: { getSubscription: vi.fn().mockResolvedValue(safariSub) } } });
+
+    await transferSubscriptionOwnership();
+    expect(safariSub.unsubscribe).not.toHaveBeenCalled();
+    expect(apiMocks.put).toHaveBeenCalledWith("/api/web-push/subscriptions", {
+      endpoint: "https://web.push.apple.com/Q-safari-owned",
+      keys: { p256dh: "k", auth: "a" },
+    });
+
+    delete (window as unknown as Record<string, unknown>).PushManager;
+    delete (window as unknown as Record<string, unknown>).Notification;
+  });
+
+  it("releaseSubscriptionOwnership deletes Safari subscription from hub and unsubscribes locally", async () => {
+    (window as unknown as Record<string, unknown>).PushManager = function FakePushManager() {};
+    (window as unknown as Record<string, unknown>).Notification = function FakeNotification() {};
+    const unsubscribe = vi.fn().mockResolvedValue(true);
+    const safariSub = {
+      endpoint: "https://web.push.apple.com/Q-safari-release",
+      unsubscribe,
+      toJSON() { return { endpoint: this.endpoint }; },
+    };
+    apiMocks.del.mockResolvedValue({ ok: true, deleted: true });
+    stubNavigator({ registration: { pushManager: { getSubscription: vi.fn().mockResolvedValue(safariSub) } } });
+
+    await releaseSubscriptionOwnership();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(apiMocks.del).toHaveBeenCalledWith("/api/web-push/subscriptions", { endpoint: "https://web.push.apple.com/Q-safari-release" });
+
     delete (window as unknown as Record<string, unknown>).PushManager;
     delete (window as unknown as Record<string, unknown>).Notification;
   });

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -60,6 +60,7 @@ export default {
     notifServerDisabled: "Not enabled on server",
     notifDenied: "Notification permission denied",
     notifDeniedHint: "Allow notifications in the browser site settings, then retry.",
+    notifIosHint: "On iPhone and iPad, add XACPX to the Home Screen and open it from there before enabling notifications.",
     notifEnable: "Enable notifications",
     notifDisable: "Disable notifications",
     account: "Account",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -58,6 +58,7 @@ export default {
     notifServerDisabled: "服务端未启用",
     notifDenied: "浏览器已拒绝通知权限",
     notifDeniedHint: "在浏览器站点设置中允许通知后重试。",
+    notifIosHint: "iPhone/iPad 需要先将 XACPX 添加到主屏幕，并从主屏幕打开后才能启用通知。",
     notifEnable: "开启通知",
     notifDisable: "关闭通知",
     account: "账户",

--- a/packages/relay-web/src/lib/web-push.ts
+++ b/packages/relay-web/src/lib/web-push.ts
@@ -166,15 +166,25 @@ export async function disableDesktopNotifications(): Promise<void> {
   const target = await getExistingSubscriptionTarget();
   if (!target.sub) return;
   const endpoint = target.sub.endpoint;
-  await target.sub.unsubscribe().catch(() => {});
-  await api.del("/api/web-push/subscriptions", { endpoint });
+
+  const hubDeleted = await api
+    .del<{ ok: boolean; deleted: boolean }>("/api/web-push/subscriptions", { endpoint })
+    .then((r) => r.deleted === true)
+    .catch(() => false);
+
+  try {
+    await destroyProven(target);
+  } catch (err) {
+    if (!hubDeleted) throw err;
+  }
 }
 
 /**
  * The ONE destruction contract for every path that must prove a push binding
- * is dead: unsubscribe() first; on rejection or a `false` return, fall back to
- * unregistering the whole registration; if neither confirms, THROW — a stale
- * binding surviving an account switch is worse than any error.
+ * is dead: unsubscribe() first (fulfilling — true or false — confirms deactivation);
+ * on rejection, fall back to unregistering the registration and verifying that
+ * both window.pushManager and reg.pushManager resolve null; if neither confirms,
+ * THROW — a stale binding surviving an account switch is worse than any error.
  */
 async function destroyProven(target: {
   sub: PushSubscription | null;

--- a/packages/relay-web/src/lib/web-push.ts
+++ b/packages/relay-web/src/lib/web-push.ts
@@ -42,7 +42,10 @@ export function urlBase64ToUint8Array(base64: string): Uint8Array {
 }
 
 export function pushSupported(): boolean {
-  return "serviceWorker" in navigator && "PushManager" in window && "Notification" in window;
+  return (
+    ("serviceWorker" in navigator && "PushManager" in window && "Notification" in window) ||
+    ("pushManager" in window && "Notification" in window)
+  );
 }
 
 /** Compare a stored subscription's applicationServerKey with the hub's current
@@ -65,18 +68,54 @@ export function subscriptionMatchesKey(sub: PushSubscription, publicKey: string)
   return subB64 === paddedHub;
 }
 
+type WindowWithPushManager = Window & {
+  pushManager?: PushManager;
+};
+
+function getWindowPushManager(): PushManager | null {
+  if (typeof window === "undefined") return null;
+  return (window as WindowWithPushManager).pushManager ?? null;
+}
+
+export interface ExistingSubscriptionTarget {
+  sub: PushSubscription | null;
+  reg: ServiceWorkerRegistration | null;
+  winPm: PushManager | null;
+}
+
 /**
- * The EXISTING registration for this origin (scope "/"), or null when none has
- * ever been created. Unlike navigator.serviceWorker.ready — which never
- * settles on dev servers / insecure contexts where nothing registers —
- * getRegistration() answers immediately in every environment, so auth can
- * probe for leftover push state without waiting.
- *
- * `ready` remains correct for CREATING a subscription (enable path), where an
- * active worker is genuinely required.
+ * Probe for an existing push subscription across both the origin-level
+ * window.pushManager (Safari 18.4+ Declarative Web Push) and the root-scoped
+ * ServiceWorkerRegistration.
  */
-async function getExistingRegistration(): Promise<ServiceWorkerRegistration | null> {
-  return (await navigator.serviceWorker.getRegistration("/")) ?? null;
+export async function getExistingSubscriptionTarget(): Promise<ExistingSubscriptionTarget> {
+  const winPm = getWindowPushManager();
+  let reg: ServiceWorkerRegistration | null = null;
+  if (
+    typeof navigator !== "undefined" &&
+    "serviceWorker" in navigator &&
+    typeof navigator.serviceWorker?.getRegistration === "function"
+  ) {
+    reg = (await navigator.serviceWorker.getRegistration("/")) ?? null;
+  }
+
+  let sub: PushSubscription | null = null;
+  // In Safari 18.4+ / Declarative Web Push, window.pushManager represents the
+  // origin-level subscription authority and may exist even when no root SW
+  // registration is active. Query window.pushManager first.
+  if (winPm) {
+    sub = (await winPm.getSubscription()) ?? null;
+  }
+  if (!sub && reg) {
+    sub = (await reg.pushManager.getSubscription()) ?? null;
+  }
+
+  return { sub, reg, winPm };
+}
+
+export async function getExistingSubscription(): Promise<PushSubscription | null> {
+  const target = await getExistingSubscriptionTarget();
+  return target.sub;
 }
 
 export async function fetchVapidPublicKey(): Promise<string | null> {
@@ -113,8 +152,8 @@ export async function enableDesktopNotifications(publicKey: string): Promise<voi
     // generic buffer loosely, so assert once at this boundary).
     applicationServerKey: keyBytes.buffer.slice(keyBytes.byteOffset, keyBytes.byteOffset + keyBytes.byteLength) as ArrayBuffer,
   });
-  // The hub only POSTes to allowlisted Chrome push-service origins — a
-  // non-Chrome browser would subscribe fine and then fail on the PUT. Detect
+  // The hub only POSTes to allowlisted push-service origins (FCM, Apple APNs) — a
+  // non-allowlisted browser would subscribe fine and then fail on the PUT. Detect
   // that here, clean up, and surface as unsupported.
   if (!isAllowedPushEndpoint(sub.endpoint)) {
     await sub.unsubscribe().catch(() => {});
@@ -124,12 +163,10 @@ export async function enableDesktopNotifications(publicKey: string): Promise<voi
 }
 
 export async function disableDesktopNotifications(): Promise<void> {
-  const reg = await getExistingRegistration();
-  if (!reg) return; // no registration: there is no subscription to drop
-  const sub = await reg.pushManager.getSubscription();
-  if (!sub) return;
-  const endpoint = sub.endpoint;
-  await sub.unsubscribe();
+  const target = await getExistingSubscriptionTarget();
+  if (!target.sub) return;
+  const endpoint = target.sub.endpoint;
+  await target.sub.unsubscribe().catch(() => {});
   await api.del("/api/web-push/subscriptions", { endpoint });
 }
 
@@ -142,37 +179,63 @@ export async function disableDesktopNotifications(): Promise<void> {
 async function destroyProven(target: {
   sub: PushSubscription | null;
   reg: ServiceWorkerRegistration | null;
+  winPm?: PushManager | null;
 }): Promise<void> {
-  // Push API: unsubscribe() fulfilling — true OR false — means the
-  // subscription is deactivated and can no longer receive pushes. Both count
-  // as proven destruction.
+  const winPm = target.winPm ?? getWindowPushManager();
+
+  // 1. If we have a subscription object, try unsubscribing it directly.
   if (target.sub) {
     try {
       await target.sub.unsubscribe();
-      return;
-    } catch {
-      // fall through to registration-level proof
-    }
-  }
-  if (target.reg) {
-    // unregister() === true does NOT prove the push binding died (a concurrent
-    // register() can resurrect the registration, and "/"-scope unregister need
-    // not deactivate push subscriptions). Prove by re-querying: the push
-    // subscription must PROVABLY resolve null. If getSubscription rejects or
-    // returns non-null, it is unproven.
-    const unregistered = await target.reg.unregister().catch(() => false);
-    if (unregistered === true) {
-      try {
-        const gone = await target.reg.pushManager.getSubscription();
-        if (gone === null) return;
-      } catch {
-        // rejection on re-query does NOT prove gone; fall through to throw
+      // If window.pushManager exists, verify that the origin-level subscription
+      // is genuinely dead (null). If it still returns a subscription, fall through.
+      if (winPm) {
+        const stillThere = await winPm.getSubscription().catch(() => null);
+        if (stillThere === null) return;
+      } else {
+        return;
       }
+    } catch {
+      // fall through to registration & origin unregister/probe
     }
   }
+
+  // 2. If a SW registration exists, try unregistering it.
+  if (target.reg) {
+    try {
+      await target.reg.unregister();
+    } catch {
+      // ignore
+    }
+  }
+
+  // 3. Prove that NO subscription remains across both window.pushManager and reg.pushManager:
+  let winPmDead = true;
+  if (winPm) {
+    try {
+      const gone = await winPm.getSubscription();
+      if (gone !== null) winPmDead = false;
+    } catch {
+      winPmDead = false;
+    }
+  }
+
+  let regDead = true;
+  if (target.reg) {
+    try {
+      const gone = await target.reg.pushManager.getSubscription();
+      if (gone !== null) regDead = false;
+    } catch {
+      regDead = false;
+    }
+  }
+
+  if (winPmDead && regDead && (target.sub || target.reg || winPm)) {
+    return;
+  }
+
   throw new Error("push-subscription-destroy-failed");
 }
-
 /**
  * Auth-lifecycle ownership transfer.
  *
@@ -184,9 +247,8 @@ async function destroyProven(target: {
  */
 export async function releaseSubscriptionOwnership(): Promise<void> {
   if (!pushSupported()) return;
-  const reg = await getExistingRegistration();
-  const sub = reg ? await reg.pushManager.getSubscription() : null;
-  if (!sub) return; // nothing held → nothing to release
+  const target = await getExistingSubscriptionTarget();
+  if (!target.sub) return; // nothing held → nothing to release
 
   // Hub binding first: the session cookie is still valid here, so this is the
   // only chance to delete the server-side row.
@@ -194,7 +256,7 @@ export async function releaseSubscriptionOwnership(): Promise<void> {
   // deleted:false (endpoint missing or owned by another account) is NOT a
   // proven server-side teardown.
   const hubDeleted = await api
-    .del<{ ok: boolean; deleted: boolean }>("/api/web-push/subscriptions", { endpoint: sub.endpoint })
+    .del<{ ok: boolean; deleted: boolean }>("/api/web-push/subscriptions", { endpoint: target.sub.endpoint })
     .then((r) => r.deleted === true)
     .catch(() => false);
 
@@ -203,7 +265,7 @@ export async function releaseSubscriptionOwnership(): Promise<void> {
   // throw: logout aborts and the user stays logged in as themselves rather
   // than leaving a live, hub-bound subscription on a shared machine.
   try {
-    await destroyProven({ sub, reg });
+    await destroyProven(target);
   } catch (err) {
     if (!hubDeleted) throw err;
   }
@@ -221,33 +283,43 @@ export async function releaseSubscriptionOwnership(): Promise<void> {
  */
 export async function transferSubscriptionOwnership(): Promise<void> {
   if (!pushSupported()) return;
-  const reg = await getExistingRegistration();
-  let sub: PushSubscription | null = null;
-  if (reg) {
+  let reg: ServiceWorkerRegistration | null = null;
+  if (
+    typeof navigator !== "undefined" &&
+    "serviceWorker" in navigator &&
+    typeof navigator.serviceWorker?.getRegistration === "function"
+  ) {
     try {
-      sub = await reg.pushManager.getSubscription();
-    } catch (err) {
-      await destroyProven({ sub: null, reg });
-      throw err;
+      reg = (await navigator.serviceWorker.getRegistration("/")) ?? null;
+    } catch {
+      reg = null;
     }
   }
-  if (!sub) return;
+  let target: ExistingSubscriptionTarget;
+  try {
+    target = await getExistingSubscriptionTarget();
+  } catch (err) {
+    await destroyProven({ sub: null, reg });
+    throw err;
+  }
+  if (!target.sub) return;
 
+  const sub = target.sub;
   let publicKey: string | null = null;
   try {
     publicKey = await fetchVapidPublicKey();
   } catch (err) {
-    await destroyProven({ sub, reg });
+    await destroyProven(target);
     throw err;
   }
   if (!publicKey) {
     // Hub push disabled -> destroy local sub for hygiene.
-    await destroyProven({ sub, reg });
+    await destroyProven(target);
     return;
   }
   if (!subscriptionMatchesKey(sub, publicKey)) {
     // Stale VAPID key -> destroy old and re-mint under new key.
-    await destroyProven({ sub, reg });
+    await destroyProven(target);
     await api.del("/api/web-push/subscriptions", { endpoint: sub.endpoint }).catch(() => {});
     await enableDesktopNotifications(publicKey);
     return;
@@ -255,7 +327,7 @@ export async function transferSubscriptionOwnership(): Promise<void> {
   try {
     await api.put("/api/web-push/subscriptions", sub.toJSON());
   } catch (err) {
-    await destroyProven({ sub, reg });
+    await destroyProven(target);
     throw err;
   }
 }
@@ -271,17 +343,15 @@ export async function transferSubscriptionOwnership(): Promise<void> {
  */
 export async function reconcileExistingSubscription(): Promise<void> {
   if (!pushSupported()) return;
-  const reg = await getExistingRegistration();
-  let sub: PushSubscription | null = null;
-  if (reg) {
-    try {
-      sub = await reg.pushManager.getSubscription();
-    } catch {
-      return; // transient local error on reload: keep registration intact
-    }
+  let target: ExistingSubscriptionTarget;
+  try {
+    target = await getExistingSubscriptionTarget();
+  } catch {
+    return; // transient local error on reload: keep registration intact
   }
-  if (!sub) return;
+  if (!target.sub) return;
 
+  const sub = target.sub;
   let publicKey: string | null = null;
   try {
     publicKey = await fetchVapidPublicKey();
@@ -291,12 +361,12 @@ export async function reconcileExistingSubscription(): Promise<void> {
   }
   if (!publicKey) {
     // Hub explicitly predates or disabled push (404) -> destroy local sub.
-    await destroyProven({ sub, reg });
+    await destroyProven(target);
     return;
   }
   if (!subscriptionMatchesKey(sub, publicKey)) {
     // Hub rotated VAPID key -> destroy old and re-mint under new key.
-    await destroyProven({ sub, reg });
+    await destroyProven(target);
     await api.del("/api/web-push/subscriptions", { endpoint: sub.endpoint }).catch(() => {});
     await enableDesktopNotifications(publicKey);
     return;

--- a/packages/relay-web/src/lib/web-push.ts
+++ b/packages/relay-web/src/lib/web-push.ts
@@ -1,21 +1,34 @@
 import { ApiError, api } from "../api/client";
 
 /**
- * Push endpoints we accept. This PR supports Chrome only, and the hub POSTes
- * to each endpoint from its own network context — an arbitrary client-supplied
- * HTTPS URL would be a blind SSRF primitive. Restrict to Google's public push
- * service (Chrome routes FCM endpoints); widen deliberately if Firefox/Safari
- * support ever lands (then: mozilla + apple push origins).
+ * Push endpoints we accept. The hub POSTes to each endpoint from its own
+ * network context — an arbitrary client-supplied HTTPS URL would be a blind
+ * SSRF primitive.
+ *
+ * Allowed providers:
+ * - Google FCM: fcm.googleapis.com, fcm.notifications.google.com (Chrome/Chromium)
+ * - Apple APNs: *.push.apple.com (Safari on macOS, iOS/iPadOS Home Screen Web Apps)
  */
-const ALLOWED_ENDPOINT_ORIGINS: Record<string, true> = {
-  "https://fcm.googleapis.com": true,
-  "https://fcm.notifications.google.com": true,
-};
-
-/** True when a subscription endpoint is one this hub will actually POST to. */
 export function isAllowedPushEndpoint(endpoint: string): boolean {
   try {
-    return ALLOWED_ENDPOINT_ORIGINS[new URL(endpoint).origin] === true;
+    const url = new URL(endpoint);
+    if (url.protocol !== "https:") return false;
+    // Push services should only be reachable over normal HTTPS (implicit or 443).
+    if (url.port !== "" && url.port !== "443") return false;
+
+    if (
+      url.hostname === "fcm.googleapis.com" ||
+      url.hostname === "fcm.notifications.google.com"
+    ) {
+      return true;
+    }
+
+    // Apple officially requires allowing any subdomain of push.apple.com.
+    if (url.hostname.endsWith(".push.apple.com")) {
+      return true;
+    }
+
+    return false;
   } catch {
     return false;
   }

--- a/packages/relay-web/src/lib/web-push.ts
+++ b/packages/relay-web/src/lib/web-push.ts
@@ -167,16 +167,14 @@ export async function disableDesktopNotifications(): Promise<void> {
   if (!target.sub) return;
   const endpoint = target.sub.endpoint;
 
-  const hubDeleted = await api
-    .del<{ ok: boolean; deleted: boolean }>("/api/web-push/subscriptions", { endpoint })
-    .then((r) => r.deleted === true)
-    .catch(() => false);
+  // Local destruction MUST be proven so same-account reload (reconcile)
+  // cannot resurrect the subscription.
+  await destroyProven(target);
 
-  try {
-    await destroyProven(target);
-  } catch (err) {
-    if (!hubDeleted) throw err;
-  }
+  // Hub binding cleanup: best-effort delete on the server.
+  await api
+    .del("/api/web-push/subscriptions", { endpoint })
+    .catch(() => {});
 }
 
 /**
@@ -198,9 +196,10 @@ async function destroyProven(target: {
     try {
       await target.sub.unsubscribe();
       // If window.pushManager exists, verify that the origin-level subscription
-      // is genuinely dead (null). If it still returns a subscription, fall through.
+      // is genuinely dead (null). A rejection during verification is NOT proof
+      // of absence — do NOT catch-to-null.
       if (winPm) {
-        const stillThere = await winPm.getSubscription().catch(() => null);
+        const stillThere = await winPm.getSubscription();
         if (stillThere === null) return;
       } else {
         return;
@@ -209,7 +208,6 @@ async function destroyProven(target: {
       // fall through to registration & origin unregister/probe
     }
   }
-
   // 2. If a SW registration exists, try unregistering it.
   if (target.reg) {
     try {

--- a/packages/relay-web/src/views/SettingsView.vue
+++ b/packages/relay-web/src/views/SettingsView.vue
@@ -191,6 +191,7 @@ void onMounted(() => { void probeNotifications(); });
         >{{ notifState === "subscribed" ? $t("settings.notifDisable") : $t("settings.notifEnable") }}</button>
       </div>
       <p v-if="notifState === 'denied'" class="mt-1 text-xs text-fg-muted">{{ $t("settings.notifDeniedHint") }}</p>
+      <p class="mt-1 text-xs text-fg-muted" data-test="notif-ios-hint">{{ $t("settings.notifIosHint") }}</p>
     </section>
     <section>
       <h2 class="mb-2 text-sm font-semibold uppercase text-fg-muted">{{ $t("settings.account") }}</h2>

--- a/packages/relay-web/src/views/SettingsView.vue
+++ b/packages/relay-web/src/views/SettingsView.vue
@@ -9,7 +9,14 @@ import { confirm } from "../lib/use-confirm";
 import { useLocaleStore } from "../stores/locale";
 import { SUPPORTED_LOCALES } from "../i18n";
 import { useI18n } from "vue-i18n";
-import { pushSupported, fetchVapidPublicKey, enableDesktopNotifications, disableDesktopNotifications, subscriptionMatchesKey } from "../lib/web-push";
+import {
+  pushSupported,
+  fetchVapidPublicKey,
+  enableDesktopNotifications,
+  disableDesktopNotifications,
+  subscriptionMatchesKey,
+  getExistingSubscription,
+} from "../lib/web-push";
 
 const auth = useAuthStore();
 const theme = useThemeStore();
@@ -64,8 +71,7 @@ async function probeNotifications(): Promise<void> {
   if (!key) { notifState.value = "server-disabled"; return; }
   vapidKey = key;
   try {
-    const reg = await navigator.serviceWorker.ready;
-    const sub = await reg.pushManager.getSubscription();
+    const sub = await getExistingSubscription();
     if (!sub) { notifState.value = "idle"; return; }
     // A sub minted under an older VAPID key can never receive pushes — show
     // it as off; reconcileExistingSubscription (auth load) re-mints it.
@@ -74,6 +80,11 @@ async function probeNotifications(): Promise<void> {
     notifState.value = "idle";
   }
 }
+
+const isIos = typeof navigator !== "undefined" && (
+  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+  (/Macintosh/.test(navigator.userAgent) && (navigator.maxTouchPoints ?? 0) > 1)
+);
 
 async function toggleNotifications(): Promise<void> {
   if (notifBusy.value) return;
@@ -191,7 +202,7 @@ void onMounted(() => { void probeNotifications(); });
         >{{ notifState === "subscribed" ? $t("settings.notifDisable") : $t("settings.notifEnable") }}</button>
       </div>
       <p v-if="notifState === 'denied'" class="mt-1 text-xs text-fg-muted">{{ $t("settings.notifDeniedHint") }}</p>
-      <p class="mt-1 text-xs text-fg-muted" data-test="notif-ios-hint">{{ $t("settings.notifIosHint") }}</p>
+      <p v-if="isIos" class="mt-1 text-xs text-fg-muted" data-test="notif-ios-hint">{{ $t("settings.notifIosHint") }}</p>
     </section>
     <section>
       <h2 class="mb-2 text-sm font-semibold uppercase text-fg-muted">{{ $t("settings.account") }}</h2>

--- a/packages/relay/src/push.ts
+++ b/packages/relay/src/push.ts
@@ -16,19 +16,35 @@ const BODY_CAP = 200;
 const GONE_STATUS = new Set([404, 410]);
 
 /**
- * Only endpoints on these origins are accepted. The hub POSTes to each stored
- * endpoint from its own network context — accepting arbitrary HTTPS URLs would
- * hand every account a blind server-side POST primitive (SSRF). Chrome routes
- * through FCM; widen deliberately if Firefox/Safari support ever lands.
+ * Only endpoints on known, standards-based push services are accepted.
+ * The hub POSTes to each stored endpoint from its own network context —
+ * accepting arbitrary HTTPS URLs would hand every account a blind server-side
+ * POST primitive (SSRF).
+ *
+ * Allowed providers:
+ * - Google FCM: fcm.googleapis.com, fcm.notifications.google.com
+ * - Apple APNs: *.push.apple.com (Safari on macOS, iOS/iPadOS Home Screen Web Apps)
  */
-const ALLOWED_ENDPOINT_ORIGINS: Record<string, true> = {
-  "https://fcm.googleapis.com": true,
-  "https://fcm.notifications.google.com": true,
-};
-
 export function isAllowedPushEndpoint(endpoint: string): boolean {
   try {
-    return ALLOWED_ENDPOINT_ORIGINS[new URL(endpoint).origin] === true;
+    const url = new URL(endpoint);
+    if (url.protocol !== "https:") return false;
+    // Push services should only be reachable over normal HTTPS (implicit or 443).
+    if (url.port !== "" && url.port !== "443") return false;
+
+    if (
+      url.hostname === "fcm.googleapis.com" ||
+      url.hostname === "fcm.notifications.google.com"
+    ) {
+      return true;
+    }
+
+    // Apple officially requires allowing any subdomain of push.apple.com.
+    if (url.hostname.endsWith(".push.apple.com")) {
+      return true;
+    }
+
+    return false;
   } catch {
     return false;
   }

--- a/tests/unit/packages/relay/http-app.test.ts
+++ b/tests/unit/packages/relay/http-app.test.ts
@@ -1231,6 +1231,9 @@ test("web-push: PUT rejects non-push-service endpoints (SSRF allowlist)", async 
     "http://fcm.googleapis.com/x",                       // right host, wrong scheme → origin mismatch
     "https://evil.example.com/fcm",                      // arbitrary https host
     "https://fcm.googleapis.com.attacker.io/x",          // suffix spoof (origin differs)
+    "https://web.push.apple.com.attacker.example/path",  // Apple subdomain spoof
+    "http://web.push.apple.com/x",                       // Apple non-https
+    "https://evilpush.apple.com/x",                      // Apple evil prefix
   ]) {
     const bad = await app.request("/api/web-push/subscriptions", {
       method: "PUT", headers: { cookie, "content-type": "application/json" },
@@ -1257,4 +1260,18 @@ test("web-push: PUT rejects non-push-service endpoints (SSRF allowlist)", async 
   });
   expect(ok.status).toBe(200);
   expect(pushSubscriptions.listByAccount(admin.id)).toHaveLength(1);
+
+  // Safari / Apple APNs endpoint is also accepted.
+  const okApple = await app.request("/api/web-push/subscriptions", {
+    method: "PUT", headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({
+      endpoint: "https://web.push.apple.com/Q-safari-token",
+      keys: {
+        p256dh: "BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U",
+        auth: "AAAAAAAAAAAAAAAAAAAAAA",
+      },
+    }),
+  });
+  expect(okApple.status).toBe(200);
+  expect(pushSubscriptions.listByAccount(admin.id)).toHaveLength(2);
 });

--- a/tests/unit/packages/relay/push-notifier.test.ts
+++ b/tests/unit/packages/relay/push-notifier.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { createSqlDriver, initSchema } from "../../../../packages/relay/src/db";
 import { PushSubscriptionStore } from "../../../../packages/relay/src/stores/push-subscriptions";
-import { PushNotifier, vapidFromEnv, PUSH_TTL_SECONDS } from "../../../../packages/relay/src/push";
+import { PushNotifier, vapidFromEnv, PUSH_TTL_SECONDS, isAllowedPushEndpoint } from "../../../../packages/relay/src/push";
 
 type SentCall = { endpoint: string; payload: string; ttl: number };
 
@@ -102,4 +102,55 @@ test("validateVapidConfig enforces decoded key lengths (65/32 bytes)", () => {
   // Subject that passes a prefix regex but is not an absolute URL (web-push
   // does new URL(subject)):
   expect(validateVapidConfig({ subject: "https://", publicKey: goodPk, privateKey: goodSk })).toBeNull();
+});
+
+test("isAllowedPushEndpoint accepts FCM and *.push.apple.com, rejects SSRF and spoof attempts", () => {
+  // Accept matrix
+  for (const ep of [
+    "https://fcm.googleapis.com/fcm/send/abc",
+    "https://fcm.notifications.google.com/fcm/send/abc",
+    "https://web.push.apple.com/Q-xxxxx",
+    "https://foo.push.apple.com/abc",
+    "https://foo.bar.push.apple.com/abc",
+    "https://web.push.apple.com:443/abc",
+  ]) {
+    expect(isAllowedPushEndpoint(ep)).toBe(true);
+  }
+
+  // Reject matrix (SSRF / non-https / wrong ports / invalid domains / suffix spoofs)
+  for (const ep of [
+    "http://web.push.apple.com/abc",
+    "https://web.push.apple.com:8443/abc",
+    "https://push.apple.com.evil.com/abc",
+    "https://evilpush.apple.com/abc",
+    "https://push.apple.com@evil.com/abc",
+    "https://push.apple.com/abc",
+    "https://evil.com/push.apple.com",
+    "https://127.0.0.1/",
+    "https://localhost/",
+    "https://169.254.169.254/",
+    "https://10.0.0.1/",
+    "https://example.com/",
+    "not-a-url",
+    "https://foo.push.apple.com.evil.example/path",
+  ]) {
+    expect(isAllowedPushEndpoint(ep)).toBe(false);
+  }
+});
+
+test("sendTaskCompletion fans out to both FCM and Apple endpoints and cleans up Apple 410", async () => {
+  const sent: SentCall[] = [];
+  // Simulate Apple returning 410 gone
+  const { notifier, subscriptions } = await makeNotifier(sent, { statusCode: 410 });
+  subscriptions.upsert({ accountId: "a1", endpoint: "https://web.push.apple.com/sub1", p256dh: "k1", auth: "a1" });
+  subscriptions.upsert({ accountId: "a1", endpoint: "https://fcm.googleapis.com/fcm/send/sub2", p256dh: "k2", auth: "a2" });
+
+  await notifier.sendTaskCompletion("a1", { instanceId: "i1", instanceName: "inst", text: "done" });
+  expect(sent).toHaveLength(2);
+  expect(sent.map((s) => s.endpoint).sort()).toEqual([
+    "https://fcm.googleapis.com/fcm/send/sub2",
+    "https://web.push.apple.com/sub1",
+  ]);
+  // 410 should have cleaned up both expired subscriptions
+  expect(subscriptions.listByAccount("a1")).toHaveLength(0);
 });


### PR DESCRIPTION
## Summary
在 PR #305 标准 Web Push 架构基础上扩展 **Apple Web Push 支持**，覆盖：
- **macOS Safari 16.1+** (Safari 18.4+ Declarative Web Push / origin-level subscription 完全兼容)
- **iOS / iPadOS 16.4+ Home Screen Web Apps**（添加到主屏幕后打开）
- 保持 Chrome / Chromium 行为与测试完全一致
- 保持严格的 SSRF 安全边界（仅放行 FCM 与 `*.push.apple.com` 443 端口）
- 保持标准 W3C Web Push 协议（无需 Apple Developer Program / APNs 专有证书）
- 严格遵循 fail-closed 账号隔离与订阅销毁证明契约

设计文档：`docs/superpowers/specs/2026-08-25-support-apple-web-push.md`

## Changes
1. **Endpoint Allowlist 扩展（前后端双端）**：
   - `packages/relay/src/push.ts` & `packages/relay-web/src/lib/web-push.ts`：统一 `isAllowedPushEndpoint()` 校验，严格放行 `fcm.googleapis.com`、`fcm.notifications.google.com` 以及 `*.push.apple.com`（`https` 协议 + 隐式/显式 `443` 端口）。拒绝非标准端口、内网 IP 及伪装域名（如 `evilpush.apple.com`、`*.push.apple.com.evil.com`）。
2. **Safari 18.4+ `window.pushManager` 原生 Origin-level 订阅隔离与严格销毁**：
   - 抽象 `ExistingSubscriptionTarget`，probe 路径优先识别 `window.pushManager`（支持无 root SW registration 独立存在的 Safari 18.4+ 原生订阅）。
   - `destroyProven` 二次验证消除 `catch-to-null`，严格要求 `window.pushManager.getSubscription()` 必须确认返回 `null`（任何查询异常均判定为未证明并 fail-closed）。
   - `disableDesktopNotifications` 强制以本地订阅成功销毁（`destroyProven`）为持久生效条件，防止同账号刷新后被 `reconcileExistingSubscription` 意外复活。
3. **Settings 视图提示与 i18n**：
   - `packages/relay-web/src/views/SettingsView.vue`、`zh-CN.ts`、`en.ts`：添加 iOS/iPadOS 提示文本（仅在 iOS/iPadOS UA 下渲染）。
4. **安全与生命周期回归测试**：
   - `tests/unit/packages/relay/push-notifier.test.ts` & `http-app.test.ts`：补充 Endpoint 安全矩阵测试、FCM + Apple 混合端点扇出及 410 清理测试。
   - `packages/relay-web/src/__tests__/web-push-lib.test.ts` & `settings-notifications.test.ts`：补充 Safari Endpoint 下的 Enable、Login Ownership Transfer、Logout Release、Disable 本地销毁严格证明、VAPID 轮转生命周期测试。
5. **文档同步**：
   - `docs/relay-module.md`：更新 Web Push 支持范围及出站网络放行要求（`*.push.apple.com`）。

## Manual Verification Release Gate
建议在合并/发版前完成真实 Safari 设备手工验证：
- **macOS Safari**：开启通知 → 发送任务触发 `task-completion` → 收到 macOS 系统通知 → 关闭标签页后仍能收到 → 点击通知聚焦 XACPX。
- **iOS / iPadOS**：添加到主屏幕 → 从主屏幕打开并开启通知 → 切后台 → 触发 `task-completion` → 锁屏/通知中心收到通知。

## Automated Verification
- Relay unit tests: `bun test tests/unit/packages/relay/` -> **397/397 passed**
- Relay-Web tests: `vitest run` -> **1310/1310 passed**
- Typechecks: `relay` & `relay-web` clean
- Package builds: clean