### PR TITLE
fix(channel-discord): streaming preview immediate, merge final text, add slash autocomplete

### DIFF
--- a/docs/superpowers/plans/2026-09-01-discord-streaming-autocomplete.md
+++ b/docs/superpowers/plans/2026-09-01-discord-streaming-autocomplete.md
@@ -1,0 +1,371 @@
+# Discord Streaming & Autocomplete Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Discord `/ss` startup to show immediate streaming progress like Feishu, stop dropping intermediate updates, and provide slash-command autocomplete via Discord Application Commands.
+
+**Architecture:** Keep existing `DiscordChannel` text-command pipeline. Shorten preview gate so session-create progress is visible in <300ms, concatenate streamed progress with final router text, forward tool/thought events into preview, and add optional Application Commands registration that maps `xacpx` parsed commands to Discord native slash commands when `applicationId` is configured.
+
+**Tech Stack:** TypeScript (ESM, Bun), `discord.js` `REST` v10, `bun:test`, `npx tsc --noEmit`
+
+## Global Constraints
+
+- Runtime import via `xacpx/plugin-api` only; `bunx publint` must pass before publish.
+- `start()` first line `setChannelLocale(input.locale ?? "en")`; log codes `discord.<area>.<verb>`.
+- `allowed_mentions: { parse: [] }` on every outbound.
+- `chatKey` format `discord:<accountId>:<kind>:<channelId>` with `accountId` must not contain `:` [config.ts:assertValidAccountId].
+- Outbound media must pass `resolveSafeOutboundMediaPath`.
+- Do not add voice/presence/exec-approval features.
+- Preview semantics F2: preview is process viewer, final answer always new MESSAGE_CREATE even for short answers.
+- Consumer lock per-token composite remains unchanged.
+
+---
+
+### Task 1: Make session-create progress visible immediately (preview-stream + progress timing)
+
+**Files:**
+- Modify: `packages/channel-discord/src/preview-stream.ts:19-136`
+- Modify: `packages/channel-discord/src/channel.ts:956-984` (preview creation options)
+- Test: `tests/unit/packages/channel-discord/discord-preview-stream.test.ts`
+
+**Interfaces:**
+- Consumes: `DiscordClientLike`, `DeliveryTarget`
+- Produces: `createDiscordPreviewStream(options)` with corrected `minInitialChars` handling; `DiscordChannel.runTurn` passes `previewThrottleMs`/`minInitialChars` correctly
+
+**Context:** Today `minInitialChars=200` + `update()` early-return swallows `🚀 Starting omp…` (≈20 chars) and the later `ℹ️ [acpx] …` (≈60 chars) until both together still <200, so no `MESSAGE_CREATE` is ever sent; the 4s gap is `DEBOUNCE_MS=3000` in `src/commands/transport-invoker.ts:99-144`. Feishu seeds a `StreamingCardController` immediately before `agent.chat`, so user sees progress at t≈0.
+
+**Decision:** Keep `DEFAULT_DISCORD_TUNING.minInitialChars=200` for long agent turns (avoids noisy empty preview), but session-create progress must bypass it. Two cooperating changes:
+1. `preview-stream.ts` — allow progress pings to create immediately even if <200 (or lower the preview default for Discord to 1 when `replyMode=streaming` and text is a transport progress note). Simplest: change `update()` so the *first* `update` with any non-empty text creates immediately when `throttleMs` elapsed, and keep `minInitialChars` only for the *first accumulation* async — measure by elapsed time, not char count, for progress.
+2. `channel.ts` — ensure `accumulated` that holds progress is also delivered via preview instantly, not held until 200.
+
+Alternative chosen: reduce `minInitialChars` default for Discord preview from 200 to 20 and ensure `runTurn` creates preview with `minInitialChars: 1` for the session-create path, or simply change `DEFAULT_DISCORD_TUNING.minInitialChars` to `20` and adjust `update()` to schedule even when < threshold after a short grace (200ms). Any solution where `🚀 Starting` appears within 300ms on fake timers is acceptable, but must not break existing test `"preview defers creation until minInitialChars"`.
+
+- [ ] **Step 1: Write failing test — short progress visibly creates preview**
+
+```ts
+// tests/unit/packages/channel-discord/discord-preview-stream.test.ts
+test("short progress like '🚀 Starting omp…' creates preview promptly", async () => {
+  vi.useFakeTimers();
+  const { client, sent } = createFakeClient();
+  // use defaults that previously hid short text
+  const preview = createDiscordPreviewStream({ client, target, throttleMs: 300, minInitialChars: 200 });
+  preview.update("🚀 Starting omp…");
+  vi.advanceTimersByTime(400);
+  await Promise.resolve(); await Promise.resolve();
+  // BEFORE fix: sent.length === 0 (bug); AFTER fix: expect 1
+  expect(sent.length).toBe(1);
+  expect(sent[0]!.content).toBe("🚀 Starting omp…");
+  vi.useRealTimers();
+});
+```
+
+Run: `bun test tests/unit/packages/channel-discord/discord-preview-stream.test.ts -t "short progress" -v`
+Expected: FAIL (sent.length 0)
+
+- [ ] **Step 2: Fix `preview-stream.ts` gating**
+
+Replace the `messageId===null && text.length < minInitialChars` early-return with a time-gated variant. Minimal patch that satisfies both old and new tests:
+
+```ts
+// packages/channel-discord/src/preview-stream.ts ~19
+const minInitialChars = options.minInitialChars ?? 20; // lower from 200
+// in update():
+if (messageId === null && text.length < minInitialChars) {
+  // keep debouncing but ensure a short progress is not starved:
+  // schedule a flush after throttleMs even when below threshold, so
+  // "🚀 Starting" appears within one throttle window.
+  if (!timer && !creating && !editing && !closed && !overflow) schedule();
+  return;
+}
+```
+
+Alternatively set default `minInitialChars` to `20` via `tuning.ts:DEFAULT_DISCORD_TUNING` and keep logic. Either is acceptable if tests above pass.
+
+Also ensure `previewStream.update` is called on every `safeReply` delta, and that throttle still coalesces rapid deltas.
+
+- [ ] **Step 3: Verify new behavior**
+
+Run same test: expect PASS.
+
+Run existing: `bun test tests/unit/packages/channel-discord/discord-preview-stream.test.ts -v`  — the original `"defers creation until minInitialChars"` test must be updated to expect `minInitialChars:5` still defers `hi` (2 chars) but allows `hello world` (11 chars). If default lowered to 20, that test still passes because `minInitialChars:5` explicit. No other change.
+
+- [ ] **Step 4: Wire `channel.ts` to use tighter preview for session-create**
+
+In `channel.ts:958-967` ensure `createDiscordPreviewStream` receives `minInitialChars: 1` when the turn is a session command (`requestText.trim().startsWith("/")`) or simply pass `1` always for streaming mode. E.g.:
+
+```ts
+active.previewStream = createDiscordPreviewStream({
+  client: runtime.client,
+  target,
+  maxChars: 2000,
+  throttleMs: runtime.account.previewThrottleMs,
+  minInitialChars: 1, // was runtime.account.minInitialChars (200)
+  onWarn: (msg) => { void this.logger?.warn("discord.preview.warn", msg, { accountId, channelId }); },
+});
+```
+
+If keeping configurable, change `config.ts` default `DEFAULT_MIN_INITIAL_CHARS = 20` (from 200) so new accounts get prompt feedback.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/channel-discord/src/preview-stream.ts packages/channel-discord/src/tuning.ts packages/channel-discord/src/channel.ts tests/unit/packages/channel-discord/discord-preview-stream.test.ts
+git commit -m "fix(channel-discord): show session-create progress immediately (preview no longer starved by 200-char gate)"
+```
+
+---
+
+### Task 2: Deliver complete answer and forward agent stream events (finalText + tool/thought)
+
+**Files:**
+- Modify: `packages/channel-discord/src/channel.ts:979-1030` (`runTurn` safeReply accumulation, agent.chat call, deliverFinalResponse)
+- Test: `tests/unit/packages/channel-discord/discord-channel.test.ts` (new cases) or extend existing stub
+
+**Interfaces:**
+- Consumes: `TransportInvoker.promptTransportSession`, `StreamingPromptState` callbacks
+- Produces: `DiscordChannel.runTurn` correctly forwards `onToolEvent/onThought/onPlan/onUsage/onCommands` and merges `accumulated + response.text`
+
+**Context:** `finalText = accumulated || response.text` drops `sessionCreated` when progress exists. Also `agent.chat` call only passes `reply` [channel.ts:987-1001], so ACP `tool_call`/`agent_thought_chunk`/`plan` never reach Discord preview. Feishu passes all four when `cardController` exists [channel.ts:749-764].
+
+- [ ] **Step 1: Write failing test — final text concatenates progress + router result**
+
+Add to a new or existing channel test that injects a fake agent:
+
+```ts
+// tests/unit/packages/channel-discord/discord-channel.test.ts
+test("runTurn finalText merges streamed progress and router response", async () => {
+  const { channel, fakeAgent, fakeClient, sent } = setupDiscordChannel({
+    replyMode: "streaming",
+    agentReply: async (opts) => {
+      await opts.reply?.("🚀 Starting omp…");
+      await opts.reply?.("ℹ️ note");
+      return { text: "Session xacpx:omp created" };
+    },
+  });
+  await channel["handleMessageEvent"]("default", fakeDiscordMessage("/ss omp -ws xacpx"));
+  // wait executor
+  await vi.waitFor(() => expect(sent.some(s => s.content.includes("Session xacpx:omp created"))).toBe(true));
+  // must contain both progress and final
+  const combined = sent.map(s=>s.content).join("\n");
+  expect(combined).toContain("🚀");
+  expect(combined).toContain("Session xacpx:omp created");
+});
+```
+
+Run: `bun test tests/unit/packages/channel-discord/discord-channel.test.ts -t "merges streamed" -v` Expect FAIL (final only contains progress).
+
+- [ ] **Step 2: Fix `channel.ts:979-1030` — merge and forward events**
+
+Change accumulation + final:
+
+```ts
+let accumulated = "";
+const safeReply = async (delta: string): Promise<void> => {
+  if (active.suppressed) return;
+  accumulated += delta;
+  // also keep plain text preview in sync; tool events will append separately
+  active.previewStream?.update(accumulated);
+};
+
+const buildPreviewToolLine = (e: ToolUseEvent): string => {
+  // lightweight: mirror feishu format without card — e.g. `🔧 tool · ${e.title}`
+  const emoji = TOOL_EMOJI[e.kind] ?? "🔧";
+  return `${emoji} ${e.title ?? e.kind}`;
+};
+
+// in runTurn before agent.chat:
+const onToolEvent = async (e: ToolUseEvent) => {
+  if (active.suppressed) return;
+  const line = buildPreviewToolLine(e);
+  accumulated += (accumulated ? "\n" : "") + line;
+  active.previewStream?.update(accumulated);
+};
+// similarly onThought appends line, onPlan renders plan bullets, onUsage ignored for text
+
+try {
+  const response = await this.agent.chat({
+    accountId,
+    conversationId: chatKey,
+    text: requestText,
+    ...(media.length>0?{media}:{}),
+    replyContextToken: messageId,
+    metadata: { channel:"discord", chatType: route.kind==="dm"?"direct":"group", senderId: active.senderId, groupId: guildId, ...(boundAlias?{boundSessionAlias:boundAlias}:{})},
+    reply: safeReply,
+    onToolEvent, onThought: async (c)=>{ accumulated += c; active.previewStream?.update(accumulated); },
+    abortSignal: abortController.signal,
+  });
+  // ...
+  const finalText = [accumulated, response.text].filter(s=> s && s.trim().length>0).join("\n\n");
+  await this.deliverFinalResponse({ runtime, target, finalText, ... });
+}
+```
+
+If forwarding all callbacks is too heavy, at minimum fix `finalText` merging:
+
+```ts
+const finalText = [accumulated.trim(), (response.text??"").trim()].filter(Boolean).join("\n\n") || response.text || accumulated;
+```
+
+Also ensure preview cleanup deletes preview before final send (existing) so final is always new `MESSAGE_CREATE`.
+
+- [ ] **Step 3: Run tests — must pass new and existing**
+
+`bun test tests/unit/packages/channel-discord/discord-channel.test.ts -v`
+`npx tsc --noEmit`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/channel-discord/src/channel.ts tests/unit/packages/channel-discord/discord-channel.test.ts
+git commit -m "fix(channel-discord): merge streamed progress with final text and stream tool/thought into preview"
+```
+
+---
+
+### Task 3: Discord Application Commands for autocomplete
+
+**Files:**
+- Create: `packages/channel-discord/src/discord-commands.ts`
+- Modify: `packages/channel-discord/src/discord-client.ts` (add `registerCommands`, `onInteraction` hook, expose `applicationId`)
+- Modify: `packages/channel-discord/src/channel.ts` (register on start, handle interactionCreate)
+- Modify: `packages/channel-discord/src/config.ts` (require `applicationId` when `registerCommands` enabled; add `enableAutocomplete` bool)
+- Test: `tests/unit/packages/channel-discord/discord-commands.test.ts` + `discord-provider.test.ts` update
+
+**Interfaces:**
+- Consumes: `discord.js` `REST` v10, `Routes.applicationCommands`, `Routes.applicationGuildCommands`
+- Produces: `registerDiscordCommands({token, applicationId, guildId?, commands})`, `buildXacpxSlashCommands(): Array<{name, description, options}>`
+
+**Context:** Text commands require users to know `/ss`, `/use`, etc. Discord native autocomplete comes from registered Application Commands. Design doc v1 deliberately left them out, but user feedback demands them. Scope here is global commands for the core xacpx surface: `help`, `ss`, `use`, `cancel`, `status`, `sessions` etc mapped from `src/commands/parse-command.ts:77-400`.
+
+- [ ] **Step 1: Write failing test — command builder emits expected names**
+
+```ts
+// tests/unit/packages/channel-discord/discord-commands.test.ts
+import { buildXacpxSlashCommands } from "../../packages/channel-discord/src/discord-commands";
+import { expect, test } from "bun:test";
+test("builds xacpx slash commands matching core aliases", () => {
+  const cmds = buildXacpxSlashCommands();
+  const names = cmds.map(c=>c.name);
+  expect(names).toContain("help");
+  expect(names).toContain("ss");
+  expect(names).toContain("use");
+  expect(names).toContain("cancel");
+  expect(names).toContain("status");
+  expect(cmds.find(c=>c.name==="ss")!.description).toMatch(/session/i);
+});
+```
+
+Run: `bun test tests/unit/packages/channel-discord/discord-commands.test.ts -v` Expect FAIL (module missing)
+
+- [ ] **Step 2: Implement `discord-commands.ts`**
+
+```ts
+// packages/channel-discord/src/discord-commands.ts
+export interface DiscordSlashCommand { name: string; description: string; options?: unknown[]; }
+export function buildXacpxSlashCommands(): DiscordSlashCommand[] {
+  return [
+    { name: "help", description: "Show xacpx help" },
+    { name: "ss", description: "Session shortcut: /ss <agent> -d <path> (creates or reuses session)", options: [
+      { name:"agent", type:3, description:"agent id", required:true },
+      { name:"workspace", type:3, description:"workspace path or name" },
+      { name:"new", type:5, description:"force new session" },
+    ]},
+    { name:"use", description:"Switch to session" },
+    { name:"cancel", description:"Cancel current or named session" },
+    { name:"status", description:"Show current session status" },
+    { name:"sessions", description:"List sessions" },
+  ];
+}
+export async function registerDiscordCommands(opts:{token:string; applicationId:string; guildId?:string; commands:DiscordSlashCommand[]}): Promise<void> {
+  const { REST } = await import("discord.js");
+  const rest = new REST({version:"10"}).setToken(opts.token);
+  const { Routes } = await import("discord.js");
+  const route = opts.guildId ? Routes.applicationGuildCommands(opts.applicationId, opts.guildId) : Routes.applicationCommands(opts.applicationId);
+  await rest.put(route, { body: opts.commands });
+}
+```
+
+Keep import lazy to avoid hard dep in tests; mock `REST` via `deps` injection for tests.
+
+- [ ] **Step 3: Integrate registration in `channel.ts:startAccount`**
+
+After `identity` is validated, if `account.applicationId` and `runtime.account.enableAutocomplete !== false`, call `registerDiscordCommands` (best-effort, log `discord.commands.register_failed` on error but do not fail account start). Add `enableAutocomplete` boolean to `DiscordResolvedAccountConfig` with default `true` when `applicationId` present.
+
+Also add `client.on("interactionCreate", ...)` mapping: if interaction is chat-input command, build `requestText` like `/<name> <args>` and feed through `handleMessageEvent` path or directly into `executor.run` with a synthetic `DiscordInboundMessage` that carries `isInteraction=true`. Simplest: in `DiscordJsClient.start` add:
+
+```ts
+client.on("interactionCreate", async (interaction: any) => {
+  if (!interaction.isChatInputCommand?.()) return;
+  const text = `/${interaction.commandName} ${interaction.options?.data?.map((o:any)=> o.value).join(" ") ?? ""}`.trim();
+  const inbound = mapInteractionToInbound(interaction, accountId); // reuse inbound.ts helpers
+  input.handlers.onMessage(inbound);
+  // acknowledge quickly to avoid 3s timeout
+  try { await interaction.deferReply(); } catch {}
+});
+```
+
+For test seam, expose `createDiscordCommandsRegistrar` via `deps`.
+
+- [ ] **Step 4: Config & provider updates**
+
+`config.ts`: add `enableAutocomplete?: boolean` to `DiscordAccountConfig`/`Resolved`, parse via `booleanOptional`, default `true` when `applicationId` provided else `false`. `parseDiscordChannelConfig` should not throw if `applicationId` missing — autocomplete simply disabled. Add `autocompleteTuning` if needed.
+
+`discord-provider.ts:parseAddArgs`: add `--application-id` already exists, add `--autocomplete` boolean flag.
+
+- [ ] **Step 5: Tests pass**
+
+`bun test tests/unit/packages/channel-discord/discord-commands.test.ts tests/unit/packages/channel-discord/discord-provider.test.ts tests/unit/packages/channel-discord/discord-inbound.test.ts -v`
+`npx tsc --noEmit`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/channel-discord/src/discord-commands.ts packages/channel-discord/src/discord-client.ts packages/channel-discord/src/channel.ts packages/channel-discord/src/config.ts tests/unit/packages/channel-discord/discord-commands.test.ts
+git commit -m "feat(channel-discord): register Discord Application Commands for autocomplete"
+```
+
+---
+
+### Task 4: Docs, i18n and config polish
+
+**Files:**
+- Modify: `packages/channel-discord/README.md` (add autocomplete section)
+- Modify: `packages/channel-discord/src/i18n/*.ts` (add `autocomplete*` keys)
+- Modify: `docs/superpowers/specs/2026-08-28-discord-channel-plugin-design-from-hy4.md` (add F9)
+- Test: `tests/unit/packages/channel-discord/no-hardcoded-cjk.test.ts` must still pass
+
+**Interfaces:**
+- Consumes: tasks 1-3
+- Produces: user-visible docs matching runtime behavior
+
+- [ ] **Step 1: Update README — explain text vs native slash**
+
+Add subsection `### Slash command autocomplete` after `### Reply modes`:
+
+```
+Discord v1 uses text commands via `@bot /ss …` (like Feishu). When `options.applicationId` is set, the plugin also registers native Application Commands (`/help`, `/ss`, `/use`, `/cancel`, `/status`, `/sessions`) so typing `/` shows autocomplete. Registration is best-effort at Gateway start; failures log `discord.commands.register_failed` and do not prevent message delivery. Without `applicationId`, only text commands work.
+```
+
+Update `Commands` CLI example to include `--autocomplete true|false`.
+
+- [ ] **Step 2: i18n — add `providerAutocompleteDisabled` etc.** Mirror `feishu` style, keep `setChannelLocale` contract.
+
+- [ ] **Step 3: Run `bun test tests/unit/packages/channel-discord/no-hardcoded-cjk.test.ts -v` and `npx tsc --noEmit`**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/channel-discord/README.md packages/channel-discord/src/i18n/* docs/superpowers/specs/*
+git commit -m "docs(channel-discord): document streaming preview and application-commands autocomplete"
+```
+
+---
+
+## Verification Gates (run by coordinator, not dispatch)
+
+- `npx tsc --noEmit` clean
+- `bun test tests/unit/packages/channel-discord -v` all green (9 suites)
+- `bunx publint --pack packages/channel-discord` (from skill lane)
+- Manual dry-run: `bun run dry-run --chat-key discord:default:g:chan1 -- "/ss omp -ws xacpx" "hi"` shows `🚀 Starting` within one throttle tick and final merged text
+```
+

--- a/packages/channel-discord/README.md
+++ b/packages/channel-discord/README.md
@@ -207,6 +207,18 @@ Top-level `options` are the defaults; `options.accounts.<id>` overrides per acco
 
 Preview editing stops once accumulated text exceeds 2000 chars (Discord hard limit); the final chunked send still delivers the full answer. Preview create/edit failures degrade silently to `static`.
 
+Session startup now shows progress within one throttle window: the first `🚀 Starting <agent>…` ping and subsequent `ℹ️` acpx notes are streamed into the preview (with typing indicator and ack reaction when enabled). The final answer merges streamed progress with the router result, so `/ss` creation confirmations are no longer swallowed. Tool calls and thought chunks are also streamed into the preview for long turns (parity with Feishu streaming cards, without the card UI).
+
+### Slash-command autocomplete (Discord Application Commands)
+
+When `options.applicationId` is set, the plugin registers Discord Application Commands on Gateway start for autocomplete when you type `/` in Discord. Commands registered:
+
+- `/help`, `/ss` (with `agent`, `workspace`, `new` options), `/use`, `/cancel`, `/status`, `/sessions`
+
+They map to the same text-command router (`@bot /ss …` still works), but native `/` shows hints. Registration is best-effort at `account.start()`; failures log `discord.commands.register_failed` and do not block the Gateway session. Toggle with `options.enableAutocomplete` (defaults to `true` when `applicationId` is present, `false` otherwise). Use `--autocomplete true|false` with `xacpx channel add`.
+
+Interaction handling: Discord sends chat-input interactions for native picks; the plugin replies ephemerally with `⏳ Processing …` and then handles the reconstructed `/<name> …` text through the normal message pipeline, delivering the final answer as a channel message (with thread fallback and chunking). No additional permissions beyond the message flow are required.
+
 ### Tables
 
 Discord does not render GFM tables. `tableMode` controls the fallback:

--- a/packages/channel-discord/src/channel.ts
+++ b/packages/channel-discord/src/channel.ts
@@ -11,6 +11,7 @@ import type {
   ConsumerLock,
   ConsumerLockOptions,
   ConsumerLockMetadata,
+  ToolUseEvent,
 } from "xacpx/plugin-api";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
@@ -43,6 +44,7 @@ import { chunkDiscordText } from "./chunk.js";
 import { renderDiscordMarkdown } from "./markdown.js";
 import { createDiscordPreviewStream, type DiscordPreviewStream } from "./preview-stream.js";
 import { sendWithThreadFallback } from "./outbound.js";
+import { buildXacpxSlashCommands, registerDiscordCommands } from "./discord-commands.js";
 type OrchestrationTaskRecord = Parameters<MessageChannelRuntime["notifyTaskCompletion"]>[0];
 
 const ACCOUNT_IDENTIFY_STAGGER_MS = 5500;
@@ -330,7 +332,6 @@ export class DiscordChannel implements MessageChannelRuntime {
       });
       throw error;
     }
-
     if (!identity.botUserId) {
       try {
         await client.destroy();
@@ -339,6 +340,25 @@ export class DiscordChannel implements MessageChannelRuntime {
         accountId: account.accountId,
       });
       throw new Error(`discord account "${account.accountId}" became ready without a bot identity`);
+    }
+
+    if (account.enableAutocomplete && account.applicationId) {
+      try {
+        await registerDiscordCommands({
+          token: account.token,
+          applicationId: account.applicationId,
+          commands: buildXacpxSlashCommands(),
+        });
+        await input.logger.info("discord.commands.registered", "registered discord application commands", {
+          accountId: account.accountId,
+          count: buildXacpxSlashCommands().length,
+        });
+      } catch (error) {
+        await input.logger.warn("discord.commands.register_failed", "failed to register discord application commands", {
+          accountId: account.accountId,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     this.accounts.set(account.accountId, {
@@ -960,7 +980,7 @@ export class DiscordChannel implements MessageChannelRuntime {
           target,
           maxChars: 2000,
           throttleMs: runtime.account.previewThrottleMs,
-          minInitialChars: runtime.account.minInitialChars,
+          minInitialChars: 1,
           onWarn: (msg) => {
             void this.logger?.warn("discord.preview.warn", msg, { accountId, channelId });
           },
@@ -982,6 +1002,19 @@ export class DiscordChannel implements MessageChannelRuntime {
         accumulated += delta;
         active.previewStream?.update(accumulated);
       };
+      const onToolEvent = async (event: ToolUseEvent): Promise<void> => {
+        if (active.suppressed) return;
+        const title = (event.title ?? event.kind ?? "tool").trim() || "tool";
+        const emoji = "🔧";
+        const line = `${emoji} ${title}`;
+        accumulated += (accumulated ? "\n" : "") + line;
+        active.previewStream?.update(accumulated);
+      };
+      const onThought = async (chunk: string): Promise<void> => {
+        if (active.suppressed || !chunk) return;
+        accumulated += chunk;
+        active.previewStream?.update(accumulated);
+      };
 
       try {
         const response = await this.agent.chat({
@@ -998,6 +1031,8 @@ export class DiscordChannel implements MessageChannelRuntime {
             ...(boundAlias ? { boundSessionAlias: boundAlias } : {}),
           },
           reply: safeReply,
+          onToolEvent,
+          onThought,
           abortSignal: abortController.signal,
         });
         if (active.suppressed) return;
@@ -1016,7 +1051,7 @@ export class DiscordChannel implements MessageChannelRuntime {
           active.previewStream = null;
         }
 
-        const finalText = accumulated || response.text || "";
+        const finalText = [accumulated.trim(), (response.text ?? "").trim()].filter(Boolean).join("\n\n") || response.text || accumulated;
         await this.deliverFinalResponse({
           runtime,
           target,

--- a/packages/channel-discord/src/channel.ts
+++ b/packages/channel-discord/src/channel.ts
@@ -1051,7 +1051,14 @@ export class DiscordChannel implements MessageChannelRuntime {
           active.previewStream = null;
         }
 
-        const finalText = [accumulated.trim(), (response.text ?? "").trim()].filter(Boolean).join("\n\n") || response.text || accumulated;
+        const trimmedAcc = accumulated.trim();
+        const trimmedResp = (response.text ?? "").trim();
+        let finalText: string;
+        if (!trimmedAcc) finalText = trimmedResp;
+        else if (!trimmedResp) finalText = trimmedAcc;
+        else if (trimmedAcc.includes(trimmedResp)) finalText = trimmedAcc;
+        else finalText = `${trimmedAcc}\n\n${trimmedResp}`;
+        if (!finalText) finalText = response.text ?? accumulated;
         await this.deliverFinalResponse({
           runtime,
           target,

--- a/packages/channel-discord/src/config.ts
+++ b/packages/channel-discord/src/config.ts
@@ -30,6 +30,7 @@ export interface DiscordAccountConfig {
   enabled?: boolean;
   token?: string;
   applicationId?: string;
+  enableAutocomplete?: boolean;
   replyMode?: DiscordReplyMode;
   tableMode?: DiscordTableMode;
   maxLinesPerMessage?: number;
@@ -59,7 +60,6 @@ export interface DiscordResolvedMediaConfig {
   maxBytes: number;
   maxAttachments: number;
 }
-
 export interface DiscordResolvedAccountConfig {
   accountId: string;
   name?: string;
@@ -67,6 +67,7 @@ export interface DiscordResolvedAccountConfig {
   configured: boolean;
   token: string;
   applicationId: string;
+  enableAutocomplete: boolean;
   replyMode: DiscordReplyMode;
   tableMode: DiscordTableMode;
   maxLinesPerMessage: number;
@@ -100,7 +101,7 @@ const DEFAULT_REPLY_MODE: DiscordReplyMode = "auto";
 const DEFAULT_TABLE_MODE: DiscordTableMode = "code";
 const DEFAULT_MAX_LINES_PER_MESSAGE = 17;
 const DEFAULT_PREVIEW_THROTTLE_MS = 1200;
-const DEFAULT_MIN_INITIAL_CHARS = 200;
+const DEFAULT_MIN_INITIAL_CHARS = 20;
 const DEFAULT_TYPING_INDICATOR = true;
 const DEFAULT_ACK_REACTION: string | null = null;
 const DEFAULT_REQUIRE_MENTION = true;
@@ -254,6 +255,8 @@ function resolveAccount(
   const enabled = booleanOptional(merged.enabled, `${path}.enabled`) ?? true;
   const token = stringOptional(merged.token, `${path}.token`);
   const applicationId = stringOptional(merged.applicationId, `${path}.applicationId`) ?? "";
+  const enableAutocompleteRaw = booleanOptional(merged.enableAutocomplete, `${path}.enableAutocomplete`);
+  const enableAutocomplete = enableAutocompleteRaw ?? Boolean(applicationId);
   const configured = Boolean(token && token.length > 0);
   const replyMode = enumValue<DiscordReplyMode>(merged.replyMode, `${path}.replyMode`, ["static", "streaming", "auto"], DEFAULT_REPLY_MODE);
   const tableMode = enumValue<DiscordTableMode>(merged.tableMode, `${path}.tableMode`, ["code", "bullets", "off"], DEFAULT_TABLE_MODE);
@@ -282,6 +285,7 @@ function resolveAccount(
     configured,
     token: token ?? "",
     applicationId,
+    enableAutocomplete,
     replyMode,
     tableMode,
     maxLinesPerMessage,

--- a/packages/channel-discord/src/discord-client.ts
+++ b/packages/channel-discord/src/discord-client.ts
@@ -82,6 +82,49 @@ class DiscordJsClient implements DiscordClientLike {
       if (inbound) input.handlers.onMessage(inbound);
     });
 
+    client.on("interactionCreate", (interaction: unknown) => {
+      const anyI = interaction as {
+        isChatInputCommand?: () => boolean;
+        commandName?: string;
+        options?: { data?: Array<{ value?: unknown }> };
+        channelId?: string;
+        channel?: { id?: string };
+        guildId?: string | null;
+        user?: { id?: string };
+        member?: { user?: { id?: string }; roles?: { cache?: Map<string, unknown> } };
+        id?: string;
+        replied?: boolean;
+        deferred?: boolean;
+        reply?: (opts: unknown) => Promise<void>;
+      };
+      if (!anyI?.isChatInputCommand?.() || !anyI.commandName) return;
+      const channelId = anyI.channelId ?? anyI.channel?.id;
+      if (!channelId) return;
+      const rawValues = anyI.options?.data?.map((o) => String(o.value ?? "")).filter((s) => s.length > 0) ?? [];
+      const text = `/${anyI.commandName}${rawValues.length > 0 ? ` ${rawValues.join(" ")}` : ""}`.trim();
+      const synthetic: DiscordInboundMessage = {
+        id: anyI.id ?? `interaction-${Date.now()}`,
+        channelId,
+        guildId: anyI.guildId ?? null,
+        author: { id: anyI.user?.id ?? anyI.member?.user?.id ?? "unknown", bot: false },
+        content: text,
+        cleanContent: text,
+        createdTimestamp: Date.now(),
+        mentions: { users: [] },
+        attachments: [],
+        senderRoleIds: anyI.member?.roles?.cache ? [...anyI.member.roles.cache.keys()] : undefined,
+      };
+      void (async () => {
+        try {
+          if (!anyI.replied && !anyI.deferred && anyI.reply) {
+            await anyI.reply({ content: `⏳ Processing \`${text}\` …`, ephemeral: true });
+          }
+        } catch {
+          // ignore interaction ack failures
+        }
+        input.handlers.onMessage(synthetic);
+      })();
+    });
     if (input.abortSignal.aborted) {
       client.destroy();
       this.client = null;

--- a/packages/channel-discord/src/discord-client.ts
+++ b/packages/channel-discord/src/discord-client.ts
@@ -102,22 +102,23 @@ class DiscordJsClient implements DiscordClientLike {
       if (!channelId) return;
       const rawValues = anyI.options?.data?.map((o) => String(o.value ?? "")).filter((s) => s.length > 0) ?? [];
       const text = `/${anyI.commandName}${rawValues.length > 0 ? ` ${rawValues.join(" ")}` : ""}`.trim();
+      const botUserId = (client as unknown as { user?: { id?: string } | null })?.user?.id ?? "";
       const synthetic: DiscordInboundMessage = {
         id: anyI.id ?? `interaction-${Date.now()}`,
         channelId,
         guildId: anyI.guildId ?? null,
         author: { id: anyI.user?.id ?? anyI.member?.user?.id ?? "unknown", bot: false },
-        content: text,
+        content: botUserId ? `<@${botUserId}> ${text}` : text,
         cleanContent: text,
         createdTimestamp: Date.now(),
-        mentions: { users: [] },
+        mentions: botUserId ? { users: [{ id: botUserId }] } : { users: [] },
         attachments: [],
         senderRoleIds: anyI.member?.roles?.cache ? [...anyI.member.roles.cache.keys()] : undefined,
       };
       void (async () => {
         try {
           if (!anyI.replied && !anyI.deferred && anyI.reply) {
-            await anyI.reply({ content: `⏳ Processing \`${text}\` …`, ephemeral: true });
+            await anyI.reply({ content: `⏳ Processing \`${text}\` …`, ephemeral: true, allowedMentions: { parse: [] } });
           }
         } catch {
           // ignore interaction ack failures

--- a/packages/channel-discord/src/discord-commands.ts
+++ b/packages/channel-discord/src/discord-commands.ts
@@ -41,7 +41,6 @@ export interface RegisterDiscordCommandsOptions {
   applicationId: string;
   guildId?: string;
   commands: DiscordSlashCommand[];
-  fetchImpl?: typeof fetch;
   restImpl?: unknown;
 }
 

--- a/packages/channel-discord/src/discord-commands.ts
+++ b/packages/channel-discord/src/discord-commands.ts
@@ -1,0 +1,74 @@
+export interface DiscordSlashCommandOption {
+  name: string;
+  description: string;
+  type: number;
+  required?: boolean;
+  choices?: Array<{ name: string; value: string }>;
+}
+
+export interface DiscordSlashCommand {
+  name: string;
+  description: string;
+  options?: DiscordSlashCommandOption[];
+}
+
+/**
+ * Build the xacpx slash command catalog that is registered as Discord
+ * Application Commands for autocomplete. Names mirror `src/commands/parse-command.ts`
+ * aliases so Discord's `/` hints directly map to the text-command router.
+ */
+export function buildXacpxSlashCommands(): DiscordSlashCommand[] {
+  return [
+    { name: "help", description: "Show xacpx help and available commands" },
+    {
+      name: "ss",
+      description: "Session shortcut: create or reuse a session",
+      options: [
+        { name: "agent", description: "agent id (e.g. codex, claude)", type: 3, required: true },
+        { name: "workspace", description: "workspace path or name", type: 3 },
+        { name: "new", description: "force new session even if one exists", type: 5 },
+      ],
+    },
+    { name: "use", description: "Switch to a session", options: [{ name: "alias", description: "session alias", type: 3, required: true }] },
+    { name: "cancel", description: "Cancel current or named session", options: [{ name: "alias", description: "session alias to cancel", type: 3 }] },
+    { name: "status", description: "Show current session status" },
+    { name: "sessions", description: "List sessions" },
+  ];
+}
+
+export interface RegisterDiscordCommandsOptions {
+  token: string;
+  applicationId: string;
+  guildId?: string;
+  commands: DiscordSlashCommand[];
+  fetchImpl?: typeof fetch;
+  restImpl?: unknown;
+}
+
+/**
+ * Register the slash command catalog via Discord REST.
+ * Best-effort: callers log and swallow failures; a failed registration must not
+ * prevent the Gateway session from starting.
+ */
+export async function registerDiscordCommands(options: RegisterDiscordCommandsOptions): Promise<void> {
+  const { token, applicationId, guildId, commands } = options;
+  if (!token || !applicationId) throw new Error("registerDiscordCommands requires token and applicationId");
+  const restCtor = options.restImpl as new (opts: unknown) => { setToken: (t: string) => unknown };
+  let REST: new (opts: unknown) => { setToken: (t: string) => unknown; put: (route: string, opts: unknown) => Promise<unknown> };
+  let Routes: { applicationCommands: (appId: string) => string; applicationGuildCommands: (appId: string, guildId: string) => string };
+  if (restCtor) {
+    REST = restCtor as unknown as typeof REST;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Routes = (options as unknown as { Routes?: typeof Routes }).Routes ?? (await import("discord.js") as unknown as { Routes: typeof Routes }).Routes;
+  } else {
+    const discord = (await import("discord.js")) as unknown as {
+      REST: typeof REST;
+      Routes: typeof Routes;
+    };
+    REST = discord.REST;
+    Routes = discord.Routes;
+  }
+  const rest = new REST({ version: "10" }).setToken(token) as unknown as { put: (route: string, opts: unknown) => Promise<unknown> };
+  const route = guildId ? Routes.applicationGuildCommands(applicationId, guildId) : Routes.applicationCommands(applicationId);
+  await rest.put(route, { body: commands });
+}

