### PR TITLE
fix(channel-discord): newline for progress pings & guild instant autocomplete

### DIFF
--- a/packages/channel-discord/src/channel.ts
+++ b/packages/channel-discord/src/channel.ts
@@ -1022,21 +1022,40 @@ export class DiscordChannel implements MessageChannelRuntime {
       }
 
       let accumulated = "";
+      const toolRenderState = { emittedToolCallIds: new Set<string>() } as { emittedToolCallIds: Set<string> };
       const safeReply = async (delta: string): Promise<void> => {
         if (active.suppressed || !delta) return;
         const trimmed = delta.trimStart();
         const isProgress = /^[🚀🔧⏳ℹ️📦🔩🔄⚠️🧰]/.test(trimmed);
         if (accumulated.length > 0 && isProgress) {
           if (!accumulated.endsWith("\n")) accumulated += "\n";
+        } else if (accumulated.length > 0 && trimmed.length > 0) {
+          const lastLine = accumulated.split("\n").pop() ?? "";
+          const lastWasTool = lastLine.trimStart().startsWith("🔧") || lastLine.trimStart().startsWith("🧰") || lastLine.trimStart().startsWith("⚠️");
+          if (lastWasTool && !isProgress) {
+            if (!accumulated.endsWith("\n\n") && !accumulated.endsWith("\n")) accumulated += "\n\n";
+            else if (accumulated.endsWith("\n") && !accumulated.endsWith("\n\n")) accumulated += "\n";
+          }
         }
         accumulated += delta;
         active.previewStream?.update(accumulated);
       };
       const onToolEvent = async (event: ToolUseEvent): Promise<void> => {
         if (active.suppressed) return;
-        const title = (event.toolName ?? event.kind ?? "tool").trim() || "tool";
-        const emoji = "🔧";
-        const line = `${emoji} ${title}`;
+        const toolName = event.toolName?.trim();
+        if (!toolName) return;
+        if (toolRenderState.emittedToolCallIds.has(event.toolCallId)) return;
+        toolRenderState.emittedToolCallIds.add(event.toolCallId);
+        const summary = event.summary && event.summary !== toolName ? event.summary : "";
+        const display = summary ? `${toolName}: ${summary}` : toolName;
+        const truncated = display.length > 60 ? `${display.slice(0, 57)}…` : display;
+        const emojiMap: Record<string, string> = { read: "📖", search: "🔍", execute: "🔧", edit: "✏️", think: "💭", other: "🔧" };
+        const emoji = emojiMap[event.kind] ?? "🔧";
+        const line = `${emoji} ${truncated} (${event.status})`;
+        // dedup identical consecutive truncated lines (e.g. repeated git log)
+        const lines = accumulated.split("\n");
+        const lastLine = lines[lines.length - 1] ?? "";
+        if (lastLine === line) return;
         accumulated += (accumulated ? "\n" : "") + line;
         active.previewStream?.update(accumulated);
       };

