### PR TITLE
feat(relay-web): composer column alignment, icon-only mobile send, unified queue layer, stable sleep transition

### DIFF
--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -118,6 +118,30 @@ it("stacks status, plan, and composer as document-flow layers (status → plan �
   expect(kids.indexOf(planEl)).toBeLessThan(kids.indexOf(composerEl!));
 });
 
+it("stacks the pending-prompt queue as its own layer between plan and input", async () => {
+  seedInstance();
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  // Queue present without busy/plan: it alone must pull the composer up.
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: {
+    type: "queue-updated", chatKey: "c", sessionAlias: "backend",
+    items: [{ id: "q1", textPreview: "queued prompt", enqueuedAt: "t" }],
+  } } as never);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+
+  const stackEl = w.find('[data-test="composer-stack"]').element as HTMLElement;
+  const queue = w.find('[data-test="queue-strip"]');
+  expect(queue.exists()).toBe(true);
+  expect(queue.classes()).toContain("stack-layer--queue");
+  const composerEl = stackEl.querySelector(".stack-layer--composer") as HTMLElement;
+  // Queue visible but no status/plan: the pull-up is driven by the queue alone.
+  expect(composerEl.classList.contains("stack-layer--pull")).toBe(true);
+  // DOM order keeps the layering: status → queue → composer.
+  const kids = [...stackEl.children] as HTMLElement[];
+  expect(kids.indexOf(queue.element as HTMLElement)).toBeLessThan(kids.indexOf(composerEl));
+});
+
 it("grouped sidebar: sleeping row lives only in groupArchived — avatar still shows its driver", async () => {
   // Production shape (grouped sidebar): archived rows are paged into
   // inst.groupArchived[*].sessions and stay OUT of inst.sessions. inst.agents is

--- a/packages/relay-web/src/__tests__/instances-group-archived.test.ts
+++ b/packages/relay-web/src/__tests__/instances-group-archived.test.ts
@@ -369,3 +369,45 @@ test("archive failure restores the pre-hand-off archivedAt (stamp rollback)", as
   expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual([]);
   vi.restoreAllMocks();
 });
+
+test("wake fails -> wake succeeds -> archive fails preserves correct archivedAt across transactions (no stamp leakage)", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const initialTimestamp = "2024-01-01T12:00:00Z";
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({
+    sessions: [{ ...sleeping("s1"), archivedAt: initialTimestamp }],
+    hasMore: false,
+  });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockClear();
+
+  // Step 1: Wake fails -> rollback must not leak any archive stamp into future transactions.
+  rpc.mockRejectedValueOnce(new Error("gateway timeout"));
+  await expect(store.unarchiveSession("i1", "s1")).rejects.toThrow("gateway timeout");
+  expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions[0].archivedAt).toBe(initialTimestamp);
+
+  // Step 2: Wake succeeds -> row is now active in inst.sessions (no archivedAt).
+  rpc.mockReset();
+  rpc.mockImplementation(async (_iid: string, type: string) => {
+    if (type === "control.sessions.list") {
+      return { sessions: [awake("s1"), awake("active")], hasMore: false };
+    }
+    return {};
+  });
+  await store.unarchiveSession("i1", "s1");
+  const activeRow = store.byId("i1")!.sessions.find((s) => s.alias === "s1")!;
+  expect(activeRow.archived).toBe(false);
+  expect(activeRow.archivedAt).toBeUndefined();
+
+  // Step 3: Archive fails -> rollback must restore archivedAt to UNDEFINED (the pre-archive
+  // state of this transaction), NOT the stale initialTimestamp from Step 1.
+  rpc.mockReset();
+  rpc.mockImplementation(async (_iid: string, type: string) => {
+    if (type === "control.sessions.archive") throw new Error("network down");
+    return { sessions: [], hasMore: false };
+  });
+  await expect(store.archiveSession("i1", "s1")).rejects.toThrow("network down");
+  expect(activeRow.archived).toBe(false);
+  expect(activeRow.archivedAt).toBeUndefined();
+  vi.restoreAllMocks();
+});

--- a/packages/relay-web/src/__tests__/instances-group-archived.test.ts
+++ b/packages/relay-web/src/__tests__/instances-group-archived.test.ts
@@ -1,6 +1,7 @@
 import { setActivePinia, createPinia } from "pinia";
 import { beforeEach, expect, test, vi } from "vitest";
 import { useInstancesStore, groupArchivedKey } from "../stores/instances";
+import { archivedLast } from "../lib/sidebar-group-mode";
 
 beforeEach(() => setActivePinia(createPinia()));
 
