### PR TITLE
fix(channel-discord): map /ss interaction options to flag syntax

### DIFF
--- a/packages/channel-discord/src/discord-client.ts
+++ b/packages/channel-discord/src/discord-client.ts
@@ -86,7 +86,7 @@ class DiscordJsClient implements DiscordClientLike {
       const anyI = interaction as {
         isChatInputCommand?: () => boolean;
         commandName?: string;
-        options?: { data?: Array<{ value?: unknown }> };
+        options?: { data?: Array<{ name?: string; value?: unknown }> };
         channelId?: string;
         channel?: { id?: string };
         guildId?: string | null;
@@ -100,8 +100,29 @@ class DiscordJsClient implements DiscordClientLike {
       if (!anyI?.isChatInputCommand?.() || !anyI.commandName) return;
       const channelId = anyI.channelId ?? anyI.channel?.id;
       if (!channelId) return;
-      const rawValues = anyI.options?.data?.map((o) => String(o.value ?? "")).filter((s) => s.length > 0) ?? [];
-      const text = `/${anyI.commandName}${rawValues.length > 0 ? ` ${rawValues.join(" ")}` : ""}`.trim();
+      const getOpt = (name: string): unknown => anyI.options?.data?.find((o) => o.name === name)?.value;
+      let text: string;
+      const cmd = anyI.commandName;
+      if (cmd === "ss") {
+        const agent = String(getOpt("agent") ?? "").trim();
+        const workspace = String(getOpt("workspace") ?? "").trim();
+        const isNew = Boolean(getOpt("new"));
+        if (!agent) {
+          text = "/ss";
+        } else {
+          text = isNew ? `/ss new ${agent}` : `/ss ${agent}`;
+          if (workspace) text += ` --ws ${workspace}`;
+        }
+      } else if (cmd === "use") {
+        const alias = String(getOpt("alias") ?? "").trim();
+        text = alias ? `/use ${alias}` : "/use";
+      } else if (cmd === "cancel") {
+        const alias = String(getOpt("alias") ?? "").trim();
+        text = alias ? `/cancel ${alias}` : "/cancel";
+      } else {
+        const rawValues = anyI.options?.data?.map((o) => String(o.value ?? "")).filter((s) => s.length > 0) ?? [];
+        text = `/${cmd}${rawValues.length > 0 ? ` ${rawValues.join(" ")}` : ""}`.trim();
+      }
       const botUserId = (client as unknown as { user?: { id?: string } | null })?.user?.id ?? "";
       const synthetic: DiscordInboundMessage = {
         id: anyI.id ?? `interaction-${Date.now()}`,


### PR DESCRIPTION
Follow-up to #322 for autocomplete Invalid command format.\n\n**问题**：注册的 `/ss` 定义为 `agent` (required) + `workspace` + `new`，Discord 以结构化 `options.data` 发送，旧合成 `rawValues.join(' ')` 生成 `/ss claude xacpx`，缺 `--ws` 前缀，导致 `parseCommand` 报 Invalid。\n\n**修复**：`discord-client.ts:interactionCreate` 按 name 取值，对 `ss` 特殊拼装 ` /ss [new] <agent> --ws <workspace>`，对 `use/cancel` 拼别名，其余回退通用 join；保留 ephemeral ack 的 `allowedMentions:{parse:[]}`。\n\n验证：`npx tsc --noEmit PASS`, `bun test 103 PASS`。\n截图中 `agent` 红框必填即 Discord 必选约束，填后即生成正确 flag 语法。