### PR TITLE
fix(relay-web): refresh model and effort during live turns

### DIFF
--- a/packages/relay-web/src/__tests__/session-controls-live-refresh-quiescence.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls-live-refresh-quiescence.test.ts
@@ -1,0 +1,104 @@
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpc = vi.fn();
+vi.mock("../api/client", () => ({
+  ApiError: class extends Error {},
+  api: { rpc: (id: string, type: string, payload?: unknown) => rpc(id, type, payload) },
+}));
+
+import { dismissToast, useToasts } from "../lib/use-toasts";
+import { useSessionControlsStore } from "../stores/session-controls";
+
+function clearToasts(): void {
+  for (const toast of [...useToasts().value]) dismissToast(toast.id);
+}
+
+describe("live session controls mutation quiescence", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    rpc.mockReset();
+    clearToasts();
+  });
+
+  afterEach(() => {
+    clearToasts();
+  });
+
+  it("drains mutations added while passive refresh is already waiting", async () => {
+    let resolveModelSet!: (value: unknown) => void;
+    let resolveEffortSet!: (value: unknown) => void;
+    let modelSnapshot = { current: "model-old", available: ["model-old", "model-new"] };
+
+    rpc.mockImplementation((_instanceId: string, type: string) => {
+      if (type === "control.session.model.get") return Promise.resolve(structuredClone(modelSnapshot));
+      if (type === "control.session.effort.get") {
+        return Promise.resolve({ current: "medium", available: ["medium", "high"] });
+      }
+      if (type === "control.session.model.set") {
+        return new Promise((resolve) => { resolveModelSet = resolve; });
+      }
+      if (type === "control.session.effort.set") {
+        return new Promise((resolve) => { resolveEffortSet = resolve; });
+      }
+      throw new Error(`unexpected rpc: ${type}`);
+    });
+
+    const controls = useSessionControlsStore();
+    await Promise.all([
+      controls.loadModel("i1", "backend"),
+      controls.loadEffort("i1", "backend"),
+    ]);
+    expect(rpc).toHaveBeenCalledTimes(2);
+
+    await controls.applyLiveEvent({
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-started", chatKey: "relay:control", sessionAlias: "backend" },
+    });
+
+    // Mutation A is already pending when first activity starts the passive refresh.
+    const pendingModelSet = controls.setModel("i1", "backend", "model-new");
+    const refresh = controls.applyLiveEvent({
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-output", chatKey: "relay:control", sessionAlias: "backend", chunk: "activity" },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(rpc).toHaveBeenCalledTimes(3);
+
+    // Mutation B starts while the refresh is already awaiting A. A one-shot pending
+    // snapshot would miss B and let loadEffort steal B's revision after A settles.
+    const pendingEffortSet = controls.setEffort("i1", "backend", "high");
+    expect(controls.effortCurrent).toBe("high");
+    expect(rpc).toHaveBeenCalledTimes(4);
+
+    modelSnapshot = { current: "model-new", available: ["model-old", "model-new"] };
+    resolveModelSet({ ok: true, current: "model-new" });
+    await expect(pendingModelSet).resolves.toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The refresh must loop back, discover B, and keep waiting. No model/effort GET
+    // is allowed between A settling and B settling.
+    expect(rpc).toHaveBeenCalledTimes(4);
+
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    resolveEffortSet({ error: { code: "internal", message: "effort switch failed" } });
+    await expect(pendingEffortSet).resolves.toBe(false);
+
+    expect(controls.effortCurrent).toBe("medium");
+    expect(useToasts().value.some((toast) => toast.key === "chat.effortSetFailed")).toBe(true);
+    expect(log).toHaveBeenCalledWith("[relay-web] effort switch failed", "effort switch failed");
+
+    // Only after B has completed (including rollback + failure feedback) may the
+    // passive refresh obtain fresh revisions and perform its two authoritative GETs.
+    await refresh;
+    expect(rpc).toHaveBeenCalledTimes(6);
+    expect(controls.modelCurrent).toBe("model-new");
+    expect(controls.effortCurrent).toBe("medium");
+
+    log.mockRestore();
+  });
+});