@@ -259,5 +260,112 @@ test("unarchive pulls the row out of loaded pages into actives in one tick (and 
   // Back in the sleeping page (not stranded in actives), roll-back complete.
   expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual(["s1"]);
   expect(store.byId("i1")!.sessions.some((s) => s.alias === "s1")).toBe(false);
+  vi.restoreAllMocks();
+});
+
+test("wake during an in-flight group refresh discards the stale snapshot instead of resurrecting the row", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const sleepingRow = sleeping("s1");
+  const activeRow = awake("active");
+  const awakeRow = awake("s1");
+
+  // Page already published with s1.
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [sleepingRow], hasMore: false });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual(["s1"]);
+
+  let isAwake = false;
+  let sawInFlightArchivedQuery = false;
+  const gate = Promise.withResolvers<void>();
+  rpc.mockReset();
+  rpc.mockImplementation(async (_iid: string, type: string, payload?: unknown) => {
+    if (type === "control.sessions.unarchive") {
+      isAwake = true;
+      return {};
+    }
+    if (type === "control.sessions.list") {
+      const isArchivedOnly = (payload as { archivedOnly?: boolean })?.archivedOnly === true;
+      if (isArchivedOnly) {
+        if (!sawInFlightArchivedQuery) {
+          sawInFlightArchivedQuery = true;
+          // HANG this pre-wake in-flight refresh until wake has optimistically
+          // moved s1 out of the page.
+          await gate.promise;
+          // STALE snapshot: carries s1 as sleeping; must be discarded via pending mark.
+          return { sessions: [sleepingRow], hasMore: false };
+        }
+        // Post-wake authoritative queries: s1 is awake, sleeping page is empty.
+        return { sessions: isAwake ? [] : [sleepingRow], hasMore: false };
+      }
+      // Plain (active) listing: includes s1 once awake.
+      return { sessions: isAwake ? [activeRow, awakeRow] : [activeRow], hasMore: false };
+    }
+    return {};
+  });
+
+  // Start an in-flight refresh (e.g. from sessions-changed), then wake mid-flight.
+  void store.refreshLoadedGroupArchivedSessions("i1");
+  await vi.waitFor(() => expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.loading).toBe(true));
+
+  const waking = store.unarchiveSession("i1", "s1");
+  // Synchronous contract: s1 moved to actives AND left the sleeping page in one tick.
+  expect(store.byId("i1")!.sessions.some((s) => s.alias === "s1" && !s.archived)).toBe(true);
+  expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual([]);
+  gate.resolve();
+
+  await waking;
+  await vi.waitFor(() => expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.loading).toBe(false));
+  const page = store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!;
+  // The stale snapshot was discarded and replaced: no duplicate in sleeping + active.
+  expect(page.sessions.map((s) => s.alias)).toEqual([]);
+  expect(store.byId("i1")!.sessions.filter((s) => !s.archived && s.alias === "s1")).toHaveLength(1);
+  vi.restoreAllMocks();
+});
+
+test("archive hands off with provisional archivedAt that sorts FIRST in archivedLast", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  // Existing sleeping rows carry older timestamps; the optimistic row starts at the tail.
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({
+    sessions: [
+      { ...sleeping("older"), archivedAt: "2024-01-01T00:00:00Z" },
+      { ...sleeping("newer"), archivedAt: "2024-06-01T00:00:00Z" },
+    ],
+    hasMore: false,
+  });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockClear();
+  rpc.mockResolvedValue({ sessions: [sleeping("older"), sleeping("newer"), { ...awake("active"), transportSession: "t-active" }], hasMore: false });
+
+  const done = store.archiveSession("i1", "active");
+  const page = store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!;
+  const row = page.sessions.find((s) => s.alias === "active")!;
+  // Provisional stamp exists even though inst.sessions' row had none.
+  expect(row.archivedAt).toBeTruthy();
+  // Render-order contract through archivedLast(): newest slept session first.
+  expect(archivedLast(page.sessions).map((s) => s.alias)).toEqual(["active", "newer", "older"]);
+  await done;
+  vi.restoreAllMocks();
+});
+
+test("archive failure restores the pre-hand-off archivedAt (stamp rollback)", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const originalStamp = "2023-05-05T00:00:00Z";
+  // The active row ALREADY has an archivedAt (woken earlier once) — a failed archive
+  // must restore that value, not delete it.
+  store.byId("i1")!.sessions.find((s) => s.alias === "active")!.archivedAt = originalStamp;
+  const rpc = vi.spyOn(api, "rpc").mockImplementation(async (_iid: string, type: string) => {
+    if (type === "control.sessions.archive") throw new Error("nope");
+    return { sessions: [], hasMore: false };
+  });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  await expect(store.archiveSession("i1", "active")).rejects.toThrow("nope");
+  const row = store.byId("i1")!.sessions.find((s) => s.alias === "active")!;
+  expect(row.archived).toBe(false);
+  expect(row.archivedAt).toBe(originalStamp);
+  // And it was pulled back out of the sleeping page.
+  expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual([]);
   vi.restoreAllMocks();
 });

--- a/packages/relay-web/src/__tests__/instances-group-archived.test.ts
+++ b/packages/relay-web/src/__tests__/instances-group-archived.test.ts
@@ -18,6 +18,10 @@ const sleeping = (alias: string, workspace = "backend", agent = "codex") => ({
   alias, agent, workspace, transportSession: `t-${alias}`, running: false, archived: true,
 });
 
