### PR TITLE
fix(runtime): per-turn tool-call snapshot normalization and text ordered-transcript parity

### DIFF
--- a/docs/superpowers/specs/2026-09-07-runtime-text-ordered-transcript-partity.md
+++ b/docs/superpowers/specs/2026-09-07-runtime-text-ordered-transcript-partity.md
@@ -1,0 +1,697 @@
+# Addendum — Runtime Text / Ordered Transcript Parity
+
+## 21. 问题
+
+Runtime engine 启用后，Relay Web 出现此前已经修复过的文字展示回归：
+
+```text
+agent text A
+tool
+agent text B
+tool
+agent text C
+```
+
+或多个逻辑 agent message，重新表现为大段连续文字，失去此前 CLI 链路下的 paragraph / activity boundary 效果。
+
+本问题不是 Relay Web 应重新实现文本切分，而是 Runtime 链路没有继承 CLI 已有的 transcript normalization。
+
+---
+
+## 22. 已有 CLI 行为
+
+`src/transport/streaming-prompt.ts` 当前维护：
+
+```ts
+lastMessageId
+lastTextTail
+activitySinceLastText
+hasAgentMessage
+```
+
+并在 agent message chunk 到来时判定：
+
+```text
+messageId changed
+OR
+tool/thought activity occurred since previous text
+    + messageId unavailable
+    + previous text ends at sentence boundary
+```
+
+若当前位置尚无已有 paragraph boundary，则在新文本前补：
+
+```text
+\n\n
+```
+
+另外：
+
+```text
+tool_call initial
+thought chunk
+```
+
+会建立 activity boundary，并在 activity event 前 flush pending text。
+
+这个行为是已经验证过的 CLI presentation contract，不应因为 engine 从 CLI 切到 Runtime 而改变。
+
+---
+
+# 23. Runtime 当前缺口
+
+Pinned acpx Runtime 的 `text_delta` 已提供：
+
+```ts
+type: "text_delta";
+text: string;
+stream?: "output" | "thought";
+tag?: AcpSessionUpdateTag;
+messageId?: string;
+meta?: {
+  origin?: string;
+  kind?: string;
+  source?: string;
+};
+```
+
+但 xacpx 当前内部 `XacpxRuntimeEvent` 只保留：
+
+```ts
+{
+  type: "text_delta";
+  text: string;
+  stream?: "output" | "thought";
+}
+```
+
+`runtime-adapter.ts::mapEvents()` 同样只转发：
+
+```ts
+yield {
+  type: "text_delta",
+  text: event.text,
+  ...(event.stream ? { stream: event.stream } : {}),
+};
+```
+
+因此 Runtime 链路当前丢失：
+
+```text
+tag
+messageId
+meta
+```
+
+随后 RuntimeEngine 将每个 text delta 直接下发为：
+
+```text
+prompt.segment
+```
+
+没有 CLI 的：
+
+```text
+logical-message boundary
+activity boundary
+paragraph reconstruction
+```
+
+---
+
+# 24. 设计原则
+
+不要在：
+
+```text
+relay-web
+relay
+channel-relay
+```
+
+层重新猜 agent message boundaries。
+
+应继续遵循：
+
+```text
+transport/runtime normalization
+        ↓
+normalized prompt.segment stream
+        ↓
+ControlService
+        ↓
+Relay ordered TurnPart timeline
+```
+
+即：
+
+> Engine 不同不能改变上层看到的 transcript semantics。
+
+---
+
+# 25. 保留 Runtime text metadata
+
+修改：
+
+```text
+src/bridge/engine/runtime/runtime-contract.ts
+```
+
+使 internal text event 至少保留：
+
+```ts
+{
+  type: "text_delta";
+  text: string;
+  stream?: "output" | "thought";
+  tag?: string;
+  messageId?: string;
+  meta?: {
+    origin?: string;
+    kind?: string;
+    source?: string;
+  };
+}
+```
+
+然后：
+
+```text
+src/bridge/engine/runtime/runtime-adapter.ts
+```
+
+完整 forward upstream allowlisted metadata：
+
+```ts
+{
+  type: "text_delta",
+  text: event.text,
+  ...(event.stream ? { stream: event.stream } : {}),
+  ...(event.tag ? { tag: event.tag } : {}),
+  ...(event.messageId ? { messageId: event.messageId } : {}),
+  ...(event.meta ? { meta: event.meta } : {}),
+}
+```
+
+不要再次在 Runtime adapter 边界丢失 upstream 已经安全筛选过的信息。
+
+---
+
+# 26. 抽取共享 Text Boundary Normalizer
+
+不要在 RuntimeEngine 里重新手抄一套与 CLI 独立发展的 heuristic。
+
+建议从：
+
+```text
+src/transport/streaming-prompt.ts
+```
+
+抽出一个纯状态机，例如：
+
+```text
+src/transport/transcript-text-boundary.ts
+```
+
+概念 API：
+
+```ts
+interface TranscriptTextBoundaryState {
+  hasAgentMessage: boolean;
+  lastMessageId?: string;
+  lastTextTail: string;
+  activitySinceLastText: boolean;
+}
+
+function markTranscriptActivity(
+  state: TranscriptTextBoundaryState,
+): void;
+
+function normalizeTranscriptTextChunk(
+  state: TranscriptTextBoundaryState,
+  input: {
+    text: string;
+    messageId?: string;
+  },
+): string;
+```
+
+CLI 和 Runtime 两边都使用同一个实现。
+
+---
+
+# 27. Normalization 规则
+
+## 27.1 同一个 messageId
+
+输入：
+
+```text
+messageId=A: "Hello "
+messageId=A: "world."
+```
+
+输出：
+
+```text
+Hello world.
+```
+
+不能因为 token/chunk 边界插入额外 paragraph。
+
+---
+
+## 27.2 messageId 改变
+
+输入：
+
+```text
+A: "First message."
+B: "Second message."
+```
+
+如果 join 处没有现成 paragraph boundary：
+
+```text
+First message.
+
+Second message.
+```
+
+---
+
+## 27.3 已有 paragraph boundary
+
+输入：
+
+```text
+A: "First.\n\n"
+B: "Second."
+```
+
+禁止再补一次：
+
+```text
+\n\n
+```
+
+---
+
+## 27.4 activity fallback
+
+若 provider 没有 messageId：
+
+```text
+text: "I'll inspect it."
+tool_call
+text: "The problem is here."
+```
+
+tool call 建立：
+
+```text
+activitySinceLastText = true
+```
+
+previous text 又以 sentence terminal 结束，因此第二段应正规化为：
+
+```text
+"\n\nThe problem is here."
+```
+
+---
+
+## 27.5 非 sentence-terminal fallback
+
+例如：
+
+```text
+text: "Result:"
+tool
+text: "42"
+```
+
+如果沿用当前 CLI contract，不应仅因为 tool 存在就武断插入 paragraph。
+
+Runtime 必须与 CLI 保持相同 heuristic，而不是设计第二套规则。
+
+---
+
+# 28. Activity events
+
+至少以下事件应与 CLI 一致地建立 text activity boundary：
+
+```text
+initial tool_call
+agent thought
+```
+
+`tool_call_update` 不应被当作一个新的 logical activity：
+
+```text
+running update
+completed update
+```
+
+只是同一个 tool call 的状态变化。
+
+这与本 spec 前半部分的：
+
+```text
+per-toolCallId snapshot normalization
+```
+
+是同一个原因。
+
+---
+
+# 29. 推荐统一 Runtime per-turn normalizer
+
+既然本次还要修 tool-call delta，可以把两个问题收敛成一个 per-turn normalizer：
+
+```text
+AcpRuntimeEvent
+       ↓
+RuntimeTranscriptNormalizer
+       ├── text boundary normalization
+       │     messageId/activity/paragraph
+       │
+       └── tool snapshot normalization
+             per-toolCallId delta → snapshot
+       ↓
+XacpxRuntimeEvent
+```
+
+生命周期：
+
+```text
+one Runtime turn
+→ one normalizer instance
+→ turn settle
+→ discard all state
+```
+
+不要把任何 accumulator 挂成：
+
+```text
+RuntimeEngine global state
+session lifetime state
+worker lifetime state
+```
+
+防止跨 turn 污染。
+
+---
+
+# 30. 保持 raw-stream 性能语义
+
+修复不能恢复旧的 30 秒 paragraph buffering。
+
+Runtime `replyMode=stream` 仍应：
+
+```text
+text delta arrives
+→ normalize boundary
+→ immediately emit
+```
+
+也就是说允许把：
+
+```text
+"Second"
+```
+
+变成：
+
+```text
+"\n\nSecond"
+```
+
+但不能为了寻找 paragraph 而缓存整个段落。
+
+目标是：
+
+```text
+raw low-latency streaming
++
+correct logical boundaries
+```
+
+而不是回退到 batched streaming。
+
+---
+
+# 31. Relay contract
+
+Relay 当前：
+
+```text
+连续 text part → coalesce
+text → tool → text → 保持三个 ordered parts
+text → reasoning → text → 保持三个 ordered parts
+```
+
+这一行为保持不变。
+
+不要为了 Runtime 在 Relay 加：
+
+```text
+if engine === runtime
+```
+
+之类的 presentation 分支。
+
+---
+
+# 32. 必须新增的 regression tests
+
+## T1 — Runtime forwards text metadata
+
+输入 upstream：
+
+```text
+text_delta
+tag=agent_message_chunk
+messageId=m1
+meta.origin=...
+```
+
+断言 xacpx internal Runtime event 全部保留。
+
+---
+
+## T2 — Same message stays contiguous
+
+```text
+m1 "Hello "
+m1 "world"
+```
+
+结果：
+
+```text
+"Hello "
+"world"
+```
+
+不得插入 separator。
+
+---
+
+## T3 — Different messageIds regain paragraph
+
+```text
+m1 "One."
+m2 "Two."
+```
+
+累计结果：
+
+```text
+One.
+
+Two.
+```
+
+---
+
+## T4 — Existing paragraph is not duplicated
+
+```text
+m1 "One.\n\n"
+m2 "Two."
+```
+
+必须仍然只有一个 logical blank line。
+
+---
+
+## T5 — Tool activity fallback without messageId
+
+```text
+text "I'll inspect it."
+initial tool_call
+text "Found it."
+```
+
+第二个 text event 必须带前导：
+
+```text
+\n\n
+```
+
+---
+
+## T6 — Tool update does not create another activity boundary
+
+```text
+text
+tool_call
+tool_call_update
+tool_call_update
+text
+```
+
+整个 tool lifecycle 只对应一个 logical activity。
+
+---
+
+## T7 — Thought boundary parity
+
+```text
+agent text
+thought
+agent text
+```
+
+与 CLI current behavior 一致。
+
+---
+
+## T8 — Ordered Relay timeline
+
+端到端喂入：
+
+```text
+text A
+tool rich-running
+tool sparse-completed
+text B
+```
+
+Relay 最终 `parts` 必须为：
+
+```text
+[
+  text(A),
+  tool(completed rich snapshot),
+  text(B)
+]
+```
+
+不能变为：
+
+```text
+[
+  tool(...),
+  text(A + B)
+]
+```
+
+也不能：
+
+```text
+[
+  text(A + B),
+  tool(...)
+]
+```
+
+这条同时验证：
+
+```text
+tool snapshot merge
++
+text/tool event ordering
++
+ordered transcript
+```
+
+---
+
+## T9 — Consecutive logical messages without tool
+
+如果 Relay 按现有设计把连续 text chunk coalesce 成一个 `TurnPartDto.text`，允许仍只有一个 part，但其中必须保有：
+
+```text
+A\n\nB
+```
+
+不能变为：
+
+```text
+AB
+```
+
+不要为了这个测试改变 Relay 的 same-type coalescing contract。
+
+---
+
+## T10 — Stream mode remains immediate
+
+测试第一个 Runtime text delta 不等待：
+
+```text
+paragraph completion
+tool
+turn completion
+timer
+```
+
+就进入 `prompt.segment`。
+
+---
+
+# 33. 验收条件
+
+完成后必须同时满足：
+
+1. Runtime 与 CLI 对 logical agent-message paragraph boundary 行为一致。
+2. Runtime 不再丢 `text_delta.messageId/tag/meta`。
+3. Read/Edit/Bash tool card 修复后的 structured events 仍按真实时序穿插于文字之间。
+4. `text → tool → text` 在 Relay history/live view 都是 ordered timeline。
+5. 独立 agent message 不再无分隔地粘成一整段。
+6. 不改变 Relay 的 consecutive same-type coalescing。
+7. 不降低 `replyMode=stream` 首 token 延迟。
+8. CLI 行为无回归。
+9. Runtime direct prompt 与 queued prompt 使用同一 normalization。
+10. live view 与 persisted `structured.parts` 结果一致。
+
+---
+
+# 34. 与 Tool Call 修复的统一 invariant
+
+前半部分解决：
+
+> ACP tool events 是 delta，xacpx 下游 contract 必须是 snapshot。
+
+本部分解决：
+
+> ACP text events 是带 logical identity/activity context 的 stream，xacpx 下游不能在 Runtime 路径把这些 boundary semantics 丢掉。
+
+因此建议最终实现一个统一的：
+
+```text
+per-turn Runtime transcript normalization layer
+```
+
+负责：
+
+```text
+tool delta → snapshot
+text metadata preservation
+logical text boundary reconstruction
+activity ordering
+```
+
+之后 RuntimeEngine、ControlService、Relay 都只消费已经正规化后的事件。

