### PR TITLE
feat(relay,control): add web push completion notifications for interactive agent turns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ packages/docs/.vitepress/cache
 packages/docs/.vitepress/dist
 .superpowers/
 .gstack/
+.reasonix/
 
 .mock-agent-*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
+## [0.23.0-beta.7] - 2026-08-25
+
+### Added
+
+- `TurnQueue`: pass `promptRequestId` to `turnStarted` on immediate execution path as well as queued drain path so `turn-started` event reliably carries provenance.
+
+## [relay 0.13.0-beta.5] - 2026-08-25
+
+### Added
+
+- Web Push for interactive agent turn completion: users prompting an agent from relay-web receive desktop push notifications when turns finish, with custom `<instance> · <session>` titles and result snippets.
+- Provenance registry with automatic TTL pruning to track relay-web interactive prompts and prevent unsolicited notifications for scheduled turns, peer agent messaging, and background orchestration workers.
+- `PushNotifier`: added `sendTurnCompletion()` with structured logging for fanout, delivery, failure, and missing subscriptions.
+
+### Fixed
+
+- `relay-web`: fixed `PlanPanel` model type compatibility under `vue-tsc`.
+
 ## [0.23.0-beta.6] - 2026-08-25
 
 ### Added

--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -116,21 +116,24 @@
   helper），完全离线可装、无需 PATH 上有任何 RMUX。发布包：https://github.com/Helvesec/rmux/releases
   （`rmux-0.10.0-windows-x86_64.zip`，固定 SHA-256 在 `scripts/rmux-release.mjs`）。
 
-## Web Push（task-completion 桌面通知）
+## Web Push（桌面系统通知）
 
-- 用途：基于 W3C 标准 Web Push / VAPID 协议，实例产生 `notice.kind === "task-completion"` 时向该账号已订阅的浏览器推送系统通知（标签页在后台或已关闭也能收到）；`task-progress` / `coordinator-message` 仅走 WS 广播。支持浏览器覆盖：
-  - **Chrome / Chromium**
-  - **macOS Safari**（Safari 16.1+ / macOS Ventura+）
-  - **iOS / iPadOS 主屏幕 Web App**（iOS/iPadOS 16.4+，添加到主屏幕并从主屏幕打开）
-  设计 specs：`docs/superpowers/specs/2026-08-24-web-push-task-completion-design.md`、`docs/superpowers/specs/2026-08-25-support-apple-web-push.md`。
+- 用途：基于 W3C 标准 Web Push / VAPID 协议，在任务或交互回合完成时向该账号已订阅的浏览器推送系统通知（标签页在后台或已关闭也能收到）。触发来源：
+  1. **Orchestration Task 完成**：实例产生 `notice.kind === "task-completion"` 时推送。
+  2. **Relay-Web 交互回合完成**：用户经 Web RPC `MSG.prompt` 发起的普通 Agent Turn 完成或失败时推送（标题为 `<instance> · <session>`，内容为回复截断 200 字或失败原因）。
+  - **过滤防线**：`task-progress` / `coordinator-message` 仅走 WS 广播；`scheduled` 定时任务、`peerOrigin` 跨 Agent 消息、用户主动 `cancelled` 以及 Hub 重启后的无凭证历史回放均不触发普通回合 Web Push。
+  - **支持浏览器覆盖**：
+    - **Chrome / Chromium**
+    - **macOS Safari**（Safari 16.1+ / macOS Ventura+）
+    - **iOS / iPadOS 主屏幕 Web App**（iOS/iPadOS 16.4+，添加到主屏幕并从主屏幕打开）
+  设计 specs：`docs/superpowers/specs/2026-08-24-web-push-task-completion-design.md`、`docs/superpowers/specs/2026-08-25-support-apple-web-push.md`、`docs/superpowers/specs/2026-08-25-agent-turn-web-push.md`。
 - 网络出站要求：Hub 出站网络需允许连接以下 Push 服务的标准 443 端口：
   - `fcm.googleapis.com`、`fcm.notifications.google.com`（Chrome / Chromium）
   - `*.push.apple.com`（Apple Safari / APNs）
 - 配置：`xacpx-relay push-keys generate` 打印 VAPID 密钥对；经环境变量 `XACPX_RELAY_VAPID_SUBJECT` / `XACPX_RELAY_VAPID_PUBLIC_KEY` / `XACPX_RELAY_VAPID_PRIVATE_KEY` 或 start 子命令 `--vapid-subject/--vapid-public-key/--vapid-private-key` 注入。未配置则推送禁用（log warn），WS 通道不受影响。
 - 存储：`push_subscriptions` 表（account_id + endpoint 主键，endpoint 全局唯一索引）。API：`GET /api/web-push/vapid-public-key`、`PUT/DELETE /api/web-push/subscriptions`（authed + requireJson，严格校验 endpoint allowlist 防 SSRF）。
-- 发送：server.ts 的 instanceNotice 分支 fire-and-forget fan-out；payload `{title=实例名, body=text 截断200, instanceId, url:"/"}`，TTL 3600；410/404 自动删订阅行。
+- 发送：`PushNotifier` 提供 `sendTaskCompletion()` 与 `sendTurnCompletion()`；支持结构化日志（`relay.push.fanout` / `sent` / `no_subscriptions` / `send_failed`，仅记录 host 避免泄露完整 endpoint），TTL 3600；410/404 自动删订阅行。
 - Web 端：SettingsView「桌面通知」开关（五态状态机）；订阅所有权转移属于认证生命周期——login fail-closed 转移（失败撤销 session），fetchMe 认证成功后 best-effort 维护同账号订阅，logout 先解绑再清 session。SW 推送处理器为 public/push-sw.js，经 pwa-options 的 workbox.importScripts 注入。
-
 ## 阶段三服务端接缝（Web 看板扇出）
 
 服务端为 Web 看板新增的接缝（见 docs/relay-web-module.md）：

