### PR TITLE
docs: add Discord channel setup guide

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
       label: 'English',
       lang: 'en-US',
       description:
-        'Control acpx agent sessions remotely from WeChat, Feishu, Yuanbao, and other chat channels.',
+        'Control acpx agent sessions remotely from WeChat, Feishu, Yuanbao, Discord, and other chat channels.',
       themeConfig: {
         nav: [
           { text: 'Guide', link: '/guide/getting-started' },
@@ -86,7 +86,8 @@ export default defineConfig({
               items: [
                 { text: 'Channel Plugin Development', link: '/plugins/development' },
                 { text: 'Feishu Channel', link: '/plugins/feishu' },
-                { text: 'Yuanbao Channel', link: '/plugins/yuanbao' }
+                { text: 'Yuanbao Channel', link: '/plugins/yuanbao' },
+                { text: 'Discord Channel', link: '/plugins/discord' }
               ]
             }
           ],
@@ -113,7 +114,7 @@ export default defineConfig({
       lang: 'zh-CN',
       link: '/zh/',
       description:
-        '通过微信、飞书、元宝等聊天频道，远程控制 acpx 上的 agent 会话。',
+        '通过微信、飞书、元宝、Discord 等聊天频道，远程控制 acpx 上的 agent 会话。',
       themeConfig: {
         nav: [
           { text: '指南', link: '/zh/guide/getting-started' },
@@ -154,7 +155,8 @@ export default defineConfig({
               items: [
                 { text: '频道插件开发', link: '/zh/plugins/development' },
                 { text: '飞书频道', link: '/zh/plugins/feishu' },
-                { text: '元宝频道', link: '/zh/plugins/yuanbao' }
+                { text: '元宝频道', link: '/zh/plugins/yuanbao' },
+                { text: 'Discord 频道', link: '/zh/plugins/discord' }
               ]
             }
           ],

--- a/packages/docs/.vitepress/theme/components/BridgeShowcase.vue
+++ b/packages/docs/.vitepress/theme/components/BridgeShowcase.vue
@@ -3,10 +3,10 @@
 // drives and the chat channels it runs in. Three connected parts:
 //   1. agents: an infinite full-colour logo marquee (@lobehub/icons)
 //   2. xacpx: the central hub the wires converge into
-//   3. channels: real brand SVG logos (WeChat / Feishu provided; Yuanbao from lobe)
+//   3. channels: real brand SVG logos (WeChat / Feishu / Discord inline; Yuanbao from lobe)
 // Converging/diverging wires + flowing packets tie the three together. Wire
-// endpoints (x = 167 / 500 / 833 of the 1000-wide viewBox) line up with the
-// channel grid columns (centres at 1/6, 1/2, 5/6).
+// endpoints (x = 125 / 375 / 625 / 875 of the 1000-wide viewBox) line up with
+// the four channel grid columns (centres at 1/8, 3/8, 5/8, 7/8).
 import { computed } from 'vue';
 import { useData } from 'vitepress';
 
@@ -63,14 +63,16 @@ const agents: Agent[] = [
 // duplicated track for a seamless infinite marquee
 const track = computed(() => [...agents, ...agents]);
 
-// Real brand marks. WeChat + Feishu provided as official SVGs; Yuanbao from @lobehub/icons.
+// Real brand marks. WeChat + Feishu + Discord are inline; Yuanbao comes from @lobehub/icons.
 const wechatSvg = `<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M32.8 18.003 32.5 18C25.732 18 20 22.798 20 29c0 1.007.151 1.976.433 2.894A18 18 0 0 1 18.5 32c-1.809 0-3.54-.274-5.137-.775-.394-.123-1.828.696-3.039 1.389-.927.53-1.724.986-1.824.886-.094-.094.169-.718.476-1.448.446-1.06.986-2.346.664-2.552C6.21 27.305 4 23.866 4 20c0-6.627 6.492-12 14.5-12 7.186 0 13.151 4.326 14.3 10.003M16 16a2 2 0 1 1-4 0 2 2 0 0 1 4 0m7 2a2 2 0 1 0 0-4 2 2 0 0 0 0 4" fill="#6bb657"/><path fill-rule="evenodd" clip-rule="evenodd" d="M44 29c0 3.362-1.908 6.336-4.833 8.149-.13.08.169.858.446 1.583.237.618.459 1.196.387 1.268-.075.075-.802-.327-1.571-.752-.829-.458-1.706-.942-1.871-.888-1.262.413-2.63.64-4.058.64C26.149 39 21 34.523 21 29s5.149-10 11.5-10S44 23.477 44 29m-6-3.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0M28.5 27a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3" fill="#6bb657"/></svg>`;
 const feishuSvg = `<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 8c0 1 7 3.5 14.745 16.744 0 0 4.184-4.363 6.255-5.744 1.5-1 2.712-1.332 2.712-1.332C33.712 15.156 29.5 8 28 8z" fill="#00d6b9"/><path d="M43.5 18.5c-1-.667-3.65-1.771-6.5-1.5a15 15 0 0 0-3.288.668S32.5 18 31 19c-2.07 1.38-6.255 5.744-6.255 5.744-1.428 1.397-3.05 2.732-5.245 3.756 0 0 7 3 11.5 3 5.063 0 7-3.5 7-3.5 1.5-3.305 3.5-7 5.5-9.5" fill="#163c9a"/><path d="M4 17.5v17c0 1 6 5.5 15 5.5 10 0 17.05-7.705 19-12 0 0-1.937 3.5-7 3.5-4.5 0-11.5-3-11.5-3-5.117-2.239-10.03-6.577-12.906-9.117C4.974 17.953 4 17.093 4 17.5" fill="#3370ff"/></svg>`;
+const discordSvg = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><path fill="#5865F2" d="M39.2 9.1A36.3 36.3 0 0 0 30.2 6l-1.1 2.2a33.4 33.4 0 0 0-10.2 0L17.8 6a36.1 36.1 0 0 0-9 3.1C3.1 17.4 1.6 25.5 2.4 33.5a36.7 36.7 0 0 0 11.1 5.7l2.7-3.7a23.4 23.4 0 0 1-4.3-2.3l1.1-.9c7.1 3.3 14.8 3.3 21.8 0l1.1.9a24 24 0 0 1-4.3 2.3l2.7 3.7a36.6 36.6 0 0 0 11.1-5.7c.9-9.3-1.5-17.3-6.2-24.4ZM17.2 29.2c-2.1 0-3.9-2-3.9-4.5s1.7-4.5 3.9-4.5 4 2 3.9 4.5c0 2.5-1.7 4.5-3.9 4.5Zm13.6 0c-2.1 0-3.9-2-3.9-4.5s1.7-4.5 3.9-4.5 4 2 3.9 4.5c0 2.5-1.7 4.5-3.9 4.5Z"/></svg>`;
 
 const channels = computed(() => [
-  { key: 'wechat', name: zh.value ? '微信' : 'WeChat', svg: wechatSvg, x: 167, size: 34 },
-  { key: 'feishu', name: zh.value ? '飞书' : 'Feishu', svg: feishuSvg, x: 500, size: 34 },
-  { key: 'yuanbao', name: zh.value ? '元宝' : 'Yuanbao', svg: yuanbaoSvg, x: 833, size: 34 },
+  { key: 'wechat', name: zh.value ? '微信' : 'WeChat', svg: wechatSvg, x: 125, size: 34 },
+  { key: 'feishu', name: zh.value ? '飞书' : 'Feishu', svg: feishuSvg, x: 375, size: 34 },
+  { key: 'yuanbao', name: zh.value ? '元宝' : 'Yuanbao', svg: yuanbaoSvg, x: 625, size: 34 },
+  { key: 'discord', name: 'Discord', svg: discordSvg, x: 875, size: 34 },
 ]);
 
 // wire geometry (viewBox 0 0 1000 220, hub centred at 500)
@@ -162,7 +164,10 @@ function botWire(x: number): string {
     </svg>
 
     <!-- 3. channels (real brand logos), columns aligned under the wire ends -->
-    <div class="bridge-channels">
+    <div
+      class="bridge-channels"
+      :style="{ gridTemplateColumns: `repeat(${channels.length}, minmax(0, 1fr))` }"
+    >
       <div v-for="c in channels" :key="c.key" class="bridge-channel">
         <span class="bridge-ctile" :style="{ '--cs': c.size + 'px' }" v-html="c.svg" />
         <span class="bridge-clabel">{{ c.name }}</span>

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: xacpx
   text: Your agents, in any chat
-  tagline: Drive Codex, Claude Code & Gemini sessions from WeChat, Feishu, Yuanbao — no terminal required.
+  tagline: Drive Codex, Claude Code & Gemini sessions from WeChat, Feishu, Yuanbao, Discord — no terminal required.
   actions:
     - theme: brand
       text: Get Started
@@ -34,7 +34,7 @@ features:
     linkText: How it works
   - icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>'
     title: Extensible channels
-    details: Add first-party or external channel plugins without touching the core console.
+    details: Add first-party channels such as Feishu, Yuanbao, and Discord — or build external plugins — without touching the core console.
     link: /plugins/development
     linkText: Build a channel
   - icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>'
@@ -85,11 +85,12 @@ The typical sequence is four steps:
 
 xacpx ships with WeChat as the built-in default channel. Additional channels are distributed as official plugin packages:
 
-| Channel | Package |
-|---------|---------|
-| WeChat (built-in) | — |
-| Feishu | `@ganglion/xacpx-channel-feishu` |
-| Yuanbao | `@ganglion/xacpx-channel-yuanbao` |
+| Channel | Package | Setup |
+|---------|---------|-------|
+| WeChat (built-in) | — | [Getting Started](/guide/getting-started) |
+| Feishu | `@ganglion/xacpx-channel-feishu` | [Feishu guide](/plugins/feishu) |
+| Yuanbao | `@ganglion/xacpx-channel-yuanbao` | [Yuanbao guide](/plugins/yuanbao) |
+| Discord | `@ganglion/xacpx-channel-discord` | [Discord guide](/plugins/discord) |
 
 Third-party channels follow the same plugin interface. Install a channel plugin with `xacpx plugin add <package>`, configure it with `xacpx channel add <name>`, then restart the daemon.
 
@@ -114,6 +115,7 @@ See [Self-Hosting the Relay Hub](/guide/relay-self-hosting) for the full walkthr
 ## Next steps
 
 - [Getting Started](/guide/getting-started) — install xacpx, log in, and run your first session
+- [Discord Channel](/plugins/discord) — create a Discord bot, configure the allowlist, and send your first agent prompt
 - [Command Reference](/reference/commands) — full listing of chat commands (`/ss`, `/use`, `/cancel`, and more)
 - [Self-Hosting the Relay Hub](/guide/relay-self-hosting) — run the multi-tenant web dashboard for several instances
 - [Configuration](/reference/configuration) — config file fields, transport options, and workspace/agent registration

--- a/packages/docs/plugins/discord.md
+++ b/packages/docs/plugins/discord.md
@@ -1,0 +1,272 @@
+# Discord Channel
+
+## Overview
+
+`@ganglion/xacpx-channel-discord` is the official Discord channel plugin for xacpx. It connects a Discord bot to xacpx over the Discord Gateway and routes DMs, server-channel messages, threads, commands, text, and supported attachments through xacpx's command and session system.
+
+Discord is a **bot-token channel**, not a QR-login channel. There is no `xacpx login discord`: create a Discord application/bot, install it into your server, then configure the bot token in xacpx.
+
+## Install
+
+Install the plugin first:
+
+```bash
+xacpx plugin add @ganglion/xacpx-channel-discord
+```
+
+Then add the channel. The interactive form is recommended because the token stays out of shell history:
+
+```bash
+xacpx channel add discord
+# Discord bot token: <paste token>
+```
+
+For automation you can pass the token explicitly:
+
+```bash
+xacpx channel add discord --token '<BOT_TOKEN>'
+```
+
+Do not restart yet if you want to use the default allowlist policy: an empty allowlist rejects everyone, so complete the access-control step below first.
+
+## Create the Discord bot
+
+1. Open the [Discord Developer Portal](https://discord.com/developers/applications).
+2. Create an **Application**.
+3. Open **Bot** and create/confirm the bot user.
+4. Copy the **Bot Token**. Treat it like a password. If it leaks, reset it in the Portal, update xacpx, and restart the daemon.
+
+### Message Content Intent
+
+Under **Bot → Privileged Gateway Intents**, enable **Message Content Intent**.
+
+The plugin requests Message Content by default (`options.intents.messageContent: true`). If the local option is `true` but the Portal toggle is disabled, Discord rejects Gateway identify with **4014 (disallowed intents)** and the bot stays offline.
+
+You can deliberately run without Message Content by setting:
+
+```jsonc
+{
+  "intents": { "messageContent": false }
+}
+```
+
+Without the intent, DMs and messages that explicitly `@mention` the bot can still carry content. A bare reply to a bot message is **not** a substitute for Message Content access: xacpx can recognize the reply relationship, but Discord may deliver the reply with empty text. For normal server usage, enabling Message Content is recommended.
+
+## Install the bot into a server
+
+Use Discord's **OAuth2 → URL Generator** or **Installation** page to create an invite with the `bot` scope and add the bot to your server.
+
+Do not grant Administrator. The message-channel flow normally needs:
+
+```text
+View Channels
+Send Messages
+Read Message History
+Add Reactions
+Attach Files
+Send Messages in Threads   # if you use threads / forum posts
+```
+
+`Send Messages in Threads` is separate from `Send Messages`.
+
+## Configure access control
+
+Discord access control uses numeric **snowflake IDs**, not usernames or display names.
+
+Enable **Discord Settings → Advanced → Developer Mode**, then use **Copy ID** to get your user ID. You may also need guild, channel, or role IDs for per-server rules.
+
+`xacpx channel add discord` currently has no `--allow-from` flag, so edit `~/.xacpx/config.json` and add your user ID:
+
+```jsonc
+{
+  "channels": [
+    {
+      "id": "discord",
+      "type": "discord",
+      "enabled": true,
+      "options": {
+        "token": "<BOT_TOKEN>",
+        "dmPolicy": "allowlist",
+        "guildPolicy": "allowlist",
+        "allowFrom": ["<YOUR_DISCORD_USER_ID>"],
+        "requireMention": true
+      }
+    }
+  ]
+}
+```
+
+The safe defaults are intentionally restrictive:
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `dmPolicy` | `allowlist` | Only senders in `allowFrom` are accepted in DMs |
+| `guildPolicy` | `allowlist` | Only allowlisted senders are accepted in servers |
+| `allowFrom` | empty | Rejects every sender until you add IDs |
+| `requireMention` | `true` | Server messages must @mention the bot or reply to it |
+| `allowBots` | `false` | Messages from other bots are ignored |
+
+`"*"` in `allowFrom` accepts any sender, but keep that for controlled environments. Avoid `guildPolicy: "open"` together with `requireMention: false` in a public server.
+
+## Restart and verify
+
+```bash
+xacpx channel show discord
+xacpx plugin doctor
+xacpx restart
+```
+
+`xacpx plugin doctor` performs a local configuration check; it does **not** validate the token against Discord live.
+
+A real connectivity check is:
+
+1. the daemon starts without a Discord Gateway error;
+2. the bot appears online in Discord;
+3. a message makes a full round trip.
+
+From an allowlisted server account:
+
+```text
+@your-bot /help
+@your-bot /ss codex -d /absolute/path/to/repo
+@your-bot inspect the current git diff
+```
+
+In a DM, a mention is not required:
+
+```text
+/help
+/ss codex -d /absolute/path/to/repo
+run the tests and summarize the failures
+```
+
+DMs are still subject to `dmPolicy` and `allowFrom`.
+
+## Temporary smoke test
+
+For a controlled test server, you can temporarily open both policies while still requiring mentions:
+
+```bash
+xacpx channel add discord \
+  --token '<BOT_TOKEN>' \
+  --dm-policy open \
+  --guild-policy open \
+  --require-mention true
+```
+
+Use this only to prove the Gateway/message path, then switch back to an allowlist for normal use.
+
+## Configuration
+
+A fuller single-account configuration looks like this:
+
+```jsonc
+{
+  "channels": [
+    {
+      "id": "discord",
+      "type": "discord",
+      "enabled": true,
+      "options": {
+        "token": "<BOT_TOKEN>",
+        "applicationId": "123456789012345678",
+        "replyMode": "auto",
+        "tableMode": "code",
+        "requireMention": true,
+        "dmPolicy": "allowlist",
+        "guildPolicy": "allowlist",
+        "allowFrom": ["<YOUR_DISCORD_USER_ID>"],
+        "guilds": {
+          "<GUILD_ID>": {
+            "users": [],
+            "roles": [],
+            "channels": {
+              "<CHANNEL_ID>": { "requireMention": false }
+            }
+          }
+        },
+        "allowBots": false,
+        "intents": {
+          "messageContent": true,
+          "guildMembers": false
+        },
+        "media": {
+          "maxBytes": 8388608,
+          "maxAttachments": 10
+        }
+      }
+    }
+  ]
+}
+```
+
+`token` is the only required credential for basic message routing. `applicationId` is optional for the current message flow.
+
+A guild entry with non-empty `users` or `roles` applies a guild-specific allowlist. If a guild entry only overrides channel settings such as `requireMention`, the global `allowFrom` remains the allowlist source.
+
+## Reply modes
+
+`options.replyMode` controls Discord reply rendering:
+
+| Mode | Behavior |
+| --- | --- |
+| `auto` | Default; currently resolves to streaming |
+| `streaming` | Edits a preview message while output is generated, deletes the preview at completion, then sends the final answer |
+| `static` | Sends only the final chunked response |
+
+Discord messages have a 2000-character limit. Final responses are chunked automatically; preview failures degrade to static delivery.
+
+## Threads and sessions
+
+Discord chat keys distinguish DMs, guild channels, and threads:
+
+```text
+discord:<accountId>:dm:<dmChannelId>
+discord:<accountId>:g:<channelId>
+discord:<accountId>:t:<threadId>
+```
+
+Each thread/forum post is an independent xacpx chat context and therefore gets its own session mapping. If a thread is archived or disappears while xacpx is replying, the channel attempts to fall back to the parent channel for text, media, and completion notices.
+
+## Multiple Discord bots
+
+Add named accounts with:
+
+```bash
+xacpx channel add discord --account work --token '<WORK_BOT_TOKEN>'
+xacpx channel add discord --account personal --token '<PERSONAL_BOT_TOKEN>'
+```
+
+Per-account overrides live under `options.accounts.<id>`. Every enabled account must resolve to a **different bot token**. xacpx rejects duplicate enabled tokens in one process and also uses a per-token consumer lock to prevent two xacpx processes from driving the same Discord bot simultaneously.
+
+## Media
+
+Inbound Discord attachments can be passed to the agent within the configured size/count limits. Outbound files are only sent from the media-store root or allowed workspace roots; paths escaping those roots and URL-like paths are rejected.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| Bot stays offline / Gateway closes with 4014 | Enable Message Content Intent in the Portal, or set local `intents.messageContent` to `false` intentionally |
+| Bot is online but ignores every message | Add your numeric Discord user ID to `allowFrom`; the default list is empty |
+| Server message is ignored | With `requireMention: true`, use an actual `@bot` mention; also check `guildPolicy` |
+| Reply-to-bot text is empty with Message Content disabled | Use an explicit `@bot` mention or enable Message Content |
+| Thread replies fail | Grant `Send Messages in Threads`; archived threads fall back to the parent when possible |
+| Attachments fail | Grant `Attach Files` and check `media.maxBytes` / `media.maxAttachments` |
+| Unsure whether config is valid | Run `xacpx channel show discord` and `xacpx plugin doctor`; use daemon logs for the live Gateway result |
+
+Policy-denied messages are dropped silently and logged under `discord.message.policy_denied` in the xacpx app log.
+
+## Update or remove
+
+```bash
+xacpx plugin update @ganglion/xacpx-channel-discord
+xacpx restart
+```
+
+To remove it:
+
+```bash
+xacpx channel rm discord
+xacpx plugin remove @ganglion/xacpx-channel-discord
+```

--- a/packages/docs/zh/index.md
+++ b/packages/docs/zh/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: xacpx
   text: 你的 Agent，就在聊天里
-  tagline: 在微信、飞书、元宝中驱动 Codex、Claude Code、Gemini 会话——无需打开终端。
+  tagline: 在微信、飞书、元宝、Discord 中驱动 Codex、Claude Code、Gemini 会话——无需打开终端。
   actions:
     - theme: brand
       text: 快速开始
@@ -34,7 +34,7 @@ features:
     linkText: 工作原理
   - icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 1 1.73l7 4a2 2 0 0 2 0l7-4A2 2 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>'
     title: 可扩展频道
-    details: 无需修改核心控制台，即可添加官方或第三方频道插件。
+    details: 无需修改核心控制台，即可添加飞书、元宝、Discord 等官方频道，或安装第三方频道插件。
     link: /zh/plugins/development
     linkText: 开发频道插件
   - icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>'
@@ -85,11 +85,12 @@ xacpx 是一个聊天频道控制台，用于远程控制 `acpx` Agent 会话。
 
 xacpx 内置微信作为默认频道。其他频道以官方插件包形式分发：
 
-| 频道 | 插件包 |
-|---------|---------|
-| 微信（内置） | — |
-| 飞书 | `@ganglion/xacpx-channel-feishu` |
-| 元宝 | `@ganglion/xacpx-channel-yuanbao` |
+| 频道 | 插件包 | 安装说明 |
+|---------|---------|---------|
+| 微信（内置） | — | [快速开始](/zh/guide/getting-started) |
+| 飞书 | `@ganglion/xacpx-channel-feishu` | [飞书教程](/zh/plugins/feishu) |
+| 元宝 | `@ganglion/xacpx-channel-yuanbao` | [元宝教程](/zh/plugins/yuanbao) |
+| Discord | `@ganglion/xacpx-channel-discord` | [Discord 教程](/zh/plugins/discord) |
 
 第三方频道遵循相同的插件接口。使用 `xacpx plugin add <package>` 安装频道插件，使用 `xacpx channel add <name>` 配置，然后重启守护进程。
 
@@ -114,6 +115,7 @@ xacpx-relay start       # 看板 + API 在 :8787
 ## 下一步
 
 - [快速开始](/zh/guide/getting-started) — 安装 xacpx、登录并运行第一个会话
+- [Discord 频道](/zh/plugins/discord) — 创建 Discord Bot、配置 allowlist，并发送第一条 Agent 提示词
 - [命令参考](/zh/reference/commands) — 聊天命令完整列表（`/ss`、`/use`、`/cancel` 等）
 - [自托管 Relay Hub](/zh/guide/relay-self-hosting) — 为多个实例运行多租户网页看板
 - [配置说明](/zh/reference/configuration) — 配置文件字段、传输选项以及工作区和 Agent 注册

--- a/packages/docs/zh/plugins/discord.md
+++ b/packages/docs/zh/plugins/discord.md
@@ -1,0 +1,272 @@
+# Discord 频道
+
+## 概述
+
+`@ganglion/xacpx-channel-discord` 是 xacpx 的官方 Discord 频道插件。它通过 Discord Gateway 连接机器人，把私信、服务器频道消息、Thread、命令、文本以及支持的附件路由到 xacpx 的命令和会话系统。
+
+Discord 是**机器人 Token 频道**，不是扫码登录频道。这里没有 `xacpx login discord`：你需要先创建 Discord Application/Bot、把机器人安装到服务器，然后在 xacpx 中配置 Bot Token。
+
+## 安装
+
+先安装插件：
+
+```bash
+xacpx plugin add @ganglion/xacpx-channel-discord
+```
+
+然后添加 Discord 频道。推荐使用交互式输入，避免 Token 留在 shell history：
+
+```bash
+xacpx channel add discord
+# Discord bot token: <粘贴 Token>
+```
+
+自动化场景也可以显式传入：
+
+```bash
+xacpx channel add discord --token '<BOT_TOKEN>'
+```
+
+如果准备使用默认 allowlist 安全策略，先不要急着重启：默认 `allowFrom` 为空，会拒绝所有人。先完成下面的访问控制配置。
+
+## 创建 Discord Bot
+
+1. 打开 [Discord Developer Portal](https://discord.com/developers/applications)。
+2. 创建一个 **Application**。
+3. 进入 **Bot** 页面，创建或确认 Bot 用户。
+4. 复制 **Bot Token**。Token 等同密码；一旦泄露，应立即在 Portal 中 Reset Token、更新 xacpx 配置并重启守护进程。
+
+### Message Content Intent
+
+在 **Bot → Privileged Gateway Intents** 中打开 **Message Content Intent**。
+
+插件默认请求 Message Content（`options.intents.messageContent: true`）。如果本地配置为 `true`，但 Portal 没开这个开关，Discord 会以 **4014（disallowed intents）** 拒绝 Gateway identify，表现为机器人无法上线。
+
+如果你明确只想运行 mention-only Bot，可以设置：
+
+```jsonc
+{
+  "intents": { "messageContent": false }
+}
+```
+
+关闭该 Intent 后，私信以及真正 `@提及` 机器人的消息仍可带有内容。**只回复机器人消息并不能替代 Message Content 权限**：xacpx 可以识别 reply 关系，但 Discord 可能把这条 reply 的正文作为空内容交给 Bot。普通服务器使用建议直接开启 Message Content。
+
+## 把 Bot 安装到服务器
+
+通过 Discord 的 **OAuth2 → URL Generator** 或 **Installation** 页面生成带 `bot` scope 的邀请链接，并把 Bot 加入服务器。
+
+不要给 Administrator。消息频道通常只需要：
+
+```text
+View Channels
+Send Messages
+Read Message History
+Add Reactions
+Attach Files
+Send Messages in Threads   # 使用 Thread / Forum 时需要
+```
+
+`Send Messages in Threads` 与普通 `Send Messages` 是两项独立权限。
+
+## 配置访问控制
+
+Discord 权限判断使用数字 **snowflake ID**，不是用户名或显示昵称。
+
+先开启 **Discord 设置 → 高级 → 开发者模式**，然后右键用户使用 **Copy ID / 复制 ID** 获取自己的 User ID。需要按服务器细分时，同样可以复制 Guild、Channel、Role ID。
+
+`xacpx channel add discord` 目前没有 `--allow-from` 参数，因此需要编辑 `~/.xacpx/config.json`，把自己的 User ID 加到 allowlist：
+
+```jsonc
+{
+  "channels": [
+    {
+      "id": "discord",
+      "type": "discord",
+      "enabled": true,
+      "options": {
+        "token": "<BOT_TOKEN>",
+        "dmPolicy": "allowlist",
+        "guildPolicy": "allowlist",
+        "allowFrom": ["<你的_DISCORD_USER_ID>"],
+        "requireMention": true
+      }
+    }
+  ]
+}
+```
+
+默认安全策略是刻意收紧的：
+
+| 字段 | 默认值 | 含义 |
+| --- | --- | --- |
+| `dmPolicy` | `allowlist` | 私信只接受 `allowFrom` 中的发送者 |
+| `guildPolicy` | `allowlist` | 服务器中只接受 allowlist 用户 |
+| `allowFrom` | 空 | 在加入 ID 前拒绝所有发送者 |
+| `requireMention` | `true` | 服务器消息必须 @Bot 或回复 Bot |
+| `allowBots` | `false` | 忽略其他机器人发来的消息 |
+
+`allowFrom` 中填写 `"*"` 可以接受任何发送者，但只建议用于受控环境。公共服务器不要长期使用 `guildPolicy: "open"` + `requireMention: false`。
+
+## 重启并验证
+
+```bash
+xacpx channel show discord
+xacpx plugin doctor
+xacpx restart
+```
+
+`xacpx plugin doctor` 只做本地配置诊断，**不会**实时调用 Discord API 验证 Token。
+
+真实连通性要看三件事：
+
+1. 守护进程启动时没有 Discord Gateway 错误；
+2. Discord 中 Bot 显示在线；
+3. 消息可以完整往返一次。
+
+使用 allowlist 中的服务器账号测试：
+
+```text
+@你的Bot /help
+@你的Bot /ss codex -d /项目的绝对路径
+@你的Bot 检查一下当前 git diff
+```
+
+私信 Bot 时不需要 @mention：
+
+```text
+/help
+/ss codex -d /项目的绝对路径
+跑一下测试并总结失败原因
+```
+
+私信仍然受 `dmPolicy` 和 `allowFrom` 控制。
+
+## 临时烟雾测试
+
+如果只想在受控测试服务器快速验证 Gateway → xacpx → Agent 链路，可以临时开放策略，但继续要求 @mention：
+
+```bash
+xacpx channel add discord \
+  --token '<BOT_TOKEN>' \
+  --dm-policy open \
+  --guild-policy open \
+  --require-mention true
+```
+
+确认链路正常后，应恢复 allowlist 作为日常配置。
+
+## 配置说明
+
+一个较完整的单账号配置如下：
+
+```jsonc
+{
+  "channels": [
+    {
+      "id": "discord",
+      "type": "discord",
+      "enabled": true,
+      "options": {
+        "token": "<BOT_TOKEN>",
+        "applicationId": "123456789012345678",
+        "replyMode": "auto",
+        "tableMode": "code",
+        "requireMention": true,
+        "dmPolicy": "allowlist",
+        "guildPolicy": "allowlist",
+        "allowFrom": ["<你的_DISCORD_USER_ID>"],
+        "guilds": {
+          "<GUILD_ID>": {
+            "users": [],
+            "roles": [],
+            "channels": {
+              "<CHANNEL_ID>": { "requireMention": false }
+            }
+          }
+        },
+        "allowBots": false,
+        "intents": {
+          "messageContent": true,
+          "guildMembers": false
+        },
+        "media": {
+          "maxBytes": 8388608,
+          "maxAttachments": 10
+        }
+      }
+    }
+  ]
+}
+```
+
+基础消息流唯一必需的凭据是 `token`。当前消息路径下 `applicationId` 是可选项。
+
+某个 Guild 配置只要有非空的 `users` 或 `roles`，就会启用该 Guild 自己的 allowlist；如果 Guild 条目只是修改 `channels.<id>.requireMention` 之类的频道设置，用户 allowlist 仍然来自全局 `allowFrom`。
+
+## 回复模式
+
+`options.replyMode` 控制 Discord 的回复渲染：
+
+| 模式 | 行为 |
+| --- | --- |
+| `auto` | 默认；当前解析为 streaming |
+| `streaming` | 生成期间原地编辑 preview，完成时删除 preview，再发送最终答案 |
+| `static` | 不显示 preview，只发送最终分片结果 |
+
+Discord 单条消息上限为 2000 字符，最终答案会自动分片。preview 创建或编辑失败时会自动降级到静态发送。
+
+## Thread 与会话
+
+Discord 的 ChatKey 会区分私信、服务器频道和 Thread：
+
+```text
+discord:<accountId>:dm:<dmChannelId>
+discord:<accountId>:g:<channelId>
+discord:<accountId>:t:<threadId>
+```
+
+每个 Thread / Forum Post 都是独立的 xacpx 聊天上下文，因此会得到独立的会话映射。若 xacpx 回复过程中 Thread 已归档或消失，文本、媒体和后台完成通知会尽可能降级发送到父频道。
+
+## 多个 Discord Bot
+
+使用命名账号添加多个 Bot：
+
+```bash
+xacpx channel add discord --account work --token '<WORK_BOT_TOKEN>'
+xacpx channel add discord --account personal --token '<PERSONAL_BOT_TOKEN>'
+```
+
+每个账号的覆盖配置位于 `options.accounts.<id>`。所有启用的账号必须解析到**不同的 Bot Token**。xacpx 会拒绝单进程中重复的启用 Token，同时通过 per-token consumer lock 防止两个 xacpx 进程同时驱动同一个 Discord Bot。
+
+## 媒体
+
+Discord 入站附件可以在配置的大小和数量上限内传给 Agent。出站文件只允许来自 media-store 根目录或允许的工作区根目录；逃逸这些目录的路径以及 URL 形式路径都会被拒绝。
+
+## 故障排查
+
+| 现象 | 检查项 |
+| --- | --- |
+| Bot 一直离线 / Gateway 4014 | 在 Portal 开启 Message Content Intent；或有意把本地 `intents.messageContent` 设为 `false` |
+| Bot 在线但完全不回复 | 把自己的数字 Discord User ID 加入 `allowFrom`；默认列表为空 |
+| 服务器消息被忽略 | 默认 `requireMention: true`，请真正 `@Bot`，并检查 `guildPolicy` |
+| 关闭 Message Content 后，回复 Bot 的正文为空 | 使用显式 `@Bot`，或重新开启 Message Content |
+| Thread 回复失败 | 授予 `Send Messages in Threads`；归档 Thread 会在可解析时降级到父频道 |
+| 附件发送失败 | 授予 `Attach Files`，并检查 `media.maxBytes` / `media.maxAttachments` |
+| 不确定配置是否正确 | 使用 `xacpx channel show discord` 和 `xacpx plugin doctor`；实时 Gateway 结果看守护进程日志 |
+
+被策略拒绝的消息会静默丢弃，并在 xacpx app log 中以 `discord.message.policy_denied` 记录。
+
+## 更新与卸载
+
+```bash
+xacpx plugin update @ganglion/xacpx-channel-discord
+xacpx restart
+```
+
+卸载：
+
+```bash
+xacpx channel rm discord
+xacpx plugin remove @ganglion/xacpx-channel-discord
+```


### PR DESCRIPTION
## Summary

- add English and Chinese Discord channel installation/usage guides under the docs site
- register Discord in both locale sidebars and site descriptions
- add Discord to the home-page hero, supported-channel table, and next-step links
- extend the animated Agent → xacpx → channel bridge with a Discord brand node and fourth connection

## Discord guide coverage

The guide follows the shipped `@ganglion/xacpx-channel-discord` behavior and covers Developer Portal setup, Message Content Intent, minimal bot permissions, User ID allowlisting, safe defaults, first `/help` + `/ss` round trip, reply modes, threads, multi-account token rules, media, troubleshooting, updates, and removal.

## Scope

Docs site only; no runtime/package behavior changes.