--- a/docs/superpowers/specs/2026-09-07-runtime-tool-call-snapshot-normalization.md
+++ b/docs/superpowers/specs/2026-09-07-runtime-tool-call-snapshot-normalization.md
@@ -1,0 +1,1332 @@
+# Runtime Tool Call Snapshot Normalization
+
+## 1. 背景
+
+PR #312 将新 session 的默认 engine 切换到 Runtime 后，Relay Web 中 structured tool call 的可读性发生明显回退：
+
+* Read 文件显示为 `tool call`
+* Edit / Update 文件显示为 `tool call`
+* Bash / execute 命令显示为 `tool call`
+* 不同工具无法从卡片标题和图标上区分
+
+CLI engine 下同类 tool call 显示正常。
+
+当前问题存在于已经发布的 Runtime 链路中，不是 Relay Web 自身的 presentation bug。
+
+---
+
+## 2. 根因
+
+ACP 的 `tool_call` / `tool_call_update` 是 **同一 `toolCallId` 的增量事件流**，不是每帧完整 snapshot。
+
+典型事件序列：
+
+```text
+tool_call:
+  toolCallId = "call-1"
+  title = "Read"
+  kind = "read"
+  rawInput = { path: "/src/foo.ts" }
+
+tool_call_update:
+  toolCallId = "call-1"
+  status = "completed"
+```
+
+终帧可能只携带 `status` / `rawOutput`，不重复：
+
+* title
+* kind
+* rawInput
+* content
+* locations
+
+CLI 链路已经通过 `mergeToolCallUpdate()` 按 `toolCallId` 累积字段，因此 terminal sparse update 不会覆盖此前富信息。
+
+Runtime 链路目前没有等价逻辑：
+
+```text
+acpx/runtime
+→ runtime-adapter.ts mapEvents()
+→ runtime-worker-main.ts
+→ RuntimeEngine
+→ mapRuntimeToolEvent()
+→ ToolUseEvent
+→ channel-relay
+```
+
+每个 Runtime `tool_call` event 都被独立转换成一个新的 `ToolUseEvent`。
+
+而 Relay / state mirror 对同一 `toolCallId` 使用的是 **replace-latest snapshot semantics**：
+
+```text
+old step
+→ new ToolUseEvent
+→ replace whole step
+```
+
+因此 sparse terminal frame 会把 rich initial frame 擦掉。
+
+### 2.1 `acpx@0.13.1` 的额外放大因素
+
+Pinned `acpx@0.13.1` 在处理缺少 title 的 `tool_call_update` 时，不会留下 `title=undefined`，而是主动生成：
+
+```text
+title = "tool call"
+```
+
+例如：
+
+```text
+ACP:
+  tool_call_update
+  toolCallId = call_ABC123
+  status = in_progress
+```
+
+会变成 Runtime event：
+
+```text
+type = tool_call
+tag = tool_call_update
+toolCallId = call_ABC123
+status = in_progress
+title = "tool call"
+```
+
+因此不能简单复制 CLI 的“所有 non-empty 字段覆盖 previous”规则。
+
+对于 Runtime，`tool_call_update` 上的 synthetic `"tool call"` 必须视为 **missing title**，不能覆盖此前已有的具体 title。
+
+---
+
+# 3. 核心设计原则
+
+## 3.1 Runtime adapter 必须输出 snapshot，而不是 delta
+
+在 xacpx Runtime adapter 边界：
+
+```text
+ACP Runtime delta stream
+```
+
+必须被正规化为：
+
+```text
+XacpxRuntimeEvent snapshot stream
+```
+
+也就是说，对每一个已有 `toolCallId`，每次向 worker / host 下游发送的 `tool_call` event，都应该包含当前已知的累计状态。
+
+下游不应该再理解 ACP 的 merge 语义。
+
+---
+
+## 3.2 Relay 不负责合并 ACP delta
+
+不要把修复放到：
+
+* `packages/channel-relay`
+* `packages/relay`
+* `packages/relay-web`
+
+Relay 当前按 `toolCallId` replace 整个 ToolStep 的行为是正确的。
+
+修复后的 invariant 应为：
+
+> Relay 收到的每一个 `ToolUseEvent` 都是当前 tool call 的完整 best-known snapshot。
+
+这样：
+
+* Relay Web
+* Feishu
+* 其它 structured-tool channel
+
+都自动获得一致行为。
+
+---
+
+## 3.3 Merge state 必须是 per-turn
+
+Accumulator 必须随着一个 Runtime turn 创建、随着 turn 完成销毁。
+
+禁止：
+
+* RuntimeEngine 实例级长期 Map
+* session 级 Map
+* global Map
+
+否则不同 turn 如果偶然复用了同一个 `toolCallId`，会发生跨 turn 信息污染。
+
+`runtime-adapter.ts::mapEvents()` 本身对应一个 turn 的 `AsyncIterable`，因此适合作为 accumulator 生命周期边界。
+
+---
+
+# 4. 具体方案
+
+## 4.1 保留 upstream event tag
+
+当前 upstream Runtime contract 对 tool call 暴露：
+
+```ts
+tag?: AcpSessionUpdateTag
+```
+
+其中至少包括：
+
+```text
+tool_call
+tool_call_update
+```
+
+xacpx 当前内部 `XacpxRuntimeEvent` 的 tool_call branch 没有保留该字段。
+
+修改：
+
+`src/bridge/engine/runtime/runtime-contract.ts`
+
+为 tool call 增加：
+
+```ts
+type: "tool_call";
+text: string;
+tag?: string;
+toolCallId?: string;
+...
+```
+
+更严格也可以定义：
+
+```ts
+tag?: "tool_call" | "tool_call_update" | string;
+```
+
+然后：
+
+`src/bridge/engine/runtime/runtime-adapter.ts`
+
+必须 forward：
+
+```ts
+...(event.tag ? { tag: event.tag } : {})
+```
+
+这是重要的 transport semantics，不应在 adapter 第一层丢弃。
+
+---
+
+# 5. Runtime Tool Snapshot Accumulator
+
+推荐放在：
+
+```text
+src/bridge/engine/runtime/runtime-adapter.ts
+```
+
+或者抽成一个同目录小模块，例如：
+
+```text
+src/bridge/engine/runtime/runtime-tool-call-merge.ts
+```
+
+如果逻辑和测试开始超过约 100 行，优先抽模块。
+
+---
+
+## 5.1 状态结构
+
+每个 `mapEvents()` 创建：
+
+```ts
+const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+```
+
+Snapshot 至少保存：
+
+```ts
+interface RuntimeToolCallSnapshot {
+  type: "tool_call";
+  text: string;
+  tag?: string;
+  toolCallId: string;
+  title?: string;
+  status?: string;
+  kind?: string;
+  locations?: unknown;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+  content?: unknown;
+}
+```
+
+---
+
+## 5.2 无 `toolCallId` 的行为
+
+如果 upstream event 没有 `toolCallId`：
+
+* 不尝试 merge
+* 保持当前 passthrough 行为
+* 不生成一个 synthetic merge key
+
+`mapRuntimeToolEvent()` 当前为了满足 `ToolUseEvent` contract 可以继续生成 fallback ID，但 accumulator 不应该以随机 ID 做跨帧合并。
+
+没有稳定 ID 就没有可靠 merge identity。
+
+---
+
+# 6. Merge semantics
+
+## 6.1 普通规则
+
+对于同一个 `toolCallId`：
+
+```text
+new field meaningful
+    → update snapshot
+
+new field missing / empty
+    → preserve previous
+```
+
+需要累计的字段：
+
+```text
+title
+kind
+status
+rawInput
+rawOutput
+content
+locations
+```
+
+`toolCallId` 固定。
+
+---
+
+## 6.2 rawInput / rawOutput 是累积关系
+
+尤其不能写成：
+
+```text
+new rawOutput exists
+→ discard rawInput
+```
+
+典型完整生命周期：
+
+```text
+initial:
+  rawInput.command = "bun test"
+
+terminal:
+  rawOutput.formatted_output = "..."
+  status = completed
+```
+
+最终 snapshot 应同时包含：
+
+```text
+rawInput.command
+rawOutput.formatted_output
+status
+```
+
+同理 Edit：
+
+```text
+initial:
+  rawInput/path/content/diff
+
+terminal:
+  status + rawOutput
+```
+
+最终都必须保留。
+
+---
+
+## 6.3 Synthetic `"tool call"` title 特例
+
+这是本方案最关键的 Runtime-specific 规则。
+
+当：
+
+```text
+event.tag === "tool_call_update"
+AND
+event.title.trim().toLowerCase() === "tool call"
+AND
+previous.title is meaningful
+```
+
+则：
+
+```text
+preserve previous.title
+```
+
+不能覆盖。
+
+伪代码：
+
+```ts
+const nextTitle = normalize(event.title);
+
+if (
+  event.tag === "tool_call_update" &&
+  nextTitle.toLowerCase() === "tool call" &&
+  previous.title
+) {
+  merged.title = previous.title;
+} else if (nextTitle) {
+  merged.title = nextTitle;
+}
+```
+
+---
+
+## 6.4 真正 title update 必须允许
+
+不能粗暴写成：
+
+```text
+tool_call_update 永远不允许修改 title
+```
+
+如果 upstream 明确发：
+
+```text
+initial title = "Running command"
+
+update title = "Building project"
+```
+
+则应该接受新 title。
+
+只特殊处理 Runtime upstream 的 generic placeholder：
+
+```text
+"tool call"
+```
+
+---
+
+## 6.5 `text` 字段
+
+`text` 不是 structured presentation 的 source of truth。
+
+它可以：
+
+* 使用 latest meaningful `event.text`
+* 或保留 latest value
+
+但不要用 `text` 替代：
+
+* title
+* rawInput
+* kind
+* rawOutput
+
+特别禁止：
+
+```ts
+summary = event.text
+```
+
+作为本次主修复。
+
+---
+
+# 7. mapEvents() 目标行为
+
+最终结构建议：
+
+```ts
+async function* mapEvents(
+  events: AsyncIterable<AcpRuntimeEvent>,
+): AsyncIterable<XacpxRuntimeEvent> {
+  const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+
+  for await (const event of events) {
+    if (event.type === "text_delta") {
+      ...
+      continue;
+    }
+
+    if (event.type === "status") {
+      ...
+      continue;
+    }
+
+    if (event.type === "tool_call") {
+      const normalized = normalizeRuntimeToolCallEvent(
+        toolCalls,
+        event,
+      );
+
+      yield normalized;
+    }
+  }
+}
+```
+
+其中：
+
+```ts
+normalizeRuntimeToolCallEvent()
+```
+
+负责：
+
+```text
+upstream event
+→ merge per toolCallId
+→ return accumulated snapshot
+```
+
+---
+
+# 8. RuntimeEngine 不再承担 merge
+
+`src/bridge/engine/runtime-engine.ts`
+
+当前：
+
+```ts
+const toolEvent = mapRuntimeToolEvent(event);
+```
+
+可以保持这种简单模式。
+
+它应该只负责：
+
+```text
+XacpxRuntime tool snapshot
+→ ToolUseEvent
+```
+
+而不是维护 per-turn Map。
+
+这样 direct prompt / queued prompt 等所有 Runtime turn 都自动获得相同 normalization。
+
+---
+
+# 9. Summary parity
+
+这是第二阶段，但建议同一个 patch 完成。
+
+当前 CLI 的 `buildToolUseEvent()` 会通过：
+
+```text
+rawInput
+fallback rawOutput
+```
+
+生成 `ToolUseEvent.summary`。
+
+Runtime 当前 `mapRuntimeToolEvent()` 不填 summary。
+
+建议抽出或复用 CLI 已有的 tool summary helper，使 Runtime snapshot 也能够得到：
+
+```ts
+summary?: string
+```
+
+原则：
+
+```text
+summary = summarize(merged.rawInput)
+       ?? summarize(merged.rawOutput)
+```
+
+并保持已有的：
+
+```text
+summary !== title
+```
+
+去重语义。
+
+### 不要这样修
+
+禁止只做：
+
+```ts
+summary = event.text;
+```
+
+因为 terminal Runtime text 可能是：
+
+```text
+tool call (completed): ...
+```
+
+这样 Relay fallback title 仍然可能变成：
+
+```text
+tool call
+```
+
+或者输出摘要，而不是 path / command。
+
+---
+
+# 10. Tool kind parity
+
+Pinned `acpx@0.13.1` Runtime tool kinds：
+
+```text
+read
+edit
+delete
+move
+search
+execute
+fetch
+think
+other
+```
+
+xacpx 当前 `ToolUseKind` 只支持：
+
+```text
+read
+search
+execute
+edit
+think
+other
+```
+
+因此还缺：
+
+```text
+delete
+move
+fetch
+```
+
+建议本次顺带做完整 parity。
+
+修改：
+
+```text
+src/channels/types.ts
+```
+
+为：
+
+```ts
+export type ToolUseKind =
+  | "read"
+  | "search"
+  | "execute"
+  | "edit"
+  | "delete"
+  | "move"
+  | "fetch"
+  | "think"
+  | "other";
+```
+
+同步修改：
+
+```text
+src/transport/tool-kind-emoji.ts
+```
+
+以及所有 exhaustive `Record<ToolUseKind, ...>`。
+
+---
+
+# 11. Relay presentation
+
+只有新增 kind 时才需要修改：
+
+```text
+packages/channel-relay/src/tool-presentation.ts
+```
+
+现有 read/edit/execute/search 的逻辑无需为本 bug 改写。
+
+修复 merge 后，它们本来就能从 merged snapshot 中恢复：
+
+### Read
+
+```text
+kind = read
+rawInput.path / file_path
+```
+
+→ title = path
+
+### Execute
+
+```text
+kind = execute
+rawInput.command / cmd
+```
+
+→ title = command
+
+### Edit
+
+```text
+kind = edit
+content diff / rawInput path + old/new
+```
+
+→ diff card
+
+所以不要在 presentation 层增加针对 `"tool call"` 的 hack。
+
+---
+
+## 11.1 新增 kind 建议 presentation
+
+### delete
+
+优先取：
+
+```text
+rawInput.file_path
+rawInput.path
+location
+```
+
+detail 可复用 fields，标题使用 path。
+
+### move
+
+优先展示：
+
+```text
+source → destination
+```
+
+可识别字段例如：
+
+```text
+from
+to
+source
+destination
+src
+dest
+old_path
+new_path
+```
+
+无法识别时退 fields。
+
+### fetch
+
+优先：
+
+```text
+url
+uri
+href
+```
+
+detail 可使用 text/fields + rawOutput。
+
+不要因为新 kind 增加过度 provider-specific 逻辑。
+
+---
+
+# 12. 必须的测试
+
+本修复的核心是 **多帧 sequence behavior**。
+
+只测单独的 `mapRuntimeToolEvent()` 不足以覆盖回归。
+
+---
+
+## Test 1 — Read sparse terminal update
+
+输入：
+
+```text
+tool_call:
+  id = "read-1"
+  title = "Read"
+  kind = "read"
+  rawInput = {
+    path: "/tmp/a.ts"
+  }
+
+tool_call_update:
+  id = "read-1"
+  title = "tool call"
+  status = "completed"
+```
+
+断言最终 emitted snapshot：
+
+```text
+toolCallId = read-1
+title = Read
+kind = read
+rawInput.path = /tmp/a.ts
+status = completed
+```
+
+再经过 `mapRuntimeToolEvent()`：
+
+```text
+toolName = Read
+kind = read
+status = success
+rawInput retained
+```
+
+再经过 relay presentation：
+
+```text
+title = /tmp/a.ts
+detail.type = read
+```
+
+这是本 bug 的最小主回归。
+
+---
+
+## Test 2 — Execute keeps input and gains output
+
+输入：
+
+```text
+tool_call:
+  id = "bash-1"
+  title = "Bash"
+  kind = "execute"
+  rawInput.command = "bun test"
+
+tool_call_update:
+  id = "bash-1"
+  title = "tool call"
+  status = "completed"
+  rawOutput.formatted_output = "42 pass"
+  rawOutput.exit_code = 0
+```
+
+最终必须同时有：
+
+```text
+title = Bash
+kind = execute
+rawInput.command = bun test
+rawOutput.formatted_output = 42 pass
+status = completed
+```
+
+Relay：
+
+```text
+title = bun test
+detail.type = command
+detail.command = bun test
+detail.output = 42 pass
+exitCode = 0
+```
+
+---
+
+## Test 3 — Edit rich frame survives sparse completion
+
+Initial：
+
+```text
+kind = edit
+path / content / diff
+```
+
+Terminal：
+
+```text
+status = completed
+title = tool call
+```
+
+最终：
+
+```text
+kind = edit
+path retained
+diff/content retained
+status = success
+```
+
+Relay 必须仍然生成 diff detail。
+
+---
+
+## Test 4 — Real title update wins
+
+输入：
+
+```text
+initial:
+  title = "Read"
+
+update:
+  tag = tool_call_update
+  title = "Read configuration"
+```
+
+断言：
+
+```text
+title = "Read configuration"
+```
+
+用于证明实现不是简单“update 不准修改 title”。
+
+---
+
+## Test 5 — Synthetic placeholder does not win
+
+输入：
+
+```text
+initial title = "Bash"
+update title = "tool call"
+```
+
+断言：
+
+```text
+title = "Bash"
+```
+
+---
+
+## Test 6 — Missing fields preserve old fields
+
+测试 update 分别省略：
+
+```text
+kind
+rawInput
+content
+locations
+```
+
+断言全部保留。
+
+---
+
+## Test 7 — New rawOutput is appended to snapshot
+
+Initial：
+
+```text
+rawInput exists
+```
+
+Update：
+
+```text
+rawOutput exists
+```
+
+最终：
+
+```text
+both exist
+```
+
+---
+
+## Test 8 — Same toolCallId across two turns does not merge
+
+Turn A：
+
+```text
+toolCallId = "1"
+title = "Read"
+```
+
+结束。
+
+Turn B：
+
+```text
+toolCallId = "1"
+title = "Bash"
+```
+
+Turn B 最终不得带：
+
+```text
+Turn A rawInput/content/title
+```
+
+这是 per-turn accumulator 生命周期回归。
+
+---
+
+## Test 9 — No toolCallId stays passthrough
+
+对于：
+
+```text
+tool_call without toolCallId
+```
+
+不得：
+
+* crash
+* 与其它无 ID event 合并
+* 使用一个全局 fallback key
+
+---
+
+## Test 10 — kind parity
+
+分别输入：
+
+```text
+delete
+move
+fetch
+```
+
+断言不会被 Runtime mapper 转为：
+
+```text
+other
+```
+
+如果本 patch 扩展 `ToolUseKind`，再分别验证 Relay presentation。
+
+---
+
+# 13. 推荐测试层级
+
+至少覆盖三个层：
+
+## A. Adapter normalization unit test
+
+目标：
+
+```text
+AcpRuntimeEvent[]
+→ mapEvents()
+→ accumulated XacpxRuntimeEvent[]
+```
+
+这是最关键测试。
+
+## B. RuntimeEngine structured event test
+
+目标：
+
+```text
+merged runtime tool event
+→ ToolUseEvent
+```
+
+验证：
+
+```text
+toolName
+kind
+summary
+rawInput
+rawOutput
+status
+```
+
+## C. channel-relay presentation regression
+
+使用最终 `ToolUseEvent` 验证：
+
+```text
+Read → path
+Edit → diff/path
+Bash → command
+Search → query
+```
+
+避免 transport 修了但 UI presentation 又退化。
+
+---
+
+# 14. 非目标
+
+本 patch 不处理：
+
+* Relay Web 卡片布局重设计
+* plan Runtime parity
+* upstream `acpx` 修改
+* tool protocol machine-name extraction 的全面 Runtime parity
+* parentToolCallId/subagent metadata parity
+* 修改 Relay 的 replace semantics
+
+这些不属于当前 regressions 的根因。
+
+---
+
+# 15. 不建议方案
+
+## 15.1 只补 `summary = event.text`
+
+不接受。
+
+它无法恢复：
+
+```text
+kind
+rawInput
+content
+locations
+```
+
+而且 `"tool call (...)"` 本身就是错误信息源。
+
+---
+
+## 15.2 在 Relay 合并 ToolStepDto
+
+不接受。
+
+这会把 ACP transport semantics 泄漏到 channel 层，并且其它 channel 仍然出错。
+
+---
+
+## 15.3 terminal update 时忽略整个 event
+
+不接受。
+
+Terminal update 通常携带重要：
+
+```text
+status
+rawOutput
+exitCode
+error
+```
+
+正确行为是：
+
+```text
+merge
+```
+
+而不是：
+
+```text
+drop
+```
+
+---
+
+## 15.4 所有 `tool_call_update.title` 都忽略
+
+不接受。
+
+真实 title update 是合法的。
+
+只针对已知 synthetic placeholder：
+
+```text
+"tool call"
+```
+
+在已有 richer title 时做保护。
+
+---
+
+# 16. 实现不变量
+
+完成后必须满足以下 invariants：
+
+### I1 — Identity preservation
+
+同一个 `toolCallId` 的 sparse update 不得擦除此前已知 tool identity。
+
+### I2 — Input preservation
+
+terminal update 不得擦除：
+
+```text
+rawInput
+content
+locations
+```
+
+### I3 — Output accumulation
+
+后续 `rawOutput` 必须可以加入此前 snapshot。
+
+### I4 — Terminal truth
+
+最终：
+
+```text
+completed → success
+failed/error → error
+```
+
+且仍保留 rich initial metadata。
+
+### I5 — Per-turn isolation
+
+一个 turn 的 accumulator 不能影响其它 turn。
+
+### I6 — Downstream snapshot contract
+
+每一个发给 structured consumer 的 Runtime `ToolUseEvent` 都应代表：
+
+> 当前这个 tool call 的完整 best-known state。
+
+### I7 — Generic title cannot downgrade specificity
+
+在已有具体 title 时：
+
+```text
+tool_call_update.title == "tool call"
+```
+
+不得把具体 title 降级为 generic placeholder。
+
+---
+
+# 17. 预期用户可见结果
+
+修复前：
+
+```text
+tool call
+tool call
+tool call
+```
+
+修复后，例如：
+
+```text
+📖 /src/foo.ts
+
+✏️ /src/foo.ts
+  diff ...
+
+💻 bun test
+  42 pass
+
+🔍 "worker fence" in src/
+```
+
+同一 tool call 的 running → completed 更新只更新同一张卡片：
+
+```text
+running
+→
+success
+```
+
+不会让标题、path、command、diff 在 terminal frame 消失。
+
+---
+
+# 18. 建议修改文件
+
+主修复：
+
+```text
+src/bridge/engine/runtime/runtime-contract.ts
+
+src/bridge/engine/runtime/runtime-adapter.ts
+或
+src/bridge/engine/runtime/runtime-tool-call-merge.ts
+
+src/bridge/engine/runtime-engine.ts
+```
+
+kind parity：
+
+```text
+src/channels/types.ts
+src/transport/tool-kind-emoji.ts
+packages/channel-relay/src/tool-presentation.ts
+```
+
+tests：
+
+```text
+tests/unit/bridge/engine/runtime/...
+tests/unit/bridge/engine/...
+tests/unit/packages/channel-relay/...
+```
+
+实际测试文件名可按现有 test organization 放置，不要求为了本 spec 新建固定命名。
+
+---
+
+# 19. 验收条件
+
+提交前必须全部满足：
+
+1. Runtime Read 卡片最终仍显示文件路径，而不是 `tool call`。
+2. Runtime Edit 最终仍显示 path/diff。
+3. Runtime Bash 最终仍显示真实 command + output。
+4. Sparse completed/error update 不擦除 initial metadata。
+5. `"tool call"` synthetic update 不覆盖 rich title。
+6. 真正的 non-generic title update 可以覆盖旧 title。
+7. rawInput + rawOutput 可以同时存在于最终 event。
+8. 两个 turn 之间 accumulator 完全隔离。
+9. CLI structured tool behavior无回归。
+10. Runtime text reply mode 无回归。
+11. Relay replace-by-toolCallId 行为无需修改。
+12. `delete/move/fetch` 如果纳入本 patch，则 Runtime → plugin API → relay presentation 全链路不再降级到 `other`。
+13. `tsc --noEmit` 通过。
+14. 相关 Runtime / bridge / channel-relay test suites 全绿。
+
+---
+
+# 20. 最终设计摘要
+
+修复位置应位于：
+
+```text
+acpx Runtime public event
+        ↓
+runtime-adapter
+        ↓
+【per-turn, per-toolCallId snapshot normalization】
+        ↓
+XacpxRuntimeEvent
+        ↓
+Runtime worker / host
+        ↓
+ToolUseEvent snapshot
+        ↓
+Relay replace
+```
+
+核心原则：
+
+> ACP 提供的是 delta；xacpx structured tool contract 对下游提供的必须是 snapshot。
+
+terminal sparse update 只能补充：
+
+```text
+status
+rawOutput
+新的真实字段
+```
+
+不能擦除已经知道的：
+
+```text
+title
+kind
+rawInput
+content
+locations
+```
+
+尤其是 `acpx@0.13.1` 自动生成的 `"tool call"`，在 `tool_call_update` 中只能作为 fallback placeholder，不能降级一个已经具备更具体 identity 的 tool call。