--- a/docs/superpowers/specs/2026-08-25-agent-turn-web-push.md
+++ b/docs/superpowers/specs/2026-08-25-agent-turn-web-push.md
@@ -1,0 +1,1299 @@
+# Relay-Web 普通 Agent Turn 完成后 Web Push 实现方案
+
+## 目标
+
+扩展现有 Web Push 功能，使用户从 **relay-web 直接向普通 session 发送 prompt** 后，当该 turn 真正结束时，也能收到桌面通知。
+
+当前 #305 只覆盖：
+
+```text
+orchestration task
+→ notifyTaskCompletion()
+→ instanceNotice(kind="task-completion")
+→ Hub Web Push
+```
+
+`RelayChannel.notifyTaskCompletion()` 确实只负责 orchestration completion notice。 Hub 也只在 `notice.kind === "task-completion"` 时调用 `PushNotifier`。
+
+普通 relay-web prompt 的真实链路则是：
+
+```text
+relay-web
+→ POST/RPC MSG.prompt
+→ connector
+→ turn-started
+→ turn-output/tool-event/...
+→ turn-finished
+```
+
+目前 `turn-finished` 只持久化历史和广播，不触发 Web Push。
+
+---
+
+# 一、核心原则
+
+**禁止直接做：**
+
+```ts
+if (event.type === "turn-finished") {
+  push();
+}
+```
+
+这会把以下全部误通知：
+
+```text
+scheduled turn
+peer/agent-message turn
+orchestration worker/internal turn
+recovery replay
+state-sync 恢复
+其他非 relay-web 用户直接发起的 turn
+```
+
+正确规则应该是：
+
+> **只有“由当前账号通过 relay-web 的 MSG.prompt RPC 发起的用户交互 turn”结束时，才发普通 turn-completion Web Push。**
+
+因此必须建立：
+
+```text
+web prompt
+      ↓
+prompt identity / provenance
+      ↓
+turn-started
+      ↓
+live TurnAccumulator 继承 provenance
+      ↓
+turn-finished
+      ↓
+Web Push exactly once
+```
+
+不要通过 `sessionAlias` 猜来源。
+
+---
+
+# 二、利用现有 `promptRequestId`
+
+当前 Hub 的 Web RPC 层已经有非常适合做这件事的 correlation ID。
+
+`MSG.prompt` 在转发 connector 前会：
+
+1. 先持久化 inbound message；
+2. 生成 `randomUUID()`；
+3. 保存为 `promptRequestId`；
+4. 注入转发给 connector 的 prompt payload。
+
+现有代码：
+
+```ts
+const promptRequestId = randomUUID();
+
+persistedPromptId = deps.messages.append(
+  instance.id,
+  p.sessionAlias,
+  "in",
+  p.text,
+  undefined,
+  attachments,
+  promptRequestId,
+);
+
+(payload as Record<string, unknown>).promptRequestId =
+  promptRequestId;
+```
+
+这就是本功能应该复用的唯一身份。
+
+**不要新增另一套 notification request ID。**
+
+---
+
+# 三、协议要求：`turn-started` 必须可靠携带 `promptRequestId`
+
+协议 DTO 当前已经支持：
+
+```ts
+{
+  type: "turn-started";
+  chatKey: string;
+  sessionAlias: string;
+  promptRequestId?: string;
+  ...
+}
+```
+
+并且注释明确说明它用于把 queued prompt drain 回关联到 Hub 已预写的 inbound row。
+
+实现 agent 第一件事应审计：
+
+```text
+relay-web MSG.prompt
+→ Hub 注入 promptRequestId
+→ channel-relay
+→ ControlService / TurnQueue
+→ turn-started.promptRequestId
+```
+
+### Gate
+
+无论 prompt 是：
+
+```text
+立即执行
+```
+
+还是：
+
+```text
+busy session
+→ queued
+→ later drain
+```
+
+最终真实的：
+
+```text
+turn-started
+```
+
+都必须携带**原始同一个**：
+
+```text
+promptRequestId
+```
+
+如果目前 immediate path 没有回显，只修这个传递链，不要在 Hub 用文本匹配兜底。
+
+---
+
+# 四、不要把 `promptRequestId` 加到所有 turn-finished
+
+不需要为了这个功能把：
+
+```ts
+promptRequestId
+```
+
+继续塞进：
+
+```text
+turn-output
+tool-event
+turn-finished
+```
+
+Hub 本来就有 live `TurnAccumulator`，而且每个 `(instanceId, sessionAlias)` 的活动 turn 已经由：
+
+```ts
+turn-started
+```
+
+创建，由：
+
+```ts
+turn-finished
+```
+
+销毁。
+
+直接扩展 accumulator：
+
+```ts
+interface TurnAccumulator {
+  text: string;
+  steps: Map<string, ToolStepDto>;
+  reasoning: string;
+  parts: TurnPartDto[];
+  startedAt: number;
+  truncated?: boolean;
+
+  webPromptRequestId?: string;
+}
+```
+
+在 `turn-started`：
+
+```ts
+const accumulator = {
+  ...,
+  webPromptRequestId:
+    typeof event.promptRequestId === "string"
+      ? event.promptRequestId
+      : undefined,
+};
+```
+
+然后 `turn-finished` 时：
+
+```ts
+const a = turnBuffers.get(k);
+turnBuffers.delete(k);
+
+if (a?.webPromptRequestId) {
+  // eligible interactive web turn
+}
+```
+
+这样来源跟着**实际 turn 生命周期**走。
+
+---
+
+# 五、必须区分“Web prompt”与其他可能携带 ID 的来源
+
+更严谨的方案是 Hub 维护一个短生命周期的 provenance registry：
+
+```ts
+const pendingWebPrompts = new Set<string>();
+```
+
+当 `/rpc MSG.prompt` 被 relay-web 接收并成功准备转发时：
+
+```ts
+pendingWebPrompts.add(promptRequestId);
+```
+
+当 Hub 收到：
+
+```text
+turn-started.promptRequestId
+```
+
+只有：
+
+```ts
+pendingWebPrompts.has(event.promptRequestId)
+```
+
+时才：
+
+```ts
+accumulator.notificationOrigin = "relay-web";
+pendingWebPrompts.delete(event.promptRequestId);
+```
+
+而不是：
+
+```ts
+if (event.promptRequestId) assume relay-web
+```
+
+这是更好的安全/语义边界。
+
+建议结构：
+
+```ts
+interface TurnNotificationContext {
+  origin: "relay-web";
+  promptRequestId: string;
+}
+
+interface TurnAccumulator {
+  ...
+  notification?: TurnNotificationContext;
+}
+```
+
+---
+
+# 六、`pendingWebPrompts` 生命周期
+
+这里必须避免内存泄漏。
+
+推荐：
+
+```ts
+Map<
+  string,
+  {
+    instanceId: string;
+    sessionAlias: string;
+    createdAt: number;
+  }
+>
+```
+
+而不是裸 Set。
+
+例如：
+
+```ts
+const pendingWebPrompts = new Map<
+  string,
+  {
+    instanceId: string;
+    sessionAlias: string;
+    createdAt: number;
+  }
+>();
+```
+
+收到 `turn-started` 时必须同时验证：
+
+```ts
+pending.instanceId === instanceId
+pending.sessionAlias === event.sessionAlias
+```
+
+才 consume。
+
+### 清理
+
+需要：
+
+* prompt RPC 明确失败 → 删除；
+* queue cancel → 最终不要通知；
+* TTL 清理遗留 entry；
+* runtime close → map 自然释放。
+
+TTL 可以比较宽：
+
+```text
+24h
+```
+
+或者跟 queue 最大生存语义对齐。
+
+重点是不要永远积累。
+
+---
+
+# 七、什么时候注册 provenance
+
+建议在 Hub `/rpc` 的 `MSG.prompt` 路径上注册。
+
+当前代码在发送 connector RPC 前已经生成 `promptRequestId`。
+
+给 `createApp()` 增加一个内部 callback：
+
+```ts
+export interface AppDeps {
+  ...
+  onWebPromptCreated?: (input: {
+    promptRequestId: string;
+    instanceId: string;
+    sessionAlias: string;
+  }) => void;
+
+  onWebPromptRejected?: (promptRequestId: string) => void;
+}
+```
+
+或者更简单：
+
+```ts
+trackWebPrompt(...)
+untrackWebPrompt(...)
+```
+
+由 `server.ts` 持有 Map，`http/app.ts` 不应该自己知道 PushNotifier。
+
+**不要让 HTTP layer 直接发通知。**
+
+职责保持：
+
+```text
+HTTP app
+→ 标记来源
+
+server runtime
+→ 管 turn 生命周期
+
+PushNotifier
+→ 只负责发送
+```
+
+---
+
+# 八、queued prompt 是必测路径
+
+这是本 PR 最容易写错的地方。
+
+普通场景：
+
+```text
+Prompt A starts
+Prompt B submitted while A running
+→ B queued
+```
+
+对于 B：
+
+```text
+HTTP 收到 B
+→ promptRequestId = B-id
+→ pendingWebPrompts[B-id]
+→ connector returns { queued: true, queueItemId }
+```
+
+现有 Hub 已经会把这个 prompt 标记为 queued。
+
+后来：
+
+```text
+A finishes
+→ B drains
+→ turn-started(promptRequestId=B-id)
+```
+
+此时才：
+
+```text
+pendingWebPrompts[B-id]
+→ accumulator.notification.origin=relay-web
+→ consume registry
+```
+
+最后：
+
+```text
+B turn-finished
+→ push B completion
+```
+
+不能在：
+
+```text
+MSG.prompt RPC resolves
+```
+
+时推。
+
+也不能在：
+
+```text
+queue dequeue
+```
+
+时推。
+
+---
+
+# 九、Recovery / restart：明确“不补发通知”
+
+这个功能应采取：
+
+> **Web Push 只针对 live turn completion，不针对历史恢复。**
+
+Hub 当前已经处理：
+
+```text
+state-sync
+finishedOffline
+recoveryId
+cross-restart dedup
+```
+
+并能在没有 live accumulator 时用 `turn-finished.text` 修复历史。
+
+这种：
+
+```ts
+const a = turnBuffers.get(k);
+```
+
+结果为：
+
+```text
+undefined
+```
+
+时：
+
+**绝对不要发 turn-completion Push。**
+
+即：
+
+```ts
+if (!a?.notification) {
+  no push;
+}
+```
+
+这样可以天然避免：
+
+```text
+Hub 重启
+→ connector 恢复旧完成
+→ 用户突然收到过去任务的通知
+```
+
+---
+
+# 十、Peer / Agent Messaging 必须排除
+
+当前 `turn-started` / `turn-finished` 已经支持：
+
+```ts
+peerOrigin?: PeerTurnOriginDto
+```
+
+这类 turn 是 agent-to-agent turn。
+
+即使未来某个错误路径碰巧带有 prompt correlation，也加一个 defense-in-depth：
+
+```ts
+if (event.peerOrigin) {
+  notification = undefined;
+}
+```
+
+最终 Gate：
+
+```ts
+eligible =
+  a.notification?.origin === "relay-web"
+  && !event.peerOrigin;
+```
+
+---
+
+# 十一、Scheduled turn 必须排除
+
+`turn-started` 已经有：
+
+```ts
+scheduled?: ScheduledOriginDto
+```
+
+scheduled task 不是用户刚刚从 relay-web 发的 interactive prompt。
+
+所以：
+
+```ts
+if (event.scheduled) {
+  do not attach relay-web notification provenance;
+}
+```
+
+即使它的 session 也是普通 session。
+
+---
+
+# 十二、Orchestration task 不得双通知
+
+现在 orchestration 已经：
+
+```text
+task completion
+→ instanceNotice.task-completion
+→ Web Push
+```
+
+这个路径继续保持。
+
+不要把它改成统一监听所有 `turn-finished`。
+
+否则典型 delegated worker 会变成：
+
+```text
+worker turn-finished
+→ 普通 turn push
+
+orchestration task completion
+→ task-completion push
+```
+
+用户收到两条。
+
+正确状态：
+
+```text
+interactive relay-web prompt
+→ turn completion push
+
+orchestration task
+→ existing task-completion push
+```
+
+互不覆盖。
+
+---
+
+# 十三、成功 / 失败 / 取消的通知语义
+
+第一版建议：
+
+### 成功
+
+```ts
+event.ok === true
+```
+
+→ 发通知。
+
+### 失败
+
+建议也发。
+
+用户离开浏览器后，如果 agent 失败，失败本身同样值得通知。
+
+例如：
+
+```text
+Codex
+任务失败
+
+connection reset / provider error / ...
+```
+
+### Cancelled
+
+建议 **不发**。
+
+原因：
+
+```text
+用户自己点击 Cancel
+→ 几秒后系统又弹“任务已完成”
+```
+
+体验很差。
+
+推荐 Gate：
+
+```ts
+if (event.cancelled === true) {
+  no push;
+}
+```
+
+所以：
+
+```text
+ok=true                  → notify
+ok=false,cancelled=false → notify failure
+cancelled=true           → no notify
+```
+
+---
+
+# 十四、PushNotifier API 不要继续叫 `sendTaskCompletion`
+
+当前类只有：
+
+```ts
+sendTaskCompletion(...)
+```
+
+建议抽象成：
+
+```ts
+sendCompletion(
+  accountId,
+  {
+    kind: "task" | "turn",
+    instanceId,
+    instanceName,
+    sessionAlias?,
+    title,
+    text,
+    status?,
+  },
+)
+```
+
+或者保留兼容 wrapper：
+
+```ts
+sendTaskCompletion(...)
+sendTurnCompletion(...)
+```
+
+两者内部走共享：
+
+```ts
+sendNotificationToAccount(...)
+```
+
+推荐后者，改动小：
+
+```ts
+sendTaskCompletion(...)
+sendTurnCompletion(...)
+```
+
+内部：
+
+```ts
+private sendToAccount(...)
+```
+
+---
+
+# 十五、普通 turn 通知内容
+
+建议：
+
+### title
+
+```text
+<instance name> · <session alias/display name>
+```
+
+例如：
+
+```text
+MacBook · backend
+```
+
+如果 Hub 当前拿不到 displayName，先：
+
+```text
+MacBook · backend
+```
+
+不要为这次功能新增一套 session metadata同步。
+
+### body
+
+成功：
+
+```text
+agent 最终回复文本前 200 字
+```
+
+失败：
+
+```text
+Task failed: <errorMessage>
+```
+
+如果 final text 为空：
+
+```text
+Task completed
+```
+
+---
+
+# 十六、最好让通知点击直接定位到 session
+
+现在 #305 payload 固定：
+
+```ts
+url: "/"
+```
+
+建议顺手增强为 relay-web 当前真实 session route。
+
+如果已有稳定 URL，例如：
+
+```text
+/?instance=<id>&session=<alias>
+```
+
+或者 router 有 session route，就使用它。
+
+如果没有稳定 deep-link，本 PR 不要创造复杂 routing，继续：
+
+```ts
+url: "/"
+```
+
+功能正确优先。
+
+---
+
+# 十七、是否在网页前台时也通知
+
+第一版**不要做 active-tab suppression**。
+
+原因是服务器不知道：
+
+```text
+哪个 subscription 对应哪个 tab
+哪个 tab focused
+用户开了多少浏览器
+```
+
+可以以后在 Service Worker：
+
+```js
+clients.matchAll(...)
+```
+
+判断同 origin 是否有 focused window 再选择 suppression。
+
+这不是本 PR 的核心。
+
+先保证：
+
+```text
+background / closed Chrome
+→ reliable push
+```
+
+---
+
+# 十八、Push 可观测性必须补
+
+这次现场排障暴露出 #305 Push 链路太黑盒。
+
+当前：
+
+```text
+无订阅 → 静默
+成功 → 静默
+失败 → relay.push.send_failed
+```
+
+建议加 structured logging。
+
+### 发起 fanout
+
+```text
+relay.push.fanout
+```
+
+字段：
+
+```ts
+{
+  kind: "turn-completion",
+  accountId,       // 如果项目日志策略允许；不允许则不要
+  instanceId,
+  subscriptionCount
+}
+```
+
+### 成功
+
+```text
+relay.push.sent
+```
+
+```ts
+{
+  kind: "turn-completion",
+  instanceId,
+  endpointHost
+}
+```
+
+### 无订阅
+
+```text
+relay.push.no_subscriptions
+```
+
+### 失败
+
+继续：
+
+```text
+relay.push.send_failed
+```
+
+**绝对不要打印完整 endpoint。**
+
+当前 `safeHost()` 已经专门避免泄漏完整 Push endpoint，这个安全策略继续保持。
+
+---
+
+# 十九、关键测试
+
+## Gate 1：普通 relay-web prompt
+
+真实 Hub seam：
+
+```text
+POST/RPC MSG.prompt
+→ promptRequestId
+→ turn-started(same promptRequestId)
+→ turn-output("done")
+→ turn-finished(ok=true)
+```
+
+断言：
+
+```text
+PushNotifier.sendTurnCompletion == 1
+```
+
+内容包含：
+
+```text
+instanceId
+sessionAlias
+done
+```
+
+---
+
+## Gate 2：无 prompt provenance 的 turn-finished
+
+```text
+turn-started(no promptRequestId)
+→ turn-finished
+```
+
+断言：
+
+```text
+0 pushes
+```
+
+---
+
+## Gate 3：orchestration 不重复
+
+```text
+orchestration worker turn
+→ turn-finished
+→ instanceNotice(task-completion)
+```
+
+断言：
+
+```text
+ordinary turn push = 0
+task-completion push = 1
+```
+
+总计：
+
+```text
+1
+```
+
+不是 2。
+
+---
+
+## Gate 4：scheduled turn
+
+```text
+turn-started({
+  scheduled: ...
+})
+→ turn-finished
+```
+
+断言：
+
+```text
+0 ordinary completion push
+```
+
+---
+
+## Gate 5：peer turn
+
+```text
+turn-started({
+  peerOrigin: ...
+})
+→ turn-finished({
+  peerOrigin: ...
+})
+```
+
+断言：
+
+```text
+0
+```
+
+---
+
+## Gate 6：cancelled
+
+```text
+relay-web prompt
+→ turn-started
+→ turn-finished({
+  ok: false,
+  cancelled: true
+})
+```
+
+断言：
+
+```text
+0
+```
+
+---
+
+## Gate 7：failed
+
+```text
+relay-web prompt
+→ turn-started
+→ turn-finished({
+  ok: false,
+  errorMessage: "provider unavailable"
+})
+```
+
+断言：
+
+```text
+1 push
+```
+
+body 能表达失败。
+
+---
+
+## Gate 8：queued prompt
+
+必须是完整链路：
+
+```text
+Prompt A active
+
+Web submits Prompt B
+→ B gets promptRequestId
+→ RPC returns queued
+→ no push
+
+A finishes
+→ no B push yet
+
+B turn-started(promptRequestId)
+→ B turn-finished
+→ exactly 1 push
+```
+
+这是 blocking test。
+
+---
+
+## Gate 9：queue cancel
+
+```text
+Web prompt B queued
+→ cancel queue item
+→ B never turn-started
+```
+
+断言：
+
+```text
+0 push
+```
+
+并确认 pending provenance 最终会清理。
+
+---
+
+## Gate 10：Hub restart / recovered finish
+
+模拟：
+
+```text
+turn-finished
+without live TurnAccumulator
+```
+
+即使：
+
+```text
+text="finished while hub down"
+```
+
+也必须：
+
+```text
+0 push
+```
+
+---
+
+## Gate 11：duplicate finish
+
+如果 connector 异常重复发：
+
+```text
+same turn-finished twice
+```
+
+第一次：
+
+```text
+accumulator exists → push
+```
+
+第二次：
+
+```text
+accumulator gone → no push
+```
+
+最终：
+
+```text
+exactly 1 push
+```
+
+---
+
+# 二十、建议改动文件
+
+主要：
+
+```text
+packages/relay/src/server.ts
+packages/relay/src/http/app.ts
+packages/relay/src/push.ts
+```
+
+可能需要：
+
+```text
+packages/channel-relay/src/channel.ts
+packages/relay-protocol/src/dtos.ts
+packages/relay-protocol/src/messages.ts
+```
+
+只有在审计发现 `promptRequestId` immediate path 没有正确传进 `turn-started` 时才改 protocol/connector。
+
+测试：
+
+```text
+tests/unit/packages/relay/runtime-fanout.test.ts
+tests/unit/packages/relay/http*.test.ts
+tests/unit/packages/channel-relay/channel.test.ts
+```
+
+优先扩充已有 suite，不要重复建测试体系。
+
+---
+
+# 二十一、不要做的实现
+
+明确禁止：
+
+```ts
+turn-finished => always push
+```
+
+禁止：
+
+```ts
+sessionAlias === something
+```
+
+推测来源。
+
+禁止：
+
+```ts
+final text matching inbound prompt
+```
+
+做 correlation。
+
+禁止：
+
+```ts
+setTimeout(...)
+```
+
+猜哪个 turn 对应哪个 request。
+
+禁止让 relay-web 客户端自己在收到：
+
+```text
+turn-finished
+```
+
+时调用：
+
+```text
+new Notification(...)
+```
+
+这解决不了标签页关闭场景，也违背 Web Push 的设计目的。
+
+正确 ownership 必须在 Hub。
+
+---
+
+# 二十二、推荐最终结构
+
+```text
+relay-web
+   │
+   │ MSG.prompt
+   ▼
+Hub HTTP RPC
+   │
+   ├─ persist inbound
+   ├─ generate promptRequestId
+   └─ pendingWebPrompts[id] = provenance
+             │
+             ▼
+         connector
+             │
+             ▼
+turn-started(promptRequestId)
+             │
+             ▼
+Hub matches pending provenance
+             │
+             ▼
+TurnAccumulator {
+  notification: {
+    origin: "relay-web",
+    promptRequestId
+  }
+}
+             │
+     output / tools / reasoning
+             │
+             ▼
+       turn-finished
+             │
+       ┌─────┴─────┐
+       │           │
+cancelled        normal
+   │               │
+ no push           ▼
+             persist history
+                   │
+                   ▼
+         PushNotifier.sendTurnCompletion()
+                   │
+             account subscriptions
+                   │
+          ┌────────┴────────┐
+          ▼                 ▼
+       Chrome             Safari
+```
+
+---
+
+# PR 验收标准
+
+在以下全部成立前不要合并：
+
+1. relay-web 普通 prompt 成功完成 → **1 条 Push**。
+2. 普通 prompt 失败 → **1 条失败 Push**。
+3. 用户取消 → **0 Push**。
+4. queued prompt 只在真实执行完成后 Push。
+5. queued 后取消 → 0 Push。
+6. orchestration completion 仍然只有原来的 1 条，不重复。
+7. scheduled turn → 0 ordinary Push。
+8. peer/agent-message turn → 0 ordinary Push。
+9. recovery/state-sync/history replay → 0 Push。
+10. duplicate `turn-finished` → exactly once。
+11. Chrome 现有 `task-completion` Push 不回归。
+12. Safari 支持 PR 如果已合入，两种 provider 都走同一 `sendTurnCompletion`。
+13. Relay unit tests 全绿。
+14. Relay-Web tests 全绿。
+15. TypeScript typecheck 全绿。
+16. build 全绿。
+17. 手工真实 Chrome 验证：
+
+    * 开启通知；
+    * relay-web 普通 session 发 prompt；
+    * 切到其他页面/关闭 relay-web；
+    * agent 完成；
+    * 收到系统通知。
+
+这个方案的关键是 **“prompt provenance 跟随真实 turn”**，而不是扩大 `turn-finished` 的触发范围。这样能解决你现在真正遇到的问题，同时不会把后台 orchestration 和 agent-to-agent 活动变成通知轰炸。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx",
-  "version": "0.23.0-beta.6",
+  "version": "0.23.0-beta.7",
   "description": "随时随地通过聊天频道（微信 / 飞书 / 元宝等）远程控制 `acpx` 上的 Claude Code、Codex 等 Agents。",
   "keywords": [
     "acpx",

--- a/packages/relay-web/src/components/PlanPanel.vue
+++ b/packages/relay-web/src/components/PlanPanel.vue
@@ -14,7 +14,7 @@ const props = withDefaults(
 // `expanded` is a two-way model so ChatPane can own it and preserve the expand/collapse
 // state across composer-stack rerenders. When no v-model is bound (standalone use /
 // tests) it is a local ref seeded below.
-const expanded = defineModel<boolean>("expanded", { default: undefined });
+const expanded = defineModel<boolean | undefined>("expanded");
 if (expanded.value === undefined) expanded.value = props.active ?? true;
 const listEl = ref<HTMLUListElement | null>(null);
 const done = computed(() => props.entries.filter((e) => e.status === "completed").length);

--- a/packages/relay-web/src/components/PlanPanel.vue
+++ b/packages/relay-web/src/components/PlanPanel.vue
@@ -13,7 +13,7 @@ const props = withDefaults(
 );
 // `expanded` is a two-way model so ChatPane can own it and preserve the expand/collapse
 // state across composer-stack rerenders. When no v-model is bound (standalone use /
-// tests) it is a local ref seeded below.
+// tests) it defaults to expanded (true).
 const expanded = defineModel<boolean>("expanded", { default: true });
 const listEl = ref<HTMLUListElement | null>(null);
 const done = computed(() => props.entries.filter((e) => e.status === "completed").length);

--- a/packages/relay-web/src/components/PlanPanel.vue
+++ b/packages/relay-web/src/components/PlanPanel.vue
@@ -14,8 +14,7 @@ const props = withDefaults(
 // `expanded` is a two-way model so ChatPane can own it and preserve the expand/collapse
 // state across composer-stack rerenders. When no v-model is bound (standalone use /
 // tests) it is a local ref seeded below.
-const expanded = defineModel<boolean | undefined>("expanded");
-if (expanded.value === undefined) expanded.value = props.active ?? true;
+const expanded = defineModel<boolean>("expanded", { default: true });
 const listEl = ref<HTMLUListElement | null>(null);
 const done = computed(() => props.entries.filter((e) => e.status === "completed").length);
 const activeIndex = computed(() => {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ganglion/xacpx-relay",
-  "version": "0.13.0-beta.4",
+  "version": "0.13.0-beta.5",
   "description": "Self-hosted relay hub for xacpx: instance gateway, accounts, and web API.",
   "license": "MIT",
   "keywords": [

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -678,7 +678,13 @@ export function createApp(deps: AppDeps): Hono<Vars> {
         }
       }
       const result = await deps.gateway.sendRequest(instance.id, body.type, payload);
-      if (webPromptRequestId && isErrorPayload(result)) {
+      const isPromptRejection =
+        body.type === MSG.prompt
+        && typeof result === "object"
+        && result !== null
+        && "ok" in result
+        && result.ok === false;
+      if (webPromptRequestId && (isErrorPayload(result) || isPromptRejection)) {
         deps.onWebPromptRejected?.(webPromptRequestId);
       }
       if (body.type === MSG.prompt && persistedPromptId !== undefined

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -61,8 +61,11 @@ export interface AppDeps {
   onWebPromptCreated?: (input: { promptRequestId: string; instanceId: string; sessionAlias: string }) => void;
   /** Web push / provenance: called when an interactive prompt fails before execution. */
   onWebPromptRejected?: (promptRequestId: string) => void;
+  /** Web push / provenance: called when an interactive prompt is queued by the connector. */
+  onWebPromptQueued?: (input: { promptRequestId: string; instanceId: string; queueItemId: string }) => void;
+  /** Web push / provenance: called when a queued prompt is cancelled via Web RPC. */
+  onWebPromptQueueCancelled?: (instanceId: string, queueItemId: string) => void;
 }
-
 const SESSION_COOKIE = "xrelay_session";
 const LOGIN_WINDOW_MS = 10 * 60 * 1000;
 export const LOGIN_MAX_FAILURES = 10;
@@ -683,13 +686,29 @@ export function createApp(deps: AppDeps): Hono<Vars> {
         && (result as { queued?: unknown }).queued === true
         && typeof (result as { queueItemId?: unknown }).queueItemId === "string") {
         const p = payload as { sessionAlias: string };
+        const queueItemId = (result as { queueItemId: string }).queueItemId;
         deps.messages.markQueued(persistedPromptId, {
           instanceId: instance.id,
           sessionAlias: p.sessionAlias,
-          queueItemId: (result as { queueItemId: string }).queueItemId,
+          queueItemId,
         });
+        if (webPromptRequestId) {
+          deps.onWebPromptQueued?.({
+            promptRequestId: webPromptRequestId,
+            instanceId: instance.id,
+            queueItemId,
+          });
+        }
       }
-      // A real delete has two histories: the connector-owned acpx record and the
+      if (body.type === MSG.queueCancel && !isErrorPayload(result)) {
+        const p = payload as { itemId?: string };
+        if (typeof p.itemId === "string") {
+          const cancelResult = result as { cancelled?: boolean };
+          if (cancelResult.cancelled !== false) {
+            deps.onWebPromptQueueCancelled?.(instance.id, p.itemId);
+          }
+        }
+      }
       // Hub-owned Web transcript. Purge the latter only after the connector confirms
       // success; archive intentionally keeps both histories.
       if (removeInput && !isErrorPayload(result)) {

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -57,6 +57,10 @@ export interface AppDeps {
   vapidPublicKey?: () => string | null;
   /** Web push: browser subscription storage; omitted = push routes 503. */
   pushSubscriptions?: PushSubscriptionStore;
+  /** Web push / provenance: called when an interactive prompt is initiated via Web RPC. */
+  onWebPromptCreated?: (input: { promptRequestId: string; instanceId: string; sessionAlias: string }) => void;
+  /** Web push / provenance: called when an interactive prompt fails before execution. */
+  onWebPromptRejected?: (promptRequestId: string) => void;
 }
 
 const SESSION_COOKIE = "xrelay_session";
@@ -591,6 +595,7 @@ export function createApp(deps: AppDeps): Hono<Vars> {
     }
     const releaseSessionRpcLocks: Array<() => void> = [];
     let persistedPromptId: number | undefined;
+    let webPromptRequestId: string | undefined;
     try {
       // Shape-validate the RPCs the hub persists BEFORE forwarding, so a malformed frame
       // can't poison history ahead of the connector's own boundary check. Error body carries
@@ -655,13 +660,24 @@ export function createApp(deps: AppDeps): Hono<Vars> {
           // queue item still correlates back to this exact row via promptRequestId —
           // text matching cannot distinguish a redelivery from a duplicate prompt.
           const promptRequestId = randomUUID();
+          if (body.type === MSG.prompt) {
+            webPromptRequestId = promptRequestId;
+          }
           persistedPromptId = deps.messages.append(instance.id, p.sessionAlias, "in", p.text, undefined, attachments, promptRequestId);
           if (body.type === MSG.prompt && typeof payload === "object" && payload !== null) {
             (payload as Record<string, unknown>).promptRequestId = promptRequestId;
+            deps.onWebPromptCreated?.({
+              promptRequestId,
+              instanceId: instance.id,
+              sessionAlias: p.sessionAlias,
+            });
           }
         }
       }
       const result = await deps.gateway.sendRequest(instance.id, body.type, payload);
+      if (webPromptRequestId && isErrorPayload(result)) {
+        deps.onWebPromptRejected?.(webPromptRequestId);
+      }
       if (body.type === MSG.prompt && persistedPromptId !== undefined
         && typeof result === "object" && result !== null
         && (result as { queued?: unknown }).queued === true
@@ -686,10 +702,10 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       }
       return c.json({ result });
     } catch (error) {
+      if (webPromptRequestId) {
+        deps.onWebPromptRejected?.(webPromptRequestId);
+      }
       const message = error instanceof Error ? error.message : String(error);
-      // 503: transient availability — the instance is offline, or the connection was
-      // superseded by a reconnect before the RPC could be answered (the caller may
-      // retry). 504: the request budget expired. Anything else is a server error.
       if (message === "instance-offline" || message === "instance-reconnected") return c.json({ error: message }, 503);
       if (message === "timeout") return c.json({ error: message }, 504);
       return c.json({ error: message }, 500);

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -65,6 +65,8 @@ export interface AppDeps {
   onWebPromptQueued?: (input: { promptRequestId: string; instanceId: string; queueItemId: string }) => void;
   /** Web push / provenance: called when a queued prompt is cancelled via Web RPC. */
   onWebPromptQueueCancelled?: (instanceId: string, queueItemId: string) => void;
+  /** Web push / provenance: called when a session is archived or removed, clearing pending queues. */
+  onWebPromptSessionCleared?: (instanceId: string, sessionAlias: string) => void;
 }
 const SESSION_COOKIE = "xrelay_session";
 const LOGIN_WINDOW_MS = 10 * 60 * 1000;
@@ -715,6 +717,13 @@ export function createApp(deps: AppDeps): Hono<Vars> {
           }
         }
       }
+      if ((body.type === MSG.sessionsRemove || body.type === MSG.sessionsArchive) && !isErrorPayload(result)) {
+        const targetAlias = removeInput ? removeInput.alias : (typeof payload === "object" && payload !== null && "alias" in payload && typeof payload.alias === "string" ? payload.alias : undefined);
+        if (targetAlias) {
+          deps.onWebPromptSessionCleared?.(instance.id, targetAlias);
+        }
+      }
+      // A real delete has two histories: the connector-owned acpx record and the
       // Hub-owned Web transcript. Purge the latter only after the connector confirms
       // success; archive intentionally keeps both histories.
       if (removeInput && !isErrorPayload(result)) {
@@ -727,10 +736,11 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       }
       return c.json({ result });
     } catch (error) {
-      if (webPromptRequestId) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isAmbiguousTransportError = message === "instance-offline" || message === "instance-reconnected" || message === "timeout";
+      if (webPromptRequestId && !isAmbiguousTransportError) {
         deps.onWebPromptRejected?.(webPromptRequestId);
       }
-      const message = error instanceof Error ? error.message : String(error);
       if (message === "instance-offline" || message === "instance-reconnected") return c.json({ error: message }, 503);
       if (message === "timeout") return c.json({ error: message }, 504);
       return c.json({ error: message }, 500);

--- a/packages/relay/src/push.ts
+++ b/packages/relay/src/push.ts
@@ -151,43 +151,114 @@ export class PushNotifier {
    *  persist path (server.ts calls this fire-and-forget). */
   async sendTaskCompletion(accountId: string, notice: { instanceId: string; instanceName: string; text: string }): Promise<void> {
     try {
-      await this.sendTaskCompletionInner(accountId, notice);
+      await this.sendToAccount(accountId, {
+        kind: "task-completion",
+        instanceId: notice.instanceId,
+        title: notice.instanceName,
+        body: notice.text.slice(0, BODY_CAP),
+        url: "/",
+      });
     } catch (err) {
       // Belt-and-braces: even a bug above must never reject into the caller.
       this.deps.logger?.warn("relay.push.fanout_failed", "push fan-out aborted unexpectedly", { error: String(err) });
     }
   }
 
-  private async sendTaskCompletionInner(accountId: string, notice: { instanceId: string; instanceName: string; text: string }): Promise<void> {
+  /** Fan out a turn-completion notification to every subscription of the account.
+   *  Never throws or rejects. */
+  async sendTurnCompletion(
+    accountId: string,
+    notice: {
+      instanceId: string;
+      instanceName: string;
+      sessionAlias: string;
+      text?: string;
+      ok: boolean;
+      errorMessage?: string;
+    },
+  ): Promise<void> {
+    try {
+      const title = `${notice.instanceName} · ${notice.sessionAlias}`;
+      let body: string;
+      if (notice.ok) {
+        const trimmed = (notice.text ?? "").trim();
+        body = (trimmed.length > 0 ? trimmed : "Task completed").slice(0, BODY_CAP);
+      } else {
+        const errMsg = (notice.errorMessage ?? "").trim();
+        body = `Task failed: ${errMsg || "Unknown error"}`.slice(0, BODY_CAP);
+      }
+      await this.sendToAccount(accountId, {
+        kind: "turn-completion",
+        instanceId: notice.instanceId,
+        title,
+        body,
+        url: "/",
+      });
+    } catch (err) {
+      this.deps.logger?.warn("relay.push.fanout_failed", "push fan-out aborted unexpectedly", { error: String(err) });
+    }
+  }
+
+  private async sendToAccount(
+    accountId: string,
+    params: {
+      kind: "task-completion" | "turn-completion";
+      instanceId: string;
+      title: string;
+      body: string;
+      url: string;
+    },
+  ): Promise<void> {
     if (!this.ensureDetails()) return;
-    const payload = JSON.stringify({
-      title: notice.instanceName,
-      body: notice.text.slice(0, BODY_CAP),
-      instanceId: notice.instanceId,
-      url: "/",
+    const subs = this.deps.subscriptions.listByAccount(accountId);
+    if (subs.length === 0) {
+      this.deps.logger?.info("relay.push.no_subscriptions", "no push subscriptions for account", {
+        kind: params.kind,
+        instanceId: params.instanceId,
+      });
+      return;
+    }
+    this.deps.logger?.info("relay.push.fanout", "fanning out push notification", {
+      kind: params.kind,
+      instanceId: params.instanceId,
+      subscriptionCount: subs.length,
     });
-    for (const sub of this.deps.subscriptions.listByAccount(accountId)) {
+    const payload = JSON.stringify({
+      title: params.title,
+      body: params.body,
+      instanceId: params.instanceId,
+      url: params.url,
+    });
+    for (const sub of subs) {
       try {
         await this.wp.sendNotification(
           { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
           payload,
           { TTL: PUSH_TTL_SECONDS },
         );
+        this.deps.logger?.info("relay.push.sent", "push notification sent", {
+          kind: params.kind,
+          instanceId: params.instanceId,
+          endpointHost: safeHost(sub.endpoint),
+        });
       } catch (err) {
-        const statusCode = (err as { statusCode?: unknown }).statusCode;
-        if (typeof statusCode === "number" && GONE_STATUS.has(statusCode)) {
+        const statusCode = err && typeof err === "object" && "statusCode" in err && typeof err.statusCode === "number"
+          ? err.statusCode
+          : undefined;
+        if (statusCode !== undefined && GONE_STATUS.has(statusCode)) {
           this.deps.subscriptions.deleteByEndpoint(sub.endpoint);
         } else {
           this.deps.logger?.warn("relay.push.send_failed", "web push delivery failed", {
+            kind: params.kind,
+            instanceId: params.instanceId,
             endpointHost: safeHost(sub.endpoint),
-            statusCode: typeof statusCode === "number" ? statusCode : undefined,
+            ...(statusCode !== undefined ? { statusCode } : {}),
           });
         }
       }
     }
   }
 }
-
 /** Log only the push endpoint's host — the full URL is a bearer-ish secret. */
 function safeHost(endpoint: string): string {
   try {

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -199,13 +199,13 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   const prunePendingWebPrompts = () => {
     const now = Date.now();
     for (const [id, entry] of pendingWebPrompts) {
-      if (now - entry.createdAt > PENDING_WEB_PROMPT_TTL_MS) {
+      if (entry.state === "pending" && now - entry.createdAt > PENDING_WEB_PROMPT_TTL_MS) {
         removePendingWebPrompt(id);
       }
     }
   };
 
-  const recordPendingWebPrompt = (promptRequestId: string, instanceId: string, sessionAlias: string) => {
+  const recordPendingWebPrompt = (promptRequestId: string, instanceId: string, sessionAlias: string): boolean => {
     prunePendingWebPrompts();
     while (pendingWebPrompts.size >= PENDING_WEB_PROMPTS_MAX) {
       // Evict oldest pending grant first to protect active turns under load
@@ -217,9 +217,13 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
         }
       }
       if (!victimId) {
-        victimId = pendingWebPrompts.keys().next().value;
+        logger.warn("relay.web_prompt.capacity_exhausted", "web prompt grant capacity exhausted by active turns", {
+          instanceId,
+          sessionAlias,
+          capacity: PENDING_WEB_PROMPTS_MAX,
+        });
+        return false;
       }
-      if (!victimId) break;
       removePendingWebPrompt(victimId);
     }
     pendingWebPrompts.set(promptRequestId, {
@@ -228,6 +232,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
       createdAt: Date.now(),
       state: "pending",
     });
+    return true;
   };
 
   const associateQueueItem = (promptRequestId: string, instanceId: string, queueItemId: string) => {
@@ -706,10 +711,18 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 // Already committed (live flush or a previous sync) but the connector
                 // never got the ack — re-ack so its FIFO can finally drop the entry.
                 ackedRecoveryIds.push(recoveryId);
+                if (finished.promptRequestId) {
+                  removePendingWebPrompt(finished.promptRequestId);
+                }
                 continue;
               }
               const fingerprint = `${instanceId}\0${finished.sessionAlias}\0${finished.prompt ?? ""}\0${text ?? ""}`;
-              if (!recoveryId && recoveredFingerprints.has(fingerprint)) continue;
+              if (!recoveryId && recoveredFingerprints.has(fingerprint)) {
+                if (finished.promptRequestId) {
+                  removePendingWebPrompt(finished.promptRequestId);
+                }
+                continue;
+              }
               const alreadyPersisted = !recoveryId && text !== undefined
                 ? finished.prompt !== undefined
                   ? hasRecentTurnPair(finished.sessionAlias, finished.prompt, text)

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -108,6 +108,7 @@ export interface RelayRuntime {
   webGateway: WebGateway;
   stateSnapshot(instanceId: string): InstanceStateSnapshotDto;
   app: ReturnType<typeof createApp>;
+  pendingWebPromptsCount?(): number;
   close(): void;
 }
 
@@ -176,17 +177,64 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     instanceId: string;
     sessionAlias: string;
     createdAt: number;
+    queueItemId?: string;
   }
   const pendingWebPrompts = new Map<string, PendingWebPrompt>();
+  const queueItemToPromptRequestId = new Map<string, string>();
+  const PENDING_WEB_PROMPTS_MAX = 4096;
   const PENDING_WEB_PROMPT_TTL_MS = 24 * 60 * 60_000;
+
+  const queueKey = (instanceId: string, queueItemId: string) => `${instanceId}\0${queueItemId}`;
+
+  const removePendingWebPrompt = (promptRequestId: string) => {
+    const entry = pendingWebPrompts.get(promptRequestId);
+    if (entry) {
+      if (entry.queueItemId) {
+        queueItemToPromptRequestId.delete(queueKey(entry.instanceId, entry.queueItemId));
+      }
+      pendingWebPrompts.delete(promptRequestId);
+    }
+  };
+
   const prunePendingWebPrompts = () => {
     const now = Date.now();
     for (const [id, entry] of pendingWebPrompts) {
       if (now - entry.createdAt > PENDING_WEB_PROMPT_TTL_MS) {
-        pendingWebPrompts.delete(id);
+        removePendingWebPrompt(id);
       }
     }
   };
+
+  const recordPendingWebPrompt = (promptRequestId: string, instanceId: string, sessionAlias: string) => {
+    prunePendingWebPrompts();
+    while (pendingWebPrompts.size >= PENDING_WEB_PROMPTS_MAX) {
+      const oldestId = pendingWebPrompts.keys().next().value;
+      if (!oldestId) break;
+      removePendingWebPrompt(oldestId);
+    }
+    pendingWebPrompts.set(promptRequestId, {
+      instanceId,
+      sessionAlias,
+      createdAt: Date.now(),
+    });
+  };
+
+  const associateQueueItem = (promptRequestId: string, instanceId: string, queueItemId: string) => {
+    const entry = pendingWebPrompts.get(promptRequestId);
+    if (entry && entry.instanceId === instanceId) {
+      entry.queueItemId = queueItemId;
+      queueItemToPromptRequestId.set(queueKey(instanceId, queueItemId), promptRequestId);
+    }
+  };
+
+  const cancelPendingQueueItem = (instanceId: string, queueItemId: string) => {
+    const qKey = queueKey(instanceId, queueItemId);
+    const promptRequestId = queueItemToPromptRequestId.get(qKey);
+    if (promptRequestId) {
+      removePendingWebPrompt(promptRequestId);
+    }
+  };
+
   const key = (instanceId: string, alias: string) => `${instanceId}\0${alias}`;
   // Content fingerprints (`instanceId, alias, prompt, outText`) of finishedOffline
   // entries this runtime has already persisted from an `instance.state.sync`. A sync
@@ -381,7 +429,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
               const pending = pendingWebPrompts.get(event.promptRequestId);
               if (pending && pending.instanceId === instanceId && pending.sessionAlias === event.sessionAlias) {
                 notification = { origin: "relay-web", promptRequestId: event.promptRequestId };
-                pendingWebPrompts.delete(event.promptRequestId);
+                removePendingWebPrompt(event.promptRequestId);
               }
             }
             // Reconcile the inbound prompt FIRST (queued promotion / pre-write
@@ -751,15 +799,16 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     vapidPublicKey: vapid ? () => vapid.publicKey : undefined,
     pushSubscriptions,
     onWebPromptCreated: ({ promptRequestId, instanceId, sessionAlias }) => {
-      prunePendingWebPrompts();
-      pendingWebPrompts.set(promptRequestId, {
-        instanceId,
-        sessionAlias,
-        createdAt: Date.now(),
-      });
+      recordPendingWebPrompt(promptRequestId, instanceId, sessionAlias);
     },
     onWebPromptRejected: (promptRequestId) => {
-      pendingWebPrompts.delete(promptRequestId);
+      removePendingWebPrompt(promptRequestId);
+    },
+    onWebPromptQueued: ({ promptRequestId, instanceId, queueItemId }) => {
+      associateQueueItem(promptRequestId, instanceId, queueItemId);
+    },
+    onWebPromptQueueCancelled: (instanceId, queueItemId) => {
+      cancelPendingQueueItem(instanceId, queueItemId);
     },
   });
   const completionRouteSweepTimer = setInterval(
@@ -778,6 +827,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     gateway,
     webGateway,
     stateSnapshot,
+    pendingWebPromptsCount: () => pendingWebPrompts.size,
     app,
     close: () => {
       clearInterval(completionRouteSweepTimer);

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -711,14 +711,14 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 // Already committed (live flush or a previous sync) but the connector
                 // never got the ack — re-ack so its FIFO can finally drop the entry.
                 ackedRecoveryIds.push(recoveryId);
-                if (finished.promptRequestId) {
+                if (grant && finished.promptRequestId) {
                   removePendingWebPrompt(finished.promptRequestId);
                 }
                 continue;
               }
               const fingerprint = `${instanceId}\0${finished.sessionAlias}\0${finished.prompt ?? ""}\0${text ?? ""}`;
               if (!recoveryId && recoveredFingerprints.has(fingerprint)) {
-                if (finished.promptRequestId) {
+                if (grant && finished.promptRequestId) {
                   removePendingWebPrompt(finished.promptRequestId);
                 }
                 continue;
@@ -753,13 +753,13 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                   recoveryReceipts.remember(instanceId, recoveryId);
                 });
                 ackedRecoveryIds.push(recoveryId);
-                if (finished.promptRequestId) {
+                if (grant && finished.promptRequestId) {
                   removePendingWebPrompt(finished.promptRequestId);
                 }
               } else {
                 persist();
                 rememberFingerprint(fingerprint);
-                if (finished.promptRequestId) {
+                if (grant && finished.promptRequestId) {
                   removePendingWebPrompt(finished.promptRequestId);
                 }
               }

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -173,17 +173,17 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     notification?: TurnNotificationContext;
   }
   const turnBuffers = new Map<string, TurnAccumulator>();
-  interface PendingWebPrompt {
+  interface WebPromptGrant {
     instanceId: string;
     sessionAlias: string;
     createdAt: number;
     queueItemId?: string;
+    state: "pending" | "active";
   }
-  const pendingWebPrompts = new Map<string, PendingWebPrompt>();
+  const pendingWebPrompts = new Map<string, WebPromptGrant>();
   const queueItemToPromptRequestId = new Map<string, string>();
   const PENDING_WEB_PROMPTS_MAX = 4096;
   const PENDING_WEB_PROMPT_TTL_MS = 24 * 60 * 60_000;
-
   const queueKey = (instanceId: string, queueItemId: string) => `${instanceId}\0${queueItemId}`;
 
   const removePendingWebPrompt = (promptRequestId: string) => {
@@ -216,6 +216,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
       instanceId,
       sessionAlias,
       createdAt: Date.now(),
+      state: "pending",
     });
   };
 
@@ -235,6 +236,13 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     }
   };
 
+  const clearPendingForSession = (instanceId: string, sessionAlias: string) => {
+    for (const [id, grant] of pendingWebPrompts) {
+      if (grant.instanceId === instanceId && grant.sessionAlias === sessionAlias && grant.state === "pending") {
+        removePendingWebPrompt(id);
+      }
+    }
+  };
   const key = (instanceId: string, alias: string) => `${instanceId}\0${alias}`;
   // Content fingerprints (`instanceId, alias, prompt, outText`) of finishedOffline
   // entries this runtime has already persisted from an `instance.state.sync`. A sync
@@ -426,11 +434,13 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             const k = key(instanceId, event.sessionAlias);
             let notification: TurnNotificationContext | undefined;
             if (typeof event.promptRequestId === "string") {
-              const pending = pendingWebPrompts.get(event.promptRequestId);
-              if (pending && pending.instanceId === instanceId && pending.sessionAlias === event.sessionAlias) {
-                removePendingWebPrompt(event.promptRequestId);
+              const grant = pendingWebPrompts.get(event.promptRequestId);
+              if (grant && grant.instanceId === instanceId && grant.sessionAlias === event.sessionAlias) {
                 if (!event.scheduled && !event.peerOrigin) {
+                  grant.state = "active";
                   notification = { origin: "relay-web", promptRequestId: event.promptRequestId };
+                } else {
+                  removePendingWebPrompt(event.promptRequestId);
                 }
               }
             }
@@ -480,8 +490,9 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             const k = key(instanceId, event.sessionAlias);
             const a = turnBuffers.get(k);
             turnBuffers.delete(k);
-            // Persist the reply row(s), shared by the live path and the transactional
-            // recovery-ack path below. A turn with no content is a warning, not a row.
+            if (a?.notification?.promptRequestId) {
+              removePendingWebPrompt(a.notification.promptRequestId);
+            }
             const flush = (): void => {
               if (!a) {
                 // No buffer (e.g. hub restarted mid-turn and the offline sweep dropped it).
@@ -662,6 +673,14 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
               // trust the running turn; it will flush normally. Different turns on the
               // same alias are both persisted.
               if (finished.recoveryId && activeRecoveryIds.has(finished.recoveryId)) continue;
+              let grant: WebPromptGrant | undefined;
+              if (typeof finished.promptRequestId === "string") {
+                const g = pendingWebPrompts.get(finished.promptRequestId);
+                if (g && g.instanceId === instanceId && g.sessionAlias === finished.sessionAlias) {
+                  grant = g;
+                  removePendingWebPrompt(finished.promptRequestId);
+                }
+              }
               // A failed turn with no (or an empty) reply must surface its error text,
               // never an empty out row: the connector's accumulator starts text at ""
               // and a legacy/buggy sync may ship text:"" alongside errorMessage.
@@ -711,6 +730,17 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 persist();
                 rememberFingerprint(fingerprint);
               }
+              if (grant && grant.state === "active" && !finished.scheduled && finished.cancelled !== true) {
+                const instanceName = instances.getOwned(instanceId, accountId)?.name ?? instanceId;
+                void pushNotifier.sendTurnCompletion(accountId, {
+                  instanceId,
+                  instanceName,
+                  sessionAlias: finished.sessionAlias,
+                  text: text,
+                  ok: finished.ok,
+                  errorMessage: finished.errorMessage,
+                });
+              }
             }
             if (ackedRecoveryIds.length > 0) {
               gateway.sendEvent(instanceId, MSG.instanceRecoveryAck, { recoveryIds: ackedRecoveryIds } satisfies InstanceRecoveryAckPayload);
@@ -731,6 +761,14 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             for (const k of sessionUsage.keys()) if (k.startsWith(prefix)) sessionUsage.delete(k);
             for (const k of sessionCommands.keys()) if (k.startsWith(prefix)) sessionCommands.delete(k);
             for (const turn of sync.turns) {
+              let notification: TurnNotificationContext | undefined;
+              if (!turn.scheduled && typeof turn.promptRequestId === "string") {
+                const grant = pendingWebPrompts.get(turn.promptRequestId);
+                if (grant && grant.instanceId === instanceId && grant.sessionAlias === turn.sessionAlias) {
+                  grant.state = "active";
+                  notification = { origin: "relay-web", promptRequestId: turn.promptRequestId };
+                }
+              }
               const text = turn.text.slice(0, STATE_SYNC_TEXT_CAP);
               const reasoning = turn.reasoning.slice(0, REASONING_CAP);
               const steps = turn.steps.slice(0, MAX_TOOL_STEPS).map(capToolStep);
@@ -756,6 +794,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 // final flush persists structured.truncated instead of a gappy reply
                 // that reads as complete.
                 ...(turn.truncated ? { truncated: true } : {}),
+                ...(notification ? { notification } : {}),
               });
             }
             for (const meter of sync.usage) {
@@ -811,6 +850,9 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     },
     onWebPromptQueueCancelled: (instanceId, queueItemId) => {
       cancelPendingQueueItem(instanceId, queueItemId);
+    },
+    onWebPromptSessionCleared: (instanceId, sessionAlias) => {
+      clearPendingForSession(instanceId, sessionAlias);
     },
   });
   const completionRouteSweepTimer = setInterval(

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -158,8 +158,35 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   // remain for the flat fallback + the persisted `text` column. `truncated` rides the
   // state sync: a connector that capped this turn at STATE_SYNC_TEXT_CAP marks it so
   // the final flush persists structured.truncated instead of a silently-gappy reply.
-  interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reasoning: string; parts: TurnPartDto[]; startedAt: number; truncated?: boolean }
+  interface TurnNotificationContext {
+    origin: "relay-web";
+    promptRequestId: string;
+  }
+  interface TurnAccumulator {
+    text: string;
+    steps: Map<string, ToolStepDto>;
+    reasoning: string;
+    parts: TurnPartDto[];
+    startedAt: number;
+    truncated?: boolean;
+    notification?: TurnNotificationContext;
+  }
   const turnBuffers = new Map<string, TurnAccumulator>();
+  interface PendingWebPrompt {
+    instanceId: string;
+    sessionAlias: string;
+    createdAt: number;
+  }
+  const pendingWebPrompts = new Map<string, PendingWebPrompt>();
+  const PENDING_WEB_PROMPT_TTL_MS = 24 * 60 * 60_000;
+  const prunePendingWebPrompts = () => {
+    const now = Date.now();
+    for (const [id, entry] of pendingWebPrompts) {
+      if (now - entry.createdAt > PENDING_WEB_PROMPT_TTL_MS) {
+        pendingWebPrompts.delete(id);
+      }
+    }
+  };
   const key = (instanceId: string, alias: string) => `${instanceId}\0${alias}`;
   // Content fingerprints (`instanceId, alias, prompt, outText`) of finishedOffline
   // entries this runtime has already persisted from an `instance.state.sync`. A sync
@@ -349,6 +376,14 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
           webGateway.broadcast(accountId, { kind: "control-event", instanceId, event });
           if (event.type === "turn-started") {
             const k = key(instanceId, event.sessionAlias);
+            let notification: TurnNotificationContext | undefined;
+            if (!event.scheduled && !event.peerOrigin && typeof event.promptRequestId === "string") {
+              const pending = pendingWebPrompts.get(event.promptRequestId);
+              if (pending && pending.instanceId === instanceId && pending.sessionAlias === event.sessionAlias) {
+                notification = { origin: "relay-web", promptRequestId: event.promptRequestId };
+                pendingWebPrompts.delete(event.promptRequestId);
+              }
+            }
             // Reconcile the inbound prompt FIRST (queued promotion / pre-write
             // correlation / scheduled append) and only install the streaming buffer
             // once it succeeded. A persistence failure here is NOT silent: it forces a
@@ -361,7 +396,14 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 { prompt: event.prompt, queueItemId: event.queueItemId, scheduled: event.scheduled, promptRequestId: event.promptRequestId },
                 true,
               );
-              turnBuffers.set(k, { text: "", steps: new Map(), reasoning: "", parts: [], startedAt: Date.now() });
+              turnBuffers.set(k, {
+                text: "",
+                steps: new Map(),
+                reasoning: "",
+                parts: [],
+                startedAt: Date.now(),
+                ...(notification ? { notification } : {}),
+              });
             } catch (err) {
               turnBuffers.delete(k);
               gateway.disconnect(instanceId);
@@ -458,6 +500,17 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
               gateway.sendEvent(instanceId, MSG.instanceRecoveryAck, { recoveryIds: [recoveryId] } satisfies InstanceRecoveryAckPayload);
             } else {
               flush();
+            }
+            if (a?.notification?.origin === "relay-web" && !event.peerOrigin && event.cancelled !== true) {
+              const instanceName = instances.getOwned(instanceId, accountId)?.name ?? instanceId;
+              void pushNotifier.sendTurnCompletion(accountId, {
+                instanceId,
+                instanceName,
+                sessionAlias: event.sessionAlias,
+                text: a.text || event.text,
+                ok: event.ok,
+                errorMessage: event.errorMessage,
+              });
             }
           } else if (event.type === "turn-usage") {
             // Retain the latest usage per session (replace) so a refreshed web client can
@@ -697,6 +750,17 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     logger,
     vapidPublicKey: vapid ? () => vapid.publicKey : undefined,
     pushSubscriptions,
+    onWebPromptCreated: ({ promptRequestId, instanceId, sessionAlias }) => {
+      prunePendingWebPrompts();
+      pendingWebPrompts.set(promptRequestId, {
+        instanceId,
+        sessionAlias,
+        createdAt: Date.now(),
+      });
+    },
+    onWebPromptRejected: (promptRequestId) => {
+      pendingWebPrompts.delete(promptRequestId);
+    },
   });
   const completionRouteSweepTimer = setInterval(
     () => gateway.sweepExpiredCompletionRoutes(),

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -120,6 +120,7 @@ export interface CreateRuntimeOptions {
   /** Web push VAPID config; omitted = resolve from env, null = force-disable. */
   vapid?: VapidConfig | null;
   logger?: RelayLogger;
+  now?: () => Date;
 }
 
 /** Testable assembly without any network listener. */
@@ -127,6 +128,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   const db = await createSqlDriver(dbPath);
   initSchema(db);
   const logger = options.logger ?? createNoopRelayLogger();
+  const nowMs = () => (options.now ? options.now().getTime() : Date.now());
   const accounts = new AccountStore(db);
   const instances = new InstanceStore(db);
   const messages = new MessageStore(db);
@@ -197,7 +199,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   };
 
   const prunePendingWebPrompts = () => {
-    const now = Date.now();
+    const now = nowMs();
     for (const [id, entry] of pendingWebPrompts) {
       if (entry.state === "pending" && now - entry.createdAt > PENDING_WEB_PROMPT_TTL_MS) {
         removePendingWebPrompt(id);
@@ -229,7 +231,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     pendingWebPrompts.set(promptRequestId, {
       instanceId,
       sessionAlias,
-      createdAt: Date.now(),
+      createdAt: nowMs(),
       state: "pending",
     });
     return true;
@@ -453,7 +455,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
               if (grant && grant.instanceId === instanceId && grant.sessionAlias === event.sessionAlias) {
                 if (!event.scheduled && !event.peerOrigin) {
                   grant.state = "active";
-                  grant.createdAt = Date.now();
+                  grant.createdAt = nowMs();
                   notification = { origin: "relay-web", promptRequestId: event.promptRequestId };
                 } else {
                   removePendingWebPrompt(event.promptRequestId);
@@ -477,7 +479,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 steps: new Map(),
                 reasoning: "",
                 parts: [],
-                startedAt: Date.now(),
+                startedAt: nowMs(),
                 ...(notification ? { notification } : {}),
               });
             } catch (err) {
@@ -799,7 +801,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 const grant = pendingWebPrompts.get(turn.promptRequestId);
                 if (grant && grant.instanceId === instanceId && grant.sessionAlias === turn.sessionAlias) {
                   grant.state = "active";
-                  grant.createdAt = Date.now();
+                  grant.createdAt = nowMs();
                   notification = { origin: "relay-web", promptRequestId: turn.promptRequestId };
                 }
               }
@@ -869,8 +871,8 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     sessionUsage: listSessionUsage,
     sessionCommands: listSessionCommands,
     trustProxy: options.trustProxy,
+    now: options.now,
     checkUpdate: createRelayUpdateChecker({ current: readRelayVersion() }),
-    logger,
     vapidPublicKey: vapid ? () => vapid.publicKey : undefined,
     pushSubscriptions,
     onWebPromptCreated: ({ promptRequestId, instanceId, sessionAlias }) => {

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -425,11 +425,13 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
           if (event.type === "turn-started") {
             const k = key(instanceId, event.sessionAlias);
             let notification: TurnNotificationContext | undefined;
-            if (!event.scheduled && !event.peerOrigin && typeof event.promptRequestId === "string") {
+            if (typeof event.promptRequestId === "string") {
               const pending = pendingWebPrompts.get(event.promptRequestId);
               if (pending && pending.instanceId === instanceId && pending.sessionAlias === event.sessionAlias) {
-                notification = { origin: "relay-web", promptRequestId: event.promptRequestId };
                 removePendingWebPrompt(event.promptRequestId);
+                if (!event.scheduled && !event.peerOrigin) {
+                  notification = { origin: "relay-web", promptRequestId: event.promptRequestId };
+                }
               }
             }
             // Reconcile the inbound prompt FIRST (queued promotion / pre-write

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -208,9 +208,19 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   const recordPendingWebPrompt = (promptRequestId: string, instanceId: string, sessionAlias: string) => {
     prunePendingWebPrompts();
     while (pendingWebPrompts.size >= PENDING_WEB_PROMPTS_MAX) {
-      const oldestId = pendingWebPrompts.keys().next().value;
-      if (!oldestId) break;
-      removePendingWebPrompt(oldestId);
+      // Evict oldest pending grant first to protect active turns under load
+      let victimId: string | undefined;
+      for (const [id, grant] of pendingWebPrompts) {
+        if (grant.state === "pending") {
+          victimId = id;
+          break;
+        }
+      }
+      if (!victimId) {
+        victimId = pendingWebPrompts.keys().next().value;
+      }
+      if (!victimId) break;
+      removePendingWebPrompt(victimId);
     }
     pendingWebPrompts.set(promptRequestId, {
       instanceId,
@@ -438,6 +448,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
               if (grant && grant.instanceId === instanceId && grant.sessionAlias === event.sessionAlias) {
                 if (!event.scheduled && !event.peerOrigin) {
                   grant.state = "active";
+                  grant.createdAt = Date.now();
                   notification = { origin: "relay-web", promptRequestId: event.promptRequestId };
                 } else {
                   removePendingWebPrompt(event.promptRequestId);
@@ -490,9 +501,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             const k = key(instanceId, event.sessionAlias);
             const a = turnBuffers.get(k);
             turnBuffers.delete(k);
-            if (a?.notification?.promptRequestId) {
-              removePendingWebPrompt(a.notification.promptRequestId);
-            }
+            const promptRequestId = a?.notification?.promptRequestId;
             const flush = (): void => {
               if (!a) {
                 // No buffer (e.g. hub restarted mid-turn and the offline sweep dropped it).
@@ -558,9 +567,15 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 gateway.disconnect(instanceId);
                 throw err;
               }
+              if (promptRequestId) {
+                removePendingWebPrompt(promptRequestId);
+              }
               gateway.sendEvent(instanceId, MSG.instanceRecoveryAck, { recoveryIds: [recoveryId] } satisfies InstanceRecoveryAckPayload);
             } else {
               flush();
+              if (promptRequestId) {
+                removePendingWebPrompt(promptRequestId);
+              }
             }
             if (a?.notification?.origin === "relay-web" && !event.peerOrigin && event.cancelled !== true) {
               const instanceName = instances.getOwned(instanceId, accountId)?.name ?? instanceId;
@@ -678,7 +693,6 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 const g = pendingWebPrompts.get(finished.promptRequestId);
                 if (g && g.instanceId === instanceId && g.sessionAlias === finished.sessionAlias) {
                   grant = g;
-                  removePendingWebPrompt(finished.promptRequestId);
                 }
               }
               // A failed turn with no (or an empty) reply must surface its error text,
@@ -726,11 +740,17 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                   recoveryReceipts.remember(instanceId, recoveryId);
                 });
                 ackedRecoveryIds.push(recoveryId);
+                if (finished.promptRequestId) {
+                  removePendingWebPrompt(finished.promptRequestId);
+                }
               } else {
                 persist();
                 rememberFingerprint(fingerprint);
+                if (finished.promptRequestId) {
+                  removePendingWebPrompt(finished.promptRequestId);
+                }
               }
-              if (grant && grant.state === "active" && !finished.scheduled && finished.cancelled !== true) {
+              if (grant && !finished.scheduled && finished.cancelled !== true) {
                 const instanceName = instances.getOwned(instanceId, accountId)?.name ?? instanceId;
                 void pushNotifier.sendTurnCompletion(accountId, {
                   instanceId,
@@ -766,6 +786,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 const grant = pendingWebPrompts.get(turn.promptRequestId);
                 if (grant && grant.instanceId === instanceId && grant.sessionAlias === turn.sessionAlias) {
                   grant.state = "active";
+                  grant.createdAt = Date.now();
                   notification = { origin: "relay-web", promptRequestId: turn.promptRequestId };
                 }
               }

--- a/src/control/turn-queue.ts
+++ b/src/control/turn-queue.ts
@@ -677,6 +677,13 @@ export class TurnQueue {
     };
     let result: TurnResult | undefined;
     try {
+      const turnStarted = params.turnStarted
+        ? (params.promptRequestId !== undefined && params.turnStarted.promptRequestId === undefined
+            ? { ...params.turnStarted, promptRequestId: params.promptRequestId }
+            : params.turnStarted)
+        : (params.promptRequestId !== undefined
+            ? { promptRequestId: params.promptRequestId }
+            : undefined);
       result = await this.deps.runTurn(
         {
           chatKey: params.chatKey,
@@ -686,7 +693,7 @@ export class TurnQueue {
           senderId: params.senderId,
           isOwner: params.isOwner,
           accountId: params.accountId,
-          turnStarted: params.turnStarted,
+          turnStarted,
           media: params.media,
           agentMentions: params.agentMentions,
           allowRestoreArchived: params.allowRestoreArchived,

--- a/tests/unit/control/turn-queue.test.ts
+++ b/tests/unit/control/turn-queue.test.ts
@@ -128,6 +128,16 @@ test("a queued prompt carries promptRequestId onto the drained turn-started", as
   await p1;
 });
 
+test("an immediate prompt carries promptRequestId onto turnStarted", async () => {
+  const { queue, pendingReqs, resolveNext } = makeQueue();
+  const p = queue.submit({ ...BASE, text: "immediate", queueable: true, promptRequestId: "req-imm-1" });
+  await tick();
+  const turnStarted = pendingReqs()[0]?.turnStarted;
+  expect(turnStarted).toEqual({ promptRequestId: "req-imm-1" });
+  resolveNext();
+  await p;
+});
+
 test("a non-queueable submit while busy rejects immediately with turn-already-running", async () => {
   const { queue, resolveNext } = makeQueue();
   const p1 = queue.submit({ ...BASE, text: "first", queueable: true });

--- a/tests/unit/packages/package-metadata.test.ts
+++ b/tests/unit/packages/package-metadata.test.ts
@@ -16,10 +16,10 @@ test("root package publishes as xacpx and exposes plugin-api", () => {
   });
 });
 
-test("root package version is 0.23.0-beta.0", () => {
+test("root package version is 0.23.0-beta.7", () => {
   const pkg = readJson("package.json");
 
-  expect(pkg.version).toBe("0.23.0-beta.6");
+  expect(pkg.version).toBe("0.23.0-beta.7");
 });
 
 test("first-party channel plugins peer depend on xacpx", () => {

--- a/tests/unit/packages/relay/push-notifier.test.ts
+++ b/tests/unit/packages/relay/push-notifier.test.ts
@@ -154,3 +154,81 @@ test("sendTaskCompletion fans out to both FCM and Apple endpoints and cleans up 
   // 410 should have cleaned up both expired subscriptions
   expect(subscriptions.listByAccount("a1")).toHaveLength(0);
 });
+
+test("sendTurnCompletion pushes success with custom title and capped body", async () => {
+  const sent: SentCall[] = [];
+  const { notifier, subscriptions } = await makeNotifier(sent);
+  subscriptions.upsert({ accountId: "a1", endpoint: "https://push/e1", p256dh: "k1", auth: "a1" });
+
+  await notifier.sendTurnCompletion("a1", {
+    instanceId: "i1",
+    instanceName: "MacBook",
+    sessionAlias: "backend",
+    text: "done with everything ".repeat(20),
+    ok: true,
+  });
+
+  expect(sent).toHaveLength(1);
+  expect(sent[0]!.ttl).toBe(PUSH_TTL_SECONDS);
+  const payload = JSON.parse(sent[0]!.payload);
+  expect(payload.title).toBe("MacBook · backend");
+  expect(payload.body).toHaveLength(200);
+  expect(payload.instanceId).toBe("i1");
+  expect(payload.url).toBe("/");
+});
+
+test("sendTurnCompletion uses Task completed fallback when success text is empty", async () => {
+  const sent: SentCall[] = [];
+  const { notifier, subscriptions } = await makeNotifier(sent);
+  subscriptions.upsert({ accountId: "a1", endpoint: "https://push/e1", p256dh: "k1", auth: "a1" });
+
+  await notifier.sendTurnCompletion("a1", {
+    instanceId: "i1",
+    instanceName: "MacBook",
+    sessionAlias: "backend",
+    text: "   ",
+    ok: true,
+  });
+
+  expect(sent).toHaveLength(1);
+  const payload = JSON.parse(sent[0]!.payload);
+  expect(payload.title).toBe("MacBook · backend");
+  expect(payload.body).toBe("Task completed");
+});
+
+test("sendTurnCompletion formats failure error message", async () => {
+  const sent: SentCall[] = [];
+  const { notifier, subscriptions } = await makeNotifier(sent);
+  subscriptions.upsert({ accountId: "a1", endpoint: "https://push/e1", p256dh: "k1", auth: "a1" });
+
+  await notifier.sendTurnCompletion("a1", {
+    instanceId: "i1",
+    instanceName: "MacBook",
+    sessionAlias: "backend",
+    ok: false,
+    errorMessage: "provider unavailable",
+  });
+
+  expect(sent).toHaveLength(1);
+  const payload = JSON.parse(sent[0]!.payload);
+  expect(payload.title).toBe("MacBook · backend");
+  expect(payload.body).toBe("Task failed: provider unavailable");
+});
+
+test("sendTurnCompletion formats failure fallback when errorMessage is missing", async () => {
+  const sent: SentCall[] = [];
+  const { notifier, subscriptions } = await makeNotifier(sent);
+  subscriptions.upsert({ accountId: "a1", endpoint: "https://push/e1", p256dh: "k1", auth: "a1" });
+
+  await notifier.sendTurnCompletion("a1", {
+    instanceId: "i1",
+    instanceName: "MacBook",
+    sessionAlias: "backend",
+    ok: false,
+  });
+
+  expect(sent).toHaveLength(1);
+  const payload = JSON.parse(sent[0]!.payload);
+  expect(payload.title).toBe("MacBook · backend");
+  expect(payload.body).toBe("Task failed: Unknown error");
+});

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -301,3 +301,313 @@ test("task-completion notice fans out to push; other kinds do not", async () => 
 
   runtime.close();
 });
+
+async function setupPushRuntime() {
+  const runtime = await createRelayRuntime(":memory:", {
+    vapid: {
+      subject: "mailto:test@example.com",
+      publicKey: "BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U",
+      privateKey: "w7gAGvS_Do-fQS4qrv63qkIsaqw6ni5nyJoh3ud-BRU",
+    },
+  });
+  runtime.db.run("INSERT INTO accounts (id, username, created_at) VALUES (?,?,?)", ["a1", "u", "t"]);
+  runtime.db.run("INSERT INTO instances (id, account_id, name, credential_hash, created_at) VALUES (?,?,?,?,?)", ["i1", "a1", "MacBook", "h", "t"]);
+  runtime.pushSubscriptions.upsert({ accountId: "a1", endpoint: "https://push/e1", p256dh: "k", auth: "a" });
+
+  const sent: Array<{ endpoint: string; payload: string }> = [];
+  (runtime.pushNotifier as unknown as { _setWebPushForTests(w: unknown): void })._setWebPushForTests({
+    setVapidDetails: () => {},
+    sendNotification: async (sub: { endpoint: string }, payload: string) => {
+      sent.push({ endpoint: sub.endpoint, payload });
+    },
+  });
+
+  const { token: loginToken } = runtime.accounts.createLoginToken("a1", "test");
+  const loginRes = await runtime.app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ token: loginToken }),
+  });
+  const cookie = loginRes.headers.get("set-cookie")?.split(";")[0] ?? "";
+  const fire = (event: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceEvent, payload: { event },
+  });
+
+  const notice = (payload: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceNotice, payload,
+  });
+
+  return { runtime, sent, cookie, fire, notice };
+}
+
+test("Gate 1: ordinary relay-web prompt completion fans out exactly 1 push with custom title and body", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let forwardedPromptRequestId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    forwardedPromptRequestId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  const rpcPromise = runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "fix bug" } }),
+  });
+  const res = await rpcPromise;
+  expect(res.status).toBe(200);
+  expect(forwardedPromptRequestId).toBeString();
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: forwardedPromptRequestId });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "bug fixed" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "bug fixed",
+    instanceId: "i1",
+    url: "/",
+  });
+  runtime.close();
+});
+
+test("Gate 2: turn-finished without prompt provenance triggers 0 pushes", async () => {
+  const { runtime, sent, fire } = await setupPushRuntime();
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend" });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "done" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+  runtime.close();
+});
+
+test("Gate 3: orchestration task completion sends task push without duplicate ordinary turn push", async () => {
+  const { runtime, sent, fire, notice } = await setupPushRuntime();
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "orch-worker" });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "orch-worker", chunk: "subtask done" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "orch-worker", ok: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+
+  notice({ kind: "task-completion", text: "orchestration finished", taskId: "t1" });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook",
+    body: "orchestration finished",
+    instanceId: "i1",
+    url: "/",
+  });
+  runtime.close();
+});
+
+test("Gate 4: scheduled turn-started triggers 0 ordinary pushes", async () => {
+  const { runtime, sent, fire } = await setupPushRuntime();
+
+  fire({
+    type: "turn-started",
+    chatKey: "relay:a1",
+    sessionAlias: "backend",
+    promptRequestId: "sched-req-1",
+    scheduled: { taskId: "task1", executeAt: new Date().toISOString() },
+  });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "scheduled result" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+  runtime.close();
+});
+
+test("Gate 5: peer turn-started triggers 0 pushes", async () => {
+  const { runtime, sent, fire } = await setupPushRuntime();
+
+  const peerOrigin = {
+    sourceNodeId: "node-1",
+    sourceHandle: "agent:test",
+    requestMessageId: "msg-1",
+    completion: "result" as const,
+  };
+  fire({
+    type: "turn-started",
+    chatKey: "relay:a1",
+    sessionAlias: "backend",
+    promptRequestId: "peer-req-1",
+    peerOrigin,
+  });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "peer result" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true, peerOrigin });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+  runtime.close();
+});
+
+test("Gate 6: cancelled turn-finished triggers 0 pushes", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "cancel me" } }),
+  });
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: reqId });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "partial" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: false, cancelled: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+  runtime.close();
+});
+
+test("Gate 7: failed turn-finished triggers 1 failure push", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "fail task" } }),
+  });
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: reqId });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: false, errorMessage: "provider unavailable" });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "Task failed: provider unavailable",
+    instanceId: "i1",
+    url: "/",
+  });
+  runtime.close();
+});
+
+test("Gate 8: queued prompt pushes only when drained turn actually finishes", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let bReqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    bReqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true, queued: true, queueItemId: "q1" };
+  };
+
+  const resB = await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "prompt B" } }),
+  });
+  expect(resB.status).toBe(200);
+  expect(bReqId).toBeString();
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+
+  // A finishes (A had no web provenance)
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+
+  // B drains and starts
+  fire({
+    type: "turn-started",
+    chatKey: "relay:a1",
+    sessionAlias: "backend",
+    queueItemId: "q1",
+    promptRequestId: bReqId,
+    prompt: "prompt B",
+  });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "B complete" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "B complete",
+    instanceId: "i1",
+    url: "/",
+  });
+  runtime.close();
+});
+
+test("Gate 9: queued prompt never started produces 0 pushes", async () => {
+  const { runtime, sent, cookie } = await setupPushRuntime();
+
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async () => {
+    return { ok: true, queued: true, queueItemId: "q1" };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "will cancel" } }),
+  });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+  runtime.close();
+});
+
+test("Gate 10: finish without live TurnAccumulator produces 0 push", async () => {
+  const { runtime, sent, fire } = await setupPushRuntime();
+
+  fire({
+    type: "turn-finished",
+    chatKey: "relay:a1",
+    sessionAlias: "backend",
+    text: "finished while hub down",
+    ok: true,
+  });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+  runtime.close();
+});
+
+test("Gate 11: duplicate turn-finished produces exactly 1 push", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "hi" } }),
+  });
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: reqId });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "first" });
+
+  // First finish
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+  // Duplicate finish
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  runtime.close();
+});

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -407,14 +407,29 @@ test("Gate 3: orchestration task completion sends task push without duplicate or
   runtime.close();
 });
 
