### PR TITLE
feat(relay-web): mark sidebar rows with an open terminal tab

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -205,7 +205,8 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
 - **打开终端指示器**：会话行不另占标题空间。`center-tabs` 里该会话仍挂着 Terminal tab 时，在
   左侧 Agent 图标右下角叠一个极小的 `SquareTerminal` 角标（`data-test="terminal-open-marker"`，
   title = `instance.sessionTerminalOpenTitle`）。切到其他会话时角标留在原行；关掉该 tab、睡眠或
-  删除会话后消失。Agent 分组下行内无品牌图标，角标以零宽度叠进左侧 padding，同样不挤标题。
+  删除会话后消失。Agent 分组下行内无品牌图标，角标 `position:absolute` 钉在行按钮左侧 padding
+  里（不进 flex、不占 `gap-2`），贴底以免挡住注意力圆点。
 
 ## 实例配置管理 Modal（`ManageInstanceDialog.vue`）
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -202,6 +202,10 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   仅「醒着且 `warm === false`」的会话行显示 `Unplug` 小图标（`data-test="cold-indicator"`，
   title = `instance.sessionColdTitle`：进程已退出，下条消息将冷启动）；`warm` 缺失（老实例）或已睡眠
   的行不显示。Hub 对 RPC 响应透传，老实例无需升级即可兼容。
+- **打开终端指示器**：会话行不另占标题空间。`center-tabs` 里该会话仍挂着 Terminal tab 时，在
+  左侧 Agent 图标右下角叠一个极小的 `SquareTerminal` 角标（`data-test="terminal-open-marker"`，
+  title = `instance.sessionTerminalOpenTitle`）。切到其他会话时角标留在原行；关掉该 tab、睡眠或
+  删除会话后消失。Agent 分组下行内无品牌图标，角标以零宽度叠进左侧 padding，同样不挤标题。
 
 ## 实例配置管理 Modal（`ManageInstanceDialog.vue`）
 

--- a/packages/relay-web/e2e/fixtures.ts
+++ b/packages/relay-web/e2e/fixtures.ts
@@ -62,7 +62,7 @@ export async function loginAndOpenTerminal(page: Page): Promise<void> {
   }
   const termBtn = page.getByTestId("toggle-terminal");
   await expect(termBtn).toBeVisible({ timeout: 30_000 });