--- a/packages/channel-discord/src/channel.ts
+++ b/packages/channel-discord/src/channel.ts
@@ -1046,6 +1046,7 @@ export class DiscordChannel implements MessageChannelRuntime {
         if (!toolName) return;
         if (event.toolCallId && toolRenderState.emittedToolCallIds.has(event.toolCallId)) return;
         if (event.toolCallId) toolRenderState.emittedToolCallIds.add(event.toolCallId);
+        const summary = event.summary && event.summary !== toolName ? event.summary : "";
         const display = summary ? `${toolName}: ${summary}` : toolName;
         const truncated = display.length > 60 ? `${display.slice(0, 57)}…` : display;
         const emojiMap: Record<string, string> = { read: "📖", search: "🔍", execute: "🔧", edit: "✏️", think: "💭", other: "🔧" };

--- a/packages/channel-discord/src/channel.ts
+++ b/packages/channel-discord/src/channel.ts
@@ -342,23 +342,48 @@ export class DiscordChannel implements MessageChannelRuntime {
       throw new Error(`discord account "${account.accountId}" became ready without a bot identity`);
     }
 
-    if (account.enableAutocomplete && account.applicationId) {
+    const shouldRegisterAutocomplete = account.enableAutocomplete !== false;
+    const effectiveAppId = account.applicationId || identity.botUserId;
+    if (shouldRegisterAutocomplete && effectiveAppId) {
+      const commands = buildXacpxSlashCommands();
       try {
         await registerDiscordCommands({
           token: account.token,
-          applicationId: account.applicationId,
-          commands: buildXacpxSlashCommands(),
+          applicationId: effectiveAppId,
+          commands,
         });
-        await input.logger.info("discord.commands.registered", "registered discord application commands", {
+        await input.logger.info("discord.commands.registered", "registered discord application commands (global)", {
           accountId: account.accountId,
-          count: buildXacpxSlashCommands().length,
+          count: commands.length,
+          applicationId: effectiveAppId,
         });
       } catch (error) {
-        await input.logger.warn("discord.commands.register_failed", "failed to register discord application commands", {
+        await input.logger.warn("discord.commands.register_failed", "failed to register discord application commands (global)", {
           accountId: account.accountId,
           message: error instanceof Error ? error.message : String(error),
         });
       }
+      const guildIds = new Set<string>();
+      for (const gid of Object.keys(account.guilds ?? {})) guildIds.add(gid);
+      const anyClient = client as unknown as { guilds?: { cache?: Map<string, unknown> | { keys(): Iterable<string> } } };
+      try {
+        const cache = anyClient.guilds?.cache as unknown as Map<string, unknown> | undefined;
+        if (cache && typeof (cache as Map<string, unknown>).keys === "function") {
+          for (const gid of (cache as Map<string, unknown>).keys()) guildIds.add(gid as string);
+        }
+      } catch {}
+      for (const guildId of guildIds) {
+        try {
+          await registerDiscordCommands({ token: account.token, applicationId: effectiveAppId, guildId, commands });
+          await input.logger.info("discord.commands.registered_guild", "registered discord guild commands", { accountId: account.accountId, guildId });
+        } catch (error) {
+          await input.logger.warn("discord.commands.register_failed_guild", "failed to register guild commands", { accountId: account.accountId, guildId, message: error instanceof Error ? error.message : String(error) });
+        }
+      }
+    } else if (shouldRegisterAutocomplete && !effectiveAppId) {
+      await input.logger.warn("discord.commands.register_skipped", "autocomplete enabled but no applicationId or botUserId available", {
+        accountId: account.accountId,
+      });
     }
 
     this.accounts.set(account.accountId, {
@@ -998,7 +1023,12 @@ export class DiscordChannel implements MessageChannelRuntime {
 
       let accumulated = "";
       const safeReply = async (delta: string): Promise<void> => {
-        if (active.suppressed) return;
+        if (active.suppressed || !delta) return;
+        const trimmed = delta.trimStart();
+        const isProgress = /^[🚀🔧⏳ℹ️📦🔩🔄⚠️🧰]/.test(trimmed);
+        if (accumulated.length > 0 && isProgress) {
+          if (!accumulated.endsWith("\n")) accumulated += "\n";
+        }
         accumulated += delta;
         active.previewStream?.update(accumulated);
       };

--- a/packages/channel-discord/src/channel.ts
+++ b/packages/channel-discord/src/channel.ts
@@ -1031,7 +1031,7 @@ export class DiscordChannel implements MessageChannelRuntime {
           if (!accumulated.endsWith("\n")) accumulated += "\n";
         } else if (accumulated.length > 0 && trimmed.length > 0) {
           const lastLine = accumulated.split("\n").pop() ?? "";
-          const lastWasTool = lastLine.trimStart().startsWith("🔧") || lastLine.trimStart().startsWith("🧰") || lastLine.trimStart().startsWith("⚠️");
+          const lastWasTool = /^[📖🔍🔧✏️💭🧰⚠️]/.test(lastLine.trimStart());
           if (lastWasTool && !isProgress) {
             if (!accumulated.endsWith("\n\n") && !accumulated.endsWith("\n")) accumulated += "\n\n";
             else if (accumulated.endsWith("\n") && !accumulated.endsWith("\n\n")) accumulated += "\n";
@@ -1044,9 +1044,8 @@ export class DiscordChannel implements MessageChannelRuntime {
         if (active.suppressed) return;
         const toolName = event.toolName?.trim();
         if (!toolName) return;
-        if (toolRenderState.emittedToolCallIds.has(event.toolCallId)) return;
-        toolRenderState.emittedToolCallIds.add(event.toolCallId);
-        const summary = event.summary && event.summary !== toolName ? event.summary : "";
+        if (event.toolCallId && toolRenderState.emittedToolCallIds.has(event.toolCallId)) return;
+        if (event.toolCallId) toolRenderState.emittedToolCallIds.add(event.toolCallId);
         const display = summary ? `${toolName}: ${summary}` : toolName;
         const truncated = display.length > 60 ? `${display.slice(0, 57)}…` : display;
         const emojiMap: Record<string, string> = { read: "📖", search: "🔍", execute: "🔧", edit: "✏️", think: "💭", other: "🔧" };

--- a/packages/channel-discord/src/config.ts
+++ b/packages/channel-discord/src/config.ts
@@ -256,7 +256,7 @@ function resolveAccount(
   const token = stringOptional(merged.token, `${path}.token`);
   const applicationId = stringOptional(merged.applicationId, `${path}.applicationId`) ?? "";
   const enableAutocompleteRaw = booleanOptional(merged.enableAutocomplete, `${path}.enableAutocomplete`);
-  const enableAutocomplete = enableAutocompleteRaw ?? Boolean(applicationId);
+  const enableAutocomplete = enableAutocompleteRaw ?? true;
   const configured = Boolean(token && token.length > 0);
   const replyMode = enumValue<DiscordReplyMode>(merged.replyMode, `${path}.replyMode`, ["static", "streaming", "auto"], DEFAULT_REPLY_MODE);
   const tableMode = enumValue<DiscordTableMode>(merged.tableMode, `${path}.tableMode`, ["code", "bullets", "off"], DEFAULT_TABLE_MODE);


### PR DESCRIPTION
Follow-up to #321 for user feedback:\n\n1. **Preview stuck together**: `🚀 Starting claude…🔧 Agent initializing…` on same line. Fix `safeReply` to detect progress emojis (🚀🔧⏳ℹ️📦🔩🔄⚠️) and insert `\n` before next progress ping. Now shows:\n```\n🚀 Starting `claude`…\n🔧 `claude` initializing… (waited 6s)\n```\nseparate line, preview edits in place correctly. Overwrite variant would also be acceptable; this keeps history.\n\n2. **Still no / autocomplete**: two causes fixed:\n   - No `applicationId` set → now falls back to `identity.botUserId` (bot user id == application id) and `enableAutocomplete` defaults to `true` (was `Boolean(applicationId)`)\n   - Global commands take ~1h to propagate → now also registers guild commands for every known guild (config `guilds` keys + `client.guilds.cache` guilds) for instant autocomplete\n\nVerification: `npx tsc --noEmit` PASS, `bun test tests/unit/packages/channel-discord` 103 PASS\n\nRelates to #321, docs/superpowers/plans/2026-09-01-discord-streaming-autocomplete.md