-test("Gate 4: scheduled turn-started triggers 0 ordinary pushes", async () => {
-  const { runtime, sent, fire } = await setupPushRuntime();
+test("Gate 4: scheduled turn-started with matching web provenance triggers 0 ordinary pushes", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let registeredId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    registeredId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  const res = await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "scheduled task" } }),
+  });
+  expect(res.status).toBe(200);
+  expect(registeredId).toBeString();
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
 
   fire({
     type: "turn-started",
     chatKey: "relay:a1",
     sessionAlias: "backend",
-    promptRequestId: "sched-req-1",
+    promptRequestId: registeredId,
     scheduled: { taskId: "task1", executeAt: new Date().toISOString() },
   });
   fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "scheduled result" });
@@ -425,20 +440,35 @@ test("Gate 4: scheduled turn-started triggers 0 ordinary pushes", async () => {
   runtime.close();
 });
 
-test("Gate 5: peer turn-started triggers 0 pushes", async () => {
-  const { runtime, sent, fire } = await setupPushRuntime();
+test("Gate 5: peer turn-started with matching web provenance triggers 0 pushes", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let registeredId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    registeredId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  const res = await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "peer task" } }),
+  });
+  expect(res.status).toBe(200);
+  expect(registeredId).toBeString();
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
 
   const peerOrigin = {
-    sourceNodeId: "node-1",
-    sourceHandle: "agent:test",
     requestMessageId: "msg-1",
     completion: "result" as const,
+    source: { nodeId: "node-1", endpointId: "ep-1" },
+    target: { nodeId: "node-2", endpointId: "ep-2" },
   };
   fire({
     type: "turn-started",
     chatKey: "relay:a1",
     sessionAlias: "backend",
-    promptRequestId: "peer-req-1",
+    promptRequestId: registeredId,
     peerOrigin,
   });
   fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "peer result" });
