### PR TITLE
feat(relay-web): turn-HUD 显示俏皮状态语（替代输入框 placeholder）

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -534,10 +534,11 @@ export interface LiveTurn {
 
 **`ChatPane` 状态 HUD**（`packages/relay-web/src/components/ChatPane.vue`）
 
-`chat.busy` 时在输入框上方显示一行 HUD：
-- 脉冲点 `●`（`animate-pulse`）+ `Working… M:SS`（每秒刷新的 elapsed 计时，由 `setInterval(1000)` + `liveTurn.startedAt` 驱动）。
+`chat.busy` 时在输入框上方显示一行 HUD（`data-test="turn-hud"`）：
+- 脉冲点 `●`（`animate-pulse`）+ 俏皮状态行 `data-test="hud-quip"`（`chat.workingQuips` 池随机抽、每 20s 轮换不连重；池为空回退 `chat.mentionActivity.working`）+ `M:SS`（每秒刷新的 elapsed 计时，由 `setInterval(1000)` + `liveTurn.startedAt` 驱动）。
 - 若有 running 状态的步骤：`· 🔧 N`（N 为 running tool 数量）。
 - 右侧 `Cancel` 按钮 → `chat.cancel()`（调 `control.prompt.cancel` RPC）。
+- 输入框 busy 时 placeholder 保持静态 `chat.working`，不再轮换俏皮语。
 
 **`PromptInput` busy-guard**（`packages/relay-web/src/components/PromptInput.vue`）
 

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -74,7 +74,9 @@ it("shows a working HUD while a live turn is active", async () => {
   const w = mount(ChatPane);
   await w.vm.$nextTick();
   expect(w.find('[data-test="turn-hud"]').exists()).toBe(true);
-  expect(w.find('[data-test="turn-hud"]').text()).toContain("Working");
+  // Quips render in the HUD status line, not the composer placeholder.
+  expect(w.find('[data-test="hud-quip"]').exists()).toBe(true);
+  expect(w.find('[data-test="hud-quip"]').text().length).toBeGreaterThan(0);
 });
 
 it("stacks status, plan, and composer as document-flow layers (status → plan → input)", async () => {
@@ -385,22 +387,28 @@ it("surfaces a create failure in the booting view with a dismiss action", async 
   expect(chat.sessionAlias).toBeNull();
 });
 
-it("cycles the working verb every ~10s while the turn runs", async () => {
+it("rotates a HUD quip every 20s while the turn runs, clears the timer when idle", async () => {
   vi.useFakeTimers();
-  vi.setSystemTime(0);
   const chat = useChatStore();
   chat.select("i1", "backend");
   chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
   const w = mount(ChatPane);
   await w.vm.$nextTick();
-  expect(w.find('[data-test="turn-hud"]').text()).toContain("Working"); // bucket 0
-  vi.advanceTimersByTime(5000); // 5s → still bucket 0 on the calm ~10s cadence
+  const first = w.find('[data-test="hud-quip"]').text();
+  expect(first.length).toBeGreaterThan(1); // quip picked, not an empty fallback
+
+  vi.advanceTimersByTime(19000);
   await w.vm.$nextTick();
-  expect(w.find('[data-test="turn-hud"]').text()).toContain("Working");
-  vi.advanceTimersByTime(6000); // 11s total → bucket 1, also drives the 1Hz clock
+  expect(w.find('[data-test="hud-quip"]').text()).toBe(first); // calm cadence: no rotation before 20s
+
+  vi.advanceTimersByTime(1000);
   await w.vm.$nextTick();
-  const t = w.find('[data-test="turn-hud"]').text();
-  expect(t).not.toContain("Working");
-  expect(t).toContain("Thinking");
+  expect(w.find('[data-test="hud-quip"]').text()).not.toBe(first); // pickQuip never repeats immediately
+
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-finished", chatKey: "c", sessionAlias: "backend", ok: true } } as never);
+  await w.vm.$nextTick();
+  expect(w.find('[data-test="turn-hud"]').exists()).toBe(false);
+  w.unmount();
+  expect(vi.getTimerCount()).toBe(0); // quip interval must not survive unmount
   vi.useRealTimers();
 });

--- a/packages/relay-web/src/__tests__/chatpane.test.ts
+++ b/packages/relay-web/src/__tests__/chatpane.test.ts
@@ -74,9 +74,11 @@ it("shows a working HUD while a live turn is active", async () => {
   const w = mount(ChatPane);
   await w.vm.$nextTick();
   expect(w.find('[data-test="turn-hud"]').exists()).toBe(true);
-  // Quips render in the HUD status line, not the composer placeholder.
-  expect(w.find('[data-test="hud-quip"]').exists()).toBe(true);
-  expect(w.find('[data-test="hud-quip"]').text().length).toBeGreaterThan(0);
+  // Quips render verbatim in the HUD status line, not the composer placeholder.
+  const quip = w.find('[data-test="hud-quip"]');
+  expect(quip.exists()).toBe(true);
+  expect(quip.text().length).toBeGreaterThan(0);
+  expect(quip.text()).not.toMatch(/…{2,}|…\s*…$/);
 });
 
 it("stacks status, plan, and composer as document-flow layers (status → plan → input)", async () => {
@@ -410,5 +412,39 @@ it("rotates a HUD quip every 20s while the turn runs, clears the timer when idle
   expect(w.find('[data-test="turn-hud"]').exists()).toBe(false);
   w.unmount();
   expect(vi.getTimerCount()).toBe(0); // quip interval must not survive unmount
+  vi.useRealTimers();
+});
+
+it("re-picks the HUD quip and restarts the 20s cadence on busy→busy session switch", async () => {
+  vi.useFakeTimers();
+  const instances = useInstancesStore();
+  instances.instances.push({
+    id: "i1", name: "prod-box", online: true, lastSeenAt: null,
+    sessions: [
+      { alias: "backend", agent: "codex", workspace: "gaia" },
+      { alias: "frontend", agent: "codex", workspace: "gaia" },
+    ],
+    agents: [], workspaces: [], agentCatalog: [],
+  } as never);
+  const chat = useChatStore();
+  chat.select("i1", "backend");
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "backend" } } as never);
+  chat.applyEvent({ kind: "control-event", instanceId: "i1", event: { type: "turn-started", chatKey: "c", sessionAlias: "frontend" } } as never);
+  const w = mount(ChatPane);
+  await w.vm.$nextTick();
+
+  // A runs 19s, then the user switches to the already-busy B: B must re-pick
+  // and restart its own 20s cadence instead of inheriting A's deadline.
+  vi.advanceTimersByTime(19000);
+  await w.vm.$nextTick();
+  chat.select("i1", "frontend");
+  await w.vm.$nextTick();
+  const onB = w.find('[data-test="hud-quip"]').text();
+  expect(onB.length).toBeGreaterThan(1);
+
+  vi.advanceTimersByTime(1000);
+  await w.vm.$nextTick();
+  expect(w.find('[data-test="hud-quip"]').text()).toBe(onB);
+  w.unmount();
   vi.useRealTimers();
 });

--- a/packages/relay-web/src/__tests__/promptinput.test.ts
+++ b/packages/relay-web/src/__tests__/promptinput.test.ts
@@ -1,5 +1,5 @@
-import { flushPromises, mount } from "@vue/test-utils";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import PromptInput from "../components/PromptInput.vue";
 import { useInstancesStore } from "../stores/instances";
@@ -1537,37 +1537,18 @@ describe("PromptInput composer", () => {
   });
 });
 