--- a/packages/channel-discord/src/discord-provider.ts
+++ b/packages/channel-discord/src/discord-provider.ts
@@ -104,6 +104,15 @@ export const discordCliProvider: ChannelCliProvider = {
           index = value.nextIndex;
           break;
         }
+        case "--autocomplete": {
+          const value = takeFlagValue(args, index, arg);
+          if (!value.ok) return value;
+          const parsed = parseBooleanFlag(value.value, arg);
+          if (!parsed.ok) return parsed;
+          input.enableAutocomplete = parsed.value;
+          index = value.nextIndex;
+          break;
+        }
         default:
           return { ok: false, message: `unknown discord option: ${arg}` };
       }
@@ -120,6 +129,7 @@ export const discordCliProvider: ChannelCliProvider = {
       requireMention: typeof input.requireMention === "boolean" ? input.requireMention : true,
       dmPolicy: stringField(input, "dmPolicy") ?? "allowlist",
       guildPolicy: stringField(input, "guildPolicy") ?? "allowlist",
+      enableAutocomplete: typeof input.enableAutocomplete === "boolean" ? input.enableAutocomplete : undefined,
       dedupTtlMs: 24 * 60 * 60 * 1000,
       dedupMaxEntries: 10000,
       inboundExpiryMs: 5 * 60 * 1000,
@@ -306,6 +316,7 @@ export const discordCliProvider: ChannelCliProvider = {
     if (dmPolicy) override.dmPolicy = dmPolicy;
     const guildPolicy = stringField(input, "guildPolicy");
     if (guildPolicy) override.guildPolicy = guildPolicy;
+    if (typeof input.enableAutocomplete === "boolean") override.enableAutocomplete = input.enableAutocomplete;
     return override;
   },
 
@@ -335,6 +346,8 @@ export const discordCliProvider: ChannelCliProvider = {
     lines.push(`requireMention: ${String(requireMention)}`);
     lines.push(`dmPolicy: ${String(dmPolicy)}`);
     lines.push(`guildPolicy: ${String(guildPolicy)}`);
+    const enableAutocomplete = acc.enableAutocomplete ?? options.enableAutocomplete ?? (applicationId ? true : false);
+    lines.push(`enableAutocomplete: ${String(enableAutocomplete)}`);
     return lines;
   },
 };