@@ -550,19 +580,40 @@ test("Gate 8: queued prompt pushes only when drained turn actually finishes", as
   runtime.close();
 });
 
-test("Gate 9: queued prompt never started produces 0 pushes", async () => {
-  const { runtime, sent, cookie } = await setupPushRuntime();
+test("Gate 9: queueCancel RPC cleans up pending provenance and produces 0 pushes", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
 
-  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async () => {
-    return { ok: true, queued: true, queueItemId: "q1" };
+  let bReqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, type: string, payload: unknown) => {
+    if (type === MSG.prompt) {
+      bReqId = (payload as { promptRequestId?: string }).promptRequestId;
+      return { ok: true, queued: true, queueItemId: "q1" };
+    }
+    if (type === MSG.queueCancel) {
+      return { ok: true, cancelled: true };
+    }
+    return { ok: true };
   };
 
-  await runtime.app.request("/api/instances/i1/rpc", {
+  const resPrompt = await runtime.app.request("/api/instances/i1/rpc", {
     method: "POST",
     headers: { cookie, "content-type": "application/json" },
     body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "will cancel" } }),
   });
+  expect(resPrompt.status).toBe(200);
+  expect(bReqId).toBeString();
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
 
+  const resCancel = await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.queueCancel, payload: { sessionAlias: "backend", itemId: "q1" } }),
+  });
+  expect(resCancel.status).toBe(200);
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
+
+  // If turn-finished of prior turn arrives, 0 push
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
   await new Promise((r) => setTimeout(r, 10));
   expect(sent).toHaveLength(0);
   runtime.close();

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -302,13 +302,14 @@ test("task-completion notice fans out to push; other kinds do not", async () => 
   runtime.close();
 });
 