-describe("PromptInput busy quip rotation", () => {
-  beforeEach(() => {
-    setActivePinia(createPinia());
-    vi.useFakeTimers();
-  });
-  afterEach(() => vi.useRealTimers());
-
-  it("picks a quip on busy, rotates every 5s, stops on busy=false, clears on unmount", async () => {
+describe("PromptInput busy placeholder", () => {
+  it("keeps the static working placeholder while busy (quips live in the turn HUD)", async () => {
     const w = mount(PromptInput, { props: { busy: false } });
-    const ta = w.find("textarea");
-    const placeholder = () => (ta.element as HTMLTextAreaElement).placeholder;
-    expect(placeholder()).toBe("Message");
+    const ta = () => (w.find("textarea").element as HTMLTextAreaElement).placeholder;
+    expect(ta()).toBe("Message");
 
     await w.setProps({ busy: true });
-    const first = placeholder();
-    expect(first).toMatch(/\(Esc to stop\)$/);
-    expect(first).not.toBe("Agent is working… (Esc to stop)"); // quip picked, not the fallback
-
-    vi.advanceTimersByTime(5000);
-    await flushPromises();
-    const second = placeholder();
-    expect(second).toMatch(/\(Esc to stop\)$/);
-    expect(second).not.toBe(first); // pickQuip never repeats immediately
+    await w.vm.$nextTick();
+    expect(ta()).toBe("Agent is working… (Esc to stop)");
 
     await w.setProps({ busy: false });
-    expect(placeholder()).toBe("Message");
-    expect(vi.getTimerCount()).toBe(0);
-
-    await w.setProps({ busy: true });
-    expect(vi.getTimerCount()).toBe(1);
-    w.unmount();
-    expect(vi.getTimerCount()).toBe(0); // interval must not survive unmount
+    await w.vm.$nextTick();
+    expect(ta()).toBe("Message");
   });
 });

--- a/packages/relay-web/src/__tests__/working-quips.test.ts
+++ b/packages/relay-web/src/__tests__/working-quips.test.ts
@@ -26,12 +26,9 @@ describe("working quips", () => {
     expect(pickQuip([], undefined)).toBe("");
   });
 
-  it("both locales ship a 20-entry unique quip pool plus an Esc suffix (catalog invariant)", () => {
-    const pools = [
-      { workingQuips: en.chat.workingQuips, escToStop: en.chat.escToStop },
-      { workingQuips: zhCN.chat.workingQuips, escToStop: zhCN.chat.escToStop },
-    ];
-    for (const { workingQuips, escToStop } of pools) {
+  it("both locales ship a 20-entry unique turn-HUD quip pool (catalog invariant)", () => {
+    const pools = [en.chat.workingQuips, zhCN.chat.workingQuips];
+    for (const workingQuips of pools) {
       // Inspect raw catalog lines: parseQuips dedupes, so routing the catalog
       // through it would mask accidental duplicate entries.
       const rawQuips = workingQuips
@@ -39,11 +36,12 @@ describe("working quips", () => {
         .map((q) => q.trim())
         .filter(Boolean);
       expect(rawQuips).toHaveLength(20);
-      expect(new Set(rawQuips).size).toBe(rawQuips.length);
+      const seen: Record<string, true> = {};
+      for (const q of rawQuips) seen[q] = true;
+      expect(Object.keys(seen)).toHaveLength(rawQuips.length);
       // vue-i18n reserves @ | { } in message syntax — quips must never use them.
       expect(rawQuips.every((q) => !/[@|{}]/.test(q))).toBe(true);
       expect(rawQuips.every((q) => q.length > 0 && q.length <= 40)).toBe(true);
-      expect(escToStop.length).toBeGreaterThan(0);
     }
   });
 });

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed, onUnmounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { useChatStore } from "../stores/chat";
 import { useInstancesStore } from "../stores/instances";
 import { useFilesStore } from "../stores/files";
 import { useComposerStore } from "../stores/composer";
 import { useVirtualKeyboardInset } from "../lib/use-virtual-keyboard";
+import { parseQuips, pickQuip } from "../lib/working-quips";
 import type { PromptAttachmentRef } from "@ganglion/xacpx-relay-protocol";
 import MessageList from "./MessageList.vue";
 import PromptInput from "./PromptInput.vue";
@@ -14,6 +16,7 @@ import { AlertTriangle, Bot, Folder, GitBranch, Loader2, X } from "lucide-vue-ne
 
 const emit = defineEmits<{ (e: "show-files"): void }>();
 
+const { t } = useI18n();
 const chat = useChatStore();
 const instances = useInstancesStore();
 const files = useFilesStore();
@@ -108,7 +111,47 @@ watch(
 // Live elapsed clock for the active turn HUD.
 const nowMs = ref(Date.now());
 const timer = setInterval(() => { nowMs.value = Date.now(); }, 1000);
-onUnmounted(() => clearInterval(timer));
+
+// Playful rotating status line in the turn HUD while a turn runs (à la Claude
+// Code / HAPI's "vibing messages"). Pool is locale-aware (chat.workingQuips);
+// pick randomly per turn, rotate every 20s without immediate repeats, fall back
+// to the short localized "Working" label when the pool is empty. Purely
+// cosmetic; the 1Hz elapsed clock stays on its own always-on interval.
+const hudQuip = ref("");
+let quipTimer: ReturnType<typeof setInterval> | null = null;
+const QUIP_ROTATE_MS = 20000;
+function rotateHudQuip(): void {
+  const quips = parseQuips(t("chat.workingQuips"));
+  if (quips.length > 0) hudQuip.value = pickQuip(quips, hudQuip.value || undefined);
+}
+watch(
+  () => chat.busy,
+  (busy) => {
+    if (quipTimer) {
+      clearInterval(quipTimer);
+      quipTimer = null;
+    }
+    if (busy) {
+      rotateHudQuip();
+      quipTimer = setInterval(rotateHudQuip, QUIP_ROTATE_MS);
+    } else {
+      hudQuip.value = "";
+    }
+  },
+  { immediate: true },
+);
+// Re-pick on locale switch mid-turn so the HUD doesn't stick in the old
+// language until the next 20s rotation.
+watch(
+  () => t("chat.workingQuips"),
+  () => {
+    if (chat.busy) rotateHudQuip();
+  },
+);
+onUnmounted(() => {
+  clearInterval(timer);
+  if (quipTimer) clearInterval(quipTimer);
+});
 
 const elapsed = computed(() => {
   if (!chat.liveTurn) return "";
@@ -116,20 +159,7 @@ const elapsed = computed(() => {
   return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
 });
 const runningTools = computed(() => chat.liveToolSteps.filter((t) => t.status === "running").length);
-
-// Whimsical near-synonyms cycled through while a turn runs (à la Claude Code / HAPI's
-// "vibing messages"). Purely cosmetic; reuses the 1Hz clock, rotating every ~10s on a
-// calm interval rather than re-rolling every frame. "Working" stays first for t≈0.
-const VERBS = [
-  "Working", "Thinking", "Pondering", "Cogitating", "Reasoning", "Computing",
-  "Churning", "Crunching", "Percolating", "Noodling", "Mulling", "Brewing",
-  "Processing", "Deliberating", "Ruminating", "Synthesizing", "Wrangling", "Tinkering",
-];
-const verb = computed(() => {
-  if (!chat.liveTurn) return VERBS[0];
-  const s = Math.max(0, Math.floor((nowMs.value - chat.liveTurn.startedAt) / 1000));
-  return VERBS[Math.floor(s / 10) % VERBS.length];
-});
+const hudStatus = computed(() => hudQuip.value || t("chat.mentionActivity.working"));
 </script>
 
 <template>
@@ -230,7 +260,7 @@ const verb = computed(() => {
           <div v-if="chat.busy" key="status-layer" data-test="turn-hud"
                class="stack-layer stack-layer--status relative z-10 mx-4 flex items-center gap-2 rounded-xl border border-run/20 bg-surface/95 px-3 pt-1.5 pb-[calc(0.375rem+var(--stack-overlap))] shadow-e2 backdrop-blur-md sm:mx-6">
             <span class="h-2 w-2 rounded-full bg-run pulse-dot" aria-hidden="true" />
-            <span class="text-[12px] font-semibold text-run">{{ verb }}…</span>
+            <span data-test="hud-quip" class="text-[12px] font-semibold text-run">{{ hudStatus }}…</span>
             <span class="font-mono text-[12px] font-semibold tabular-nums text-run">{{ elapsed }}</span>
             <span v-if="runningTools > 0" class="text-[11.5px] text-fg-muted">· {{ runningTools }} {{ runningTools === 1 ? $t("chat.tool") : $t("chat.tools") }}</span>
             <span class="flex-1" />

--- a/packages/relay-web/src/components/ChatPane.vue
+++ b/packages/relay-web/src/components/ChatPane.vue
@@ -124,14 +124,23 @@ function rotateHudQuip(): void {
   const quips = parseQuips(t("chat.workingQuips"));
   if (quips.length > 0) hudQuip.value = pickQuip(quips, hudQuip.value || undefined);
 }
+// Identity of the turn the HUD is showing. Keying on the boolean `busy` alone
+// misses busy→busy session switches (the new session would inherit the old
+// quip and its remaining rotation deadline), so re-pick and restart the 20s
+// cadence whenever the turn itself changes; clear when no turn is live.
+const turnKey = computed(() =>
+  chat.liveTurn && chat.instanceId && chat.sessionAlias
+    ? `${chat.instanceId}\0${chat.sessionAlias}\0${chat.liveTurn.startedAt}`
+    : null,
+);
 watch(
-  () => chat.busy,
-  (busy) => {
+  turnKey,
+  (key) => {
     if (quipTimer) {
       clearInterval(quipTimer);
       quipTimer = null;
     }
-    if (busy) {
+    if (key) {
       rotateHudQuip();
       quipTimer = setInterval(rotateHudQuip, QUIP_ROTATE_MS);
     } else {
@@ -159,7 +168,9 @@ const elapsed = computed(() => {
   return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
 });
 const runningTools = computed(() => chat.liveToolSteps.filter((t) => t.status === "running").length);
-const hudStatus = computed(() => hudQuip.value || t("chat.mentionActivity.working"));
+// Quips are complete status sentences (some already end in "…" or "."), so
+// render them verbatim; only the short fallback label gets a trailing "…".
+const hudStatus = computed(() => hudQuip.value || `${t("chat.mentionActivity.working")}…`);
 </script>
 
 <template>
@@ -260,7 +271,7 @@ const hudStatus = computed(() => hudQuip.value || t("chat.mentionActivity.workin
           <div v-if="chat.busy" key="status-layer" data-test="turn-hud"
                class="stack-layer stack-layer--status relative z-10 mx-4 flex items-center gap-2 rounded-xl border border-run/20 bg-surface/95 px-3 pt-1.5 pb-[calc(0.375rem+var(--stack-overlap))] shadow-e2 backdrop-blur-md sm:mx-6">
             <span class="h-2 w-2 rounded-full bg-run pulse-dot" aria-hidden="true" />
-            <span data-test="hud-quip" class="text-[12px] font-semibold text-run">{{ hudStatus }}…</span>
+            <span data-test="hud-quip" class="text-[12px] font-semibold text-run">{{ hudStatus }}</span>
             <span class="font-mono text-[12px] font-semibold tabular-nums text-run">{{ elapsed }}</span>
             <span v-if="runningTools > 0" class="text-[11.5px] text-fg-muted">· {{ runningTools }} {{ runningTools === 1 ? $t("chat.tool") : $t("chat.tools") }}</span>
             <span class="flex-1" />

--- a/packages/relay-web/src/components/PromptInput.vue
+++ b/packages/relay-web/src/components/PromptInput.vue
@@ -23,7 +23,6 @@ import {
   type AgentAutocompleteContext,
 } from "../lib/agent-mention-ranking";
 import { loadDraft, saveDraft } from "../lib/composer-drafts";
-import { parseQuips, pickQuip } from "../lib/working-quips";
 import { createDebouncedFlush } from "../lib/debounce-flush";
 import { clampPanelWidth, createBottomPanelResize } from "../lib/resize-panel";
 import UsagePopover from "./UsagePopover.vue";
@@ -561,34 +560,6 @@ function flushDraft(): void {
   draftPersist.flush();
 }
 
-// Playful rotating status line for the composer placeholder while a turn runs.
-const busyQuip = ref("");
-let quipTimer: ReturnType<typeof setInterval> | null = null;
-const QUIP_ROTATE_MS = 5000;
-function rotateBusyQuip(): void {
-  const quips = parseQuips(t("chat.workingQuips"));
-  if (quips.length > 0) busyQuip.value = pickQuip(quips, busyQuip.value || undefined);
-}
-watch(
-  () => props.busy,
-  (busy) => {
-    if (quipTimer) {
-      clearInterval(quipTimer);
-      quipTimer = null;
-    }
-    if (busy) {
-      rotateBusyQuip();
-      quipTimer = setInterval(rotateBusyQuip, QUIP_ROTATE_MS);
-    } else {
-      busyQuip.value = "";
-    }
-  },
-  { immediate: true },
-);
-const workingPlaceholder = computed(() =>
-  busyQuip.value ? `${busyQuip.value}${t("chat.escToStop")}` : t("chat.working"),
-);
-
 onMounted(() => {
   window.addEventListener("pagehide", flushDraft);
   if (typeof window.matchMedia === "function") {
@@ -598,7 +569,6 @@ onMounted(() => {
   }
 });
 onBeforeUnmount(() => {
-  if (quipTimer) clearInterval(quipTimer);
   window.removeEventListener("pagehide", flushDraft);
   desktopMql?.removeEventListener("change", onDesktopChange);
   flushDraft();
@@ -947,7 +917,7 @@ function onInput() {
         rows="2"
         class="w-full resize-none bg-transparent px-3.5 pt-2.5 pb-1 text-[16px] lg:text-[14px] leading-relaxed text-fg placeholder:text-fg-muted focus:outline-none"
         :style="isDesktop ? { height: composerHeight + 'px' } : undefined"
-        :placeholder="busy ? workingPlaceholder : $t('chat.message')"
+        :placeholder="busy ? $t('chat.working') : $t('chat.message')"
         @input="onInput"
         @click="updateMentionState"
         @keyup="updateMentionState"

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -95,10 +95,9 @@ export default {
     effort: "effort",
     effortSetFailed: "Failed to switch effort. Try again.",
     working: "Agent is working… (Esc to stop)",
-    // Newline-delimited pool (never use "|" — vue-i18n reserves it for pluralization).
+    // Newline-delimited pool for the turn HUD (never use "|" — vue-i18n reserves it for pluralization).
     workingQuips:
       "Ideas loading…\nSparks flying off the keyboard\nKeyboard smoking — do not disturb\nCPU is sweating a little\nArguing with a bug\nTranslating requirements into code\nLaying it down line by line\nKnee-deep in the docs\nCoffee refilled, back at it\nFingers flying, code flowing\nBrain fans at full speed\nNeurons firing wildly\nPaddling through the knowledge sea\nUnboxing your requirements\nPuzzle in progress — no rushing\nDeleted, rewritten, repeat\nCooking up something big\nGears turning, clickety-clack\nInjecting soul into the code\nBytes flying, bugs fleeing",
-    escToStop: " (Esc to stop)",
     mentionSource: {
       worker: "Worker",
       weixin: "WeChat",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -95,7 +95,6 @@ export default {
     working: "Agent 正在工作…（按 Esc 停止）",
     workingQuips:
       "灵感加载中…\n正在敲键盘，火花四溅\n键盘冒烟中，请勿打扰\nCPU 微微出汗\n正在与 bug 斗智斗勇\n正在把需求翻译成代码\n一行一行搬砖中…\n正在翻文档第八十页\n咖啡续满，继续冲\n十指翻飞，代码狂飙\n大脑风扇全速运转\n神经元疯狂放电中\n在知识的海洋里狗刨\n正在拆需求盲盒\n拼图进行中，别催\n删删改改又一版\n正在憋大招\n齿轮咔咔转动中\n正在给代码注入灵魂\n字节在飞，bug 在逃",
-    escToStop: "（按 Esc 停止）",
     mentionSource: {
       worker: "Worker",
       weixin: "微信",

--- a/packages/relay-web/src/lib/working-quips.ts
+++ b/packages/relay-web/src/lib/working-quips.ts
@@ -1,4 +1,4 @@
-// Playful status lines for the busy composer placeholder. The i18n catalog keeps
+// Playful status lines for the turn HUD while a turn runs. The i18n catalog keeps
 // values as plain strings, so the pool is stored as one newline-delimited string.
 export function parseQuips(raw: string | undefined | null): string[] {
   if (!raw) return [];


### PR DESCRIPTION
接 #327/#328：俏皮语从 busy 输入框 placeholder 搬到 turn-hud（`data-test=hud-quip`）。

- HUD 每回合随机抽 `chat.workingQuips`，每 20s 轮换、不连重；中途切换语言即时重抽；池空回退 `chat.mentionActivity.working`
- 输入框 busy placeholder 恢复静态 `chat.working`；删除无用 `chat.escToStop` key
- 删掉 ChatPane 旧的 VERBS 动词轮换（Working/Thinking… 10s 一跳）
- docs/relay-web-module.md HUD 小节同步

验证：`vitest run chatpane/promptinput/working-quips` 54 用例绿；全套 131 文件 / 1405 用例绿；`vue-tsc --noEmit` 干净。