--- a/docs/superpowers/specs/2026-09-07-runtime-tool-call-snapshot-normalization.md
+++ b/docs/superpowers/specs/2026-09-07-runtime-tool-call-snapshot-normalization.md
@@ -1330,3 +1330,11 @@ locations
 ```
 
 尤其是 `acpx@0.13.1` 自动生成的 `"tool call"`，在 `tool_call_update` 中只能作为 fallback placeholder，不能降级一个已经具备更具体 identity 的 tool call。
+
+---
+
+# 21. 已知局限与 Gaps (Known Limitations)
+
+### Claude Status-less Terminal Parity Gap
+
+Pinned `acpx@0.13.1` Runtime `tool_call` event 没有透传 `_meta` 字段。当 Claude emitted 一个省略了 `status`、仅在 `_meta.claudeCode.toolResponse` 中携带执行结果的 sparse terminal frame 时，Runtime engine 无法区分它是 keep-alive running 还是 completed terminal，因此会保持 `running`。CLI 链路能够通过 `hasClaudeToolResponse` 判定完成并关闭 spinner。此 parity gap 需要 upstream acpx 在 Runtime `tool_call` event 中暴露 `_meta` 或规范化 `status` 信号，当前保留 mapping logic 不变。

--- a/packages/channel-discord/src/channel.ts
+++ b/packages/channel-discord/src/channel.ts
@@ -1031,7 +1031,7 @@ export class DiscordChannel implements MessageChannelRuntime {
           if (!accumulated.endsWith("\n")) accumulated += "\n";
         } else if (accumulated.length > 0 && trimmed.length > 0) {
           const lastLine = accumulated.split("\n").pop() ?? "";
-          const lastWasTool = /^[📖🔍🔧✏️💭🧰⚠️]/.test(lastLine.trimStart());
+          const lastWasTool = /^[📖🔍🔧✏️💭🧰⚠️🗑️📦🌐]/.test(lastLine.trimStart());
           if (lastWasTool && !isProgress) {
             if (!accumulated.endsWith("\n\n") && !accumulated.endsWith("\n")) accumulated += "\n\n";
             else if (accumulated.endsWith("\n") && !accumulated.endsWith("\n\n")) accumulated += "\n";
@@ -1049,7 +1049,7 @@ export class DiscordChannel implements MessageChannelRuntime {
         const summary = event.summary && event.summary !== toolName ? event.summary : "";
         const display = summary ? `${toolName}: ${summary}` : toolName;
         const truncated = display.length > 60 ? `${display.slice(0, 57)}…` : display;
-        const emojiMap: Record<string, string> = { read: "📖", search: "🔍", execute: "🔧", edit: "✏️", think: "💭", other: "🔧" };
+        const emojiMap: Record<string, string> = { read: "📖", search: "🔍", execute: "🔧", edit: "✏️", delete: "🗑️", move: "📦", fetch: "🌐", think: "💭", other: "🔧" };
         const emoji = emojiMap[event.kind] ?? "🔧";
         const line = `${emoji} ${truncated} (${event.status})`;
         // dedup identical consecutive truncated lines (e.g. repeated git log)

--- a/packages/channel-feishu/src/card/card-builder.ts
+++ b/packages/channel-feishu/src/card/card-builder.ts
@@ -263,6 +263,9 @@ const TOOL_KIND_ICON: Record<string, string> = {
   search: "\u{1F50D}",
   execute: "\u{1F4BB}",
   edit: "\u{270F}\u{FE0F}",
+  delete: "\u{1F5D1}\u{FE0F}",
+  move: "\u{1F4E6}",
+  fetch: "\u{1F310}",
   think: "\u{1F9E0}",
   other: "\u{1F527}",
 };

--- a/packages/channel-relay/src/tool-presentation.ts
+++ b/packages/channel-relay/src/tool-presentation.ts
@@ -336,6 +336,31 @@ export function toolUseEventToStepDto(event: ToolUseEvent): ToolStepDto {
     if (!text) return { ...base, title: fallbackTitle };
     return { ...base, title: fallbackTitle, detail: { type: "text", text: cap(text) } };
   }
+  if (event.kind === "delete") {
+    const path = asString(input.file_path) ?? asString(input.path) ?? locationPath(event) ?? fallbackTitle;
+    const fields = primitiveFields(input);
+    const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
+    if (fields.length === 0 && !out) return { ...base, title: path };
+    return { ...base, title: path, detail: { type: "fields", fields, ...(out ? { output: cap(out) } : {}) } };
+  }
+
+  if (event.kind === "move") {
+    const from = asString(input.from) ?? asString(input.source) ?? asString(input.src) ?? asString(input.old_path) ?? asString(input.oldPath);
+    const to = asString(input.to) ?? asString(input.destination) ?? asString(input.dest) ?? asString(input.new_path) ?? asString(input.newPath);
+    const title = from && to ? `${from} → ${to}` : from ?? to ?? locationPath(event) ?? fallbackTitle;
+    const fields = primitiveFields(input);
+    const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
+    if (fields.length === 0 && !out) return { ...base, title };
+    return { ...base, title, detail: { type: "fields", fields, ...(out ? { output: cap(out) } : {}) } };
+  }
+
+  if (event.kind === "fetch") {
+    const url = asString(input.url) ?? asString(input.uri) ?? asString(input.href) ?? fallbackTitle;
+    const fields = primitiveFields(input);
+    const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
+    if (fields.length === 0 && !out) return { ...base, title: url };
+    return { ...base, title: url, detail: { type: "fields", fields, ...(out ? { output: cap(out) } : {}) } };
+  }
 
   const out = textFromBlocks(blocks) ?? asString(output.stdout) ?? terminalOut ?? asString(output.text) ?? rawOutputText;
   const fields = primitiveFields(input);

--- a/packages/relay-protocol/dist/dtos.d.ts
+++ b/packages/relay-protocol/dist/dtos.d.ts
@@ -105,7 +105,7 @@ export interface OrchestrationTaskDto {
     updatedAt: string;
 }
 export type ToolStepStatus = "running" | "success" | "error";
-export type ToolStepKind = "read" | "search" | "execute" | "edit" | "think" | "other";
+export type ToolStepKind = "read" | "search" | "execute" | "edit" | "delete" | "move" | "fetch" | "think" | "other";
 /** Friendly, presentation-ready detail for one tool call (no raw JSON crosses the wire). */
 export type ToolDetailDto = {
     type: "diff";

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -129,7 +129,15 @@ export interface OrchestrationTaskDto {
 
 export type ToolStepStatus = "running" | "success" | "error";
 export type ToolStepKind =
-  "read" | "search" | "execute" | "edit" | "think" | "other";
+  | "read"
+  | "search"
+  | "execute"
+  | "edit"
+  | "delete"
+  | "move"
+  | "fetch"
+  | "think"
+  | "other";
 
 /** Friendly, presentation-ready detail for one tool call (no raw JSON crosses the wire). */
 export type ToolDetailDto =

--- a/packages/relay-web/src/lib/tool-summary.ts
+++ b/packages/relay-web/src/lib/tool-summary.ts
@@ -1,5 +1,5 @@
 import type { Component } from "vue";
-import { BookOpen, Search, SquareTerminal, Pencil, Brain, Wrench, Loader2, Check, X } from "lucide-vue-next";
+import { BookOpen, Search, SquareTerminal, Pencil, Brain, Trash2, FolderInput, Globe, Wrench, Loader2, Check, X } from "lucide-vue-next";
 import type { ToolStepDto, ToolStepKind, ToolStepStatus } from "@ganglion/xacpx-relay-protocol";
 
 /** Shared icon tables + a pure step-summarizer for ToolCallPanel. Borrowed from
@@ -12,6 +12,9 @@ export const KIND_ICON: Record<ToolStepKind, Component> = {
   execute: SquareTerminal,
   edit: Pencil,
   think: Brain,
+  delete: Trash2,
+  move: FolderInput,
+  fetch: Globe,
   other: Wrench,
 };
 
@@ -21,7 +24,7 @@ export const STATUS_ICON: Record<ToolStepStatus, Component> = {
   error: X,
 };
 
-const KIND_ORDER: ToolStepKind[] = ["read", "search", "execute", "edit", "think", "other"];
+const KIND_ORDER: ToolStepKind[] = ["read", "search", "execute", "edit", "think", "delete", "move", "fetch", "other"];
 const STATUS_ORDER: ToolStepStatus[] = ["running", "success", "error"];
 
 /** Only long legacy groups need the first-use hint; every group starts collapsed. */

--- a/src/bridge/engine/runtime-engine.ts
+++ b/src/bridge/engine/runtime-engine.ts
@@ -15,7 +15,7 @@ import type { NonInteractivePermissions, PermissionMode } from "../../config/typ
 import type { BridgeEngine, EngineInjectInput, EngineListInput, EnginePromptInput, EnginePromptStreamEvent, EngineSessionInput } from "./bridge-engine";
 import type { PlanEntry, ToolUseEvent, ToolUseKind, ToolUseStatus } from "../../channels/types.js";
 import { formatToolUseEventForText } from "../../transport/tool-use-text-format.js";
-import { summarizeToolInput } from "../../transport/tool-summary.js";
+import { summarizeToolInput, summarizeToolOutput } from "../../transport/tool-summary.js";
 import { readImageFileBounded } from "../../transport/prompt-media.js";
 import { parseSessionEffortRecord } from "../../transport/session-effort.js";
 import type { PromptMediaInput } from "../../transport/types.js";
@@ -2936,8 +2936,12 @@ export function mapRuntimeToolEvent(event: {
   const toolCallId = event.toolCallId || `tc-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   const title = (event.title ?? "").trim();
   const toolName = title || "Tool";
-  const summaryRaw = event.summary || summarizeToolInput(event.rawInput, title) || summarizeToolInput(event.rawOutput, title);
+  const summaryRaw = event.summary || summarizeToolInput(event.rawInput, title) || summarizeToolOutput(event.rawOutput);
   const summary = summaryRaw && summaryRaw !== title ? summaryRaw : undefined;
+  // Note: pinned acpx 0.13.1 Runtime tool_call exposes no _meta, so a status-less
+  // terminal carrying only _meta.claudeCode.toolResponse is indistinguishable from
+  // a keep-alive and stays running; CLI closes it via hasClaudeToolResponse; fixing
+  // needs an upstream contract signal — do NOT change mapping logic.
   const statusRaw = (event.status ?? "").toLowerCase();
   const status: ToolUseStatus =
     statusRaw === "completed" || statusRaw === "success"

--- a/src/bridge/engine/runtime-engine.ts
+++ b/src/bridge/engine/runtime-engine.ts
@@ -15,6 +15,7 @@ import type { NonInteractivePermissions, PermissionMode } from "../../config/typ
 import type { BridgeEngine, EngineInjectInput, EngineListInput, EnginePromptInput, EnginePromptStreamEvent, EngineSessionInput } from "./bridge-engine";
 import type { PlanEntry, ToolUseEvent, ToolUseKind, ToolUseStatus } from "../../channels/types.js";
 import { formatToolUseEventForText } from "../../transport/tool-use-text-format.js";
+import { summarizeToolInput } from "../../transport/tool-summary.js";
 import { readImageFileBounded } from "../../transport/prompt-media.js";
 import { parseSessionEffortRecord } from "../../transport/session-effort.js";
 import type { PromptMediaInput } from "../../transport/types.js";
