### PR TITLE
feat(relay-web): rotate playful quips in busy composer placeholder

### DIFF
--- a/packages/relay-web/src/__tests__/working-quips.test.ts
+++ b/packages/relay-web/src/__tests__/working-quips.test.ts
@@ -4,8 +4,10 @@ import zhCN from "../i18n/messages/zh-CN";
 import { parseQuips, pickQuip } from "../lib/working-quips";
 
 describe("working quips", () => {
-  it("parses newline-delimited pools and drops empties", () => {
+  it("parses newline-delimited pools, trims, drops empties, and dedupes", () => {
     expect(parseQuips("a\n b \n\n c")).toEqual(["a", "b", "c"]);
+    expect(parseQuips("a\na\nb")).toEqual(["a", "b"]);
+    expect(parseQuips("a\n a ")).toEqual(["a"]);
     expect(parseQuips("")).toEqual([]);
     expect(parseQuips(undefined)).toEqual([]);
     expect(parseQuips(null)).toEqual([]);
@@ -18,18 +20,23 @@ describe("working quips", () => {
       expect(pick).not.toBe("a");
       expect(pool).toContain(pick);
     }
+    // Filtering out `avoid` would empty the pool → fall back to the full pool.
+    expect(pickQuip(["a", "a"], "a")).toBe("a");
     expect(pickQuip(["only"], "only")).toBe("only");
     expect(pickQuip([], undefined)).toBe("");
   });
 
   it("both locales ship a non-empty pool of unique quips plus an Esc suffix", () => {
-    for (const catalog of [en, zhCN]) {
-      const chat = catalog.chat as Record<string, string>;
-      const quips = parseQuips(chat.workingQuips);
+    const pools = [
+      { workingQuips: en.chat.workingQuips, escToStop: en.chat.escToStop },
+      { workingQuips: zhCN.chat.workingQuips, escToStop: zhCN.chat.escToStop },
+    ];
+    for (const { workingQuips, escToStop } of pools) {
+      const quips = parseQuips(workingQuips);
       expect(quips.length).toBeGreaterThanOrEqual(10);
       expect(new Set(quips).size).toBe(quips.length);
       expect(quips.every((q) => q.length > 0 && q.length <= 40)).toBe(true);
-      expect(chat.escToStop.length).toBeGreaterThan(0);
+      expect(escToStop.length).toBeGreaterThan(0);
     }
   });
 });

--- a/packages/relay-web/src/__tests__/working-quips.test.ts
+++ b/packages/relay-web/src/__tests__/working-quips.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import en from "../i18n/messages/en";
+import zhCN from "../i18n/messages/zh-CN";
+import { parseQuips, pickQuip } from "../lib/working-quips";
+
+describe("working quips", () => {
+  it("parses newline-delimited pools and drops empties", () => {
+    expect(parseQuips("a\n b \n\n c")).toEqual(["a", "b", "c"]);
+    expect(parseQuips("")).toEqual([]);
+    expect(parseQuips(undefined)).toEqual([]);
+    expect(parseQuips(null)).toEqual([]);
+  });
+
+  it("picks randomly but never repeats immediately when there is a choice", () => {
+    const pool = ["a", "b", "c"];
+    for (let i = 0; i < 50; i++) {
+      const pick = pickQuip(pool, "a");
+      expect(pick).not.toBe("a");
+      expect(pool).toContain(pick);
+    }
+    expect(pickQuip(["only"], "only")).toBe("only");
+    expect(pickQuip([], undefined)).toBe("");
+  });
+
+  it("both locales ship a non-empty pool of unique quips plus an Esc suffix", () => {
+    for (const catalog of [en, zhCN]) {
+      const chat = catalog.chat as Record<string, string>;
+      const quips = parseQuips(chat.workingQuips);
+      expect(quips.length).toBeGreaterThanOrEqual(10);
+      expect(new Set(quips).size).toBe(quips.length);
+      expect(quips.every((q) => q.length > 0 && q.length <= 40)).toBe(true);
+      expect(chat.escToStop.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -23,6 +23,7 @@ import {
   type AgentAutocompleteContext,
 } from "../lib/agent-mention-ranking";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
+import { parseQuips, pickQuip } from "../lib/working-quips";
 import { createDebouncedFlush } from "../lib/debounce-flush";
 import { clampPanelWidth, createBottomPanelResize } from "../lib/resize-panel";
 import UsagePopover from "./UsagePopover.vue";
@@ -559,6 +560,35 @@ watch(
 function flushDraft(): void {
   draftPersist.flush();
 }
+
+// Playful rotating status line for the composer placeholder while a turn runs.
+const busyQuip = ref("");
+let quipTimer: ReturnType<typeof setInterval> | null = null;
+const QUIP_ROTATE_MS = 5000;
+function rotateBusyQuip(): void {
+  const quips = parseQuips(t("chat.workingQuips"));
+  if (quips.length > 0) busyQuip.value = pickQuip(quips, busyQuip.value || undefined);
+}
+watch(
+  () => props.busy,
+  (busy) => {
+    if (quipTimer) {
+      clearInterval(quipTimer);
+      quipTimer = null;
+    }
+    if (busy) {
+      rotateBusyQuip();
+      quipTimer = setInterval(rotateBusyQuip, QUIP_ROTATE_MS);
+    } else {
+      busyQuip.value = "";
+    }
+  },
+  { immediate: true },
+);
+const workingPlaceholder = computed(() =>
+  busyQuip.value ? `${busyQuip.value}${t("chat.escToStop")}` : t("chat.working"),
+);
+
 onMounted(() => {
   window.addEventListener("pagehide", flushDraft);
   if (typeof window.matchMedia === "function") {
@@ -568,6 +598,7 @@ onMounted(() => {
   }
 });
 onBeforeUnmount(() => {
+  if (quipTimer) clearInterval(quipTimer);
   window.removeEventListener("pagehide", flushDraft);
   desktopMql?.removeEventListener("change", onDesktopChange);
   flushDraft();
@@ -916,7 +947,7 @@ function onInput() {
         rows="2"
         class="w-full resize-none bg-transparent px-3.5 pt-2.5 pb-1 text-[16px] lg:text-[14px] leading-relaxed text-fg placeholder:text-fg-muted focus:outline-none"
         :style="isDesktop ? { height: composerHeight + 'px' } : undefined"
-        :placeholder="busy ? $t('chat.working') : $t('chat.message')"
+        :placeholder="busy ? workingPlaceholder : $t('chat.message')"
         @input="onInput"
         @click="updateMentionState"
         @keyup="updateMentionState"

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -95,6 +95,10 @@ export default {
     effort: "effort",
     effortSetFailed: "Failed to switch effort. Try again.",
     working: "Agent is working… (Esc to stop)",
+    // Newline-delimited pool (never use "|" — vue-i18n reserves it for pluralization).
+    workingQuips:
+      "Ideas loading…\nSparks flying off the keyboard\nKeyboard smoking — do not disturb\nCPU is sweating a little\nArguing with a bug\nTranslating requirements into code\nLaying it down line by line\nKnee-deep in the docs\nCoffee refilled, back at it\nFingers flying, code flowing\nBrain fans at full speed\nNeurons firing wildly\nPaddling through the knowledge sea\nUnboxing your requirements\nPuzzle in progress — no rushing\nDeleted, rewritten, repeat\nCooking up something big\nGears turning, clickety-clack\nInjecting soul into the code\nBytes flying, bugs fleeing",
+    escToStop: " (Esc to stop)",
     mentionSource: {
       worker: "Worker",
       weixin: "WeChat",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -93,6 +93,9 @@ export default {
     effort: "推理强度",
     effortSetFailed: "切换推理强度失败，请重试。",
     working: "Agent 正在工作…（按 Esc 停止）",
+    workingQuips:
+      "灵感加载中…\n正在敲键盘，火花四溅\n键盘冒烟中，请勿打扰\nCPU 微微出汗\n正在与 bug 斗智斗勇\n正在把需求翻译成代码\n一行一行搬砖中…\n正在翻文档第八十页\n咖啡续满，继续冲\n十指翻飞，代码狂飙\n大脑风扇全速运转\n神经元疯狂放电中\n在知识的海洋里狗刨\n正在拆需求盲盒\n拼图进行中，别催\n删删改改又一版\n正在憋大招\n齿轮咔咔转动中\n正在给代码注入灵魂\n字节在飞，bug 在逃",
+    escToStop: "（按 Esc 停止）",
     mentionSource: {
       worker: "Worker",
       weixin: "微信",

--- a/packages/relay-web/src/lib/working-quips.ts
+++ b/packages/relay-web/src/lib/working-quips.ts
@@ -2,16 +2,19 @@
 // values as plain strings, so the pool is stored as one newline-delimited string.
 export function parseQuips(raw: string | undefined | null): string[] {
   if (!raw) return [];
-  return raw
-    .split("\n")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+  const seen = new Set<string>();
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) seen.add(trimmed);
+  }
+  return [...seen];
 }
 
-/** Random pick, avoiding an immediate repeat when the pool allows a choice. */
+/** Random pick, avoiding an immediate repeat when the pool allows a choice.
+ *  Falls back to the full pool when filtering would empty it. */
 export function pickQuip(quips: string[], avoid?: string): string {
   if (quips.length === 0) return "";
-  if (quips.length === 1) return quips[0];
-  const pool = avoid ? quips.filter((q) => q !== avoid) : quips;
-  return pool[Math.floor(Math.random() * pool.length)];
+  const filtered = avoid ? quips.filter((q) => q !== avoid) : quips;
+  const pool = filtered.length > 0 ? filtered : quips;
+  return pool[Math.floor(Math.random() * pool.length)] ?? "";
 }

--- a/packages/relay-web/src/lib/working-quips.ts
+++ b/packages/relay-web/src/lib/working-quips.ts
@@ -1,0 +1,17 @@
+// Playful status lines for the busy composer placeholder. The i18n catalog keeps
+// values as plain strings, so the pool is stored as one newline-delimited string.
+export function parseQuips(raw: string | undefined | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Random pick, avoiding an immediate repeat when the pool allows a choice. */
+export function pickQuip(quips: string[], avoid?: string): string {
+  if (quips.length === 0) return "";
+  if (quips.length === 1) return quips[0];
+  const pool = avoid ? quips.filter((q) => q !== avoid) : quips;
+  return pool[Math.floor(Math.random() * pool.length)];
+}


### PR DESCRIPTION
## What

The busy composer placeholder was a single static line (`Agent 正在工作…（按 Esc 停止）`). This PR replaces it with a rotating pool of playful status lines, one shown per turn and rotated every 5s while the turn runs:

> 灵感加载中…（按 Esc 停止） / CPU 微微出汗（按 Esc 停止） / 在知识的海洋里狗刨（按 Esc 停止） / …

- 20 quips per locale (zh-CN + en), stored as a newline-delimited string under `chat.workingQuips` (avoiding `|`, which vue-i18n reserves for pluralization)
- `chat.escToStop` is a fixed suffix so the cancel hint never rotates away
- `chat.working` kept as fallback when the pool is empty
- New `lib/working-quips.ts` (`parseQuips` / `pickQuip`); `pickQuip` avoids an immediate repeat
- Timer cleared on busy-false and on unmount
- The per-mention activity chips (`执行中/等待中/空闲`) are intentionally left as-is for scannability

## Test plan

- [x] New `src/__tests__/working-quips.test.ts`: parse/trim/dedupe behavior, no-immediate-repeat, both catalogs ship ≥10 unique quips + Esc suffix
- [x] Static check: both pools 20 unique entries, no vue-i18n special chars (`@|{}`), i18n parity keys aligned
- [x] `vitest run` for `working-quips` / `i18n-parity` / `promptinput` + `vue-tsc --noEmit` (via `build:packages`) verified in CI — exact-head run 34020247105 green
