### PR TITLE
docs: add Discord install tab to homepage

### DIFF
--- a/packages/docs/.vitepress/theme/components/InstallCommand.vue
+++ b/packages/docs/.vitepress/theme/components/InstallCommand.vue
@@ -44,6 +44,16 @@ const tabs = computed<Tab[]>(() => [
       'xacpx channel add yuanbao',
     ],
   },
+  {
+    key: 'discord',
+    label: 'Discord',
+    note: zh.value ? '插件' : 'plugin',
+    lines: [
+      'npm i -g @ganglion/xacpx',
+      'xacpx plugin add @ganglion/xacpx-channel-discord',
+      'xacpx channel add discord',
+    ],
+  },
 ]);
 
 const active = ref('wechat');


### PR DESCRIPTION
## Summary

- add a Discord tab to the docs homepage install command component
- use the existing official install flow:
  - `npm i -g @ganglion/xacpx`
  - `xacpx plugin add @ganglion/xacpx-channel-discord`
  - `xacpx channel add discord`
- keep the existing localized `plugin` note behavior

## Scope

Docs-only change: `packages/docs/.vitepress/theme/components/InstallCommand.vue` (+10 lines).