@@ -2930,10 +2931,13 @@ export function mapRuntimeToolEvent(event: {
   rawInput?: unknown;
   rawOutput?: unknown;
   content?: unknown;
+  summary?: string;
 }): ToolUseEvent {
   const toolCallId = event.toolCallId || `tc-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   const title = (event.title ?? "").trim();
   const toolName = title || "Tool";
+  const summaryRaw = event.summary || summarizeToolInput(event.rawInput, title) || summarizeToolInput(event.rawOutput, title);
+  const summary = summaryRaw && summaryRaw !== title ? summaryRaw : undefined;
   const statusRaw = (event.status ?? "").toLowerCase();
   const status: ToolUseStatus =
     statusRaw === "completed" || statusRaw === "success"
@@ -2941,7 +2945,7 @@ export function mapRuntimeToolEvent(event: {
       : statusRaw === "failed" || statusRaw === "error"
         ? "error"
         : "running";
-  const validKinds = new Set(["read", "search", "execute", "edit", "think", "other"]);
+  const validKinds = new Set(["read", "search", "execute", "edit", "delete", "move", "fetch", "think", "other"]);
   const kind: ToolUseKind =
     typeof event.kind === "string" && validKinds.has(event.kind.toLowerCase())
       ? (event.kind.toLowerCase() as ToolUseKind)
@@ -2952,6 +2956,7 @@ export function mapRuntimeToolEvent(event: {
     toolName,
     kind,
     status,
+    ...(summary ? { summary } : {}),
     ...(event.rawInput !== undefined ? { rawInput: event.rawInput } : {}),
     ...(event.rawOutput !== undefined ? { rawOutput: event.rawOutput } : {}),
     ...(event.content !== undefined ? { content: event.content } : {}),
@@ -3040,29 +3045,4 @@ export function extractTextFromAcpMessage(parsed: Record<string, unknown>): stri
     }
   }
   return results;
-}
-
-function emitPromptEvent(event: XacpxRuntimeEvent, onEvent?: (event: EnginePromptStreamEvent) => void): void {
-  if (!onEvent) return;
-  if (event.type === "text_delta") {
-    onEvent(event.stream === "thought"
-      ? { type: "prompt.thought", text: event.text }
-      : { type: "prompt.segment", text: event.text });
-  } else if (event.type === "tool_call") {
-    onEvent({ type: "prompt.tool_event", event: mapRuntimeToolEvent(event) });
-  } else if (event.type === "status") {
-    // G9: missing usage means unknown, NOT zero. Never fabricate 0 for undefined fields.
-    if (typeof event.used === "number" && typeof event.size === "number") {
-      onEvent({
-        type: "prompt.usage",
-        used: event.used,
-        size: event.size,
-        ...(event.cost ? { cost: event.cost as never } : {}),
-        ...(event.breakdown ? { breakdown: event.breakdown as never } : {}),
-      });
-    }
-    if (event.availableCommands && event.availableCommands.length > 0) {
-      onEvent({ type: "prompt.commands", commands: event.availableCommands.map((command) => ({ name: command.name, description: command.description })) as never });
-    }
-  }
 }

--- a/src/bridge/engine/runtime/runtime-adapter.ts
+++ b/src/bridge/engine/runtime/runtime-adapter.ts
@@ -31,6 +31,15 @@ import type {
   XacpxTurnHandle,
   XacpxTurnResult,
 } from "./runtime-contract";
+import {
+  normalizeRuntimeToolCallEvent,
+  type RuntimeToolCallSnapshot,
+} from "./runtime-tool-call-merge";
+import {
+  createTranscriptTextBoundaryState,
+  markTranscriptActivity,
+  normalizeTranscriptTextChunk,
+} from "../../../transport/transcript-text-boundary.js";
 
 export type XacpxMcpServers = AcpRuntimeOptions["mcpServers"];
 export type XacpxPermissionRequest = AcpPermissionRequest;
@@ -161,10 +170,51 @@ export function createXacpxRuntimeAdapter(options: CreateXacpxRuntimeAdapterOpti
   };
 }
 
-async function* mapEvents(events: AsyncIterable<AcpRuntimeEvent>): AsyncIterable<XacpxRuntimeEvent> {
+function normalizeTextDeltaMeta(
+  meta: unknown,
+): { origin?: string; kind?: string; source?: string } | undefined {
+  if (!meta || typeof meta !== "object") return undefined;
+  const raw = meta as Record<string, unknown>;
+  const result: { origin?: string; kind?: string; source?: string } = {};
+  if (typeof raw.origin === "string" && raw.origin.length > 0) result.origin = raw.origin;
+  if (typeof raw.kind === "string" && raw.kind.length > 0) result.kind = raw.kind;
+  if (typeof raw.source === "string" && raw.source.length > 0) result.source = raw.source;
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export async function* mapEvents(events: AsyncIterable<AcpRuntimeEvent>): AsyncIterable<XacpxRuntimeEvent> {
+  const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+  const textBoundary = createTranscriptTextBoundaryState();
+
   for await (const event of events) {
     if (event.type === "text_delta") {
-      yield { type: "text_delta", text: event.text, ...(event.stream ? { stream: event.stream } : {}) };
+      const isThought = event.stream === "thought";
+      if (isThought) {
+        markTranscriptActivity(textBoundary);
+        const meta = normalizeTextDeltaMeta(event.meta);
+        yield {
+          type: "text_delta",
+          text: event.text,
+          stream: "thought",
+          ...(event.tag ? { tag: event.tag } : {}),
+          ...(event.messageId ? { messageId: event.messageId } : {}),
+          ...(meta ? { meta } : {}),
+        };
+      } else {
+        const text = normalizeTranscriptTextChunk(textBoundary, {
+          text: event.text,
+          messageId: event.messageId,
+        });
+        const meta = normalizeTextDeltaMeta(event.meta);
+        yield {
+          type: "text_delta",
+          text,
+          ...(event.stream ? { stream: event.stream } : {}),
+          ...(event.tag ? { tag: event.tag } : {}),
+          ...(event.messageId ? { messageId: event.messageId } : {}),
+          ...(meta ? { meta } : {}),
+        };
+      }
     } else if (event.type === "status") {
       yield {
         type: "status",
@@ -177,9 +227,16 @@ async function* mapEvents(events: AsyncIterable<AcpRuntimeEvent>): AsyncIterable
         ...(event.availableCommands ? { availableCommands: event.availableCommands } : {}),
       };
     } else if (event.type === "tool_call") {
-      yield {
+      const isInitialToolEvent = typeof event.toolCallId === "string"
+        ? !toolCalls.has(event.toolCallId)
+        : event.tag !== "tool_call_update";
+      if (isInitialToolEvent) {
+        markTranscriptActivity(textBoundary);
+      }
+      yield normalizeRuntimeToolCallEvent(toolCalls, {
         type: "tool_call",
         text: event.text,
+        ...(event.tag ? { tag: event.tag } : {}),
         ...(event.toolCallId ? { toolCallId: event.toolCallId } : {}),
         ...(event.status ? { status: event.status } : {}),
         ...(event.title ? { title: event.title } : {}),
@@ -188,7 +245,7 @@ async function* mapEvents(events: AsyncIterable<AcpRuntimeEvent>): AsyncIterable
         ...(event.rawInput !== undefined ? { rawInput: event.rawInput } : {}),
         ...(event.rawOutput !== undefined ? { rawOutput: event.rawOutput } : {}),
         ...(event.content !== undefined ? { content: event.content } : {}),
-      };
+      });
     }
     // "done"/"error" only surface via runTurn(); startTurn uses .result instead.
   }

--- a/src/bridge/engine/runtime/runtime-contract.ts
+++ b/src/bridge/engine/runtime/runtime-contract.ts
@@ -9,7 +9,22 @@ export type XacpxNonInteractivePermissions = "deny" | "fail";
 
 /** Streamed runtime turn event, shaped for the bridge prompt.* mapping. */
 export type XacpxRuntimeEvent =
-  | { type: "text_delta"; text: string; stream?: "output" | "thought" }
+  | {
+      type: "text_delta";
+      text: string;
+      stream?: "output" | "thought";
+      tag?: string;
+      messageId?: string;
+      /**
+       * Producer-supplied routing hint (e.g. subagent / worker origin);
+       * never use for auth or authorization boundaries.
+       */
+      meta?: {
+        origin?: string;
+        kind?: string;
+        source?: string;
+      };
+    }
   | {
       type: "status";
       text: string;
@@ -23,6 +38,7 @@ export type XacpxRuntimeEvent =
   | {
       type: "tool_call";
       text: string;
+      tag?: string;
       toolCallId?: string;
       status?: string;
       title?: string;

--- a/src/bridge/engine/runtime/runtime-tool-call-merge.ts
+++ b/src/bridge/engine/runtime/runtime-tool-call-merge.ts
@@ -1,0 +1,115 @@
+/**
+ * Per-turn, per-toolCallId snapshot normalization for the Runtime engine (spec §5-§7).
+ * Accumulates sparse delta updates into full snapshots before yielding to the host/worker.
+ */
+
+import type { XacpxRuntimeEvent } from "./runtime-contract.js";
+import { isEmptyToolField } from "../../../transport/tool-summary.js";
+
+export interface RuntimeToolCallSnapshot {
+  type: "tool_call";
+  text: string;
+  tag?: string;
+  toolCallId: string;
+  title?: string;
+  status?: string;
+  kind?: string;
+  locations?: unknown;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+  content?: unknown;
+}
+
+export interface RuntimeToolCallInputEvent {
+  type: "tool_call";
+  text: string;
+  tag?: string;
+  toolCallId?: string;
+  status?: string;
+  title?: string;
+  kind?: string;
+  locations?: unknown;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+  content?: unknown;
+}
+
+export function isMeaningfulTitle(title: unknown): title is string {
+  if (typeof title !== "string") return false;
+  const trimmed = title.trim();
+  return trimmed.length > 0 && trimmed.toLowerCase() !== "tool call";
+}
+
+export function mergeTitle(
+  prevTitle: string | undefined,
+  nextTitle: string | undefined,
+): string | undefined {
+  if (nextTitle === undefined || nextTitle === null || nextTitle.trim().length === 0) {
+    return prevTitle;
+  }
+  const nextTrimmed = nextTitle.trim();
+  if (isMeaningfulTitle(nextTrimmed)) {
+    return nextTrimmed;
+  }
+  // nextTitle is a generic placeholder (e.g. "tool call")
+  if (isMeaningfulTitle(prevTitle)) {
+    return prevTitle;
+  }
+  return nextTrimmed;
+}
+
+export function normalizeRuntimeToolCallEvent(
+  toolCalls: Map<string, RuntimeToolCallSnapshot>,
+  event: RuntimeToolCallInputEvent,
+): XacpxRuntimeEvent {
+  const toolCallId = event.toolCallId;
+  if (!toolCallId) {
+    return {
+      type: "tool_call",
+      text: event.text,
+      ...(event.tag ? { tag: event.tag } : {}),
+      ...(event.status ? { status: event.status } : {}),
+      ...(event.title ? { title: event.title } : {}),
+      ...(event.kind ? { kind: event.kind } : {}),
+      ...(event.locations !== undefined ? { locations: event.locations } : {}),
+      ...(event.rawInput !== undefined ? { rawInput: event.rawInput } : {}),
+      ...(event.rawOutput !== undefined ? { rawOutput: event.rawOutput } : {}),
+      ...(event.content !== undefined ? { content: event.content } : {}),
+    };
+  }
+
+  const prev = toolCalls.get(toolCallId);
+
+  const title = mergeTitle(prev?.title, event.title);
+
+  const text =
+    typeof event.text === "string" && event.text.trim().length > 0
+      ? event.text
+      : (prev?.text ?? event.text ?? "");
+
+  const tag = event.tag ?? prev?.tag;
+
+  const kind = !isEmptyToolField(event.kind) ? event.kind : prev?.kind;
+  const status = !isEmptyToolField(event.status) ? event.status : prev?.status;
+  const rawInput = !isEmptyToolField(event.rawInput) ? event.rawInput : prev?.rawInput;
+  const rawOutput = !isEmptyToolField(event.rawOutput) ? event.rawOutput : prev?.rawOutput;
+  const content = !isEmptyToolField(event.content) ? event.content : prev?.content;
+  const locations = !isEmptyToolField(event.locations) ? event.locations : prev?.locations;
+
+  const snapshot: RuntimeToolCallSnapshot = {
+    type: "tool_call",
+    toolCallId,
+    text,
+    ...(tag ? { tag } : {}),
+    ...(title !== undefined ? { title } : {}),
+    ...(kind !== undefined ? { kind } : {}),
+    ...(status !== undefined ? { status } : {}),
+    ...(rawInput !== undefined ? { rawInput } : {}),
+    ...(rawOutput !== undefined ? { rawOutput } : {}),
+    ...(content !== undefined ? { content } : {}),
+    ...(locations !== undefined ? { locations } : {}),
+  };
+
+  toolCalls.set(toolCallId, snapshot);
+  return snapshot;
+}

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -246,7 +246,15 @@ export type ToolUseStatus = "running" | "success" | "error";
 // Matches the kinds emitted by acpx via streaming-prompt.ts KIND_EMOJI.
 // Any kind the transport doesn't recognize maps to "other".
 export type ToolUseKind =
-  "read" | "search" | "execute" | "edit" | "think" | "other";
+  | "read"
+  | "search"
+  | "execute"
+  | "edit"
+  | "delete"
+  | "move"
+  | "fetch"
+  | "think"
+  | "other";
 
 export interface ToolUseEvent {
   toolCallId: string;

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -8,6 +8,7 @@ import {
   isRecord,
   isEmptyToolField,
   summarizeToolInput,
+  summarizeToolOutput,
   summarizeTaskInput,
   cursorToolInput,
   readFirstString,
@@ -369,7 +370,7 @@ function formatToolCallEvent(update: NonNullable<StreamEvent["params"]>["update"
   // For tool_call_update, the useful payload is often in rawOutput rather
   // than rawInput (e.g. terminal command stdout). Fall back to rawOutput
   // when rawInput yields nothing actionable.
-  const inputSummary = summarizeToolInput(update.rawInput, title) || summarizeToolInput(update.rawOutput, title);
+  const inputSummary = summarizeToolInput(update.rawInput, title) || summarizeToolOutput(update.rawOutput);
   const status = readString(update, "status");
 
   // Some agents first emit a placeholder pending tool_call (for example
@@ -446,7 +447,7 @@ function buildToolUseEvent(
   // For tool_call_update, the useful payload is often in rawOutput rather
   // than rawInput (e.g. terminal command stdout). Fall back to rawOutput
   // when rawInput yields nothing actionable.
-  const summaryRaw = summarizeToolInput(update.rawInput, title) || summarizeToolInput(update.rawOutput, title);
+  const summaryRaw = summarizeToolInput(update.rawInput, title) || summarizeToolOutput(update.rawOutput);
   const summary = summaryRaw && summaryRaw !== title ? summaryRaw : undefined;
   const statusRaw = readString(update, "status");
   // claude-agent-acp sometimes emits a sparse terminal update after the prompt

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -8,7 +8,6 @@ import {
   isRecord,
   isEmptyToolField,
   summarizeToolInput,
-  summarizeToolOutput,
   summarizeTaskInput,
   cursorToolInput,
   readFirstString,
@@ -370,7 +369,7 @@ function formatToolCallEvent(update: NonNullable<StreamEvent["params"]>["update"
   // For tool_call_update, the useful payload is often in rawOutput rather
   // than rawInput (e.g. terminal command stdout). Fall back to rawOutput
   // when rawInput yields nothing actionable.
-  const inputSummary = summarizeToolInput(update.rawInput, title) || summarizeToolOutput(update.rawOutput);
+  const inputSummary = summarizeToolInput(update.rawInput, title) || summarizeToolInput(update.rawOutput, title);
   const status = readString(update, "status");
 
   // Some agents first emit a placeholder pending tool_call (for example
@@ -447,7 +446,7 @@ function buildToolUseEvent(
   // For tool_call_update, the useful payload is often in rawOutput rather
   // than rawInput (e.g. terminal command stdout). Fall back to rawOutput
   // when rawInput yields nothing actionable.
-  const summaryRaw = summarizeToolInput(update.rawInput, title) || summarizeToolOutput(update.rawOutput);
+  const summaryRaw = summarizeToolInput(update.rawInput, title) || summarizeToolInput(update.rawOutput, title);
   const summary = summaryRaw && summaryRaw !== title ? summaryRaw : undefined;
   const statusRaw = readString(update, "status");
   // claude-agent-acp sometimes emits a sparse terminal update after the prompt

--- a/src/transport/streaming-prompt.ts
+++ b/src/transport/streaming-prompt.ts
@@ -4,11 +4,25 @@ import { isAsyncAgentLaunchOutput } from "./background-followup.js";
 import { resolveToolEventMode } from "./tool-event-mode.js";
 import type { ToolEventMode } from "./tool-event-mode.js";
 import { TOOL_KIND_EMOJI, DEFAULT_TOOL_EMOJI } from "./tool-kind-emoji.js";
+import {
+  isRecord,
+  isEmptyToolField,
+  summarizeToolInput,
+  summarizeTaskInput,
+  cursorToolInput,
+  readFirstString,
+  readFirstStringArray,
+} from "./tool-summary.js";
+import {
+  createTranscriptTextBoundaryState,
+  markTranscriptActivity,
+  normalizeTranscriptTextChunk,
+  type TranscriptTextBoundaryState,
+} from "./transcript-text-boundary.js";
 
-export interface StreamingPromptState {
+export interface StreamingPromptState extends TranscriptTextBoundaryState {
   buffer: string;
   segments: string[];
-  hasAgentMessage: boolean;
   pendingLine: string;
   formatToolCalls: boolean;
   emittedToolCallIds: Set<string>;
@@ -30,9 +44,6 @@ export interface StreamingPromptState {
   // trades the batched paragraph model (good for discrete chat messages) for low
   // first-token latency and smooth token streaming.
   rawStream: boolean;
-  lastMessageId?: string;
-  lastTextTail: string;
-  activitySinceLastText: boolean;
   onBeforeActivityEvent?: () => void;
   onToolEvent?: (event: ToolUseEvent) => void | Promise<void>;
   onThought?: (chunk: string) => void | Promise<void>;
@@ -140,9 +151,9 @@ export function createStreamingPromptState(
   }
 
   return {
+    ...createTranscriptTextBoundaryState(),
     buffer: "",
     segments: [],
-    hasAgentMessage: false,
     pendingLine: "",
     formatToolCalls,
     emittedToolCallIds: new Set(),
@@ -152,8 +163,6 @@ export function createStreamingPromptState(
     toolEventMode,
     driver,
     rawStream,
-    lastTextTail: "",
-    activitySinceLastText: false,
     onBeforeActivityEvent,
     onToolEvent,
     onThought,
@@ -315,31 +324,15 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
 
   if (!isMessageChunk) return;
 
-  state.hasAgentMessage = true;
-  let chunk = update.content!.text ?? "";
-  if (chunk.length === 0) return;
+  const rawChunk = update.content!.text ?? "";
+  if (rawChunk.length === 0) return;
 
-  const messageId =
-    typeof update.messageId === "string" && update.messageId.length > 0
-      ? update.messageId
-      : undefined;
-  const messageIdChanged =
-    state.lastMessageId !== undefined &&
-    messageId !== undefined &&
-    state.lastMessageId !== messageId;
-  const fallbackBoundary =
-    state.activitySinceLastText &&
-    (state.lastMessageId === undefined || messageId === undefined) &&
-    endsWithSentenceTerminal(state.lastTextTail);
-  if ((messageIdChanged || fallbackBoundary) && !hasParagraphBoundaryAtJoin(state.lastTextTail, chunk)) {
-    chunk = `\n\n${chunk}`;
-    state.lastTextTail = "";
-  }
+  const chunk = normalizeTranscriptTextChunk(state, {
+    text: rawChunk,
+    messageId: update.messageId,
+  });
 
   state.buffer += chunk;
-  state.lastMessageId = messageId;
-  state.activitySinceLastText = false;
-  state.lastTextTail = `${state.lastTextTail}${chunk}`.slice(-256);
 
   // Raw streaming: leave the text in `buffer` untouched — the transport's short flush
   // timer drains it verbatim, so paragraph structure is preserved without splitting.
@@ -356,33 +349,10 @@ export function parseStreamingChunks(state: StreamingPromptState, line: string):
   }
 }
 
-const SENTENCE_TERMINAL_AT_END =
-  /(?:\p{Sentence_Terminal}|…|⋯)[\p{Close_Punctuation}\p{Final_Punctuation}"“”‘’*_~`]*$/u;
-const PARAGRAPH_BOUNDARY_AT_END = /\r?\n[\t ]*\r?\n[\t ]*$/;
-const PARAGRAPH_BOUNDARY_AT_START = /^[\t ]*\r?\n[\t ]*\r?\n/;
-const LINE_BREAK_AT_END = /\r?\n[\t ]*$/;
-const LINE_BREAK_AT_START = /^[\t ]*\r?\n/;
-const PARTIAL_CRLF_PARAGRAPH_BOUNDARY_AT_END = /\r?\n[\t ]*\r$/;
-
-function endsWithSentenceTerminal(text: string): boolean {
-  return SENTENCE_TERMINAL_AT_END.test(text.trimEnd());
-}
-
-function hasParagraphBoundaryAtJoin(left: string, right: string): boolean {
-  const leftHasBoundary = PARAGRAPH_BOUNDARY_AT_END.test(left);
-  const rightHasBoundary = PARAGRAPH_BOUNDARY_AT_START.test(right);
-  const boundarySpansJoin =
-    LINE_BREAK_AT_END.test(left) &&
-    LINE_BREAK_AT_START.test(right);
-  const crlfBoundarySpansJoin =
-    PARTIAL_CRLF_PARAGRAPH_BOUNDARY_AT_END.test(left) &&
-    right.startsWith("\n");
-  return leftHasBoundary || rightHasBoundary || boundarySpansJoin || crlfBoundarySpansJoin;
-}
 
 function markActivityBoundary(state: StreamingPromptState): void {
   flushBeforeActivityEvent(state);
-  state.activitySinceLastText = state.hasAgentMessage;
+  markTranscriptActivity(state);
 }
 
 function flushBeforeActivityEvent(state: StreamingPromptState): void {
@@ -417,17 +387,6 @@ function formatToolCallEvent(update: NonNullable<StreamEvent["params"]>["update"
 /** Accumulated raw tool-call fields across partial ACP `tool_call_update` frames. */
 export type MergedToolUpdate = NonNullable<NonNullable<StreamEvent["params"]>["update"]>;
 
-/** True for values that carry no information and so must NOT clobber a prior value:
- *  undefined/null, blank strings, and empty objects/arrays. acpx's initial `tool_call`
- *  frame ships empty `content: []` / `rawInput: {}`, and a terminal frame omits fields
- *  entirely — neither should erase data a richer in-progress frame already supplied. */
-function isEmptyToolField(v: unknown): boolean {
-  if (v === undefined || v === null) return true;
-  if (typeof v === "string") return v.trim().length === 0;
-  if (Array.isArray(v)) return v.length === 0;
-  if (typeof v === "object") return Object.keys(v as object).length === 0;
-  return false;
-}
 
 /** Merge a partial update into the per-toolCallId accumulator (present, non-empty
  *  fields override; absent/empty fields keep the prior value) and return the merged
@@ -720,16 +679,10 @@ function normalizePlanPriority(value: unknown): PlanEntry["priority"] | undefine
   return value;
 }
 
-function cursorToolInput(rawInput: unknown): Record<string, unknown> | undefined {
-  if (!isRecord(rawInput)) return undefined;
-  if (isRecord(rawInput.args)) return rawInput.args;
-  return rawInput;
-}
 
 function normalizeCursorToolName(title: string | undefined): string {
   return (title ?? "").trim().toLowerCase().replace(/[\s_-]+/g, "");
 }
-
 /** cursor-agent labels a call with a display `title` ("Update TODOs", "Read File")
  *  and puts the machine name in `rawInput._toolName` ("updateTodos"). Match on the
  *  machine name first — the display title is prose and varies between releases. */
@@ -749,7 +702,7 @@ function normalizeToolKind(
 ): ToolUseKind {
   const kindRaw = update?.kind?.trim().toLowerCase() ?? "";
   switch (kindRaw) {
-    case "read": case "search": case "execute": case "edit": case "think": return kindRaw;
+    case "read": case "search": case "execute": case "edit": case "delete": case "move": case "fetch": case "think": return kindRaw;
   }
   if (driver !== "cursor") return "other";
   switch (cursorToolIdentity(update ?? {})) {
@@ -794,7 +747,6 @@ function isCursorSubagentInput(rawInput: unknown, title: string): boolean {
   return input !== undefined
     && readFirstString(input, ["subagent_type", "subagentType", "agent", "agentType", "prompt", "instructions"]) !== undefined;
 }
-
 function isKimiSubagentInput(rawInput: unknown): boolean {
   return isRecord(rawInput)
     && readFirstString(rawInput, ["prompt"]) !== undefined
@@ -808,105 +760,6 @@ function isCodexSubagentMeta(meta: { threadId?: string; activity?: string } | un
     && meta.activity.trim().length > 0;
 }
 
-function summarizeToolInput(rawInput: unknown, title = ""): string | undefined {
-  if (rawInput == null) return undefined;
-  if (typeof rawInput === "string" || typeof rawInput === "number" || typeof rawInput === "boolean") {
-    return String(rawInput);
-  }
-  if (!isRecord(rawInput)) return undefined;
-
-  const nestedInput = cursorToolInput(rawInput);
-  if (nestedInput !== rawInput) {
-    const nestedSummary = summarizeToolInput(nestedInput, title);
-    if (nestedSummary) return nestedSummary;
-  }
-
-  const taskSummary = summarizeTaskInput(rawInput, title);
-  if (taskSummary) return taskSummary;
-
-  const command = readFirstString(rawInput, ["command", "cmd", "program"]);
-  const args = readFirstStringArray(rawInput, ["args", "arguments"]);
-  if (command) {
-    return [command, ...(args ?? [])].join(" ");
-  }
-
-  const parsedCmd = rawInput.parsed_cmd;
-  if (Array.isArray(parsedCmd) && parsedCmd.length > 0) {
-    const parts: string[] = [];
-    for (const entry of parsedCmd) {
-      if (isRecord(entry) && typeof entry.cmd === "string" && entry.cmd.length > 0) {
-        parts.push(entry.cmd);
-      }
-    }
-    if (parts.length > 0) {
-      return parts.join(" ");
-    }
-  }
-
-  const globPattern = readFirstString(rawInput, ["glob_pattern"]);
-  if (globPattern) {
-    const targetDirectory = readFirstString(rawInput, ["target_directory"]);
-    return targetDirectory ? `${globPattern} in ${targetDirectory}` : globPattern;
-  }
-
-  const mode = readFirstString(rawInput, ["target_mode_id", "mode_id"]);
-  const explanation = readFirstString(rawInput, ["explanation"]);
-  if (mode || explanation) {
-    return mode && explanation ? `${mode}: ${explanation}` : mode ?? explanation;
-  }
-
-  return readFirstString(rawInput, [
-    "path",
-    "file",
-    "filePath",
-    "filepath",
-    "file_path",
-    "target",
-    "uri",
-    "url",
-    "query",
-    "pattern",
-    "text",
-    "search",
-    "working_directory",
-    "name",
-    "description",
-  ]);
-}
-
-function summarizeTaskInput(rawInput: Record<string, unknown>, title: string): string | undefined {
-  const subagentType = readFirstString(rawInput, ["subagent_type", "subagentType", "agent", "agentType"]);
-  const description = readFirstString(rawInput, ["description", "task", "summary"]);
-  if (subagentType && description) {
-    return description === title ? subagentType : `${subagentType}: ${description}`;
-  }
-  if (subagentType) return subagentType;
-  return undefined;
-}
-
-function readFirstString(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value.trim();
-    }
-  }
-  return undefined;
-}
-
-function readFirstStringArray(record: Record<string, unknown>, keys: readonly string[]): string[] | undefined {
-  for (const key of keys) {
-    const value = record[key];
-    if (!Array.isArray(value)) continue;
-    const entries = value
-      .map((entry) => (typeof entry === "string" && entry.trim().length > 0 ? entry.trim() : undefined))
-      .filter((entry): entry is string => entry !== undefined);
-    if (entries.length > 0) {
-      return entries;
-    }
-  }
-  return undefined;
-}
 
 const USAGE_BREAKDOWN_FIELDS: ReadonlyArray<readonly [keyof UsageBreakdown, readonly string[]]> = [
   ["inputTokens", ["inputTokens", "input_tokens"]],
@@ -960,9 +813,6 @@ function normalizeAgentCommands(value: unknown): AgentCommand[] {
   return out;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function readString(rawInput: unknown, key: string): string | undefined {
   if (!isRecord(rawInput)) return undefined;

--- a/src/transport/tool-kind-emoji.ts
+++ b/src/transport/tool-kind-emoji.ts
@@ -5,6 +5,9 @@ export const TOOL_KIND_EMOJI: Record<ToolUseKind, string> = {
   search: "\u{1F50D}",
   execute: "\u{1F4BB}",
   edit: "\u{270F}\u{FE0F}",
+  delete: "\u{1F5D1}\u{FE0F}",
+  move: "\u{1F4E6}",
+  fetch: "\u{1F310}",
   think: "\u{1F9E0}",
   other: "\u{1F527}",
 };

--- a/src/transport/tool-summary.ts
+++ b/src/transport/tool-summary.ts
@@ -122,10 +122,40 @@ export function summarizeToolInput(rawInput: unknown, title = ""): string | unde
     "working_directory",
     "name",
     "description",
-    "output",
-    "stdout",
-    "formatted_output",
-    "result",
-    "message",
   ]);
+}
+
+export const TOOL_OUTPUT_SUMMARY_MAX_CHARS = 500;
+
+export function summarizeToolOutput(rawOutput: unknown): string | undefined {
+  if (rawOutput == null) return undefined;
+  if (typeof rawOutput === "string" || typeof rawOutput === "number" || typeof rawOutput === "boolean") {
+    const text = String(rawOutput).trim();
+    if (!text) return undefined;
+    return text.length > TOOL_OUTPUT_SUMMARY_MAX_CHARS ? text.slice(0, TOOL_OUTPUT_SUMMARY_MAX_CHARS) : text;
+  }
+  if (!isRecord(rawOutput)) return undefined;
+
+  const direct = readFirstString(rawOutput, ["text", "message", "error", "stdout", "stderr", "content"]);
+  if (direct) {
+    return direct.length > TOOL_OUTPUT_SUMMARY_MAX_CHARS ? direct.slice(0, TOOL_OUTPUT_SUMMARY_MAX_CHARS) : direct;
+  }
+
+  if (Array.isArray(rawOutput.content)) {
+    const parts: string[] = [];
+    for (const item of rawOutput.content) {
+      if (typeof item === "string" && item.trim().length > 0) {
+        parts.push(item.trim());
+      } else if (isRecord(item)) {
+        const itemText = readFirstString(item, ["text", "content"]);
+        if (itemText) parts.push(itemText);
+      }
+    }
+    if (parts.length > 0) {
+      const text = parts.join("\n");
+      return text.length > TOOL_OUTPUT_SUMMARY_MAX_CHARS ? text.slice(0, TOOL_OUTPUT_SUMMARY_MAX_CHARS) : text;
+    }
+  }
+
+  return undefined;
 }

--- a/src/transport/tool-summary.ts
+++ b/src/transport/tool-summary.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared tool input summarization and emptiness guards for CLI and Runtime
+ * transport pipelines (normalization spec §9).
+ */
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** True for values that carry no information and so must NOT clobber a prior value:
+ *  undefined/null, blank strings, and empty objects/arrays. acpx's initial `tool_call`
+ *  frame ships empty `content: []` / `rawInput: {}`, and a terminal frame omits fields
+ *  entirely — neither should erase data a richer in-progress frame already supplied. */
+export function isEmptyToolField(v: unknown): boolean {
+  if (v === undefined || v === null) return true;
+  if (typeof v === "string") return v.trim().length === 0;
+  if (Array.isArray(v)) return v.length === 0;
+  if (typeof v === "object") return Object.keys(v as object).length === 0;
+  return false;
+}
+
+export function cursorToolInput(rawInput: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(rawInput)) return undefined;
+  if (isRecord(rawInput.args)) return rawInput.args;
+  return rawInput;
+}
+
+export function readFirstString(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+export function readFirstStringArray(record: Record<string, unknown>, keys: readonly string[]): string[] | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (!Array.isArray(value)) continue;
+    const entries = value
+      .map((entry) => (typeof entry === "string" && entry.trim().length > 0 ? entry.trim() : undefined))
+      .filter((entry): entry is string => entry !== undefined);
+    if (entries.length > 0) {
+      return entries;
+    }
+  }
+  return undefined;
+}
+
+export function summarizeTaskInput(rawInput: Record<string, unknown>, title: string): string | undefined {
+  const subagentType = readFirstString(rawInput, ["subagent_type", "subagentType", "agent", "agentType"]);
+  const description = readFirstString(rawInput, ["description", "task", "summary"]);
+  if (subagentType && description) {
+    return description === title ? subagentType : `${subagentType}: ${description}`;
+  }
+  if (subagentType) return subagentType;
+  return undefined;
+}
+
+export function summarizeToolInput(rawInput: unknown, title = ""): string | undefined {
+  if (rawInput == null) return undefined;
+  if (typeof rawInput === "string" || typeof rawInput === "number" || typeof rawInput === "boolean") {
+    return String(rawInput);
+  }
+  if (!isRecord(rawInput)) return undefined;
+
+  const nestedInput = cursorToolInput(rawInput);
+  if (nestedInput !== rawInput) {
+    const nestedSummary = summarizeToolInput(nestedInput, title);
+    if (nestedSummary) return nestedSummary;
+  }
+
+  const taskSummary = summarizeTaskInput(rawInput, title);
+  if (taskSummary) return taskSummary;
+
+  const command = readFirstString(rawInput, ["command", "cmd", "program"]);
+  const args = readFirstStringArray(rawInput, ["args", "arguments"]);
+  if (command) {
+    return [command, ...(args ?? [])].join(" ");
+  }
+
+  const parsedCmd = rawInput.parsed_cmd;
+  if (Array.isArray(parsedCmd) && parsedCmd.length > 0) {
+    const parts: string[] = [];
+    for (const entry of parsedCmd) {
+      if (isRecord(entry) && typeof entry.cmd === "string" && entry.cmd.length > 0) {
+        parts.push(entry.cmd);
+      }
+    }
+    if (parts.length > 0) {
+      return parts.join(" ");
+    }
+  }
+
+  const globPattern = readFirstString(rawInput, ["glob_pattern"]);
+  if (globPattern) {
+    const targetDirectory = readFirstString(rawInput, ["target_directory"]);
+    return targetDirectory ? `${globPattern} in ${targetDirectory}` : globPattern;
+  }
+
+  const mode = readFirstString(rawInput, ["target_mode_id", "mode_id"]);
+  const explanation = readFirstString(rawInput, ["explanation"]);
+  if (mode || explanation) {
+    return mode && explanation ? `${mode}: ${explanation}` : mode ?? explanation;
+  }
+
+  return readFirstString(rawInput, [
+    "path",
+    "file",
+    "filePath",
+    "filepath",
+    "file_path",
+    "target",
+    "uri",
+    "url",
+    "query",
+    "pattern",
+    "text",
+    "search",
+    "working_directory",
+    "name",
+    "description",
+    "output",
+    "stdout",
+    "formatted_output",
+    "result",
+    "message",
+  ]);
+}

--- a/src/transport/transcript-text-boundary.ts
+++ b/src/transport/transcript-text-boundary.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared state machine for transcript text boundary normalization (spec §26-§27).
+ * Reconstructs logical agent message paragraph boundaries across raw streaming
+ * chunks, messageId transitions, and activity (tool/thought) interruptions.
+ */
+
+export interface TranscriptTextBoundaryState {
+  hasAgentMessage: boolean;
+  lastMessageId?: string;
+  lastTextTail: string;
+  activitySinceLastText: boolean;
+}
+
+export function createTranscriptTextBoundaryState(): TranscriptTextBoundaryState {
+  return {
+    hasAgentMessage: false,
+    lastMessageId: undefined,
+    lastTextTail: "",
+    activitySinceLastText: false,
+  };
+}
+
+export function markTranscriptActivity(state: TranscriptTextBoundaryState): void {
+  state.activitySinceLastText = state.hasAgentMessage;
+}
+
+const SENTENCE_TERMINAL_AT_END =
+  /(?:\p{Sentence_Terminal}|…|⋯)[\p{Close_Punctuation}\p{Final_Punctuation}"“”‘’*_~`]*$/u;
+const PARAGRAPH_BOUNDARY_AT_END = /\r?\n[\t ]*\r?\n[\t ]*$/;
+const PARAGRAPH_BOUNDARY_AT_START = /^[\t ]*\r?\n[\t ]*\r?\n/;
+const LINE_BREAK_AT_END = /\r?\n[\t ]*$/;
+const LINE_BREAK_AT_START = /^[\t ]*\r?\n/;
+const PARTIAL_CRLF_PARAGRAPH_BOUNDARY_AT_END = /\r?\n[\t ]*\r$/;
+
+export function endsWithSentenceTerminal(text: string): boolean {
+  return SENTENCE_TERMINAL_AT_END.test(text.trimEnd());
+}
+
+export function hasParagraphBoundaryAtJoin(left: string, right: string): boolean {
+  const leftHasBoundary = PARAGRAPH_BOUNDARY_AT_END.test(left);
+  const rightHasBoundary = PARAGRAPH_BOUNDARY_AT_START.test(right);
+  const boundarySpansJoin =
+    LINE_BREAK_AT_END.test(left) &&
+    LINE_BREAK_AT_START.test(right);
+  const crlfBoundarySpansJoin =
+    PARTIAL_CRLF_PARAGRAPH_BOUNDARY_AT_END.test(left) &&
+    right.startsWith("\n");
+  return leftHasBoundary || rightHasBoundary || boundarySpansJoin || crlfBoundarySpansJoin;
+}
+
+export function normalizeTranscriptTextChunk(
+  state: TranscriptTextBoundaryState,
+  input: {
+    text: string;
+    messageId?: string;
+  },
+): string {
+  state.hasAgentMessage = true;
+  let chunk = input.text;
+  if (chunk.length === 0) return chunk;
+
+  const messageId =
+    typeof input.messageId === "string" && input.messageId.length > 0
+      ? input.messageId
+      : undefined;
+  const messageIdChanged =
+    state.lastMessageId !== undefined &&
+    messageId !== undefined &&
+    state.lastMessageId !== messageId;
+  const fallbackBoundary =
+    state.activitySinceLastText &&
+    (state.lastMessageId === undefined || messageId === undefined) &&
+    endsWithSentenceTerminal(state.lastTextTail);
+  if ((messageIdChanged || fallbackBoundary) && !hasParagraphBoundaryAtJoin(state.lastTextTail, chunk)) {
+    chunk = `\n\n${chunk}`;
+    state.lastTextTail = "";
+  }
+
+  state.lastMessageId = messageId;
+  state.activitySinceLastText = false;
+  state.lastTextTail = `${state.lastTextTail}${chunk}`.slice(-256);
+
+  return chunk;
+}

--- a/tests/unit/bridge/bridge-runtime-free-warm-process.test.ts
+++ b/tests/unit/bridge/bridge-runtime-free-warm-process.test.ts
@@ -1,11 +1,12 @@
 import { test, expect, mock } from "bun:test";
+import { AcpxQueueOwnerLauncher } from "../../../src/transport/acpx-queue-owner-launcher";
 
 const terminate = mock(async (_sessionId: string) => {});
 // Stub the launcher helper; bridge-runtime imports it from
 // "../transport/acpx-queue-owner-launcher". Re-export AcpxQueueOwnerLauncher so
 // the runtime's other import from that module still resolves.
 mock.module("../../../src/transport/acpx-queue-owner-launcher", () => ({
-  AcpxQueueOwnerLauncher: class {},
+  AcpxQueueOwnerLauncher,
   terminateAcpxQueueOwner: terminate,
 }));
 

--- a/tests/unit/bridge/engine/runtime/runtime-engine-tool-event.test.ts
+++ b/tests/unit/bridge/engine/runtime/runtime-engine-tool-event.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { mapRuntimeToolEvent } from "../../../../../src/bridge/engine/runtime-engine";
+
+describe("RuntimeEngine mapRuntimeToolEvent (spec §9-§10, §13B)", () => {
+  test("derives summary from rawInput and excludes summary when equal to title", () => {
+    // rawInput has path
+    const event1 = mapRuntimeToolEvent({
+      toolCallId: "call-1",
+      title: "Read",
+      kind: "read",
+      status: "completed",
+      rawInput: { path: "/src/main.ts" },
+    });
+
+    expect(event1).toMatchObject({
+      toolCallId: "call-1",
+      toolName: "Read",
+      kind: "read",
+      status: "success",
+      summary: "/src/main.ts",
+      rawInput: { path: "/src/main.ts" },
+    });
+
+    // When summary equals title, summary is omitted (dedup)
+    const event2 = mapRuntimeToolEvent({
+      toolCallId: "call-2",
+      title: "my-command",
+      kind: "execute",
+      status: "completed",
+      rawInput: { command: "my-command" },
+    });
+
+    expect(event2.toolName).toBe("my-command");
+    expect(event2.summary).toBeUndefined();
+  });
+
+  test("falls back to rawOutput when rawInput yields no summary", () => {
+    const event = mapRuntimeToolEvent({
+      toolCallId: "call-3",
+      title: "Bash",
+      kind: "execute",
+      status: "completed",
+      rawOutput: { stdout: "build succeeded" },
+    });
+
+    expect(event.summary).toBe("build succeeded");
+  });
+
+  test("preserves both rawInput and rawOutput on the mapped ToolUseEvent", () => {
+    const event = mapRuntimeToolEvent({
+      toolCallId: "call-4",
+      title: "Bash",
+      kind: "execute",
+      status: "completed",
+      rawInput: { command: "bun test" },
+      rawOutput: { formatted_output: "10 passed", exit_code: 0 },
+    });
+
+    expect(event.rawInput).toEqual({ command: "bun test" });
+    expect(event.rawOutput).toEqual({ formatted_output: "10 passed", exit_code: 0 });
+    expect(event.status).toBe("success");
+  });
+
+  test("maps statuses correctly (completed/success -> success, failed/error -> error, running -> running)", () => {
+    expect(mapRuntimeToolEvent({ status: "completed" }).status).toBe("success");
+    expect(mapRuntimeToolEvent({ status: "SUCCESS" }).status).toBe("success");
+    expect(mapRuntimeToolEvent({ status: "failed" }).status).toBe("error");
+    expect(mapRuntimeToolEvent({ status: "Error" }).status).toBe("error");
+    expect(mapRuntimeToolEvent({ status: "in_progress" }).status).toBe("running");
+    expect(mapRuntimeToolEvent({ status: undefined }).status).toBe("running");
+  });
+
+  // Spec Test 10 — kind parity
+  test("Test 10: kind parity preserves delete, move, and fetch without downgrading to other", () => {
+    const deleteEvent = mapRuntimeToolEvent({
+      toolCallId: "del-1",
+      title: "Delete",
+      kind: "delete",
+      rawInput: { file_path: "temp.txt" },
+    });
+    expect(deleteEvent.kind).toBe("delete");
+
+    const moveEvent = mapRuntimeToolEvent({
+      toolCallId: "mv-1",
+      title: "Move",
+      kind: "move",
+      rawInput: { source: "a.txt", destination: "b.txt" },
+    });
+    expect(moveEvent.kind).toBe("move");
+
+    const fetchEvent = mapRuntimeToolEvent({
+      toolCallId: "fetch-1",
+      title: "Fetch",
+      kind: "fetch",
+      rawInput: { url: "https://example.com/api" },
+    });
+    expect(fetchEvent.kind).toBe("fetch");
+  });
+});

--- a/tests/unit/bridge/engine/runtime/runtime-text-parity.test.ts
+++ b/tests/unit/bridge/engine/runtime/runtime-text-parity.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, test } from "bun:test";
+import { mapEvents } from "../../../../../src/bridge/engine/runtime/runtime-adapter";
+import type { AcpRuntimeEvent } from "acpx/runtime";
+import type { XacpxRuntimeEvent } from "../../../../../src/bridge/engine/runtime/runtime-contract";
+
+async function collectEvents(events: AsyncIterable<AcpRuntimeEvent>): Promise<XacpxRuntimeEvent[]> {
+  const result: XacpxRuntimeEvent[] = [];
+  for await (const event of mapEvents(events)) {
+    result.push(event);
+  }
+  return result;
+}
+
+async function* asyncStream<T>(items: T[]): AsyncIterable<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+describe("Runtime Text / Ordered Transcript Parity (spec §25-§33)", () => {
+  // Spec T1 — Runtime forwards text metadata
+  test("T1: Runtime forwards text metadata (tag, messageId, meta allowlist)", async () => {
+    const inputEvents: AcpRuntimeEvent[] = [
+      {
+        type: "text_delta",
+        text: "Hello from worker",
+        tag: "agent_message_chunk" as never,
+        messageId: "m1",
+        meta: {
+          origin: "subagent",
+          kind: "explore",
+          source: "worker",
+          // Non-allowlisted / extra fields that must be stripped
+          secretKey: "forbidden",
+        } as never,
+      },
+    ];
+
+    const mapped = await collectEvents(asyncStream(inputEvents));
+    expect(mapped).toHaveLength(1);
+    const event = mapped[0];
+    expect(event.type).toBe("text_delta");
+    if (event.type === "text_delta") {
+      expect(event.text).toBe("Hello from worker");
+      expect(event.tag).toBe("agent_message_chunk");
+      expect(event.messageId).toBe("m1");
+      expect(event.meta).toEqual({
+        origin: "subagent",
+        kind: "explore",
+        source: "worker",
+      });
+      // Ensure extra keys are not present
+      expect((event.meta as Record<string, unknown>).secretKey).toBeUndefined();
+    }
+  });
+
+  // Spec T2 — Same message stays contiguous
+  test("T2: Same message stays contiguous without inserting paragraph breaks", async () => {
+    const inputEvents: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "Hello ", messageId: "m1" },
+      { type: "text_delta", text: "world.", messageId: "m1" },
+    ];
+
+    const mapped = await collectEvents(asyncStream(inputEvents));
+    expect(mapped).toHaveLength(2);
+    expect(mapped.map((e) => (e.type === "text_delta" ? e.text : "")).join("")).toBe("Hello world.");
+    expect(mapped[0]).toMatchObject({ type: "text_delta", text: "Hello " });
+    expect(mapped[1]).toMatchObject({ type: "text_delta", text: "world." });
+  });
+
+  // Spec T3 — Different messageIds regain paragraph
+  test("T3: Different messageIds regain paragraph separation", async () => {
+    const inputEvents: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "One.", messageId: "m1" },
+      { type: "text_delta", text: "Two.", messageId: "m2" },
+    ];
+
+    const mapped = await collectEvents(asyncStream(inputEvents));
+    expect(mapped).toHaveLength(2);
+    expect(mapped[0]).toMatchObject({ type: "text_delta", text: "One." });
+    expect(mapped[1]).toMatchObject({ type: "text_delta", text: "\n\nTwo." });
+    expect(mapped.map((e) => (e.type === "text_delta" ? e.text : "")).join("")).toBe("One.\n\nTwo.");
+  });
+
+  // Spec T4 — Existing paragraph is not duplicated
+  test("T4: Existing paragraph boundary is not duplicated when messageId changes", async () => {
+    // Case 1: Trailing \n\n on first message
+    const inputEvents1: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "One.\n\n", messageId: "m1" },
+      { type: "text_delta", text: "Two.", messageId: "m2" },
+    ];
+    const mapped1 = await collectEvents(asyncStream(inputEvents1));
+    expect(mapped1[0]).toMatchObject({ type: "text_delta", text: "One.\n\n" });
+    expect(mapped1[1]).toMatchObject({ type: "text_delta", text: "Two." });
+    expect(mapped1.map((e) => (e.type === "text_delta" ? e.text : "")).join("")).toBe("One.\n\nTwo.");
+
+    // Case 2: Boundary split across join
+    const inputEvents2: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "One.\n", messageId: "m1" },
+      { type: "text_delta", text: "\nTwo.", messageId: "m2" },
+    ];
+    const mapped2 = await collectEvents(asyncStream(inputEvents2));
+    expect(mapped2[0]).toMatchObject({ type: "text_delta", text: "One.\n" });
+    expect(mapped2[1]).toMatchObject({ type: "text_delta", text: "\nTwo." });
+    expect(mapped2.map((e) => (e.type === "text_delta" ? e.text : "")).join("")).toBe("One.\n\nTwo.");
+  });
+
+  // Spec T5 — Tool activity fallback without messageId
+  test("T5: Tool activity fallback inserts paragraph when messageId is absent and text ends with sentence terminal", async () => {
+    const inputEvents: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "I'll inspect it." },
+      {
+        type: "tool_call",
+        text: "reading",
+        toolCallId: "tool-1",
+        title: "Read",
+        kind: "read" as never,
+        rawInput: { path: "src/foo.ts" },
+      },
+      { type: "text_delta", text: "Found it." },
+    ];
+
+    const mapped = await collectEvents(asyncStream(inputEvents));
+    expect(mapped).toHaveLength(3);
+    expect(mapped[0]).toMatchObject({ type: "text_delta", text: "I'll inspect it." });
+    expect(mapped[1]).toMatchObject({ type: "tool_call", toolCallId: "tool-1" });
+    expect(mapped[2]).toMatchObject({ type: "text_delta", text: "\n\nFound it." });
+
+    // Non-sentence-terminal fallback: does NOT insert \n\n
+    const nonSentenceEvents: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "Result: " },
+      {
+        type: "tool_call",
+        text: "computing",
+        toolCallId: "tool-calc",
+        title: "Calc",
+        kind: "other" as never,
+      },
+      { type: "text_delta", text: "42" },
+    ];
+    const nonSentenceMapped = await collectEvents(asyncStream(nonSentenceEvents));
+    expect(nonSentenceMapped[2]).toMatchObject({ type: "text_delta", text: "42" });
+  });
+
+  // Spec T6 — Tool update does not create another activity boundary
+  test("T6: Tool update does not create another activity boundary", async () => {
+    const inputEvents: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "I'll inspect it." },
+      {
+        type: "tool_call",
+        text: "reading",
+        toolCallId: "tool-1",
+        title: "Read",
+        kind: "read" as never,
+        rawInput: { path: "src/foo.ts" },
+      },
+      {
+        type: "tool_call",
+        text: "reading update",
+        tag: "tool_call_update" as never,
+        toolCallId: "tool-1",
+        status: "in_progress",
+      },
+      {
+        type: "tool_call",
+        text: "reading completed",
+        tag: "tool_call_update" as never,
+        toolCallId: "tool-1",
+        status: "completed",
+        rawOutput: { lines: 100 },
+      },
+      { type: "text_delta", text: "Found it." },
+      { type: "text_delta", text: " It has 100 lines." },
+    ];
+
+    const mapped = await collectEvents(asyncStream(inputEvents));
+    expect(mapped).toHaveLength(6);
+    expect(mapped[0]).toMatchObject({ type: "text_delta", text: "I'll inspect it." });
+    // First tool event (initial)
+    expect(mapped[1]).toMatchObject({ type: "tool_call", toolCallId: "tool-1", title: "Read" });
+    // Updates
+    expect(mapped[2]).toMatchObject({ type: "tool_call", toolCallId: "tool-1", status: "in_progress" });
+    expect(mapped[3]).toMatchObject({ type: "tool_call", toolCallId: "tool-1", status: "completed" });
+    // Text after tool: gains single \n\n
+    expect(mapped[4]).toMatchObject({ type: "text_delta", text: "\n\nFound it." });
+    // Subsequent text without activity: contiguous, no extra separator
+    expect(mapped[5]).toMatchObject({ type: "text_delta", text: " It has 100 lines." });
+  });
+
+  // Spec T7 — Thought boundary parity
+  test("T7: Thought chunks create activity boundary matching CLI behavior", async () => {
+    const inputEvents: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "Thinking through this." },
+      { type: "text_delta", text: "let's check the code...", stream: "thought" },
+      { type: "text_delta", text: "Here is the answer." },
+    ];
+
+    const mapped = await collectEvents(asyncStream(inputEvents));
+    expect(mapped).toHaveLength(3);
+    expect(mapped[0]).toMatchObject({ type: "text_delta", text: "Thinking through this." });
+    expect(mapped[1]).toMatchObject({ type: "text_delta", text: "let's check the code...", stream: "thought" });
+    expect(mapped[2]).toMatchObject({ type: "text_delta", text: "\n\nHere is the answer." });
+  });
+
+  // Spec T8 — Ordered Relay timeline including tool snapshot merge
+  test("T8: Ordered timeline preserves event arrival order and snapshot merge", async () => {
+    const inputEvents: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "Step 1: start." },
+      {
+        type: "tool_call",
+        text: "editing",
+        toolCallId: "edit-1",
+        title: "Edit",
+        kind: "edit" as never,
+        rawInput: { file: "test.ts", change: "foo -> bar" },
+        status: "in_progress",
+      },
+      {
+        type: "tool_call",
+        text: "completed",
+        tag: "tool_call_update" as never,
+        toolCallId: "edit-1",
+        status: "completed",
+        rawOutput: { success: true },
+      },
+      { type: "text_delta", text: "Step 2: done." },
+    ];
+
+    const mapped = await collectEvents(asyncStream(inputEvents));
+    expect(mapped).toHaveLength(4);
+
+    // Sequence check: Text -> Tool in-progress -> Tool completed -> Text
+    expect(mapped[0].type).toBe("text_delta");
+    expect((mapped[0] as { text: string }).text).toBe("Step 1: start.");
+
+    expect(mapped[1].type).toBe("tool_call");
+    expect(mapped[1]).toMatchObject({
+      type: "tool_call",
+      toolCallId: "edit-1",
+      title: "Edit",
+      kind: "edit",
+      status: "in_progress",
+      rawInput: { file: "test.ts", change: "foo -> bar" },
+    });
+
+    expect(mapped[2].type).toBe("tool_call");
+    expect(mapped[2]).toMatchObject({
+      type: "tool_call",
+      toolCallId: "edit-1",
+      title: "Edit",
+      kind: "edit",
+      status: "completed",
+      rawInput: { file: "test.ts", change: "foo -> bar" },
+      rawOutput: { success: true },
+    });
+
+    expect(mapped[3].type).toBe("text_delta");
+    expect((mapped[3] as { text: string }).text).toBe("\n\nStep 2: done.");
+  });
+
+  // Spec T9 — Consecutive logical messages coalesce keeps A\n\nB
+  test("T9: Consecutive logical messages coalesce retains paragraph separation", async () => {
+    const inputEvents: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "Message A.", messageId: "m1" },
+      { type: "text_delta", text: "Message B.", messageId: "m2" },
+      { type: "text_delta", text: "Message C.", messageId: "m3" },
+    ];
+
+    const mapped = await collectEvents(asyncStream(inputEvents));
+    const coalesced = mapped
+      .filter((e): e is Extract<XacpxRuntimeEvent, { type: "text_delta" }> => e.type === "text_delta")
+      .map((e) => e.text)
+      .join("");
+
+    expect(coalesced).toBe("Message A.\n\nMessage B.\n\nMessage C.");
+  });
+
+  // Spec T10 — Stream mode remains immediate
+  test("T10: First text delta is emitted immediately without waiting for paragraph or turn completion", async () => {
+    // Create an async generator that pauses before emitting second event
+    let firstEmitted = false;
+    let releaseSecond: () => void;
+    const secondPromise = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    async function* slowStream(): AsyncIterable<AcpRuntimeEvent> {
+      yield { type: "text_delta", text: "First chunk" };
+      await secondPromise;
+      yield { type: "text_delta", text: " Second chunk" };
+    }
+
+    const generator = mapEvents(slowStream());
+    const firstResult = await generator[Symbol.asyncIterator]().next();
+
+    expect(firstResult.done).toBe(false);
+    expect(firstResult.value).toMatchObject({
+      type: "text_delta",
+      text: "First chunk",
+    });
+    firstEmitted = true;
+
+    // Release the second chunk now
+    releaseSecond!();
+    const secondResult = await generator[Symbol.asyncIterator]().next();
+    expect(secondResult.done).toBe(false);
+    expect(secondResult.value).toMatchObject({
+      type: "text_delta",
+      text: " Second chunk",
+    });
+
+    expect(firstEmitted).toBe(true);
+  });
+});

