### PR TITLE
test(relay-web): lock quip catalog invariants and busy-placeholder timer lifecycle

### DIFF
--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -1,5 +1,5 @@
-import { mount } from "@vue/test-utils";
-import { beforeEach, describe, expect, it } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import PromptInput from "../components/PromptInput.vue";
 import { useInstancesStore } from "../stores/instances";
@@ -1534,5 +1534,40 @@ describe("PromptInput composer", () => {
     expect(items.length).toBe(2);
     expect(items[0].find('[data-test="mention-secondary"]').text()).toContain("Worker");
     expect(items[1].find('[data-test="mention-secondary"]').text()).toContain("WeChat");
+  });
+});
+
+describe("PromptInput busy quip rotation", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("picks a quip on busy, rotates every 5s, stops on busy=false, clears on unmount", async () => {
+    const w = mount(PromptInput, { props: { busy: false } });
+    const ta = w.find("textarea");
+    const placeholder = () => (ta.element as HTMLTextAreaElement).placeholder;
+    expect(placeholder()).toBe("Message");
+
+    await w.setProps({ busy: true });
+    const first = placeholder();
+    expect(first).toMatch(/\(Esc to stop\)$/);
+    expect(first).not.toBe("Agent is working… (Esc to stop)"); // quip picked, not the fallback
+
+    vi.advanceTimersByTime(5000);
+    await flushPromises();
+    const second = placeholder();
+    expect(second).toMatch(/\(Esc to stop\)$/);
+    expect(second).not.toBe(first); // pickQuip never repeats immediately
+
+    await w.setProps({ busy: false });
+    expect(placeholder()).toBe("Message");
+    expect(vi.getTimerCount()).toBe(0);
+
+    await w.setProps({ busy: true });
+    expect(vi.getTimerCount()).toBe(1);
+    w.unmount();
+    expect(vi.getTimerCount()).toBe(0); // interval must not survive unmount
   });
 });

--- a/packages/relay-web/src/__tests__/working-quips.test.ts
+++ b/packages/relay-web/src/__tests__/working-quips.test.ts
@@ -26,16 +26,23 @@ describe("working quips", () => {
     expect(pickQuip([], undefined)).toBe("");
   });
 
-  it("both locales ship a non-empty pool of unique quips plus an Esc suffix", () => {
+  it("both locales ship a 20-entry unique quip pool plus an Esc suffix (catalog invariant)", () => {
     const pools = [
       { workingQuips: en.chat.workingQuips, escToStop: en.chat.escToStop },
       { workingQuips: zhCN.chat.workingQuips, escToStop: zhCN.chat.escToStop },
     ];
     for (const { workingQuips, escToStop } of pools) {
-      const quips = parseQuips(workingQuips);
-      expect(quips.length).toBeGreaterThanOrEqual(10);
-      expect(new Set(quips).size).toBe(quips.length);
-      expect(quips.every((q) => q.length > 0 && q.length <= 40)).toBe(true);
+      // Inspect raw catalog lines: parseQuips dedupes, so routing the catalog
+      // through it would mask accidental duplicate entries.
+      const rawQuips = workingQuips
+        .split("\n")
+        .map((q) => q.trim())
+        .filter(Boolean);
+      expect(rawQuips).toHaveLength(20);
+      expect(new Set(rawQuips).size).toBe(rawQuips.length);
+      // vue-i18n reserves @ | { } in message syntax — quips must never use them.
+      expect(rawQuips.every((q) => !/[@|{}]/.test(q))).toBe(true);
+      expect(rawQuips.every((q) => q.length > 0 && q.length <= 40)).toBe(true);
       expect(escToStop.length).toBeGreaterThan(0);
     }
   });


### PR DESCRIPTION
Follow-up to #327 (merged as 1afabe5c), addressing the final review round.

## Fixes

**1. [P3] Vacuous catalog-uniqueness assertion** — the old test asserted uniqueness on `parseQuips()` *output*, which now dedupes, so `new Set(quips).size === quips.length` was always true and a catalog edited to contain duplicate lines would still pass. The test now inspects the **raw catalog lines** (split → trim → filter) and locks:
- exactly 20 entries per locale (was `>= 10`, which let a 20→10 regression slip through)
- uniqueness on the raw lines
- no vue-i18n-reserved characters (`@ | { }`) — previously only claimed in the PR body, now enforced
- non-empty `escToStop`

**2. Coverage gap: PromptInput timer lifecycle** — new fake-timer test in `promptinput.test.ts` covering the actual wiring this feature ships:
- `busy=false` → placeholder is the normal composer hint
- `busy=true` → a quip is picked immediately, suffixed with `(Esc to stop)`, not the fallback line
- +5s → rotated to a different quip (`pickQuip` never repeats immediately)
- `busy=false` → placeholder restored and **timer count drops to 0**
- `busy=true` again → exactly 1 timer; `unmount()` → **0 timers survive**

Production code is unchanged — test-only diff (+49/−7).

## Test plan

- [x] CI Test workflow green on this branch — run 34023092522: Run tests (incl. new lifecycle test) ✓, Build (all packages) vue-tsc ✓, Relay Web E2E ✓
