### PR TITLE
fix(relay-web): slot live turns by hub insert order, not wall clocks

### DIFF
--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -269,6 +269,7 @@ interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reaso
 
 - `MessageStore.append(instanceId, alias, dir, text, structured?, attachments?, promptRequestId?, createdAt?, startedAt?, slotAfterId?, startedAfterSeq?)` 序列化写入；`listBySession` 反序列化后在 `MessageRecordDto` 中返回完整行（含可选 `startedAt` / `slotAfterId` / `startedAfterSeq`）。HTTP 列表在 `view=compact` 时由 `compactHistoryMessage` 投影后再发给看板——**不得丢弃** `slotAfterId`（live-slot 重排依赖 Hub 插入序，不能按 `createdAt` 完结时间或跨机器墙钟排序）；`startedAt` 仅作 HUD 遥测。`getById` 仍返回未经投影的原文。
 - Hub 在 `turn-started`（对账 inbound prompt 之后）把当时该 session 最后一条 `messages.id` 写入 `turn_slot_anchors`，并带到 accumulator / `out` 行。Hub 重启后 `finishedOffline` 与无 buffer 的 `turn-finished` 都从该锚点恢复，而不是用 `lastId`（会把中途到达的 card 当成触发卡）或 connector 墙钟。
+- 锚点按 **recovery 身份** 精确查找：非空 `recoveryId` 未命中时 **不得** 回落到该 session 的其它 leftover（过期/FIFO 逐出的 turn A 不能绑到后来的 turn B）。权威 `instance.state.sync` 成功后只保留 `turns ∪ finishedOffline` 中的锚点。无 `recoveryId` 的旧 connector 使用 per-session 专用 key，同一 instance 上 backend/frontend 互不覆盖。Session / instance 删除会清掉对应锚点。
 
 ## 阶段七：Hub 重启状态恢复（instance.state.sync + turn-finished.text）
 

--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -267,7 +267,7 @@ interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reaso
 
 `messages` 表含 `structured TEXT` 列（存 JSON 序列化的 `{ toolSteps, reasoning? }`），直接由建表 DDL 定义。
 
-- `MessageStore.append(instanceId, alias, dir, text, structured?)` 序列化写入；`listBySession` 反序列化后在 `MessageRecordDto.structured` 中返回完整行。HTTP 列表在 `view=compact` 时由 `compactHistoryMessage` 投影后再发给看板；`getById` 仍返回未经投影的原文。
+- `MessageStore.append(instanceId, alias, dir, text, structured?, attachments?, promptRequestId?, createdAt?, startedAt?)` 序列化写入；`listBySession` 反序列化后在 `MessageRecordDto` 中返回完整行（含可选 `startedAt`）。HTTP 列表在 `view=compact` 时由 `compactHistoryMessage` 投影后再发给看板——**不得丢弃** `startedAt`（live-slot 重排依赖它，不能只按 `createdAt` 完结时间排序）；`getById` 仍返回未经投影的原文。
 
 ## 阶段七：Hub 重启状态恢复（instance.state.sync + turn-finished.text）
 

--- a/docs/relay-module.md
+++ b/docs/relay-module.md
@@ -261,13 +261,14 @@ interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reaso
   其中 `structured = { toolSteps, reasoning? }`（仅当有步骤或 reasoning 时携带）；之后删除 accumulator。
 - 实例离线（`onStatusChange online=false`）→ 按前缀批量删除对应实例的所有 accumulator，防内存泄漏。
 
-所有事件先经 `webGateway.broadcast` 实时广播给 Web 客户端，再处理累积逻辑（广播与持久化并行，互不阻塞）。
+所有事件先经 `webGateway.broadcast` 实时广播给 Web 客户端，再处理累积逻辑（广播与持久化并行，互不阻塞）。`turn-started` 例外：先对账 inbound + 写入 `turn_slot_anchors`（`slotAfterId` = 当时最后一条 Hub `messages.id`），再广播带 `slotAfterId` 的事件，这样 live 与 history 共用插入序锚点。
 
 ### 数据库 `messages.structured` 列（packages/relay/src/db.ts）
 
 `messages` 表含 `structured TEXT` 列（存 JSON 序列化的 `{ toolSteps, reasoning? }`），直接由建表 DDL 定义。
 
-- `MessageStore.append(instanceId, alias, dir, text, structured?, attachments?, promptRequestId?, createdAt?, startedAt?)` 序列化写入；`listBySession` 反序列化后在 `MessageRecordDto` 中返回完整行（含可选 `startedAt`）。HTTP 列表在 `view=compact` 时由 `compactHistoryMessage` 投影后再发给看板——**不得丢弃** `startedAt`（live-slot 重排依赖它，不能只按 `createdAt` 完结时间排序）；`getById` 仍返回未经投影的原文。
+- `MessageStore.append(instanceId, alias, dir, text, structured?, attachments?, promptRequestId?, createdAt?, startedAt?, slotAfterId?, startedAfterSeq?)` 序列化写入；`listBySession` 反序列化后在 `MessageRecordDto` 中返回完整行（含可选 `startedAt` / `slotAfterId` / `startedAfterSeq`）。HTTP 列表在 `view=compact` 时由 `compactHistoryMessage` 投影后再发给看板——**不得丢弃** `slotAfterId`（live-slot 重排依赖 Hub 插入序，不能按 `createdAt` 完结时间或跨机器墙钟排序）；`startedAt` 仅作 HUD 遥测。`getById` 仍返回未经投影的原文。
+- Hub 在 `turn-started`（对账 inbound prompt 之后）把当时该 session 最后一条 `messages.id` 写入 `turn_slot_anchors`，并带到 accumulator / `out` 行。Hub 重启后 `finishedOffline` 与无 buffer 的 `turn-finished` 都从该锚点恢复，而不是用 `lastId`（会把中途到达的 card 当成触发卡）或 connector 墙钟。
 
 ## 阶段七：Hub 重启状态恢复（instance.state.sync + turn-finished.text）
 