--- a/tests/unit/bridge/engine/runtime/runtime-text-parity.test.ts
+++ b/tests/unit/bridge/engine/runtime/runtime-text-parity.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { mapEvents } from "../../../../../src/bridge/engine/runtime/runtime-adapter";
 import type { AcpRuntimeEvent } from "acpx/runtime";
 import type { XacpxRuntimeEvent } from "../../../../../src/bridge/engine/runtime/runtime-contract";
-
+import { AcpxBridgeTransport } from "../../../../../src/transport/acpx-bridge/acpx-bridge-transport";
+import type { BridgeEvent } from "../../../../../src/transport/acpx-bridge/acpx-bridge-client";
+import { mapRuntimeToolEvent } from "../../../../../src/bridge/engine/runtime-engine";
+import { toolUseEventToStepDto } from "../../../../../packages/channel-relay/src/tool-presentation";
+import { createStateMirror } from "../../../../../packages/channel-relay/src/state-mirror";
+import { MSG, type TurnPartDto } from "../../../../../packages/relay-protocol/src/index";
+import type { ResolvedSession } from "../../../../../src/transport/types";
 async function collectEvents(events: AsyncIterable<AcpRuntimeEvent>): Promise<XacpxRuntimeEvent[]> {
   const result: XacpxRuntimeEvent[] = [];
   for await (const event of mapEvents(events)) {
@@ -256,6 +262,106 @@ describe("Runtime Text / Ordered Transcript Parity (spec §25-§33)", () => {
 
     expect(mapped[3].type).toBe("text_delta");
     expect((mapped[3] as { text: string }).text).toBe("\n\nStep 2: done.");
+  });
+
+  // Spec T8-Relay — Ordered Relay timeline through bridge-serialized path into StateMirror TurnPartDto[]
+  test("T8-Relay: Ordered timeline end-to-end through bridge-serialized queue into Relay state mirror yields [text(A), tool(completed rich snapshot), text(B)]", async () => {
+    const inputEvents: AcpRuntimeEvent[] = [
+      { type: "text_delta", text: "Step 1: start." },
+      {
+        type: "tool_call",
+        text: "editing",
+        toolCallId: "edit-1",
+        title: "Edit",
+        kind: "edit" as never,
+        rawInput: { file: "test.ts", change: "foo -> bar" },
+        status: "in_progress",
+      },
+      {
+        type: "tool_call",
+        text: "completed",
+        tag: "tool_call_update" as never,
+        toolCallId: "edit-1",
+        status: "completed",
+        rawOutput: { success: true },
+      },
+      { type: "text_delta", text: "Step 2: done." },
+    ];
+
+    const mapped = await collectEvents(asyncStream(inputEvents));
+
+    const mirror = createStateMirror({
+      isReady: () => true,
+      recoveryId: () => "r1",
+      logger: { warn: async () => {} },
+      now: () => 1_700_000_000_000,
+    });
+    mirror.handleEnvelope(MSG.instanceEvent, {
+      event: { type: "turn-started", chatKey: "relay:acc", sessionAlias: "backend", prompt: "do edit" },
+    });
+
+    const client = {
+      async request<TResult>(_method: string, _params: Record<string, unknown>, onEvent?: (event: BridgeEvent) => void): Promise<TResult> {
+        for (const evt of mapped) {
+          if (evt.type === "text_delta") {
+            onEvent?.({ type: "prompt.segment", text: evt.text });
+          } else if (evt.type === "tool_call") {
+            const toolUseEvent = mapRuntimeToolEvent(evt);
+            onEvent?.({ type: "prompt.tool_event", event: toolUseEvent });
+          }
+        }
+        return { text: "done" } as TResult;
+      },
+    };
+
+    const transport = new AcpxBridgeTransport(client);
+    const session = {
+      alias: "backend",
+      type: "claude",
+      account: "default",
+      sessionKey: "backend",
+      replyMode: "stream",
+      effectiveReplyMode: "stream",
+    } as unknown as ResolvedSession;
+
+    await transport.prompt(session, "do edit", undefined, undefined, {
+      onSegment: (segmentText) => {
+        mirror.handleEnvelope(MSG.instanceEvent, {
+          event: { type: "turn-output", chatKey: "relay:acc", sessionAlias: "backend", chunk: segmentText },
+        });
+      },
+      onToolEvent: (toolEvent) => {
+        const step = toolUseEventToStepDto(toolEvent);
+        mirror.handleEnvelope(MSG.instanceEvent, {
+          event: { type: "tool-event", chatKey: "relay:acc", sessionAlias: "backend", step },
+        });
+      },
+      toolEventMode: "both",
+    });
+
+    const { snapshot } = mirror.buildStateSync(new Set(["backend"]));
+    const turn = snapshot.turns[0]!;
+    const parts: TurnPartDto[] = turn.parts;
+
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toEqual({ type: "text", text: "Step 1: start." });
+
+    expect(parts[1].type).toBe("tool");
+    if (parts[1].type === "tool") {
+      expect(parts[1].step.toolCallId).toBe("edit-1");
+      expect(parts[1].step.kind).toBe("edit");
+      expect(parts[1].step.status).toBe("success");
+      expect(parts[1].step.title).toBe("test.ts");
+      expect(parts[1].step.detail).toMatchObject({
+        type: "fields",
+        fields: [
+          { label: "file", value: "test.ts" },
+          { label: "change", value: "foo -> bar" },
+        ],
+      });
+    }
+
+    expect(parts[2]).toEqual({ type: "text", text: "\n\nStep 2: done." });
   });
 
   // Spec T9 — Consecutive logical messages coalesce keeps A\n\nB

--- a/tests/unit/bridge/engine/runtime/runtime-tool-call-merge.test.ts
+++ b/tests/unit/bridge/engine/runtime/runtime-tool-call-merge.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeRuntimeToolCallEvent,
+  mergeTitle,
+  isMeaningfulTitle,
+  type RuntimeToolCallSnapshot,
+} from "../../../../../src/bridge/engine/runtime/runtime-tool-call-merge";
+import type { XacpxRuntimeEvent } from "../../../../../src/bridge/engine/runtime/runtime-contract";
+
+describe("Runtime Tool Call Snapshot Normalization (spec §5-§7, §12)", () => {
+  test("isMeaningfulTitle correctly filters generic placeholders and whitespace", () => {
+    expect(isMeaningfulTitle(undefined)).toBe(false);
+    expect(isMeaningfulTitle(null)).toBe(false);
+    expect(isMeaningfulTitle("")).toBe(false);
+    expect(isMeaningfulTitle("   ")).toBe(false);
+    expect(isMeaningfulTitle("tool call")).toBe(false);
+    expect(isMeaningfulTitle("Tool Call")).toBe(false);
+    expect(isMeaningfulTitle("TOOL CALL")).toBe(false);
+    expect(isMeaningfulTitle("  tool call  ")).toBe(false);
+
+    expect(isMeaningfulTitle("Read")).toBe(true);
+    expect(isMeaningfulTitle("Bash")).toBe(true);
+    expect(isMeaningfulTitle("Edit")).toBe(true);
+    expect(isMeaningfulTitle("Read configuration")).toBe(true);
+  });
+
+  test("mergeTitle semantics", () => {
+    // Missing new title keeps previous
+    expect(mergeTitle("Read", undefined)).toBe("Read");
+    expect(mergeTitle("Read", "")).toBe("Read");
+    expect(mergeTitle("Read", "   ")).toBe("Read");
+
+    // Meaningful new title overwrites previous
+    expect(mergeTitle("Read", "Read configuration")).toBe("Read configuration");
+
+    // Generic placeholder new title does not overwrite meaningful previous
+    expect(mergeTitle("Read", "tool call")).toBe("Read");
+    expect(mergeTitle("Read", "Tool Call")).toBe("Read");
+
+    // Meaningful new title overwrites previous generic placeholder
+    expect(mergeTitle("tool call", "Read")).toBe("Read");
+
+    // Initial generic placeholder when no previous exists returns trimmed generic title
+    expect(mergeTitle(undefined, "tool call")).toBe("tool call");
+  });
+
+  // Spec Test 1 — Read sparse terminal update
+  test("Test 1: Read sparse terminal update retains title, kind, rawInput, and updates status", () => {
+    const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+
+    const event1 = normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "reading file",
+      toolCallId: "read-1",
+      title: "Read",
+      kind: "read",
+      rawInput: { path: "/tmp/a.ts" },
+    });
+
+    expect(event1).toMatchObject({
+      type: "tool_call",
+      toolCallId: "read-1",
+      title: "Read",
+      kind: "read",
+      rawInput: { path: "/tmp/a.ts" },
+    });
+
+    const event2 = normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "tool call (completed)",
+      tag: "tool_call_update",
+      toolCallId: "read-1",
+      title: "tool call",
+      status: "completed",
+    });
+
+    expect(event2).toMatchObject({
+      type: "tool_call",
+      toolCallId: "read-1",
+      title: "Read",
+      kind: "read",
+      rawInput: { path: "/tmp/a.ts" },
+      status: "completed",
+      tag: "tool_call_update",
+    });
+  });
+
+  // Spec Test 2 — Execute keeps input and gains output
+  test("Test 2: Execute keeps rawInput.command and gains rawOutput.formatted_output", () => {
+    const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+
+    normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "running bash",
+      toolCallId: "bash-1",
+      title: "Bash",
+      kind: "execute",
+      rawInput: { command: "bun test" },
+    });
+
+    const terminal = normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "tool call (completed)",
+      tag: "tool_call_update",
+      toolCallId: "bash-1",
+      title: "tool call",
+      status: "completed",
+      rawOutput: { formatted_output: "42 pass", exit_code: 0 },
+    });
+
+    expect(terminal).toMatchObject({
+      type: "tool_call",
+      toolCallId: "bash-1",
+      title: "Bash",
+      kind: "execute",
+      rawInput: { command: "bun test" },
+      rawOutput: { formatted_output: "42 pass", exit_code: 0 },
+      status: "completed",
+    });
+  });
+
+  // Spec Test 3 — Edit rich frame survives sparse completion
+  test("Test 3: Edit rich frame survives sparse completion", () => {
+    const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+
+    normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "editing file",
+      toolCallId: "edit-1",
+      title: "Edit",
+      kind: "edit",
+      rawInput: { file_path: "src/foo.ts", old_string: "let a = 1", new_string: "let a = 2" },
+      content: [{ type: "diff", path: "src/foo.ts", oldText: "let a = 1", newText: "let a = 2" }],
+      locations: [{ path: "src/foo.ts" }],
+    });
+
+    const terminal = normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "tool call (completed)",
+      tag: "tool_call_update",
+      toolCallId: "edit-1",
+      title: "tool call",
+      status: "completed",
+    });
+
+    expect(terminal).toMatchObject({
+      type: "tool_call",
+      toolCallId: "edit-1",
+      title: "Edit",
+      kind: "edit",
+      rawInput: { file_path: "src/foo.ts", old_string: "let a = 1", new_string: "let a = 2" },
+      content: [{ type: "diff", path: "src/foo.ts", oldText: "let a = 1", newText: "let a = 2" }],
+      locations: [{ path: "src/foo.ts" }],
+      status: "completed",
+    });
+  });
+
+  // Spec Test 4 — Real title update wins
+  test("Test 4: Real title update wins over initial title", () => {
+    const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+
+    normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "reading",
+      toolCallId: "call-4",
+      title: "Read",
+    });
+
+    const update = normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "reading config",
+      tag: "tool_call_update",
+      toolCallId: "call-4",
+      title: "Read configuration",
+    });
+
+    expect(update.title).toBe("Read configuration");
+  });
+
+  // Spec Test 5 — Synthetic placeholder does not win
+  test("Test 5: Synthetic placeholder 'tool call' does not win over rich initial title", () => {
+    const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+
+    normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "executing",
+      toolCallId: "call-5",
+      title: "Bash",
+    });
+
+    const update = normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "tool call",
+      toolCallId: "call-5",
+      title: "tool call",
+    });
+
+    expect(update.title).toBe("Bash");
+  });
+
+  // Spec Test 6 — Missing fields preserve old fields
+  test("Test 6: Update with omitted/empty fields preserves all previous fields", () => {
+    const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+
+    normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "initial text",
+      tag: "tool_call",
+      toolCallId: "call-6",
+      title: "CustomTool",
+      kind: "search",
+      rawInput: { query: "worker fence" },
+      content: [{ type: "text", text: "searching" }],
+      locations: ["src/index.ts"],
+    });
+
+    const update = normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "",
+      toolCallId: "call-6",
+      status: "in_progress",
+      rawInput: {}, // Empty object should not clobber
+      content: [],  // Empty array should not clobber
+    });
+
+    expect(update).toMatchObject({
+      toolCallId: "call-6",
+      title: "CustomTool",
+      kind: "search",
+      rawInput: { query: "worker fence" },
+      content: [{ type: "text", text: "searching" }],
+      locations: ["src/index.ts"],
+      status: "in_progress",
+    });
+  });
+
+  // Spec Test 7 — New rawOutput is appended to snapshot
+  test("Test 7: New rawOutput coexists with previous rawInput", () => {
+    const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+
+    normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "executing",
+      toolCallId: "call-7",
+      rawInput: { cmd: "echo 123" },
+    });
+
+    const update = normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "done",
+      toolCallId: "call-7",
+      rawOutput: { stdout: "123\n" },
+    });
+
+    expect(update.rawInput).toEqual({ cmd: "echo 123" });
+    expect(update.rawOutput).toEqual({ stdout: "123\n" });
+  });
+
+  // Spec Test 8 — Same toolCallId across two turns does not merge
+  test("Test 8: Same toolCallId across two turns does not merge (per-turn isolation)", () => {
+    // Turn A
+    const turnAToolCalls = new Map<string, RuntimeToolCallSnapshot>();
+    normalizeRuntimeToolCallEvent(turnAToolCalls, {
+      type: "tool_call",
+      text: "reading",
+      toolCallId: "1",
+      title: "Read",
+      kind: "read",
+      rawInput: { path: "/turn-a.ts" },
+    });
+
+    // Turn B (fresh map)
+    const turnBToolCalls = new Map<string, RuntimeToolCallSnapshot>();
+    const turnBEvent = normalizeRuntimeToolCallEvent(turnBToolCalls, {
+      type: "tool_call",
+      text: "executing",
+      toolCallId: "1",
+      title: "Bash",
+      kind: "execute",
+      rawInput: { command: "ls" },
+    });
+
+    expect(turnBEvent.title).toBe("Bash");
+    expect(turnBEvent.kind).toBe("execute");
+    expect(turnBEvent.rawInput).toEqual({ command: "ls" });
+    expect(turnBEvent.rawInput).not.toEqual({ path: "/turn-a.ts" });
+  });
+
+  // Spec Test 9 — No toolCallId stays passthrough
+  test("Test 9: Events without toolCallId stay passthrough and do not mutate map", () => {
+    const toolCalls = new Map<string, RuntimeToolCallSnapshot>();
+
+    const eventWithoutId = normalizeRuntimeToolCallEvent(toolCalls, {
+      type: "tool_call",
+      text: "no id event",
+      title: "NoIdTool",
+      status: "in_progress",
+    });
+
+    expect(eventWithoutId.toolCallId).toBeUndefined();
+    expect(eventWithoutId.title).toBe("NoIdTool");
+    expect(toolCalls.size).toBe(0);
+  });
+});