-  const sessionRow = page.getByTestId("session-row");
+  const sessionRow = page.getByTestId("session-row").first();
   if (!(await sessionRow.isVisible().catch(() => false))) {
     const open = page.getByTestId("open-instances");
     if (await open.isVisible().catch(() => false)) await open.click();

--- a/packages/relay-web/e2e/mock-hub.ts
+++ b/packages/relay-web/e2e/mock-hub.ts
@@ -70,7 +70,8 @@ function canonicalBase64(text: string): string {
   return Buffer.from(text, "utf8").toString("base64");
 }
 
-export async function startMockHub(): Promise<MockHub> {
+export async function startMockHub(opts?: { extraAliases?: string[] }): Promise<MockHub> {
+  const sessionAliases = [SESSION_ALIAS, ...(opts?.extraAliases ?? [])];
   const sockets: WebSocket[] = [];
   const resizes: Array<{ cols: number; rows: number }> = [];
   const inputs: string[] = [];
@@ -123,16 +124,16 @@ export async function startMockHub(): Promise<MockHub> {
       if (type === "control.sessions.list") {
         json(res, 200, {
           result: {
-            sessions: [{
-              alias: SESSION_ALIAS,
+            sessions: sessionAliases.map((alias, i) => ({
+              alias,
               agent: "codex",
               workspace: "/w",
-              transportSession: "t1",
+              transportSession: `t${i + 1}`,
               running: true,
               archived: false,
-            }],
+            })),
             hasMore: false,
-            nextOffset: 1,
+            nextOffset: sessionAliases.length,
           },
         });
         return;
@@ -262,6 +263,16 @@ export async function startMockHub(): Promise<MockHub> {
         attachmentId: ATTACHMENT_ID,
         role: "controller",
         viewerCount: 1,
+      });
+      return;
+    }
+    if (msg.kind === "terminal-terminate") {
+      send({
+        kind: "terminal-request-failed",
+        requestId: msg.requestId,
+        instanceId: INSTANCE_ID,
+        code: "terminated",
+        message: "terminated",
       });
       return;
     }

--- a/packages/relay-web/e2e/sidebar-terminal-marker.spec.ts
+++ b/packages/relay-web/e2e/sidebar-terminal-marker.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect, loginAndOpenTerminal } from "./fixtures";
+
+test.describe("sidebar terminal-open marker", () => {
+  test("marks the session row once its Terminal tab is open", async ({ page }) => {
+    await loginAndOpenTerminal(page);
+    const row = page.getByTestId("session-row");
+    if (!(await row.isVisible().catch(() => false))) {
+      const open = page.getByTestId("open-instances");
+      if (await open.isVisible().catch(() => false)) {
+        await open.evaluate((el) => (el as HTMLElement).click());
+      }
+    }
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("terminal-open-marker")).toBeVisible();
+    await expect(row.getByTestId("terminal-open-marker")).toHaveAttribute("title", /.+/);
+  });
+});

--- a/packages/relay-web/e2e/sidebar-terminal-marker.spec.ts
+++ b/packages/relay-web/e2e/sidebar-terminal-marker.spec.ts
@@ -1,17 +1,58 @@
-import { test, expect, loginAndOpenTerminal } from "./fixtures";
+import { test as base, expect, loginAndOpenTerminal } from "./fixtures";
+import { startMockHub, SESSION_ALIAS } from "./mock-hub";
+
+const OTHER_ALIAS = "other";
+
+const test = base.extend({
+  hub: async ({}, use) => {
+    const hub = await startMockHub({ extraAliases: [OTHER_ALIAS] });
+    await use(hub);
+    await hub.close();
+  },
+});
+
+async function showSidebar(page: import("@playwright/test").Page): Promise<void> {
+  const open = page.getByTestId("open-instances");
+  if (await open.isVisible().catch(() => false)) {
+    await open.evaluate((el) => (el as HTMLElement).click());
+  }
+}
+
+function sessionRow(page: import("@playwright/test").Page, alias: string) {
+  return page.getByTestId("session-row").filter({
+    has: page.getByTestId("session-name").filter({ hasText: new RegExp(`^${alias}$`) }),
+  });
+}
 
 test.describe("sidebar terminal-open marker", () => {
   test("marks the session row once its Terminal tab is open", async ({ page }) => {
     await loginAndOpenTerminal(page);
-    const row = page.getByTestId("session-row");
-    if (!(await row.isVisible().catch(() => false))) {
-      const open = page.getByTestId("open-instances");
-      if (await open.isVisible().catch(() => false)) {
-        await open.evaluate((el) => (el as HTMLElement).click());
-      }
-    }
+    await showSidebar(page);
+    const row = sessionRow(page, SESSION_ALIAS);
     await expect(row).toBeVisible();
     await expect(row.getByTestId("terminal-open-marker")).toBeVisible();
     await expect(row.getByTestId("terminal-open-marker")).toHaveAttribute("title", /.+/);
+  });
+
+  test("keeps the marker after switching sessions and drops it when the Terminal tab is closed", async ({ page }) => {
+    await loginAndOpenTerminal(page);
+    await showSidebar(page);
+    const demo = sessionRow(page, SESSION_ALIAS);
+    const other = sessionRow(page, OTHER_ALIAS);
+    await expect(demo.getByTestId("terminal-open-marker")).toBeVisible();
+    await expect(other.getByTestId("terminal-open-marker")).toHaveCount(0);
+
+    await other.getByTestId("session-name").evaluate((el) => (el as HTMLElement).click());
+    await showSidebar(page);
+    await expect(demo.getByTestId("terminal-open-marker")).toBeVisible();
+    await expect(other.getByTestId("terminal-open-marker")).toHaveCount(0);
+
+    await demo.getByTestId("session-name").evaluate((el) => (el as HTMLElement).click());
+    page.once("dialog", (dialog) => dialog.accept());
+    await page.getByTestId("tab-close").locator("visible=true").click();
+    await expect(page.getByTestId("terminal-host")).toHaveCount(0);
+
+    await showSidebar(page);
+    await expect(demo.getByTestId("terminal-open-marker")).toHaveCount(0);
   });
 });

--- a/packages/relay-web/src/__tests__/center-tabs.test.ts
+++ b/packages/relay-web/src/__tests__/center-tabs.test.ts
@@ -156,6 +156,20 @@ describe("center-tabs store", () => {
     expect(term).toEqual({ kind: "terminal", id: "terminal" });
   });
 
+  it("hasTerminal tracks the Terminal tab independently of the active tab and of other sessions", () => {
+    const s = useCenterTabsStore();
+    const K2 = sessionKey("i1", "s2");
+    expect(s.hasTerminal(K)).toBe(false);
+    s.openTerminal(K);
+    s.openFile(K2, "a.ts");
+    expect(s.hasTerminal(K)).toBe(true);
+    expect(s.hasTerminal(K2)).toBe(false);
+    s.setActive(K, "chat"); // tab still open, just not focused
+    expect(s.hasTerminal(K)).toBe(true);
+    s.closeTab(K, "terminal");
+    expect(s.hasTerminal(K)).toBe(false);
+  });
+
   it("persists tab state to sessionStorage after the debounce window", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/relay-web/src/__tests__/instancetree-grouping.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree-grouping.test.ts
@@ -4,6 +4,7 @@ import { createPinia, setActivePinia } from "pinia";
 import InstanceTree from "../components/InstanceTree.vue";
 import ManageInstanceDialog from "../components/ManageInstanceDialog.vue";
 import { useInstancesStore } from "../stores/instances";
+import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
 import { loadGroupMode } from "../lib/sidebar-group-mode";
 
 const sess = (alias: string, workspace: string, agent: string, archived = false) => ({
@@ -62,6 +63,18 @@ describe("InstanceTree grouped rendering", () => {
     expect(w.find('[data-test="session-name"]').text()).toBe("web");
     // The row's AgentIcon is dropped in agent mode; the group header carries the brand icon.
     expect(w.find('[data-test="session-row"]').findComponent({ name: "AgentIcon" }).exists()).toBe(false);
+  });
+
+  it("still shows the terminal-open marker in agent mode without inserting a per-row agent icon", () => {
+    const store = useInstancesStore();
+    store.setGroupMode("i1", "agent");
+    store.instances = [instance([sess("web-claude", "web", "claude")])] as never;
+    useCenterTabsStore().openTerminal(sessionKey("i1", "web-claude"));
+    const w = mountTree();
+    expect(w.find('[data-test="session-row"]').findComponent({ name: "AgentIcon" }).exists()).toBe(false);
+    const marker = w.find('[data-test="terminal-open-marker"]');
+    expect(marker.exists()).toBe(true);
+    expect(marker.attributes("title")).toBe("Terminal tab is open");
   });
 
   it("collapses and re-expands a group via its header (view-state only)", async () => {

--- a/packages/relay-web/src/__tests__/instancetree-grouping.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree-grouping.test.ts
@@ -65,16 +65,21 @@ describe("InstanceTree grouped rendering", () => {
     expect(w.find('[data-test="session-row"]').findComponent({ name: "AgentIcon" }).exists()).toBe(false);
   });
 
-  it("still shows the terminal-open marker in agent mode without inserting a per-row agent icon", () => {
+  it("still shows the terminal-open marker in agent mode without inserting a per-row agent icon or a flex host", () => {
     const store = useInstancesStore();
     store.setGroupMode("i1", "agent");
     store.instances = [instance([sess("web-claude", "web", "claude")])] as never;
     useCenterTabsStore().openTerminal(sessionKey("i1", "web-claude"));
     const w = mountTree();
-    expect(w.find('[data-test="session-row"]').findComponent({ name: "AgentIcon" }).exists()).toBe(false);
-    const marker = w.find('[data-test="terminal-open-marker"]');
+    const row = w.find('[data-test="session-row"]');
+    expect(row.findComponent({ name: "AgentIcon" }).exists()).toBe(false);
+    const marker = row.find('[data-test="terminal-open-marker"]');
     expect(marker.exists()).toBe(true);
     expect(marker.attributes("title")).toBe("Terminal tab is open");
+    // Out of the flex flow: absolute on the row button, no w-0 gap-consuming host.
+    expect(marker.classes()).toContain("absolute");
+    expect(marker.element.closest(".w-0")).toBeNull();
+    expect(marker.element.closest("button")).not.toBeNull();
   });
 
   it("collapses and re-expands a group via its header (view-state only)", async () => {

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -448,12 +448,15 @@ describe("InstanceTree session management", () => {
     expect(centerTabs.tabsFor(key)).toHaveLength(1);
     const clearSession = vi.spyOn(centerTabs, "clearSession");
     const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="terminal-open-marker"]').exists()).toBe(true);
     await w.find('[data-test="session-menu"]').trigger("click");
     await w.find('[data-test="delete-session"]').trigger("click");
     settleConfirm(true);
     await flushPromises();
     expect(clearSession).toHaveBeenCalledWith(key);
     expect(centerTabs.tabsFor(key)).toEqual([]);
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="terminal-open-marker"]').exists()).toBe(false);
   });
 
   // A connector business error (HTTP 200 {error:…} surfaced by the store) must

--- a/packages/relay-web/src/__tests__/instancetree.test.ts
+++ b/packages/relay-web/src/__tests__/instancetree.test.ts
@@ -300,6 +300,59 @@ describe("InstanceTree session management", () => {
     expect(w.find('[data-test="session-elapsed"]').exists()).toBe(false);
   });
 
+  it("shows no terminal-open marker until that session's Terminal tab is open", () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="terminal-open-marker"]').exists()).toBe(false);
+  });
+
+  it("overlays a terminal-open marker on the agent icon when the Terminal tab is open", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    const centerTabs = useCenterTabsStore();
+    centerTabs.openTerminal(sessionKey("i1", "backend"));
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const marker = w.find('[data-test="terminal-open-marker"]');
+    expect(marker.exists()).toBe(true);
+    expect(marker.attributes("title")).toBe("Terminal tab is open");
+    expect(marker.attributes("aria-label")).toBe("Terminal tab is open");
+    const row = w.find('[data-test="session-row"]');
+    expect(row.findComponent({ name: "AgentIcon" }).exists()).toBe(true);
+    expect(marker.element.parentElement?.contains(row.findComponent({ name: "AgentIcon" }).element)).toBe(true);
+  });
+
+  it("hides the terminal-open marker when that session's Terminal tab is closed", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([{ alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false }])] as never;
+    const centerTabs = useCenterTabsStore();
+    const key = sessionKey("i1", "backend");
+    centerTabs.openTerminal(key);
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="terminal-open-marker"]').exists()).toBe(true);
+    centerTabs.closeTab(key, "terminal");
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="terminal-open-marker"]').exists()).toBe(false);
+  });
+
+  it("keeps the terminal-open marker on a non-selected session that still has a Terminal tab", async () => {
+    const store = useInstancesStore();
+    store.instances = [instance([
+      { alias: "backend", agent: "claude", workspace: "home", transportSession: "t", running: false, archived: false },
+      { alias: "frontend", agent: "codex", workspace: "home", transportSession: "t2", running: false, archived: false },
+    ])] as never;
+    const chat = useChatStore();
+    chat.select("i1", "backend");
+    const centerTabs = useCenterTabsStore();
+    centerTabs.openTerminal(sessionKey("i1", "frontend"));
+    const w = mount(InstanceTree, { global: { stubs: { NewSessionDialog: true } } });
+    const rows = w.findAll('[data-test="session-row"]');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.find('[data-test="terminal-open-marker"]').exists()).toBe(false); // selected, no terminal
+    expect(rows[1]!.find('[data-test="terminal-open-marker"]').exists()).toBe(true);  // background terminal
+    expect(rows[1]!.find('[data-test="session-name"]').text()).toBe("frontend");
+  });
+
   it("hides archived sessions from the sidebar", () => {
     const store = useInstancesStore();
     store.instances = [instance([
@@ -349,6 +402,7 @@ describe("InstanceTree session management", () => {
     expect(centerTabs.tabsFor(key)).toHaveLength(1);
     const clearSession = vi.spyOn(centerTabs, "clearSession");
     const w = mount(InstanceTree, { attachTo: document.body, global: { stubs: { NewSessionDialog: true } } });
+    expect(w.find('[data-test="terminal-open-marker"]').exists()).toBe(true);
     await w.find('[data-test="session-menu"]').trigger("mousedown");
     await w.find('[data-test="session-menu"]').trigger("click");
     const item = w.find('[data-test="action-archive"]');
@@ -357,6 +411,8 @@ describe("InstanceTree session management", () => {
     await flushPromises();
     expect(clearSession).toHaveBeenCalledWith(key);
     expect(centerTabs.tabsFor(key)).toEqual([]);
+    await w.vm.$nextTick();
+    expect(w.find('[data-test="terminal-open-marker"]').exists()).toBe(false);
     w.unmount();
   });
 

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -518,14 +518,14 @@ const rowSwipes = computed(() => {
                   </span>
                   <span
                     v-else-if="hasOpenTerminal(inst.id, s.alias)"
-                    data-test="terminal-open-marker"
                     class="relative w-0 shrink-0 self-end"
-                    :title="$t('instance.sessionTerminalOpenTitle')"
-                    :aria-label="$t('instance.sessionTerminalOpenTitle')"
                   >
-                    <span class="absolute bottom-1 right-0 grid h-2.5 w-2.5 -translate-x-0.5 place-items-center rounded-sm bg-surface text-accent ring-1 ring-accent/50">
-                      <SquareTerminal :size="8" :stroke-width="2.5" />
-                    </span>
+                    <span
+                      data-test="terminal-open-marker"
+                      class="absolute bottom-1 right-0 grid h-2.5 w-2.5 -translate-x-0.5 place-items-center rounded-sm bg-surface text-accent ring-1 ring-accent/50"
+                      :title="$t('instance.sessionTerminalOpenTitle')"
+                      :aria-label="$t('instance.sessionTerminalOpenTitle')"
+                    ><SquareTerminal :size="8" :stroke-width="2.5" /></span>
                   </span>
                   <input v-if="renamingFor === `${inst.id}:${s.alias}`" data-test="rename-input"
                          v-model="renameDraft" :maxlength="60" :placeholder="$t('instance.sessionRenamePlaceholder')"

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { ArchiveRestore, ChevronDown, ChevronRight, Folder, Link2, Loader2, Moon, MoreHorizontal, Pencil, Plus, Settings2, Trash2, Unplug } from "lucide-vue-next";
+import { ArchiveRestore, ChevronDown, ChevronRight, Folder, Link2, Loader2, Moon, MoreHorizontal, Pencil, Plus, Settings2, SquareTerminal, Trash2, Unplug } from "lucide-vue-next";
 import { useInstancesStore, groupArchivedKey, parseGroupArchivedKey } from "../stores/instances";
 import { useChatStore } from "../stores/chat";
 import { useCenterTabsStore, sessionKey } from "../stores/center-tabs";
@@ -59,6 +59,14 @@ function elapsedLabel(instanceId: string, alias: string): string {
 
 function isSelected(instanceId: string, alias: string): boolean {
   return chat.instanceId === instanceId && chat.sessionAlias === alias;
+}
+
+// Terminal-open marker: the center-tabs store already keeps a Terminal tab per session
+// (including background sessions). Overlay it on the agent glyph so the row width and
+// title space stay unchanged. Agent-grouping drops the glyph, so that path uses a
+// zero-width host that overflows into the left padding instead of inserting a new icon.
+function hasOpenTerminal(instanceId: string, alias: string): boolean {
+  return centerTabs.hasTerminal(sessionKey(instanceId, alias));
 }
 
 // Per-instance collapse state (expanded by default). Sessions are loaded by an explicit
@@ -494,9 +502,31 @@ const rowSwipes = computed(() => {
                   <span v-else-if="!s.archived && s.running" data-test="attention-dot" data-attention="running" class="h-2 w-2 shrink-0 rounded-full bg-run" />
                   <!-- Agent brand glyph (driver icon) BEFORE the name, in place of a text badge —
                        saves horizontal space; the agent name stays available on hover. Redundant
-                       inside an agent-mode group (the group header already carries it) → dropped. -->
-                  <AgentIcon v-if="groupModeOf(inst) !== 'agent'" :driver="driverFor(inst, s)" :title="s.agent" :size="14"
-                             :class="s.archived ? 'opacity-60' : ''" />
+                       inside an agent-mode group (the group header already carries it) → dropped.
+                       Terminal-open is a corner overlay on this glyph so it does not steal title
+                       space; agent-mode uses a zero-width host in the same slot. -->
+                  <span v-if="groupModeOf(inst) !== 'agent'" class="relative shrink-0">
+                    <AgentIcon :driver="driverFor(inst, s)" :title="s.agent" :size="14"
+                               :class="s.archived ? 'opacity-60' : ''" />
+                    <span
+                      v-if="hasOpenTerminal(inst.id, s.alias)"
+                      data-test="terminal-open-marker"
+                      class="absolute -bottom-px -right-px grid h-2.5 w-2.5 place-items-center rounded-sm bg-surface text-accent ring-1 ring-accent/50"
+                      :title="$t('instance.sessionTerminalOpenTitle')"
+                      :aria-label="$t('instance.sessionTerminalOpenTitle')"
+                    ><SquareTerminal :size="8" :stroke-width="2.5" /></span>
+                  </span>
+                  <span
+                    v-else-if="hasOpenTerminal(inst.id, s.alias)"
+                    data-test="terminal-open-marker"
+                    class="relative w-0 shrink-0 self-end"
+                    :title="$t('instance.sessionTerminalOpenTitle')"
+                    :aria-label="$t('instance.sessionTerminalOpenTitle')"
+                  >
+                    <span class="absolute bottom-1 right-0 grid h-2.5 w-2.5 -translate-x-0.5 place-items-center rounded-sm bg-surface text-accent ring-1 ring-accent/50">
+                      <SquareTerminal :size="8" :stroke-width="2.5" />
+                    </span>
+                  </span>
                   <input v-if="renamingFor === `${inst.id}:${s.alias}`" data-test="rename-input"
                          v-model="renameDraft" :maxlength="60" :placeholder="$t('instance.sessionRenamePlaceholder')"
                          class="min-w-0 flex-1 rounded border border-accent bg-bg px-1 py-px text-[13px] text-fg outline-none"

--- a/packages/relay-web/src/components/InstanceTree.vue
+++ b/packages/relay-web/src/components/InstanceTree.vue
@@ -63,8 +63,9 @@ function isSelected(instanceId: string, alias: string): boolean {
 
 // Terminal-open marker: the center-tabs store already keeps a Terminal tab per session
 // (including background sessions). Overlay it on the agent glyph so the row width and
-// title space stay unchanged. Agent-grouping drops the glyph, so that path uses a
-// zero-width host that overflows into the left padding instead of inserting a new icon.
+// title space stay unchanged. Agent-grouping drops the glyph, so that path pins the
+// badge with position:absolute in the button's left padding — out of the flex flow,
+// so it neither consumes gap-2 nor overlaps the attention-dot.
 function hasOpenTerminal(instanceId: string, alias: string): boolean {
   return centerTabs.hasTerminal(sessionKey(instanceId, alias));
 }
@@ -491,7 +492,7 @@ const rowSwipes = computed(() => {
                 <!-- Selected row: left accent bar. -->
                 <span v-if="isSelected(inst.id, s.alias)" class="absolute bottom-1 left-0 top-1 w-[3px] rounded-full bg-accent" />
                 <button
-                  class="flex min-w-0 flex-1 items-center gap-2 py-2 pl-2.5 pr-1.5 text-left"
+                  class="relative flex min-w-0 flex-1 items-center gap-2 py-2 pl-2.5 pr-1.5 text-left"
                   @click="onRowTap(inst.id, s.alias)"
                 >
                   <Loader2 v-if="s.creating" data-test="session-creating" :size="12" class="shrink-0 animate-spin motion-reduce:animate-none text-accent" />
@@ -504,7 +505,7 @@ const rowSwipes = computed(() => {
                        saves horizontal space; the agent name stays available on hover. Redundant
                        inside an agent-mode group (the group header already carries it) → dropped.
                        Terminal-open is a corner overlay on this glyph so it does not steal title
-                       space; agent-mode uses a zero-width host in the same slot. -->
+                       space. Agent-mode pins the same badge into the button's left padding. -->
                   <span v-if="groupModeOf(inst) !== 'agent'" class="relative shrink-0">
                     <AgentIcon :driver="driverFor(inst, s)" :title="s.agent" :size="14"
                                :class="s.archived ? 'opacity-60' : ''" />
@@ -516,17 +517,16 @@ const rowSwipes = computed(() => {
                       :aria-label="$t('instance.sessionTerminalOpenTitle')"
                     ><SquareTerminal :size="8" :stroke-width="2.5" /></span>
                   </span>
+                  <!-- Agent grouping: out-of-flow, in pl-2.5 (10px) × py-2 bottom padding.
+                       left-0.5 keeps it off the 3px selected bar; bottom-0.5 keeps it below
+                       the vertically-centered attention-dot so the two do not cover each other. -->
                   <span
                     v-else-if="hasOpenTerminal(inst.id, s.alias)"
-                    class="relative w-0 shrink-0 self-end"
-                  >
-                    <span
-                      data-test="terminal-open-marker"
-                      class="absolute bottom-1 right-0 grid h-2.5 w-2.5 -translate-x-0.5 place-items-center rounded-sm bg-surface text-accent ring-1 ring-accent/50"
-                      :title="$t('instance.sessionTerminalOpenTitle')"
-                      :aria-label="$t('instance.sessionTerminalOpenTitle')"
-                    ><SquareTerminal :size="8" :stroke-width="2.5" /></span>
-                  </span>
+                    data-test="terminal-open-marker"
+                    class="absolute bottom-0.5 left-0.5 grid h-2.5 w-2.5 place-items-center rounded-sm bg-surface text-accent ring-1 ring-accent/50"
+                    :title="$t('instance.sessionTerminalOpenTitle')"
+                    :aria-label="$t('instance.sessionTerminalOpenTitle')"
+                  ><SquareTerminal :size="8" :stroke-width="2.5" /></span>
                   <input v-if="renamingFor === `${inst.id}:${s.alias}`" data-test="rename-input"
                          v-model="renameDraft" :maxlength="60" :placeholder="$t('instance.sessionRenamePlaceholder')"
                          class="min-w-0 flex-1 rounded border border-accent bg-bg px-1 py-px text-[13px] text-fg outline-none"

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -318,6 +318,7 @@ export default {
     sessionArchivedLabel: "sleeping",
     sleepTooltip: "Sleeping closes the session process immediately. History is kept — send a message to wake it.",
     sessionColdTitle: "Process exited — next message cold-starts.",
+    sessionTerminalOpenTitle: "Terminal tab is open",
     sessionNativeBadgeTitle: "Resumed from an existing agent-side session",
     sessionArchivedToast: "Slept \"{alias}\" — process closed, message to wake",
     undo: "Undo",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -316,6 +316,7 @@ export default {
     sessionArchivedLabel: "已睡眠",
     sleepTooltip: "睡眠会立即关闭会话进程，历史保留，发消息即唤醒",
     sessionColdTitle: "进程已退出，下条消息将冷启动",
+    sessionTerminalOpenTitle: "终端标签页已打开",
     sessionNativeBadgeTitle: "从已有的 agent 原生会话续接",
     sessionArchivedToast: "已睡眠「{alias}」，进程已关闭，发消息即唤醒",
     undo: "撤销",

--- a/packages/relay-web/src/stores/center-tabs.ts
+++ b/packages/relay-web/src/stores/center-tabs.ts
@@ -80,6 +80,11 @@ export const useCenterTabsStore = defineStore("center-tabs", () => {
     return bySession.value[key]?.activeId ?? "chat";
   }
 
+  /** True while this session still has a Terminal tab in the center pane (including background sessions). */
+  function hasTerminal(key: string): boolean {
+    return (bySession.value[key]?.tabs ?? []).some((t) => t.kind === "terminal");
+  }
+
   /** Insert-or-activate a tab by id: existing id just activates; new id is appended and activated. */
   function upsertAndActivate(key: string, tab: CenterTab): void {
     const current = bySession.value[key] ?? { tabs: [], activeId: "chat" };
@@ -190,7 +195,7 @@ export const useCenterTabsStore = defineStore("center-tabs", () => {
   }
 
   return {
-    tabsFor, activeFor,
+    tabsFor, activeFor, hasTerminal,
     openFile, openDiff, openTerminal,
     setActive, closeTab, reorder, clearSession, allOpenTabs,
     setDirty, isDirty, closeTabGuarded,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The HUB session list had no marker once a session’s Terminal tab was open, so switching to another session hid that terminal with no way to tell it was still running.

**Chosen approach:** overlay a tiny `SquareTerminal` badge on the existing left-side agent glyph. `center-tabs` already tracks Terminal tabs per session (including background sessions); the sidebar just wasn’t reading that state.

This does **not** add a right-side icon or extra flex item, so row density and title space stay the same. The badge is absolutely positioned on the 14px agent icon.

**Agent-grouping:** the per-row glyph is dropped, so the same badge is `position: absolute` on the row button, pinned into the left padding (`left-0.5 bottom-0.5`). It is out of the flex flow (no `gap-2` tax, no `w-0` host) and sits below the vertically-centered attention-dot.

The marker:
- shows whenever that session still has a Terminal tab (even if another session is selected, or Chat is the active tab)
- disappears when the tab is closed, or when the session is slept/deleted (`clearSession`)

## How to verify

1. Open HUB, pick a session, open **终端**.
2. The left row’s agent icon should show a small accent terminal badge in the corner.
3. Switch to another session — the original row keeps the badge; the new row does not (until you open its terminal).
4. Close the original session’s Terminal tab (or sleep/delete it) — the badge disappears.
5. In **agent** sidebar grouping, the badge sits in the row’s left padding and does not shift the title or cover the status dot.

## Tests

- Unit: marker shown when the Terminal tab is open, hidden when closed, remains on a non-selected session, still shown in agent-grouping as an `absolute` badge (no `w-0` host), gone after archive and after delete
- E2E: opens a Terminal tab, asserts the marker; switching to another session keeps it on the original row; closing the Terminal tab removes it (desktop + mobile)

[Session row before opening Terminal](https://cursor.com/agents/bc-6a8bf076-2af8-4cb5-a6ea-bc1153d64ed1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_row_before_terminal.png)
[Session row after opening Terminal — accent badge on the agent icon](https://cursor.com/agents/bc-6a8bf076-2af8-4cb5-a6ea-bc1153d64ed1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_row_after_terminal.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a8bf076-2af8-4cb5-a6ea-bc1153d64ed1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a8bf076-2af8-4cb5-a6ea-bc1153d64ed1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