--- a/packages/relay-web/src/__tests__/session-controls-live-refresh.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls-live-refresh.test.ts
@@ -1,0 +1,164 @@
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  encodeEnvelope,
+  webEventEnvelope,
+  type WebServerEvent,
+} from "@ganglion/xacpx-relay-protocol";
+
+const rpc = vi.fn();
+vi.mock("../api/client", () => ({
+  ApiError: class extends Error {},
+  api: { rpc: (id: string, type: string, payload?: unknown) => rpc(id, type, payload) },
+}));
+
+import { connectEvents, _resetTerminalRequestStateForTests } from "../api/events";
+import { useSessionControlsStore } from "../stores/session-controls";
+
+class FakeWS {
+  static instances: FakeWS[] = [];
+  static OPEN = 1;
+  readyState = 1;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => this.onclose?.());
+
+  constructor(public url: string) {
+    FakeWS.instances.push(this);
+  }
+}
+
+function pushEvent(ws: FakeWS, event: WebServerEvent): void {
+  ws.onmessage?.({ data: encodeEnvelope(webEventEnvelope(event)) });
+}
+
+describe("live session controls refresh", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    rpc.mockReset();
+    FakeWS.instances = [];
+    _resetTerminalRequestStateForTests();
+    vi.stubGlobal("WebSocket", FakeWS as never);
+    vi.stubGlobal("location", { protocol: "http:", host: "x" } as never);
+  });
+
+  afterEach(() => {
+    _resetTerminalRequestStateForTests();
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes model and effort on first live activity before turn-finished", async () => {
+    let model = { current: "model-old", available: ["model-old"] };
+    let effort = { current: "medium", available: ["medium"] };
+    rpc.mockImplementation(async (_instanceId: string, type: string) => {
+      if (type === "control.session.model.get") return structuredClone(model);
+      if (type === "control.session.effort.get") return structuredClone(effort);
+      throw new Error(`unexpected rpc: ${type}`);
+    });
+
+    const controls = useSessionControlsStore();
+    await Promise.all([
+      controls.loadModel("i1", "backend"),
+      controls.loadEffort("i1", "backend"),
+    ]);
+    expect(controls.modelCurrent).toBe("model-old");
+    expect(controls.effortCurrent).toBe("medium");
+    expect(rpc).toHaveBeenCalledTimes(2);
+
+    const disconnect = connectEvents(() => {});
+    const ws = FakeWS.instances[0]!;
+    ws.onopen?.();
+
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-started", chatKey: "relay:control", sessionAlias: "backend" },
+    });
+
+    // Simulate adapter-side config changing after prompt dispatch. The first streamed
+    // activity must make the chips authoritative immediately, before turn-finished.
+    model = { current: "model-new", available: ["model-new", "model-alt"] };
+    effort = { current: "high", available: ["low", "medium", "high"] };
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-output", chatKey: "relay:control", sessionAlias: "backend", chunk: "first token" },
+    });
+
+    await vi.waitFor(() => {
+      expect(controls.modelCurrent).toBe("model-new");
+      expect(controls.modelAvailable).toEqual(["model-new", "model-alt"]);
+      expect(controls.effortCurrent).toBe("high");
+      expect(controls.effortAvailable).toEqual(["low", "medium", "high"]);
+    });
+    expect(rpc).toHaveBeenCalledTimes(4);
+
+    // Streaming output is hot; don't turn this into per-token management polling.
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-output", chatKey: "relay:control", sessionAlias: "backend", chunk: "second token" },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(rpc).toHaveBeenCalledTimes(4);
+
+    // One final authoritative convergence is allowed at completion.
+    model = { current: "model-final", available: ["model-final"] };
+    effort = { current: "xhigh", available: ["high", "xhigh"] };
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-finished", chatKey: "relay:control", sessionAlias: "backend", ok: true },
+    });
+    await vi.waitFor(() => {
+      expect(controls.modelCurrent).toBe("model-final");
+      expect(controls.effortCurrent).toBe("xhigh");
+    });
+    expect(rpc).toHaveBeenCalledTimes(6);
+
+    disconnect();
+  });
+
+  it("ignores live events for a background session", async () => {
+    rpc.mockImplementation(async (_instanceId: string, type: string) => {
+      if (type === "control.session.model.get") return { current: "selected-model", available: ["selected-model"] };
+      if (type === "control.session.effort.get") return { current: "medium", available: ["medium"] };
+      throw new Error(`unexpected rpc: ${type}`);
+    });
+
+    const controls = useSessionControlsStore();
+    await Promise.all([
+      controls.loadModel("i1", "selected"),
+      controls.loadEffort("i1", "selected"),
+    ]);
+    const disconnect = connectEvents(() => {});
+    const ws = FakeWS.instances[0]!;
+
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-started", chatKey: "relay:control", sessionAlias: "background" },
+    });
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-usage", chatKey: "relay:control", sessionAlias: "background", used: 123, size: 1000 },
+    });
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-finished", chatKey: "relay:control", sessionAlias: "background", ok: true },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(rpc).toHaveBeenCalledTimes(2);
+    expect(controls.modelCurrent).toBe("selected-model");
+    expect(controls.effortCurrent).toBe("medium");
+
+    disconnect();
+  });
+});