-async function setupPushRuntime() {
+async function setupPushRuntime(opts?: { now?: () => Date }) {
   const runtime = await createRelayRuntime(":memory:", {
     vapid: {
       subject: "mailto:test@example.com",
       publicKey: "BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U",
       privateKey: "w7gAGvS_Do-fQS4qrv63qkIsaqw6ni5nyJoh3ud-BRU",
     },
+    ...(opts?.now ? { now: opts.now } : {}),
   });
   runtime.db.run("INSERT INTO accounts (id, username, created_at) VALUES (?,?,?)", ["a1", "u", "t"]);
   runtime.db.run("INSERT INTO instances (id, account_id, name, credential_hash, created_at) VALUES (?,?,?,?,?)", ["i1", "a1", "MacBook", "h", "t"]);
@@ -1216,33 +1217,52 @@ test("capacity saturation with only active grants rejects new registration witho
   expect(JSON.parse(sent[0]!.payload).title).toBe("MacBook · active-session-0");
   runtime.close();
 });
+test("active grant is NOT pruned by 24h pending TTL while pending grants expire", async () => {
+  let currentTime = Date.now();
+  const { runtime, sent, cookie, fire } = await setupPushRuntime({
+    now: () => new Date(currentTime),
+  });
+  let pendingId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    pendingId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true, queued: true, queueItemId: "q-stale" };
+  };
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "pending-session", text: "abandoned" } }),
+  });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
 