--- a/tests/unit/packages/channel-discord/discord-review-fixes.test.ts
+++ b/tests/unit/packages/channel-discord/discord-review-fixes.test.ts
@@ -5,7 +5,7 @@ import type { DiscordBotIdentity, DiscordClientLike } from "../../../../packages
 import type { DiscordInboundMessage } from "../../../../packages/channel-discord/src/types";
 import { MessageChannelRegistry } from "../../../../src/channels/channel-registry";
 import { registerKnownChannelId } from "../../../../src/channels/channel-scope";
-import type { ChannelStartInput } from "xacpx/plugin-api";
+import type { ChannelStartInput, ToolUseEvent } from "xacpx/plugin-api";
 
 beforeAll(() => {
   // Production registers this via registerChannelFactory when the plugin loads.
@@ -658,4 +658,54 @@ test("M4: a thread inherits the parent channel's requireMention override on the 
   h.state.gate.resolve({ text: "late" });
   h.abort.abort();
   await h.startPromise;
+});
+
+test("Discord onToolEvent renders delete (🗑️), move (📦), and fetch (🌐) emoji matching standard kinds", async () => {
+  const client = makeGatewayClient({ botUserId: "bot-123" });
+  const recorded: string[] = [];
+  client.sendMessage = async (_target: unknown, body: { content?: string | null }) => {
+    if (body.content) recorded.push(body.content);
+    return { messageId: `s${recorded.length}` };
+  };
+  client.editMessage = async (_target: unknown, _msgId: string, body: { content?: string | null }) => {
+    if (body.content) recorded.push(body.content);
+  };
+  const abort = new AbortController();
+  const gate = Promise.withResolvers<{ text: string }>();
+  const ch = new DiscordChannel(
+    { token: "x", dmPolicy: "open", guildPolicy: "open", replyMode: "streaming", previewThrottleMs: 250 },
+    { logger: makeLogger() as never, createClient: () => client, identifyStaggerMs: 0 },
+  );
+  const startPromise = ch.start({
+    logger: makeLogger(),
+    abortSignal: abort.signal,
+    agent: {
+      chat: async (req: { onToolEvent?: (event: ToolUseEvent) => Promise<void> }) => {
+        const onTool = req.onToolEvent;
+        if (onTool) {
+          await onTool({ toolCallId: "t1", toolName: "file.txt", kind: "delete", status: "success" });
+          await onTool({ toolCallId: "t2", toolName: "src/a → src/b", kind: "move", status: "success" });
+          await onTool({ toolCallId: "t3", toolName: "https://example.com", kind: "fetch", status: "success" });
+        }
+        return await gate.promise;
+      },
+    },
+    activeTurns: { markActive: () => {}, markInactive: () => {} },
+    sessions: { peekCurrentSessionAlias: () => "worker", setBackgroundResult: async () => {} },
+    quota: { onInbound: () => {} },
+    locale: "en",
+  } as unknown as ChannelStartInput);
+
+  await waitStarted(ch);
+  client.emit(inboundMessage({ author: { id: "u1", bot: false }, content: "run tools" }));
+  await settle(400);
+
+  expect(recorded.some((text) => text.includes("🗑️ file.txt (success)"))).toBe(true);
+  expect(recorded.some((text) => text.includes("📦 src/a → src/b (success)"))).toBe(true);
+  expect(recorded.some((text) => text.includes("🌐 https://example.com (success)"))).toBe(true);
+
+  gate.resolve({ text: "done" });
+  await settle();
+  abort.abort();
+  await startPromise;
 });

--- a/tests/unit/packages/channel-relay/agent-send-anchoring-seam.test.ts
+++ b/tests/unit/packages/channel-relay/agent-send-anchoring-seam.test.ts
@@ -135,10 +135,12 @@ test("Claude seam: display title ≠ agent_send, machine name in _meta.claudeCod
 
   const terminal = events.at(-1)!;
   expect(terminal.toolName).toBe("Send peer message to Worker B"); // display stays display
+  expect(terminal.summary).toBeUndefined();
   expect(terminal.machineToolName).toBe("mcp__xacpx__agent_send");
   expect(terminal.status).toBe("success");
 
   const step = toolUseEventToStepDto(terminal);
+  expect(step.title).toBe("Send peer message to Worker B");
   expect(step.agentMessageId).toBe(RECEIPT.messageId);
 });
 