--- a/packages/relay-web/src/__tests__/session-controls-live-refresh.test.ts
+++ b/packages/relay-web/src/__tests__/session-controls-live-refresh.test.ts
@@ -13,6 +13,7 @@ vi.mock("../api/client", () => ({
 }));
 
 import { connectEvents, _resetTerminalRequestStateForTests } from "../api/events";
+import { dismissToast, useToasts } from "../lib/use-toasts";
 import { useSessionControlsStore } from "../stores/session-controls";
 
 class FakeWS {
@@ -34,18 +35,24 @@ function pushEvent(ws: FakeWS, event: WebServerEvent): void {
   ws.onmessage?.({ data: encodeEnvelope(webEventEnvelope(event)) });
 }
 
+function clearToasts(): void {
+  for (const toast of [...useToasts().value]) dismissToast(toast.id);
+}
+
 describe("live session controls refresh", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     rpc.mockReset();
     FakeWS.instances = [];
     _resetTerminalRequestStateForTests();
+    clearToasts();
     vi.stubGlobal("WebSocket", FakeWS as never);
     vi.stubGlobal("location", { protocol: "http:", host: "x" } as never);
   });
 
   afterEach(() => {
     _resetTerminalRequestStateForTests();
+    clearToasts();
     vi.unstubAllGlobals();
   });
 
@@ -122,6 +129,169 @@ describe("live session controls refresh", () => {
     disconnect();
   });
 