-test("active grant is NOT pruned by 24h pending TTL", async () => {
-  const { runtime, sent, cookie, fire } = await setupPushRuntime();
-
+  // 2. Submit active prompt and start it
   let activeId: string | undefined;
   (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
     activeId = (payload as { promptRequestId?: string }).promptRequestId;
     return { ok: true };
   };
-
   await runtime.app.request("/api/instances/i1/rpc", {
     method: "POST",
     headers: { cookie, "content-type": "application/json" },
     body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "multi-day task" } }),
   });
   fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: activeId });
-  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+  expect(runtime.pendingWebPromptsCount?.()).toBe(2);
 
-  // Register another prompt with normal clock to run prunePendingWebPrompts
+  // 3. Advance clock by 48 hours (well past 24h TTL)
+  currentTime += 48 * 60 * 60_000;
+
+  // 4. Register another prompt at current time to trigger prunePendingWebPrompts()
   await runtime.app.request("/api/instances/i1/rpc", {
     method: "POST",
     headers: { cookie, "content-type": "application/json" },
-    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "other", text: "trigger prune" } }),
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "new-session", text: "trigger prune" } }),
   });
 
+  // The expired pending grant was pruned, but the 48h-old active grant was preserved!
+  // Count: 2 (active grant + new trigger grant)
   expect(runtime.pendingWebPromptsCount?.()).toBe(2);
 