--- a/packages/channel-discord/src/preview-stream.ts
+++ b/packages/channel-discord/src/preview-stream.ts
@@ -19,7 +19,7 @@ export interface DiscordPreviewStream {
 export function createDiscordPreviewStream(options: DiscordPreviewStreamOptions): DiscordPreviewStream {
   const maxChars = options.maxChars ?? 2000;
   const throttleMs = Math.max(250, options.throttleMs ?? 1200);
-  const minInitialChars = options.minInitialChars ?? 200;
+  const minInitialChars = options.minInitialChars ?? 20;
   const client = options.client;
   const target = options.target;
 

--- a/packages/channel-discord/src/tuning.ts
+++ b/packages/channel-discord/src/tuning.ts
@@ -13,7 +13,7 @@ export interface DiscordTuning {
 
 export const DEFAULT_DISCORD_TUNING: DiscordTuning = {
   previewThrottleMs: 1200,
-  minInitialChars: 200,
+  minInitialChars: 20,
   previewMaxChars: 2000,
 };
 

--- a/tests/unit/packages/channel-discord/discord-commands.test.ts
+++ b/tests/unit/packages/channel-discord/discord-commands.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { buildXacpxSlashCommands } from "../../../../packages/channel-discord/src/discord-commands";
+
+test("builds xacpx slash commands matching core aliases", () => {
+  const cmds = buildXacpxSlashCommands();
+  const names = cmds.map((c) => c.name);
+  expect(names).toContain("help");
+  expect(names).toContain("ss");
+  expect(names).toContain("use");
+  expect(names).toContain("cancel");
+  expect(names).toContain("status");
+  expect(names).toContain("sessions");
+  const ss = cmds.find((c) => c.name === "ss")!;
+  expect(ss.description.toLowerCase()).toContain("session");
+  expect(ss.options?.some((o) => o.name === "agent")).toBe(true);
+});
+
+test("each command has name and description", () => {
+  const cmds = buildXacpxSlashCommands();
+  for (const cmd of cmds) {
+    expect(cmd.name.length).toBeGreaterThan(0);
+    expect(cmd.description.length).toBeGreaterThan(0);
+    expect(cmd.name).toMatch(/^[a-z0-9_-]+$/);
+  }
+});

--- a/tests/unit/packages/channel-discord/discord-preview-stream.test.ts
+++ b/tests/unit/packages/channel-discord/discord-preview-stream.test.ts
@@ -181,3 +181,33 @@ test("preview pending during create is flushed after create", async () => {
   expect(editedContents.length).toBe(1);
   expect(editedContents[0]).toBe("hello world pending");
 });
+test("short progress like '🚀 Starting' with minInitialChars=1 creates promptly", async () => {
+  vi.useFakeTimers();
+  const { client, sent } = createFakeClient();
+  const preview = createDiscordPreviewStream({ client, target, throttleMs: 300, minInitialChars: 1 });
+  preview.update("🚀 Starting omp…");
+  vi.advanceTimersByTime(400);
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(sent.length).toBe(1);
+  expect(sent[0]!.content).toBe("🚀 Starting omp…");
+  vi.useRealTimers();
+});
+
+test("channel streaming default should be responsive with minInitialChars 20 but accumulated grows", async () => {
+  vi.useFakeTimers();
+  const { client, sent, edited } = createFakeClient();
+  const preview = createDiscordPreviewStream({ client, target, throttleMs: 300, minInitialChars: 20 });
+  preview.update("🚀 Starting omp…");
+  vi.advanceTimersByTime(400);
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(sent.length).toBe(0);
+  preview.update("🚀 Starting omp…\n\nℹ️ [acpx] agent advertised auth methods [agent] but no matching credentials found — skipping (waited 4s)");
+  vi.advanceTimersByTime(400);
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(sent.length).toBe(1);
+  expect(sent[0]!.content).toContain("ℹ️");
+  vi.useRealTimers();
+});


### PR DESCRIPTION
Fixes Discord UX gap vs Feishu:\n\n- **Streaming preview**: tuning/config default `minInitialChars` 200→20, channel preview uses `1` so `🚀 Starting` appears within one throttle window (<1.2s) instead of being starved 4s; preview still throttled 1200ms and respects 2000 char limit (F2)\n- **Final text merging**: `accumulated || response.text` → merge, so `/ss` progress pings no longer swallow 'Session created' confirmation\n- **Tool/thought streaming**: forward `onToolEvent/onThought` into preview accumulated → long turns show 🔧 tool lines\n- **Autocomplete**: register Discord Application Commands (`/help,/ss,/use,/cancel,/status,/sessions`) when `applicationId` present; `enableAutocomplete` toggle (default true when appId set) + `--autocomplete` flag; `interactionCreate` handled as synthetic text with ephemeral ack\n- **Docs**: README documents new streaming and autocomplete behavior\n\nVerification: `npx tsc --noEmit` PASS, `bun test tests/unit/packages/channel-discord` 103 PASS, new tests for preview short progress and command builder\n\nPlan: docs/superpowers/plans/2026-09-01-discord-streaming-autocomplete.md\n\nPending: discord插件审查员 review will update this PR