### PR TITLE
feat(relay-web): 回合结束后折叠中间过程 trace（zcode 式）

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -571,7 +571,7 @@ export interface LiveTurn {
 
 - **触发与折叠时机**：`turn-finished` 把 live turn 定型为历史消息的瞬间（`streaming` prop
   消失）即折叠。它就是 ACP `session/prompt` response 落定（`stopReason:"end_turn"`）在
-  xacpx 管线里的等价事件，无需协议改动。live（streaming）行不折叠，仍由 HUD 计时。
+  xacpx 管线里的等价事件，无需引入新的控制事件种类。live（streaming）行不折叠，仍由 HUD 计时。
 - **policy 在 `MessageList`**（`collapseTrace = !isFailedTurn(m) && hasTraceParts(m)`，
   失败判定读**持久化终态** `structured.turnStatus === "error"`（乐观 `failed` 标志在 hub
   历史收敛替换行后即消失，不能作为依据）、**presentation 在 `TurnParts`**（`trace-items`
@@ -579,11 +579,12 @@ export interface LiveTurn {
   计数段以 `·` 连接、英文走 vue-i18n 复数）。
 - **终态持久化**：hub 在三个持久化点（live flush、无 buffer 兜底、offline recovery）把
   `turnStatus: "done" | "cancelled" | "error"`（由 `ok`/`cancelled` 派生）盖进
-  `structured`，compact history 以 spread 原样保留。失败 trace 因此在刷新与收敛后
-  依然不折叠。
-- **展开记忆按 `traceKey`**：一律优先 `«instance»:«session»:t:«startedAt»`——`startedAt`
-  为 connector 戳，乐观 flush 行与持久行同值且被 hub 持久化（compact 也保留），所以
-  乐观行 → 持久行收敛时 key 不变，手动展开必然存活；无 `startedAt` 的 legacy 行退回
+  `structured`，compact history 以 spread 原样保留。Web 的 `keepRicherStructured()`
+  在收到 compact 页面时合并 hub 权威元数据（`turnStatus` / `truncated`），不再整份覆盖
+  导致冲掉状态。失败 trace 因此在刷新与收敛后依然不折叠。
+- **展开记忆按 `traceKey`**：一律优先 `«instance»:«session»:t:«startedAt»`——hub 在
+  `turn-started` 广播中携带自身 buffer 的 `startedAt`，乐观 flush 行与持久行同源同值
+  且被 hub 持久化（compact 也保留），所以乐观行 → 持久行收敛时 key 不变，手动展开必然存活；无 `startedAt` 的 legacy 行退回
   `«instance»:«session»:id:«n»`。存模块级 reactive Set（`lib/trace-expansion.ts`）；
   无身份行回退组件局部状态（不记忆）。
 - **耗时口径**：`createdAt − startedAt`（浏览器/hub 时钟 − connector 时钟），仅展示用、

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -546,7 +546,8 @@ export interface LiveTurn {
 
 **`MessageList.vue` 渲染**（`packages/relay-web/src/components/MessageList.vue`）
 
-- 历史 `out` 消息正文始终展开，复制、时间及失败/停止状态保持可见；消息本身没有折叠开关。
+- 历史 `out` 消息的复制、时间及失败/停止状态始终可见；失败行永不折叠（错误必须显眼），
+  其余 finished 行的中间过程 trace 默认折叠进回合头部（见下文「回合 trace 折叠」）。
 - `structured.parts` 由 `TurnParts` 按 Markdown 顶层块派生展示顺序：工具或推理不会切断正在生成的段落、
   列表、表格或代码围栏，而是在该块结束后显示；若事件本来位于两个块之间，则保持文字—活动—文字的穿插结构。
   实时 streaming 与历史回放使用同一派生规则。
@@ -562,6 +563,25 @@ export interface LiveTurn {
   user prompt）挪到该 `out` 之后；无 `slotAfterId` 的旧行不重排。**不以** `createdAt` /
   `startedAt` 墙钟比较决定顺序（发送端 daemon、Hub、浏览器时钟不可比）。Stick-to-bottom /
   jump-latest 在 live turn 存在时跟随 live 气泡，而不是最新一行。
+
+### 回合 trace 折叠（turn-trace collapse，spec 2026-09-07）
+
+参照 zcode：回合结束后把思考/工具/子代理等中间过程折叠进一条弱化头部行
+（`▸ 已工作 4分32秒 · 6 步工具 · 3 段思考`），正文（text）与 agent-message 卡永不折叠。
+
+- **触发与折叠时机**：`turn-finished` 把 live turn 定型为历史消息的瞬间（`streaming` prop
+  消失）即折叠。它就是 ACP `session/prompt` response 落定（`stopReason:"end_turn"`）在
+  xacpx 管线里的等价事件，无需协议改动。live（streaming）行不折叠，仍由 HUD 计时。
+- **policy 在 `MessageList`**（`collapseTrace = !m.failed && hasTraceParts(m)`）、
+  **presentation 在 `TurnParts`**（`trace-items` 过滤 `text`/`agent-message` 之外的全部
+  presentation 项，头部固定在回合顶部）。
+- **展开记忆按 `traceKey`**（`id:<n>` 持久行 / `t:<startedAt>` 乐观 flush 行，hub 历史收敛
+  整行替换后 key 不变——两处的 `startedAt` 同为 connector 戳）存模块级 reactive Set
+  （`lib/trace-expansion.ts`）；无身份行回退组件局部状态（不记忆）。
+- **耗时口径**：`createdAt − startedAt`（浏览器/hub 时钟 − connector 时钟），仅展示用、
+  非正值得降级为只显计数；精确耗时需 hub 落 durationMs 列（未做）。
+- 手动展开状态在 `turn-finished` 后的 hub 历史收敛窗口内可能丢一次（乐观 `t:` 键切到持久
+  `id:` 键），接受：收敛在亚秒级窗口内完成，用户尚未交互。
 
 ## 桌面系统通知（Web Push 与 本地 Notification Fallback）
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -572,16 +572,22 @@ export interface LiveTurn {
 - **触发与折叠时机**：`turn-finished` 把 live turn 定型为历史消息的瞬间（`streaming` prop
   消失）即折叠。它就是 ACP `session/prompt` response 落定（`stopReason:"end_turn"`）在
   xacpx 管线里的等价事件，无需协议改动。live（streaming）行不折叠，仍由 HUD 计时。
-- **policy 在 `MessageList`**（`collapseTrace = !m.failed && hasTraceParts(m)`）、
-  **presentation 在 `TurnParts`**（`trace-items` 过滤 `text`/`agent-message` 之外的全部
-  presentation 项，头部固定在回合顶部）。
-- **展开记忆按 `traceKey`**（`id:<n>` 持久行 / `t:<startedAt>` 乐观 flush 行，hub 历史收敛
-  整行替换后 key 不变——两处的 `startedAt` 同为 connector 戳）存模块级 reactive Set
-  （`lib/trace-expansion.ts`）；无身份行回退组件局部状态（不记忆）。
+- **policy 在 `MessageList`**（`collapseTrace = !isFailedTurn(m) && hasTraceParts(m)`，
+  失败判定读**持久化终态** `structured.turnStatus === "error"`（乐观 `failed` 标志在 hub
+  历史收敛替换行后即消失，不能作为依据）、**presentation 在 `TurnParts`**（`trace-items`
+  过滤 `text`/`agent-message` 之外的全部 presentation 项，头部固定在回合顶部，
+  计数段以 `·` 连接、英文走 vue-i18n 复数）。
+- **终态持久化**：hub 在三个持久化点（live flush、无 buffer 兜底、offline recovery）把
+  `turnStatus: "done" | "cancelled" | "error"`（由 `ok`/`cancelled` 派生）盖进
+  `structured`，compact history 以 spread 原样保留。失败 trace 因此在刷新与收敛后
+  依然不折叠。
+- **展开记忆按 `traceKey`**：一律优先 `«instance»:«session»:t:«startedAt»`——`startedAt`
+  为 connector 戳，乐观 flush 行与持久行同值且被 hub 持久化（compact 也保留），所以
+  乐观行 → 持久行收敛时 key 不变，手动展开必然存活；无 `startedAt` 的 legacy 行退回
+  `«instance»:«session»:id:«n»`。存模块级 reactive Set（`lib/trace-expansion.ts`）；
+  无身份行回退组件局部状态（不记忆）。
 - **耗时口径**：`createdAt − startedAt`（浏览器/hub 时钟 − connector 时钟），仅展示用、
-  非正值得降级为只显计数；精确耗时需 hub 落 durationMs 列（未做）。
-- 手动展开状态在 `turn-finished` 后的 hub 历史收敛窗口内可能丢一次（乐观 `t:` 键切到持久
-  `id:` 键），接受：收敛在亚秒级窗口内完成，用户尚未交互。
+  非正值得降级为只显计数，亚秒显示 `<1s`；精确耗时需 hub 落 durationMs 列（未做）。
 
 ## 桌面系统通知（Web Push 与 本地 Notification Fallback）
 

--- a/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
+++ b/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
@@ -27,12 +27,12 @@ relay-web 现状：`turn-finished` 后 live turn 经 `flushTurn` 定型为历史
 - **折叠是纯视图状态，放演示层（TurnParts），不动 store/wire 数据**。`structured.parts` 是不可变传输数据，hub 历史收敛（`keepRicherStructured`）会整行替换消息对象，任何写进 store 的折叠状态都会被冲掉或引出同步负担。
 - **头部固定在回合顶部**（zcode 一致），不是第一个 trace 项的位置——回合常以正文开头，按 trace 位置插头部会把头部夹在两段正文中间。
 - **error 行永不折叠**：红色失败 ring 与错误卡片必须显眼；cancelled 行折叠（与 done 一致，内容一键可展开）。
-- **手动展开状态放模块级 `Set<string>`，key = `traceKey`**，不用组件局部 ref：`turn-finished` 后 hub 历史收敛替换消息行，组件会被重建，局部状态必丢。`traceKey` 用持久行 `id:<n>`、乐观行 `t:<startedAt>`——flush 行与持久行的 `startedAt` 同源（都是 connector 在 turn-start 盖的戳，hub 存 `started_at` 列并回传 `MessageRecordDto.startedAt`），跨收敛稳定。
+- **手动展开状态放模块级 reactive `Set`，key = `traceKey`**，不用组件局部 ref：`turn-finished` 后 hub 历史收敛替换消息行，组件会被重建，局部状态必丢。`traceKey` **一律优先 `«instance»:«session»:t:«startedAt»`**——`startedAt` 为 connector 戳，乐观 flush 行与持久行同值、且被 hub 持久化（`started_at` 列，compact 亦保留），收敛前后 key 不变，手动展开必然存活；无 `startedAt` 的 legacy 行退回 `…:id:«n»`（只出现在已持久行，不存在中途切换）。无任何身份的行回退组件局部状态（不记忆）。
 - **纯 v-show/v-if 切换，无过渡动画**：省掉 `prefers-reduced-motion` 分支；行高变化由既有的 `content-visibility` 虚拟化和 tail-follow watcher 自然消化。
 
 ## 组件设计
 
-### `TurnParts.vue`（唯一改动的渲染组件）
+### `TurnParts.vue`（渲染层改动；hub/protocol 侧见「终态持久化」）
 
 新增 props（全部可选，现有调用点零破坏）：
 
@@ -61,58 +61,94 @@ traceElapsedMs?: number | null  // 回合耗时（展示用；null/undefined = �
 
 ### `MessageList.vue`（policy 计算与 props 装配）
 
-仅 assistant 历史行的 `TurnParts` 调用点（`msg-content` 内，现 `:parts="m.structured.parts"` 一处）传新 props；live 行的三个调用点不动：
+
+仅 assistant 历史行的 `TurnParts` 调用点（`msg-content` 内）传新 props；live 行的调用点不动：
 
 ```ts
 // script:
-const hasTrace = (m: ChatMessage): boolean => {
-  const parts = m.structured?.parts ?? [];
-  return parts.some((p) => p.type !== "text" && p.type !== "agent-message");
-};
-const traceKeyOf = (m: ChatMessage): string =>
-  m.id !== undefined ? `id:${m.id}` : m.startedAt !== undefined ? `t:${m.startedAt}` : "";
-const traceElapsedOf = (m: ChatMessage): number | null => {
+function hasTraceParts(m: ChatMessage): boolean {
+  return m.structured?.parts?.some((p) => p.type !== "text") ?? false;  // wire parts: text | reasoning | tool
+}
+function isFailedTurn(m: ChatMessage): boolean {
+  return m.failed === true || m.structured?.turnStatus === "error";
+}
+function traceKeyOf(m: ChatMessage): string | undefined {
+  if (m.startedAt !== undefined) return `${m.instanceId}:${m.sessionAlias}:t:${m.startedAt}`;
+  if (m.id !== undefined) return `${m.instanceId}:${m.sessionAlias}:id:${m.id}`;
+  return undefined;
+}
+function traceElapsedOf(m: ChatMessage): number | null {
   if (m.startedAt === undefined) return null;
   const ms = Date.parse(m.createdAt) - m.startedAt;
   return Number.isFinite(ms) && ms > 0 ? ms : null;   // 跨机时钟偏差 → clamp 成 null
-};
+}
 ```
 
-- `:collapse-trace="!m.failed && hasTrace(m)"`（failed 行永不折叠）。
+- `:collapse-trace="!isFailedTurn(m) && hasTraceParts(m)"`。
 - `:trace-key="traceKeyOf(m)"`、`:trace-elapsed-ms="traceElapsedOf(m)"`。
+
+### 终态持久化（评审修正）：`structured.turnStatus`
+
+web 本地的 `failed`/`status` 只存在于乐观 flush 行，hub 历史收敛（`loadHistory` 用
+`MessageRecordDto[]` 整表替换）后即丢失——只看 `m.failed` 会让失败 trace 在收敛后
+被折叠（对 main 是回归）。因此 hub 在**全部三个持久化点**把终态盖进 `structured`：
+
+```ts
+turnStatus: cancelled ? "cancelled" : ok ? "done" : "error"
+```
+
+- live flush（有 buffer）：`structured` 始终携带 `turnStatus`（含此前 `structured` 为
+  undefined 的纯文本回合——现在是一枚 `{ turnStatus }`）；
+- 无 buffer 兜底（hub 重启于回合中）：`{ turnStatus }`（text/errorMessage 兜底行同样盖戳）；
+- offline recovery（`finishedOffline`）：由 `finished.ok/cancelled` 就地派生，连接器零改动。
+
+compact history 以 `{ ...structured }` spread 透传未知 key，`turnStatus` 天然存活；
+`capSeededStructured`/`capSyncedParts` 只裁剪超长字符串，不影响该字段。
 
 耗时口径：`createdAt`（乐观行=浏览器时钟 / 持久行=hub 时钟）减 `startedAt`（connector 时钟）。同机部署近似精确；跨机有时钟偏差，只作展示、偏差过大（负值）时降级为只显计数。精确耗时若将来要保证，需 hub 落 `durationMs` 列，不在本期。
 
 ### 数据流不变
 
-`turn-finished` → `flushTurn` 定型（行带 `startedAt`/`createdAt`/`structured.parts`）→ `streaming` prop 消失 → 折叠即时生效；随后 hub 历史收敛整行替换，`traceKey` 从乐观 `t:` 切到持久 `id:` —— 已记录的展开状态会丢一次（`Set` 里是 `t:` 键，替换后查 `id:` 键不中）。接受：收敛发生在回合结束的亚秒级窗口内，用户此时还没来得及点开；不做双键迁移的复杂度。
+`turn-finished` → `flushTurn` 定型（行带 `startedAt`/`createdAt`/`structured.parts`）→ `streaming` prop 消失 → 折叠即时生效；随后 hub 历史收敛整行替换——`traceKey` 以 `startedAt` 为主键、收敛前后不变，手动展开跨收敛存活（有回归测试：乐观行点开 → setProps 持久行（同 `startedAt`、新 `id`）→ 仍展开）。
 
 ## i18n（`en.ts` + `zh-CN.ts` 镜像，parity 测试强制）
 
 ```ts
 turnTrace: {
   worked: "Worked",            // 已工作
-  tools: "{n} tool steps",     // {n} 步工具
-  thoughts: "{n} thoughts",    // {n} 段思考
+  tools: "{count} tool step | {count} tool steps",  // {count} 步工具（zh 单形）
+  thoughts: "{count} thought | {count} thoughts",   // {count} 段思考
   toggleTrace: "Toggle intermediate steps",  // aria-label：展开/收起中间过程
 },
 ```
 
-时长格式不走 i18n（`4:32` → `4分32秒` / `4m 32s` 在组件内按 locale 分支，与 `ChatPane` HUD 的 mm:ss 同级别近似；如 parity 不允许硬分支则退化为 `fmtDuration` 现有秒格式）。
+时长格式不走 i18n（`m分s秒` / `m m s s` 在组件内按 locale 分支；亚秒显示 `<1s`）。
 
 ## 测试
 
 `packages/relay-web/src/__tests__/turnparts-collapse.test.ts`（新，mount TurnParts）：
 
 1. `collapseTrace` 缺省/live：trace 项内联、无头部（回归确认）。
-2. finished + trace 存在：头部渲染且含计数，trace 项不在 DOM；text 项保留。
+2. finished + trace 存在：头部渲染且计数以 `·` 连接（英文复数：`1 tool step` / `2 tool steps`），trace 项不在 DOM；text 项保留。
 3. 点头部展开：trace 项出现、`aria-expanded=true`；再点收起。
 4. 同 `traceKey` 重挂载（模拟行替换）：展开状态保持；不同 key 不串。
 5. 纯 text 行：无头部。
-6. `traceElapsedMs` 传/不传：头部带/不带耗时段。
+6. `traceElapsedMs` 传/不传/亚秒（`<1s`）：头部耗时段相应变化。
 7. zh/en 文案分支冒烟（设置 locale 后断言头部文本）。
+8. agent-message 真锚定（step 带 `agentMessageId` + map 含该条目）：折叠态下卡片仍在、tool 卡不在。
 
-`messagelist.test.ts` 补一条：failed 行 `collapseTrace=false`、done 行 `=true`（可通过 DOM 断言头部有无）。
+`turnparts-collapse.test.ts` 的 MessageList 收敛组（评审回归）：
+
+1. 乐观行（无 id、`startedAt=X`）点开 → setProps 持久行（`id=7`、同 `startedAt`）→ 仍展开（key 稳定性）。
+2. 持久行 `structured.turnStatus: "error"`（无本地 `failed` 标志）→ 不折叠，trace 内联。
+3. 持久行 `turnStatus: "done"` → 折叠。
+
+hub 侧（bun test）：
+
+- `runtime-fanout.test.ts`：live flush 持久行的 `structured.turnStatus` 为 error/cancelled/done（含 buffered trace 的失败回合）。
+- `runtime-state-sync.test.ts`：recovery 行按 `finished.ok/cancelled` 派生 turnStatus；既有 exact-equality structured 断言更新为带 `turnStatus` 的新形状。
+
+`messagelist.test.ts`：failed 行（乐观标志）不折叠、done 行折叠（DOM 断言头部有无）。
 
 `i18n-parity.test.ts` 自动覆盖新 key。
 

--- a/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
+++ b/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
@@ -1,0 +1,127 @@
+# relay-web 回合 trace 折叠（zcode 式「结束即收起中间过程」）
+
+日期：2026-09-07
+状态：已定稿，随实现微调
+
+## 背景与目标
+
+参照 zcode 的会话气泡：回合进行中，思考/工具等中间过程以弱化单行 chip 内联展开；回合结束后整个 trace 折叠进一条回合头部（「已工作 5 分 5 秒 ›」），正文直接呈现。
+
+relay-web 现状：`turn-finished` 后 live turn 经 `flushTurn` 定型为历史消息，`TurnParts` 原样渲染全部 parts——推理面板、工具卡、子代理卡永远内联常驻，长回合把最终回复淹没。回合耗时只存在于输入框上方的 HUD（`ChatPane` `turn-hud`），回合结束即消失。
+
+目标：**回合结束后默认折叠 trace**，收进一条回合头部；用户可展开。正文（text）与已发出的 peer 消息卡（agent-message）永不折叠。
+
+**触发信号（已用真实流验证）**：ACP 回合边界 = `session/prompt` 的 JSON-RPC response（`{"result":{"stopReason":"end_turn",…}}`，实际值为 snake_case `end_turn`）。xacpx 管线里它的等价物就是 `turn-finished` 控制事件（`src/control/session-turn-runner.ts` 在 `agent.chat()` resolve 后发出，带 `ok/cancelled/errorMessage`）——web 端在该事件定型消息的瞬间折叠，零协议改动。
+
+## 非目标
+
+- **不改协议**：relay-protocol / relay hub / connector 零改动。`stopReason` 端到端透传（区分 `max_tokens` 截断不折叠等）是后续增强，链路见文末。
+- 不改 live（streaming）行渲染：进行中回合照旧内联展开 + HUD 计时（zcode 进行中也是展开的）。
+- legacy 历史行（无 `parts`，走 `ToolCallPanel` + `ReasoningPanel` fallback）不涉及：两组件本来就默认折叠。
+- 不做相邻 read/search 工具聚合（「查阅 · 1 搜索, 1 列表」，P2）。
+- 不做 reasoning chip 时长 / 工具行 diffstat（P1）。
+- 不做全局「新回合默认折叠」的设置项。
+
+## 方案取舍
+
+- **折叠是纯视图状态，放演示层（TurnParts），不动 store/wire 数据**。`structured.parts` 是不可变传输数据，hub 历史收敛（`keepRicherStructured`）会整行替换消息对象，任何写进 store 的折叠状态都会被冲掉或引出同步负担。
+- **头部固定在回合顶部**（zcode 一致），不是第一个 trace 项的位置——回合常以正文开头，按 trace 位置插头部会把头部夹在两段正文中间。
+- **error 行永不折叠**：红色失败 ring 与错误卡片必须显眼；cancelled 行折叠（与 done 一致，内容一键可展开）。
+- **手动展开状态放模块级 `Set<string>`，key = `traceKey`**，不用组件局部 ref：`turn-finished` 后 hub 历史收敛替换消息行，组件会被重建，局部状态必丢。`traceKey` 用持久行 `id:<n>`、乐观行 `t:<startedAt>`——flush 行与持久行的 `startedAt` 同源（都是 connector 在 turn-start 盖的戳，hub 存 `started_at` 列并回传 `MessageRecordDto.startedAt`），跨收敛稳定。
+- **纯 v-show/v-if 切换，无过渡动画**：省掉 `prefers-reduced-motion` 分支；行高变化由既有的 `content-visibility` 虚拟化和 tail-follow watcher 自然消化。
+
+## 组件设计
+
+### `TurnParts.vue`（唯一改动的渲染组件）
+
+新增 props（全部可选，现有调用点零破坏）：
+
+```ts
+collapseTrace?: boolean      // true = 回合已结束且允许折叠（policy 由调用方算）
+traceKey?: string            // 展开状态的持久 key；缺省时每次渲染都折叠
+traceElapsedMs?: number | null  // 回合耗时（展示用；null/undefined = 只显示计数）
+```
+
+行为：
+
+- `collapseTrace` 为假（含 live 行不传）→ **现状行为**，无头部、全部内联。
+- 为真且 presentation 中存在 trace 项（`reasoning`/`tool`/`subagent`）→ 顶部渲染折叠头：
+
+  ```
+  ▸ 已工作 4分32秒 · 6 步工具 · 3 段思考     ← en: "Worked 4m 32s · 6 tool steps · 3 thoughts"
+  ```
+
+  - 计数：tool+subagent 卡数为「步工具」，reasoning 段数为「段思考」；为 0 的段省略。
+  - 耗时：`traceElapsedMs` 格式化为 `m分s秒` / `m m s s`（<1s 显示 `<1s`）；缺失时头部只有计数。
+  - 无 trace 项（纯文本回复）→ 不渲染头部，与现状一致。
+- **折叠态**：trace 项全部不渲染，只保留 text / agent-message 项（保持其在 parts 中的相对顺序）。
+- **展开态**：头部 chevron 翻转，trace 项按原顺序内联渲染（`ensure-full`、subagent 卡、`streaming` 锚定等行为不变——live 才传 `streaming`，finished 行本就不传）。
+- 展开状态：模块级 `const expandedTraces = new Set<string>()`；`traceKey` 存在时 toggle 增删；无 `traceKey` 的行不可记忆（始终折叠）。头部 `<button>` 带 `aria-expanded` 与 `data-test="trace-toggle"`。
+- 头部样式：无边框弱化行（`text-fg-muted text-[11.5px]`），与 zcode 的低调头部对齐；整行可点。
+
+### `MessageList.vue`（policy 计算与 props 装配）
+
+仅 assistant 历史行的 `TurnParts` 调用点（`msg-content` 内，现 `:parts="m.structured.parts"` 一处）传新 props；live 行的三个调用点不动：
+
+```ts
+// script:
+const hasTrace = (m: ChatMessage): boolean => {
+  const parts = m.structured?.parts ?? [];
+  return parts.some((p) => p.type !== "text" && p.type !== "agent-message");
+};
+const traceKeyOf = (m: ChatMessage): string =>
+  m.id !== undefined ? `id:${m.id}` : m.startedAt !== undefined ? `t:${m.startedAt}` : "";
+const traceElapsedOf = (m: ChatMessage): number | null => {
+  if (m.startedAt === undefined) return null;
+  const ms = Date.parse(m.createdAt) - m.startedAt;
+  return Number.isFinite(ms) && ms > 0 ? ms : null;   // 跨机时钟偏差 → clamp 成 null
+};
+```
+
+- `:collapse-trace="!m.failed && hasTrace(m)"`（failed 行永不折叠）。
+- `:trace-key="traceKeyOf(m)"`、`:trace-elapsed-ms="traceElapsedOf(m)"`。
+
+耗时口径：`createdAt`（乐观行=浏览器时钟 / 持久行=hub 时钟）减 `startedAt`（connector 时钟）。同机部署近似精确；跨机有时钟偏差，只作展示、偏差过大（负值）时降级为只显计数。精确耗时若将来要保证，需 hub 落 `durationMs` 列，不在本期。
+
+### 数据流不变
+
+`turn-finished` → `flushTurn` 定型（行带 `startedAt`/`createdAt`/`structured.parts`）→ `streaming` prop 消失 → 折叠即时生效；随后 hub 历史收敛整行替换，`traceKey` 从乐观 `t:` 切到持久 `id:` —— 已记录的展开状态会丢一次（`Set` 里是 `t:` 键，替换后查 `id:` 键不中）。接受：收敛发生在回合结束的亚秒级窗口内，用户此时还没来得及点开；不做双键迁移的复杂度。
+
+## i18n（`en.ts` + `zh-CN.ts` 镜像，parity 测试强制）
+
+```ts
+turnTrace: {
+  worked: "Worked",            // 已工作
+  tools: "{n} tool steps",     // {n} 步工具
+  thoughts: "{n} thoughts",    // {n} 段思考
+  toggleTrace: "Toggle intermediate steps",  // aria-label：展开/收起中间过程
+},
+```
+
+时长格式不走 i18n（`4:32` → `4分32秒` / `4m 32s` 在组件内按 locale 分支，与 `ChatPane` HUD 的 mm:ss 同级别近似；如 parity 不允许硬分支则退化为 `fmtDuration` 现有秒格式）。
+
+## 测试
+
+`packages/relay-web/src/__tests__/turnparts-collapse.test.ts`（新，mount TurnParts）：
+
+1. `collapseTrace` 缺省/live：trace 项内联、无头部（回归确认）。
+2. finished + trace 存在：头部渲染且含计数，trace 项不在 DOM；text 项保留。
+3. 点头部展开：trace 项出现、`aria-expanded=true`；再点收起。
+4. 同 `traceKey` 重挂载（模拟行替换）：展开状态保持；不同 key 不串。
+5. 纯 text 行：无头部。
+6. `traceElapsedMs` 传/不传：头部带/不带耗时段。
+7. zh/en 文案分支冒烟（设置 locale 后断言头部文本）。
+
+`messagelist.test.ts` 补一条：failed 行 `collapseTrace=false`、done 行 `=true`（可通过 DOM 断言头部有无）。
+
+`i18n-parity.test.ts` 自动覆盖新 key。
+
+## 文档
+
+- `docs/relay-web-module.md`：「阶段六」之后补「回合 trace 折叠」小节（行为、traceKey 策略、error 不折叠）。
+
+## 后续增强（不在本期）
+
+- **stopReason 透传**：`streaming-prompt.ts` 捕获 response `result.stopReason`（acpx-cli 与 acpx-bridge 共用此解析器，一处改两路径；runtime 引擎 `runtime-adapter.ts` 已映射、`executeRuntimeTurn` 丢弃）→ prompt 结果带出 → `turn-finished` 加 `stopReason?` → `relay-protocol` DTO + hub 校验透传 → web。语义：`max_tokens`/`max_turns` 截断不自动折叠，头部加「已截断」徽标。
+- 相邻同类工具聚合 chip（「查阅 · 1 搜索, 1 列表」）。
+- reasoning chip 时长（客户端近似）、工具行 diffstat（+4 −1）。

--- a/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
+++ b/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
@@ -11,11 +11,11 @@ relay-web 现状：`turn-finished` 后 live turn 经 `flushTurn` 定型为历史
 
 目标：**回合结束后默认折叠 trace**，收进一条回合头部；用户可展开。正文（text）与已发出的 peer 消息卡（agent-message）永不折叠。
 
-**触发信号（已用真实流验证）**：ACP 回合边界 = `session/prompt` 的 JSON-RPC response（`{"result":{"stopReason":"end_turn",…}}`，实际值为 snake_case `end_turn`）。xacpx 管线里它的等价物就是 `turn-finished` 控制事件（`src/control/session-turn-runner.ts` 在 `agent.chat()` resolve 后发出，带 `ok/cancelled/errorMessage`）——web 端在该事件定型消息的瞬间折叠，零协议改动。
+**触发信号（已用真实流验证）**：ACP 回合边界 = `session/prompt` 的 JSON-RPC response（`{"result":{"stopReason":"end_turn",…}}`，实际值为 snake_case `end_turn`）。xacpx 管线里它的等价物就是 `turn-finished` 控制事件（`src/control/session-turn-runner.ts` 在 `agent.chat()` resolve 后发出，带 `ok/cancelled/errorMessage`）——web 端在该事件定型消息的瞬间折叠（无需新增事件种类；为闭环持久化和收敛键稳定性，我们在既有 DTO 上增补了 `structured.turnStatus` 与 `turn-started.startedAt` 字段）。
 
 ## 非目标
 
-- **不改协议**：relay-protocol / relay hub / connector 零改动。`stopReason` 端到端透传（区分 `max_tokens` 截断不折叠等）是后续增强，链路见文末。
+- 不引入新的控制事件类别。`stopReason` 端到端透传（区分 `max_tokens` 截断不折叠等）是后续增强，链路见文末。
 - 不改 live（streaming）行渲染：进行中回合照旧内联展开 + HUD 计时（zcode 进行中也是展开的）。
 - legacy 历史行（无 `parts`，走 `ToolCallPanel` + `ReasoningPanel` fallback）不涉及：两组件本来就默认折叠。
 - 不做相邻 read/search 工具聚合（「查阅 · 1 搜索, 1 列表」，P2）。
@@ -27,7 +27,7 @@ relay-web 现状：`turn-finished` 后 live turn 经 `flushTurn` 定型为历史
 - **折叠是纯视图状态，放演示层（TurnParts），不动 store/wire 数据**。`structured.parts` 是不可变传输数据，hub 历史收敛（`keepRicherStructured`）会整行替换消息对象，任何写进 store 的折叠状态都会被冲掉或引出同步负担。
 - **头部固定在回合顶部**（zcode 一致），不是第一个 trace 项的位置——回合常以正文开头，按 trace 位置插头部会把头部夹在两段正文中间。
 - **error 行永不折叠**：红色失败 ring 与错误卡片必须显眼；cancelled 行折叠（与 done 一致，内容一键可展开）。
-- **手动展开状态放模块级 reactive `Set`，key = `traceKey`**，不用组件局部 ref：`turn-finished` 后 hub 历史收敛替换消息行，组件会被重建，局部状态必丢。`traceKey` **一律优先 `«instance»:«session»:t:«startedAt»`**——`startedAt` 为 connector 戳，乐观 flush 行与持久行同值、且被 hub 持久化（`started_at` 列，compact 亦保留），收敛前后 key 不变，手动展开必然存活；无 `startedAt` 的 legacy 行退回 `…:id:«n»`（只出现在已持久行，不存在中途切换）。无任何身份的行回退组件局部状态（不记忆）。
+- **手动展开状态放模块级 reactive `Set`，key = `traceKey`**，不用组件局部 ref：`turn-finished` 后 hub 历史收敛替换消息行，组件会被重建，局部状态必丢。`traceKey` **一律优先 `«instance»:«session»:t:«startedAt»`**——hub 在 `turn-started` 广播中携带自身的 `startedAt`，乐观 flush 行与持久行同值、且被 hub 持久化（`started_at` 列，compact 亦保留），收敛前后 key 不变，手动展开必然存活；无 `startedAt` 的 legacy 行退回 `…:id:«n»`（只出现在已持久行，不存在中途切换）。无任何身份的行回退组件局部状态（不记忆）。
 - **纯 v-show/v-if 切换，无过渡动画**：省掉 `prefers-reduced-motion` 分支；行高变化由既有的 `content-visibility` 虚拟化和 tail-follow watcher 自然消化。
 
 ## 组件设计
@@ -109,8 +109,7 @@ compact history 以 `{ ...structured }` spread 透传未知 key，`turnStatus` �
 
 ### 数据流不变
 
-`turn-finished` → `flushTurn` 定型（行带 `startedAt`/`createdAt`/`structured.parts`）→ `streaming` prop 消失 → 折叠即时生效；随后 hub 历史收敛整行替换——`traceKey` 以 `startedAt` 为主键、收敛前后不变，手动展开跨收敛存活（有回归测试：乐观行点开 → setProps 持久行（同 `startedAt`、新 `id`）→ 仍展开）。
-
+`turn-finished` → `flushTurn` 定型（行带 `startedAt`/`createdAt`/`structured.parts`）→ `streaming` prop 消失 → 折叠即时生效；随后 hub 历史收敛整行替换——hub 广播的 `startedAt` 与持久行同值，`traceKey` 收敛前后不变，手动展开跨收敛存活（有回归测试：从 real `turn-started` 事件开始、或乐观行点开 → setProps 持久行（同 `startedAt`、新 `id`）→ 仍展开）。同时 `keepRicherStructured()` 在收到 compact 页面时合并 hub 权威元数据（`turnStatus` / `truncated`），不再整份覆盖，失败终态与展开状态均不丢失。
 ## i18n（`en.ts` + `zh-CN.ts` 镜像，parity 测试强制）
 
 ```ts

--- a/packages/relay-protocol/dist/dtos.d.ts
+++ b/packages/relay-protocol/dist/dtos.d.ts
@@ -231,6 +231,11 @@ export type ControlEventDto = {
     recoveryId?: string;
     /** Hub-stamped last message id at turn-start (0 = empty transcript). Web live slot. */
     slotAfterId?: number;
+    /** Hub-stamped epoch ms for this turn's start — the SAME value the eventual
+     *  persisted row's `startedAt` carries, so web optimistic rows and their
+     *  persisted replacements share one identity (trace-key stability). Optional:
+     *  older hubs omit it and the web falls back to its own clock. */
+    startedAt?: number;
 } | {
     type: "tool-event";
     chatKey: string;

--- a/packages/relay-protocol/dist/index.js
+++ b/packages/relay-protocol/dist/index.js
@@ -470,7 +470,7 @@ function validControlEvent(e) {
     case "scheduled-changed":
       return typeof c.chatKey === "string";
     case "turn-started":
-      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && optStr(c.prompt) && optStr(c.queueItemId) && optStr(c.promptRequestId) && optStr(c.recoveryId) && validScheduledOrigin(c.scheduled) && validPeerTurnOrigin(c.peerOrigin) && optNonNegInt(c.startedAfterSeq) && optNonNegInt(c.slotAfterId);
+      return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && optStr(c.prompt) && optStr(c.queueItemId) && optStr(c.promptRequestId) && optStr(c.recoveryId) && validScheduledOrigin(c.scheduled) && validPeerTurnOrigin(c.peerOrigin) && optNonNegInt(c.startedAfterSeq) && optNonNegInt(c.slotAfterId) && (c.startedAt === undefined || finiteNonNegative(c.startedAt));
     case "turn-thought":
       return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
     case "plan":

--- a/packages/relay-protocol/dist/web-dtos.d.ts
+++ b/packages/relay-protocol/dist/web-dtos.d.ts
@@ -60,6 +60,11 @@ export interface MessageRecordDto {
         truncated?: boolean;
         compact?: boolean;
         agentMessage?: PeerMessageHistoryEntry;
+        /** Terminal status of the assistant turn, stamped by the hub at persist time so
+         *  failure/cancel survive history convergence and page reload (the web-local
+         *  `failed`/`status` flags live only on optimistic rows). Collapsing policies key
+         *  off `error` — a failed turn's trace must stay unmissable. */
+        turnStatus?: "done" | "cancelled" | "error";
     };
     attachments?: AttachmentMetadata[];
 }

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -252,6 +252,11 @@ export type ControlEventDto =
       recoveryId?: string;
       /** Hub-stamped last message id at turn-start (0 = empty transcript). Web live slot. */
       slotAfterId?: number;
+      /** Hub-stamped epoch ms for this turn's start — the SAME value the eventual
+       *  persisted row's `startedAt` carries, so web optimistic rows and their
+       *  persisted replacements share one identity (trace-key stability). Optional:
+       *  older hubs omit it and the web falls back to its own clock. */
+      startedAt?: number;
     }
   | {
       type: "tool-event";

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -77,7 +77,12 @@ export interface MessageRecordDto {
    *  STATE_SYNC_TEXT_CAP — the persisted text is a prefix, not the full reply.
    *  `compact` is set by `GET .../messages?view=compact`: bulky tool details were
    *  omitted (collapsed cards still render); `GET .../messages/:id` returns the full row. */
-  structured?: { toolSteps?: ToolStepDto[]; reasoning?: string; parts?: TurnPartDto[]; scheduled?: ScheduledOriginDto; truncated?: boolean; compact?: boolean; agentMessage?: PeerMessageHistoryEntry };
+  structured?: { toolSteps?: ToolStepDto[]; reasoning?: string; parts?: TurnPartDto[]; scheduled?: ScheduledOriginDto; truncated?: boolean; compact?: boolean; agentMessage?: PeerMessageHistoryEntry;
+    /** Terminal status of the assistant turn, stamped by the hub at persist time so
+     *  failure/cancel survive history convergence and page reload (the web-local
+     *  `failed`/`status` flags live only on optimistic rows). Collapsing policies key
+     *  off `error` — a failed turn's trace must stay unmissable. */
+    turnStatus?: "done" | "cancelled" | "error"; };
   attachments?: AttachmentMetadata[];
 }
 

--- a/packages/relay-protocol/src/web-dtos.ts
+++ b/packages/relay-protocol/src/web-dtos.ts
@@ -501,7 +501,8 @@ export function validControlEvent(e: unknown): boolean {
         && optStr(c.prompt) && optStr(c.queueItemId) && optStr(c.promptRequestId) && optStr(c.recoveryId)
         && validScheduledOrigin(c.scheduled)
         && validPeerTurnOrigin(c.peerOrigin)
-        && optNonNegInt(c.startedAfterSeq) && optNonNegInt(c.slotAfterId);
+        && optNonNegInt(c.startedAfterSeq) && optNonNegInt(c.slotAfterId)
+        && (c.startedAt === undefined || finiteNonNegative(c.startedAt));
     case "turn-thought":
       return typeof c.chatKey === "string" && typeof c.sessionAlias === "string" && typeof c.chunk === "string";
     case "plan":

--- a/packages/relay-web/src/__tests__/chat.test.ts
+++ b/packages/relay-web/src/__tests__/chat.test.ts
@@ -677,7 +677,7 @@ test("loadHistory keeps a locally richer structured payload over a compact page"
       direction: "out",
       text: "done",
       createdAt: "t",
-      structured: { compact: true, parts: [{ type: "text", text: "done" }, { type: "tool", step: { toolCallId: "t1", toolName: "Bash", kind: "execute", status: "success", title: "ls", detail: { type: "command", command: "ls" } } }] },
+      structured: { compact: true, turnStatus: "error" as const, parts: [{ type: "text", text: "done" }, { type: "tool", step: { toolCallId: "t1", toolName: "Bash", kind: "execute", status: "success", title: "ls", detail: { type: "command", command: "ls" } } }] },
     }],
   }), { status: 200 })));
 
@@ -693,9 +693,27 @@ test("loadHistory keeps a locally richer structured payload over a compact page"
     structured: full,
   }];
   await chat.loadHistory();
+  // Convergence must MERGE the hub's authoritative metadata into the locally
+  // richer payload, not replace wholesale: the optimistic row has no turnStatus,
+  // and dropping it would fold a failed turn's trace right after the turn ended.
   const part = chat.messages[0]?.structured?.parts?.find((p) => p.type === "tool");
   expect(chat.messages[0]?.structured?.compact).toBeUndefined();
+  expect(chat.messages[0]?.structured?.turnStatus).toBe("error");
   expect(part?.type === "tool" ? part.step.detail : undefined).toEqual({ type: "command", command: "ls", output: "a.ts" });
+});
+
+test("a hub-stamped turn-started seeds the live turn and survives flush into the optimistic row", () => {
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  const STARTED = 1_757_000_000_000;
+  // Real event chain (not hand-filled rows): hub broadcasts startedAt on
+  // turn-started; the live turn and the flushed optimistic row must carry the
+  // SAME value the persisted row will get — that identity is the trace key.
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend", startedAt: STARTED } } as never);
+  expect(chat.liveTurn?.startedAt).toBe(STARTED);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "hi" } } as never);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true } } as never);
+  expect(chat.messages.at(-1)?.startedAt).toBe(STARTED);
 });
 
 test("select persists the open session so a refresh can restore it", () => {

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -1,4 +1,4 @@
-import { mount } from "@vue/test-utils";
+import { mount, type DOMWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 
@@ -93,8 +93,15 @@ const turnWithSend = (messageId?: string): ChatMessage => msg({
   },
 });
 
+// Finished turns collapse their activity trace behind a summary header (spec
+// 2026-09-07); tests that assert inline trace items expand it first.
+async function expandTrace(wrapper: { find(selector: string): DOMWrapper<Element> }): Promise<void> {
+  const toggle = wrapper.find('[data-test="trace-toggle"]');
+  if (toggle.exists()) await toggle.trigger("click");
+}
+
 describe("MessageList", () => {
-  it("shows agent text immediately while keeping inline tool details collapsed by default", () => {
+  it("shows agent text immediately while keeping inline tool details collapsed by default", async () => {
     const wrapper = mount(MessageList, {
       props: {
         messages: [msg({
@@ -121,8 +128,14 @@ describe("MessageList", () => {
       },
     });
 
+    // Finished turn: the trace folds behind a header, the reply text stays visible.
     expect(wrapper.find('[data-test="msg-content"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="msg-out"]').html()).toContain("<strong>finished</strong>");
+    expect(wrapper.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(wrapper.findComponent(ToolStepCard).exists()).toBe(false);
+
+    // Expanding restores the inline trace with its detail collapsed by default.
+    await expandTrace(wrapper);
     expect(wrapper.findComponent(ToolStepCard).exists()).toBe(true);
     expect(wrapper.find('[data-test="cmd-output"]').exists()).toBe(false);
   });
@@ -498,13 +511,14 @@ describe("MessageList", () => {
     expect(wrapper.find('[data-test="msg-in"]').exists()).toBe(false);
   });
 
-  it("anchors a sent card after its agent_send step and suppresses the standalone row (Gate A)", () => {
+  it("anchors a sent card after its agent_send step and suppresses the standalone row (Gate A)", async () => {
     const wrapper = mount(MessageList, {
       props: { messages: [turnWithSend("m1"), sentCard("m1")], liveTurn: null },
     });
 
     // Exactly one card — the anchored one; the standalone m1 row is suppressed.
     expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
+    await expandTrace(wrapper);
     const anchored = wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]');
     expect(anchored.exists()).toBe(true);
     expect(wrapper.text()).toContain("hello m1");
@@ -543,6 +557,7 @@ describe("MessageList", () => {
       messages: [turnWithSend("m1"), sentCard("m1")],
     });
     expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
+    await expandTrace(wrapper);
     const anchored = wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]');
     expect(anchored.exists()).toBe(true);
     const tool = wrapper.find('[data-test="tool-step-card"]');
@@ -550,7 +565,7 @@ describe("MessageList", () => {
     expect(tool.element.compareDocumentPosition(anchored.element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it("keeps a received card standalone even when a turn step references its message id (Gate B)", () => {
+  it("keeps a received card standalone even when a turn step references its message id (Gate B)", async () => {
     const wrapper = mount(MessageList, {
       props: {
         messages: [
@@ -579,7 +594,8 @@ describe("MessageList", () => {
     expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
     expect(wrapper.find('[data-test="agent-message-card"]').attributes("data-direction")).toBe("received");
     expect(wrapper.find('[data-test="turn-agent-message"]').exists()).toBe(false);
-    // The assistant turn itself renders unchanged.
+    // The assistant turn itself renders unchanged (trace expanded).
+    await expandTrace(wrapper);
     expect(wrapper.find('[data-test="tool-step-card"]').exists()).toBe(true);
   });
 
@@ -748,7 +764,7 @@ it("renders legacy persisted tool steps (no parts) in a collapsed panel", () => 
   expect(wrapper.find('[data-test="tool-row"]').exists()).toBe(false);
 });
 
-it("replays persisted activity after the Markdown block it interrupted", () => {
+it("replays persisted activity after the Markdown block it interrupted", async () => {
   const wrapper = mount(MessageList, {
     props: {
       messages: [msg({
@@ -766,7 +782,7 @@ it("replays persisted activity after the Markdown block it interrupted", () => {
       liveTurn: null,
     },
   });
-
+  await expandTrace(wrapper);
   const output = wrapper.find('[data-test="msg-out"]');
   expect(output.findAll(".stream-md")).toHaveLength(1);
   expect(output.find(".stream-md").html()).toContain("<strong>continuous prose</strong>");
@@ -799,6 +815,7 @@ it("shows a failed tool's error message in red when its card is expanded", async
     },
   });
   expect(wrapper.find('[data-test="tool-step-error"]').exists()).toBe(false);
+  await expandTrace(wrapper);
   await wrapper.find('[data-test="tool-step-header"]').trigger("click");
   const err = wrapper.find('[data-test="tool-step-error"]');
   expect(err.exists()).toBe(true);

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -157,8 +157,9 @@ describe("MessageList convergence", () => {
     expect(w.find('[data-test="trace-toggle"]').attributes("aria-expanded")).toBe("true");
 
     // Convergence replaces the optimistic row with the persisted one (new object
-    // identity → TurnParts rebuilds). startedAt is the stable key (both rows carry
-    // the same connector-stamped value), so the expansion must survive.
+    // identity → TurnParts rebuilds). startedAt is the stable key (hub broadcasts it
+    // on turn-started, so optimistic and persisted rows carry the identical hub timestamp),
+    // and the manual expansion survives.
     await w.setProps({ messages: [{ ...optimistic, id: 7 } as never] });
     expect(w.find('[data-test="trace-toggle"]').attributes("aria-expanded")).toBe("true");
     expect(w.find('[data-test="tool-step-card"]').exists()).toBe(true);

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import type { ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
+import TurnParts from "../components/TurnParts.vue";
+import MessageList from "../components/MessageList.vue";
+import { createPinia, setActivePinia } from "pinia";
+import { i18n } from "../i18n";
+import { expandedTraces } from "../lib/trace-expansion";
+
+const tool = (id: string): ToolStepDto => ({
+  toolCallId: id,
+  toolName: "Read",
+  kind: "read",
+  status: "success",
+  title: `${id}.ts`,
+});
+
+const finishedTurn = (): TurnPartDto[] => [
+  { type: "reasoning", text: "thinking about it" },
+  { type: "tool", step: tool("read-1") },
+  { type: "text", text: "first paragraph\n\n" },
+  { type: "tool", step: tool("read-2") },
+  { type: "reasoning", text: "more thinking" },
+  { type: "text", text: "final answer" },
+];
+
+async function mountWithLocale(locale: "en" | "zh-CN", props: Record<string, unknown>) {
+  i18n.global.locale.value = locale;
+  const w = mount(TurnParts, { props: props as never });
+  return w;
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  expandedTraces.clear();
+  i18n.global.locale.value = "en";
+});
+
+describe("TurnParts trace collapse", () => {
+  it("keeps live/default rendering fully inline with no header", () => {
+    const w = mount(TurnParts, { props: { parts: finishedTurn(), streaming: true } });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(false);
+    expect(w.findAll('[data-test="turn-narrative"]').length).toBe(2);
+    expect(w.findAll(".shimmer-text, [data-test='tool-step-card']").length).toBeGreaterThan(0);
+  });
+
+  it("collapses finished-turn trace behind a summary header, keeping text in order", () => {
+    const w = mount(TurnParts, {
+      props: { parts: finishedTurn(), collapseTrace: true, traceKey: "t:123", traceElapsedMs: 272_000 },
+    });
+    const header = w.find('[data-test="trace-toggle"]');
+    expect(header.exists()).toBe(true);
+    expect(header.attributes("aria-expanded")).toBe("false");
+    expect(header.text()).toContain("Worked 4m 32s");
+    expect(header.text()).toContain("2 tool steps");
+    expect(header.text()).toContain("2 thoughts");
+    // Only the reply survives; every trace card is gone.
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual(["first paragraph", "final answer"]);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
+  });
+
+  it("expands on header click and remembers by traceKey across remounts", async () => {
+    const props = { parts: finishedTurn(), collapseTrace: true, traceKey: "t:123" };
+    const w = await mountWithLocale("en", props);
+    await w.find('[data-test="trace-toggle"]').trigger("click");
+    expect(w.find('[data-test="trace-toggle"]').attributes("aria-expanded")).toBe("true");
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(true);
+
+    // Hub history convergence replaces the row → component rebuilds; the memory is module-level.
+    const w2 = mount(TurnParts, { props: props as never });
+    expect(w2.find('[data-test="trace-toggle"]').attributes("aria-expanded")).toBe("true");
+    expect(w2.find('[data-test="tool-step-card"]').exists()).toBe(true);
+
+    await w2.find('[data-test="trace-toggle"]').trigger("click");
+    expect(w2.find('[data-test="trace-toggle"]').attributes("aria-expanded")).toBe("false");
+  });
+
+  it("does not share expansion state between different traceKeys", () => {
+    const base = { parts: finishedTurn(), collapseTrace: true };
+    expandedTraces.add("t:1");
+    const w = mount(TurnParts, { props: { ...base, traceKey: "t:2" } as never });
+    expect(w.find('[data-test="trace-toggle"]').attributes("aria-expanded")).toBe("false");
+  });
+
+  it("omits the header for a pure-text reply", () => {
+    const w = mount(TurnParts, {
+      props: { parts: [{ type: "text", text: "just an answer" }] as TurnPartDto[], collapseTrace: true, traceKey: "t:9" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(false);
+    expect(w.text()).toContain("just an answer");
+  });
+
+  it("shows counts only when no elapsed time is available", () => {
+    const w = mount(TurnParts, {
+      props: { parts: finishedTurn(), collapseTrace: true, traceKey: "t:5", traceElapsedMs: null },
+    });
+    const header = w.find('[data-test="trace-toggle"]');
+    expect(header.text()).not.toContain("Worked");
+    expect(header.text()).toContain("2 tool steps");
+  });
+
+  it("renders the header in Chinese under the zh-CN locale", async () => {
+    const w = await mountWithLocale("zh-CN", {
+      parts: finishedTurn(),
+      collapseTrace: true,
+      traceKey: "t:7",
+      traceElapsedMs: 65_000,
+    });
+    const header = w.find('[data-test="trace-toggle"]');
+    expect(header.text()).toContain("已工作 1分5秒");
+    expect(header.text()).toContain("2 步工具");
+    expect(header.text()).toContain("2 段思考");
+  });
+
+  it("keeps agent-message cards visible while the trace is collapsed", () => {
+    const parts: TurnPartDto[] = [
+      { type: "tool", step: tool("send-1") },
+      { type: "text", text: "answer" },
+    ];
+    const w = mount(TurnParts, {
+      props: {
+        parts,
+        collapseTrace: true,
+        traceKey: "t:11",
+        sentAgentMessages: new Map([["m1", { messageId: "m1", direction: "sent", peer: { handle: "p" }, content: "hi", createdAt: 1 } as never]]),
+      },
+    });
+    // agent-message items only render when joined via presentation; the unjoined map
+    // here means the send step still renders as a plain tool card in expanded mode —
+    // collapsed mode must at minimum keep the narrative.
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text())).toEqual(["answer"]);
+  });
+});
+
+describe("MessageList collapse policy", () => {
+  const base = { instanceId: "i1", sessionAlias: "s1", direction: "out" as const, text: "reply" };
+
+  it("passes collapse props on done rows and withholds them on failed rows", () => {
+    const mk = (extra: Record<string, unknown>) => ({
+      ...base,
+      createdAt: "2026-09-07T10:00:00.000Z",
+      ...extra,
+    });
+    const parts: TurnPartDto[] = [{ type: "tool", step: tool("read-1") }, { type: "text", text: "done" }];
+    const w = mount(MessageList, {
+      props: {
+        messages: [
+          mk({ id: 7, startedAt: Date.parse("2026-09-07T09:59:30.000Z"), structured: { parts } }),
+          mk({ id: 8, startedAt: Date.parse("2026-09-07T09:59:30.000Z"), structured: { parts }, failed: true }),
+        ],
+        liveTurn: null,
+      },
+    });
+    const headers = w.findAll('[data-test="trace-toggle"]');
+    expect(headers.length).toBe(1);
+    expect(headers[0]!.attributes("aria-expanded")).toBe("false");
+    expect(headers[0]!.text()).toContain("Worked 30s");
+    // The failed row renders its trace inline (error must stay unmissable).
+    expect(w.findAll('[data-test="tool-step-card"]').length).toBe(1);
+  });
+});

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -113,8 +113,11 @@ describe("TurnParts trace collapse", () => {
   });
 
   it("keeps agent-message cards visible while the trace is collapsed", () => {
+    // A REAL anchor: the send step carries agentMessageId and the map holds the sent
+    // entry, so deriveTurnPresentation actually emits an agent-message item — the
+    // card must survive the collapse while its tool step folds away.
     const parts: TurnPartDto[] = [
-      { type: "tool", step: tool("send-1") },
+      { type: "tool", step: { ...tool("send-1"), agentMessageId: "m1" } },
       { type: "text", text: "answer" },
     ];
     const w = mount(TurnParts, {
@@ -122,13 +125,59 @@ describe("TurnParts trace collapse", () => {
         parts,
         collapseTrace: true,
         traceKey: "t:11",
-        sentAgentMessages: new Map([["m1", { messageId: "m1", direction: "sent", peer: { handle: "p" }, content: "hi", createdAt: 1 } as never]]),
+        sentAgentMessages: new Map([["m1", { messageId: "m1", direction: "sent", peer: { handle: "p", displayName: "Peer" }, content: "hi", createdAt: 1 } as never]]),
       },
     });
-    // agent-message items only render when joined via presentation; the unjoined map
-    // here means the send step still renders as a plain tool card in expanded mode —
-    // collapsed mode must at minimum keep the narrative.
+    expect(w.find('[data-test="turn-agent-message"]').exists()).toBe(true);
+    expect(w.find('[data-test="agent-message-card"]').text()).toContain("hi");
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
     expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text())).toEqual(["answer"]);
+  });
+
+  it("renders sub-second elapsed as <1s", () => {
+    const w = mount(TurnParts, {
+      props: { parts: finishedTurn(), collapseTrace: true, traceKey: "t:6", traceElapsedMs: 400 },
+    });
+    expect(w.find('[data-test="trace-label"]').text()).toContain("Worked <1s");
+  });
+});
+
+describe("MessageList convergence", () => {
+  const parts: TurnPartDto[] = [{ type: "tool", step: tool("read-1") }, { type: "text", text: "done" }];
+  const STARTED = 1_757_000_000_000;
+  const optimistic = {
+    instanceId: "i1", sessionAlias: "s1", direction: "out" as const, text: "reply",
+    createdAt: "2026-09-07T10:00:30.000Z", startedAt: STARTED, structured: { parts },
+  };
+
+  it("keeps a manual expansion across hub history convergence (optimistic → persisted row)", async () => {
+    const w = mount(MessageList, { props: { messages: [optimistic as never], liveTurn: null } });
+    expect(w.find('[data-test="trace-toggle"]').attributes("aria-expanded")).toBe("false");
+    await w.find('[data-test="trace-toggle"]').trigger("click");
+    expect(w.find('[data-test="trace-toggle"]').attributes("aria-expanded")).toBe("true");
+
+    // Convergence replaces the optimistic row with the persisted one (new object
+    // identity → TurnParts rebuilds). startedAt is the stable key (both rows carry
+    // the same connector-stamped value), so the expansion must survive.
+    await w.setProps({ messages: [{ ...optimistic, id: 7 } as never] });
+    expect(w.find('[data-test="trace-toggle"]').attributes("aria-expanded")).toBe("true");
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(true);
+  });
+
+  it("never collapses a failed turn after convergence (persisted turnStatus = error, no local failed flag)", () => {
+    const failedRow = { ...optimistic, id: 8, structured: { parts, turnStatus: "error" as const } };
+    const w = mount(MessageList, { props: { messages: [failedRow as never], liveTurn: null } });
+    // The optimistic `failed` flag is gone; only the hub-stamped terminal status
+    // says this turn failed — its trace must stay inline.
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(false);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(true);
+  });
+
+  it("collapses a converged done row (persisted turnStatus = done)", () => {
+    const doneRow = { ...optimistic, id: 9, structured: { parts, turnStatus: "done" as const } };
+    const w = mount(MessageList, { props: { messages: [doneRow as never], liveTurn: null } });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
   });
 });
 

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -29,6 +29,25 @@ function schedOf(m: ChatMessage): ScheduledOriginDto | undefined {
   return m.scheduled ?? m.structured?.scheduled;
 }
 
+// Finished-turn trace collapse (spec 2026-09-07): assistant rows fold their activity
+// parts behind a summary header. Policy here, presentation in TurnParts. Failed rows
+// never collapse (the error ring/banner must stay unmissable); live rows don't pass
+// the props at all. Duration is display-only: createdAt (browser/hub clock) minus
+// startedAt (connector clock) — cross-machine skew clamps to "counts only".
+function hasTraceParts(m: ChatMessage): boolean {
+  // Wire parts are text | reasoning | tool — agent-message/subagent lanes are
+  // presentation-derived, so everything non-text here is collapsible trace.
+  return m.structured?.parts?.some((p) => p.type !== "text") ?? false;
+}
+function traceKeyOf(m: ChatMessage): string | undefined {
+  return m.id !== undefined ? `id:${m.id}` : m.startedAt !== undefined ? `t:${m.startedAt}` : undefined;
+}
+function traceElapsedOf(m: ChatMessage): number | null {
+  if (m.startedAt === undefined) return null;
+  const ms = Date.parse(m.createdAt) - m.startedAt;
+  return Number.isFinite(ms) && ms > 0 ? ms : null;
+}
+
 // Presentation-only join (v0.3 spec §8): a SENT peer-message card anchors right after
 // the agent_send tool step whose structured receipt carries its messageId. The map
 // indexes the transcript's sent card rows; assistant rows and the live turn contribute
@@ -549,8 +568,8 @@ watch(
               <!-- Structured transcript: activity cards stay grouped above one continuous
                    Markdown narrative. Tool cards own their collapsed state. -->
               <div data-test="msg-content" class="space-y-2.5">
-                <TurnParts v-if="m.structured?.parts?.length" :parts="m.structured.parts" :ensure-full="ensureFullOf(m)" :sent-agent-messages="sentAgentMessageById" />
-                <!-- Legacy rows persisted before `parts`: aggregated fallback. -->
+                <TurnParts v-if="m.structured?.parts?.length" :parts="m.structured.parts" :ensure-full="ensureFullOf(m)" :sent-agent-messages="sentAgentMessageById"
+                           :collapse-trace="!m.failed && hasTraceParts(m)" :trace-key="traceKeyOf(m)" :trace-elapsed-ms="traceElapsedOf(m)" />
                 <template v-else>
                   <ToolCallPanel v-if="m.structured?.toolSteps?.length" :steps="m.structured.toolSteps" :ensure-full="ensureFullOf(m)" />
                   <ReasoningPanel v-if="m.structured?.reasoning?.trim()" :reasoning="m.structured.reasoning" :default-open="false" />

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -39,8 +39,24 @@ function hasTraceParts(m: ChatMessage): boolean {
   // presentation-derived, so everything non-text here is collapsible trace.
   return m.structured?.parts?.some((p) => p.type !== "text") ?? false;
 }
+// Failure must be judged on the PERSISTED terminal status, not the web-local flag:
+// `failed` lives only on optimistic flush rows and vanishes when hub history
+// convergence replaces the row, which would fold a failed turn's trace right after
+// the user watched it finish. The hub stamps `structured.turnStatus` at persist
+// time (live flush, no-buffer fallback, and offline recovery alike).
+function isFailedTurn(m: ChatMessage): boolean {
+  return m.failed === true || m.structured?.turnStatus === "error";
+}
+// `startedAt` is the STABLE key: the hub persists it (survives convergence and
+// compact history) and the optimistic flush row carries the same connector-stamped
+// value, so the optimistic → persisted transition keeps one key and a manual
+// expand survives convergence. `id` exists only on persisted rows — legacy-row
+// fallback only, it can never be switched to mid-flight. Namespaced by
+// instance+session: connector epochs are unique within a session, not globally.
 function traceKeyOf(m: ChatMessage): string | undefined {
-  return m.id !== undefined ? `id:${m.id}` : m.startedAt !== undefined ? `t:${m.startedAt}` : undefined;
+  if (m.startedAt !== undefined) return `${m.instanceId}:${m.sessionAlias}:t:${m.startedAt}`;
+  if (m.id !== undefined) return `${m.instanceId}:${m.sessionAlias}:id:${m.id}`;
+  return undefined;
 }
 function traceElapsedOf(m: ChatMessage): number | null {
   if (m.startedAt === undefined) return null;
@@ -569,7 +585,7 @@ watch(
                    Markdown narrative. Tool cards own their collapsed state. -->
               <div data-test="msg-content" class="space-y-2.5">
                 <TurnParts v-if="m.structured?.parts?.length" :parts="m.structured.parts" :ensure-full="ensureFullOf(m)" :sent-agent-messages="sentAgentMessageById"
-                           :collapse-trace="!m.failed && hasTraceParts(m)" :trace-key="traceKeyOf(m)" :trace-elapsed-ms="traceElapsedOf(m)" />
+                           :collapse-trace="!isFailedTurn(m) && hasTraceParts(m)" :trace-key="traceKeyOf(m)" :trace-elapsed-ms="traceElapsedOf(m)" />
                 <template v-else>
                   <ToolCallPanel v-if="m.structured?.toolSteps?.length" :steps="m.structured.toolSteps" :ensure-full="ensureFullOf(m)" />
                   <ReasoningPanel v-if="m.structured?.reasoning?.trim()" :reasoning="m.structured.reasoning" :default-open="false" />

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -22,8 +22,10 @@ const props = defineProps<{
   /** Turn has finished and may collapse its trace — policy (done vs failed) and
    *  trace availability live with the caller (MessageList rows). */
   collapseTrace?: boolean;
-  /** Stable identity for the expand-toggle memory: `id:<n>` on persisted rows,
-   *  `t:<startedAt>` on optimistic flush rows. Absent = toggle not remembered. */
+  /** Stable identity for the expand-toggle memory — `«instance»:«session»:t:«startedAt»`
+   *  built by MessageList (hub-stamped startedAt is identical on optimistic and
+   *  persisted rows, so the key survives hub history convergence); legacy rows fall
+   *  back to `…:id:«n»`. Absent = toggle not remembered. */
   traceKey?: string;
   /** Display-only turn duration (finished rows). Absent/non-positive → counts only. */
   traceElapsedMs?: number | null;

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
   traceElapsedMs?: number | null;
 }>();
 
-const { locale } = useI18n();
+const { t, locale } = useI18n();
 
 const presentation = computed(() =>
   deriveTurnPresentation(
@@ -64,7 +64,8 @@ const toolCount = computed(() =>
 const thoughtCount = computed(() => presentation.value.filter((item) => item.type === "reasoning").length);
 
 function formatElapsed(ms: number): string {
-  const total = Math.max(1, Math.round(ms / 1000));
+  if (ms < 1000) return locale.value.startsWith("zh") ? "<1秒" : "<1s";
+  const total = Math.round(ms / 1000);
   const m = Math.floor(total / 60);
   const s = total % 60;
   return locale.value.startsWith("zh") ? (m > 0 ? `${m}分${s}秒` : `${s}秒`) : m > 0 ? `${m}m ${s}s` : `${s}s`;
@@ -72,6 +73,15 @@ function formatElapsed(ms: number): string {
 const elapsedText = computed(() => {
   const ms = props.traceElapsedMs;
   return typeof ms === "number" && Number.isFinite(ms) && ms > 0 ? formatElapsed(ms) : "";
+});
+// One " · "-separated label (zcode-style) so segments never wrap apart; vue-i18n
+// plural picks "1 tool step" vs "2 tool steps".
+const headerLabel = computed(() => {
+  const parts: string[] = [];
+  if (elapsedText.value) parts.push(`${t("turnTrace.worked")} ${elapsedText.value}`);
+  if (toolCount.value > 0) parts.push(t("turnTrace.tools", toolCount.value));
+  if (thoughtCount.value > 0) parts.push(t("turnTrace.thoughts", thoughtCount.value));
+  return parts.join(" · ");
 });
 
 function toggleTrace(): void {
@@ -94,9 +104,7 @@ function toggleTrace(): void {
             :data-trace-key="traceKey ?? ''" @click="toggleTrace">
       <ChevronDown v-if="expanded" :size="12" class="shrink-0" />
       <ChevronRight v-else :size="12" class="shrink-0" />
-      <span v-if="elapsedText">{{ $t("turnTrace.worked") }} {{ elapsedText }}</span>
-      <span v-if="toolCount > 0" data-test="trace-tools">{{ $t("turnTrace.tools", { n: toolCount }) }}</span>
-      <span v-if="thoughtCount > 0" data-test="trace-thoughts">{{ $t("turnTrace.thoughts", { n: thoughtCount }) }}</span>
+      <span data-test="trace-label">{{ headerLabel }}</span>
     </button>
     <template v-for="item in visibleItems" :key="item.key">
       <StreamMarkdown v-if="item.type === 'text'" data-test="turn-narrative"

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { ChevronDown, ChevronRight } from "lucide-vue-next";
 import type { PeerMessageHistoryEntry, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
 import StreamMarkdown from "./StreamMarkdown.vue";
 import ReasoningPanel from "./ReasoningPanel.vue";
@@ -7,6 +9,7 @@ import ToolStepCard from "./ToolStepCard.vue";
 import SubagentStepCard from "./SubagentStepCard.vue";
 import AgentMessageCard from "./AgentMessageCard.vue";
 import { deriveTurnPresentation } from "../lib/turn-presentation";
+import { expandedTraces } from "../lib/trace-expansion";
 
 // Wire parts preserve arrival order, but transport events are not necessarily safe
 // Markdown boundaries. The presentation module anchors activity after the top-level
@@ -16,18 +19,86 @@ const props = defineProps<{
   streaming?: boolean;
   ensureFull?: () => Promise<void>;
   sentAgentMessages?: Map<string, PeerMessageHistoryEntry>;
+  /** Turn has finished and may collapse its trace — policy (done vs failed) and
+   *  trace availability live with the caller (MessageList rows). */
+  collapseTrace?: boolean;
+  /** Stable identity for the expand-toggle memory: `id:<n>` on persisted rows,
+   *  `t:<startedAt>` on optimistic flush rows. Absent = toggle not remembered. */
+  traceKey?: string;
+  /** Display-only turn duration (finished rows). Absent/non-positive → counts only. */
+  traceElapsedMs?: number | null;
 }>();
+
+const { locale } = useI18n();
+
 const presentation = computed(() =>
   deriveTurnPresentation(
     props.parts,
     props.sentAgentMessages ? { sentAgentMessageById: props.sentAgentMessages } : undefined,
   ),
 );
+
+// Trace = activity cards that fold away on turn end; text and agent-message cards
+// are the reply itself and never collapse.
+const hasTrace = computed(() =>
+  presentation.value.some((item) => item.type !== "text" && item.type !== "agent-message"),
+);
+const collapsible = computed(() => props.collapseTrace === true && hasTrace.value);
+// Keyed rows remember toggles in the module set (survives hub history convergence,
+// which replaces the message row and rebuilds this component); anonymous rows fall
+// back to component-local state — lost on rebuild, but they have no stable identity.
+const localExpanded = ref(false);
+const expanded = computed(() => {
+  if (!collapsible.value) return false;
+  return props.traceKey ? expandedTraces.has(props.traceKey) : localExpanded.value;
+});
+// When collapsed, only reply-shaped items render; the header summarizes the hidden rest.
+const visibleItems = computed(() =>
+  expanded.value || !collapsible.value
+    ? presentation.value
+    : presentation.value.filter((item) => item.type === "text" || item.type === "agent-message"),
+);
+const toolCount = computed(() =>
+  presentation.value.filter((item) => item.type === "tool" || item.type === "subagent").length,
+);
+const thoughtCount = computed(() => presentation.value.filter((item) => item.type === "reasoning").length);
+
+function formatElapsed(ms: number): string {
+  const total = Math.max(1, Math.round(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return locale.value.startsWith("zh") ? (m > 0 ? `${m}分${s}秒` : `${s}秒`) : m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+const elapsedText = computed(() => {
+  const ms = props.traceElapsedMs;
+  return typeof ms === "number" && Number.isFinite(ms) && ms > 0 ? formatElapsed(ms) : "";
+});
+
+function toggleTrace(): void {
+  if (props.traceKey) {
+    if (expandedTraces.has(props.traceKey)) expandedTraces.delete(props.traceKey);
+    else expandedTraces.add(props.traceKey);
+  } else {
+    localExpanded.value = !localExpanded.value;
+  }
+}
 </script>
 
 <template>
   <div class="space-y-2.5">
-    <template v-for="item in presentation" :key="item.key">
+    <!-- Collapsed-trace header (finished turns): one muted row summarizing the hidden
+         activity; expanding re-renders the trace items inline below it. -->
+    <button v-if="collapsible" type="button" data-test="trace-toggle"
+            class="flex w-full flex-wrap items-center gap-x-1.5 gap-y-0.5 py-0.5 text-left text-[11.5px] text-fg-muted transition-colors hover:text-fg"
+            :aria-expanded="expanded" :aria-label="$t('turnTrace.toggleTrace')"
+            :data-trace-key="traceKey ?? ''" @click="toggleTrace">
+      <ChevronDown v-if="expanded" :size="12" class="shrink-0" />
+      <ChevronRight v-else :size="12" class="shrink-0" />
+      <span v-if="elapsedText">{{ $t("turnTrace.worked") }} {{ elapsedText }}</span>
+      <span v-if="toolCount > 0" data-test="trace-tools">{{ $t("turnTrace.tools", { n: toolCount }) }}</span>
+      <span v-if="thoughtCount > 0" data-test="trace-thoughts">{{ $t("turnTrace.thoughts", { n: thoughtCount }) }}</span>
+    </button>
+    <template v-for="item in visibleItems" :key="item.key">
       <StreamMarkdown v-if="item.type === 'text'" data-test="turn-narrative"
                       :text="item.text" :streaming="streaming === true && item.isLatest"
                       class="text-[14px] leading-relaxed text-fg"

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -494,8 +494,8 @@ export default {
   },
   turnTrace: {
     worked: "Worked",
-    tools: "{n} tool steps",
-    thoughts: "{n} thoughts",
+    tools: "{count} tool step | {count} tool steps",
+    thoughts: "{count} thought | {count} thoughts",
     toggleTrace: "Toggle intermediate steps",
   },
   taskPanel: {

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -492,6 +492,12 @@ export default {
     reasoning: "Reasoning",
     reasoningStreaming: "Reasoning…",
   },
+  turnTrace: {
+    worked: "Worked",
+    tools: "{n} tool steps",
+    thoughts: "{n} thoughts",
+    toggleTrace: "Toggle intermediate steps",
+  },
   taskPanel: {
     noSession: "No session selected.",
   },

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -489,6 +489,12 @@ export default {
     reasoning: "推理",
     reasoningStreaming: "推理中…",
   },
+  turnTrace: {
+    worked: "已工作",
+    tools: "{n} 步工具",
+    thoughts: "{n} 段思考",
+    toggleTrace: "展开/收起中间过程",
+  },
   taskPanel: {
     noSession: "未选择会话。",
   },

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -491,8 +491,8 @@ export default {
   },
   turnTrace: {
     worked: "已工作",
-    tools: "{n} 步工具",
-    thoughts: "{n} 段思考",
+    tools: "{count} 步工具",
+    thoughts: "{count} 段思考",
     toggleTrace: "展开/收起中间过程",
   },
   taskPanel: {

--- a/packages/relay-web/src/lib/trace-expansion.ts
+++ b/packages/relay-web/src/lib/trace-expansion.ts
@@ -1,0 +1,10 @@
+import { reactive } from "vue";
+
+/** Finished turns collapse their activity trace (reasoning / tool / subagent cards)
+ *  into one header row; the user's expand toggles are remembered here, keyed by
+ *  traceKey (`id:<n>` on persisted rows, `t:<startedAt>` on optimistic flush rows —
+ *  both stable across hub history convergence, which REPLACES the message row and
+ *  rebuilds the TurnParts component; component-local state would silently reset).
+ *  Reactive so TurnParts computeds re-evaluate on toggle. Intentionally unbounded
+ *  and session-scoped: entries are tiny strings and the set dies with the page. */
+export const expandedTraces = reactive(new Set<string>());

--- a/packages/relay-web/src/stores/chat.ts
+++ b/packages/relay-web/src/stores/chat.ts
@@ -107,8 +107,26 @@ function isFullStructured(structured: MessageRecordDto["structured"] | undefined
   return structured !== undefined && structured.compact !== true;
 }
 
+/** The hub stamps authoritative metadata at persist time (turnStatus, truncated) —
+ *  a locally richer payload (live-flushed / previously-hydrated) lacks it. Keep the
+ *  full transcript payload from the local row but let the incoming compact row's
+ *  authoritative fields survive the merge; `compact` itself is dropped because the
+ *  result is a full payload. */
+function mergeCompactMetadata(
+  incoming: MessageRecordDto["structured"],
+  richer: MessageRecordDto["structured"],
+): MessageRecordDto["structured"] {
+  if (!incoming || !richer) return richer ?? incoming;
+  const merged = { ...incoming, ...richer };
+  delete merged.compact;
+  return merged;
+}
+
 /** Prefer already-hydrated / live-flushed structured over a compact list row so
- *  turn-finished convergence and a cache seed with full details don't regress. */
+ *  turn-finished convergence and a cache seed with full details don't regress.
+ *  The merge keeps hub-authoritative metadata (turnStatus/truncated) that the
+ *  local payload cannot have — replacing wholesale used to drop a failed turn's
+ *  terminal status at the exact moment of convergence. */
 function keepRicherStructured(incoming: MessageRecordDto[], previous: ChatMessage[]): MessageRecordDto[] {
   if (previous.length === 0) return incoming;
   const byId = new Map<number, ChatMessage>();
@@ -124,9 +142,9 @@ function keepRicherStructured(incoming: MessageRecordDto[], previous: ChatMessag
     const prev = typeof row.id === "number" ? byId.get(row.id) : undefined;
     let next: MessageRecordDto = row;
     if (row.structured?.compact === true && isFullStructured(prev?.structured)) {
-      next = { ...row, structured: prev!.structured };
+      next = { ...row, structured: mergeCompactMetadata(row.structured, prev!.structured) };
     } else if (i === lastOutIndex && flushed?.structured && row.structured?.compact === true && flushed.text === row.text) {
-      next = { ...row, structured: flushed.structured };
+      next = { ...row, structured: mergeCompactMetadata(row.structured, flushed.structured) };
     }
     const startedAt = next.startedAt ?? prev?.startedAt ?? (i === lastOutIndex ? flushed?.startedAt : undefined);
     if (startedAt !== undefined && next.startedAt === undefined) next = { ...next, startedAt };
@@ -243,14 +261,17 @@ export const useChatStore = defineStore("chat", () => {
   let transcriptRevision = 0;
   const touchTranscript = (): void => { transcriptRevision += 1; };
 
-  function ensureTurn(k: string): LiveTurn {
+  function ensureTurn(k: string, startedAt?: number): LiveTurn {
     let t = liveTurns.value[k];
     if (!t) {
       const selected = selectedKey.value === k;
       t = {
         parts: [],
         status: "working",
-        startedAt: Date.now(),
+        // Hub-stamped turn start (newer hubs broadcast it on turn-started): the SAME
+        // value the persisted row will carry, so the optimistic → persisted transition
+        // keeps one identity. Browser clock is the fallback for older hubs.
+        startedAt: startedAt ?? Date.now(),
         slotAfterIndex: selected ? messages.value.length - 1 : -1,
       };
       liveTurns.value[k] = t;
@@ -679,7 +700,7 @@ export const useChatStore = defineStore("chat", () => {
     if (e.type === "turn-started") {
       const k = bufKey(event.instanceId, e.sessionAlias);
       finishedTurns.delete(k); // a fresh turn supersedes any prior finish on this key
-      ensureTurn(k);
+      ensureTurn(k, e.startedAt);
       // Scheduled turns have no optimistic bubble; drained queue turns use queueItemId
       // to move their existing bubble. Other clients can add the carried prompt here.
       const selected = event.instanceId === instanceId.value && e.sessionAlias === sessionAlias.value;

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -580,7 +580,12 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 ...(slot!.startedAfterSeq !== undefined ? { startedAfterSeq: slot!.startedAfterSeq } : {}),
                 ...(notification ? { notification } : {}),
               });
-              outbound = { ...event, slotAfterId: slot!.slotAfterId };
+              // Broadcast the buffer's startedAt so the web's optimistic row and the
+              // eventual persisted row (flushed from THIS buffer) carry the SAME value —
+              // the web's trace-key identity survives history convergence. Whatever
+              // clock stamped slot.startedAt (hub now, or a restored connector anchor),
+              // flush and broadcast always agree because both read it back from here.
+              outbound = { ...event, slotAfterId: slot!.slotAfterId, startedAt };
             } catch (err) {
               turnBuffers.delete(k);
               gateway.disconnect(instanceId);

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -97,6 +97,14 @@ function capSyncedParts(parts: TurnPartDto[]): TurnPartDto[] {
   return out;
 }
 
+/** Terminal status stamped into a persisted `out` row's `structured` so failure and
+ *  cancellation survive history convergence and page reload (the web's `failed`/
+ *  `status` flags live only on optimistic rows). The turn-trace collapse policy keys
+ *  off `error` — a failed turn's trace must stay visible. */
+function turnStatusOf(ok: boolean, cancelled?: boolean): "done" | "cancelled" | "error" {
+  return cancelled ? "cancelled" : ok ? "done" : "error";
+}
+
 export interface RelayRuntime {
   db: SqlDriver;
   accounts: AccountStore;
@@ -622,9 +630,9 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                   startedAt: event.startedAt,
                 });
                 if (event.text !== undefined) {
-                  appendAssistantOut(event.sessionAlias, event.text, undefined, slot);
+                  appendAssistantOut(event.sessionAlias, event.text, { turnStatus: turnStatusOf(event.ok, event.cancelled) }, slot);
                 } else if (!event.ok && event.errorMessage !== undefined) {
-                  appendAssistantOut(event.sessionAlias, event.errorMessage, undefined, slot);
+                  appendAssistantOut(event.sessionAlias, event.errorMessage, { turnStatus: turnStatusOf(event.ok, event.cancelled) }, slot);
                 } else {
                   logger.warn("relay.event.turn_finished_without_content", "turn finished with no buffered content", {
                     instanceId, sessionAlias: event.sessionAlias,
@@ -655,9 +663,10 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                 return;
               }
               if (hasStructured || text !== "" || event.ok) {
+                const turnStatus = turnStatusOf(event.ok, event.cancelled);
                 const structured = hasStructured
-                  ? { toolSteps: steps, ...(hasReasoning ? { reasoning: a.reasoning } : {}), ...(a.parts.length ? { parts: a.parts } : {}), ...(a.truncated ? { truncated: true } : {}) }
-                  : (a.truncated ? { truncated: true } : undefined);
+                  ? { toolSteps: steps, ...(hasReasoning ? { reasoning: a.reasoning } : {}), ...(a.parts.length ? { parts: a.parts } : {}), ...(a.truncated ? { truncated: true } : {}), turnStatus }
+                  : { ...(a.truncated ? { truncated: true } : {}), turnStatus };
                 slotAnchors.take(instanceId, event.sessionAlias, event.recoveryId);
                 appendAssistantOut(event.sessionAlias, text, structured, {
                   slotAfterId: a.slotAfterId,
@@ -881,7 +890,7 @@ export async function createRelayRuntime(dbPath: string, options: CreateRuntimeO
                   appendAssistantOut(
                     finished.sessionAlias,
                     text,
-                    finished.truncated ? { truncated: true } : undefined,
+                    { ...(finished.truncated ? { truncated: true } : {}), turnStatus: turnStatusOf(finished.ok, finished.cancelled) },
                     slot,
                   );
                 } else {

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -230,7 +230,7 @@ test("a finish with no buffer but text persists the reply (hub restarted mid-tur
   fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true, text: "late answer" });
   const cached = runtime.messages.listBySession("a1", "i1", "backend").messages;
   expect(cached.map((m) => [m.direction, m.text])).toEqual([["out", "late answer"]]);
-  expect(cached[0].structured).toBeUndefined(); // no chunks/steps buffered — nothing structured
+  expect(cached[0].structured).toEqual({ turnStatus: "done" }); // no chunks/steps buffered — status only
   runtime.close();
 });
 
@@ -1354,4 +1354,35 @@ test("active grant is NOT pruned by 24h pending TTL while pending grants expire"
     sessionAlias: "backend",
     url: "/",
   });
+});
+
+test("persisted out rows carry the terminal turnStatus so failed traces survive convergence", async () => {
+  const runtime = await seeded();
+  const fire = (event: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceEvent, payload: { event },
+  });
+
+  // Failed turn with buffered trace: the web folds finished traces behind a header
+  // and keys "never collapse failed rows" off THIS persisted field — the optimistic
+  // `failed` flag dies at history convergence.
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend" });
+  fire({ type: "tool-event", chatKey: "relay:a1", sessionAlias: "backend", step: { toolCallId: "t1", toolName: "Bash", kind: "execute", status: "error", title: "npm test" } });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "partial" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: false, errorMessage: "boom" });
+  const failed = runtime.messages.listBySession("a1", "i1", "backend").messages;
+  expect(failed.map((m) => [m.direction, m.text])).toEqual([["out", "partial"]]);
+  expect(failed[0]!.structured?.turnStatus).toBe("error");
+  expect(failed[0]!.structured?.toolSteps).toHaveLength(1);
+
+  // Cancelled and done turns get their own terminal status.
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "cancelled-s" });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "cancelled-s", chunk: "half" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "cancelled-s", ok: false, cancelled: true });
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "done-s" });
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "done-s", chunk: "full" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "done-s", ok: true });
+  expect(runtime.messages.listBySession("a1", "i1", "cancelled-s").messages[0]!.structured?.turnStatus).toBe("cancelled");
+  expect(runtime.messages.listBySession("a1", "i1", "done-s").messages[0]!.structured?.turnStatus).toBe("done");
+
+  runtime.close();
 });

--- a/tests/unit/packages/relay/runtime-fanout.test.ts
+++ b/tests/unit/packages/relay/runtime-fanout.test.ts
@@ -1383,6 +1383,31 @@ test("persisted out rows carry the terminal turnStatus so failed traces survive 
   fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "done-s", ok: true });
   expect(runtime.messages.listBySession("a1", "i1", "cancelled-s").messages[0]!.structured?.turnStatus).toBe("cancelled");
   expect(runtime.messages.listBySession("a1", "i1", "done-s").messages[0]!.structured?.turnStatus).toBe("done");
+  runtime.close();
+});
 
+test("turn-started broadcast carries the hub startedAt that the persisted row keeps", async () => {
+  const runtime = await seeded();
+  const web = new FakeSocket();
+  runtime.webGateway.register("a1", web as never);
+  const fire = (event: unknown) => runtime.gateway["deps"].onEvent!("i1", "a1", {
+    protocolVersion: RELAY_PROTOCOL_VERSION, kind: "event", type: MSG.instanceEvent, payload: { event },
+  });
+
+  fire({ type: "turn-started", chatKey: "relay:a1", sessionAlias: "backend" });
+  const startedEnv = decodeEnvelope(web.sent[0]!);
+  const started = startedEnv.ok ? parseWebServerEvent(startedEnv.envelope) : null;
+  if (!started || started.kind !== "control-event" || started.event.type !== "turn-started") {
+    throw new Error("expected a turn-started control-event broadcast");
+  }
+  const hubStartedAt = started.event.startedAt;
+  expect(typeof hubStartedAt).toBe("number");
+
+  fire({ type: "turn-output", chatKey: "relay:a1", sessionAlias: "backend", chunk: "x" });
+  fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
+  // The optimistic row the web builds from the broadcast and the persisted row the
+  // hub flushes from the SAME buffer must share one startedAt (trace-key identity).
+  const row = runtime.messages.listBySession("a1", "i1", "backend").messages[0]!;
+  expect(row.startedAt).toBe(hubStartedAt);
   runtime.close();
 });

--- a/tests/unit/packages/relay/runtime-state-sync.test.ts
+++ b/tests/unit/packages/relay/runtime-state-sync.test.ts
@@ -509,8 +509,8 @@ test("a restored turn keeps absorbing live events and flushes exactly one comple
   expect(cached).toHaveLength(1);
   expect(cached[0].direction).toBe("out");
   expect(cached[0].text).toBe("partial"); // pre-restart mirror text + post-restart chunks
-  // Text-only turns persist without `structured` (same as the live flush path).
-  expect(cached[0].structured).toBeUndefined();
+  // Text-only turns persist with just the terminal status (same as the live path).
+  expect(cached[0].structured).toEqual({ turnStatus: "done" });
   expect(runtime.stateSnapshot("i1").turns).toEqual([]); // buffer flushed
   runtime.close();
 });
@@ -615,7 +615,7 @@ test("a truncated offline reply is persisted with the flag in its structured met
   });
   const rows = runtime.messages.listBySession("a1", "i1", "backend").messages;
   expect(rows.map((m) => [m.direction, m.text])).toEqual([["in", "q"], ["out", "capped"]]);
-  expect(rows[1]!.structured).toEqual({ truncated: true });
+  expect(rows[1]!.structured).toEqual({ truncated: true, turnStatus: "done" });
   runtime.close();
 });
 
@@ -763,7 +763,7 @@ test("a restored turn that was truncated by the connector persists structured.tr
   fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: true });
   const rows = runtime.messages.listBySession("a1", "i1", "backend").messages;
   expect(rows.map((m) => [m.direction, m.text])).toEqual([["out", "capped prefix"]]);
-  expect(rows[0]!.structured).toEqual({ truncated: true });
+  expect(rows[0]!.structured).toEqual({ truncated: true, turnStatus: "done" });
   runtime.close();
 });
 
@@ -802,5 +802,19 @@ test("a live turn-finished with no buffer and an errorMessage persists the error
   fire({ type: "turn-finished", chatKey: "relay:a1", sessionAlias: "backend", ok: false, errorMessage: "boom" });
   expect(runtime.messages.listBySession("a1", "i1", "backend").messages.map((m) => [m.direction, m.text]))
     .toEqual([["out", "boom"]]);
+  runtime.close();
+});
+
+test("recovered offline rows carry turnStatus derived from ok/cancelled", async () => {
+  const { runtime } = await seeded();
+  sync(runtime, {
+    turns: [], usage: [], commands: [],
+    finishedOffline: [
+      { sessionAlias: "done", ok: true, text: "offline reply" },
+      { sessionAlias: "failed", ok: false, errorMessage: "agent exploded" },
+    ],
+  });
+  expect(runtime.messages.listBySession("a1", "i1", "done").messages[0]!.structured?.turnStatus).toBe("done");
+  expect(runtime.messages.listBySession("a1", "i1", "failed").messages[0]!.structured?.turnStatus).toBe("error");
   runtime.close();
 });


### PR DESCRIPTION
## 背景

参照 zcode 的会话气泡：回合进行中，思考/工具等中间过程内联展开；回合结束后整个 trace 折叠进一条回合头部，正文直接呈现。relay-web 此前 `turn-finished` 后所有 parts 原样常驻，长回合把最终回复淹没。

**触发信号（已用真实流验证）**：ACP 回合边界 = `session/prompt` 的 JSON-RPC response（`{"result":{"stopReason":"end_turn",…}}`）。xacpx 管线里它的等价物就是 `turn-finished` 控制事件——web 端在该事件定型消息的瞬间折叠。为闭环终态持久化与收敛键稳定性，协议增补了向后兼容的 `structured.turnStatus` 与 `turn-started.startedAt` 字段。

## 改动

| 文件 | 内容 |
|---|---|
| `TurnParts.vue` | 新增 `collapseTrace / traceKey / traceElapsedMs` props；折叠头 `▸ 已工作 4分32秒 · 6 步工具 · 3 段思考` 置于回合顶部（各段以 `·` 连接，英文支持 vue-i18n 复数，亚秒展示 `<1s`）；折叠时隐藏 `reasoning`/`tool`/`subagent`，`text`/`agent-message` 永不折叠 |
| `lib/trace-expansion.ts` | 模块级 reactive Set：手动展开状态按 traceKey 跨 hub 历史收敛存活；无身份行回退组件局部状态 |
| `MessageList.vue` | policy：`collapseTrace = !isFailedTurn(m) && hasTraceParts(m)`（读持久化 `structured.turnStatus === "error"`，收敛后失败行永不折叠）；traceKey 一律优先 `«instance»:«session»:t:«startedAt»` |
| `stores/chat.ts` | `keepRicherStructured()` 在收到 compact 页面时合并 hub 权威元数据（`turnStatus` / `truncated`），不再整份覆盖丢状态；`ensureTurn()` 优先消费 hub 广播的 `startedAt` |
| `packages/relay/server.ts` | 在 live flush、no-buffer 兜底、offline recovery 全部三个持久化点向 `structured` 注入 `turnStatus`（`"done" | "cancelled" | "error"`）；在 `turn-started` 广播中带出 buffer 的 `startedAt`，使乐观行与持久行同源同值 |
| `packages/relay-protocol` | `MessageRecordDto.structured.turnStatus` 字段；`ControlEventDto` `turn-started` 携带可选 `startedAt` 并增加相应校验 |
| i18n | `turnTrace.*` 4 key，en + zh-CN 镜像（parity 测试覆盖，英文支持复数） |

Live（streaming）行不折叠，仍由 HUD 计时；cancelled 行折叠、error 行不折叠。

## 设计细节

- **终态持久化闭环**：hub 在持久化时盖戳 `turnStatus`，compact projector 借 `{ ...structured }` spread 原样保留，web 端 `keepRicherStructured()` 合并而不是整份覆盖，失败 trace 在收敛与刷新后均保持展开
- **收敛键稳定性**：hub 广播自身 buffer 的 `startedAt`，web live turn 与乐观 flush 行均记录该值，最终 persisted row 也由同一 buffer 持久化同值。因此乐观行与持久行共享唯一的 `t:«startedAt»` 身份，展开状态在收敛前后完全稳定
- 头部固定回合顶部（zcode 一致），不按首个 trace 项位置插入
- agent-message 真实锚定（`agentMessageId` + map），折叠态下 peer message 正常展现，工具卡片收起
- stopReason 端到端透传（`max_tokens` 截断不折叠等语义分级）为后续增强，链路见 spec 文末

## 验证

- web：131 文件 / **1410 测试全绿**；`vue-tsc` 干净
  - `turnparts-collapse.test.ts` 13 测试：live 不折叠、折叠头计数/耗时/文案（zh-CN）、展开记忆跨重挂载、key 隔离、纯文本无头部、真锚定 agent-message、MessageList 收敛（跨行替换保持展开、persisted error 不折叠、persisted done 折叠）
  - `chat.test.ts`：测试 compact convergence 合并 `turnStatus`、测试 real `turn-started` 广播 `startedAt` 注入 live turn 并持久化进 optimistic row
  - `messagelist.test.ts`：更新旧断言适配新契约
- relay hub bun 测试 **107 绿**（含 live 三态持久化、turn-started 广播 startedAt、recovery 派生测试）
- relay-protocol 测试 **95 绿**；relay 包 `tsc` 干净
- 浏览器实测未做：relay hub 未运行且看板需登录态；行为面由组件级 DOM 断言与 store 收敛测试覆盖

## 文档

- spec：`docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md`
- `docs/relay-web-module.md` 新增「回合 trace 折叠」小节并同步更新持久化与收敛机制说明