+  // 5. Active turn finishes and successfully pushes
   fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true, text: "finally done" });
   await new Promise((r) => setTimeout(r, 10));
   expect(sent).toHaveLength(1);

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -1040,3 +1040,92 @@ test("capacity pressure evicts oldest pending grant while protecting active gran
   });
   runtime.close();
 });
+
+test("finishedOffline persistence failure-injection: first persist throws -> grant stays alive -> re-sent finishedOffline succeeds and pushes exactly once", async () => {
+  const { runtime, sent, cookie } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "flaky offline prompt" } }),
+  });
+
+  expect(reqId).toBeString();
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+
+  // Mock db.transaction to fail once on first state-sync
+  const origTransaction = runtime.db.transaction.bind(runtime.db);
+  let failOnce = true;
+  runtime.db.transaction = (fn: () => void) => {
+    if (failOnce) {
+      failOnce = false;
+      throw new Error("simulated sync disk error");
+    }
+    return origTransaction(fn);
+  };
+
+  const syncEvent = (payload: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceStateSync, payload,
+  });
+
+  // First sync throws, logs persist_failed, and forces disconnect
+  syncEvent({
+    instanceId: "i1",
+    turns: [],
+    usage: [],
+    commands: [],
+    finishedOffline: [
+      {
+        sessionAlias: "backend",
+        chatKey: "relay:a1",
+        startedAt: Date.now() - 5000,
+        text: "flaky offline done",
+        prompt: "flaky offline prompt",
+        promptRequestId: reqId,
+        recoveryId: "rec-offline-1",
+        ok: true,
+      },
+    ],
+  });
+
+  expect(sent).toHaveLength(0);
+  // Grant must still be present for the retry
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+
+  // Second sync succeeds
+  syncEvent({
+    instanceId: "i1",
+    turns: [],
+    usage: [],
+    commands: [],
+    finishedOffline: [
+      {
+        sessionAlias: "backend",
+        chatKey: "relay:a1",
+        startedAt: Date.now() - 5000,
+        text: "flaky offline done",
+        prompt: "flaky offline prompt",
+        promptRequestId: reqId,
+        recoveryId: "rec-offline-1",
+        ok: true,
+      },
+    ],
+  });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "flaky offline done",
+    instanceId: "i1",
+    url: "/",
+  });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
+  runtime.close();
+});

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -432,6 +432,7 @@ test("Gate 4: scheduled turn-started with matching web provenance triggers 0 ord
     promptRequestId: registeredId,
     scheduled: { taskId: "task1", executeAt: new Date().toISOString() },
   });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
   fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "scheduled result" });
   fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
 
@@ -471,6 +472,7 @@ test("Gate 5: peer turn-started with matching web provenance triggers 0 pushes",
     promptRequestId: registeredId,
     peerOrigin,
   });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
   fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "peer result" });
   fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true, peerOrigin });
 
@@ -616,6 +618,26 @@ test("Gate 9: queueCancel RPC cleans up pending provenance and produces 0 pushes
   fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
   await new Promise((r) => setTimeout(r, 10));
   expect(sent).toHaveLength(0);
+  runtime.close();
+});
+
+test("prompt business rejection (e.g. queue-full) cleans up pending provenance immediately", async () => {
+  const { runtime, cookie } = await setupPushRuntime();
+
+  let registeredId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    registeredId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: false, errorMessage: "queue-full" };
+  };
+
+  const res = await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "overflow task" } }),
+  });
+  expect(res.status).toBe(200);
+  expect(registeredId).toBeString();
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
   runtime.close();
 });
 

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -1129,3 +1129,128 @@ test("finishedOffline persistence failure-injection: first persist throws -> gra
   expect(runtime.pendingWebPromptsCount?.()).toBe(0);
   runtime.close();
 });
+
+test("finishedOffline with matching promptRequestId but wrong session does not push and does not delete grant", async () => {
+  const { runtime, sent, cookie } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "task on backend" } }),
+  });
+
+  expect(reqId).toBeString();
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+
+  const syncEvent = (payload: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceStateSync, payload,
+  });
+  syncEvent({
+    instanceId: "i1",
+    turns: [],
+    usage: [],
+    commands: [],
+    finishedOffline: [
+      {
+        sessionAlias: "other-session",
+        chatKey: "relay:a1",
+        startedAt: Date.now() - 5000,
+        text: "done on other",
+        prompt: "task on backend",
+        promptRequestId: reqId,
+        ok: true,
+      },
+    ],
+  });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(0);
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+  runtime.close();
+});
+
+test("capacity saturation with only active grants rejects new registration without evicting active grants", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  const activeIds: string[] = [];
+  for (let i = 0; i < 4096; i++) {
+    const alias = `active-session-${i}`;
+    let registeredId: string | undefined;
+    (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+      registeredId = (payload as { promptRequestId?: string }).promptRequestId;
+      return { ok: true };
+    };
+    await runtime.app.request("/api/instances/i1/rpc", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: alias, text: `task-${i}` } }),
+    });
+    fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: alias, promptRequestId: registeredId });
+    activeIds.push(registeredId!);
+  }
+
+  expect(runtime.pendingWebPromptsCount?.()).toBe(4096);
+
+  let overflowId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    overflowId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "overflow-session", text: "overflow" } }),
+  });
+
+  expect(runtime.pendingWebPromptsCount?.()).toBe(4096);
+
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "active-session-0", ok: true, text: "done 0" });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload).title).toBe("MacBook · active-session-0");
+  runtime.close();
+});
+
+test("active grant is NOT pruned by 24h pending TTL", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let activeId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    activeId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "multi-day task" } }),
+  });
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: activeId });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+
+  // Register another prompt with normal clock to run prunePendingWebPrompts
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "other", text: "trigger prune" } }),
+  });
+
+  expect(runtime.pendingWebPromptsCount?.()).toBe(2);
+
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true, text: "finally done" });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "finally done",
+    instanceId: "i1",
+    url: "/",
+  });
+  runtime.close();
+});

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -684,3 +684,192 @@ test("Gate 11: duplicate turn-finished produces exactly 1 push", async () => {
   expect(sent).toHaveLength(1);
   runtime.close();
 });