--- a/tests/unit/packages/channel-relay/tool-presentation.test.ts
+++ b/tests/unit/packages/channel-relay/tool-presentation.test.ts
@@ -483,3 +483,120 @@ test("agentMessageId survives every detail-variant path via the base spread", ()
     expect(step.agentMessageId).toBe(MSG_ID);
   }
 });
+
+test("delete presents path as title and primitive fields in detail", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "d1", toolName: "Delete", kind: "delete", status: "success",
+    rawInput: { file_path: "temp/cache.json", recursive: true },
+  });
+  expect(step.title).toBe("temp/cache.json");
+  expect(step.kind).toBe("delete");
+  expect(step.detail).toMatchObject({
+    type: "fields",
+    fields: [
+      { label: "file_path", value: "temp/cache.json" },
+      { label: "recursive", value: "true" },
+    ],
+  });
+});
+
+test("move presents 'source → destination' as title and fields in detail", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "m1", toolName: "Move", kind: "move", status: "success",
+    rawInput: { source: "src/old.ts", destination: "src/new.ts" },
+  });
+  expect(step.title).toBe("src/old.ts → src/new.ts");
+  expect(step.kind).toBe("move");
+  expect(step.detail).toMatchObject({
+    type: "fields",
+    fields: [
+      { label: "source", value: "src/old.ts" },
+      { label: "destination", value: "src/new.ts" },
+    ],
+  });
+});
+
+test("fetch presents url as title and fields in detail", () => {
+  const step = toolUseEventToStepDto({
+    toolCallId: "f1", toolName: "Fetch", kind: "fetch", status: "success",
+    rawInput: { url: "https://api.example.com/v1/health" },
+    rawOutput: { stdout: '{"status":"ok"}' },
+  });
+  expect(step.title).toBe("https://api.example.com/v1/health");
+  expect(step.kind).toBe("fetch");
+  expect(step.detail).toMatchObject({
+    type: "fields",
+    fields: [{ label: "url", value: "https://api.example.com/v1/health" }],
+    output: '{"status":"ok"}',
+  });
+});
+
+test("end-to-end: runtime sparse Read sequence results in rich Read step DTO", () => {
+  const { normalizeRuntimeToolCallEvent } = require("../../../../src/bridge/engine/runtime/runtime-tool-call-merge");
+  const { mapRuntimeToolEvent } = require("../../../../src/bridge/engine/runtime-engine");
+
+  const toolCalls = new Map();
+  normalizeRuntimeToolCallEvent(toolCalls, {
+    type: "tool_call",
+    toolCallId: "read-1",
+    title: "Read",
+    kind: "read",
+    rawInput: { path: "/tmp/a.ts" },
+    text: "reading",
+  });
+
+  const terminalSnapshot = normalizeRuntimeToolCallEvent(toolCalls, {
+    type: "tool_call",
+    tag: "tool_call_update",
+    toolCallId: "read-1",
+    title: "tool call",
+    status: "completed",
+    text: "tool call (completed)",
+  });
+
+  const toolEvent = mapRuntimeToolEvent(terminalSnapshot);
+  const step = toolUseEventToStepDto(toolEvent);
+
+  expect(step.title).toBe("/tmp/a.ts");
+  expect(step.status).toBe("success");
+  expect(step.kind).toBe("read");
+  expect(step.detail).toMatchObject({ type: "read", path: "/tmp/a.ts" });
+});
+
+test("end-to-end: runtime sparse Execute sequence results in rich Command step DTO", () => {
+  const { normalizeRuntimeToolCallEvent } = require("../../../../src/bridge/engine/runtime/runtime-tool-call-merge");
+  const { mapRuntimeToolEvent } = require("../../../../src/bridge/engine/runtime-engine");
+
+  const toolCalls = new Map();
+  normalizeRuntimeToolCallEvent(toolCalls, {
+    type: "tool_call",
+    toolCallId: "bash-1",
+    title: "Bash",
+    kind: "execute",
+    rawInput: { command: "bun test" },
+    text: "running",
+  });
+
+  const terminalSnapshot = normalizeRuntimeToolCallEvent(toolCalls, {
+    type: "tool_call",
+    tag: "tool_call_update",
+    toolCallId: "bash-1",
+    title: "tool call",
+    status: "completed",
+    rawOutput: { formatted_output: "42 pass", exit_code: 0 },
+    text: "tool call (completed)",
+  });
+
+  const toolEvent = mapRuntimeToolEvent(terminalSnapshot);
+  const step = toolUseEventToStepDto(toolEvent);
+
+  expect(step.title).toBe("bun test");
+  expect(step.status).toBe("success");
+  expect(step.kind).toBe("execute");
+  expect(step.detail).toMatchObject({
+    type: "command",
+    command: "bun test",
+    output: "42 pass",
+    exitCode: 0,
+  });
+});