+  it("refreshes an active selected turn from reconnect state-snapshot without waiting for finish", async () => {
+    let model = { current: "model-old", available: ["model-old"] };
+    let effort = { current: "medium", available: ["medium"] };
+    rpc.mockImplementation(async (_instanceId: string, type: string) => {
+      if (type === "control.session.model.get") return structuredClone(model);
+      if (type === "control.session.effort.get") return structuredClone(effort);
+      throw new Error(`unexpected rpc: ${type}`);
+    });
+
+    const controls = useSessionControlsStore();
+    await Promise.all([
+      controls.loadModel("i1", "backend"),
+      controls.loadEffort("i1", "backend"),
+    ]);
+
+    const disconnect = connectEvents(() => {});
+    const ws = FakeWS.instances[0]!;
+    ws.onopen?.();
+
+    // No turn-started reaches this socket: it represents a reconnect after that delta
+    // was missed. The authoritative snapshot says the selected turn is still running.
+    model = { current: "model-during-offline", available: ["model-during-offline", "model-alt"] };
+    effort = { current: "high", available: ["medium", "high"] };
+    pushEvent(ws, {
+      kind: "state-snapshot",
+      instanceId: "i1",
+      turns: [{
+        instanceId: "i1",
+        sessionAlias: "backend",
+        status: "streaming",
+        startedAt: 10,
+        parts: [],
+      }],
+      usage: [],
+      commands: [],
+    });
+
+    await vi.waitFor(() => {
+      expect(controls.modelCurrent).toBe("model-during-offline");
+      expect(controls.modelAvailable).toEqual(["model-during-offline", "model-alt"]);
+      expect(controls.effortCurrent).toBe("high");
+      expect(controls.effortAvailable).toEqual(["medium", "high"]);
+    });
+    expect(rpc).toHaveBeenCalledTimes(4);
+
+    // The snapshot itself consumed the reconnect refresh; the next token is not a poll.
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-output", chatKey: "relay:control", sessionAlias: "backend", chunk: "resumed token" },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(rpc).toHaveBeenCalledTimes(4);
+
+    disconnect();
+  });
+
+  it("live refresh waits for a pending model set failure so rollback and toast are preserved", async () => {
+    let resolveModelSet!: (value: unknown) => void;
+    rpc.mockImplementation((_instanceId: string, type: string) => {
+      if (type === "control.session.model.get") {
+        return Promise.resolve({ current: "model-old", available: ["model-old", "model-new"] });
+      }
+      if (type === "control.session.effort.get") {
+        return Promise.resolve({ current: "medium", available: ["medium", "high"] });
+      }
+      if (type === "control.session.model.set") {
+        return new Promise((resolve) => { resolveModelSet = resolve; });
+      }
+      throw new Error(`unexpected rpc: ${type}`);
+    });
+
+    const controls = useSessionControlsStore();
+    await Promise.all([
+      controls.loadModel("i1", "backend"),
+      controls.loadEffort("i1", "backend"),
+    ]);
+    const disconnect = connectEvents(() => {});
+    const ws = FakeWS.instances[0]!;
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-started", chatKey: "relay:control", sessionAlias: "backend" },
+    });
+    const pendingSet = controls.setModel("i1", "backend", "model-new");
+    expect(controls.modelCurrent).toBe("model-new");
+
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-output", chatKey: "relay:control", sessionAlias: "backend", chunk: "activity" },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    // Initial model+effort GETs + the set RPC only. Passive refresh is waiting and has
+    // not allocated a new load revision that could silence the set's failure handler.
+    expect(rpc).toHaveBeenCalledTimes(3);
+
+    resolveModelSet({ error: { code: "internal", message: "model switch failed" } });
+    await expect(pendingSet).resolves.toBe(false);
+    await vi.waitFor(() => {
+      expect(controls.modelCurrent).toBe("model-old");
+      expect(useToasts().value.some((toast) => toast.key === "chat.modelSetFailed")).toBe(true);
+      expect(rpc).toHaveBeenCalledTimes(5);
+    });
+    expect(log).toHaveBeenCalledWith("[relay-web] model switch failed", "model switch failed");
+
+    log.mockRestore();
+    disconnect();
+  });
+
+  it("finish refresh waits for a pending effort set failure so rollback and toast are preserved", async () => {
+    let resolveEffortSet!: (value: unknown) => void;
+    rpc.mockImplementation((_instanceId: string, type: string) => {
+      if (type === "control.session.model.get") {
+        return Promise.resolve({ current: "model-old", available: ["model-old"] });
+      }
+      if (type === "control.session.effort.get") {
+        return Promise.resolve({ current: "medium", available: ["medium", "high"] });
+      }
+      if (type === "control.session.effort.set") {
+        return new Promise((resolve) => { resolveEffortSet = resolve; });
+      }
+      throw new Error(`unexpected rpc: ${type}`);
+    });
+
+    const controls = useSessionControlsStore();
+    await Promise.all([
+      controls.loadModel("i1", "backend"),
+      controls.loadEffort("i1", "backend"),
+    ]);
+    const disconnect = connectEvents(() => {});
+    const ws = FakeWS.instances[0]!;
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const pendingSet = controls.setEffort("i1", "backend", "high");
+    expect(controls.effortCurrent).toBe("high");
+
+    pushEvent(ws, {
+      kind: "control-event",
+      instanceId: "i1",
+      event: { type: "turn-finished", chatKey: "relay:control", sessionAlias: "backend", ok: true },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(rpc).toHaveBeenCalledTimes(3);
+
+    resolveEffortSet({ error: { code: "internal", message: "effort switch failed" } });
+    await expect(pendingSet).resolves.toBe(false);
+    await vi.waitFor(() => {
+      expect(controls.effortCurrent).toBe("medium");
+      expect(useToasts().value.some((toast) => toast.key === "chat.effortSetFailed")).toBe(true);
+      expect(rpc).toHaveBeenCalledTimes(5);
+    });
+    expect(log).toHaveBeenCalledWith("[relay-web] effort switch failed", "effort switch failed");
+
+    log.mockRestore();
+    disconnect();
+  });
+
   it("ignores live events for a background session", async () => {
     rpc.mockImplementation(async (_instanceId: string, type: string) => {
       if (type === "control.session.model.get") return { current: "selected-model", available: ["selected-model"] };
@@ -151,6 +321,19 @@ describe("live session controls refresh", () => {
       kind: "control-event",
       instanceId: "i1",
       event: { type: "turn-finished", chatKey: "relay:control", sessionAlias: "background", ok: true },
+    });
+    pushEvent(ws, {
+      kind: "state-snapshot",
+      instanceId: "i1",
+      turns: [{
+        instanceId: "i1",
+        sessionAlias: "background",
+        status: "working",
+        startedAt: 10,
+        parts: [],
+      }],
+      usage: [],
+      commands: [],
     });
     await Promise.resolve();
     await Promise.resolve();

--- a/packages/relay-web/src/api/events.ts
+++ b/packages/relay-web/src/api/events.ts
@@ -10,6 +10,26 @@ import {
 
 let activeSocket: WebSocket | null = null;
 
+type WebEventSubscriber = (event: WebServerEvent) => void;
+const webEventSubscribers = new Set<WebEventSubscriber>();
+
+/** Subscribe to every decoded server event without owning the websocket lifecycle. */
+export function subscribeWebEvents(listener: WebEventSubscriber): () => void {
+  webEventSubscribers.add(listener);
+  return () => { webEventSubscribers.delete(listener); };
+}
+
+function publishWebEvent(event: WebServerEvent): void {
+  for (const listener of [...webEventSubscribers]) {
+    try {
+      listener(event);
+    } catch (error) {
+      // Passive observers must never break the primary dashboard fan-out.
+      console.error("[relay-web] passive web event subscriber failed", error);
+    }
+  }
+}
+
 /** Send a browser→hub frame up the live /ws socket. No-op if disconnected. */
 export function sendWebClientMessage(msg: WebClientMessage): void {
   if (activeSocket && activeSocket.readyState === WebSocket.OPEN) {
@@ -224,6 +244,7 @@ export function connectEvents(onEvent: (event: WebServerEvent) => void, onStatus
       const event = parseWebServerEvent(decoded.envelope);
       if (!event) return;
       settleTerminalRequest(event);
+      publishWebEvent(event);
       onEvent(event);
     };
     socket.onopen = () => {
@@ -257,4 +278,5 @@ export function _resetTerminalRequestStateForTests(): void {
   rejectAllPending("instance-offline", "test reset");
   requestSeq = 0;
   reconnectHandler = null;
+  webEventSubscribers.clear();
 }

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -390,11 +390,17 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   }
 
   async function waitForPendingControlMutations(context: string): Promise<void> {
-    const pending = [
-      pendingModelSets.get(context),
-      pendingEffortSets.get(context),
-    ].filter((promise): promise is Promise<void> => promise !== undefined);
-    if (pending.length > 0) await Promise.all(pending);
+    // Drain to quiescence rather than snapshotting the maps once. A second mutation can
+    // start while we are awaiting the first one; passive refresh must not allocate load
+    // revisions until the latest model/effort mutations for this context have all settled.
+    while (true) {
+      const pending = [
+        pendingModelSets.get(context),
+        pendingEffortSets.get(context),
+      ].filter((promise): promise is Promise<void> => promise !== undefined);
+      if (pending.length === 0) return;
+      await Promise.all(pending);
+    }
   }
 
   async function refreshLiveControls(instanceId: string, alias: string): Promise<void> {

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -389,8 +389,21 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     return activeContext === context || effortActiveContext === context;
   }
 
+  async function waitForPendingControlMutations(context: string): Promise<void> {
+    const pending = [
+      pendingModelSets.get(context),
+      pendingEffortSets.get(context),
+    ].filter((promise): promise is Promise<void> => promise !== undefined);
+    if (pending.length > 0) await Promise.all(pending);
+  }
+
   async function refreshLiveControls(instanceId: string, alias: string): Promise<void> {
     const context = contextKey(instanceId, alias);
+    if (!isSelectedContext(context)) return;
+    // A passive readback must not take revision ownership away from a user mutation.
+    // Let setModel/setEffort finish (including rollback + error toast) first, then
+    // re-check selection and only now let loadModel/loadEffort allocate fresh revisions.
+    await waitForPendingControlMutations(context);
     if (!isSelectedContext(context)) return;
     await Promise.all([
       loadModel(instanceId, alias),
@@ -401,10 +414,25 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   /**
    * Turn lifecycle bridge for controls that ACP can mutate while a prompt is running.
    * We deliberately refresh once on the first live activity (not once per token/chunk),
-   * then once on finish. This makes model/effort/catalog changes visible promptly while
-   * keeping management RPC traffic bounded at two snapshots per turn.
+   * then once on finish. A reconnect state-snapshot with an active selected turn also
+   * refreshes immediately because turn-started may have been missed while offline.
    */
   async function applyLiveEvent(event: WebServerEvent): Promise<void> {
+    if (event.kind === "state-snapshot") {
+      const activeTurn = event.turns.find((turn) =>
+        isSelectedContext(contextKey(event.instanceId, turn.sessionAlias)),
+      );
+      if (!activeTurn) {
+        if (awaitingFirstActivityFor?.startsWith(`${event.instanceId}\u0000`)) {
+          awaitingFirstActivityFor = null;
+        }
+        return;
+      }
+      awaitingFirstActivityFor = null;
+      await refreshLiveControls(event.instanceId, activeTurn.sessionAlias);
+      return;
+    }
+
     if (event.kind !== "control-event") return;
     const e = event.event;
     if (!("sessionAlias" in e) || typeof e.sessionAlias !== "string") return;

--- a/packages/relay-web/src/stores/session-controls.ts
+++ b/packages/relay-web/src/stores/session-controls.ts
@@ -1,18 +1,29 @@
 import { defineStore } from "pinia";
-import { ref, watch } from "vue";
+import { onScopeDispose, ref, watch } from "vue";
 import {
   isErrorPayload,
   type SessionEffortResult,
   type SessionEffortSetResult,
   type SessionModelResult,
   type SessionModelSetResult,
+  type WebServerEvent,
 } from "@ganglion/xacpx-relay-protocol";
 import { api } from "../api/client";
+import { subscribeWebEvents } from "../api/events";
 import { pushToast } from "../lib/use-toasts";
 import * as viewCache from "../lib/view-snapshot-cache";
 import { useAuthStore } from "./auth";
 
 type ControlSnapshot = { current?: string; available: string[] };
+
+const LIVE_CONTROL_ACTIVITY_TYPES = new Set([
+  "turn-output",
+  "tool-event",
+  "turn-thought",
+  "plan",
+  "turn-usage",
+  "agent-commands",
+]);
 
 /** Per-session model and effort controls for the composer chips. The hub stamps chatKey for
  *  these chat-scoped RPCs, so the web only sends sessionAlias. */
@@ -32,6 +43,11 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   const pendingEffortSets = new Map<string, Promise<void>>();
   const authoritativeEfforts = new Map<string, { revision: number; current: string | undefined }>();
   let accountGeneration = 0;
+  // The web store intentionally holds controls for only the selected session. When that
+  // session starts a turn, refresh model+effort on its FIRST real-time activity event so
+  // adapter-side config changes become visible during the turn instead of waiting for the
+  // final history/session round-trip. A final refresh still converges authoritative state.
+  let awaitingFirstActivityFor: string | null = null;
 
   const cacheUser = (): string | null => useAuthStore().account?.username ?? null;
   const contextKey = (instanceId: string, alias: string): string => `${instanceId}\u0000${alias}`;
@@ -108,6 +124,7 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     effortRevision += 1;
     effortLoading.value = false;
     clearEffortState();
+    awaitingFirstActivityFor = null;
   }
 
   function resetForAccountChange(): void {
@@ -122,7 +139,10 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
   async function loadModel(instanceId: string | null, alias: string | null): Promise<void> {
     if (!instanceId || !alias) { reset(); return; }
     const context = contextKey(instanceId, alias);
-    if (activeContext !== context) clearModelState();
+    if (activeContext !== context) {
+      clearModelState();
+      awaitingFirstActivityFor = null;
+    }
     activeContext = context;
     const revision = ++requestRevision;
     const cacheOwner = cacheUser();
@@ -253,10 +273,14 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
       effortRevision += 1;
       effortLoading.value = false;
       clearEffortState();
+      awaitingFirstActivityFor = null;
       return;
     }
     const context = contextKey(instanceId, alias);
-    if (effortActiveContext !== context) clearEffortState();
+    if (effortActiveContext !== context) {
+      clearEffortState();
+      awaitingFirstActivityFor = null;
+    }
     effortActiveContext = context;
     const revision = ++effortRevision;
     const cacheOwner = cacheUser();
@@ -361,12 +385,59 @@ export const useSessionControlsStore = defineStore("session-controls", () => {
     return pendingEffortSets.get(contextKey(instanceId, alias));
   }
 
+  function isSelectedContext(context: string): boolean {
+    return activeContext === context || effortActiveContext === context;
+  }
+
+  async function refreshLiveControls(instanceId: string, alias: string): Promise<void> {
+    const context = contextKey(instanceId, alias);
+    if (!isSelectedContext(context)) return;
+    await Promise.all([
+      loadModel(instanceId, alias),
+      loadEffort(instanceId, alias),
+    ]);
+  }
+
+  /**
+   * Turn lifecycle bridge for controls that ACP can mutate while a prompt is running.
+   * We deliberately refresh once on the first live activity (not once per token/chunk),
+   * then once on finish. This makes model/effort/catalog changes visible promptly while
+   * keeping management RPC traffic bounded at two snapshots per turn.
+   */
+  async function applyLiveEvent(event: WebServerEvent): Promise<void> {
+    if (event.kind !== "control-event") return;
+    const e = event.event;
+    if (!("sessionAlias" in e) || typeof e.sessionAlias !== "string") return;
+    const context = contextKey(event.instanceId, e.sessionAlias);
+    if (!isSelectedContext(context)) return;
+
+    if (e.type === "turn-started") {
+      awaitingFirstActivityFor = context;
+      return;
+    }
+
+    if (e.type === "turn-finished") {
+      if (awaitingFirstActivityFor === context) awaitingFirstActivityFor = null;
+      await refreshLiveControls(event.instanceId, e.sessionAlias);
+      return;
+    }
+
+    if (LIVE_CONTROL_ACTIVITY_TYPES.has(e.type) && awaitingFirstActivityFor === context) {
+      awaitingFirstActivityFor = null;
+      await refreshLiveControls(event.instanceId, e.sessionAlias);
+    }
+  }
+
+  const unsubscribeWebEvents = subscribeWebEvents((event) => { void applyLiveEvent(event); });
+  onScopeDispose(unsubscribeWebEvents);
+
   const auth = useAuthStore();
   watch(() => auth.account?.username ?? null, () => resetForAccountChange(), { flush: "sync" });
 
   return {
     modelCurrent, modelAvailable, modelLoading, reset, loadModel, setModel,
     effortCurrent, effortAvailable, effortLoading, loadEffort, setEffort, waitForEffortSet,
+    applyLiveEvent,
   };
 });
 


### PR DESCRIPTION
## Summary

- refresh the selected session's model/available-model and effort/available-effort snapshots on the **first live turn activity**, instead of waiting for turn completion
- recover missed `turn-started` events on WebSocket reconnect: an authoritative `state-snapshot` containing the selected active turn triggers an immediate controls refresh
- keep the hot token stream bounded: subsequent `turn-output` chunks do **not** poll management RPCs; one final refresh at `turn-finished` performs authoritative convergence
- expose a passive relay-web event tap so the session-controls store can observe the existing WebSocket without owning or duplicating the connection
- leave context usage on its existing direct `turn-usage` push path (it already applies each event immediately)

## Why

relay-web's model/effort chips are snapshot/RPC based (`control.session.model.get` / `control.session.effort.get`), while context usage is already event-driven. In practice the controls therefore stayed stale during a running turn. The live refresh moves the visible update to the first streamed activity, and reconnect snapshots close the gap where that first lifecycle delta was missed while offline.

## Safety / races

- refreshes only the currently selected `(instance, session)`; background-session events and snapshots cannot mutate the global composer controls
- passive live/finish refreshes drain pending model/effort mutations **to quiescence** before `loadModel` / `loadEffort` allocate new revisions; mutations that begin while the refresh is already waiting are included in the next drain iteration
- this preserves each user mutation's rollback + error-toast ownership on failure, including cross-control and rapid consecutive mutations
- selection is checked again after all pending mutations settle, so a session switch during the wait cannot refresh the old session
- once the quiescence loop observes no pending mutations, there is no `await` before the passive loads start; any later user mutation correctly supersedes those read-only GET revisions
- existing request revisions and authoritative caches still prevent stale GETs from overwriting newer state
- no per-token polling: one model+effort read at first activity (or reconnect snapshot), one at finish

## Tests

`session-controls-live-refresh.test.ts` covers:
- model + model catalog + effort + effort catalog update before `turn-finished`
- repeated stream chunks do not cause repeated management polling
- final authoritative convergence
- reconnect with missed `turn-started`: `state-snapshot(turns=[active selected turn])` refreshes controls before finish
- pending model-set failure racing first activity still rolls back and shows `chat.modelSetFailed`
- pending effort-set failure racing finish refresh still rolls back and shows `chat.effortSetFailed`
- background-session control events and state snapshots are ignored

`session-controls-live-refresh-quiescence.test.ts` covers the follow-up race:
- model set A is pending when first-activity refresh begins waiting
- effort set B starts while the refresh is already waiting for A
- after A settles, the refresh performs **no GET** while B is still pending
- B failure rolls effort back and emits `chat.effortSetFailed`
- only after B settles does the passive refresh perform its two authoritative GETs

## Verification

Latest head: `656a01dca6f56b47951e6f6950b90b161b043b5d`

GitHub Actions Test run #1181: **success**
- full tests ✅
- acpx compat smoke (Linux) ✅
- build (all packages) ✅
- Relay Web Chromium desktop + mobile E2E ✅
- Windows/RMUX jobs correctly skipped for relay-web-only changes ✅

Note: this intentionally does not change the context-usage pipeline; `turn-usage` is already a replace-latest WebSocket event consumed immediately by the chat store.