+
+test("state-sync restores notification provenance for matching active turn and completes with exactly 1 push", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "long running" } }),
+  });
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: reqId });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "partial" });
+
+  const syncEvent = (payload: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceStateSync, payload,
+  });
+  syncEvent({
+    instanceId: "i1",
+    turns: [
+      {
+        sessionAlias: "backend",
+        chatKey: "relay:a1",
+        startedAt: Date.now() - 5000,
+        text: "partial",
+        steps: [],
+        reasoning: "",
+        promptRequestId: reqId,
+      },
+    ],
+    usage: [],
+    commands: [],
+    finishedOffline: [],
+  });
+
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: " complete" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "partial complete",
+    instanceId: "i1",
+    url: "/",
+  });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
+  runtime.close();
+});
+
+test("ambiguous transport error preserves pending grant for state-sync recovery and push", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    throw new Error("instance-reconnected");
+  };
+
+  const res = await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "ambiguous prompt" } }),
+  });
+  expect(res.status).toBe(503);
+  expect(reqId).toBeString();
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+
+  const syncEvent = (payload: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceStateSync, payload,
+  });
+  syncEvent({
+    instanceId: "i1",
+    turns: [
+      {
+        sessionAlias: "backend",
+        chatKey: "relay:a1",
+        startedAt: Date.now() - 5000,
+        text: "working",
+        steps: [],
+        reasoning: "",
+        promptRequestId: reqId,
+      },
+    ],
+    usage: [],
+    commands: [],
+    finishedOffline: [],
+  });
+
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: " done" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "working done",
+    instanceId: "i1",
+    url: "/",
+  });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
+  runtime.close();
+});
+
+test("active Web turn completed during connector outage sends delayed push on finishedOffline sync", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "run in outage" } }),
+  });
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: reqId });
+
+  const syncEvent = (payload: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceStateSync, payload,
+  });
+  syncEvent({
+    instanceId: "i1",
+    turns: [],
+    usage: [],
+    commands: [],
+    finishedOffline: [
+      {
+        sessionAlias: "backend",
+        chatKey: "relay:a1",
+        startedAt: Date.now() - 5000,
+        text: "outage result",
+        prompt: "run in outage",
+        promptRequestId: reqId,
+        ok: true,
+      },
+    ],
+  });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "outage result",
+    instanceId: "i1",
+    url: "/",
+  });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
+  runtime.close();
+});
+
+test("session archive RPC clears pending web prompts for that session", async () => {
+  const { runtime, cookie } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, type: string, payload: unknown) => {
+    if (type === MSG.prompt) {
+      reqId = (payload as { promptRequestId?: string }).promptRequestId;
+      return { ok: true, queued: true, queueItemId: "q1" };
+    }
+    return { ok: true };
+  };
+
+  const resPrompt = await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "will be archived" } }),
+  });
+  expect(resPrompt.status).toBe(200);
+  expect(reqId).toBeString();
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+
+  const resArchive = await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.sessionsArchive, payload: { alias: "backend" } }),
+  });
+  expect(resArchive.status).toBe(200);
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
+  runtime.close();
+});

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -873,3 +873,170 @@ test("session archive RPC clears pending web prompts for that session", async ()
   expect(runtime.pendingWebPromptsCount?.()).toBe(0);
   runtime.close();
 });
+
+test("ambiguous prompt goes directly pending -> finishedOffline on reconnect (no turn-started on Hub) and triggers exactly 1 push", async () => {
+  const { runtime, sent, cookie } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    throw new Error("instance-reconnected");
+  };
+
+  const res = await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "ambiguous finished offline" } }),
+  });
+  expect(res.status).toBe(503);
+  expect(reqId).toBeString();
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+
+  // Connector completes the turn entirely in outage and sends ONLY finishedOffline (no sync.turns)
+  const syncEvent = (payload: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceStateSync, payload,
+  });
+  syncEvent({
+    instanceId: "i1",
+    turns: [],
+    usage: [],
+    commands: [],
+    finishedOffline: [
+      {
+        sessionAlias: "backend",
+        chatKey: "relay:a1",
+        startedAt: Date.now() - 5000,
+        text: "direct finish in outage",
+        prompt: "ambiguous finished offline",
+        promptRequestId: reqId,
+        ok: true,
+      },
+    ],
+  });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "direct finish in outage",
+    instanceId: "i1",
+    url: "/",
+  });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
+  runtime.close();
+});
+
+test("live Web turn failure-injection: first DB transaction throws -> grant stays alive -> reconnect state-sync retry triggers exactly 1 push", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let reqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    reqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "flaky db prompt" } }),
+  });
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: reqId });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "flaky done" });
+
+  // Mock db.transaction to fail once
+  const origTransaction = runtime.db.transaction.bind(runtime.db);
+  let failOnce = true;
+  runtime.db.transaction = (fn: () => void) => {
+    if (failOnce) {
+      failOnce = false;
+      throw new Error("simulated disk error");
+    }
+    return origTransaction(fn);
+  };
+  // First finish fails transaction, logs persist_failed, and forces disconnect (swallowed at onEvent boundary)
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true, recoveryId: "rec-1" });
+  expect(sent).toHaveLength(0);
+  // Grant must STILL be present in memory for the retry
+  expect(runtime.pendingWebPromptsCount?.()).toBe(1);
+  // Connector reconnects and re-sends via finishedOffline
+  const syncEvent = (payload: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceStateSync, payload,
+  });
+  syncEvent({
+    instanceId: "i1",
+    turns: [],
+    usage: [],
+    commands: [],
+    finishedOffline: [
+      {
+        sessionAlias: "backend",
+        chatKey: "relay:a1",
+        startedAt: Date.now() - 5000,
+        text: "flaky done",
+        prompt: "flaky db prompt",
+        promptRequestId: reqId,
+        recoveryId: "rec-1",
+        ok: true,
+      },
+    ],
+  });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "flaky done",
+    instanceId: "i1",
+    url: "/",
+  });
+  expect(runtime.pendingWebPromptsCount?.()).toBe(0);
+  runtime.close();
+});
+
+test("capacity pressure evicts oldest pending grant while protecting active grants", async () => {
+  const { runtime, sent, cookie, fire } = await setupPushRuntime();
+
+  let activeReqId: string | undefined;
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, payload: unknown) => {
+    activeReqId = (payload as { promptRequestId?: string }).promptRequestId;
+    return { ok: true };
+  };
+
+  // Submit active prompt and start it
+  await runtime.app.request("/api/instances/i1/rpc", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: "backend", text: "active prompt" } }),
+  });
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", promptRequestId: activeReqId });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "running" });
+
+  // Flood with 5000 queued/pending prompts to trigger capacity eviction (limit 4096)
+  (runtime.gateway as unknown as { sendRequest: unknown }).sendRequest = async (_instanceId: string, _type: string, _payload: unknown) => {
+    return { ok: true, queued: true, queueItemId: "q-flood" };
+  };
+  for (let i = 0; i < 4100; i++) {
+    await runtime.app.request("/api/instances/i1/rpc", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ type: MSG.prompt, payload: { sessionAlias: `s-${i}`, text: `flood-${i}` } }),
+    });
+  }
+
+  // Capacity capped at 4096, and active grant was NOT evicted
+  expect(runtime.pendingWebPromptsCount?.()).toBe(4096);
+
+  // Active turn finishes and sends push successfully
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(sent).toHaveLength(1);
+  expect(JSON.parse(sent[0]!.payload)).toEqual({
+    title: "MacBook · backend",
+    body: "running",
+    instanceId: "i1",
+    url: "/",
+  });
+  runtime.close();
+});

--- a/weacpx-compat/package.json
+++ b/weacpx-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weacpx",
-  "version": "0.23.0-beta.6",
+  "version": "0.23.0-beta.7",
   "description": "Deprecated: weacpx has been renamed to `xacpx` (npm package `@ganglion/xacpx`, command `xacpx`). Install `@ganglion/xacpx` instead. This package forwards `weacpx/plugin-api` to `@ganglion/xacpx/plugin-api` for backward compatibility and has no CLI.",
   "keywords": [
     "xacpx",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ganglion/xacpx": "^0.23.0-beta.6"
+    "@ganglion/xacpx": "^0.23.0-beta.7"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- **Web Push for Interactive Turns**: Users prompting agents from `relay-web` now receive desktop Web Push notifications when turns complete.
  - Notification titles formatted as `<instance name> · <session alias>`.
  - Notification bodies include the agent's final text summary (capped to 200 characters) on success, or `Task failed: <errorMessage>` on failure.
- **`TurnQueue` Correlation**: `promptRequestId` is now passed to `turnStarted` on immediate prompt execution as well as queued prompt drains, ensuring `turn-started` reliably carries origin correlation.
- **`WebPromptGrant` Lifecycle & Reconnect Continuity**: Relay Hub tracks provenance as a lifecycle grant (`pending` -> `active` -> terminal cleanup).
  - **Commit-bound retirement**: Grants are retired ONLY after terminal DB persistence/receipt commit succeeds (protects against SQLite rollback -> state-sync reconnect retry).
  - **Direct `finishedOffline` push**: Conclusively matches and delivers delayed notifications for prompts that finish during connector outages (including ambiguous prompts that skipped Hub-side `turn-started` before reconnect).
  - **Scoped retirement**: `finishedOffline` only retires grants that strictly match both `instanceId` and `sessionAlias`, preventing cross-session provenance destruction.
  - **Capacity & TTL protection**: Hard limit (`PENDING_WEB_PROMPTS_MAX = 4096`) evicts oldest `pending` grants first and fails closed without evicting active turns; 24h TTL only prunes `pending` grants.
  - **Rejection & Session Cleanup**: Immediate cleanup upon prompt business rejection (`ok: false`), queue cancellation (`MSG.queueCancel`), or session archival/removal (`MSG.sessionsArchive`/`MSG.sessionsRemove`).
- **`PushNotifier`**: Added `sendTurnCompletion()` with structured logging for fanout, success, failure, and missing subscriptions.
- **Documentation**: Updated `docs/relay-module.md` Web Push section with both orchestration and interactive turn sources and filter boundaries.

## Test Coverage

- `tests/unit/control/turn-queue.test.ts`: verified immediate prompts forward `promptRequestId` to `turnStarted`.
- `tests/unit/packages/relay/push-notifier.test.ts`: verified `sendTurnCompletion` payload generation, title/body rules, failure formatting, and 410 gone cleanup.
- `tests/unit/packages/relay/runtime-fanout.test.ts`: verified all 37 turn gates and continuity scenarios:
  - Gate 1: ordinary relay-web prompt completion fans out exactly 1 push.
  - Gate 2: turn-finished without prompt provenance triggers 0 pushes.
  - Gate 3: orchestration task completion sends 1 task push without duplicate turn push.
  - Gate 4: scheduled turn-started with matching web provenance triggers 0 ordinary pushes and consumes provenance.
  - Gate 5: peer turn-started with matching web provenance triggers 0 pushes (using valid `PeerTurnOriginDto`) and consumes provenance.
  - Gate 6: cancelled turn-finished triggers 0 pushes.
  - Gate 7: failed turn-finished triggers 1 failure push.
  - Gate 8: queued prompt pushes only when drained turn finishes.
  - Gate 9: `queueCancel` RPC cleans up pending provenance and produces 0 pushes.
  - Prompt business rejection (e.g. `queue-full`) cleans up pending provenance immediately.
  - State-sync restores notification provenance for matching active turn and completes with exactly 1 push.
  - Ambiguous transport error (`instance-reconnected`/`timeout`) preserves pending grant for state-sync recovery.
  - Ambiguous prompt goes directly `pending` -> `finishedOffline` on reconnect (no `turn-started` on Hub) and triggers exactly 1 push.
  - Live Web turn failure injection: first DB transaction throws -> grant stays alive -> reconnect state-sync retry triggers exactly 1 push.
  - `finishedOffline` persistence failure-injection: first persist throws -> grant stays alive -> re-sent `finishedOffline` succeeds and pushes exactly once.
  - `finishedOffline` with matching `promptRequestId` but wrong session does not push and does not delete grant.
  - Capacity saturation with only active grants rejects new registration without evicting active grants.
  - Active grant is NOT pruned by 24h pending TTL while pending grants expire (tested with fake clock 48h advancement).
  - Capacity pressure evicts oldest `pending` grant while protecting `active` grants.
  - Session archive clears pending web prompts for that session.
  - Gate 10: hub restart / historical `finishedOffline` without grant produces 0 push.
  - Gate 11: duplicate turn-finished produces exactly 1 push.

## Test plan

- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `bun test tests/unit/packages/relay/` (420 tests pass)
- [x] `bun test tests/unit/packages/channel-relay/` (385 tests pass)
- [x] `bun test tests/unit/control/` (355 tests pass)
- [x] `bun run build:packages` builds all packages and relay-web dashboard cleanly
- [x] GitHub Actions CI checks all green (test, terminal-windows, Relay Web terminal E2E, Detect changed paths)