@@ -280,7 +281,9 @@ interface TurnAccumulator { text: string; steps: Map<string, ToolStepDto>; reaso
 - 新消息类型 `MSG.instanceStateSync = "instance.state.sync"`，载荷为 `InstanceStateSyncPayload`
   `{ turns, usage, commands, finishedOffline }`（见 src/messages.ts）：连接器在每次（重）连
   完成鉴权后立即推送一份内存镜像快照给 hub。纯增量协议：旧 hub 忽略未知消息类型，
-  旧 connector 不发送则回退到原行为。`finishedOffline` 每项携带 `recoveryId` 与 `truncated`。
+  旧 connector 不发送则回退到原行为。`finishedOffline` 每项携带 `recoveryId` 与 `truncated`，
+  以及 `startedAfterSeq` / `startedAt`（connector 在 `turn-started` 记下的接收序与 HUD 遥测；
+  Hub 用 seq/锚点表映射到 `slotAfterId`，不以墙钟重排）。
 - 新消息类型 `MSG.instanceRecoveryAck = "instance.recovery.ack"`（hub → connector，载荷 `{ recoveryIds }`）：
   hub 只在**数据库提交之后**（消息行 + receipt 同一事务）ack 对应的 recoveryId。
 - 三个回合内容上限（`STATE_SYNC_TEXT_CAP = 256KiB` / `MAX_TOOL_STEPS = 200` /

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -551,6 +551,15 @@ export interface LiveTurn {
   列表、表格或代码围栏，而是在该块结束后显示；若事件本来位于两个块之间，则保持文字—活动—文字的穿插结构。
   实时 streaming 与历史回放使用同一派生规则。
 - 旧历史没有 `parts` 时回退到聚合 `ToolCallPanel` + markdown/reasoning，其中工具面板与 reasoning 同样默认折叠。
+- **Live-turn 槽位（跨会话 received card）**：`turn-started` 把 live turn 锚在当时最后一条 transcript
+  之后（触发用 received card / prompt），而不是列表底部。回合中途再来的 received card 追加到
+  `messages[]`，因此出现在 live 气泡**下面**：`card1 → live turn → card2`。`parts.length === 0`
+  时仍占据该槽（working spinner），避免第二张卡叠在尚未可见的 turn 上。Sent card 仍按
+  `agentMessageId` 接入 `TurnParts`（Gate A）；received card 永不抑制、永不嵌进 turn（Gate B）。
+  `turn-finished` 把 `out` 行 **splice 进该槽**（带 `startedAt`，与 `LiveTurn.startedAt` 相同的 epoch ms），
+  而不是 `push` 到末尾。`loadHistory` 对带 `startedAt` 的 `out` 把 `createdAt` 更晚的 inbound
+  agent-message 挪到该 `out` 之后；无 `startedAt` 的旧行不重排。Stick-to-bottom / jump-latest
+  在 live turn 存在时跟随 live 气泡，而不是最新一行。
 
 ## 桌面系统通知（Web Push 与 本地 Notification Fallback）
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -556,10 +556,12 @@ export interface LiveTurn {
   `messages[]`，因此出现在 live 气泡**下面**：`card1 → live turn → card2`。`parts.length === 0`
   时仍占据该槽（working spinner），避免第二张卡叠在尚未可见的 turn 上。Sent card 仍按
   `agentMessageId` 接入 `TurnParts`（Gate A）；received card 永不抑制、永不嵌进 turn（Gate B）。
-  `turn-finished` 把 `out` 行 **splice 进该槽**（带 `startedAt`，与 `LiveTurn.startedAt` 相同的 epoch ms），
-  而不是 `push` 到末尾。`loadHistory` 对带 `startedAt` 的 `out` 把 `createdAt` 更晚的 inbound
-  agent-message 挪到该 `out` 之后；无 `startedAt` 的旧行不重排。Stick-to-bottom / jump-latest
-  在 live turn 存在时跟随 live 气泡，而不是最新一行。
+  `turn-finished` 把 `out` 行 **splice 进该槽**（带 `startedAt` 作 HUD 遥测，以及 Hub
+  `slotAfterId` 作插入序锚点），而不是 `push` 到末尾。`loadHistory` 对带 `slotAfterId`
+  的 `out` 把 **Hub id 大于该锚点** 的 transcript 行（received card **以及** 忙时排队的
+  user prompt）挪到该 `out` 之后；无 `slotAfterId` 的旧行不重排。**不以** `createdAt` /
+  `startedAt` 墙钟比较决定顺序（发送端 daemon、Hub、浏览器时钟不可比）。Stick-to-bottom /
+  jump-latest 在 live turn 存在时跟随 live 气泡，而不是最新一行。
 
 ## 桌面系统通知（Web Push 与 本地 Notification Fallback）
 

--- a/packages/channel-relay/src/channel.ts
+++ b/packages/channel-relay/src/channel.ts
@@ -294,14 +294,14 @@ export class RelayChannel implements MessageChannelRuntime {
     }
 
     this.unsubscribe = subscribeControlEvents(control, (type, payload) => {
-      const finishedRecoveryId = mirror.handleEnvelope(type, payload);
+      const patch = mirror.handleEnvelope(type, payload);
       const forwardedPayload =
-        finishedRecoveryId && typeof payload === "object" && payload !== null
+        patch && typeof payload === "object" && payload !== null
           ? {
               ...(payload as Record<string, unknown>),
               event: {
                 ...(payload as { event: Record<string, unknown> }).event,
-                recoveryId: finishedRecoveryId,
+                ...patch,
               },
             }
           : payload;

--- a/packages/channel-relay/src/state-mirror.ts
+++ b/packages/channel-relay/src/state-mirror.ts
@@ -44,9 +44,11 @@ interface MirrorTurn {
   /** Hub-issued pre-write correlation (PromptPayload.promptRequestId); carried into
    *  the sync so the hub can tie the turn back to its pre-written inbound row. */
   promptRequestId?: string;
-  /** Stamped locally when the connector first saw `turn-started`, so a sync
-   *  restores the ORIGINAL start time on the hub after a restart. */
+  /** Stamped locally when the connector first saw `turn-started` — HUD telemetry
+   *  only. Hub insert-order (`slotAfterId`) is the timeline identity. */
   startedAt: number;
+  /** Per-session receive-order seq at this turn-start. Hub maps it to `slotAfterId`. */
+  startedAfterSeq: number;
   text: string;
   reasoning: string;
   steps: Map<string, ToolStepDto>;
@@ -75,15 +77,26 @@ interface PendingFinishedTurn {
    *  persist the flag so the recovered reply is not mistaken for a complete one. */
   truncated?: boolean;
   recoveryId: string;
+  /** Connector-local epoch ms at the original turn-start (HUD telemetry only). */
+  startedAt?: number;
+  /** Connector-local receive-order seq at the original turn-start. */
+  startedAfterSeq?: number;
   /** Local timestamp when the turn finished. Drives expiry (expirePendingFinished):
    *  past RECOVERY_RETENTION_MS the entry is dropped — the hub prunes its receipt on
    *  the same horizon, so an expired entry can never be re-delivered into a duplicate. */
   createdAt: number;
 }
 
+export interface MirrorEventPatch {
+  recoveryId?: string;
+  startedAfterSeq?: number;
+  startedAt?: number;
+}
+
 export interface StateMirror {
-  /** Consume one envelope the forwarder is about to send; non-instanceEvent types are ignored. */
-  handleEnvelope(type: string, payload: unknown): string | undefined;
+  /** Consume one envelope the forwarder is about to send; non-instanceEvent types are ignored.
+   *  Returns fields to merge into the forwarded control event (recovery id + slot seq). */
+  handleEnvelope(type: string, payload: unknown): MirrorEventPatch | undefined;
   /** Distinct chatKeys seen on mirrored events (used to resolve the live session list). */
   chatKeys(): string[];
   /** All session aliases mirrored for one chatKey (fallback keep-set when the live
@@ -135,6 +148,15 @@ export function createStateMirror(deps: StateMirrorDeps): StateMirror {
   const usage = new Map<string, { chatKey: string; used: number; size: number; cost?: UsageCostDto; breakdown?: UsageBreakdownDto }>();
   const commands = new Map<string, { chatKey: string; commands: AgentCommandDto[] }>();
   const pendingFinished: PendingFinishedTurn[] = [];
+  // Per-session receive-order counter. Incremented on turn-started (and each
+  // inbound agent-message) so Hub restart can map `startedAfterSeq` to insert
+  // order instead of comparing wall clocks.
+  const sessionSeq = new Map<string, number>();
+  const bumpSeq = (alias: string): number => {
+    const n = (sessionSeq.get(alias) ?? 0) + 1;
+    sessionSeq.set(alias, n);
+    return n;
+  };
   // Per-alias mutation generation. `buildStateSync` records each alias's generation
   // with the snapshot; `pruneStateMirror` only deletes an alias when its generation is
   // UNCHANGED since the build — a same-alias turn re-created or finished after the
@@ -183,25 +205,29 @@ export function createStateMirror(deps: StateMirrorDeps): StateMirror {
     }
   };
 
-  const handle = (event: ControlEventDto): string | undefined => {
+  const handle = (event: ControlEventDto): MirrorEventPatch | undefined => {
     switch (event.type) {
-      case "turn-started":
+      case "turn-started": {
+        const startedAfterSeq = bumpSeq(event.sessionAlias);
+        const id = recoveryId();
         turns.set(event.sessionAlias, {
           chatKey: event.chatKey,
           startedAt: now(),
+          startedAfterSeq,
           text: "",
           reasoning: "",
           steps: new Map(),
           parts: [],
           truncated: false,
-          recoveryId: recoveryId(),
+          recoveryId: id,
           ...(event.prompt !== undefined ? { prompt: event.prompt } : {}),
           ...(event.scheduled ? { scheduled: event.scheduled } : {}),
           ...(event.queueItemId ? { queueItemId: event.queueItemId } : {}),
           ...(event.promptRequestId !== undefined ? { promptRequestId: event.promptRequestId } : {}),
         });
         bump(event.sessionAlias);
-        return;
+        return { recoveryId: id, startedAfterSeq };
+      }
       case "turn-output": {
         const a = turns.get(event.sessionAlias);
         if (!a || a.truncated) return;
@@ -276,6 +302,7 @@ export function createStateMirror(deps: StateMirrorDeps): StateMirror {
           ...(a?.truncated ? { truncated: true } : {}),
           recoveryId: id,
           createdAt: now(),
+          ...(a ? { startedAt: a.startedAt, startedAfterSeq: a.startedAfterSeq } : {}),
         });
         expirePendingFinished();
         bump(event.sessionAlias);
@@ -287,8 +314,14 @@ export function createStateMirror(deps: StateMirrorDeps): StateMirror {
             { limit: PENDING_FINISHED_MAX },
           );
         }
-        return id;
+        return {
+          recoveryId: id,
+          ...(a ? { startedAt: a.startedAt, startedAfterSeq: a.startedAfterSeq } : {}),
+        };
       }
+      case "agent-message":
+        bumpSeq(event.sessionAlias);
+        return;
       default:
         return;
     }
@@ -332,6 +365,7 @@ export function createStateMirror(deps: StateMirrorDeps): StateMirror {
         payload.turns.push({
           sessionAlias: alias,
           startedAt: a.startedAt,
+          startedAfterSeq: a.startedAfterSeq,
           text: a.text,
           reasoning: a.reasoning,
           steps: [...a.steps.values()],
@@ -373,6 +407,8 @@ export function createStateMirror(deps: StateMirrorDeps): StateMirror {
           ...(f.promptRequestId !== undefined ? { promptRequestId: f.promptRequestId } : {}),
           ...(f.truncated ? { truncated: true } : {}),
           recoveryId: f.recoveryId,
+          ...(f.startedAt !== undefined ? { startedAt: f.startedAt } : {}),
+          ...(f.startedAfterSeq !== undefined ? { startedAfterSeq: f.startedAfterSeq } : {}),
         });
       }
       return { snapshot: payload, aliases };

--- a/packages/relay-protocol/dist/dtos.d.ts
+++ b/packages/relay-protocol/dist/dtos.d.ts
@@ -225,6 +225,12 @@ export type ControlEventDto = {
     queueItemId?: string;
     promptRequestId?: string;
     peerOrigin?: PeerTurnOriginDto;
+    /** Connector-local per-session seq at this turn-start (receive order, not a clock). */
+    startedAfterSeq?: number;
+    /** Connector recovery id for this turn; Hub keys the durable slot anchor with it. */
+    recoveryId?: string;
+    /** Hub-stamped last message id at turn-start (0 = empty transcript). Web live slot. */
+    slotAfterId?: number;
 } | {
     type: "tool-event";
     chatKey: string;
@@ -265,6 +271,10 @@ export type ControlEventDto = {
     silent?: boolean;
     recoveryId?: string;
     peerOrigin?: PeerTurnOriginDto;
+    /** Connector-local seq captured at the original turn-start (Hub maps to insert order). */
+    startedAfterSeq?: number;
+    /** Connector-local epoch ms at turn-start — HUD telemetry only; never a reorder key. */
+    startedAt?: number;
 } | {
     type: "sessions-changed";
 } | {

--- a/packages/relay-protocol/dist/index.js
+++ b/packages/relay-protocol/dist/index.js
@@ -210,6 +210,7 @@ var optBool = (v) => v === undefined || typeof v === "boolean";
 var isBoundedStr = (v, maxLen) => typeof v === "string" && v.length > 0 && v.length <= maxLen;
 var isIntInRange = (v, min, max) => typeof v === "number" && Number.isInteger(v) && v >= min && v <= max;
 var isNonNegInt = (v) => typeof v === "number" && Number.isInteger(v) && v >= 0;
+var optNonNegInt = (v) => v === undefined || isNonNegInt(v);
 function decodeCanonicalBase64(encoded) {
   if (typeof globalThis.atob === "function" && typeof globalThis.btoa === "function") {
     const binary = globalThis.atob(encoded);
@@ -394,7 +395,7 @@ function validStateSnapshot(candidate) {
     if (typeof turn !== "object" || turn === null)
       return false;
     const c = turn;
-    return c.instanceId === instanceId && typeof c.sessionAlias === "string" && Array.isArray(c.parts) && c.parts.every(validTurnPart) && (c.status === "working" || c.status === "streaming") && finiteNonNegative(c.startedAt);
+    return c.instanceId === instanceId && typeof c.sessionAlias === "string" && Array.isArray(c.parts) && c.parts.every(validTurnPart) && (c.status === "working" || c.status === "streaming") && finiteNonNegative(c.startedAt) && optNonNegInt(c.slotAfterId);
   }))
     return false;
   if (!Array.isArray(candidate.usage) || !candidate.usage.every((usage) => {
@@ -465,11 +466,11 @@ function validControlEvent(e) {
     case "turn-output":
       return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
     case "turn-finished":
-      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.ok === "boolean" && optStr(c.text) && optStr(c.recoveryId) && optStr(c.errorMessage) && optBool(c.cancelled) && optBool(c.silent) && validPeerTurnOrigin(c.peerOrigin);
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.ok === "boolean" && optStr(c.text) && optStr(c.recoveryId) && optStr(c.errorMessage) && optBool(c.cancelled) && optBool(c.silent) && validPeerTurnOrigin(c.peerOrigin) && optNonNegInt(c.startedAfterSeq) && (c.startedAt === undefined || finiteNonNegative(c.startedAt));
     case "scheduled-changed":
       return typeof c.chatKey === "string";
     case "turn-started":
-      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && optStr(c.prompt) && optStr(c.queueItemId) && optStr(c.promptRequestId) && validScheduledOrigin(c.scheduled) && validPeerTurnOrigin(c.peerOrigin);
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && optStr(c.prompt) && optStr(c.queueItemId) && optStr(c.promptRequestId) && optStr(c.recoveryId) && validScheduledOrigin(c.scheduled) && validPeerTurnOrigin(c.peerOrigin) && optNonNegInt(c.startedAfterSeq) && optNonNegInt(c.slotAfterId);
     case "turn-thought":
       return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
     case "plan":
@@ -511,7 +512,7 @@ function validInstanceStateSync(p) {
     if (typeof t !== "object" || t === null)
       return false;
     const turn = t;
-    return typeof turn.sessionAlias === "string" && optStr(turn.prompt) && optStr(turn.queueItemId) && optStr(turn.recoveryId) && optStr(turn.promptRequestId) && validScheduledOrigin(turn.scheduled) && finiteNonNegative(turn.startedAt) && typeof turn.text === "string" && typeof turn.reasoning === "string" && Array.isArray(turn.steps) && turn.steps.every(validToolStep) && (turn.parts === undefined || Array.isArray(turn.parts) && validStateSyncParts(turn.parts)) && (turn.truncated === undefined || typeof turn.truncated === "boolean");
+    return typeof turn.sessionAlias === "string" && optStr(turn.prompt) && optStr(turn.queueItemId) && optStr(turn.recoveryId) && optStr(turn.promptRequestId) && validScheduledOrigin(turn.scheduled) && finiteNonNegative(turn.startedAt) && optNonNegInt(turn.startedAfterSeq) && typeof turn.text === "string" && typeof turn.reasoning === "string" && Array.isArray(turn.steps) && turn.steps.every(validToolStep) && (turn.parts === undefined || Array.isArray(turn.parts) && validStateSyncParts(turn.parts)) && (turn.truncated === undefined || typeof turn.truncated === "boolean");
   }))
     return false;
   if (!Array.isArray(c.usage) || !c.usage.every((u) => {
@@ -532,7 +533,7 @@ function validInstanceStateSync(p) {
     if (typeof f !== "object" || f === null)
       return false;
     const finished = f;
-    return typeof finished.sessionAlias === "string" && typeof finished.ok === "boolean" && optStr(finished.errorMessage) && optStr(finished.text) && optStr(finished.prompt) && optStr(finished.queueItemId) && optStr(finished.recoveryId) && optStr(finished.promptRequestId) && validScheduledOrigin(finished.scheduled) && (finished.cancelled === undefined || typeof finished.cancelled === "boolean") && (finished.truncated === undefined || typeof finished.truncated === "boolean");
+    return typeof finished.sessionAlias === "string" && typeof finished.ok === "boolean" && optStr(finished.errorMessage) && optStr(finished.text) && optStr(finished.prompt) && optStr(finished.queueItemId) && optStr(finished.recoveryId) && optStr(finished.promptRequestId) && validScheduledOrigin(finished.scheduled) && (finished.cancelled === undefined || typeof finished.cancelled === "boolean") && (finished.truncated === undefined || typeof finished.truncated === "boolean") && (finished.startedAt === undefined || finiteNonNegative(finished.startedAt)) && optNonNegInt(finished.startedAfterSeq);
   });
 }
 function validNotice(n) {
@@ -1005,6 +1006,7 @@ export {
   parseCanonicalBase64,
   optStr,
   optNum,
+  optNonNegInt,
   optBool,
   normalizeCapabilities,
   maxBase64EncodedLength,

--- a/packages/relay-protocol/dist/messages.d.ts
+++ b/packages/relay-protocol/dist/messages.d.ts
@@ -144,8 +144,10 @@ export interface InstanceStateSyncPayload {
          *  stamps on the eventual `turn-finished`), so the hub can tell a running turn
          *  apart from a finished-offline entry of the same session. */
         recoveryId?: string;
-        /** ms epoch captured by the connector at the ORIGINAL turn start. */
+        /** ms epoch captured by the connector at the ORIGINAL turn start (HUD telemetry). */
         startedAt: number;
+        /** Connector-local per-session seq at the original turn-start (receive order). */
+        startedAfterSeq?: number;
         text: string;
         reasoning: string;
         steps: ToolStepDto[];
@@ -190,6 +192,10 @@ export interface InstanceStateSyncPayload {
         promptRequestId?: string;
         recoveryId?: string;
         truncated?: boolean;
+        /** Connector-local epoch ms at the original turn-start (HUD telemetry only). */
+        startedAt?: number;
+        /** Connector-local per-session seq at the original turn-start (receive order). */
+        startedAfterSeq?: number;
     }>;
 }
 export interface InstanceNoticePayload {

--- a/packages/relay-protocol/dist/validate-primitives.d.ts
+++ b/packages/relay-protocol/dist/validate-primitives.d.ts
@@ -14,6 +14,8 @@ export declare const isBoundedStr: (v: unknown, maxLen: number) => v is string;
 export declare const isIntInRange: (v: unknown, min: number, max: number) => v is number;
 /** Finite non-negative integer. */
 export declare const isNonNegInt: (v: unknown) => v is number;
+/** Optional finite non-negative integer: absent or `isNonNegInt`. */
+export declare const optNonNegInt: (v: unknown) => boolean;
 /**
  * Decode a canonical base64 payload with an encoded-length pre-check.
  * Runtime-neutral: browsers use `atob`/`btoa`; Node/Bun can fall back to

--- a/packages/relay-protocol/dist/web-dtos.d.ts
+++ b/packages/relay-protocol/dist/web-dtos.d.ts
@@ -24,13 +24,23 @@ export interface MessageRecordDto {
     text: string;
     createdAt: string;
     /**
-     * Epoch ms the assistant turn began (`LiveTurn.startedAt`). Present on completed
-     * `out` rows so history reload can place the turn in its live slot (after the
-     * triggering prompt/received card, before messages that arrived mid-turn) instead
-     * of ordering only by `createdAt` (finish time). Omitted on legacy rows — do not
-     * reorder those. Survives `view=compact`.
+     * Epoch ms the assistant turn began (`LiveTurn.startedAt`). HUD telemetry only —
+     * never a history-reorder key (peer/hub/browser clocks are not comparable).
+     * Survives `view=compact`.
      */
     startedAt?: number;
+    /**
+     * Hub `messages.id` of the last transcript row at turn-start (0 = empty transcript).
+     * History apply places this `out` immediately after that id; later-inserted rows
+     * (received cards AND queued prompts) move after it. Omitted on legacy rows —
+     * do not reorder those. Survives `view=compact`.
+     */
+    slotAfterId?: number;
+    /**
+     * Connector-local per-session seq at turn-start. Auxiliary to `slotAfterId` so a
+     * Hub restart can map receive-order back to insert order. Survives `view=compact`.
+     */
+    startedAfterSeq?: number;
     /** Present while an inbound Web prompt is queued, so a history reload can still
      *  associate it with the later drain event. Cleared when execution starts. */
     queueItemId?: string;
@@ -64,6 +74,11 @@ export interface LiveTurnSnapshotDto {
     status: "working" | "streaming";
     /** Epoch ms the turn began on the hub, so the elapsed-time HUD stays accurate. */
     startedAt: number;
+    /**
+     * Hub `messages.id` the live bubble is slotted after (0 = start of transcript).
+     * Web places the live turn by this id, never by comparing clocks.
+     */
+    slotAfterId?: number;
 }
 /** The latest context-usage meter retained per session, handed to a (re)connecting web
  *  client so the context-usage bar survives a page refresh. Mirrors the `turn-usage`

--- a/packages/relay-protocol/dist/web-dtos.d.ts
+++ b/packages/relay-protocol/dist/web-dtos.d.ts
@@ -23,6 +23,14 @@ export interface MessageRecordDto {
     direction: MessageDirection;
     text: string;
     createdAt: string;
+    /**
+     * Epoch ms the assistant turn began (`LiveTurn.startedAt`). Present on completed
+     * `out` rows so history reload can place the turn in its live slot (after the
+     * triggering prompt/received card, before messages that arrived mid-turn) instead
+     * of ordering only by `createdAt` (finish time). Omitted on legacy rows — do not
+     * reorder those. Survives `view=compact`.
+     */
+    startedAt?: number;
     /** Present while an inbound Web prompt is queued, so a history reload can still
      *  associate it with the later drain event. Cleared when execution starts. */
     queueItemId?: string;

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -246,6 +246,12 @@ export type ControlEventDto =
       queueItemId?: string;
       promptRequestId?: string;
       peerOrigin?: PeerTurnOriginDto;
+      /** Connector-local per-session seq at this turn-start (receive order, not a clock). */
+      startedAfterSeq?: number;
+      /** Connector recovery id for this turn; Hub keys the durable slot anchor with it. */
+      recoveryId?: string;
+      /** Hub-stamped last message id at turn-start (0 = empty transcript). Web live slot. */
+      slotAfterId?: number;
     }
   | {
       type: "tool-event";
@@ -297,6 +303,10 @@ export type ControlEventDto =
       silent?: boolean;
       recoveryId?: string;
       peerOrigin?: PeerTurnOriginDto;
+      /** Connector-local seq captured at the original turn-start (Hub maps to insert order). */
+      startedAfterSeq?: number;
+      /** Connector-local epoch ms at turn-start — HUD telemetry only; never a reorder key. */
+      startedAt?: number;
     }
   | { type: "sessions-changed" }
   // The configured workspace set changed (out-of-band CLI edit or `/config`); the web

--- a/packages/relay-protocol/src/messages.ts
+++ b/packages/relay-protocol/src/messages.ts
@@ -204,8 +204,10 @@ export interface InstanceStateSyncPayload {
      *  stamps on the eventual `turn-finished`), so the hub can tell a running turn
      *  apart from a finished-offline entry of the same session. */
     recoveryId?: string;
-    /** ms epoch captured by the connector at the ORIGINAL turn start. */
+    /** ms epoch captured by the connector at the ORIGINAL turn start (HUD telemetry). */
     startedAt: number;
+    /** Connector-local per-session seq at the original turn-start (receive order). */
+    startedAfterSeq?: number;
     text: string;
     reasoning: string;
     steps: ToolStepDto[];
@@ -247,6 +249,10 @@ export interface InstanceStateSyncPayload {
     promptRequestId?: string;
     recoveryId?: string;
     truncated?: boolean;
+    /** Connector-local epoch ms at the original turn-start (HUD telemetry only). */
+    startedAt?: number;
+    /** Connector-local per-session seq at the original turn-start (receive order). */
+    startedAfterSeq?: number;
   }>;
 }
 export interface InstanceNoticePayload {

--- a/packages/relay-protocol/src/validate-primitives.ts
+++ b/packages/relay-protocol/src/validate-primitives.ts
@@ -33,6 +33,9 @@ export const isIntInRange = (v: unknown, min: number, max: number): v is number 
 export const isNonNegInt = (v: unknown): v is number =>
   typeof v === "number" && Number.isInteger(v) && v >= 0;
 
+/** Optional finite non-negative integer: absent or `isNonNegInt`. */
+export const optNonNegInt = (v: unknown): boolean => v === undefined || isNonNegInt(v);
+
 type Base64BufferCtor = {
   from(value: string, encoding: "base64"): {
     length: number;

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -48,6 +48,14 @@ export interface MessageRecordDto {
   direction: MessageDirection;
   text: string;
   createdAt: string;
+  /**
+   * Epoch ms the assistant turn began (`LiveTurn.startedAt`). Present on completed
+   * `out` rows so history reload can place the turn in its live slot (after the
+   * triggering prompt/received card, before messages that arrived mid-turn) instead
+   * of ordering only by `createdAt` (finish time). Omitted on legacy rows — do not
+   * reorder those. Survives `view=compact`.
+   */
+  startedAt?: number;
   /** Present while an inbound Web prompt is queued, so a history reload can still
    *  associate it with the later drain event. Cleared when execution starts. */
   queueItemId?: string;

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -20,7 +20,7 @@ import {
   TERMINAL_REBASE_CHUNK_BYTES,
 } from "./limits.js";
 import type { InstanceNoticePayload, TerminalRole } from "./messages.js";
-import { isBoundedStr, isIntInRange, isNonNegInt, isStr, optStr, optNum, optBool, parseCanonicalBase64 } from "./validate-primitives.js";
+import { isBoundedStr, isIntInRange, isNonNegInt, isStr, optStr, optNum, optBool, optNonNegInt, parseCanonicalBase64 } from "./validate-primitives.js";
 
 
 /** Envelope `type` for every relay→web push. */
@@ -49,13 +49,23 @@ export interface MessageRecordDto {
   text: string;
   createdAt: string;
   /**
-   * Epoch ms the assistant turn began (`LiveTurn.startedAt`). Present on completed
-   * `out` rows so history reload can place the turn in its live slot (after the
-   * triggering prompt/received card, before messages that arrived mid-turn) instead
-   * of ordering only by `createdAt` (finish time). Omitted on legacy rows — do not
-   * reorder those. Survives `view=compact`.
+   * Epoch ms the assistant turn began (`LiveTurn.startedAt`). HUD telemetry only —
+   * never a history-reorder key (peer/hub/browser clocks are not comparable).
+   * Survives `view=compact`.
    */
   startedAt?: number;
+  /**
+   * Hub `messages.id` of the last transcript row at turn-start (0 = empty transcript).
+   * History apply places this `out` immediately after that id; later-inserted rows
+   * (received cards AND queued prompts) move after it. Omitted on legacy rows —
+   * do not reorder those. Survives `view=compact`.
+   */
+  slotAfterId?: number;
+  /**
+   * Connector-local per-session seq at turn-start. Auxiliary to `slotAfterId` so a
+   * Hub restart can map receive-order back to insert order. Survives `view=compact`.
+   */
+  startedAfterSeq?: number;
   /** Present while an inbound Web prompt is queued, so a history reload can still
    *  associate it with the later drain event. Cleared when execution starts. */
   queueItemId?: string;
@@ -82,6 +92,11 @@ export interface LiveTurnSnapshotDto {
   status: "working" | "streaming";
   /** Epoch ms the turn began on the hub, so the elapsed-time HUD stays accurate. */
   startedAt: number;
+  /**
+   * Hub `messages.id` the live bubble is slotted after (0 = start of transcript).
+   * Web places the live turn by this id, never by comparing clocks.
+   */
+  slotAfterId?: number;
 }
 
 /** The latest context-usage meter retained per session, handed to a (re)connecting web
@@ -394,7 +409,8 @@ function validStateSnapshot(candidate: Record<string, unknown>): boolean {
       && Array.isArray(c.parts)
       && c.parts.every(validTurnPart)
       && (c.status === "working" || c.status === "streaming")
-      && finiteNonNegative(c.startedAt);
+      && finiteNonNegative(c.startedAt)
+      && optNonNegInt(c.slotAfterId);
   })) return false;
   if (!Array.isArray(candidate.usage) || !candidate.usage.every((usage) => {
     if (typeof usage !== "object" || usage === null) return false;
@@ -470,13 +486,17 @@ export function validControlEvent(e: unknown): boolean {
       // into SQLite and trigger a disconnect loop.
       return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.ok === "boolean"
         && optStr(c.text) && optStr(c.recoveryId) && optStr(c.errorMessage) && optBool(c.cancelled) && optBool(c.silent)
-        && validPeerTurnOrigin(c.peerOrigin);
+        && validPeerTurnOrigin(c.peerOrigin)
+        && optNonNegInt(c.startedAfterSeq)
+        && (c.startedAt === undefined || finiteNonNegative(c.startedAt));
     case "scheduled-changed":
       return typeof c.chatKey === "string";
     case "turn-started":
       return typeof c.chatKey === "string" && typeof c.sessionAlias === "string"
-        && optStr(c.prompt) && optStr(c.queueItemId) && optStr(c.promptRequestId) && validScheduledOrigin(c.scheduled)
-        && validPeerTurnOrigin(c.peerOrigin);
+        && optStr(c.prompt) && optStr(c.queueItemId) && optStr(c.promptRequestId) && optStr(c.recoveryId)
+        && validScheduledOrigin(c.scheduled)
+        && validPeerTurnOrigin(c.peerOrigin)
+        && optNonNegInt(c.startedAfterSeq) && optNonNegInt(c.slotAfterId);
     case "turn-thought":
       return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
     case "plan":
@@ -541,6 +561,7 @@ export function validInstanceStateSync(p: unknown): boolean {
       && optStr(turn.prompt) && optStr(turn.queueItemId) && optStr(turn.recoveryId) && optStr(turn.promptRequestId)
       && validScheduledOrigin(turn.scheduled)
       && finiteNonNegative(turn.startedAt)
+      && optNonNegInt(turn.startedAfterSeq)
       && typeof turn.text === "string"
       && typeof turn.reasoning === "string"
       && Array.isArray(turn.steps) && turn.steps.every(validToolStep)
@@ -569,7 +590,9 @@ export function validInstanceStateSync(p: unknown): boolean {
       && optStr(finished.queueItemId) && optStr(finished.recoveryId) && optStr(finished.promptRequestId)
       && validScheduledOrigin(finished.scheduled)
       && (finished.cancelled === undefined || typeof finished.cancelled === "boolean")
-      && (finished.truncated === undefined || typeof finished.truncated === "boolean");
+      && (finished.truncated === undefined || typeof finished.truncated === "boolean")
+      && (finished.startedAt === undefined || finiteNonNegative(finished.startedAt))
+      && optNonNegInt(finished.startedAfterSeq);
   });
 }
 

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -1192,3 +1192,114 @@ test("rollback after the row was replaced by a re-fetch is a no-op on the new ro
   expect(freshRow.warm).toBe(true);
   expect(freshRow.archived).toBe(false);
 });
+
+function receivedPeer(messageId: string, createdAt: number) {
+  return {
+    kind: "agent_message" as const,
+    direction: "received" as const,
+    messageId,
+    conversationId: `conv_${messageId}`,
+    peer: { handle: "agent:n:e", displayName: "Peer", agent: "claude" },
+    content: messageId,
+    createdAt,
+    status: "delivered" as const,
+  };
+}
+
+test("a mid-turn second received card stays after the live slot (does not stack above the turn)", () => {
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({
+    kind: "control-event",
+    instanceId: "i1",
+    event: { type: "agent-message", chatKey: "c", sessionAlias: "backend", message: receivedPeer("card1", 1_000) },
+  } as never);
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
+  expect(store.liveTurn?.slotAfterIndex).toBe(0);
+
+  store.applyEvent({
+    kind: "control-event",
+    instanceId: "i1",
+    event: { type: "agent-message", chatKey: "c", sessionAlias: "backend", message: receivedPeer("card2", 3_000) },
+  } as never);
+  expect(store.messages.map((m) => m.text)).toEqual(["card1", "card2"]);
+  expect(store.liveTurn?.slotAfterIndex).toBe(0);
+  expect(store.busy).toBe(true);
+});
+
+test("flushTurn inserts the out row into the live slot, not at the end", () => {
+  vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({
+    kind: "control-event",
+    instanceId: "i1",
+    event: { type: "agent-message", chatKey: "c", sessionAlias: "backend", message: receivedPeer("card1", 1_000) },
+  } as never);
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
+  const startedAt = store.liveTurn!.startedAt;
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "backend", chunk: "reply" } } as never);
+  store.applyEvent({
+    kind: "control-event",
+    instanceId: "i1",
+    event: { type: "agent-message", chatKey: "c", sessionAlias: "backend", message: receivedPeer("card2", startedAt + 10) },
+  } as never);
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "backend", ok: true } } as never);
+
+  expect(store.messages.map((m) => [m.direction, m.text])).toEqual([
+    ["in", "card1"],
+    ["out", "reply"],
+    ["in", "card2"],
+  ]);
+  expect(store.messages[1]).toMatchObject({ direction: "out", text: "reply", startedAt });
+});
+
+test("loadHistory reorders mid-turn received cards after outs that carry startedAt", async () => {
+  const card1 = {
+    id: 1, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "card1",
+    createdAt: new Date(1_000).toISOString(),
+    structured: { agentMessage: receivedPeer("card1", 1_000) },
+  };
+  const card2 = {
+    id: 2, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "card2",
+    createdAt: new Date(3_000).toISOString(),
+    structured: { agentMessage: receivedPeer("card2", 3_000) },
+  };
+  const out = {
+    id: 3, instanceId: "i1", sessionAlias: "backend", direction: "out", text: "reply",
+    createdAt: new Date(5_000).toISOString(), startedAt: 2_000,
+  };
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    messages: [card1, card2, out], hasMore: false,
+  }), { status: 200 })));
+
+  const store = useChatStore();
+  store.select("i1", "backend");
+  await store.loadHistory();
+  expect(store.messages.map((m) => m.text)).toEqual(["card1", "reply", "card2"]);
+});
+
+test("loadHistory does not reorder legacy outs without startedAt", async () => {
+  const card1 = {
+    id: 1, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "card1",
+    createdAt: new Date(1_000).toISOString(),
+    structured: { agentMessage: receivedPeer("card1", 1_000) },
+  };
+  const card2 = {
+    id: 2, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "card2",
+    createdAt: new Date(3_000).toISOString(),
+    structured: { agentMessage: receivedPeer("card2", 3_000) },
+  };
+  const out = {
+    id: 3, instanceId: "i1", sessionAlias: "backend", direction: "out", text: "old",
+    createdAt: new Date(5_000).toISOString(),
+  };
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    messages: [card1, card2, out], hasMore: false,
+  }), { status: 200 })));
+
+  const store = useChatStore();
+  store.select("i1", "backend");
+  await store.loadHistory();
+  expect(store.messages.map((m) => m.text)).toEqual(["card1", "card2", "old"]);
+});

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -1254,7 +1254,44 @@ test("flushTurn inserts the out row into the live slot, not at the end", () => {
   expect(store.messages[1]).toMatchObject({ direction: "out", text: "reply", startedAt });
 });
 
-test("loadHistory reorders mid-turn received cards after outs that carry startedAt", async () => {
+test("busy send then turn-finished then history (before queued drain) keeps queued prompt after out", async () => {
+  let resolveHistory!: (value: Response) => void;
+  const history = new Promise<Response>((resolve) => { resolveHistory = resolve; });
+  vi.stubGlobal("fetch", vi.fn(() => history));
+
+  const store = useChatStore();
+  store.select("i1", "backend");
+  store.applyEvent({
+    kind: "control-event",
+    instanceId: "i1",
+    event: { type: "turn-started", chatKey: "c", sessionAlias: "backend", prompt: "prompt1", slotAfterId: 1 },
+  } as never);
+  // Optimistic busy-send: queued prompt appends after the live slot.
+  store.messages.push({
+    instanceId: "i1",
+    sessionAlias: "backend",
+    direction: "in",
+    text: "queued prompt2",
+    createdAt: new Date().toISOString(),
+  });
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "c", sessionAlias: "backend", chunk: "reply" } } as never);
+  store.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "backend", ok: true } } as never);
+  expect(store.messages.map((m) => m.text)).toEqual(["prompt1", "reply", "queued prompt2"]);
+
+  resolveHistory(new Response(JSON.stringify({
+    messages: [
+      { id: 1, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "prompt1", createdAt: new Date(1_000).toISOString() },
+      { id: 2, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "queued prompt2", createdAt: new Date(3_000).toISOString() },
+      { id: 3, instanceId: "i1", sessionAlias: "backend", direction: "out", text: "reply", createdAt: new Date(5_000).toISOString(), startedAt: 2_000, slotAfterId: 1 },
+    ],
+    hasMore: false,
+  }), { status: 200 }));
+  await vi.waitFor(() => {
+    expect(store.messages.map((m) => m.text)).toEqual(["prompt1", "reply", "queued prompt2"]);
+  });
+});
+
+test("loadHistory reorders mid-turn rows after outs that carry slotAfterId (not startedAt)", async () => {
   const card1 = {
     id: 1, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "card1",
     createdAt: new Date(1_000).toISOString(),
@@ -1267,7 +1304,7 @@ test("loadHistory reorders mid-turn received cards after outs that carry started
   };
   const out = {
     id: 3, instanceId: "i1", sessionAlias: "backend", direction: "out", text: "reply",
-    createdAt: new Date(5_000).toISOString(), startedAt: 2_000,
+    createdAt: new Date(5_000).toISOString(), startedAt: 2_000, slotAfterId: 1,
   };
   vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
     messages: [card1, card2, out], hasMore: false,
@@ -1279,7 +1316,32 @@ test("loadHistory reorders mid-turn received cards after outs that carry started
   expect(store.messages.map((m) => m.text)).toEqual(["card1", "reply", "card2"]);
 });
 
-test("loadHistory does not reorder legacy outs without startedAt", async () => {
+test("loadHistory still places a mid-turn card after the out when peer createdAt is 30s before startedAt", async () => {
+  const card1 = {
+    id: 1, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "card1",
+    createdAt: new Date(1_000).toISOString(),
+    structured: { agentMessage: receivedPeer("card1", 1_000) },
+  };
+  const card2 = {
+    id: 2, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "card2",
+    createdAt: new Date(2_000 - 30_000).toISOString(),
+    structured: { agentMessage: receivedPeer("card2", 2_000 - 30_000) },
+  };
+  const out = {
+    id: 3, instanceId: "i1", sessionAlias: "backend", direction: "out", text: "reply",
+    createdAt: new Date(5_000).toISOString(), startedAt: 2_000, slotAfterId: 1,
+  };
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    messages: [card1, card2, out], hasMore: false,
+  }), { status: 200 })));
+
+  const store = useChatStore();
+  store.select("i1", "backend");
+  await store.loadHistory();
+  expect(store.messages.map((m) => m.text)).toEqual(["card1", "reply", "card2"]);
+});
+
+test("loadHistory does not reorder legacy outs without slotAfterId (startedAt alone is not enough)", async () => {
   const card1 = {
     id: 1, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "card1",
     createdAt: new Date(1_000).toISOString(),
@@ -1292,7 +1354,7 @@ test("loadHistory does not reorder legacy outs without startedAt", async () => {
   };
   const out = {
     id: 3, instanceId: "i1", sessionAlias: "backend", direction: "out", text: "old",
-    createdAt: new Date(5_000).toISOString(),
+    createdAt: new Date(5_000).toISOString(), startedAt: 2_000,
   };
   vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
     messages: [card1, card2, out], hasMore: false,
@@ -1302,4 +1364,27 @@ test("loadHistory does not reorder legacy outs without startedAt", async () => {
   store.select("i1", "backend");
   await store.loadHistory();
   expect(store.messages.map((m) => m.text)).toEqual(["card1", "card2", "old"]);
+});
+
+test("loadHistory after busy send restores queued prompt after the out (history before drain)", async () => {
+  const prompt1 = {
+    id: 1, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "prompt1",
+    createdAt: new Date(1_000).toISOString(),
+  };
+  const queued = {
+    id: 2, instanceId: "i1", sessionAlias: "backend", direction: "in", text: "queued prompt2",
+    createdAt: new Date(3_000).toISOString(),
+  };
+  const out = {
+    id: 3, instanceId: "i1", sessionAlias: "backend", direction: "out", text: "reply",
+    createdAt: new Date(5_000).toISOString(), startedAt: 2_000, slotAfterId: 1,
+  };
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    messages: [prompt1, queued, out], hasMore: false,
+  }), { status: 200 })));
+
+  const store = useChatStore();
+  store.select("i1", "backend");
+  await store.loadHistory();
+  expect(store.messages.map((m) => m.text)).toEqual(["prompt1", "reply", "queued prompt2"]);
 });

--- a/packages/relay-web/src/__tests__/history-turn-slots.test.ts
+++ b/packages/relay-web/src/__tests__/history-turn-slots.test.ts
@@ -1,92 +1,121 @@
 import { describe, expect, it } from "vitest";
 import type { MessageRecordDto, PeerMessageHistoryEntry } from "@ganglion/xacpx-relay-protocol";
 import {
-  placeReceivedCardsAfterTurns,
-  slotAfterIndexFromStartedAt,
+  placeTurnsInSlots,
+  slotAfterIndexFromAnchor,
 } from "../lib/history-turn-slots";
 
 const iso = (ms: number) => new Date(ms).toISOString();
 
-const received = (id: string, createdAt: number): MessageRecordDto => ({
+const received = (id: number, messageId: string, createdAt: number): MessageRecordDto => ({
+  id,
   instanceId: "i1",
   sessionAlias: "s",
   direction: "in",
-  text: id,
+  text: messageId,
   createdAt: iso(createdAt),
   structured: {
     agentMessage: {
       kind: "agent_message",
       direction: "received",
-      messageId: id,
-      conversationId: `conv_${id}`,
+      messageId,
+      conversationId: `conv_${messageId}`,
       peer: { handle: "agent:n:e", displayName: "Peer", agent: "codex" },
-      content: id,
+      content: messageId,
       createdAt,
       status: "delivered",
     } satisfies PeerMessageHistoryEntry,
   },
 });
 
-const assistantOut = (text: string, startedAt: number, createdAt = startedAt + 5_000): MessageRecordDto => ({
+const prompt = (id: number, text: string, createdAt: number): MessageRecordDto => ({
+  id,
+  instanceId: "i1",
+  sessionAlias: "s",
+  direction: "in",
+  text,
+  createdAt: iso(createdAt),
+});
+
+const assistantOut = (id: number, text: string, slotAfterId: number, startedAt = 2_000): MessageRecordDto => ({
+  id,
   instanceId: "i1",
   sessionAlias: "s",
   direction: "out",
   text,
-  createdAt: iso(createdAt),
+  createdAt: iso(startedAt + 5_000),
   startedAt,
+  slotAfterId,
 });
 
-describe("slotAfterIndexFromStartedAt", () => {
+describe("slotAfterIndexFromAnchor", () => {
   it("places the live slot after the triggering received card and before a mid-turn card", () => {
-    const rows = [received("card1", 1_000), received("card2", 3_000)];
-    expect(slotAfterIndexFromStartedAt(rows, 2_000)).toBe(0);
+    const rows = [received(1, "card1", 1_000), received(2, "card2", 3_000)];
+    expect(slotAfterIndexFromAnchor(rows, 1)).toBe(0);
   });
 
-  it("returns -1 when every row arrived after the turn started", () => {
-    expect(slotAfterIndexFromStartedAt([received("card2", 3_000)], 2_000)).toBe(-1);
+  it("returns -1 when every row was inserted after the turn started", () => {
+    expect(slotAfterIndexFromAnchor([received(2, "card2", 3_000)], 1)).toBe(-1);
   });
 });
 
-describe("placeReceivedCardsAfterTurns", () => {
+describe("placeTurnsInSlots", () => {
   it("moves a mid-turn received card to immediately after the out (hub insertion order)", () => {
-    const card1 = received("card1", 1_000);
-    const card2 = received("card2", 3_000);
-    const out = assistantOut("reply", 2_000, 5_000);
-    const placed = placeReceivedCardsAfterTurns([card1, card2, out]);
+    const card1 = received(1, "card1", 1_000);
+    const card2 = received(2, "card2", 3_000);
+    const out = assistantOut(3, "reply", 1);
+    const placed = placeTurnsInSlots([card1, card2, out]);
     expect(placed.map((m) => m.text)).toEqual(["card1", "reply", "card2"]);
   });
 
-  it("leaves a triggering received card (created before startedAt) in front of the out", () => {
-    const card1 = received("card1", 1_000);
-    const out = assistantOut("reply", 2_000, 3_000);
-    expect(placeReceivedCardsAfterTurns([card1, out]).map((m) => m.text)).toEqual(["card1", "reply"]);
+  it("still places a mid-turn card after the out when its peer createdAt is 30s before hub startedAt", () => {
+    const card1 = received(1, "card1", 1_000);
+    const card2 = received(2, "card2", 2_000 - 30_000);
+    const out = assistantOut(3, "reply", 1, 2_000);
+    const placed = placeTurnsInSlots([card1, card2, out]);
+    expect(placed.map((m) => m.text)).toEqual(["card1", "reply", "card2"]);
   });
 
-  it("does not reorder legacy outs that lack startedAt", () => {
-    const card1 = received("card1", 1_000);
-    const card2 = received("card2", 3_000);
+  it("moves a queued user prompt inserted after turn-start to after the out", () => {
+    const p1 = prompt(1, "prompt1", 1_000);
+    const queued = prompt(2, "queued prompt2", 3_000);
+    const out = assistantOut(3, "reply", 1);
+    expect(placeTurnsInSlots([p1, queued, out]).map((m) => m.text)).toEqual(["prompt1", "reply", "queued prompt2"]);
+  });
+
+  it("leaves a triggering received card (id <= slotAfterId) in front of the out", () => {
+    const card1 = received(1, "card1", 1_000);
+    const out = assistantOut(2, "reply", 1);
+    expect(placeTurnsInSlots([card1, out]).map((m) => m.text)).toEqual(["card1", "reply"]);
+  });
+
+  it("does not reorder legacy outs that lack slotAfterId", () => {
+    const card1 = received(1, "card1", 1_000);
+    const card2 = received(2, "card2", 3_000);
     const legacy: MessageRecordDto = {
       instanceId: "i1",
       sessionAlias: "s",
       direction: "out",
       text: "old",
       createdAt: iso(5_000),
+      startedAt: 2_000,
     };
-    expect(placeReceivedCardsAfterTurns([card1, card2, legacy]).map((m) => m.text)).toEqual(["card1", "card2", "old"]);
+    expect(placeTurnsInSlots([card1, card2, legacy]).map((m) => m.text)).toEqual(["card1", "card2", "old"]);
   });
 
   it("does not pull a later turn's trigger backward onto an earlier out", () => {
-    const card1 = received("card1", 1_000);
-    const card2 = received("card2", 3_000);
-    const out1 = assistantOut("t1", 2_000, 4_000);
-    const card3 = received("card3", 7_000);
-    const out2 = assistantOut("t2", 6_000, 8_000);
-    const placed = placeReceivedCardsAfterTurns([card1, card2, out1, card3, out2]);
-    expect(placed.map((m) => m.text)).toEqual(["card1", "t1", "card2", "t2", "card3"]);
+    const card1 = received(1, "card1", 1_000);
+    const card2 = received(2, "card2", 3_000);
+    const out1 = assistantOut(3, "t1", 1, 2_000);
+    const card3 = received(4, "card3", 7_000);
+    const out2 = assistantOut(5, "t2", 4, 6_000);
+    const placed = placeTurnsInSlots([card1, card2, out1, card3, out2]);
+    expect(placed.map((m) => m.text)).toEqual(["card1", "t1", "card2", "card3", "t2"]);
   });
 
-  it("does not nest or move sent agent-message rows (direction=sent)", () => {
+  it("does not nest or drop sent agent-message rows (direction=sent)", () => {
     const sent: MessageRecordDto = {
+      id: 2,
       instanceId: "i1",
       sessionAlias: "s",
       direction: "out",
@@ -105,14 +134,17 @@ describe("placeReceivedCardsAfterTurns", () => {
         },
       },
     };
-    const out = assistantOut("reply", 2_000, 5_000);
-    expect(placeReceivedCardsAfterTurns([sent, out]).map((m) => m.text)).toEqual(["sent", "reply"]);
+    const out = assistantOut(3, "reply", 1);
+    // Sent card was inserted after turn-start (id 2 > 1) so it moves after the out
+    // as a standalone row — Gate B still forbids nesting received cards; sent join
+    // is presentation-only and does not suppress this row.
+    expect(placeTurnsInSlots([sent, out]).map((m) => m.text)).toEqual(["reply", "sent"]);
   });
 
   it("is a no-op when the out is already in its live slot", () => {
-    const card1 = received("card1", 1_000);
-    const out = assistantOut("reply", 2_000, 4_000);
-    const card2 = received("card2", 3_000);
-    expect(placeReceivedCardsAfterTurns([card1, out, card2]).map((m) => m.text)).toEqual(["card1", "reply", "card2"]);
+    const card1 = received(1, "card1", 1_000);
+    const out = assistantOut(2, "reply", 1);
+    const card2 = received(3, "card2", 3_000);
+    expect(placeTurnsInSlots([card1, out, card2]).map((m) => m.text)).toEqual(["card1", "reply", "card2"]);
   });
 });

--- a/packages/relay-web/src/__tests__/history-turn-slots.test.ts
+++ b/packages/relay-web/src/__tests__/history-turn-slots.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { MessageRecordDto, PeerMessageHistoryEntry } from "@ganglion/xacpx-relay-protocol";
+import {
+  placeReceivedCardsAfterTurns,
+  slotAfterIndexFromStartedAt,
+} from "../lib/history-turn-slots";
+
+const iso = (ms: number) => new Date(ms).toISOString();
+
+const received = (id: string, createdAt: number): MessageRecordDto => ({
+  instanceId: "i1",
+  sessionAlias: "s",
+  direction: "in",
+  text: id,
+  createdAt: iso(createdAt),
+  structured: {
+    agentMessage: {
+      kind: "agent_message",
+      direction: "received",
+      messageId: id,
+      conversationId: `conv_${id}`,
+      peer: { handle: "agent:n:e", displayName: "Peer", agent: "codex" },
+      content: id,
+      createdAt,
+      status: "delivered",
+    } satisfies PeerMessageHistoryEntry,
+  },
+});
+
+const assistantOut = (text: string, startedAt: number, createdAt = startedAt + 5_000): MessageRecordDto => ({
+  instanceId: "i1",
+  sessionAlias: "s",
+  direction: "out",
+  text,
+  createdAt: iso(createdAt),
+  startedAt,
+});
+
+describe("slotAfterIndexFromStartedAt", () => {
+  it("places the live slot after the triggering received card and before a mid-turn card", () => {
+    const rows = [received("card1", 1_000), received("card2", 3_000)];
+    expect(slotAfterIndexFromStartedAt(rows, 2_000)).toBe(0);
+  });
+
+  it("returns -1 when every row arrived after the turn started", () => {
+    expect(slotAfterIndexFromStartedAt([received("card2", 3_000)], 2_000)).toBe(-1);
+  });
+});
+
+describe("placeReceivedCardsAfterTurns", () => {
+  it("moves a mid-turn received card to immediately after the out (hub insertion order)", () => {
+    const card1 = received("card1", 1_000);
+    const card2 = received("card2", 3_000);
+    const out = assistantOut("reply", 2_000, 5_000);
+    const placed = placeReceivedCardsAfterTurns([card1, card2, out]);
+    expect(placed.map((m) => m.text)).toEqual(["card1", "reply", "card2"]);
+  });
+
+  it("leaves a triggering received card (created before startedAt) in front of the out", () => {
+    const card1 = received("card1", 1_000);
+    const out = assistantOut("reply", 2_000, 3_000);
+    expect(placeReceivedCardsAfterTurns([card1, out]).map((m) => m.text)).toEqual(["card1", "reply"]);
+  });
+
+  it("does not reorder legacy outs that lack startedAt", () => {
+    const card1 = received("card1", 1_000);
+    const card2 = received("card2", 3_000);
+    const legacy: MessageRecordDto = {
+      instanceId: "i1",
+      sessionAlias: "s",
+      direction: "out",
+      text: "old",
+      createdAt: iso(5_000),
+    };
+    expect(placeReceivedCardsAfterTurns([card1, card2, legacy]).map((m) => m.text)).toEqual(["card1", "card2", "old"]);
+  });
+
+  it("does not pull a later turn's trigger backward onto an earlier out", () => {
+    const card1 = received("card1", 1_000);
+    const card2 = received("card2", 3_000);
+    const out1 = assistantOut("t1", 2_000, 4_000);
+    const card3 = received("card3", 7_000);
+    const out2 = assistantOut("t2", 6_000, 8_000);
+    const placed = placeReceivedCardsAfterTurns([card1, card2, out1, card3, out2]);
+    expect(placed.map((m) => m.text)).toEqual(["card1", "t1", "card2", "t2", "card3"]);
+  });
+
+  it("does not nest or move sent agent-message rows (direction=sent)", () => {
+    const sent: MessageRecordDto = {
+      instanceId: "i1",
+      sessionAlias: "s",
+      direction: "out",
+      text: "sent",
+      createdAt: iso(3_000),
+      structured: {
+        agentMessage: {
+          kind: "agent_message",
+          direction: "sent",
+          messageId: "s1",
+          conversationId: "c",
+          peer: { handle: "agent:n:e", displayName: "Peer", agent: "codex" },
+          content: "sent",
+          createdAt: 3_000,
+          status: "sent",
+        },
+      },
+    };
+    const out = assistantOut("reply", 2_000, 5_000);
+    expect(placeReceivedCardsAfterTurns([sent, out]).map((m) => m.text)).toEqual(["sent", "reply"]);
+  });
+
+  it("is a no-op when the out is already in its live slot", () => {
+    const card1 = received("card1", 1_000);
+    const out = assistantOut("reply", 2_000, 4_000);
+    const card2 = received("card2", 3_000);
+    expect(placeReceivedCardsAfterTurns([card1, out, card2]).map((m) => m.text)).toEqual(["card1", "reply", "card2"]);
+  });
+});

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -682,6 +682,60 @@ describe("MessageList", () => {
   });
 });
 
+describe("live turn slot", () => {
+  it("renders the live turn between the triggering received card and a later received card", () => {
+    const card1 = receivedCard("card1");
+    const card2 = receivedCard("card2");
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [card1, card2],
+        liveTurn: { parts: [{ type: "text", text: "working on it" }], status: "streaming", startedAt: 0, slotAfterIndex: 0 },
+      },
+    });
+    const streaming = wrapper.find('[data-test="msg-streaming"]');
+    const cards = wrapper.findAll('[data-test="agent-message-card"]');
+    expect(cards).toHaveLength(2);
+    expect(streaming.exists()).toBe(true);
+    expect(cards[0]!.element.compareDocumentPosition(streaming.element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(streaming.element.compareDocumentPosition(cards[1]!.element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("occupies the live slot with a working spinner when parts are empty", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [receivedCard("card1"), receivedCard("card2")],
+        liveTurn: { parts: [], status: "working", startedAt: 0, slotAfterIndex: 0 },
+      },
+    });
+    expect(wrapper.find('[data-test="msg-streaming"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="live-working"]').exists()).toBe(true);
+    const streaming = wrapper.find('[data-test="msg-streaming"]');
+    const cards = wrapper.findAll('[data-test="agent-message-card"]');
+    expect(cards[0]!.element.compareDocumentPosition(streaming.element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(streaming.element.compareDocumentPosition(cards[1]!.element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("never suppresses a received card while the live turn occupies its slot (Gate B)", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [receivedCard("card1"), receivedCard("card2")],
+        liveTurn: { parts: [{ type: "text", text: "stream" }], status: "streaming", startedAt: 0, slotAfterIndex: 0 },
+      },
+    });
+    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(2);
+    expect(wrapper.find('[data-test="turn-agent-message"]').exists()).toBe(false);
+    expect(wrapper.findAll('[data-test="agent-message-card"][data-direction="received"]')).toHaveLength(2);
+  });
+
+  it("hides the history skeleton when a live turn exists even with empty parts", () => {
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: { parts: [], status: "working", startedAt: 0, slotAfterIndex: -1 }, loadingHistory: true },
+    });
+    expect(wrapper.find('[data-test="history-skeleton"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="live-working"]').exists()).toBe(true);
+  });
+});
+
 it("renders legacy persisted tool steps (no parts) in a collapsed panel", () => {
   const wrapper = mount(MessageList, {
     props: {

--- a/packages/relay-web/src/__tests__/session-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/session-tail-cache.test.ts
@@ -47,6 +47,11 @@ describe("session-tail-cache", () => {
     expect((await read("alice", "i1", "s1"))![0]!.structured?.toolSteps?.[0]).toMatchObject({ toolCallId: "t" });
   });
 
+  it("round-trips startedAt so a cache seed can keep the live slot after reload", async () => {
+    await write("alice", "i1", "s1", [{ ...row(1), startedAt: 1_700_000_000_000 }]);
+    expect((await read("alice", "i1", "s1"))![0]!.startedAt).toBe(1_700_000_000_000);
+  });
+
   it("misses across accounts, instances and aliases (key isolation)", async () => {
     await write("alice", "i1", "s1", [row(1)]);
     expect(await read("bob", "i1", "s1")).toBeNull();

--- a/packages/relay-web/src/__tests__/session-tail-cache.test.ts
+++ b/packages/relay-web/src/__tests__/session-tail-cache.test.ts
@@ -47,9 +47,16 @@ describe("session-tail-cache", () => {
     expect((await read("alice", "i1", "s1"))![0]!.structured?.toolSteps?.[0]).toMatchObject({ toolCallId: "t" });
   });
 
-  it("round-trips startedAt so a cache seed can keep the live slot after reload", async () => {
+  it("round-trips startedAt so a cache seed can keep HUD elapsed after reload", async () => {
     await write("alice", "i1", "s1", [{ ...row(1), startedAt: 1_700_000_000_000 }]);
     expect((await read("alice", "i1", "s1"))![0]!.startedAt).toBe(1_700_000_000_000);
+  });
+
+  it("round-trips slotAfterId so a cache seed can keep the live-slot anchor", async () => {
+    await write("alice", "i1", "s1", [{ ...row(1), slotAfterId: 7, startedAfterSeq: 3 }]);
+    const cached = (await read("alice", "i1", "s1"))![0]!;
+    expect(cached.slotAfterId).toBe(7);
+    expect(cached.startedAfterSeq).toBe(3);
   });
 
   it("misses across accounts, instances and aliases (key isolation)", async () => {

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -71,13 +71,33 @@ function messageKey(m: ChatMessage, index: number): string {
   return `${m.instanceId}:${m.sessionAlias}:${recordKey}`;
 }
 
+// Index in the FULL messages array after which the live turn renders. Falls back to
+// the end of the list when the store has not yet recorded a slot (legacy tests / seed).
+const liveSlotAfterIndex = computed(() => {
+  if (!props.liveTurn) return null;
+  return typeof props.liveTurn.slotAfterIndex === "number"
+    ? props.liveTurn.slotAfterIndex
+    : props.messages.length - 1;
+});
+// Live slot sits above the visible window (including "no messages yet at turn start").
+const liveAtStartOfVisible = computed(() => {
+  const slot = liveSlotAfterIndex.value;
+  return props.liveTurn !== null && visibleMessages.value.length > 0 && slot !== null && slot < hiddenCount.value;
+});
+// Visible-array index after which to insert the live row; null if it is not in this window.
+const liveAfterVisibleIndex = computed(() => {
+  const slot = liveSlotAfterIndex.value;
+  if (!props.liveTurn || slot === null || slot < hiddenCount.value) return null;
+  return slot - hiddenCount.value;
+});
+
 // Initial-history skeleton: fills the pane while the first page of a freshly selected
 // session loads. Only when the transcript is truly empty — a background reload (e.g.
 // turn-finished convergence) or an already-streaming turn never triggers it.
 const showSkeleton = computed(() =>
   (props.loadingHistory ?? false)
   && props.messages.length === 0
-  && !(props.liveTurn && props.liveTurn.parts.length > 0));
+  && !props.liveTurn);
 
 // Alternates agent cards / user bubbles with varied widths so the placeholder reads as
 // a conversation, not a form. Rows pulse with a staggered delay (see --sk-delay).
@@ -120,7 +140,7 @@ function revealStep(): void {
     const e = scroller.value;
     if (e) {
       if (anchor !== null) e.scrollTop = e.scrollHeight - anchor;
-      else if (atBottom.value) e.scrollTop = e.scrollHeight;
+      else if (atBottom.value) pinToFollowTarget(e, false);
     }
     if (hiddenCount.value > 0) revealRaf = requestAnimationFrame(revealStep);
   });
@@ -171,10 +191,43 @@ watch(
 // distance-from-bottom is content-invariant). Null when no prepend is pending.
 let pendingDistFromBottom: number | null = null;
 
+function liveBubble(el: HTMLElement): HTMLElement | null {
+  const node = el.querySelector("[data-test=msg-streaming]");
+  return node instanceof HTMLElement ? node : null;
+}
+
+/** Stick-to-bottom while a live turn exists follows the live bubble, not the newest
+ *  list row — a mid-turn received card below the stream must not steal the caret. */
+function isPinnedToFollowTarget(el: HTMLElement): boolean {
+  const live = props.liveTurn ? liveBubble(el) : null;
+  if (live) {
+    const liveBottom = live.offsetTop + live.offsetHeight;
+    return liveBottom - el.scrollTop - el.clientHeight <= THRESHOLD
+      && el.scrollTop + el.clientHeight >= live.offsetTop - THRESHOLD;
+  }
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= THRESHOLD;
+}
+
+function pinToFollowTarget(el: HTMLElement, smooth: boolean): void {
+  const live = props.liveTurn ? liveBubble(el) : null;
+  if (live) {
+    if (typeof live.scrollIntoView === "function") {
+      live.scrollIntoView({ behavior: smooth ? "smooth" : "auto", block: "end" });
+    } else {
+      const top = live.offsetTop + live.offsetHeight - el.clientHeight;
+      if (typeof el.scrollTo === "function") el.scrollTo({ top: Math.max(0, top), behavior: smooth ? "smooth" : "auto" });
+      else el.scrollTop = Math.max(0, top);
+    }
+    return;
+  }
+  if (typeof el.scrollTo === "function") el.scrollTo({ top: el.scrollHeight, behavior: smooth ? "smooth" : "auto" });
+  else el.scrollTop = el.scrollHeight;
+}
+
 function onScroll(): void {
   const el = scroller.value;
   if (!el) return;
-  atBottom.value = el.scrollHeight - el.scrollTop - el.clientHeight <= THRESHOLD;
+  atBottom.value = isPinnedToFollowTarget(el);
   // Near the top while older rows are still mounting locally → nothing to fetch yet;
   // the reveal loop is already draining hiddenCount.
   if (hiddenCount.value > 0) return;
@@ -257,9 +310,9 @@ if (props.sessionKey && props.messages.length === 0) beginEnter();
 // fixed frame count; releasing earlier would let late settle frames move scrollTop
 // mid-PLAY.
 watch(
-  () => [props.messages.length, props.liveTurn?.parts.length ?? 0] as const,
-  ([msgs, liveParts]) => {
-    if (enterPhase.value !== "hold" || (msgs === 0 && liveParts === 0)) return;
+  () => [props.messages.length, props.liveTurn ? 1 : 0] as const,
+  ([msgs, live]) => {
+    if (enterPhase.value !== "hold" || (msgs === 0 && live === 0)) return;
     void nextTick(() => {
       if (enterPhase.value !== "hold") return;
       if (typeof requestAnimationFrame !== "function") { finishEnter(); return; }
@@ -293,7 +346,7 @@ watch(
       return;
     }
     if (!prev) return;
-    if (props.messages.length === 0 && !(props.liveTurn && props.liveTurn.parts.length)) finishEnter();
+    if (props.messages.length === 0 && !props.liveTurn) finishEnter();
     else armEnterCap();
   },
 );
@@ -306,7 +359,7 @@ const ENTER_STAGGER = 6;
 const ENTER_STEP_MS = 55;
 const enterRowClass = computed(() => (enterPhase.value === "play" ? "enter-row" : ""));
 const newestRowIndex = computed(() =>
-  visibleMessages.value.length - (props.liveTurn && props.liveTurn.parts.length ? 0 : 1));
+  visibleMessages.value.length - (props.liveTurn ? 0 : 1));
 function enterStyle(rowIndex: number): Record<string, string> | undefined {
   if (enterPhase.value !== "play") return undefined;
   const fromBottom = newestRowIndex.value - rowIndex;
@@ -318,8 +371,7 @@ let settleRaf = 0;
 function scrollToBottom(smooth = false): void {
   const el = scroller.value;
   if (!el) return;
-  if (typeof el.scrollTo === "function") el.scrollTo({ top: el.scrollHeight, behavior: smooth ? "smooth" : "auto" });
-  else el.scrollTop = el.scrollHeight; // jsdom / older engines
+  pinToFollowTarget(el, smooth);
   atBottom.value = true;
   // `content-visibility:auto` rows render lazily at the contain-intrinsic-size ESTIMATE,
   // so on a long history the first jump can stop short of the true bottom (the real row
@@ -333,7 +385,7 @@ function scrollToBottom(smooth = false): void {
     settleRaf = 0;
     const e = scroller.value;
     if (!e) return;
-    if (e.scrollHeight - e.scrollTop - e.clientHeight > 1) e.scrollTop = e.scrollHeight;
+    if (!isPinnedToFollowTarget(e)) pinToFollowTarget(e, false);
     if (++tries < 4) settleRaf = requestAnimationFrame(settle);
   };
   settleRaf = requestAnimationFrame(settle);
@@ -380,7 +432,7 @@ watch(
     const lt = props.liveTurn;
     const last = lt?.parts[lt.parts.length - 1];
     const tail = last ? (last.type === "tool" ? last.step.status : last.text.length) : 0;
-    return [props.messages.length, lt?.parts.length ?? 0, tail] as const;
+    return [props.messages.length, lt ? 1 : 0, lt?.parts.length ?? 0, tail, lt?.slotAfterIndex ?? -1] as const;
   },
   () => {
     if (atBottom.value) void nextTick(() => scrollToBottom(false));
@@ -426,6 +478,24 @@ watch(
              the key index is translated back to the FULL-array index so optimistic-row
              keys stay stable while older rows are still being revealed above. -->
         <template v-for="(m, i) in visibleMessages" :key="messageKey(m, hiddenCount + i)">
+          <!-- Live slot at the start of the visible window (empty prefix at turn-start,
+               or the anchor is still in unrevealed older rows). -->
+          <div
+            v-if="i === 0 && liveAtStartOfVisible && liveTurn"
+            class="flex gap-2.5"
+            :class="enterRowClass"
+            :style="enterStyle(0)"
+          >
+            <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden">
+              <AgentIcon :driver="driver" :size="15" fill />
+            </div>
+            <div data-test="msg-streaming" class="min-w-0 flex-1">
+              <TurnParts v-if="liveTurn.parts.length" :parts="liveTurn.parts" :streaming="true" :sent-agent-messages="sentAgentMessageById" />
+              <div v-else data-test="live-working" class="flex items-center gap-2 py-1 text-fg-muted">
+                <Loader2 :size="14" class="animate-spin motion-reduce:animate-none" />
+              </div>
+            </div>
+          </div>
           <!-- AGENT MESSAGE card (sender / receiver collaboration event). A sent card
                already anchored inside an assistant turn's agent_send step renders
                there; its standalone row is suppressed so the card never shows twice. -->
@@ -496,16 +566,37 @@ watch(
               </div>
             </div>
           </div>
+          <!-- Live slot after this row when it is the turn-started anchor. Later
+               received cards in the list therefore render below the still-running turn. -->
+          <div
+            v-if="liveTurn && liveAfterVisibleIndex === i"
+            class="flex gap-2.5"
+            :class="enterRowClass"
+            :style="enterStyle(i + 1)"
+          >
+            <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden">
+              <AgentIcon :driver="driver" :size="15" fill />
+            </div>
+            <div data-test="msg-streaming" class="min-w-0 flex-1">
+              <TurnParts v-if="liveTurn.parts.length" :parts="liveTurn.parts" :streaming="true" :sent-agent-messages="sentAgentMessageById" />
+              <div v-else data-test="live-working" class="flex items-center gap-2 py-1 text-fg-muted">
+                <Loader2 :size="14" class="animate-spin motion-reduce:animate-none" />
+              </div>
+            </div>
+          </div>
         </template>
 
-        <!-- live streaming assistant row -->
-        <div v-if="liveTurn && liveTurn.parts.length" class="flex gap-2.5" :class="enterRowClass"
-             :style="enterStyle(visibleMessages.length)">
+        <!-- live streaming assistant row when the transcript is empty (working spinner occupies the slot even with no parts yet) -->
+        <div v-if="liveTurn && visibleMessages.length === 0" class="flex gap-2.5" :class="enterRowClass"
+             :style="enterStyle(0)">
           <div class="mt-0.5 grid h-6 w-6 shrink-0 place-items-center overflow-hidden">
             <AgentIcon :driver="driver" :size="15" fill />
           </div>
           <div data-test="msg-streaming" class="min-w-0 flex-1">
-            <TurnParts :parts="liveTurn.parts" :streaming="true" :sent-agent-messages="sentAgentMessageById" />
+            <TurnParts v-if="liveTurn.parts.length" :parts="liveTurn.parts" :streaming="true" :sent-agent-messages="sentAgentMessageById" />
+            <div v-else data-test="live-working" class="flex items-center gap-2 py-1 text-fg-muted">
+              <Loader2 :size="14" class="animate-spin motion-reduce:animate-none" />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/relay-web/src/lib/history-turn-slots.ts
+++ b/packages/relay-web/src/lib/history-turn-slots.ts
@@ -1,0 +1,83 @@
+import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
+
+/** Rows the slot/reorder helpers can inspect. Matches persisted history and live transcript. */
+export type SlottableMessage = Pick<MessageRecordDto, "direction" | "createdAt" | "startedAt" | "structured">;
+
+export function isReceivedAgentMessage(row: SlottableMessage): boolean {
+  return row.structured?.agentMessage?.direction === "received";
+}
+
+/** Prefer the peer card's epoch ms; fall back to the row ISO timestamp. Invalid/missing → undefined. */
+export function messageCreatedAtMs(row: SlottableMessage): number | undefined {
+  const fromPeer = row.structured?.agentMessage?.createdAt;
+  if (typeof fromPeer === "number" && Number.isFinite(fromPeer)) return fromPeer;
+  if (typeof row.createdAt !== "string") return undefined;
+  const t = Date.parse(row.createdAt);
+  return Number.isFinite(t) ? t : undefined;
+}
+
+export function isAssistantOutRow(row: SlottableMessage): boolean {
+  return row.direction === "out" && row.structured?.agentMessage === undefined;
+}
+
+/**
+ * Index of the last message that existed at `startedAt` (inclusive). The live turn
+ * renders after this index. `-1` means the slot is at the start of the list.
+ *
+ * Mid-turn received cards (created after the turn began) stop the scan so they
+ * stay below the live bubble.
+ */
+export function slotAfterIndexFromStartedAt(messages: SlottableMessage[], startedAt: number): number {
+  let idx = -1;
+  for (let i = 0; i < messages.length; i++) {
+    const t = messageCreatedAtMs(messages[i]!);
+    if (t === undefined || t <= startedAt) idx = i;
+    else break;
+  }
+  return idx;
+}
+
+/**
+ * History apply: for each assistant `out` with `startedAt`, move inbound agent-message
+ * cards that currently sit BEFORE that out and whose `createdAt` is after `startedAt`
+ * to immediately after the out.
+ *
+ * Hub insertion order is card1, card2, out (finish time). Without this, reload restacks
+ * both received cards above the finished turn. Rows without `startedAt` are not moved
+ * (legacy). Only predecessor cards are considered so a later turn's trigger is not
+ * pulled backward onto an earlier out.
+ */
+export function placeReceivedCardsAfterTurns<T extends SlottableMessage>(rows: T[]): T[] {
+  const out = rows.slice();
+  let i = 0;
+  while (i < out.length) {
+    const row = out[i]!;
+    if (!isAssistantOutRow(row) || typeof row.startedAt !== "number" || !Number.isFinite(row.startedAt)) {
+      i += 1;
+      continue;
+    }
+    const startedAt = row.startedAt;
+    const movers: T[] = [];
+    for (let j = 0; j < i; j++) {
+      const prev = out[j]!;
+      if (!isReceivedAgentMessage(prev)) continue;
+      const t = messageCreatedAtMs(prev);
+      if (t !== undefined && t > startedAt) movers.push(prev);
+    }
+    if (movers.length === 0) {
+      i += 1;
+      continue;
+    }
+    for (const mover of movers) {
+      const at = out.indexOf(mover);
+      if (at >= 0 && at < i) {
+        out.splice(at, 1);
+        i -= 1;
+      }
+    }
+    const insertAt = out.indexOf(row) + 1;
+    out.splice(insertAt, 0, ...movers);
+    i = insertAt + movers.length;
+  }
+  return out;
+}

--- a/packages/relay-web/src/lib/history-turn-slots.ts
+++ b/packages/relay-web/src/lib/history-turn-slots.ts
@@ -1,68 +1,61 @@
 import type { MessageRecordDto } from "@ganglion/xacpx-relay-protocol";
 
 /** Rows the slot/reorder helpers can inspect. Matches persisted history and live transcript. */
-export type SlottableMessage = Pick<MessageRecordDto, "direction" | "createdAt" | "startedAt" | "structured">;
+export type SlottableMessage = Pick<MessageRecordDto, "id" | "direction" | "startedAt" | "slotAfterId" | "structured">;
 
 export function isReceivedAgentMessage(row: SlottableMessage): boolean {
   return row.structured?.agentMessage?.direction === "received";
-}
-
-/** Prefer the peer card's epoch ms; fall back to the row ISO timestamp. Invalid/missing → undefined. */
-export function messageCreatedAtMs(row: SlottableMessage): number | undefined {
-  const fromPeer = row.structured?.agentMessage?.createdAt;
-  if (typeof fromPeer === "number" && Number.isFinite(fromPeer)) return fromPeer;
-  if (typeof row.createdAt !== "string") return undefined;
-  const t = Date.parse(row.createdAt);
-  return Number.isFinite(t) ? t : undefined;
 }
 
 export function isAssistantOutRow(row: SlottableMessage): boolean {
   return row.direction === "out" && row.structured?.agentMessage === undefined;
 }
 
+function isSlotAfterId(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
 /**
- * Index of the last message that existed at `startedAt` (inclusive). The live turn
- * renders after this index. `-1` means the slot is at the start of the list.
+ * Index of the last message whose Hub id is `<= slotAfterId` (the durable insert-order
+ * anchor from `turn-started`). `-1` means the slot is at the start of the list.
  *
- * Mid-turn received cards (created after the turn began) stop the scan so they
- * stay below the live bubble.
+ * Live path uses transcript index at turn-start; this is for history/seed/snapshot
+ * where rows carry Hub ids. Do not infer this from wall clocks.
  */
-export function slotAfterIndexFromStartedAt(messages: SlottableMessage[], startedAt: number): number {
+export function slotAfterIndexFromAnchor(messages: SlottableMessage[], slotAfterId: number): number {
   let idx = -1;
   for (let i = 0; i < messages.length; i++) {
-    const t = messageCreatedAtMs(messages[i]!);
-    if (t === undefined || t <= startedAt) idx = i;
-    else break;
+    const id = messages[i]!.id;
+    if (typeof id === "number" && id <= slotAfterId) idx = i;
   }
   return idx;
 }
 
 /**
- * History apply: for each assistant `out` with `startedAt`, move inbound agent-message
- * cards that currently sit BEFORE that out and whose `createdAt` is after `startedAt`
- * to immediately after the out.
+ * History apply: for each assistant `out` with `slotAfterId`, move every transcript
+ * row currently sitting BEFORE that out whose Hub `id` is greater than the anchor
+ * (inserted after turn-start) to immediately after the out.
  *
- * Hub insertion order is card1, card2, out (finish time). Without this, reload restacks
- * both received cards above the finished turn. Rows without `startedAt` are not moved
- * (legacy). Only predecessor cards are considered so a later turn's trigger is not
- * pulled backward onto an earlier out.
+ * Hub insertion order is trigger, mid-turn rows, then `out` (finish time). Without
+ * this, reload restacks mid-turn received cards AND queued prompts above the finished
+ * turn. Rows without `slotAfterId` are not moved (legacy). Relative order of movers
+ * is preserved. Clocks (`createdAt` / `startedAt`) are never consulted.
  */
-export function placeReceivedCardsAfterTurns<T extends SlottableMessage>(rows: T[]): T[] {
+export function placeTurnsInSlots<T extends SlottableMessage>(rows: T[]): T[] {
   const out = rows.slice();
   let i = 0;
   while (i < out.length) {
     const row = out[i]!;
-    if (!isAssistantOutRow(row) || typeof row.startedAt !== "number" || !Number.isFinite(row.startedAt)) {
+    if (!isAssistantOutRow(row) || !isSlotAfterId(row.slotAfterId)) {
       i += 1;
       continue;
     }
-    const startedAt = row.startedAt;
+    const anchor = row.slotAfterId;
     const movers: T[] = [];
     for (let j = 0; j < i; j++) {
       const prev = out[j]!;
-      if (!isReceivedAgentMessage(prev)) continue;
-      const t = messageCreatedAtMs(prev);
-      if (t !== undefined && t > startedAt) movers.push(prev);
+      if (typeof prev.id !== "number") continue;
+      if (prev.id > anchor) movers.push(prev);
     }
     if (movers.length === 0) {
       i += 1;

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -186,6 +186,8 @@ function toCachedRow(row: MessageRecordDto): MessageRecordDto {
   // tail holds an attachment row. toRaw yields the underlying plain tree.
   if (row.attachments !== undefined) out.attachments = toRaw(row.attachments);
   if (row.startedAt !== undefined) out.startedAt = row.startedAt;
+  if (row.slotAfterId !== undefined) out.slotAfterId = row.slotAfterId;
+  if (row.startedAfterSeq !== undefined) out.startedAfterSeq = row.startedAfterSeq;
   return out;
 }
 

--- a/packages/relay-web/src/lib/session-tail-cache.ts
+++ b/packages/relay-web/src/lib/session-tail-cache.ts
@@ -185,6 +185,7 @@ function toCachedRow(row: MessageRecordDto): MessageRecordDto {
   // proxies (DataCloneError), silently killing every write for a session whose
   // tail holds an attachment row. toRaw yields the underlying plain tree.
   if (row.attachments !== undefined) out.attachments = toRaw(row.attachments);
+  if (row.startedAt !== undefined) out.startedAt = row.startedAt;
   return out;
 }
 

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -3,7 +3,7 @@ import { computed, markRaw, ref } from "vue";
 import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, QueueItemDto, ScheduledOriginDto, SessionCommandsSnapshotDto, SessionUsageSnapshotDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 import { createDebouncedFlush } from "../lib/debounce-flush";
-import { placeReceivedCardsAfterTurns, slotAfterIndexFromStartedAt } from "../lib/history-turn-slots";
+import { placeTurnsInSlots, slotAfterIndexFromAnchor } from "../lib/history-turn-slots";
 import * as tailCache from "../lib/session-tail-cache";
 import { useAuthStore } from "./auth";
 import { useInstancesStore } from "./instances";
@@ -44,11 +44,18 @@ export interface LiveTurn {
   startedAt: number;
   /**
    * Index of the last transcript message that existed at turn-started (inclusive).
-   * The live bubble renders after this row so later received cards can append below
-   * the still-running turn. `-1` = slot at the start of the list. Omitted → render
-   * after the last current message (legacy / tests).
+   * The live bubble renders after this row so later received cards / queued prompts
+   * can append below the still-running turn. `-1` = slot at the start of the list.
+   * Omitted → render after the last current message (legacy / tests).
+   * This is insert-order (transcript index at turn-start), never inferred from clocks.
    */
   slotAfterIndex?: number;
+  /**
+   * Hub `messages.id` of the last row at turn-start (0 = empty transcript). Used to
+   * recompute `slotAfterIndex` after history apply. Absent on purely local live turns
+   * whose transcript rows have not yet been assigned Hub ids.
+   */
+  slotAfterId?: number;
 }
 
 // Coalescing appenders — consecutive same-type chunks merge into one part. Text chunks
@@ -123,6 +130,10 @@ function keepRicherStructured(incoming: MessageRecordDto[], previous: ChatMessag
     }
     const startedAt = next.startedAt ?? prev?.startedAt ?? (i === lastOutIndex ? flushed?.startedAt : undefined);
     if (startedAt !== undefined && next.startedAt === undefined) next = { ...next, startedAt };
+    const slotAfterId = next.slotAfterId ?? prev?.slotAfterId ?? (i === lastOutIndex ? flushed?.slotAfterId : undefined);
+    if (slotAfterId !== undefined && next.slotAfterId === undefined) next = { ...next, slotAfterId };
+    const startedAfterSeq = next.startedAfterSeq ?? prev?.startedAfterSeq ?? (i === lastOutIndex ? flushed?.startedAfterSeq : undefined);
+    if (startedAfterSeq !== undefined && next.startedAfterSeq === undefined) next = { ...next, startedAfterSeq };
     return next;
   });
 }
@@ -247,11 +258,13 @@ export const useChatStore = defineStore("chat", () => {
     return t;
   }
 
-  /** Place the live bubble after messages that existed at `startedAt` (history/seed). */
+  /** Place the live bubble after the Hub insert-order anchor (history/seed/snapshot). */
   function syncLiveSlot(k: string): void {
     const t = liveTurns.value[k];
     if (!t || selectedKey.value !== k) return;
-    t.slotAfterIndex = slotAfterIndexFromStartedAt(messages.value, t.startedAt);
+    if (typeof t.slotAfterId === "number") {
+      t.slotAfterIndex = slotAfterIndexFromAnchor(messages.value, t.slotAfterId);
+    }
   }
 
   // Known transport incarnations (SessionDto.transportSession) per session, fed
@@ -367,6 +380,7 @@ export const useChatStore = defineStore("chat", () => {
         text,
         createdAt: new Date().toISOString(),
         startedAt: t.startedAt,
+        ...(typeof t.slotAfterId === "number" ? { slotAfterId: t.slotAfterId } : {}),
         failed: status === "error",
         status,
         ...(structured ? { structured } : {}),
@@ -420,7 +434,7 @@ export const useChatStore = defineStore("chat", () => {
     if (!cached || cached.length === 0) return;
     if (id !== instanceId.value || alias !== sessionAlias.value) return;
     if (messages.value.length > 0 || revision !== transcriptRevision) return;
-    messages.value = placeReceivedCardsAfterTurns(cached.map(rawStructured));
+    messages.value = placeTurnsInSlots(cached.map(rawStructured));
     touchTranscript();
     seededFromCache = true;
     seedRowsPresent = true;
@@ -494,7 +508,7 @@ export const useChatStore = defineStore("chat", () => {
       // would leave the pane with only the live turn. Retry against the same
       // selection so persisted history and the current turn converge.
       if (revision !== transcriptRevision) return loadHistory();
-      messages.value = placeReceivedCardsAfterTurns(keepRicherStructured(rows, messages.value).map(rawStructured));
+      messages.value = placeTurnsInSlots(keepRicherStructured(rows, messages.value).map(rawStructured));
       touchTranscript();
       seededFromCache = false;
       seedRowsPresent = false;
@@ -526,10 +540,11 @@ export const useChatStore = defineStore("chat", () => {
       // The session may have changed while awaiting; only apply if still selected.
       if (id !== instanceId.value || alias !== sessionAlias.value) return;
       if (older.length > 0) {
-        messages.value = placeReceivedCardsAfterTurns([...older.map(rawStructured), ...messages.value]);
+        messages.value = placeTurnsInSlots([...older.map(rawStructured), ...messages.value]);
         touchTranscript();
         const live = liveTurns.value[bufKey(id, alias)];
         if (live) live.slotAfterIndex = (live.slotAfterIndex ?? 0) + older.length;
+        syncLiveSlot(bufKey(id, alias));
       }
       hasMoreOlder.value = hasMore ?? false;
     } catch {
@@ -553,7 +568,10 @@ export const useChatStore = defineStore("chat", () => {
         parts: t.parts as TurnPart[],
         status: t.status,
         startedAt: t.startedAt,
-        slotAfterIndex: selectedKey.value === k ? slotAfterIndexFromStartedAt(messages.value, t.startedAt) : -1,
+        ...(typeof t.slotAfterId === "number" ? { slotAfterId: t.slotAfterId } : {}),
+        slotAfterIndex: selectedKey.value === k && typeof t.slotAfterId === "number"
+          ? slotAfterIndexFromAnchor(messages.value, t.slotAfterId)
+          : selectedKey.value === k ? messages.value.length - 1 : -1,
       };
     }
   }
@@ -579,7 +597,10 @@ export const useChatStore = defineStore("chat", () => {
         parts: turn.parts as TurnPart[],
         status: turn.status,
         startedAt: turn.startedAt,
-        slotAfterIndex: selectedKey.value === k ? slotAfterIndexFromStartedAt(messages.value, turn.startedAt) : -1,
+        ...(typeof turn.slotAfterId === "number" ? { slotAfterId: turn.slotAfterId } : {}),
+        slotAfterIndex: selectedKey.value === k && typeof turn.slotAfterId === "number"
+          ? slotAfterIndexFromAnchor(messages.value, turn.slotAfterId)
+          : selectedKey.value === k ? messages.value.length - 1 : -1,
       };
     }
     liveTurns.value = nextTurns;
@@ -694,11 +715,13 @@ export const useChatStore = defineStore("chat", () => {
       }
       // Anchor the live slot after whatever is now last (triggering received card,
       // the prompt just appended, or the drained queued bubble). Later mid-turn
-      // received cards append below this slot. Do not infer from startedAt here:
-      // the locally-stamped prompt ISO can be 1ms after Date.now() on the turn.
+      // rows append below this slot. Insert order — never infer from startedAt.
       if (selected) {
         const live = liveTurns.value[k];
-        if (live) live.slotAfterIndex = messages.value.length - 1;
+        if (live) {
+          live.slotAfterIndex = messages.value.length - 1;
+          if (typeof e.slotAfterId === "number") live.slotAfterId = e.slotAfterId;
+        }
       }
     } else if (e.type === "turn-output") {
       const t = ensureTurn(bufKey(event.instanceId, e.sessionAlias));

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -3,6 +3,7 @@ import { computed, markRaw, ref } from "vue";
 import type { AgentCommandDto, AttachmentMetadata, LiveTurnSnapshotDto, MessageRecordDto, PlanEntryDto, PromptAttachmentRef, QueueItemDto, ScheduledOriginDto, SessionCommandsSnapshotDto, SessionUsageSnapshotDto, ToolStepDto, TurnPartDto, UsageBreakdownDto, UsageCostDto, WebServerEvent } from "@ganglion/xacpx-relay-protocol";
 import { api, ApiError } from "../api/client";
 import { createDebouncedFlush } from "../lib/debounce-flush";
+import { placeReceivedCardsAfterTurns, slotAfterIndexFromStartedAt } from "../lib/history-turn-slots";
 import * as tailCache from "../lib/session-tail-cache";
 import { useAuthStore } from "./auth";
 import { useInstancesStore } from "./instances";
@@ -41,6 +42,13 @@ export interface LiveTurn {
   parts: TurnPart[];
   status: "working" | "streaming";
   startedAt: number;
+  /**
+   * Index of the last transcript message that existed at turn-started (inclusive).
+   * The live bubble renders after this row so later received cards can append below
+   * the still-running turn. `-1` = slot at the start of the list. Omitted → render
+   * after the last current message (legacy / tests).
+   */
+  slotAfterIndex?: number;
 }
 
 // Coalescing appenders — consecutive same-type chunks merge into one part. Text chunks
@@ -107,13 +115,15 @@ function keepRicherStructured(incoming: MessageRecordDto[], previous: ChatMessag
   }
   return incoming.map((row, i) => {
     const prev = typeof row.id === "number" ? byId.get(row.id) : undefined;
+    let next: MessageRecordDto = row;
     if (row.structured?.compact === true && isFullStructured(prev?.structured)) {
-      return { ...row, structured: prev!.structured };
+      next = { ...row, structured: prev!.structured };
+    } else if (i === lastOutIndex && flushed?.structured && row.structured?.compact === true && flushed.text === row.text) {
+      next = { ...row, structured: flushed.structured };
     }
-    if (i === lastOutIndex && flushed?.structured && row.structured?.compact === true && flushed.text === row.text) {
-      return { ...row, structured: flushed.structured };
-    }
-    return row;
+    const startedAt = next.startedAt ?? prev?.startedAt ?? (i === lastOutIndex ? flushed?.startedAt : undefined);
+    if (startedAt !== undefined && next.startedAt === undefined) next = { ...next, startedAt };
+    return next;
   });
 }
 
@@ -224,8 +234,24 @@ export const useChatStore = defineStore("chat", () => {
 
   function ensureTurn(k: string): LiveTurn {
     let t = liveTurns.value[k];
-    if (!t) { t = { parts: [], status: "working", startedAt: Date.now() }; liveTurns.value[k] = t; }
+    if (!t) {
+      const selected = selectedKey.value === k;
+      t = {
+        parts: [],
+        status: "working",
+        startedAt: Date.now(),
+        slotAfterIndex: selected ? messages.value.length - 1 : -1,
+      };
+      liveTurns.value[k] = t;
+    }
     return t;
+  }
+
+  /** Place the live bubble after messages that existed at `startedAt` (history/seed). */
+  function syncLiveSlot(k: string): void {
+    const t = liveTurns.value[k];
+    if (!t || selectedKey.value !== k) return;
+    t.slotAfterIndex = slotAfterIndexFromStartedAt(messages.value, t.startedAt);
   }
 
   // Known transport incarnations (SessionDto.transportSession) per session, fed
@@ -333,12 +359,14 @@ export const useChatStore = defineStore("chat", () => {
       const structured = hasStructured
         ? markRaw({ toolSteps, ...(reasoning ? { reasoning } : {}), parts: t.parts })
         : undefined;
-      messages.value.push({
+      const insertAt = Math.min(Math.max((t.slotAfterIndex ?? messages.value.length - 1) + 1, 0), messages.value.length);
+      messages.value.splice(insertAt, 0, {
         instanceId: instId,
         sessionAlias: alias,
         direction: "out",
         text,
         createdAt: new Date().toISOString(),
+        startedAt: t.startedAt,
         failed: status === "error",
         status,
         ...(structured ? { structured } : {}),
@@ -380,6 +408,7 @@ export const useChatStore = defineStore("chat", () => {
       next.delete(k);
       unread.value = next;
     }
+    syncLiveSlot(k);
   }
 
   /** Apply the cached tail for a freshly selected session, unless the selection
@@ -391,10 +420,11 @@ export const useChatStore = defineStore("chat", () => {
     if (!cached || cached.length === 0) return;
     if (id !== instanceId.value || alias !== sessionAlias.value) return;
     if (messages.value.length > 0 || revision !== transcriptRevision) return;
-    messages.value = cached.map(rawStructured);
+    messages.value = placeReceivedCardsAfterTurns(cached.map(rawStructured));
     touchTranscript();
     seededFromCache = true;
     seedRowsPresent = true;
+    if (instanceId.value && sessionAlias.value) syncLiveSlot(bufKey(instanceId.value, sessionAlias.value));
   }
 
   /** Drop the active selection back to the empty "no session" state — used when the
@@ -464,13 +494,14 @@ export const useChatStore = defineStore("chat", () => {
       // would leave the pane with only the live turn. Retry against the same
       // selection so persisted history and the current turn converge.
       if (revision !== transcriptRevision) return loadHistory();
-      messages.value = keepRicherStructured(rows, messages.value).map(rawStructured);
+      messages.value = placeReceivedCardsAfterTurns(keepRicherStructured(rows, messages.value).map(rawStructured));
       touchTranscript();
       seededFromCache = false;
       seedRowsPresent = false;
       hasMoreOlder.value = hasMore ?? false;
       // Authoritative rows landed — refresh this session's cached tail (debounced).
       cacheWrite.schedule();
+      syncLiveSlot(historyKey);
     } finally {
       // Only the newest request owns the flag — a stale response must not dismiss
       // the skeleton a newer selection just raised.
@@ -495,8 +526,10 @@ export const useChatStore = defineStore("chat", () => {
       // The session may have changed while awaiting; only apply if still selected.
       if (id !== instanceId.value || alias !== sessionAlias.value) return;
       if (older.length > 0) {
-        messages.value = [...older.map(rawStructured), ...messages.value];
+        messages.value = placeReceivedCardsAfterTurns([...older.map(rawStructured), ...messages.value]);
         touchTranscript();
+        const live = liveTurns.value[bufKey(id, alias)];
+        if (live) live.slotAfterIndex = (live.slotAfterIndex ?? 0) + older.length;
       }
       hasMoreOlder.value = hasMore ?? false;
     } catch {
@@ -516,7 +549,12 @@ export const useChatStore = defineStore("chat", () => {
       // Don't overwrite a live turn already tracked from the ws stream (it's fresher),
       // and don't resurrect one that finished in the snapshot→seed gap (see finishedTurns).
       if (liveTurns.value[k] || finishedTurns.has(k)) continue;
-      liveTurns.value[k] = { parts: t.parts as TurnPart[], status: t.status, startedAt: t.startedAt };
+      liveTurns.value[k] = {
+        parts: t.parts as TurnPart[],
+        status: t.status,
+        startedAt: t.startedAt,
+        slotAfterIndex: selectedKey.value === k ? slotAfterIndexFromStartedAt(messages.value, t.startedAt) : -1,
+      };
     }
   }
 
@@ -537,7 +575,12 @@ export const useChatStore = defineStore("chat", () => {
     for (const k of Object.keys(nextTurns)) if (k.startsWith(prefix)) delete nextTurns[k];
     for (const turn of turns) {
       const k = bufKey(instId, turn.sessionAlias);
-      nextTurns[k] = { parts: turn.parts as TurnPart[], status: turn.status, startedAt: turn.startedAt };
+      nextTurns[k] = {
+        parts: turn.parts as TurnPart[],
+        status: turn.status,
+        startedAt: turn.startedAt,
+        slotAfterIndex: selectedKey.value === k ? slotAfterIndexFromStartedAt(messages.value, turn.startedAt) : -1,
+      };
     }
     liveTurns.value = nextTurns;
 
@@ -648,6 +691,14 @@ export const useChatStore = defineStore("chat", () => {
         });
         touchTranscript();
         seededFromCache = false;
+      }
+      // Anchor the live slot after whatever is now last (triggering received card,
+      // the prompt just appended, or the drained queued bubble). Later mid-turn
+      // received cards append below this slot. Do not infer from startedAt here:
+      // the locally-stamped prompt ISO can be 1ms after Date.now() on the turn.
+      if (selected) {
+        const live = liveTurns.value[k];
+        if (live) live.slotAfterIndex = messages.value.length - 1;
       }
     } else if (e.type === "turn-output") {
       const t = ensureTurn(bufKey(event.instanceId, e.sessionAlias));

--- a/packages/relay/src/db.ts
+++ b/packages/relay/src/db.ts
@@ -170,7 +170,8 @@ export function initSchema(db: SqlDriver): void {
       queue_item_id TEXT,
       queue_fallback INTEGER NOT NULL DEFAULT 0,
       origin_queue_item_id TEXT,
-      prompt_request_id TEXT
+      prompt_request_id TEXT,
+      started_at INTEGER
     );
     CREATE INDEX IF NOT EXISTS idx_messages_session ON messages (instance_id, session_alias, id);
     CREATE TABLE IF NOT EXISTS recovery_receipts (
@@ -226,6 +227,9 @@ export function initSchema(db: SqlDriver): void {
   }
   if (!messageCols.some((c) => c.name === "prompt_request_id")) {
     db.exec("ALTER TABLE messages ADD COLUMN prompt_request_id TEXT");
+  }
+  if (!messageCols.some((c) => c.name === "started_at")) {
+    db.exec("ALTER TABLE messages ADD COLUMN started_at INTEGER");
   }
   const instanceCols = db.all<{ name: string }>("PRAGMA table_info(instances)");
   if (!instanceCols.some((c) => c.name === "capabilities_json")) {

--- a/packages/relay/src/db.ts
+++ b/packages/relay/src/db.ts
@@ -171,7 +171,9 @@ export function initSchema(db: SqlDriver): void {
       queue_fallback INTEGER NOT NULL DEFAULT 0,
       origin_queue_item_id TEXT,
       prompt_request_id TEXT,
-      started_at INTEGER
+      started_at INTEGER,
+      slot_after_id INTEGER,
+      started_after_seq INTEGER
     );
     CREATE INDEX IF NOT EXISTS idx_messages_session ON messages (instance_id, session_alias, id);
     CREATE TABLE IF NOT EXISTS recovery_receipts (
@@ -180,6 +182,16 @@ export function initSchema(db: SqlDriver): void {
       created_at TEXT NOT NULL,
       PRIMARY KEY (instance_id, recovery_id)
     );
+    CREATE TABLE IF NOT EXISTS turn_slot_anchors (
+      instance_id TEXT NOT NULL,
+      session_alias TEXT NOT NULL,
+      recovery_id TEXT NOT NULL DEFAULT '',
+      slot_after_id INTEGER NOT NULL,
+      started_at INTEGER,
+      started_after_seq INTEGER,
+      PRIMARY KEY (instance_id, recovery_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_turn_slot_anchors_session ON turn_slot_anchors (instance_id, session_alias);
     CREATE TABLE IF NOT EXISTS pending_completion_routes (
       request_message_id TEXT PRIMARY KEY,
       account_id TEXT NOT NULL,
@@ -230,6 +242,12 @@ export function initSchema(db: SqlDriver): void {
   }
   if (!messageCols.some((c) => c.name === "started_at")) {
     db.exec("ALTER TABLE messages ADD COLUMN started_at INTEGER");
+  }
+  if (!messageCols.some((c) => c.name === "slot_after_id")) {
+    db.exec("ALTER TABLE messages ADD COLUMN slot_after_id INTEGER");
+  }
+  if (!messageCols.some((c) => c.name === "started_after_seq")) {
+    db.exec("ALTER TABLE messages ADD COLUMN started_after_seq INTEGER");
   }
   const instanceCols = db.all<{ name: string }>("PRAGMA table_info(instances)");
   if (!instanceCols.some((c) => c.name === "capabilities_json")) {

--- a/packages/relay/src/http/app.ts
+++ b/packages/relay/src/http/app.ts
@@ -17,6 +17,7 @@ import {
 import type { AccountRow, AccountStore } from "../stores/accounts.js";
 import type { InstanceStore } from "../stores/instances.js";
 import type { MessageStore } from "../stores/messages.js";
+import type { TurnSlotAnchorStore } from "../stores/turn-slot-anchors.js";
 import type { PushSubscriptionStore } from "../stores/push-subscriptions.js";
 import { isAllowedPushEndpoint } from "../push.js";
 import type { RelayLogger } from "../logging.js";
@@ -36,6 +37,8 @@ export interface AppDeps {
   instances: InstanceStore;
   gateway: GatewayForApp;
   messages: MessageStore;
+  /** Live-slot anchors; cleared when a session or instance is deleted. */
+  turnSlotAnchors?: TurnSlotAnchorStore;
   /** Snapshot the in-flight turns for an instance (for the active-turns endpoint). */
   activeTurns?: (instanceId: string) => LiveTurnSnapshotDto[];
   /** Snapshot the latest per-session context-usage for an instance (for the active-turns endpoint). */
@@ -513,7 +516,9 @@ export function createApp(deps: AppDeps): Hono<Vars> {
 
   app.delete("/api/instances/:id", (c) => {
     const account = c.get("account");
-    const removed = deps.instances.remove(c.req.param("id"), account.id);
+    const instanceId = c.req.param("id");
+    const removed = deps.instances.remove(instanceId, account.id);
+    if (removed) deps.turnSlotAnchors?.deleteByInstance(instanceId);
     return removed ? c.json({ ok: true }) : c.json({ error: "not-found" }, 404);
   });
   app.get("/api/agent-directory", (c) => {
@@ -728,6 +733,7 @@ export function createApp(deps: AppDeps): Hono<Vars> {
       // success; archive intentionally keeps both histories.
       if (removeInput && !isErrorPayload(result)) {
         deps.messages.deleteBySession(instance.id, removeInput.alias);
+        deps.turnSlotAnchors?.deleteBySession(instance.id, removeInput.alias);
       }
       if (body.type === MSG.commandExecute) {
         const p = payload as { sessionAlias?: string; text?: string };

--- a/packages/relay/src/http/compact-history.ts
+++ b/packages/relay/src/http/compact-history.ts
@@ -110,6 +110,8 @@ function structuredIsHeavy(structured: StructuredTurn): boolean {
  * `parts` already carries them, and strip bulky tool bodies (diffs, command output,
  * file previews). Collapsed cards keep titles/status plus a short subagent snippet.
  * The full row is available from `GET .../messages/:id`.
+ * Top-level fields such as `startedAt` are copied through unchanged — compact must
+ * not drop the live-slot timestamp used to restack mid-turn received cards.
  */
 export function compactHistoryMessage(row: MessageRecordDto): MessageRecordDto {
   const structured = row.structured;

--- a/packages/relay/src/http/compact-history.ts
+++ b/packages/relay/src/http/compact-history.ts
@@ -110,8 +110,8 @@ function structuredIsHeavy(structured: StructuredTurn): boolean {
  * `parts` already carries them, and strip bulky tool bodies (diffs, command output,
  * file previews). Collapsed cards keep titles/status plus a short subagent snippet.
  * The full row is available from `GET .../messages/:id`.
- * Top-level fields such as `startedAt` are copied through unchanged — compact must
- * not drop the live-slot timestamp used to restack mid-turn received cards.
+ * Top-level fields such as `startedAt`, `slotAfterId`, and `startedAfterSeq` are
+ * copied through unchanged — compact must not drop the durable slot anchor.
  */
 export function compactHistoryMessage(row: MessageRecordDto): MessageRecordDto {
   const structured = row.structured;

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -16,7 +16,7 @@ import { InstanceStore } from "./stores/instances.js";
 import { MessageStore } from "./stores/messages.js";
 import { PendingCompletionRouteStore } from "./stores/pending-completion-routes.js";
 import { RecoveryReceiptStore } from "./stores/recovery-receipts.js";
-import { TurnSlotAnchorStore } from "./stores/turn-slot-anchors.js";
+import { TurnSlotAnchorStore, canonicalRecoveryId } from "./stores/turn-slot-anchors.js";
 import { DEFAULT_REQUEST_TIMEOUT_MS, InstanceGateway } from "./gateway/instance-gateway.js";
 import { WebGateway } from "./gateway/web-gateway.js";
 import { PushNotifier, vapidFromEnv, validateVapidConfig, type VapidConfig } from "./push.js";
@@ -103,6 +103,7 @@ export interface RelayRuntime {
   instances: InstanceStore;
   messages: MessageStore;
   recoveryReceipts: RecoveryReceiptStore;
+  slotAnchors: TurnSlotAnchorStore;
   pushSubscriptions: PushSubscriptionStore;
   pushNotifier: PushNotifier;
   gateway: InstanceGateway;
@@ -440,7 +441,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
         slotAnchors.put({
           instanceId,
           sessionAlias,
-          recoveryId: recoveryId ?? "",
+          recoveryId: canonicalRecoveryId(sessionAlias, recoveryId),
           slotAfterId: slot.slotAfterId,
           ...(slot.startedAt !== undefined ? { startedAt: slot.startedAt } : {}),
           ...(slot.startedAfterSeq !== undefined ? { startedAfterSeq: slot.startedAfterSeq } : {}),
@@ -469,8 +470,10 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
         sessionAlias: string,
         turn: { recoveryId?: string; startedAfterSeq?: number; startedAt: number },
       ): OutSlot => {
-        const stored = (turn.recoveryId ? slotAnchors.get(instanceId, turn.recoveryId) : undefined)
-          ?? slotAnchors.getBySession(instanceId, sessionAlias);
+        // Exact recovery identity only. A non-empty recoveryId miss means Hub
+        // never saw this start — snapshot lastId after prompt reconcile. Do
+        // not bind a leftover session anchor from an expired earlier turn.
+        const stored = slotAnchors.get(instanceId, canonicalRecoveryId(sessionAlias, turn.recoveryId));
         if (stored) {
           return {
             slotAfterId: stored.slotAfterId,
@@ -974,8 +977,9 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 // Restored original start so the elapsed-time HUD survives the restart.
                 startedAt: turn.startedAt,
                 // Durable insert-order slot: prefer the SQLite anchor from the original
-                // turn-started (survives Hub restart). Turns that started during outage
-                // snapshot lastId AFTER prompt reconcile — mid-turn cards were not persisted
+                // turn-started (exact recoveryId, or per-session legacy key). A miss
+                // snapshots lastId AFTER prompt reconcile — leftover anchors from
+                // expired turns are never inherited. Mid-turn cards were not persisted
                 // while the Hub was down.
                 ...(() => {
                   const slot = restoreRunningSlot(turn.sessionAlias, {
@@ -1001,6 +1005,12 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             for (const entry of sync.commands) {
               sessionCommands.set(key(instanceId, entry.sessionAlias), entry.commands);
             }
+            // Drop leftover anchors the connector no longer reports (expired /
+            // FIFO-evicted pendingFinished). A later turn must not inherit them.
+            const keepAnchors = new Set<string>();
+            for (const turn of sync.turns) keepAnchors.add(canonicalRecoveryId(turn.sessionAlias, turn.recoveryId));
+            for (const finished of sync.finishedOffline) keepAnchors.add(canonicalRecoveryId(finished.sessionAlias, finished.recoveryId));
+            slotAnchors.retain(instanceId, keepAnchors);
             webGateway.broadcast(accountId, { kind: "state-snapshot", instanceId, ...stateSnapshot(instanceId) });
           } catch (err) {
             // Same posture as the live flush: a persistence failure must never be
@@ -1052,6 +1062,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     onWebPromptSessionCleared: (instanceId, sessionAlias) => {
       clearPendingForSession(instanceId, sessionAlias);
     },
+    turnSlotAnchors: slotAnchors,
   });
   const completionRouteSweepTimer = setInterval(
     () => gateway.sweepExpiredCompletionRoutes(),
@@ -1064,6 +1075,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     instances,
     messages,
     recoveryReceipts,
+    slotAnchors,
     pushSubscriptions,
     pushNotifier,
     gateway,

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -558,7 +558,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 const structured = hasStructured
                   ? { toolSteps: steps, ...(hasReasoning ? { reasoning: a.reasoning } : {}), ...(a.parts.length ? { parts: a.parts } : {}), ...(a.truncated ? { truncated: true } : {}) }
                   : (a.truncated ? { truncated: true } : undefined);
-                messages.append(instanceId, event.sessionAlias, "out", text, structured);
+                messages.append(instanceId, event.sessionAlias, "out", text, structured, undefined, undefined, undefined, a.startedAt);
               }
             };
             const recoveryId = event.recoveryId;

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -16,6 +16,7 @@ import { InstanceStore } from "./stores/instances.js";
 import { MessageStore } from "./stores/messages.js";
 import { PendingCompletionRouteStore } from "./stores/pending-completion-routes.js";
 import { RecoveryReceiptStore } from "./stores/recovery-receipts.js";
+import { TurnSlotAnchorStore } from "./stores/turn-slot-anchors.js";
 import { DEFAULT_REQUEST_TIMEOUT_MS, InstanceGateway } from "./gateway/instance-gateway.js";
 import { WebGateway } from "./gateway/web-gateway.js";
 import { PushNotifier, vapidFromEnv, validateVapidConfig, type VapidConfig } from "./push.js";
@@ -171,8 +172,17 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
     reasoning: string;
     parts: TurnPartDto[];
     startedAt: number;
+    /** Hub `messages.id` at turn-start (0 = empty transcript). History reorder key. */
+    slotAfterId: number;
+    /** Connector-local receive-order seq at turn-start; maps to `slotAfterId` after restart. */
+    startedAfterSeq?: number;
     truncated?: boolean;
     notification?: TurnNotificationContext;
+  }
+  interface OutSlot {
+    slotAfterId: number;
+    startedAt?: number;
+    startedAfterSeq?: number;
   }
   const turnBuffers = new Map<string, TurnAccumulator>();
   interface WebPromptGrant {
@@ -278,6 +288,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
   // store's doc comment). Written in the SAME transaction as the message rows it
   // vouches for, so a receipt can never outlive its rows or vice versa.
   const recoveryReceipts = new RecoveryReceiptStore(db);
+  const slotAnchors = new TurnSlotAnchorStore(db);
   // Latest context-usage meter per (instance, session). Unlike turnBuffers this is
   // session-scoped — it survives turn-finished (replace-latest) so a (re)connecting web
   // client can restore the usage bar after a refresh (see GET /api/active-turns). Cleared
@@ -322,6 +333,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
         parts: a.parts,
         status: a.text ? "streaming" : "working",
         startedAt: a.startedAt,
+        ...(typeof a.slotAfterId === "number" ? { slotAfterId: a.slotAfterId } : {}),
       });
     }
     return out;
@@ -424,6 +436,72 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
           messages.append(instanceId, sessionAlias, "in", opts.prompt, opts.scheduled ? { scheduled: opts.scheduled } : undefined);
         }
       };
+      const rememberAnchor = (sessionAlias: string, slot: OutSlot, recoveryId?: string): void => {
+        slotAnchors.put({
+          instanceId,
+          sessionAlias,
+          recoveryId: recoveryId ?? "",
+          slotAfterId: slot.slotAfterId,
+          ...(slot.startedAt !== undefined ? { startedAt: slot.startedAt } : {}),
+          ...(slot.startedAfterSeq !== undefined ? { startedAfterSeq: slot.startedAfterSeq } : {}),
+        });
+      };
+      const snapshotSlotAfterReconcile = (sessionAlias: string, extras: { startedAt?: number; startedAfterSeq?: number } = {}): OutSlot => ({
+        slotAfterId: messages.lastId(instanceId, sessionAlias) ?? 0,
+        ...(extras.startedAt !== undefined ? { startedAt: extras.startedAt } : {}),
+        ...(extras.startedAfterSeq !== undefined ? { startedAfterSeq: extras.startedAfterSeq } : {}),
+      });
+      const resolveFinishSlot = (
+        sessionAlias: string,
+        opts: { recoveryId?: string; startedAfterSeq?: number; startedAt?: number },
+      ): OutSlot => {
+        const stored = slotAnchors.take(instanceId, sessionAlias, opts.recoveryId);
+        if (stored) {
+          return {
+            slotAfterId: stored.slotAfterId,
+            startedAt: stored.startedAt ?? opts.startedAt,
+            startedAfterSeq: stored.startedAfterSeq ?? opts.startedAfterSeq,
+          };
+        }
+        return snapshotSlotAfterReconcile(sessionAlias, { startedAt: opts.startedAt, startedAfterSeq: opts.startedAfterSeq });
+      };
+      const restoreRunningSlot = (
+        sessionAlias: string,
+        turn: { recoveryId?: string; startedAfterSeq?: number; startedAt: number },
+      ): OutSlot => {
+        const stored = (turn.recoveryId ? slotAnchors.get(instanceId, turn.recoveryId) : undefined)
+          ?? slotAnchors.getBySession(instanceId, sessionAlias);
+        if (stored) {
+          return {
+            slotAfterId: stored.slotAfterId,
+            startedAt: stored.startedAt ?? turn.startedAt,
+            startedAfterSeq: stored.startedAfterSeq ?? turn.startedAfterSeq,
+          };
+        }
+        const slot = snapshotSlotAfterReconcile(sessionAlias, { startedAt: turn.startedAt, startedAfterSeq: turn.startedAfterSeq });
+        rememberAnchor(sessionAlias, slot, turn.recoveryId);
+        return slot;
+      };
+      const appendAssistantOut = (
+        sessionAlias: string,
+        text: string,
+        structured: Parameters<MessageStore["append"]>[4],
+        slot: OutSlot,
+      ): void => {
+        messages.append(
+          instanceId,
+          sessionAlias,
+          "out",
+          text,
+          structured,
+          undefined,
+          undefined,
+          undefined,
+          slot.startedAt,
+          slot.slotAfterId,
+          slot.startedAfterSeq,
+        );
+      };
       // Wraps the whole handler (not just messages.append): a throwing DB write must be
       // attributed to this instance's event persistence, not surface as the gateway's
       // generic relay.instance.message_failed (see instance-gateway's outer message guard).
@@ -446,7 +524,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             const e = raw as ControlEventDto;
             return e.type === "tool-event" ? { ...e, step: capToolStep(e.step) } : e;
           })();
-          webGateway.broadcast(accountId, { kind: "control-event", instanceId, event });
+          let outbound: ControlEventDto = event;
           if (event.type === "turn-started") {
             const k = key(instanceId, event.sessionAlias);
             let notification: TurnNotificationContext | undefined;
@@ -464,30 +542,42 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
             }
             // Reconcile the inbound prompt FIRST (queued promotion / pre-write
             // correlation / scheduled append) and only install the streaming buffer
-            // once it succeeded. A persistence failure here is NOT silent: it forces a
-            // reconnect so the connector re-sends its state sync and the prompt row can
-            // land — otherwise the turn would stream + persist its reply while the
-            // prompt row is permanently missing (an orphan answer).
+            // once it succeeded. Snapshot the last Hub message id AFTER that write —
+            // that id is the durable live-slot anchor (receive/insert order, not a clock).
             try {
-              reconcileInboundPrompt(
-                event.sessionAlias,
-                { prompt: event.prompt, queueItemId: event.queueItemId, scheduled: event.scheduled, promptRequestId: event.promptRequestId },
-                true,
-              );
+              let slot: OutSlot | undefined;
+              db.transaction(() => {
+                reconcileInboundPrompt(
+                  event.sessionAlias,
+                  { prompt: event.prompt, queueItemId: event.queueItemId, scheduled: event.scheduled, promptRequestId: event.promptRequestId },
+                  true,
+                );
+                slot = snapshotSlotAfterReconcile(event.sessionAlias, {
+                  startedAt: nowMs(),
+                  startedAfterSeq: event.startedAfterSeq,
+                });
+                rememberAnchor(event.sessionAlias, slot, event.recoveryId);
+              });
+              const startedAt = slot!.startedAt ?? nowMs();
               turnBuffers.set(k, {
                 text: "",
                 steps: new Map(),
                 reasoning: "",
                 parts: [],
-                startedAt: nowMs(),
+                startedAt,
+                slotAfterId: slot!.slotAfterId,
+                ...(slot!.startedAfterSeq !== undefined ? { startedAfterSeq: slot!.startedAfterSeq } : {}),
                 ...(notification ? { notification } : {}),
               });
+              outbound = { ...event, slotAfterId: slot!.slotAfterId };
             } catch (err) {
               turnBuffers.delete(k);
               gateway.disconnect(instanceId);
               throw err;
             }
-          } else if (event.type === "turn-output") {
+          }
+          webGateway.broadcast(accountId, { kind: "control-event", instanceId, event: outbound });
+          if (event.type === "turn-output") {
             // Only append to an existing buffer; never lazily resurrect one. A buffer
             // is created solely by turn-started, so a stray streaming event arriving
             // after an offline sweep (or with no turn-started) is dropped instead of
@@ -520,12 +610,18 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 // for successes.
                 // Silent overflow tips are toast-only: do not persist an empty out row.
                 if (event.silent && (event.text === undefined || event.text === "")) {
+                  slotAnchors.take(instanceId, event.sessionAlias, event.recoveryId);
                   return;
                 }
+                const slot = resolveFinishSlot(event.sessionAlias, {
+                  recoveryId: event.recoveryId,
+                  startedAfterSeq: event.startedAfterSeq,
+                  startedAt: event.startedAt,
+                });
                 if (event.text !== undefined) {
-                  messages.append(instanceId, event.sessionAlias, "out", event.text);
+                  appendAssistantOut(event.sessionAlias, event.text, undefined, slot);
                 } else if (!event.ok && event.errorMessage !== undefined) {
-                  messages.append(instanceId, event.sessionAlias, "out", event.errorMessage);
+                  appendAssistantOut(event.sessionAlias, event.errorMessage, undefined, slot);
                 } else {
                   logger.warn("relay.event.turn_finished_without_content", "turn finished with no buffered content", {
                     instanceId, sessionAlias: event.sessionAlias,
@@ -552,13 +648,21 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
               // Silent overflow tips skip that empty-success row so the toast is not
               // duplicated as a blank chat bubble.
               if (event.silent && !hasStructured && text === "") {
+                slotAnchors.take(instanceId, event.sessionAlias, event.recoveryId);
                 return;
               }
               if (hasStructured || text !== "" || event.ok) {
                 const structured = hasStructured
                   ? { toolSteps: steps, ...(hasReasoning ? { reasoning: a.reasoning } : {}), ...(a.parts.length ? { parts: a.parts } : {}), ...(a.truncated ? { truncated: true } : {}) }
                   : (a.truncated ? { truncated: true } : undefined);
-                messages.append(instanceId, event.sessionAlias, "out", text, structured, undefined, undefined, undefined, a.startedAt);
+                slotAnchors.take(instanceId, event.sessionAlias, event.recoveryId);
+                appendAssistantOut(event.sessionAlias, text, structured, {
+                  slotAfterId: a.slotAfterId,
+                  startedAt: a.startedAt,
+                  startedAfterSeq: a.startedAfterSeq,
+                });
+              } else {
+                slotAnchors.take(instanceId, event.sessionAlias, event.recoveryId);
               }
             };
             const recoveryId = event.recoveryId;
@@ -766,7 +870,19 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 }
                 // Presence (not truthiness): an empty-string reply still gets its row.
                 if (text !== undefined && !alreadyPersisted) {
-                  messages.append(instanceId, finished.sessionAlias, "out", text, finished.truncated ? { truncated: true } : undefined);
+                  const slot = resolveFinishSlot(finished.sessionAlias, {
+                    recoveryId: finished.recoveryId,
+                    startedAfterSeq: finished.startedAfterSeq,
+                    startedAt: finished.startedAt,
+                  });
+                  appendAssistantOut(
+                    finished.sessionAlias,
+                    text,
+                    finished.truncated ? { truncated: true } : undefined,
+                    slot,
+                  );
+                } else {
+                  slotAnchors.take(instanceId, finished.sessionAlias, finished.recoveryId);
                 }
               };
               if (recoveryId) {
@@ -857,6 +973,21 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 parts,
                 // Restored original start so the elapsed-time HUD survives the restart.
                 startedAt: turn.startedAt,
+                // Durable insert-order slot: prefer the SQLite anchor from the original
+                // turn-started (survives Hub restart). Turns that started during outage
+                // snapshot lastId AFTER prompt reconcile — mid-turn cards were not persisted
+                // while the Hub was down.
+                ...(() => {
+                  const slot = restoreRunningSlot(turn.sessionAlias, {
+                    recoveryId: turn.recoveryId,
+                    startedAfterSeq: turn.startedAfterSeq,
+                    startedAt: turn.startedAt,
+                  });
+                  return {
+                    slotAfterId: slot.slotAfterId,
+                    ...(slot.startedAfterSeq !== undefined ? { startedAfterSeq: slot.startedAfterSeq } : {}),
+                  };
+                })(),
                 // A mirror that capped this turn at STATE_SYNC_TEXT_CAP marks it so the
                 // final flush persists structured.truncated instead of a gappy reply
                 // that reads as complete.

--- a/packages/relay/src/stores/accounts.ts
+++ b/packages/relay/src/stores/accounts.ts
@@ -233,6 +233,10 @@ export class AccountStore {
         "DELETE FROM messages WHERE instance_id IN (SELECT id FROM instances WHERE account_id = ?)",
         [accountId],
       );
+      this.db.run(
+        "DELETE FROM turn_slot_anchors WHERE instance_id IN (SELECT id FROM instances WHERE account_id = ?)",
+        [accountId],
+      );
       this.db.run("DELETE FROM instances WHERE account_id = ?", [accountId]);
       this.db.run("DELETE FROM pairing_tokens WHERE account_id = ?", [accountId]);
       this.db.run("DELETE FROM web_sessions WHERE account_id = ?", [accountId]);

--- a/packages/relay/src/stores/instances.ts
+++ b/packages/relay/src/stores/instances.ts
@@ -140,6 +140,7 @@ export class InstanceStore {
 
   remove(instanceId: string, accountId: string): boolean {
     if (!this.getOwned(instanceId, accountId)) return false;
+    this.db.run("DELETE FROM turn_slot_anchors WHERE instance_id = ?", [instanceId]);
     this.db.run("DELETE FROM instances WHERE id = ?", [instanceId]);
     return true;
   }

--- a/packages/relay/src/stores/messages.ts
+++ b/packages/relay/src/stores/messages.ts
@@ -15,6 +15,8 @@ interface MessageRow {
   attachments: string | null;
   queue_item_id: string | null;
   started_at: number | null;
+  slot_after_id: number | null;
+  started_after_seq: number | null;
 }
 
 export interface MessagePage {
@@ -39,6 +41,8 @@ function toDto(r: MessageRow): MessageRecordDto {
     createdAt: r.created_at,
     ...(r.queue_item_id ? { queueItemId: r.queue_item_id } : {}),
     ...(typeof r.started_at === "number" ? { startedAt: r.started_at } : {}),
+    ...(typeof r.slot_after_id === "number" ? { slotAfterId: r.slot_after_id } : {}),
+    ...(typeof r.started_after_seq === "number" ? { startedAfterSeq: r.started_after_seq } : {}),
     ...(r.structured ? { structured: JSON.parse(r.structured) as StructuredTurn } : {}),
     ...(r.attachments ? { attachments: JSON.parse(r.attachments) as AttachmentMetadata[] } : {}),
   };
@@ -57,9 +61,11 @@ export class MessageStore {
     promptRequestId?: string,
     createdAt?: string,
     startedAt?: number,
+    slotAfterId?: number,
+    startedAfterSeq?: number,
   ): number {
     this.db.run(
-      "INSERT INTO messages (instance_id, session_alias, direction, text, created_at, structured, attachments, prompt_request_id, started_at) VALUES (?,?,?,?,?,?,?,?,?)",
+      "INSERT INTO messages (instance_id, session_alias, direction, text, created_at, structured, attachments, prompt_request_id, started_at, slot_after_id, started_after_seq) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
       [
         instanceId,
         sessionAlias,
@@ -70,6 +76,8 @@ export class MessageStore {
         attachments && attachments.length > 0 ? JSON.stringify(attachments) : null,
         promptRequestId ?? null,
         startedAt ?? null,
+        slotAfterId ?? null,
+        startedAfterSeq ?? null,
       ],
     );
     return this.db.get<{ id: number }>("SELECT last_insert_rowid() AS id")!.id;
@@ -316,7 +324,7 @@ export class MessageStore {
     const before = opts.before ?? null;
     // Fetch one extra row to detect whether older history remains, then drop it.
     const rows = this.db.all<MessageRow>(
-      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments, m.queue_item_id, m.started_at
+      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments, m.queue_item_id, m.started_at, m.slot_after_id, m.started_after_seq
        FROM messages m JOIN instances i ON i.id = m.instance_id
        WHERE i.account_id = ? AND m.instance_id = ? AND m.session_alias = ?
          AND (? IS NULL OR m.id < ?)
@@ -339,12 +347,20 @@ export class MessageStore {
     id: number,
   ): MessageRecordDto | null {
     const row = this.db.get<MessageRow>(
-      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments, m.queue_item_id, m.started_at
+      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments, m.queue_item_id, m.started_at, m.slot_after_id, m.started_after_seq
        FROM messages m JOIN instances i ON i.id = m.instance_id
        WHERE i.account_id = ? AND m.instance_id = ? AND m.session_alias = ? AND m.id = ?`,
       [accountId, instanceId, sessionAlias, id],
     );
     return row ? toDto(row) : null;
+  }
+
+  /** Latest Hub `messages.id` for this session, or `undefined` when the transcript is empty. */
+  lastId(instanceId: string, sessionAlias: string): number | undefined {
+    return this.db.get<{ id: number }>(
+      "SELECT id FROM messages WHERE instance_id = ? AND session_alias = ? ORDER BY id DESC LIMIT 1",
+      [instanceId, sessionAlias],
+    )?.id;
   }
 
   /** Permanently removes the Hub-cached history for one logical session. */

--- a/packages/relay/src/stores/messages.ts
+++ b/packages/relay/src/stores/messages.ts
@@ -14,6 +14,7 @@ interface MessageRow {
   structured: string | null;
   attachments: string | null;
   queue_item_id: string | null;
+  started_at: number | null;
 }
 
 export interface MessagePage {
@@ -37,6 +38,7 @@ function toDto(r: MessageRow): MessageRecordDto {
     text: r.text,
     createdAt: r.created_at,
     ...(r.queue_item_id ? { queueItemId: r.queue_item_id } : {}),
+    ...(typeof r.started_at === "number" ? { startedAt: r.started_at } : {}),
     ...(r.structured ? { structured: JSON.parse(r.structured) as StructuredTurn } : {}),
     ...(r.attachments ? { attachments: JSON.parse(r.attachments) as AttachmentMetadata[] } : {}),
   };
@@ -54,9 +56,10 @@ export class MessageStore {
     attachments?: AttachmentMetadata[],
     promptRequestId?: string,
     createdAt?: string,
+    startedAt?: number,
   ): number {
     this.db.run(
-      "INSERT INTO messages (instance_id, session_alias, direction, text, created_at, structured, attachments, prompt_request_id) VALUES (?,?,?,?,?,?,?,?)",
+      "INSERT INTO messages (instance_id, session_alias, direction, text, created_at, structured, attachments, prompt_request_id, started_at) VALUES (?,?,?,?,?,?,?,?,?)",
       [
         instanceId,
         sessionAlias,
@@ -66,6 +69,7 @@ export class MessageStore {
         structured ? JSON.stringify(structured) : null,
         attachments && attachments.length > 0 ? JSON.stringify(attachments) : null,
         promptRequestId ?? null,
+        startedAt ?? null,
       ],
     );
     return this.db.get<{ id: number }>("SELECT last_insert_rowid() AS id")!.id;
@@ -312,7 +316,7 @@ export class MessageStore {
     const before = opts.before ?? null;
     // Fetch one extra row to detect whether older history remains, then drop it.
     const rows = this.db.all<MessageRow>(
-      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments, m.queue_item_id
+      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments, m.queue_item_id, m.started_at
        FROM messages m JOIN instances i ON i.id = m.instance_id
        WHERE i.account_id = ? AND m.instance_id = ? AND m.session_alias = ?
          AND (? IS NULL OR m.id < ?)
@@ -335,7 +339,7 @@ export class MessageStore {
     id: number,
   ): MessageRecordDto | null {
     const row = this.db.get<MessageRow>(
-      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments, m.queue_item_id
+      `SELECT m.id, m.instance_id, m.session_alias, m.direction, m.text, m.created_at, m.structured, m.attachments, m.queue_item_id, m.started_at
        FROM messages m JOIN instances i ON i.id = m.instance_id
        WHERE i.account_id = ? AND m.instance_id = ? AND m.session_alias = ? AND m.id = ?`,
       [accountId, instanceId, sessionAlias, id],

--- a/packages/relay/src/stores/turn-slot-anchors.ts
+++ b/packages/relay/src/stores/turn-slot-anchors.ts
@@ -1,0 +1,107 @@
+import type { SqlDriver } from "../db.js";
+
+export interface TurnSlotAnchor {
+  instanceId: string;
+  sessionAlias: string;
+  recoveryId: string;
+  slotAfterId: number;
+  startedAt?: number;
+  startedAfterSeq?: number;
+}
+
+/**
+ * Durable live-slot identity for an in-flight turn. Written at Hub `turn-started`
+ * (last persisted `messages.id` for the session) so a Hub restart can flush the
+ * `out` row into the same slot without guessing from peer/hub/browser clocks.
+ *
+ * Keyed by `(instance_id, recovery_id)` so a finished-offline entry and a later
+ * running turn on the same alias cannot steal each other's anchor. Empty
+ * `recovery_id` is the legacy/session fallback when the connector omitted it.
+ */
+export class TurnSlotAnchorStore {
+  constructor(private readonly db: SqlDriver) {}
+
+  put(row: TurnSlotAnchor): void {
+    this.db.run(
+      `INSERT INTO turn_slot_anchors (
+         instance_id, session_alias, recovery_id, slot_after_id, started_at, started_after_seq
+       ) VALUES (?,?,?,?,?,?)
+       ON CONFLICT(instance_id, recovery_id) DO UPDATE SET
+         session_alias = excluded.session_alias,
+         slot_after_id = excluded.slot_after_id,
+         started_at = excluded.started_at,
+         started_after_seq = excluded.started_after_seq`,
+      [
+        row.instanceId,
+        row.sessionAlias,
+        row.recoveryId,
+        row.slotAfterId,
+        row.startedAt ?? null,
+        row.startedAfterSeq ?? null,
+      ],
+    );
+  }
+
+  get(instanceId: string, recoveryId: string): TurnSlotAnchor | undefined {
+    return this.toAnchor(this.db.get<{
+      instance_id: string;
+      session_alias: string;
+      recovery_id: string;
+      slot_after_id: number;
+      started_at: number | null;
+      started_after_seq: number | null;
+    }>(
+      `SELECT instance_id, session_alias, recovery_id, slot_after_id, started_at, started_after_seq
+       FROM turn_slot_anchors WHERE instance_id = ? AND recovery_id = ?`,
+      [instanceId, recoveryId],
+    ));
+  }
+
+  getBySession(instanceId: string, sessionAlias: string): TurnSlotAnchor | undefined {
+    return this.toAnchor(this.db.get<{
+      instance_id: string;
+      session_alias: string;
+      recovery_id: string;
+      slot_after_id: number;
+      started_at: number | null;
+      started_after_seq: number | null;
+    }>(
+      `SELECT instance_id, session_alias, recovery_id, slot_after_id, started_at, started_after_seq
+       FROM turn_slot_anchors WHERE instance_id = ? AND session_alias = ?
+       ORDER BY rowid DESC LIMIT 1`,
+      [instanceId, sessionAlias],
+    ));
+  }
+
+  /** Lookup then delete. Prefer `recoveryId`; fall back to the session's latest row. */
+  take(instanceId: string, sessionAlias: string, recoveryId?: string): TurnSlotAnchor | undefined {
+    const row = recoveryId
+      ? (this.get(instanceId, recoveryId) ?? this.getBySession(instanceId, sessionAlias))
+      : this.getBySession(instanceId, sessionAlias);
+    if (!row) return undefined;
+    this.db.run(
+      "DELETE FROM turn_slot_anchors WHERE instance_id = ? AND recovery_id = ?",
+      [row.instanceId, row.recoveryId],
+    );
+    return row;
+  }
+
+  private toAnchor(row: {
+    instance_id: string;
+    session_alias: string;
+    recovery_id: string;
+    slot_after_id: number;
+    started_at: number | null;
+    started_after_seq: number | null;
+  } | undefined): TurnSlotAnchor | undefined {
+    if (!row) return undefined;
+    return {
+      instanceId: row.instance_id,
+      sessionAlias: row.session_alias,
+      recoveryId: row.recovery_id,
+      slotAfterId: row.slot_after_id,
+      ...(typeof row.started_at === "number" ? { startedAt: row.started_at } : {}),
+      ...(typeof row.started_after_seq === "number" ? { startedAfterSeq: row.started_after_seq } : {}),
+    };
+  }
+}

--- a/packages/relay/src/stores/turn-slot-anchors.ts
+++ b/packages/relay/src/stores/turn-slot-anchors.ts
@@ -10,13 +10,28 @@ export interface TurnSlotAnchor {
 }
 
 /**
+ * Dedicated PK value for connectors that omit `recoveryId` on `turn-started`.
+ * The NUL prefix cannot collide with connector `randomUUID()` recovery ids.
+ * Legacy fallback is instance + session scoped: two sessions on one instance
+ * must not share `(instanceId, "")`.
+ */
+export const LEGACY_RECOVERY_ID_PREFIX = "\0legacy:";
+
+export function canonicalRecoveryId(sessionAlias: string, recoveryId?: string): string {
+  return typeof recoveryId === "string" && recoveryId.length > 0
+    ? recoveryId
+    : `${LEGACY_RECOVERY_ID_PREFIX}${sessionAlias}`;
+}
+
+/**
  * Durable live-slot identity for an in-flight turn. Written at Hub `turn-started`
  * (last persisted `messages.id` for the session) so a Hub restart can flush the
  * `out` row into the same slot without guessing from peer/hub/browser clocks.
  *
- * Keyed by `(instance_id, recovery_id)` so a finished-offline entry and a later
- * running turn on the same alias cannot steal each other's anchor. Empty
- * `recovery_id` is the legacy/session fallback when the connector omitted it.
+ * Keyed by `(instance_id, recovery_id)`:
+ * - Non-empty `recoveryId` is the real recovery identity (exact match only).
+ * - Empty/omitted `recoveryId` uses {@link canonicalRecoveryId} (per-session
+ *   dedicated key). A miss must never fall back to another session's leftover.
  */
 export class TurnSlotAnchorStore {
   constructor(private readonly db: SqlDriver) {}
@@ -57,33 +72,48 @@ export class TurnSlotAnchorStore {
     ));
   }
 
-  getBySession(instanceId: string, sessionAlias: string): TurnSlotAnchor | undefined {
-    return this.toAnchor(this.db.get<{
-      instance_id: string;
-      session_alias: string;
-      recovery_id: string;
-      slot_after_id: number;
-      started_at: number | null;
-      started_after_seq: number | null;
-    }>(
-      `SELECT instance_id, session_alias, recovery_id, slot_after_id, started_at, started_after_seq
-       FROM turn_slot_anchors WHERE instance_id = ? AND session_alias = ?
-       ORDER BY rowid DESC LIMIT 1`,
-      [instanceId, sessionAlias],
-    ));
-  }
-
-  /** Lookup then delete. Prefer `recoveryId`; fall back to the session's latest row. */
+  /**
+   * Lookup then delete. Non-empty `recoveryId` is exact-match only: a miss
+   * means Hub never saw this start (do not bind a leftover session anchor).
+   * Empty/omitted `recoveryId` uses the dedicated per-session legacy key.
+   */
   take(instanceId: string, sessionAlias: string, recoveryId?: string): TurnSlotAnchor | undefined {
-    const row = recoveryId
-      ? (this.get(instanceId, recoveryId) ?? this.getBySession(instanceId, sessionAlias))
-      : this.getBySession(instanceId, sessionAlias);
+    const id = canonicalRecoveryId(sessionAlias, recoveryId);
+    const row = this.get(instanceId, id);
     if (!row) return undefined;
     this.db.run(
       "DELETE FROM turn_slot_anchors WHERE instance_id = ? AND recovery_id = ?",
       [row.instanceId, row.recoveryId],
     );
     return row;
+  }
+
+  /**
+   * After an authoritative `instance.state.sync`, drop leftover anchors that
+   * are not in the connector's `turns ∪ finishedOffline` set.
+   */
+  retain(instanceId: string, keepRecoveryIds: ReadonlySet<string>): void {
+    if (keepRecoveryIds.size === 0) {
+      this.db.run("DELETE FROM turn_slot_anchors WHERE instance_id = ?", [instanceId]);
+      return;
+    }
+    const ids = [...keepRecoveryIds];
+    const placeholders = ids.map(() => "?").join(",");
+    this.db.run(
+      `DELETE FROM turn_slot_anchors WHERE instance_id = ? AND recovery_id NOT IN (${placeholders})`,
+      [instanceId, ...ids],
+    );
+  }
+
+  deleteBySession(instanceId: string, sessionAlias: string): void {
+    this.db.run(
+      "DELETE FROM turn_slot_anchors WHERE instance_id = ? AND session_alias = ?",
+      [instanceId, sessionAlias],
+    );
+  }
+
+  deleteByInstance(instanceId: string): void {
+    this.db.run("DELETE FROM turn_slot_anchors WHERE instance_id = ?", [instanceId]);
   }
 
   private toAnchor(row: {

--- a/tests/unit/packages/channel-relay/state-mirror.test.ts
+++ b/tests/unit/packages/channel-relay/state-mirror.test.ts
@@ -27,6 +27,24 @@ function makeMirror(ready: () => boolean, now?: () => number) {
   return { mirror, warns };
 }
 
+test("finishedOffline and running turns carry startedAfterSeq + startedAt (not clocks as order identity)", () => {
+  const { mirror } = makeMirror(() => true, () => 1_700_000_000_000);
+  fire(mirror, { type: "turn-started", chatKey: "relay:acc", sessionAlias: "backend", prompt: "hi" });
+  const running = mirror.buildStateSync(LIVE).snapshot.turns[0]!;
+  expect(running).toMatchObject({ startedAt: 1_700_000_000_000, startedAfterSeq: 1, recoveryId: "r1" });
+  fire(mirror, { type: "turn-output", chatKey: "relay:acc", sessionAlias: "backend", chunk: "done" });
+  fire(mirror, { type: "turn-finished", chatKey: "relay:acc", sessionAlias: "backend", ok: true });
+  expect(mirror.buildStateSync(LIVE).snapshot.finishedOffline[0]).toMatchObject({
+    sessionAlias: "backend",
+    ok: true,
+    text: "done",
+    recoveryId: "r1",
+    startedAt: 1_700_000_000_000,
+    startedAfterSeq: 1,
+    prompt: "hi",
+  });
+});
+
 test("accumulates a turn across event kinds and builds a valid sync payload", () => {
   const { mirror } = makeMirror(() => true, () => 1_700_000_000_000);
   fire(mirror, { type: "turn-started", chatKey: "relay:acc", sessionAlias: "backend", prompt: "hi" });
@@ -44,7 +62,7 @@ test("accumulates a turn across event kinds and builds a valid sync payload", ()
       { type: "text", text: "hello" },
       { type: "reasoning", text: "thinking" },
       { type: "tool", step: step("t1") },
-    ], prompt: "hi", recoveryId: "r1",
+    ], prompt: "hi", recoveryId: "r1", startedAfterSeq: 1,
   }]);
   expect(payload.usage).toEqual([{ sessionAlias: "backend", used: 10, size: 100 }]);
   expect(payload.commands).toEqual([{ sessionAlias: "backend", commands: [{ name: "compact" }] }]);
@@ -101,7 +119,7 @@ test("turn-finished stays recoverable until its send is confirmed", () => {
   fire(mirror, { type: "turn-finished", chatKey: "relay:acc", sessionAlias: "backend", ok: true });
   const { snapshot: payload } = mirror.buildStateSync(LIVE);
   expect(payload.turns).toEqual([]);
-  expect(payload.finishedOffline).toEqual([{ sessionAlias: "backend", ok: true, text: "done", recoveryId: "r1" }]);
+  expect(payload.finishedOffline).toMatchObject([{ sessionAlias: "backend", ok: true, text: "done", recoveryId: "r1", startedAfterSeq: 1, startedAt: expect.any(Number) }]);
   mirror.confirmFinished(["r1"]);
   expect(mirror.buildStateSync(LIVE).snapshot.finishedOffline).toEqual([]);
 });
@@ -112,7 +130,7 @@ test("turn-finished while offline queues the turn with its accumulated text", ()
   fire(mirror, { type: "turn-output", chatKey: "relay:acc", sessionAlias: "backend", chunk: "reply text" });
   fire(mirror, { type: "turn-finished", chatKey: "relay:acc", sessionAlias: "backend", ok: true });
   const { snapshot: payload } = mirror.buildStateSync(LIVE);
-  expect(payload.finishedOffline).toEqual([{ sessionAlias: "backend", ok: true, text: "reply text", recoveryId: "r1" }]);
+  expect(payload.finishedOffline).toMatchObject([{ sessionAlias: "backend", ok: true, text: "reply text", recoveryId: "r1", startedAfterSeq: 1, startedAt: expect.any(Number) }]);
   mirror.confirmFinished(["r1"]);
   expect(mirror.buildStateSync(LIVE).snapshot.finishedOffline).toEqual([]);
 });
@@ -162,15 +180,15 @@ test("failed turn with an empty accumulator ships its errorMessage, not an empty
   // and leave an empty reply where the failure story belongs.
   fire(mirror, { type: "turn-started", chatKey: "relay:acc", sessionAlias: "backend", prompt: "deploy" });
   fire(mirror, { type: "turn-finished", chatKey: "relay:acc", sessionAlias: "backend", ok: false, errorMessage: "boom" });
-  expect(mirror.buildStateSync(LIVE).snapshot.finishedOffline).toEqual([
-    { sessionAlias: "backend", ok: false, errorMessage: "boom", prompt: "deploy", recoveryId: "r1" },
+  expect(mirror.buildStateSync(LIVE).snapshot.finishedOffline).toMatchObject([
+    { sessionAlias: "backend", ok: false, errorMessage: "boom", prompt: "deploy", recoveryId: "r1", startedAfterSeq: 1, startedAt: expect.any(Number) },
   ]);
   // A successful turn with no output still ships its (empty) reply — presence semantics.
   fire(mirror, { type: "turn-started", chatKey: "relay:acc", sessionAlias: "frontend" });
   fire(mirror, { type: "turn-finished", chatKey: "relay:acc", sessionAlias: "frontend", ok: true });
-  expect(mirror.buildStateSync(LIVE).snapshot.finishedOffline).toEqual([
-    { sessionAlias: "backend", ok: false, errorMessage: "boom", prompt: "deploy", recoveryId: "r1" },
-    { sessionAlias: "frontend", ok: true, text: "", recoveryId: "r2" },
+  expect(mirror.buildStateSync(LIVE).snapshot.finishedOffline).toMatchObject([
+    { sessionAlias: "backend", ok: false, errorMessage: "boom", prompt: "deploy", recoveryId: "r1", startedAfterSeq: 1 },
+    { sessionAlias: "frontend", ok: true, text: "", recoveryId: "r2", startedAfterSeq: 1 },
   ]);
 });
 

--- a/tests/unit/packages/relay/http/compact-history.test.ts
+++ b/tests/unit/packages/relay/http/compact-history.test.ts
@@ -24,20 +24,32 @@ test("leaves a text-only row unchanged", () => {
   expect(compactHistoryMessage(base)).toEqual(base);
 });
 
-test("leaves startedAt in place (compact must not drop the live-slot timestamp)", () => {
+test("leaves startedAt in place (compact must not drop HUD telemetry)", () => {
   const row: MessageRecordDto = { ...base, startedAt: 1_700_000_000_000 };
   expect(compactHistoryMessage(row).startedAt).toBe(1_700_000_000_000);
 });
 
-test("keeps startedAt when stripping heavy tool details", () => {
+test("leaves slotAfterId and startedAfterSeq in place (compact must not drop the slot anchor)", () => {
+  const row: MessageRecordDto = { ...base, slotAfterId: 7, startedAfterSeq: 3, startedAt: 1_700_000_000_000 };
+  const compact = compactHistoryMessage(row);
+  expect(compact.slotAfterId).toBe(7);
+  expect(compact.startedAfterSeq).toBe(3);
+  expect(compact.startedAt).toBe(1_700_000_000_000);
+});
+
+test("keeps slotAfterId when stripping heavy tool details", () => {
   const row: MessageRecordDto = {
     ...base,
     startedAt: 42,
+    slotAfterId: 9,
+    startedAfterSeq: 2,
     structured: {
       parts: [{ type: "tool", step: readStep }],
     },
   };
   const compact = compactHistoryMessage(row);
+  expect(compact.slotAfterId).toBe(9);
+  expect(compact.startedAfterSeq).toBe(2);
   expect(compact.startedAt).toBe(42);
   expect(compact.structured?.compact).toBe(true);
 });

--- a/tests/unit/packages/relay/http/compact-history.test.ts
+++ b/tests/unit/packages/relay/http/compact-history.test.ts
@@ -24,6 +24,24 @@ test("leaves a text-only row unchanged", () => {
   expect(compactHistoryMessage(base)).toEqual(base);
 });
 
+test("leaves startedAt in place (compact must not drop the live-slot timestamp)", () => {
+  const row: MessageRecordDto = { ...base, startedAt: 1_700_000_000_000 };
+  expect(compactHistoryMessage(row).startedAt).toBe(1_700_000_000_000);
+});
+
+test("keeps startedAt when stripping heavy tool details", () => {
+  const row: MessageRecordDto = {
+    ...base,
+    startedAt: 42,
+    structured: {
+      parts: [{ type: "tool", step: readStep }],
+    },
+  };
+  const compact = compactHistoryMessage(row);
+  expect(compact.startedAt).toBe(42);
+  expect(compact.structured?.compact).toBe(true);
+});
+
 test("drops duplicate toolSteps when parts already carry them and strips heavy detail", () => {
   const row: MessageRecordDto = {
     ...base,

--- a/tests/unit/packages/relay/http/messages-endpoint.test.ts
+++ b/tests/unit/packages/relay/http/messages-endpoint.test.ts
@@ -255,18 +255,22 @@ test("GET messages without view=compact still returns full structured rows", asy
   runtime.close();
 });
 
-test("GET messages?view=compact keeps startedAt on the assistant out row", async () => {
+test("GET messages?view=compact keeps startedAt and slotAfterId on the assistant out row", async () => {
   const { runtime, cookie } = await loggedIn();
-  runtime.messages.append("i1", "backend", "out", "looked", undefined, undefined, undefined, undefined, 1_700_000_000_000);
+  runtime.messages.append("i1", "backend", "out", "looked", undefined, undefined, undefined, undefined, 1_700_000_000_000, 4, 2);
   const listed = await runtime.app.request("/api/instances/i1/sessions/backend/messages?view=compact", { headers: { cookie } });
-  const page = (await listed.json()) as { messages: Array<{ startedAt?: number; text: string }> };
+  const page = (await listed.json()) as { messages: Array<{ startedAt?: number; slotAfterId?: number; startedAfterSeq?: number; text: string }> };
   expect(page.messages).toHaveLength(1);
   expect(page.messages[0]?.text).toBe("looked");
   expect(page.messages[0]?.startedAt).toBe(1_700_000_000_000);
+  expect(page.messages[0]?.slotAfterId).toBe(4);
+  expect(page.messages[0]?.startedAfterSeq).toBe(2);
 
   const full = await runtime.app.request("/api/instances/i1/sessions/backend/messages", { headers: { cookie } });
-  const body = (await full.json()) as { messages: Array<{ startedAt?: number }> };
+  const body = (await full.json()) as { messages: Array<{ startedAt?: number; slotAfterId?: number; startedAfterSeq?: number }> };
   expect(body.messages[0]?.startedAt).toBe(1_700_000_000_000);
+  expect(body.messages[0]?.slotAfterId).toBe(4);
+  expect(body.messages[0]?.startedAfterSeq).toBe(2);
   runtime.close();
 });
 

--- a/tests/unit/packages/relay/http/messages-endpoint.test.ts
+++ b/tests/unit/packages/relay/http/messages-endpoint.test.ts
@@ -111,12 +111,14 @@ test("delete then same-alias create returns an empty Web history", async () => {
   (runtime.gateway as unknown as { sendRequest: () => Promise<unknown> }).sendRequest = async () => ({ ok: true });
   runtime.messages.append("i1", "backend", "in", "old question");
   runtime.messages.append("i1", "backend", "out", "old answer");
+  runtime.slotAnchors.put({ instanceId: "i1", sessionAlias: "backend", recoveryId: "r-old", slotAfterId: 1 });
 
   const remove = await runtime.app.request("/api/instances/i1/rpc", {
     method: "POST", headers: { cookie, "content-type": "application/json" },
     body: JSON.stringify({ type: MSG.sessionsRemove, payload: { alias: "backend" } }),
   });
   expect(remove.status).toBe(200);
+  expect(runtime.slotAnchors.get("i1", "r-old")).toBeUndefined();
   const create = await runtime.app.request("/api/instances/i1/rpc", {
     method: "POST", headers: { cookie, "content-type": "application/json" },
     body: JSON.stringify({ type: MSG.sessionsCreate, payload: { alias: "backend", agent: "claude", workspace: "home" } }),

--- a/tests/unit/packages/relay/http/messages-endpoint.test.ts
+++ b/tests/unit/packages/relay/http/messages-endpoint.test.ts
@@ -255,6 +255,21 @@ test("GET messages without view=compact still returns full structured rows", asy
   runtime.close();
 });
 
+test("GET messages?view=compact keeps startedAt on the assistant out row", async () => {
+  const { runtime, cookie } = await loggedIn();
+  runtime.messages.append("i1", "backend", "out", "looked", undefined, undefined, undefined, undefined, 1_700_000_000_000);
+  const listed = await runtime.app.request("/api/instances/i1/sessions/backend/messages?view=compact", { headers: { cookie } });
+  const page = (await listed.json()) as { messages: Array<{ startedAt?: number; text: string }> };
+  expect(page.messages).toHaveLength(1);
+  expect(page.messages[0]?.text).toBe("looked");
+  expect(page.messages[0]?.startedAt).toBe(1_700_000_000_000);
+
+  const full = await runtime.app.request("/api/instances/i1/sessions/backend/messages", { headers: { cookie } });
+  const body = (await full.json()) as { messages: Array<{ startedAt?: number }> };
+  expect(body.messages[0]?.startedAt).toBe(1_700_000_000_000);
+  runtime.close();
+});
+
 test("GET a missing message id is 404", async () => {
   const { runtime, cookie } = await loggedIn();
   const res = await runtime.app.request("/api/instances/i1/sessions/backend/messages/99", { headers: { cookie } });

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -117,6 +117,7 @@ test("accumulates tool steps + reasoning and persists structured on finish", asy
     { type: "text", text: "done" },
   ]);
   expect(typeof cached[0].startedAt).toBe("number");
+  expect(typeof cached[0].slotAfterId).toBe("number");
   runtime.close();
 });
 

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -116,6 +116,7 @@ test("accumulates tool steps + reasoning and persists structured on finish", asy
     { type: "reasoning", text: "think more" },
     { type: "text", text: "done" },
   ]);
+  expect(typeof cached[0].startedAt).toBe("number");
   runtime.close();
 });
 

--- a/tests/unit/packages/relay/runtime-restart.test.ts
+++ b/tests/unit/packages/relay/runtime-restart.test.ts
@@ -185,3 +185,125 @@ test("no-buffer turn-finished after hub restart uses the durable slot anchor", a
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("leftover anchor A is not inherited by outage-started turn B (uses post-reconcile lastId)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "relay-stale-anchor-"));
+  const dbPath = join(dir, "relay.db");
+  try {
+    const a = await createRelayRuntime(dbPath);
+    seedIdentity(a);
+    fire(a, receivedCard("card1", STARTED_AT - 1_000));
+    fire(a, { type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", recoveryId: "r-A", startedAfterSeq: 1 });
+    const triggerA = a.messages.listBySession("a1", "i1", "backend").messages[0]!.id!;
+    for (let i = 2; i <= 12; i++) fire(a, receivedCard(`card${i}`, STARTED_AT + i));
+    const lastBeforeOutage = a.messages.listBySession("a1", "i1", "backend").messages.at(-1)!.id!;
+    expect(lastBeforeOutage).toBeGreaterThan(triggerA);
+    expect(a.slotAnchors.get("i1", "r-A")?.slotAfterId).toBe(triggerA);
+    a.close();
+
+    const b = await createRelayRuntime(dbPath);
+    sync(b, {
+      turns: [{
+        sessionAlias: "backend",
+        startedAt: STARTED_AT + 50_000,
+        text: "B running",
+        reasoning: "",
+        steps: [],
+        prompt: "turn B",
+        recoveryId: "r-B",
+        startedAfterSeq: 2,
+      }],
+      usage: [],
+      commands: [],
+      finishedOffline: [],
+    });
+    const promptB = b.messages.listBySession("a1", "i1", "backend").messages.find((m) => m.text === "turn B");
+    expect(promptB).toBeDefined();
+    const restored = b.stateSnapshot("i1").turns.find((t) => t.sessionAlias === "backend");
+    expect(restored?.slotAfterId).toBe(promptB!.id);
+    expect(restored?.slotAfterId).not.toBe(triggerA);
+    expect(b.slotAnchors.get("i1", "r-A")).toBeUndefined();
+    expect(b.slotAnchors.get("i1", "r-B")?.slotAfterId).toBe(promptB!.id);
+    b.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("leftover anchor A is not inherited by finishedOffline B (uses post-reconcile lastId)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "relay-stale-finish-"));
+  const dbPath = join(dir, "relay.db");
+  try {
+    const a = await createRelayRuntime(dbPath);
+    seedIdentity(a);
+    fire(a, receivedCard("card1", STARTED_AT - 1_000));
+    fire(a, { type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", recoveryId: "r-A", startedAfterSeq: 1 });
+    const triggerA = a.messages.listBySession("a1", "i1", "backend").messages[0]!.id!;
+    for (let i = 2; i <= 12; i++) fire(a, receivedCard(`card${i}`, STARTED_AT + i));
+    a.close();
+
+    const b = await createRelayRuntime(dbPath);
+    sync(b, {
+      turns: [],
+      usage: [],
+      commands: [],
+      finishedOffline: [{
+        sessionAlias: "backend",
+        ok: true,
+        text: "B reply",
+        prompt: "turn B",
+        recoveryId: "r-B",
+        startedAfterSeq: 2,
+        startedAt: STARTED_AT + 50_000,
+      }],
+    });
+    const rows = b.messages.listBySession("a1", "i1", "backend").messages;
+    const promptB = rows.find((m) => m.text === "turn B");
+    const out = rows.find((m) => m.direction === "out");
+    expect(promptB).toBeDefined();
+    expect(out?.text).toBe("B reply");
+    expect(out?.slotAfterId).toBe(promptB!.id);
+    expect(out?.slotAfterId).not.toBe(triggerA);
+    expect(b.slotAnchors.get("i1", "r-A")).toBeUndefined();
+    b.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("legacy empty recoveryId backend+frontend each restore their own slot after hub restart", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "relay-legacy-slot-"));
+  const dbPath = join(dir, "relay.db");
+  try {
+    const a = await createRelayRuntime(dbPath);
+    seedIdentity(a);
+    fire(a, { ...receivedCard("be1", STARTED_AT - 1_000), sessionAlias: "backend" });
+    fire(a, { type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", prompt: "be-prompt" });
+    const backendSlot = a.messages.listBySession("a1", "i1", "backend").messages.at(-1)!.id!;
+    fire(a, { ...receivedCard("be2", STARTED_AT + 10), sessionAlias: "backend" });
+
+    fire(a, { ...receivedCard("fe1", STARTED_AT - 1_000), sessionAlias: "frontend" });
+    fire(a, { type: "turn-started", chatKey: "relay:a1", sessionAlias: "frontend", prompt: "fe-prompt" });
+    const frontendSlot = a.messages.listBySession("a1", "i1", "frontend").messages.at(-1)!.id!;
+    fire(a, { ...receivedCard("fe2", STARTED_AT + 10), sessionAlias: "frontend" });
+    expect(backendSlot).not.toBe(frontendSlot);
+    a.close();
+
+    const b = await createRelayRuntime(dbPath);
+    sync(b, {
+      turns: [
+        { sessionAlias: "backend", startedAt: STARTED_AT, text: "be-out", reasoning: "", steps: [], prompt: "be-prompt" },
+        { sessionAlias: "frontend", startedAt: STARTED_AT, text: "fe-out", reasoning: "", steps: [], prompt: "fe-prompt" },
+      ],
+      usage: [],
+      commands: [],
+      finishedOffline: [],
+    });
+    const turns = Object.fromEntries(b.stateSnapshot("i1").turns.map((t) => [t.sessionAlias, t.slotAfterId]));
+    expect(turns.backend).toBe(backendSlot);
+    expect(turns.frontend).toBe(frontendSlot);
+    b.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/packages/relay/runtime-restart.test.ts
+++ b/tests/unit/packages/relay/runtime-restart.test.ts
@@ -88,3 +88,100 @@ test("simulated hub restart: turn/rows recover via state sync, flush once, dedup
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+function receivedCard(messageId: string, createdAt: number) {
+  return {
+    type: "agent-message" as const,
+    chatKey: "relay:a1",
+    sessionAlias: "backend",
+    message: {
+      kind: "agent_message" as const,
+      direction: "received" as const,
+      messageId,
+      conversationId: `conv_${messageId}`,
+      peer: { handle: "agent:n:e", displayName: "Peer", agent: "codex" },
+      content: messageId,
+      createdAt,
+      status: "delivered" as const,
+    },
+  };
+}
+
+test("hub restart + finishedOffline persists slotAfterId from turn-start, not lastId or clocks", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "relay-slot-"));
+  const dbPath = join(dir, "relay.db");
+  const turnStart = STARTED_AT;
+  const peerBehind = turnStart - 30_000;
+  try {
+    const a = await createRelayRuntime(dbPath);
+    seedIdentity(a);
+    fire(a, receivedCard("card1", turnStart - 1_000));
+    fire(a, { type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", recoveryId: "r-slot", startedAfterSeq: 1 });
+    const afterStart = a.messages.listBySession("a1", "i1", "backend").messages;
+    const triggerId = afterStart[0]!.id!;
+    fire(a, receivedCard("card2", peerBehind));
+    expect(a.messages.listBySession("a1", "i1", "backend").messages.map((m) => m.text)).toEqual(["card1", "card2"]);
+    a.close();
+
+    const b = await createRelayRuntime(dbPath);
+    sync(b, {
+      turns: [],
+      usage: [],
+      commands: [],
+      finishedOffline: [{
+        sessionAlias: "backend",
+        ok: true,
+        text: "reply",
+        recoveryId: "r-slot",
+        startedAfterSeq: 1,
+        startedAt: turnStart,
+      }],
+    });
+    const rows = b.messages.listBySession("a1", "i1", "backend").messages;
+    expect(rows.map((m) => m.text)).toEqual(["card1", "card2", "reply"]);
+    const out = rows.find((m) => m.direction === "out");
+    expect(out?.slotAfterId).toBe(triggerId);
+    expect(out?.startedAfterSeq).toBe(1);
+    expect(typeof out?.startedAt).toBe("number");
+    // Insert order is still trigger, mid-turn card, out — web reorders by slotAfterId.
+    expect(rows[0]!.id).toBe(triggerId);
+    expect(rows[1]!.text).toBe("card2");
+    b.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("no-buffer turn-finished after hub restart uses the durable slot anchor", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "relay-nobuffer-"));
+  const dbPath = join(dir, "relay.db");
+  try {
+    const a = await createRelayRuntime(dbPath);
+    seedIdentity(a);
+    fire(a, receivedCard("card1", STARTED_AT - 1_000));
+    fire(a, { type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", recoveryId: "r-nb", startedAfterSeq: 2 });
+    const triggerId = a.messages.listBySession("a1", "i1", "backend").messages[0]!.id!;
+    fire(a, receivedCard("card2", STARTED_AT + 10));
+    a.close();
+
+    const b = await createRelayRuntime(dbPath);
+    fire(b, {
+      type: "turn-finished",
+      chatKey: "relay:a1",
+      sessionAlias: "backend",
+      ok: true,
+      text: "offline reply",
+      recoveryId: "r-nb",
+      startedAfterSeq: 2,
+      startedAt: STARTED_AT,
+    });
+    const rows = b.messages.listBySession("a1", "i1", "backend").messages;
+    const out = rows.find((m) => m.direction === "out");
+    expect(out?.text).toBe("offline reply");
+    expect(out?.slotAfterId).toBe(triggerId);
+    expect(out?.startedAfterSeq).toBe(2);
+    b.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/packages/relay/runtime-state-sync.test.ts
+++ b/tests/unit/packages/relay/runtime-state-sync.test.ts
@@ -52,6 +52,7 @@ test("state sync restores turns/usage/commands into stateSnapshot with the origi
   const snapshot = runtime.stateSnapshot("i1");
   expect(snapshot.turns).toEqual([{
     instanceId: "i1", sessionAlias: "backend", status: "streaming", startedAt: STARTED_AT,
+    slotAfterId: 0,
     parts: [
       { type: "text", text: "before" },
       { type: "tool", step: { toolCallId: "t1", toolName: "Bash", kind: "execute", status: "success", title: "ls" } },

--- a/tests/unit/packages/relay/stores-accounts.test.ts
+++ b/tests/unit/packages/relay/stores-accounts.test.ts
@@ -338,6 +338,10 @@ test("deleteAccountCascade removes all related rows", async () => {
     "INSERT INTO messages (instance_id, session_alias, direction, text, created_at) VALUES (?, ?, ?, ?, ?)",
     ["inst-1", "alias1", "in", "hello", "2026-06-13T10:00:00.000Z"]
   );
+  db.run(
+    "INSERT INTO turn_slot_anchors (instance_id, session_alias, recovery_id, slot_after_id) VALUES (?, ?, ?, ?)",
+    ["inst-1", "alias1", "r-1", 1]
+  );
 
   store.deleteAccountCascade(account.id);
 
@@ -347,6 +351,7 @@ test("deleteAccountCascade removes all related rows", async () => {
   expect(store.getSessionAccount(sessionToken)).toBeNull();
   expect(db.get("SELECT 1 FROM instances WHERE account_id = ?", [account.id])).toBeUndefined();
   expect(db.get("SELECT 1 FROM messages WHERE instance_id = ?", ["inst-1"])).toBeUndefined();
+  expect(db.get("SELECT 1 FROM turn_slot_anchors WHERE instance_id = ?", ["inst-1"])).toBeUndefined();
   expect(db.get("SELECT 1 FROM pairing_tokens WHERE account_id = ?", [account.id])).toBeUndefined();
   expect(db.get("SELECT 1 FROM login_tokens WHERE account_id = ?", [account.id])).toBeUndefined();
   expect(db.get("SELECT 1 FROM web_sessions WHERE account_id = ?", [account.id])).toBeUndefined();

--- a/tests/unit/packages/relay/stores-instances.test.ts
+++ b/tests/unit/packages/relay/stores-instances.test.ts
@@ -11,7 +11,7 @@ async function makeStores(nowIso = "2026-06-13T10:00:00.000Z") {
   const accounts = new AccountStore(db, { now: () => now });
   const instances = new InstanceStore(db, { now: () => now });
   const account = accounts.createAccount("alice");
-  return { instances, account, setNow: (iso: string) => { now = new Date(iso); } };
+  return { db, instances, account, setNow: (iso: string) => { now = new Date(iso); } };
 }
 
 test("pairing token redeems once into an instance with a fresh credential", async () => {
@@ -87,12 +87,16 @@ test("rename of a non-existent instance returns false", async () => {
 });
 
 test("touch updates last_seen; listByAccount scopes; remove enforces ownership", async () => {
-  const { instances, account, setNow } = await makeStores();
+  const { db, instances, account, setNow } = await makeStores();
   const redeemed = instances.redeemPairingToken(
     instances.issuePairingToken(account.id, "pc", 600_000).token,
   )!;
   setNow("2026-06-13T10:05:00.000Z");
   instances.touch(redeemed.instanceId);
+  db.run(
+    "INSERT INTO turn_slot_anchors (instance_id, session_alias, recovery_id, slot_after_id) VALUES (?,?,?,?)",
+    [redeemed.instanceId, "backend", "r-1", 1],
+  );
   const listed = instances.listByAccount(account.id);
   expect(listed).toHaveLength(1);
   expect(listed[0]?.lastSeenAt).toBe("2026-06-13T10:05:00.000Z");
@@ -101,6 +105,7 @@ test("touch updates last_seen; listByAccount scopes; remove enforces ownership",
   expect(instances.remove(redeemed.instanceId, "other-account")).toBe(false);
   expect(instances.remove(redeemed.instanceId, account.id)).toBe(true);
   expect(instances.listByAccount(account.id)).toEqual([]);
+  expect(db.get("SELECT 1 FROM turn_slot_anchors WHERE instance_id = ?", [redeemed.instanceId])).toBeUndefined();
 });
 
 test("setCapabilities replaces the full set; missing column/null reads as empty", async () => {

--- a/tests/unit/packages/relay/stores/messages.test.ts
+++ b/tests/unit/packages/relay/stores/messages.test.ts
@@ -83,3 +83,12 @@ test("append stores structured agentMessage metadata and custom createdAt", asyn
   expect(rows[0]?.createdAt).toBe(customIso);
   expect(rows[0]?.structured?.agentMessage).toEqual(agentMsg);
 });
+
+test("append persists startedAt on an assistant out row and listBySession returns it", async () => {
+  const db = await freshDb();
+  const store = new MessageStore(db);
+  store.append("i1", "backend", "out", "reply", undefined, undefined, undefined, undefined, 1_700_000_000_000);
+  const rows = store.listBySession("a1", "i1", "backend").messages;
+  expect(rows[0]?.startedAt).toBe(1_700_000_000_000);
+  expect(store.getById("a1", "i1", "backend", rows[0]!.id!)?.startedAt).toBe(1_700_000_000_000);
+});

--- a/tests/unit/packages/relay/stores/messages.test.ts
+++ b/tests/unit/packages/relay/stores/messages.test.ts
@@ -84,11 +84,15 @@ test("append stores structured agentMessage metadata and custom createdAt", asyn
   expect(rows[0]?.structured?.agentMessage).toEqual(agentMsg);
 });
 
-test("append persists startedAt on an assistant out row and listBySession returns it", async () => {
+test("append persists startedAt and slotAfterId on an assistant out row", async () => {
   const db = await freshDb();
   const store = new MessageStore(db);
-  store.append("i1", "backend", "out", "reply", undefined, undefined, undefined, undefined, 1_700_000_000_000);
+  store.append("i1", "backend", "out", "reply", undefined, undefined, undefined, undefined, 1_700_000_000_000, 4, 2);
   const rows = store.listBySession("a1", "i1", "backend").messages;
   expect(rows[0]?.startedAt).toBe(1_700_000_000_000);
-  expect(store.getById("a1", "i1", "backend", rows[0]!.id!)?.startedAt).toBe(1_700_000_000_000);
+  expect(rows[0]?.slotAfterId).toBe(4);
+  expect(rows[0]?.startedAfterSeq).toBe(2);
+  const full = store.getById("a1", "i1", "backend", rows[0]!.id!);
+  expect(full?.slotAfterId).toBe(4);
+  expect(full?.startedAfterSeq).toBe(2);
 });

--- a/tests/unit/packages/relay/stores/turn-slot-anchors.test.ts
+++ b/tests/unit/packages/relay/stores/turn-slot-anchors.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { createSqlDriver, initSchema } from "../../../../../packages/relay/src/db";
+import {
+  TurnSlotAnchorStore,
+  canonicalRecoveryId,
+} from "../../../../../packages/relay/src/stores/turn-slot-anchors";
+
+async function fresh() {
+  const db = await createSqlDriver(":memory:");
+  initSchema(db);
+  db.run("INSERT INTO accounts (id, username, created_at) VALUES (?,?,?)", ["a1", "u1", "t"]);
+  db.run("INSERT INTO instances (id, account_id, name, credential_hash, created_at) VALUES (?,?,?,?,?)", ["i1", "a1", "pc", "h", "t"]);
+  db.run("INSERT INTO instances (id, account_id, name, credential_hash, created_at) VALUES (?,?,?,?,?)", ["i2", "a1", "pc2", "h", "t"]);
+  return { db, store: new TurnSlotAnchorStore(db) };
+}
+
+test("take with a non-empty recoveryId miss does not bind a leftover session anchor", async () => {
+  const { store } = await fresh();
+  store.put({ instanceId: "i1", sessionAlias: "backend", recoveryId: "r-A", slotAfterId: 10 });
+  expect(store.take("i1", "backend", "r-B")).toBeUndefined();
+  expect(store.get("i1", "r-A")?.slotAfterId).toBe(10);
+});
+
+test("empty recoveryId is isolated per session (backend and frontend do not clobber)", async () => {
+  const { store } = await fresh();
+  store.put({
+    instanceId: "i1",
+    sessionAlias: "backend",
+    recoveryId: canonicalRecoveryId("backend"),
+    slotAfterId: 10,
+  });
+  store.put({
+    instanceId: "i1",
+    sessionAlias: "frontend",
+    recoveryId: canonicalRecoveryId("frontend"),
+    slotAfterId: 20,
+  });
+  expect(store.take("i1", "backend")?.slotAfterId).toBe(10);
+  expect(store.take("i1", "frontend")?.slotAfterId).toBe(20);
+  expect(store.get("i1", canonicalRecoveryId("backend"))).toBeUndefined();
+  expect(store.get("i1", canonicalRecoveryId("frontend"))).toBeUndefined();
+});
+
+test("retain drops leftover anchors not in turns ∪ finishedOffline", async () => {
+  const { store } = await fresh();
+  store.put({ instanceId: "i1", sessionAlias: "backend", recoveryId: "r-A", slotAfterId: 10 });
+  store.put({ instanceId: "i1", sessionAlias: "backend", recoveryId: "r-B", slotAfterId: 100 });
+  store.put({ instanceId: "i1", sessionAlias: "frontend", recoveryId: "r-C", slotAfterId: 5 });
+  store.retain("i1", new Set(["r-B"]));
+  expect(store.get("i1", "r-A")).toBeUndefined();
+  expect(store.get("i1", "r-B")?.slotAfterId).toBe(100);
+  expect(store.get("i1", "r-C")).toBeUndefined();
+});
+
+test("deleteBySession and deleteByInstance clear only the targeted rows", async () => {
+  const { store } = await fresh();
+  store.put({ instanceId: "i1", sessionAlias: "backend", recoveryId: "r-be", slotAfterId: 1 });
+  store.put({ instanceId: "i1", sessionAlias: "frontend", recoveryId: "r-fe", slotAfterId: 2 });
+  store.put({ instanceId: "i2", sessionAlias: "backend", recoveryId: "r-other", slotAfterId: 3 });
+  store.deleteBySession("i1", "backend");
+  expect(store.get("i1", "r-be")).toBeUndefined();
+  expect(store.get("i1", "r-fe")?.slotAfterId).toBe(2);
+  expect(store.get("i2", "r-other")?.slotAfterId).toBe(3);
+  store.deleteByInstance("i1");
+  expect(store.get("i1", "r-fe")).toBeUndefined();
+  expect(store.get("i2", "r-other")?.slotAfterId).toBe(3);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the receiver session, a received Agent Message card sits above the live turn (correct). If the agent `agent_send`s during that turn and the peer replies **before the turn ends**, a second received card is appended to `messages[]` while `liveTurn` was always rendered after the whole list. Visually two received cards stacked on top of the still-running turn.

## Slot design (insert order, not split, not clocks)

Do **not** split/cancel the ACP turn. Do **not** nest received cards into `TurnParts` (rejected: looks like the agent sent them).

**Ordering identity is Hub insert/receive order, not wall clocks.** Peer `AgentMessage.createdAt`, Hub `nowMs()`, connector `Date.now()`, and browser `Date.now()` are different machines and must not decide transcript order.

1. On Hub `turn-started` (after inbound prompt reconcile), snapshot the last persisted `messages.id` for that session as `slotAfterId` (`0` = empty transcript). Persist it in `turn_slot_anchors` (keyed by recovery identity) and on the live accumulator.
2. Render the live turn after that anchor (web live path still uses transcript index at turn-start — insert order, never `createdAt`).
3. Later rows append to `messages` and appear **after** the live slot: `card1 → live turn1 → card2 / queued prompt → (later) turn2`.
4. When the turn finishes, splice the `out` row into that slot and persist `slotAfterId` (plus `startedAfterSeq` and `startedAt` as telemetry). Do not `push` it to the end.
5. Occupy the live slot even when `parts.length === 0` (working spinner).
6. Stick-to-bottom / jump-latest while a live turn exists follows the **live bubble**.

## Anchor identity and lifecycle (no stale bind)

Non-empty `recoveryId` is the real recovery identity: **exact match only**. If Hub never saw that start, snapshot current `lastId` after prompt reconcile. Do **not** fall back to the session's leftover anchor (expired/FIFO-evicted turn A must not bind to later turn B — that would rewrite every row after A's old id).

After a successful authoritative `instance.state.sync`, drop anchors for that instance that are not in `turns ∪ finishedOffline`. Session delete and instance delete (and account cascade) also clear matching anchors.

Legacy connectors that omit `recoveryId` on `turn-started` use a **dedicated per-session** key (`instanceId` + `sessionAlias`). Concurrent backend + frontend starts no longer clobber one `(instance, "")` row.

## Connector recovery + Hub restart

The connector cannot see Hub message ids. It stamps a per-session monotonic `startedAfterSeq` on `turn-started` / `turn-finished` and carries `startedAt` + `startedAfterSeq` through `MirrorTurn` → `PendingFinishedTurn` → `finishedOffline` and `state.sync` turns.

Hub maps that seq back to insert order via the SQLite `turn_slot_anchors` row written at the original `turn-started`. After Hub restart:

- `finishedOffline` persist uses the stored `slotAfterId` for that recovery id, not `lastId` (which would treat a mid-turn card as the trigger) and not clocks.
- No-buffer `turn-finished` (accumulator gone) uses the same exact-match anchor.
- Turns that started during a complete outage (exact recoveryId miss) snapshot `lastId` **after** prompt reconcile (mid-turn cards were not persisted while the Hub was down). A leftover from an earlier turn is not inherited.

`startedAt` remains HUD telemetry only. Compact and history HTTP APIs keep `slotAfterId` and `startedAfterSeq`; they must not drop them in `view=compact`. History is **not** ordered only by `createdAt` (finish time).

## History apply (all post-start rows)

On `loadHistory` / history apply: for each assistant `out` with `slotAfterId`, move **every** transcript row currently before that out whose Hub `id` is greater than the anchor to immediately after the out — received cards **and** queued user prompts, not only `direction === "received"`.

This matches live busy-send: `prompt1 → out1 → queued prompt2`. Legacy outs without `slotAfterId` are not reordered (even if they have `startedAt`).

A peer card whose `createdAt` is 30s *before* Hub `startedAt` but whose Hub id is *after* the anchor still lands after the `out`.

## Gate B

Received cards stay standalone “From” timeline rows. Sent-card join is unchanged (`direction === "sent"` by `agentMessageId`). Received cards are never suppressed or nested into the turn.

## Out of scope

- Presentation-only freeze/split of one ACP turn (rejected option C)
- Nesting received cards into TurnParts (rejected option A)
- Merge

## Tests

- Chat store: mid-turn second received card after live slot; flush inserts `out` in slot; history reorder by `slotAfterId`; clock-skew card still after `out`; busy send → turn-finished → history before queued drain
- MessageList: inline live slot, empty-parts spinner, Gate B standalone
- Hub/API: compact and full list keep `slotAfterId` / `startedAfterSeq`; Hub restart `finishedOffline` and no-buffer `turn-finished` persist the start-time anchor
- Stale-anchor: leftover A + outage-started B must use post-reconcile lastId, not A's `slotAfterId`; leftover A is dropped after `state.sync`
- Legacy empty recoveryId: backend + frontend both start, Hub restart, each restores its own slot
- Connector mirror: `startedAfterSeq` + `startedAt` ride `finishedOffline` / running turns

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-111b38fc-967b-4dea-84a7-1e7067688421?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-111b38fc-967b-4dea-84a7-1e7067688421&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