--- a/tests/unit/transport/acpx-cli-free-warm-process.test.ts
+++ b/tests/unit/transport/acpx-cli-free-warm-process.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, spyOn, mock } from "bun:test";
+import { AcpxQueueOwnerLauncher } from "../../../src/transport/acpx-queue-owner-launcher";
 
 const terminate = mock(async (_sessionId: string) => {});
 // Stub the launcher helper so we assert freeWarmProcess kills the warm owner by
@@ -7,7 +8,7 @@ const terminate = mock(async (_sessionId: string) => {});
 // matches by resolved source path. Re-export the other named imports the
 // transport pulls from that module so the real ones still resolve.
 mock.module("../../../src/transport/acpx-queue-owner-launcher", () => ({
-  AcpxQueueOwnerLauncher: class {},
+  AcpxQueueOwnerLauncher,
   terminateAcpxQueueOwner: terminate,
 }));
 

--- a/tests/unit/transport/acpx-cli-is-session-warm.test.ts
+++ b/tests/unit/transport/acpx-cli-is-session-warm.test.ts
@@ -1,11 +1,12 @@
 import { test, expect, spyOn, mock } from "bun:test";
+import { AcpxQueueOwnerLauncher } from "../../../src/transport/acpx-queue-owner-launcher";
 
 // Stub the lock-file pid reader and the pid liveness probe so isSessionWarm is
 // tested without touching ~/.acpx/queues or real processes. Re-export the other
 // names the transport pulls from each module so the real ones still resolve.
 const readPid = mock(async (_sessionId: string): Promise<number | undefined> => undefined);
 mock.module("../../../src/transport/acpx-queue-owner-launcher", () => ({
-  AcpxQueueOwnerLauncher: class {},
+  AcpxQueueOwnerLauncher,
   terminateAcpxQueueOwner: async () => {},
   readQueueOwnerPid: readPid,
 }));

--- a/tests/unit/transport/streaming-prompt-tool-events.test.ts
+++ b/tests/unit/transport/streaming-prompt-tool-events.test.ts
@@ -908,3 +908,38 @@ test("wrong-driver Claude metadata does not alter an ordinary tool event", () =>
     status: "success",
   }]);
 });
+
+test("tool_call_update falls back to rawOutput with input-like fields (path, command/query) for structured summary", () => {
+  const events: ToolUseEvent[] = [];
+  const state = createStreamingPromptState(false, (e) => events.push(e));
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: {
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "t-path",
+        title: "Result",
+        rawOutput: { path: "/tmp/result.ts" },
+        status: "completed",
+      },
+    },
+  }));
+
+  expect(events.at(-1)?.summary).toBe("/tmp/result.ts");
+
+  parseStreamingChunks(state, JSON.stringify({
+    method: "session/update",
+    params: {
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "t-cmd",
+        title: "Result",
+        rawOutput: { command: "git status" },
+        status: "completed",
+      },
+    },
+  }));
+
+  expect(events.at(-1)?.summary).toBe("git status");
+});

--- a/tests/unit/transport/transcript-text-boundary.test.ts
+++ b/tests/unit/transport/transcript-text-boundary.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createTranscriptTextBoundaryState,
+  markTranscriptActivity,
+  normalizeTranscriptTextChunk,
+  endsWithSentenceTerminal,
+  hasParagraphBoundaryAtJoin,
+} from "../../../src/transport/transcript-text-boundary";
+
+describe("Transcript Text Boundary State Machine (spec §26-§27)", () => {
+  test("initial state has hasAgentMessage=false and activitySinceLastText=false", () => {
+    const state = createTranscriptTextBoundaryState();
+    expect(state.hasAgentMessage).toBe(false);
+    expect(state.activitySinceLastText).toBe(false);
+    expect(state.lastMessageId).toBeUndefined();
+    expect(state.lastTextTail).toBe("");
+  });
+
+  test("activity before any agent message does not set activitySinceLastText", () => {
+    const state = createTranscriptTextBoundaryState();
+    markTranscriptActivity(state);
+    expect(state.activitySinceLastText).toBe(false);
+
+    // First text chunk has no leading \n\n even after early activity
+    const chunk = normalizeTranscriptTextChunk(state, { text: "Hello" });
+    expect(chunk).toBe("Hello");
+    expect(state.hasAgentMessage).toBe(true);
+  });
+
+  test("activity after agent message sets activitySinceLastText", () => {
+    const state = createTranscriptTextBoundaryState();
+    normalizeTranscriptTextChunk(state, { text: "Initial text." });
+    expect(state.hasAgentMessage).toBe(true);
+    expect(state.activitySinceLastText).toBe(false);
+
+    markTranscriptActivity(state);
+    expect(state.activitySinceLastText).toBe(true);
+  });
+
+  test("endsWithSentenceTerminal correctly identifies sentence terminals and punctuation", () => {
+    expect(endsWithSentenceTerminal("Hello.")).toBe(true);
+    expect(endsWithSentenceTerminal("Hello!")).toBe(true);
+    expect(endsWithSentenceTerminal("Hello?")).toBe(true);
+    expect(endsWithSentenceTerminal("Hello。")).toBe(true);
+    expect(endsWithSentenceTerminal("Hello！")).toBe(true);
+    expect(endsWithSentenceTerminal("Hello…")).toBe(true);
+    expect(endsWithSentenceTerminal('Hello."')).toBe(true);
+    expect(endsWithSentenceTerminal("Hello.” ")).toBe(true);
+    expect(endsWithSentenceTerminal("Hello.*")).toBe(true);
+
+    expect(endsWithSentenceTerminal("Hello")).toBe(false);
+    expect(endsWithSentenceTerminal("Result:")).toBe(false);
+    expect(endsWithSentenceTerminal("comma,")).toBe(false);
+    expect(endsWithSentenceTerminal("")).toBe(false);
+  });
+
+  test("hasParagraphBoundaryAtJoin detects various paragraph boundary formats", () => {
+    // Boundary at end of left
+    expect(hasParagraphBoundaryAtJoin("first\n\n", "second")).toBe(true);
+    expect(hasParagraphBoundaryAtJoin("first\r\n\r\n", "second")).toBe(true);
+
+    // Boundary at start of right
+    expect(hasParagraphBoundaryAtJoin("first", "\n\nsecond")).toBe(true);
+    expect(hasParagraphBoundaryAtJoin("first", "\r\n\r\nsecond")).toBe(true);
+
+    // Boundary spanning join (\n + \n)
+    expect(hasParagraphBoundaryAtJoin("first\n", "\nsecond")).toBe(true);
+    expect(hasParagraphBoundaryAtJoin("first\r\n", "\r\nsecond")).toBe(true);
+
+    // CRLF split inside line break (\r\n\r + \n)
+    expect(hasParagraphBoundaryAtJoin("first\r\n\r", "\nsecond")).toBe(true);
+
+    // Single line break is NOT a paragraph boundary
+    expect(hasParagraphBoundaryAtJoin("first\n", "second")).toBe(false);
+    expect(hasParagraphBoundaryAtJoin("first", "\nsecond")).toBe(false);
+    expect(hasParagraphBoundaryAtJoin("first", "second")).toBe(false);
+  });
+
+  test("empty text chunk returns empty string and does not alter state", () => {
+    const state = createTranscriptTextBoundaryState();
+    const result = normalizeTranscriptTextChunk(state, { text: "", messageId: "m1" });
+    expect(result).toBe("");
+    expect(state.lastMessageId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

After PR #312 switched the default engine to Runtime, Relay Web regressed two presentation contracts the CLI engine already honored:

1. Every structured tool card shows generic `tool call` — Read / Edit / Bash indistinguishable (no path / command / diff, kind icon lost).
2. Long agent replies glue into one unbroken block; `text → tool → text` loses paragraph / activity boundaries.

Root cause (same in both): ACP `tool_call` / `tool_call_update` are delta streams, and Runtime forwarded each frame as-is while Relay uses replace-by-`toolCallId` snapshot semantics — so sparse terminal frames erased the rich in-progress frames. The text path additionally dropped upstream `tag` / `messageId` / `meta` in `mapEvents` and bypassed the CLI boundary heuristics entirely.

## Fix (per specs)

Implements both specs (also committed under `docs/superpowers/specs/`):

- `2026-09-07-runtime-tool-call-snapshot-normalization.md`
- `2026-09-07-runtime-text-ordered-transcript-partity.md`

Tool-call snapshot normalization (`src/bridge/engine/runtime/`):

- New `runtime-tool-call-merge.ts`: pure per-turn, per-`toolCallId` accumulator. Per-field replace guarded by emptiness checks (no `rawInput` deep-merge); `rawInput` + `rawOutput` coexist; synthetic `"tool call"` title never downgrades a rich title; real title updates win; newest non-empty `text`; no-`toolCallId` events stay passthrough.
- `tool_call` branch gains `tag`; `mapEvents()` holds the snapshot map plus text boundary state per turn (discarded at turn end, no engine/session/global state) and yields accumulated snapshots. First-seen `toolCallId` marks transcript activity; updates never do; every `thought` marks.
- `mapRuntimeToolEvent()`: summary from merged `rawInput` (exact base input semantics) `??` `summarizeToolOutput(rawOutput)` (separate helper, 500-char cap, acpx parity) with title dedup. Removed dead second text-event path (zero callers) so live paths share one heuristic.
- Summary helpers in `src/transport/tool-summary.ts`: `summarizeToolInput` byte-identical to base, `summarizeToolOutput` output-only; all three call sites (CLI text + structured, Runtime mapper) use the input/output split. Seam regression pins `agent_send` terminal summary undefined + display title.
- Kind parity `delete` / `move` / `fetch` end to end: core types, emoji, protocol dto, relay-web icons and order, feishu + discord icons, channel-relay presentation branches. `switch_mode` stays `other`.

Text / ordered-transcript parity:

- Text branch gains `tag`, `messageId`, `meta` (allowlist `origin/kind/source` strings only, routing hint not auth); `mapEvents` forwards all three with meta sanitized.
- New `src/transport/transcript-text-boundary.ts` pure state machine shared by CLI and Runtime. Boundary fix is newline-prefix only — no buffering or splitting, stream stays immediate.

Untouched as specified: `packages/relay`, channel-relay replace semantics, `session-turn-runner`, relay-web layout, plan parity, subagent metadata, acpx upstream.

Known limitation: Claude status-less terminal (`_meta.claudeCode.toolResponse` without status, no `_meta` on pinned Runtime contract) stays `running` — documented in code + spec section 21, mapping untouched pending an upstream signal. T8-Relay asserts final ordered `TurnPartDto [text, tool, text]` through the serialized bridge queue into StateMirror.

## Verification

- `npx tsc --noEmit` clean.
- New suites: `runtime-tool-call-merge.test.ts` (Tests 1-9), `runtime-engine-tool-event.test.ts` (engine event plus kind Test 10), `transcript-text-boundary.test.ts` plus `runtime-text-parity.test.ts` (T1-T10).
- Presentation regression in `tests/unit/packages/channel-relay/tool-presentation.test.ts`.
- Independent final gate: 24 of 24 acceptance items PASS; both phase reviews PASS with zero blockers.
- Note: gate fixed 3 test-only mocks (`free-warm-process` / `is-session-warm`) to preserve the real launcher prototype across `mock.module`; no `src` changes for that.
- Follow-up `69f118d4`: review fixes (summary split, terminal-gap docs, Relay T8, discord kinds), atomic review PASS. Exact-head CI `34107601252` 7/7 green (completed/success) on `69f118d4`; follow-up `37db455b` restores byte-identical base CLI rawOutput fallback (input||legacy-input) in both CLI call sites, Runtime keeps input||summarizeToolOutput, regression pins rawOutput path/command shapes, atomic review PASS, exact-head CI `34112048543` 7/7 green (completed/success) on exact head `37db455b`.