+const awake = (alias: string, workspace = "backend", agent = "codex") => ({
+  alias, agent, workspace, transportSession: `t-${alias}`, running: false, archived: false,
+});
+
 test("loadGroupArchivedSessions fetches one archivedOnly page scoped to the group", async () => {
   const store = seed();
   const { api } = await import("../api/client");
@@ -176,5 +180,84 @@ test("unarchiveSession refreshes loaded group pages", async () => {
 
   const archivedCalls = rpc.mock.calls.filter((call) => (call[2] as { archivedOnly?: boolean })?.archivedOnly);
   expect(archivedCalls).toHaveLength(1);
+  vi.restoreAllMocks();
+});
+
+test("archive moves the row into loaded group pages synchronously (no remove-then-reappear)", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  // Group page for workspace "backend" is loaded BEFORE the archive.
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [sleeping("s1")], hasMore: false });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockClear();
+  rpc.mockResolvedValue({ sessions: [], hasMore: false });
+
+  // Capture state SYNCHRONOUSLY after invoking archiveSession (not awaiting it):
+  // the point of the fix is that the row never disappears between the click and
+  // the refetch publishing.
+  const done = store.archiveSession("i1", "active");
+  expect(store.byId("i1")!.sessions.filter((s) => !s.archived).map((s) => s.alias)).toEqual([]);
+  const page = store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!;
+  expect(page.sessions.map((s) => s.alias)).toEqual(["s1", "active"]);
+  expect(page.sessions[1].archived).toBe(true);
+  await done;
+  vi.restoreAllMocks();
+});
+
+test("archive failure rolls the row back out of the group pages", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  const rpc = vi.spyOn(api, "rpc").mockResolvedValue({ sessions: [sleeping("s1")], hasMore: false });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockReset();
+  rpc.mockRejectedValue(new Error("still draining"));
+
+  await expect(store.archiveSession("i1", "active")).rejects.toThrow("still draining");
+  expect(store.byId("i1")!.sessions.find((s) => s.alias === "active")!.archived).toBe(false);
+  const page = store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!;
+  expect(page.sessions.map((s) => s.alias)).toEqual(["s1"]);
+  vi.restoreAllMocks();
+});
+
+test("unarchive pulls the row out of loaded pages into actives in one tick (and rolls back on failure)", async () => {
+  const store = seed();
+  const { api } = await import("../api/client");
+  // First (archivedOnly) load returns s1 SLEEPING; every later list call sees it AWAKE.
+  let firstList = true;
+  const rpc = vi.spyOn(api, "rpc").mockImplementation(async (_iid: string, type: string) => {
+    if (type === "control.sessions.list") {
+      const sleepingFirst = firstList;
+      firstList = false;
+      return { sessions: [sleepingFirst ? sleeping("s1") : awake("s1")], hasMore: false };
+    }
+    return {};
+  });
+  await store.loadGroupArchivedSessions("i1", "workspace", "backend");
+  rpc.mockClear();
+
+  // Success path: synchronous move before the awaited refresh lands.
+  const done = store.unarchiveSession("i1", "s1");
+  expect(store.byId("i1")!.sessions.some((s) => s.alias === "s1" && !s.archived)).toBe(true);
+  expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual([]);
+  await done;
+
+  // Failure path: wake a sleeping session whose RPC rejects. Re-seed the page with
+  // the row (as if woken then re-slept), and have every list call fail-free while
+  // the unarchive RPC itself rejects.
+  const inst = store.byId("i1")!;
+  inst.groupArchived![groupArchivedKey("workspace", "backend")] = {
+    sessions: [{ ...sleeping("s1"), archived: true }],
+    loaded: true, hasMore: false, nextOffset: 0,
+  };
+  inst.sessions = inst.sessions.filter((s) => s.alias !== "s1");
+  rpc.mockReset();
+  rpc.mockImplementation(async (_iid: string, type: string) => {
+    if (type === "control.sessions.unarchive") throw new Error("offline");
+    return { sessions: [], hasMore: false };
+  });
+  await expect(store.unarchiveSession("i1", "s1")).rejects.toThrow("offline");
+  // Back in the sleeping page (not stranded in actives), roll-back complete.
+  expect(store.byId("i1")!.groupArchived![groupArchivedKey("workspace", "backend")]!.sessions.map((s) => s.alias)).toEqual(["s1"]);
+  expect(store.byId("i1")!.sessions.some((s) => s.alias === "s1")).toBe(false);
   vi.restoreAllMocks();
 });

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -28,6 +28,9 @@ const keyboardInset = useVirtualKeyboardInset();
 // Keep expansion state here so toggles survive stack rerenders.
 const planExpanded = ref(chat.busy);
 const showPlan = computed(() => (chat.sessionPlan?.length ?? 0) > 0);
+// Pending-prompt queue joins the same document-flow stack as its own layer
+// (between plan and input).
+const showQueue = computed(() => chat.sessionQueue.length > 0);
 
 function onSend(
   text: string,
@@ -211,6 +214,10 @@ const verb = computed(() => {
       <div class="shrink-0 bg-gradient-to-t from-bg to-transparent px-2 lg:px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-1.5"
            :style="keyboardInset ? { paddingBottom: '0.5rem' } : undefined"
            data-test="composer-area">
+        <!-- Same centered 48rem column as the transcript rows (MessageList mx-auto
+             max-w-3xl), so status/plan/composer never outgrow the conversation on
+             wide panes. Narrow screens ignore the cap (w-full). -->
+        <div class="mx-auto w-full max-w-3xl">
         <!-- Document-flow stack: status (bottom) → plan (middle) → input (top).
              Overlap is visual only — lower layers reserve padding-bottom equal to the
              pull-up so content stays fully visible. -->
@@ -234,16 +241,17 @@ const verb = computed(() => {
           <PlanPanel v-if="showPlan" key="plan-layer" v-model:expanded="planExpanded" :entries="chat.sessionPlan!" :active="chat.busy" variant="stack"
                      class="stack-layer stack-layer--plan relative z-20 mx-2 pb-[var(--stack-overlap)] shadow-e3 sm:mx-3"
                      :class="{ 'stack-layer--pull': chat.busy }" />
+          <QueueStrip v-if="showQueue" key="queue-layer"
+                      class="stack-layer stack-layer--queue relative z-25 mx-2 pb-[var(--stack-overlap)] shadow-e2 rounded-lg sm:mx-3"
+                      :class="{ 'stack-layer--pull': chat.busy || showPlan }" />
           <div key="composer-layer" class="stack-layer stack-layer--composer relative z-30"
-               :class="{ 'stack-layer--pull': chat.busy || showPlan }">
-            <div class="space-y-2">
-              <QueueStrip />
-              <PromptInput :busy="chat.busy" :draft-key="`${chat.instanceId}\0${chat.sessionAlias}`"
-                           :instance-id="chat.instanceId" :session-alias="chat.sessionAlias"
-                           @send="onSend" @cancel="chat.cancel" />
-            </div>
+               :class="{ 'stack-layer--pull': chat.busy || showPlan || showQueue }">
+            <PromptInput :busy="chat.busy" :draft-key="`${chat.instanceId}\0${chat.sessionAlias}`"
+                         :instance-id="chat.instanceId" :session-alias="chat.sessionAlias"
+                         @send="onSend" @cancel="chat.cancel" />
           </div>
         </TransitionGroup>
+        </div>
       </div>
       </template>
     </template>

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -242,7 +242,7 @@ const verb = computed(() => {
                      class="stack-layer stack-layer--plan relative z-20 mx-2 pb-[var(--stack-overlap)] shadow-e3 sm:mx-3"
                      :class="{ 'stack-layer--pull': chat.busy }" />
           <QueueStrip v-if="showQueue" key="queue-layer"
-                      class="stack-layer stack-layer--queue relative z-25 mx-2 pb-[var(--stack-overlap)] shadow-e2 rounded-lg sm:mx-3"
+                      class="stack-layer stack-layer--queue relative z-[25] mx-2 pb-[var(--stack-overlap)] shadow-e2 rounded-lg sm:mx-3"
                       :class="{ 'stack-layer--pull': chat.busy || showPlan }" />
           <div key="composer-layer" class="stack-layer stack-layer--composer relative z-30"
                :class="{ 'stack-layer--pull': chat.busy || showPlan || showQueue }">

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -1096,9 +1096,10 @@ function onInput() {
               (!text.trim() &&
                 !composer.pending.filter((p) => p.status === 'ready').length)
             "
-            class="flex items-center gap-1.5 whitespace-nowrap pl-3 pr-2.5 py-1.5 rounded-md bg-accent text-white text-[12.5px] font-semibold shadow-e1 hover:bg-accent-hover hover:shadow-e2 transition-all disabled:bg-fg/10 disabled:text-fg-muted disabled:shadow-none"
+            class="flex items-center gap-1.5 whitespace-nowrap rounded-md bg-accent p-2 text-[12.5px] font-semibold text-white shadow-e1 transition-all hover:bg-accent-hover hover:shadow-e2 disabled:bg-fg/10 disabled:text-fg-muted disabled:shadow-none sm:pl-3 sm:pr-2.5"
+            :aria-label="$t('chat.send')"
           >
-            {{ $t("chat.send") }}
+            <span class="hidden sm:inline">{{ $t("chat.send") }}</span>
             <Send :size="14" />
           </button>
         </div>

--- a/packages/relay-web/src/components/QueueStrip.vue
+++ b/packages/relay-web/src/components/QueueStrip.vue
@@ -9,7 +9,7 @@ const chat = useChatStore();
   <!-- Server-side pending-prompt queue for the selected session (Task 6's sessionQueue).
        Renders nothing when the queue is empty — no v-if needed at the call site. -->
   <div v-if="chat.sessionQueue.length" data-test="queue-strip"
-       class="flex items-center gap-2 rounded-lg border border-border bg-raised/60 px-3 py-1.5">
+       class="flex items-center gap-2 rounded-lg border border-border/70 bg-surface/95 px-3 py-1.5 backdrop-blur-md">
     <span class="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">{{ $t("chat.queuedHeader") }}</span>
     <TransitionGroup tag="div"
         move-class="transition-transform duration-200 ease-out motion-reduce:transition-none"

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -169,12 +169,6 @@ export const useInstancesStore = defineStore("instances", () => {
       { mode: "agent", groupKey: row.agent },
     ];
   }
-
-  // Provisional archivedAt stamps set during an optimistic archive so a failed RPC
-  // can restore the pre-hand-off value. Keyed `${instanceId}\0${alias}` → old value
-  // (undefined when the row never had one).
-  const handOffArchiveStamps = new Map<string, string | undefined>();
-
   /** Mirror `archived` for `row` into every LOADED group page covering it.
    *  Unloaded pages are skipped — they must not materialise half-truths. */
   function handOffRowToGroups(instanceId: string, row: SessionRow, archived: boolean): void {
@@ -191,21 +185,12 @@ export const useInstancesStore = defineStore("instances", () => {
       if (state.loading) pendingGroupArchivedRefreshes.add(groupArchivedPendingKey(instanceId, mode, groupKey));
       if (archived) {
         if (state.sessions.some((s) => s.alias === row.alias)) continue;
-        // Provisional archivedAt keeps the newly-slept row FIRST under the
-        // sidebar's archivedLast() sort instead of sinking to the bottom until
-        // the authoritative refresh delivers the server timestamp. If the RPC
-        // later fails, the caller restores the original value via the stamp map.
-        if (!handOffArchiveStamps.has(`${instanceId}\0${row.alias}`)) {
-          handOffArchiveStamps.set(`${instanceId}\0${row.alias}`, row.archivedAt);
-        }
-        if (!row.archivedAt) row.archivedAt = new Date().toISOString();
         inst.groupArchived[key] = { ...state, sessions: [...state.sessions, { ...row }] };
       } else if (state.sessions.some((s) => s.alias === row.alias)) {
         inst.groupArchived[key] = { ...state, sessions: state.sessions.filter((s) => s.alias !== row.alias) };
       }
     }
   }
-
   /** Pop a sleeping row out of the loaded group pages on wake, returning a copy for
    *  re-insertion into inst.sessions (undefined when no page held it). */
   function takeRowFromGroups(instanceId: string, alias: string): SessionRow | undefined {
@@ -790,8 +775,13 @@ export const useInstancesStore = defineStore("instances", () => {
     // instead of dropping it from the active list mid-transition.
     const sessionRow = byId(instanceId)?.sessions.find((s) => s.alias === alias);
     const prevArchived = sessionRow?.archived === true;
+    const prevArchivedAt = sessionRow?.archivedAt;
     if (sessionRow) {
       sessionRow.archived = true;
+      // Provisional archivedAt keeps the newly-slept row FIRST under the
+      // sidebar's archivedLast() sort instead of sinking to the bottom until
+      // the authoritative refresh delivers the server timestamp.
+      if (!sessionRow.archivedAt) sessionRow.archivedAt = new Date().toISOString();
       // Move the row into any LOADED per-group sleeping page in the same tick so the
       // grouped sidebar shows it as sleeping immediately (no remove-then-reappear).
       // On failure the rollback below undoes both flips.
@@ -804,19 +794,13 @@ export const useInstancesStore = defineStore("instances", () => {
     } catch (error) {
       if (sessionRow && !prevArchived) {
         sessionRow.archived = false;
+        sessionRow.archivedAt = prevArchivedAt;
         // Mirror the rollback: pull the row back out of any loaded group page so
-        // the sidebar returns to its pre-archive state, provisional archivedAt
-        // included.
+        // the sidebar returns to its pre-archive state.
         takeRowFromGroups(instanceId, alias);
-        const stampKey = `${instanceId}\0${alias}`;
-        if (handOffArchiveStamps.has(stampKey)) {
-          sessionRow.archivedAt = handOffArchiveStamps.get(stampKey);
-          handOffArchiveStamps.delete(stampKey);
-        }
       }
       throw error;
     }
-    handOffArchiveStamps.delete(`${instanceId}\0${alias}`);
     // No cache purge: a sleeping session stays resumable, and its cached tail
     // lets waking it paint instantly.
     await loadSessions(instanceId);

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -156,6 +156,54 @@ export const useInstancesStore = defineStore("instances", () => {
     return mode === "workspace" ? { workspace: groupKey } : { agent: groupKey };
   }
 
+  // Optimistic active↔sleeping hand-off for the per-group pages. The grouped sidebar
+  // renders a group's active rows from inst.sessions and its sleeping rows from
+  // groupArchived pages; flipping the archived flag alone therefore makes a row fall
+  // out of the active list while it is still missing from the (stale) page — it
+  // vanishes and only reappears when the post-RPC refetch publishes. Mirroring the
+  // flip INTO the loaded pages at the same moment lets the row move sections in one
+  // render; the authoritative refresh converges to the same content.
+  function groupModesForRow(row: Pick<SessionRow, "workspace" | "agent">): Array<{ mode: GroupArchivedMode; groupKey: string }> {
+    return [
+      { mode: "workspace", groupKey: row.workspace },
+      { mode: "agent", groupKey: row.agent },
+    ];
+  }
+
+  /** Mirror `archived` for `row` into every LOADED group page covering it.
+   *  Unloaded pages are skipped — they must not materialise half-truths. */
+  function handOffRowToGroups(instanceId: string, row: SessionRow, archived: boolean): void {
+    const inst = byId(instanceId);
+    if (!inst?.groupArchived) return;
+    for (const { mode, groupKey } of groupModesForRow(row)) {
+      const key = groupArchivedKey(mode, groupKey);
+      const state = inst.groupArchived[key];
+      if (!state?.loaded) continue;
+      if (archived) {
+        if (state.sessions.some((s) => s.alias === row.alias)) continue;
+        // Clone: page rows stay independent of the live inst.sessions object.
+        inst.groupArchived[key] = { ...state, sessions: [...state.sessions, { ...row }] };
+      } else if (state.sessions.some((s) => s.alias === row.alias)) {
+        inst.groupArchived[key] = { ...state, sessions: state.sessions.filter((s) => s.alias !== row.alias) };
+      }
+    }
+  }
+
+  /** Pop a sleeping row out of the loaded group pages on wake, returning a copy for
+   *  re-insertion into inst.sessions (undefined when no page held it). */
+  function takeRowFromGroups(instanceId: string, alias: string): SessionRow | undefined {
+    const inst = byId(instanceId);
+    let woken: SessionRow | undefined;
+    if (!inst?.groupArchived) return woken;
+    for (const [key, state] of Object.entries(inst.groupArchived)) {
+      if (!state.loaded) continue;
+      if (!state.sessions.some((s) => s.alias === alias)) continue;
+      woken ??= { ...state.sessions.find((s) => s.alias === alias)! };
+      inst.groupArchived[key] = { ...state, sessions: state.sessions.filter((s) => s.alias !== alias) };
+    }
+    return woken;
+  }
+
   // Discard-and-refetch idiom shared by every session-list loader: an event that
   // lands while a fetch is in flight leaves a pending mark; once the fetch settles,
   // re-run the work until no new mark survives a full pass.
@@ -352,7 +400,7 @@ export const useInstancesStore = defineStore("instances", () => {
       const inst = byId(instanceId);
       if (inst) {
         const key = groupArchivedKey(mode, groupKey);
-        const rows = page.sessions.map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest));
+        const rows = page.sessions.filter((session) => session.archived).map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest));
         const base = append ? (inst.groupArchived?.[key]?.sessions ?? []) : [];
         patchGroupArchivedState(instanceId, mode, groupKey, {
           sessions: [...base, ...rows.filter((row) => !base.some((old) => old.alias === row.alias))],
@@ -407,7 +455,7 @@ export const useInstancesStore = defineStore("instances", () => {
             offset, limit: Math.min(100, target - all.length), archivedOnly: true,
             ...groupArchivedFilter(mode, groupKey),
           });
-          all.push(...page.sessions.map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest)));
+          all.push(...page.sessions.filter((session) => session.archived).map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest)));
           hasMore = page.hasMore === true;
           nextOffset = page.nextOffset ?? offset + page.sessions.length;
           if (!hasMore || nextOffset <= offset) break;
@@ -714,13 +762,24 @@ export const useInstancesStore = defineStore("instances", () => {
     // instead of dropping it from the active list mid-transition.
     const sessionRow = byId(instanceId)?.sessions.find((s) => s.alias === alias);
     const prevArchived = sessionRow?.archived === true;
-    if (sessionRow) sessionRow.archived = true;
+    if (sessionRow) {
+      sessionRow.archived = true;
+      // Move the row into any LOADED per-group sleeping page in the same tick so the
+      // grouped sidebar shows it as sleeping immediately (no remove-then-reappear).
+      // On failure the rollback below undoes both flips.
+      handOffRowToGroups(instanceId, sessionRow, true);
+    }
     try {
       // unwrap: a connector business error (e.g. session-missing, still draining)
       // arrives as HTTP 200 {error:…} and must also trigger the rollback below.
       unwrap(await api.rpc(instanceId, "control.sessions.archive", { alias }));
     } catch (error) {
-      if (sessionRow && !prevArchived) sessionRow.archived = false;
+      if (sessionRow && !prevArchived) {
+        sessionRow.archived = false;
+        // Mirror the rollback: pull the row back out of any loaded group page so
+        // the sidebar returns to its pre-archive state.
+        takeRowFromGroups(instanceId, alias);
+      }
       throw error;
     }
     // No cache purge: a sleeping session stays resumable, and its cached tail
@@ -731,8 +790,29 @@ export const useInstancesStore = defineStore("instances", () => {
   }
 
   async function unarchiveSession(instanceId: string, alias: string): Promise<void> {
-    unwrap(await api.rpc(instanceId, "control.sessions.unarchive", { alias }));
-    if (byId(instanceId)?.archivedSessionsLoaded) await loadArchivedSessions(instanceId);
+    // Wake is also optimistic-first: pull the row out of any LOADED per-group page
+    // and re-insert it into the active list in the same tick, so the grouped sidebar
+    // moves it between sections in one render instead of remove-then-reappear.
+    const inst = byId(instanceId);
+    const woken = takeRowFromGroups(instanceId, alias);
+    if (inst && woken) {
+      woken.archived = false;
+      if (!inst.sessions.some((s) => s.alias === alias)) inst.sessions = [woken, ...inst.sessions];
+    }
+    try {
+      unwrap(await api.rpc(instanceId, "control.sessions.unarchive", { alias }));
+      if (inst && woken) woken.archived = false; // confirm the optimistic flip
+    } catch (error) {
+      // Roll back both halves: out of the active list, back into the group pages
+      // with its sleeping state intact.
+      if (inst && woken) {
+        if (!woken.archived) woken.archived = true;
+        handOffRowToGroups(instanceId, woken, true);
+        inst.sessions = inst.sessions.filter((s) => s.alias !== alias);
+      }
+      throw error;
+    }
+    if (inst?.archivedSessionsLoaded) await loadArchivedSessions(instanceId);
     else await loadSessions(instanceId);
     refreshLoadedGroupArchivedSessions(instanceId);
   }

--- a/packages/relay-web/src/stores/instances.ts
+++ b/packages/relay-web/src/stores/instances.ts
@@ -170,6 +170,11 @@ export const useInstancesStore = defineStore("instances", () => {
     ];
   }
 
+  // Provisional archivedAt stamps set during an optimistic archive so a failed RPC
+  // can restore the pre-hand-off value. Keyed `${instanceId}\0${alias}` → old value
+  // (undefined when the row never had one).
+  const handOffArchiveStamps = new Map<string, string | undefined>();
+
   /** Mirror `archived` for `row` into every LOADED group page covering it.
    *  Unloaded pages are skipped — they must not materialise half-truths. */
   function handOffRowToGroups(instanceId: string, row: SessionRow, archived: boolean): void {
@@ -179,9 +184,21 @@ export const useInstancesStore = defineStore("instances", () => {
       const key = groupArchivedKey(mode, groupKey);
       const state = inst.groupArchived[key];
       if (!state?.loaded) continue;
+      // An optimistic hand-off invalidates any snapshot already in flight for this
+      // group (it predates the flip). Marking the pending key makes the in-flight
+      // drain DISCARD the stale response and refetch — same idiom as sessions-changed
+      // — instead of publishing a page that resurrects/erases the moved row.
+      if (state.loading) pendingGroupArchivedRefreshes.add(groupArchivedPendingKey(instanceId, mode, groupKey));
       if (archived) {
         if (state.sessions.some((s) => s.alias === row.alias)) continue;
-        // Clone: page rows stay independent of the live inst.sessions object.
+        // Provisional archivedAt keeps the newly-slept row FIRST under the
+        // sidebar's archivedLast() sort instead of sinking to the bottom until
+        // the authoritative refresh delivers the server timestamp. If the RPC
+        // later fails, the caller restores the original value via the stamp map.
+        if (!handOffArchiveStamps.has(`${instanceId}\0${row.alias}`)) {
+          handOffArchiveStamps.set(`${instanceId}\0${row.alias}`, row.archivedAt);
+        }
+        if (!row.archivedAt) row.archivedAt = new Date().toISOString();
         inst.groupArchived[key] = { ...state, sessions: [...state.sessions, { ...row }] };
       } else if (state.sessions.some((s) => s.alias === row.alias)) {
         inst.groupArchived[key] = { ...state, sessions: state.sessions.filter((s) => s.alias !== row.alias) };
@@ -198,11 +215,17 @@ export const useInstancesStore = defineStore("instances", () => {
     for (const [key, state] of Object.entries(inst.groupArchived)) {
       if (!state.loaded) continue;
       if (!state.sessions.some((s) => s.alias === alias)) continue;
+      // Same in-flight invalidation as handOffRowToGroups (see above).
+      const parsed = parseGroupArchivedKey(key);
+      if (parsed && state.loading) {
+        pendingGroupArchivedRefreshes.add(groupArchivedPendingKey(instanceId, parsed.mode, parsed.groupKey));
+      }
       woken ??= { ...state.sessions.find((s) => s.alias === alias)! };
       inst.groupArchived[key] = { ...state, sessions: state.sessions.filter((s) => s.alias !== alias) };
     }
     return woken;
   }
+
 
   // Discard-and-refetch idiom shared by every session-list loader: an event that
   // lands while a fetch is in flight leaves a pending mark; once the fetch settles,
@@ -397,17 +420,22 @@ export const useInstancesStore = defineStore("instances", () => {
         offset, limit, archivedOnly: true,
         ...groupArchivedFilter(mode, groupKey),
       });
-      const inst = byId(instanceId);
-      if (inst) {
-        const key = groupArchivedKey(mode, groupKey);
-        const rows = page.sessions.filter((session) => session.archived).map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest));
-        const base = append ? (inst.groupArchived?.[key]?.sessions ?? []) : [];
-        patchGroupArchivedState(instanceId, mode, groupKey, {
-          sessions: [...base, ...rows.filter((row) => !base.some((old) => old.alias === row.alias))],
-          loaded: true,
-          hasMore: page.hasMore === true,
-          nextOffset: page.nextOffset ?? offset + page.sessions.length,
-        });
+      // A hand-off (or event) that landed while this page was in flight marked the
+      // pending key — discard the stale response; the drain re-runs and refetches.
+      const pk = groupArchivedPendingKey(instanceId, mode, groupKey);
+      if (!pendingGroupArchivedRefreshes.has(pk)) {
+        const inst = byId(instanceId);
+        if (inst) {
+          const key = groupArchivedKey(mode, groupKey);
+          const rows = page.sessions.filter((session) => session.archived).map((session) => overlaySessionRename(instanceId, session, confirmedRevisionsAtRequest));
+          const base = append ? (inst.groupArchived?.[key]?.sessions ?? []) : [];
+          patchGroupArchivedState(instanceId, mode, groupKey, {
+            sessions: [...base, ...rows.filter((row) => !base.some((old) => old.alias === row.alias))],
+            loaded: true,
+            hasMore: page.hasMore === true,
+            nextOffset: page.nextOffset ?? offset + page.sessions.length,
+          });
+        }
       }
     } finally {
       patchGroupArchivedState(instanceId, mode, groupKey, { loading: false });
@@ -777,11 +805,18 @@ export const useInstancesStore = defineStore("instances", () => {
       if (sessionRow && !prevArchived) {
         sessionRow.archived = false;
         // Mirror the rollback: pull the row back out of any loaded group page so
-        // the sidebar returns to its pre-archive state.
+        // the sidebar returns to its pre-archive state, provisional archivedAt
+        // included.
         takeRowFromGroups(instanceId, alias);
+        const stampKey = `${instanceId}\0${alias}`;
+        if (handOffArchiveStamps.has(stampKey)) {
+          sessionRow.archivedAt = handOffArchiveStamps.get(stampKey);
+          handOffArchiveStamps.delete(stampKey);
+        }
       }
       throw error;
     }
+    handOffArchiveStamps.delete(`${instanceId}\0${alias}`);
     // No cache purge: a sleeping session stays resumable, and its cached tail
     // lets waking it paint instantly.
     await loadSessions(instanceId);


### PR DESCRIPTION
## Summary

Four relay-web dashboard polish fixes, each verified in a real browser plus unit tests:

1. **Composer width matches the transcript** — the composer area (status HUD / plan / queue / input) was uncapped and stretched edge-to-edge on wide panes. It now sits in the same centered `max-w-3xl` (48rem) column as the transcript rows (`MessageList`).
2. **Icon-only Send button on narrow screens** — below `sm` the label hides (`hidden sm:inline`) leaving a symmetric icon button; `aria-label` preserves accessibility. Desktop layout unchanged.
3. **Queue panel joins the composer stack** — `QueueStrip` moved from floating inside the composer layer to its own document-flow layer with the shared pull-up/reserved-overlap mechanics: **status (z-10) → plan (z-20) → queue (z-25) → input (z-30)**. Its background also aligns with siblings (`bg-surface/95` + `backdrop-blur-md`, `border-border/70`; was `bg-raised/60`).
4. **No flicker when sleeping a session in grouped sidebar** — in workspace/agent grouping modes, sleep first dropped the row from the active list and only re-inserted it into the group's sleeping page after the post-RPC refetch published (remove → reappear → move again). Archive/unarchive now hands the row between `inst.sessions` and loaded `groupArchived` pages **in the same tick** (optimistic hand-off, rolled back on RPC failure). Group page publishes also drop non-archived rows instead of resurrecting stale copies.

## Changes

- `components/ChatPane.vue` — centered composer column; queue promoted to stack layer; `showQueue` computed
- `components/PromptInput.vue` — responsive send button
- `components/QueueStrip.vue` — background/border alignment
- `stores/instances.ts` — optimistic active↔sleeping hand-off helpers wired into archive/unarchive + rollback; archived-only filter at both page publish points
- Tests: chatpane queue-layer stacking test; 3 instances-group-archived tests (sync hand-off, archive failure rollback, wake + failure rollback)

## Test plan

- [x] `vitest` — chatpane/promptinput/queuestrip/chat-queue/instances-group-archived/instancetree suites all green (106 sidebar + 62 composer-related assertions)
- [x] `vue-tsc --noEmit` clean
- [x] Real-browser verification (vite dev + e2e mock hub): transcript/composer columns pixel-aligned at 1440px; icon-only send at 400px; four layers overlap exactly by `--stack-overlap` (16px desktop / 12px mobile), queue chips and cancel buttons clickable under the overlap; per-frame DOM sampling during UI-triggered sleep shows zero row-presence flips in workspace-grouped mode