### PR TITLE
feat(relay-web): 工具调用与思考过程去卡片化（zcode 风格流式展示）

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -509,18 +509,18 @@ export interface LiveTurn {
 **`ToolCallPanel.vue`**（`packages/relay-web/src/components/ToolCallPanel.vue`）
 
 - props: `steps: ToolStepDto[]`。
-- 兼容旧历史格式的聚合面板，默认折叠；展开后列出每个 step（状态图标、kind 图标、title、耗时）。
-- 点击行展开 `<ToolDetail>` 详情；折叠头显示总步数。
+- 兼容旧历史格式的聚合面板，去卡片化单行头部（Wrench 图标、kind 统计小标、步数）；默认折叠，展开后以左侧导向线缩进呈现各 step。
+- 点击行展开 `<ToolDetail>` 详情。
 
 **`ToolStepCard.vue`**（`packages/relay-web/src/components/ToolStepCard.vue`）
 
-- 有序 `parts` 中单个 tool call 的卡片，标题行始终可见，详情默认折叠。
-- 点击标题展开 `<ToolDetail>`；历史消息和实时 streaming 消息使用相同的默认折叠规则。
+- 有序 `parts` 中单个 tool call 的去卡片化流式行（zcode 风格）：无外层边框与卡片背景，由图标、操作动词（终端/编辑/写入/查阅/搜索等）、文件扩展名角标（TS/VUE/PY 等）、标题、行级 diff stat（`+4` / `−1`）、耗时及状态图标构成单行摘要。
+- 详情默认折叠，点击后在行下方以左侧导向线（`border-l-2`）无缝缩发展开 `<ToolDetail>`；历史消息和实时 streaming 消息遵循同一规则。
 
 **`ReasoningPanel.vue`**（`packages/relay-web/src/components/ReasoningPanel.vue`）
 
-- props: `reasoning: string; defaultOpen?: boolean`。
-- 可折叠，`defaultOpen` 默认 `false`；历史与实时 reasoning 都默认折叠，用户可按需展开。
+- props: `reasoning: string; defaultOpen?: boolean; streaming?: boolean`。
+- 去卡片化极简单行（Brain 图标、思考/思考中文案、streaming 脉冲点）；默认折叠，展开后在下方以左侧导向线缩进渲染思考正文，不产生外层卡片框线。用户可按需展开。
 
 **`ToolDetail.vue`**（`packages/relay-web/src/components/ToolDetail.vue`）
 

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -573,8 +573,7 @@ export interface LiveTurn {
 - **触发与折叠时机**：`turn-finished` 把 live turn 定型为历史消息的瞬间（`streaming` prop
   消失）即折叠。它就是 ACP `session/prompt` response 落定（`stopReason:"end_turn"`）在
   xacpx 管线里的等价事件，无需引入新的控制事件种类。live（streaming）行不折叠，仍由 HUD 计时。
-- **policy 在 `MessageList`**（`collapseTrace = !isFailedTurn(m) && hasTraceParts(m)`，
-  失败判定读**持久化终态** `structured.turnStatus === "error"`，复制按钮通过 `copyTextOf` 与折叠态显示使用同一 `extractFinalReplyText` 语义结果）、**presentation 在 `TurnParts`**（折叠时调用 `extractFinalReplyText` 安全提取 Markdown 顶层块级别的最终回复，未闭合的 unsafe block 如代码块/表格通过 fail-safe 仅留折叠头；点击展开恢复完整交错 presentation）。
+- **架构与计算分工**：`MessageList` 作为父层持有 `sentAgentMessageById` 并管理复制按钮与折叠参数，通过 `extractCollapsedTraceSummary()` 一次性从同一 presentation 派生提取 `finalReplyText`、`toolCount` 与 `thoughtCount`，并以 WeakMap（`(ChatMessage, parts)` 为键）缓存，避免父子重复解析。计算结果作为 `:collapsed-reply-text`、`:collapsed-tool-count`、`:collapsed-thought-count` 下发给 `TurnParts`；`TurnParts` 在独立测试或未提供预计算 props 时 fallback 执行 `extractFinalReplyText`。折叠时安全提取 Markdown 顶层块级别的最终回复（未闭合的 unsafe block 如代码块/表格/列表、或被切断的 inline 结构通过 fail-safe 仅留折叠头）；点击展开时延迟渲染完整的交错 presentation。复制按钮通过 `copyTextOf` 与折叠态显示使用同一 `finalReplyText` 语义结果。
 - **终态持久化**：hub 在三个持久化点（live flush、无 buffer 兜底、offline recovery）把
   `turnStatus: "done" | "cancelled" | "error"`（由 `ok`/`cancelled` 派生）盖进
   `structured`，compact history 以 spread 原样保留。Web 的 `keepRicherStructured()`

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -567,17 +567,14 @@ export interface LiveTurn {
 
 ### 回合 trace 折叠（turn-trace collapse，spec 2026-09-07）
 
-参照 zcode：回合结束后把思考/工具/子代理等中间过程折叠进一条弱化头部行
-（`▸ 已工作 4分32秒 · 6 步工具 · 3 段思考`），正文（text）与 agent-message 卡永不折叠。
+参照 zcode：回合结束后把思考、工具、子代理以及穿插在过程中的叙述文字等中间过程全部折叠进一条弱化头部行
+（`▸ 已工作 4分32秒 · 6 步工具 · 3 段思考`），仅在折叠行下方展示最终回复正文；点击展开恢复完整的交错执行过程。纯文字回合与失败回合不折叠。
 
 - **触发与折叠时机**：`turn-finished` 把 live turn 定型为历史消息的瞬间（`streaming` prop
   消失）即折叠。它就是 ACP `session/prompt` response 落定（`stopReason:"end_turn"`）在
   xacpx 管线里的等价事件，无需引入新的控制事件种类。live（streaming）行不折叠，仍由 HUD 计时。
 - **policy 在 `MessageList`**（`collapseTrace = !isFailedTurn(m) && hasTraceParts(m)`，
-  失败判定读**持久化终态** `structured.turnStatus === "error"`（乐观 `failed` 标志在 hub
-  历史收敛替换行后即消失，不能作为依据）、**presentation 在 `TurnParts`**（`trace-items`
-  过滤 `text`/`agent-message` 之外的全部 presentation 项，头部固定在回合顶部，
-  计数段以 `·` 连接、英文走 vue-i18n 复数）。
+  失败判定读**持久化终态** `structured.turnStatus === "error"`，复制按钮通过 `copyTextOf` 与折叠态显示使用同一 `extractFinalReplyText` 语义结果）、**presentation 在 `TurnParts`**（折叠时调用 `extractFinalReplyText` 安全提取 Markdown 顶层块级别的最终回复，未闭合的 unsafe block 如代码块/表格通过 fail-safe 仅留折叠头；点击展开恢复完整交错 presentation）。
 - **终态持久化**：hub 在三个持久化点（live flush、无 buffer 兜底、offline recovery）把
   `turnStatus: "done" | "cancelled" | "error"`（由 `ok`/`cancelled` 派生）盖进
   `structured`，compact history 以 spread 原样保留。Web 的 `keepRicherStructured()`

--- a/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
+++ b/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
@@ -127,13 +127,13 @@ turnTrace: {
 `packages/relay-web/src/__tests__/turnparts-collapse.test.ts`（新，mount TurnParts）：
 
 1. `collapseTrace` 缺省/live：trace 项内联、无头部（回归确认）。
-2. finished + trace 存在：头部渲染且计数以 `·` 连接（英文复数：`1 tool step` / `2 tool steps`），trace 项不在 DOM；text 项保留。
+2. finished + trace 存在：头部渲染且计数以 `·` 连接（英文复数：`1 tool step` / `2 tool steps`），中间过程（推理、工具、过程文字）折叠收起，仅保留 trailing final reply。
 3. 点头部展开：trace 项出现、`aria-expanded=true`；再点收起。
 4. 同 `traceKey` 重挂载（模拟行替换）：展开状态保持；不同 key 不串。
 5. 纯 text 行：无头部。
 6. `traceElapsedMs` 传/不传/亚秒（`<1s`）：头部耗时段相应变化。
 7. zh/en 文案分支冒烟（设置 locale 后断言头部文本）。
-8. agent-message 真锚定（step 带 `agentMessageId` + map 含该条目）：折叠态下卡片仍在、tool 卡不在。
+8. agent-message 真锚定（step 带 `agentMessageId` + map 含该条目）：中间发送卡作为过程活动折叠收起，展开后出现。
 
 `turnparts-collapse.test.ts` 的 MessageList 收敛组（评审回归）：
 

--- a/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
+++ b/docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md
@@ -1,7 +1,7 @@
 # relay-web 回合 trace 折叠（zcode 式「结束即收起中间过程」）
 
 日期：2026-09-07
-状态：已定稿，随实现微调
+状态：已被 2026-09-08 去卡片化与过程折叠增强设计（docs/superpowers/specs/2026-09-08-relay-web-decardify-tools-reasoning.md）supersede。最终契约：折叠时将中间过程（推理、工具、子代理、已发出 peer 消息卡及穿插其间的过程文字）全部收起，仅保留最终回复正文；复制按钮（CopyButton）与折叠显示共享同一语义结果。
 
 ## 背景与目标
 
@@ -9,8 +9,7 @@
 
 relay-web 现状：`turn-finished` 后 live turn 经 `flushTurn` 定型为历史消息，`TurnParts` 原样渲染全部 parts——推理面板、工具卡、子代理卡永远内联常驻，长回合把最终回复淹没。回合耗时只存在于输入框上方的 HUD（`ChatPane` `turn-hud`），回合结束即消失。
 
-目标：**回合结束后默认折叠 trace**，收进一条回合头部；用户可展开。正文（text）与已发出的 peer 消息卡（agent-message）永不折叠。
-
+目标：**回合结束后默认折叠 trace**，收进一条回合头部；用户可展开。中间过程（推理、工具、子代理、发送卡及过程叙述文字）全部折叠，仅保留最终回复正文。
 **触发信号（已用真实流验证）**：ACP 回合边界 = `session/prompt` 的 JSON-RPC response（`{"result":{"stopReason":"end_turn",…}}`，实际值为 snake_case `end_turn`）。xacpx 管线里它的等价物就是 `turn-finished` 控制事件（`src/control/session-turn-runner.ts` 在 `agent.chat()` resolve 后发出，带 `ok/cancelled/errorMessage`）——web 端在该事件定型消息的瞬间折叠（无需新增事件种类；为闭环持久化和收敛键稳定性，我们在既有 DTO 上增补了 `structured.turnStatus` 与 `turn-started.startedAt` 字段）。
 
 ## 非目标
@@ -54,7 +53,7 @@ traceElapsedMs?: number | null  // 回合耗时（展示用；null/undefined = �
   - 计数：tool+subagent 卡数为「步工具」，reasoning 段数为「段思考」；为 0 的段省略。
   - 耗时：`traceElapsedMs` 格式化为 `m分s秒` / `m m s s`（<1s 显示 `<1s`）；缺失时头部只有计数。
   - 无 trace 项（纯文本回复）→ 不渲染头部，与现状一致。
-- **折叠态**：trace 项全部不渲染，只保留 text / agent-message 项（保持其在 parts 中的相对顺序）。
+- **折叠态**：中间过程（推理、工具、子代理、发送卡及过程叙述文字）全部折叠收起，仅保留最终回复正文。
 - **展开态**：头部 chevron 翻转，trace 项按原顺序内联渲染（`ensure-full`、subagent 卡、`streaming` 锚定等行为不变——live 才传 `streaming`，finished 行本就不传）。
 - 展开状态：模块级 `const expandedTraces = new Set<string>()`；`traceKey` 存在时 toggle 增删；无 `traceKey` 的行不可记忆（始终折叠）。头部 `<button>` 带 `aria-expanded` 与 `data-test="trace-toggle"`。
 - 头部样式：无边框弱化行（`text-fg-muted text-[11.5px]`），与 zcode 的低调头部对齐；整行可点。

--- a/docs/superpowers/specs/2026-09-08-relay-web-decardify-tools-reasoning.md
+++ b/docs/superpowers/specs/2026-09-08-relay-web-decardify-tools-reasoning.md
@@ -1,0 +1,64 @@
+# relay-web 工具调用与思考过程去卡片化（zcode 风格流式展示）设计
+
+日期：2026-09-08
+状态：已实现
+
+## 背景与目标
+
+PR #329 实现了回合结束后的 trace 折叠与展开。但在回合进行中（streaming）以及用户展开中间过程时，各个推理和工具步骤依然以独立的厚重浮动卡片（`rounded-lg border border-border bg-surface shadow-e1`）呈现。在执行多次工具调用（如连续读写文件、运行命令、多次思考）时，数十个卡片层叠导致视觉极其拥挤、噪音过大。
+
+参照 zcode 的界面风格：
+- **去卡片化（De-cardified）**：中间过程是轻量级的背景元数据，不应使用厚重边框、阴影和 surface 底色独立成卡。
+- **单行流式时间线**：每项以极简单行呈现——动作图标 + 操作动词（终端/编辑/写入/查阅等）+ 文件角标（TS/VUE/PY）+ 标题/路径 + 右侧 diff stat（`+4` / `−1`）、耗时和状态。
+- **左导向线展开**：展开时在步骤行下方以 `border-l-2 border-border/50` 导向线缩进展示思考文本或工具输出（diff / command output），不包裹在额外的卡片中。
+- **紧凑垂直节奏**：步骤行之间采用紧凑间距（`space-y-1.5`），与正文叙述（`text`）拉开清晰层次。
+
+## 详细设计
+
+### 1. `ReasoningPanel.vue`
+- 去除 `rounded-lg border border-border bg-surface shadow-e1`。
+- 头部行：`group flex items-center gap-1.5 py-1 px-1.5 -mx-1.5 rounded-md hover:bg-fg/5 text-fg-muted hover:text-fg`。
+  - 前置 Brain 图标（streaming 时 `text-accent`，常态 `text-fg-muted`）。
+  - 文案：`思考` / `思考中…`（en: `Reasoning` / `Reasoning…`）。
+  - streaming 脉冲圆点（`bg-accent`）。
+  - 后置轻量展开指示器（`ChevronDown` / `ChevronRight`）。
+- 展开正文：以 `ml-2.5 my-1 border-l-2 border-border/60 pl-3 py-0.5 text-[12px] text-fg-muted/85 whitespace-pre-wrap` 缩进呈现，去除原顶部分隔线。
+
+### 2. `ToolStepCard.vue`
+- 去除 `rounded-lg border bg-surface shadow-e1`。
+- 单行头部：
+  - 前置种类图标（`KIND_ICON[step.kind]`）。
+  - 操作动词：`$t("tools.kinds." + kindLabel)`——`终端`（execute）、`编辑`（edit）、`写入`（write，识别新文件/写入操作）、`查阅`（read）、`搜索`（search）、`工具`（other）。
+  - 文件扩展名角标：对 read/edit 步骤智能提取文件名后缀（`TS`、`VUE`、`PY`、`JSON` 等），显示为 `rounded bg-accent/10 px-1 py-0.5 text-[9px] font-semibold text-accent/80 font-mono`。
+  - 目标参数/命令/文件名：`truncate font-mono text-[11.5px]`。
+  - 右侧状态区：
+    - Diff 变更统计：对 diff 类型详情调用 `diffLines()` 提取 `+add`（绿色 `text-run`）与 `−del`（红色 `text-danger`）。
+    - 运行时长：`fmtDuration(step.durationMs)`。
+    - 状态图标：`Check`（仅在无 diff 统计时展示或伴随状态）、`Loader2`（执行中旋转）、`AlertTriangle`（失败）。
+    - 悬浮展开提示图标（`ChevronDown` / `ChevronRight`）。
+- 展开详情：以 `ml-2.5 my-1.5 border-l-2 border-border/50 pl-3 space-y-1` 在步骤下方无缝展开 `<ToolDetail>`。
+
+### 3. `SubagentStepCard.vue`
+- 去除 `rounded-xl border bg-surface shadow-e1`。
+- 头部行采用同款 `py-1 px-1.5 -mx-1.5 rounded-md hover:bg-fg/5` 单行布局，前置 `Bot` 图标与 `子代理` 标签。
+- 闭合时的活动轮播与展开时的子任务时间线均以 `ml-2.5 my-0.5 border-l-2 border-border/40 pl-3` 缩进展示。
+
+### 4. `ToolCallPanel.vue`（旧历史兼容）
+- 去除外层边框与背景，头部单行对齐，展开列表缩进。
+
+### 5. `TurnParts.vue`
+- 容器间距调优为 `space-y-1.5`，使中间过程的多行步骤紧凑咬合；正文叙述附带 `my-1` 上下微距，清晰区隔活动与正文。
+
+### 6. i18n
+- `en.ts` 与 `zh-CN.ts` 增补 `tools.kinds.*`（read, search, execute, edit, write, think, other）。
+- `zh-CN.ts` 中 `reasoning` 更新为 `思考` 与 `思考中…`。
+
+## 验证覆盖
+
+- `packages/relay-web/src/__tests__/toolstepcard.test.ts`：
+  - 断言卡片边框、背景与阴影类已被移除。
+  - 断言各种类操作动词与文件角标正确展示。
+  - 断言 edit 步骤展示 `+add` / `−del` 差分数据。
+  - 断言新文件写入被识别为 `Write`（写入）。
+- 既有测试全部兼容并绿：`toolstepcard.test.ts`（11/11）、`toolcallpanel.test.ts`（11/11）、`subagentstepcard.test.ts`（13/13）、`tooldetail.test.ts`（9/9）、`turnparts-collapse.test.ts`（13/13）、`messagelist.test.ts`（62/62）、`i18n-parity.test.ts`（2/2）。
+- Web 全套 131 文件 / 1415 测试全绿，`vue-tsc` 与根 `tsc` 零错误。

--- a/docs/superpowers/specs/2026-09-08-relay-web-decardify-tools-reasoning.md
+++ b/docs/superpowers/specs/2026-09-08-relay-web-decardify-tools-reasoning.md
@@ -11,7 +11,7 @@ PR #329 实现了回合结束后的 trace 折叠与展开。但在回合进行�
 - **去卡片化（De-cardified）**：中间过程是轻量级的背景元数据，不应使用厚重边框、阴影和 surface 底色独立成卡。
 - **单行流式时间线**：每项以极简单行呈现——动作图标 + 操作动词（终端/编辑/写入/查阅等）+ 文件角标（TS/VUE/PY）+ 标题/路径 + 右侧 diff stat（`+4` / `−1`）、耗时和状态。
 - **左导向线展开**：展开时在步骤行下方以 `border-l-2 border-border/50` 导向线缩进展示思考文本或工具输出（diff / command output），不包裹在额外的卡片中。
-- **紧凑垂直节奏**：步骤行之间采用紧凑间距（`space-y-1.5`），与正文叙述（`text`）拉开清晰层次。
+- **紧凑垂直节奏**：步骤行之间采用统一 `space-y-2` 呼吸间距，与正文叙述（`text`）拉开清晰层次。
 
 ## 详细设计
 
@@ -47,7 +47,7 @@ PR #329 实现了回合结束后的 trace 折叠与展开。但在回合进行�
 - 去除外层边框与背景，头部单行对齐，展开列表缩进。
 
 ### 5. `TurnParts.vue`
-- 容器间距调优为 `space-y-1.5`，使中间过程的多行步骤紧凑咬合；正文叙述附带 `my-1` 上下微距，清晰区隔活动与正文。
+- 容器采用统一 `space-y-2` 间距，使中间过程的多行步骤紧凑咬合且垂直节奏一致；折叠时通过 `extractFinalReplyText` 保证 Markdown 顶层块完整性，且与 `MessageList` 复制按钮共用同一语义结果。
 
 ### 6. i18n
 - `en.ts` 与 `zh-CN.ts` 增补 `tools.kinds.*`（read, search, execute, edit, write, think, other）。
@@ -60,5 +60,5 @@ PR #329 实现了回合结束后的 trace 折叠与展开。但在回合进行�
   - 断言各种类操作动词与文件角标正确展示。
   - 断言 edit 步骤展示 `+add` / `−del` 差分数据。
   - 断言新文件写入被识别为 `Write`（写入）。
-- 既有测试全部兼容并绿：`toolstepcard.test.ts`（11/11）、`toolcallpanel.test.ts`（11/11）、`subagentstepcard.test.ts`（13/13）、`tooldetail.test.ts`（9/9）、`turnparts-collapse.test.ts`（13/13）、`messagelist.test.ts`（62/62）、`i18n-parity.test.ts`（2/2）。
-- Web 全套 131 文件 / 1415 测试全绿，`vue-tsc` 与根 `tsc` 零错误。
+- 既有测试全部兼容并绿：`toolstepcard.test.ts`、`toolcallpanel.test.ts`、`subagentstepcard.test.ts`、`tooldetail.test.ts`、`turnparts-collapse.test.ts`、`messagelist.test.ts`、`i18n-parity.test.ts`。
+- Web 全套 131 文件所有测试全绿，`vue-tsc` 与根 `tsc` 零错误。

--- a/docs/superpowers/specs/2026-09-08-relay-web-decardify-tools-reasoning.md
+++ b/docs/superpowers/specs/2026-09-08-relay-web-decardify-tools-reasoning.md
@@ -46,9 +46,10 @@ PR #329 实现了回合结束后的 trace 折叠与展开。但在回合进行�
 ### 4. `ToolCallPanel.vue`（旧历史兼容）
 - 去除外层边框与背景，头部单行对齐，展开列表缩进。
 
-### 5. `TurnParts.vue`
-- 容器采用统一 `space-y-2` 间距，使中间过程的多行步骤紧凑咬合且垂直节奏一致；折叠时通过 `extractFinalReplyText` 保证 Markdown 顶层块完整性，且与 `MessageList` 复制按钮共用同一语义结果。
-
+### 5. `TurnParts.vue` 与 `MessageList.vue` 架构分工
+- 容器采用统一 `space-y-2` 间距，使中间过程的多行步骤紧凑咬合且垂直节奏一致。
+- 架构采用「父层预计算 + 子层 fallback」模式：`MessageList` 通过 `extractCollapsedTraceSummary()` 一次性派生 final reply 与步骤/思考计数并通过 WeakMap 缓存，预计算结果下发给 `TurnParts`（`:collapsed-reply-text`, `:collapsed-tool-count`, `:collapsed-thought-count`），使折叠状态无需访问 `presentation.value`；`TurnParts` 在独立调用时 fallback 派生。
+- 折叠时严格检验块级与 inline 级 Markdown 完整性（fail-safe 防破损），且与 `MessageList` 复制按钮共用同一语义结果。
 ### 6. i18n
 - `en.ts` 与 `zh-CN.ts` 增补 `tools.kinds.*`（read, search, execute, edit, write, think, other）。
 - `zh-CN.ts` 中 `reasoning` 更新为 `思考` 与 `思考中…`。

--- a/packages/relay-web/src/__tests__/line-diff.test.ts
+++ b/packages/relay-web/src/__tests__/line-diff.test.ts
@@ -67,4 +67,27 @@ describe("diffLines", () => {
     expect(d.add).toBe(0);
     expect(d.rows.some((r) => r.type === "context")).toBe(false);
   });
+
+  it("handles a single-line file with a trailing newline as 1 addition", () => {
+    expect(diffLines("", "export const x = 1;\n")).toMatchObject({ add: 1, del: 0 });
+  });
+
+  it("handles deleting a single-line file with a trailing newline as 1 deletion", () => {
+    expect(diffLines("export const x = 1;\n", "")).toMatchObject({ add: 0, del: 1 });
+  });
+
+  it("handles multi-line files with trailing newline correctly without off-by-one", () => {
+    expect(diffLines("", "a\nb\n")).toMatchObject({ add: 2, del: 0 });
+    expect(diffLines("a\nb\n", "")).toMatchObject({ add: 0, del: 2 });
+  });
+
+  it("preserves true empty lines in the middle of text", () => {
+    const d = diffLines("", "a\n\nb\n");
+    expect(d.add).toBe(3);
+  });
+
+  it("does not treat adding or removing a terminal newline as a whole line addition/deletion", () => {
+    expect(diffLines("a", "a\n")).toMatchObject({ add: 0, del: 0 });
+    expect(diffLines("a\n", "a")).toMatchObject({ add: 0, del: 0 });
+  });
 });

--- a/packages/relay-web/src/__tests__/line-diff.test.ts
+++ b/packages/relay-web/src/__tests__/line-diff.test.ts
@@ -90,4 +90,16 @@ describe("diffLines", () => {
     expect(diffLines("a", "a\n")).toMatchObject({ add: 0, del: 0 });
     expect(diffLines("a\n", "a")).toMatchObject({ add: 0, del: 0 });
   });
+
+  it("marks exact: true for standard LCS diffs", () => {
+    const d = diffLines("a\nb\nc", "a\nx\nc");
+    expect(d.exact).toBe(true);
+  });
+
+  it("marks exact: false when falling back to naive diff on n * m > 250,000 cells (501 lines)", () => {
+    const lines501 = Array.from({ length: 501 }, (_, i) => `${i}`).join("\n");
+    const mod501 = lines501.replace("0", "zero");
+    const d = diffLines(lines501, mod501);
+    expect(d.exact).toBe(false);
+  });
 });

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -266,6 +266,30 @@ describe("MessageList", () => {
     expect(copy.exists()).toBe(false);
   });
 
+  it("omits the assistant copy button when trailing content is only reference link definitions", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [
+          msg({
+            direction: "out",
+            text: "See [docs][ref]\n\n[ref]: https://example.com",
+            status: "done",
+            structured: {
+              parts: [
+                { type: "text", text: "See [docs][ref]" },
+                { type: "tool", step: sendStep("read-1") },
+                { type: "text", text: "\n\n[ref]: https://example.com" },
+              ],
+            },
+          }),
+        ],
+        liveTurn: null,
+      },
+    });
+    const copy = wrapper.find('[data-test="msg-out"] [data-test="msg-actions"]').findComponent(CopyButton);
+    expect(copy.exists()).toBe(false);
+  });
+
   it("retains full text on failed assistant turns that do not collapse", () => {
     const wrapper = mount(MessageList, {
       props: {

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -236,7 +236,8 @@ describe("MessageList", () => {
     const turnParts = wrapper.findComponent(TurnParts);
     expect(turnParts.exists()).toBe(true);
     expect(turnParts.props("collapsedReplyText")).toBe("Fixed. The issue was X.");
-
+    expect(turnParts.props("collapsedToolCount")).toBe(1);
+    expect(turnParts.props("collapsedThoughtCount")).toBe(0);
     const copy = wrapper.find('[data-test="msg-out"] [data-test="msg-actions"]').findComponent(CopyButton);
     expect(copy.exists()).toBe(true);
     expect(copy.props("text")).toBe("Fixed. The issue was X.");

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -12,6 +12,7 @@ import type { ChatMessage, LiveTurn } from "../stores/chat";
 import ToolCallPanel from "../components/ToolCallPanel.vue";
 import ToolStepCard from "../components/ToolStepCard.vue";
 import CopyButton from "../components/CopyButton.vue";
+import TurnParts from "../components/TurnParts.vue";
 
 // StreamMarkdown (rendered for "out" messages) reads useThemeStore() to re-hydrate mermaid
 // diagrams on theme change, so every mount here needs an active Pinia instance.
@@ -207,6 +208,35 @@ describe("MessageList", () => {
         liveTurn: null,
       },
     });
+    const copy = wrapper.find('[data-test="msg-out"] [data-test="msg-actions"]').findComponent(CopyButton);
+    expect(copy.exists()).toBe(true);
+    expect(copy.props("text")).toBe("Fixed. The issue was X.");
+  });
+
+  it("shares precomputed collapsed reply text with TurnParts and caches it across renders", () => {
+    const assistantMessage = msg({
+      direction: "out",
+      text: "I'll inspect this.Fixed. The issue was X.",
+      status: "done",
+      structured: {
+        parts: [
+          { type: "text", text: "I'll inspect this." },
+          { type: "tool", step: sendStep("read-1") },
+          { type: "text", text: "Fixed. The issue was X." },
+        ],
+      },
+    });
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [assistantMessage],
+        liveTurn: null,
+      },
+    });
+
+    const turnParts = wrapper.findComponent(TurnParts);
+    expect(turnParts.exists()).toBe(true);
+    expect(turnParts.props("collapsedReplyText")).toBe("Fixed. The issue was X.");
+
     const copy = wrapper.find('[data-test="msg-out"] [data-test="msg-actions"]').findComponent(CopyButton);
     expect(copy.exists()).toBe(true);
     expect(copy.props("text")).toBe("Fixed. The issue was X.");

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -187,6 +187,80 @@ describe("MessageList", () => {
     expect(copy.props("text")).toBe("**raw source**");
   });
 
+  it("copies only the final reply on collapsed assistant rows, suppressing hidden process text", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [
+          msg({
+            direction: "out",
+            text: "I'll inspect this.Fixed. The issue was X.",
+            status: "done",
+            structured: {
+              parts: [
+                { type: "text", text: "I'll inspect this." },
+                { type: "tool", step: sendStep("read-1") },
+                { type: "text", text: "Fixed. The issue was X." },
+              ],
+            },
+          }),
+        ],
+        liveTurn: null,
+      },
+    });
+    const copy = wrapper.find('[data-test="msg-out"] [data-test="msg-actions"]').findComponent(CopyButton);
+    expect(copy.exists()).toBe(true);
+    expect(copy.props("text")).toBe("Fixed. The issue was X.");
+  });
+
+  it("omits the assistant copy button when the turn ends on a process item with no final reply", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [
+          msg({
+            direction: "out",
+            text: "running the checks",
+            status: "done",
+            structured: {
+              parts: [
+                { type: "text", text: "running the checks" },
+                { type: "tool", step: sendStep("read-1") },
+              ],
+            },
+          }),
+        ],
+        liveTurn: null,
+      },
+    });
+    const copy = wrapper.find('[data-test="msg-out"] [data-test="msg-actions"]').findComponent(CopyButton);
+    expect(copy.exists()).toBe(false);
+  });
+
+  it("retains full text on failed assistant turns that do not collapse", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [
+          msg({
+            direction: "out",
+            text: "I'll inspect this.Error occurred.",
+            status: "error",
+            structured: {
+              turnStatus: "error",
+              parts: [
+                { type: "text", text: "I'll inspect this." },
+                { type: "tool", step: sendStep("read-1") },
+                { type: "text", text: "Error occurred." },
+              ],
+            },
+          }),
+        ],
+        liveTurn: null,
+      },
+    });
+    const copy = wrapper.find('[data-test="msg-out"] [data-test="msg-actions"]').findComponent(CopyButton);
+    expect(copy.exists()).toBe(true);
+    expect(copy.props("text")).toBe("I'll inspect this.Error occurred.");
+  });
+
   it("badges an inbound prompt from a fired scheduled task (live origin)", () => {
     const wrapper = mount(MessageList, {
       props: { messages: [msg({ direction: "in", text: "summarize commits", scheduled: { taskId: "ab12", executeAt: "2026-06-16T09:00:00.000Z" } })], liveTurn: null },

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -516,9 +516,11 @@ describe("MessageList", () => {
       props: { messages: [turnWithSend("m1"), sentCard("m1")], liveTurn: null },
     });
 
-    // Exactly one card — the anchored one; the standalone m1 row is suppressed.
-    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
+    // The anchored card is process: it folds with the collapsed trace and appears
+    // on expand (the standalone m1 row is suppressed either way).
+    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(0);
     await expandTrace(wrapper);
+    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
     const anchored = wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]');
     expect(anchored.exists()).toBe(true);
     expect(wrapper.text()).toContain("hello m1");
@@ -556,8 +558,10 @@ describe("MessageList", () => {
     await wrapper.setProps({
       messages: [turnWithSend("m1"), sentCard("m1")],
     });
-    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
+    // The re-anchored card is process: folded with the collapsed trace, visible on expand.
+    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(0);
     await expandTrace(wrapper);
+    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
     const anchored = wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]');
     expect(anchored.exists()).toBe(true);
     const tool = wrapper.find('[data-test="tool-step-card"]');
@@ -599,13 +603,17 @@ describe("MessageList", () => {
     expect(wrapper.find('[data-test="tool-step-card"]').exists()).toBe(true);
   });
 
-  it("never suppresses a received card whose id is also an anchored sent card (echo topology)", () => {
+  it("never suppresses a received card whose id is also an anchored sent card (echo topology)", async () => {
     const wrapper = mount(MessageList, {
       props: { messages: [turnWithSend("m1"), sentCard("m1"), receivedCard("m1")], liveTurn: null },
     });
 
-    // Both render: the sent twin anchors inside the turn; the received twin keeps
-    // its own standalone row — the anchored id must not swallow the receiver's copy.
+    // Both render after expanding the folded trace: the sent twin anchors inside the
+    // turn; the received twin keeps its own standalone row — the anchored id must not
+    // swallow the receiver's copy.
+    expect(wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]').exists()).toBe(false);
+    expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
+    await expandTrace(wrapper);
     expect(wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]').exists()).toBe(true);
     expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(2);
     const received = wrapper.find('[data-test="agent-message-card"][data-direction="received"]');
@@ -642,7 +650,7 @@ describe("MessageList", () => {
     expect(wrapper.find('[data-test="turn-agent-message"]').exists()).toBe(false);
   });
 
-  it("anchors two sends in one turn in tool order (no swap)", () => {
+  it("anchors two sends in one turn in tool order (no swap)", async () => {
     const wrapper = mount(MessageList, {
       props: {
         messages: [
@@ -664,6 +672,10 @@ describe("MessageList", () => {
       },
     });
 
+    // Both anchored cards are process: folded until the trace expands, then rendered
+    // in tool order (no swap).
+    expect(wrapper.findAll('[data-test="turn-agent-message"]')).toHaveLength(0);
+    await expandTrace(wrapper);
     const anchoredCards = wrapper.findAll('[data-test="turn-agent-message"]');
     expect(anchoredCards).toHaveLength(2);
     expect(anchoredCards[0]!.text()).toContain("hello m1");
@@ -677,10 +689,12 @@ describe("MessageList", () => {
     const assistant = turnWithSend("m1");
     const wrapper = mount(MessageList, { props: { messages: [assistant], liveTurn: null } });
     expect(wrapper.find('[data-test="agent-message-card"]').exists()).toBe(false);
-
     // The agent-message ControlEvent lands after the tool event: the store pushes the
     // row, and the reactive join moves the card into the turn — no manual refresh.
+    // The turn is finished, so the anchored card is folded; it shows once expanded.
     await wrapper.setProps({ messages: [assistant, sentCard("m1")] });
+    expect(wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]').exists()).toBe(false);
+    await expandTrace(wrapper);
     expect(wrapper.find('[data-test="msg-out"] [data-test="turn-agent-message"]').exists()).toBe(true);
     expect(wrapper.findAll('[data-test="agent-message-card"]')).toHaveLength(1);
   });

--- a/packages/relay-web/src/__tests__/toolstepcard.test.ts
+++ b/packages/relay-web/src/__tests__/toolstepcard.test.ts
@@ -225,7 +225,7 @@ describe("ToolStepCard de-cardified activity stream", () => {
     expect(w.text()).not.toContain("Edit");
   });
 
-  it("does not open an empty detail drawer for steps without details", async () => {
+  it("renders step header as a non-interactive div without button semantics when hasDetail is false", async () => {
     const w = mount(ToolStepCard, {
       props: {
         step: {
@@ -237,7 +237,57 @@ describe("ToolStepCard de-cardified activity stream", () => {
         } as ToolStepDto,
       },
     });
-    await w.find('[data-test="tool-step-header"]').trigger("click");
+    const header = w.find('[data-test="tool-step-header"]');
+    expect(header.element.tagName).toBe("DIV");
+    expect(header.attributes("type")).toBeUndefined();
+    expect(header.attributes("aria-expanded")).toBeUndefined();
+    expect(header.classes()).not.toContain("hover:bg-fg/5");
+    expect(header.classes()).toContain("cursor-default");
+    await header.trigger("click");
     expect(w.find('[data-test="tool-step-detail"]').exists()).toBe(false);
+  });
+
+  it("omits diff stats when naive diff fallback triggers on large inputs (501 lines)", () => {
+    const lines501 = Array.from({ length: 501 }, (_, i) => `${i}`).join("\n");
+    const mod501 = lines501.replace("0", "zero");
+    const w = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          kind: "edit",
+          toolName: "Edit",
+          title: "big.ts",
+          status: "success",
+          detail: {
+            type: "diff",
+            path: "big.ts",
+            oldText: lines501,
+            newText: mod501,
+          },
+        } as ToolStepDto,
+      },
+    });
+    expect(w.find('[data-test="step-diff-stats"]').exists()).toBe(false);
+  });
+
+  it("omits diff stats when diff input contains truncated marker", () => {
+    const w = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          kind: "edit",
+          toolName: "Edit",
+          title: "truncated.ts",
+          status: "success",
+          detail: {
+            type: "diff",
+            path: "truncated.ts",
+            oldText: "const a = 1;\n…(truncated)",
+            newText: "const a = 2;\n…(truncated)",
+          },
+        } as ToolStepDto,
+      },
+    });
+    expect(w.find('[data-test="step-diff-stats"]').exists()).toBe(false);
   });
 });

--- a/packages/relay-web/src/__tests__/toolstepcard.test.ts
+++ b/packages/relay-web/src/__tests__/toolstepcard.test.ts
@@ -132,6 +132,45 @@ describe("ToolStepCard de-cardified activity stream", () => {
     expect(w.text()).toContain("grep -rn foo");
   });
 
+
+  it("does not treat dotted directory names or dotfiles as file extensions", () => {
+    const w1 = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          kind: "read",
+          title: "src.v2/x",
+          status: "success",
+        } as ToolStepDto,
+      },
+    });
+    expect(w1.text()).not.toContain("V2/X");
+    expect(w1.text()).not.toContain("V2");
+
+    const w2 = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t2",
+          kind: "read",
+          title: "a.b/c",
+          status: "success",
+        } as ToolStepDto,
+      },
+    });
+    expect(w2.text()).not.toContain("B/C");
+
+    const w3 = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t3",
+          kind: "read",
+          title: "src.v2/component.vue",
+          status: "success",
+        } as ToolStepDto,
+      },
+    });
+    expect(w3.text()).toContain("VUE");
+  });
   it("renders diff stats (+add, −del) in the header for edit steps", () => {
     const w = mount(ToolStepCard, {
       props: {

--- a/packages/relay-web/src/__tests__/toolstepcard.test.ts
+++ b/packages/relay-web/src/__tests__/toolstepcard.test.ts
@@ -144,8 +144,7 @@ describe("ToolStepCard de-cardified activity stream", () => {
         } as ToolStepDto,
       },
     });
-    expect(w1.text()).not.toContain("V2/X");
-    expect(w1.text()).not.toContain("V2");
+    expect(w1.find('[data-test="file-ext-badge"]').exists()).toBe(false);
 
     const w2 = mount(ToolStepCard, {
       props: {
@@ -157,7 +156,7 @@ describe("ToolStepCard de-cardified activity stream", () => {
         } as ToolStepDto,
       },
     });
-    expect(w2.text()).not.toContain("B/C");
+    expect(w2.find('[data-test="file-ext-badge"]').exists()).toBe(false);
 
     const w3 = mount(ToolStepCard, {
       props: {
@@ -169,7 +168,45 @@ describe("ToolStepCard de-cardified activity stream", () => {
         } as ToolStepDto,
       },
     });
-    expect(w3.text()).toContain("VUE");
+    expect(w3.find('[data-test="file-ext-badge"]').text()).toBe("VUE");
+  });
+
+  it("correctly extracts extension from Windows absolute paths and scheme URIs", () => {
+    const w1 = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          kind: "read",
+          title: "C:\\repo\\src\\index.ts",
+          status: "success",
+        } as ToolStepDto,
+      },
+    });
+    expect(w1.find('[data-test="file-ext-badge"]').text()).toBe("TS");
+
+    const w2 = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t2",
+          kind: "read",
+          title: "C:\\repo.v2\\README",
+          status: "success",
+        } as ToolStepDto,
+      },
+    });
+    expect(w2.find('[data-test="file-ext-badge"]').exists()).toBe(false);
+
+    const w3 = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t3",
+          kind: "read",
+          title: "file:///home/user/src/main.py?line=10",
+          status: "success",
+        } as ToolStepDto,
+      },
+    });
+    expect(w3.find('[data-test="file-ext-badge"]').text()).toBe("PY");
   });
   it("renders diff stats (+add, −del) in the header for edit steps", () => {
     const w = mount(ToolStepCard, {

--- a/packages/relay-web/src/__tests__/toolstepcard.test.ts
+++ b/packages/relay-web/src/__tests__/toolstepcard.test.ts
@@ -177,6 +177,67 @@ describe("ToolStepCard de-cardified activity stream", () => {
       },
     });
     expect(w.text()).toContain("Write");
-    expect(w.text()).toContain("+2");
+    expect(w.text()).toContain("+1");
+  });
+
+  it("does not misclassify a compact Edit diff as Write", () => {
+    const w = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          kind: "edit",
+          toolName: "Edit",
+          title: "packages/relay-web/src/index.ts",
+          status: "success",
+          detail: {
+            type: "diff",
+            path: "packages/relay-web/src/index.ts",
+            oldText: "",
+            newText: "",
+          },
+        } as ToolStepDto,
+      },
+    });
+    expect(w.text()).toContain("Edit");
+    expect(w.text()).not.toContain("Write");
+    expect(w.find('[data-test="step-diff-stats"]').exists()).toBe(false);
+  });
+
+  it("still labels an explicit Write tool as Write in compact mode", () => {
+    const w = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          kind: "edit",
+          toolName: "Write",
+          title: "packages/relay-web/src/index.ts",
+          status: "success",
+          detail: {
+            type: "diff",
+            path: "packages/relay-web/src/index.ts",
+            oldText: "",
+            newText: "",
+          },
+        } as ToolStepDto,
+      },
+    });
+    expect(w.text()).toContain("Write");
+    expect(w.text()).not.toContain("Edit");
+  });
+
+  it("does not open an empty detail drawer for steps without details", async () => {
+    const w = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          toolName: "Todo",
+          kind: "think",
+          title: "Update todos",
+          status: "success",
+        } as ToolStepDto,
+      },
+    });
+    await w.find('[data-test="tool-step-header"]').trigger("click");
+    expect(w.find('[data-test="tool-step-detail"]').exists()).toBe(false);
   });
 });

--- a/packages/relay-web/src/__tests__/toolstepcard.test.ts
+++ b/packages/relay-web/src/__tests__/toolstepcard.test.ts
@@ -107,3 +107,76 @@ describe("ToolStepCard error banner de-duplication", () => {
     expect(w.find('[data-test="read-path"]').text()).toContain("a.ts");
   });
 });
+
+describe("ToolStepCard de-cardified activity stream", () => {
+  it("renders as a borderless minimal stream item without card background or shadow", () => {
+    const w = card({ status: "success", title: "npm test" });
+    const root = w.find('[data-test="tool-step-card"]');
+    expect(root.classes()).not.toContain("bg-surface");
+    expect(root.classes()).not.toContain("shadow-e1");
+    expect(root.classes()).not.toContain("border");
+  });
+
+  it("renders kind verb label and file extension badge", () => {
+    const w = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          kind: "execute",
+          title: "grep -rn foo",
+          status: "success",
+        } as ToolStepDto,
+      },
+    });
+    expect(w.text()).toContain("Terminal");
+    expect(w.text()).toContain("grep -rn foo");
+  });
+
+  it("renders diff stats (+add, −del) in the header for edit steps", () => {
+    const w = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          kind: "edit",
+          toolName: "Edit",
+          title: "packages/relay-web/src/index.ts",
+          status: "success",
+          detail: {
+            type: "diff",
+            path: "packages/relay-web/src/index.ts",
+            oldText: "line 1\nline 2",
+            newText: "line 1\nline 2 modified\nline 3\nline 4\nline 5",
+          },
+        } as ToolStepDto,
+      },
+    });
+    expect(w.text()).toContain("Edit");
+    expect(w.text()).toContain("TS");
+    const stats = w.find('[data-test="step-diff-stats"]');
+    expect(stats.exists()).toBe(true);
+    expect(stats.text()).toContain("+4");
+    expect(stats.text()).toContain("−1");
+  });
+
+  it("identifies new-file write operations as Write instead of Edit", () => {
+    const w = mount(ToolStepCard, {
+      props: {
+        step: {
+          toolCallId: "t1",
+          kind: "edit",
+          toolName: "Write",
+          title: "packages/relay-web/src/new-file.ts",
+          status: "success",
+          detail: {
+            type: "diff",
+            path: "packages/relay-web/src/new-file.ts",
+            oldText: "",
+            newText: "export const x = 1;\n",
+          },
+        } as ToolStepDto,
+      },
+    });
+    expect(w.text()).toContain("Write");
+    expect(w.text()).toContain("+2");
+  });
+});

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -578,6 +578,19 @@ describe("TurnParts trace collapse", () => {
       "See docs now.",
     ]);
   });
+
+  it("fails safe and shows header only when trailing content is only reference link definitions", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "See [docs][ref]" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "\n\n[ref]: https://example.com" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:ref-def-only" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
 });
 
 describe("MessageList convergence", () => {

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -44,7 +44,7 @@ describe("TurnParts trace collapse", () => {
     expect(w.findAll(".shimmer-text, [data-test='tool-step-card']").length).toBeGreaterThan(0);
   });
 
-  it("collapses finished-turn trace behind a summary header, keeping text in order", () => {
+  it("collapses the entire process and keeps only the trailing final reply", () => {
     const w = mount(TurnParts, {
       props: { parts: finishedTurn(), collapseTrace: true, traceKey: "t:123", traceElapsedMs: 272_000 },
     });
@@ -54,8 +54,9 @@ describe("TurnParts trace collapse", () => {
     expect(header.text()).toContain("Worked 4m 32s");
     expect(header.text()).toContain("2 tool steps");
     expect(header.text()).toContain("2 thoughts");
-    // Only the reply survives; every trace card is gone.
-    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual(["first paragraph", "final answer"]);
+    // Process text interleaved before/between activity folds with the trace;
+    // only the trailing text after the last process item is the final reply.
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual(["final answer"]);
     expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
   });
 
@@ -112,10 +113,11 @@ describe("TurnParts trace collapse", () => {
     expect(header.text()).toContain("2 段思考");
   });
 
-  it("keeps agent-message cards visible while the trace is collapsed", () => {
+  it("collapses anchored agent-message cards as part of the process", async () => {
     // A REAL anchor: the send step carries agentMessageId and the map holds the sent
-    // entry, so deriveTurnPresentation actually emits an agent-message item — the
-    // card must survive the collapse while its tool step folds away.
+    // entry, so deriveTurnPresentation actually emits an agent-message item. A mid-turn
+    // peer message is process, not the final reply — it folds with the trace and
+    // returns on expand.
     const parts: TurnPartDto[] = [
       { type: "tool", step: { ...tool("send-1"), agentMessageId: "m1" } },
       { type: "text", text: "answer" },
@@ -128,10 +130,12 @@ describe("TurnParts trace collapse", () => {
         sentAgentMessages: new Map([["m1", { messageId: "m1", direction: "sent", peer: { handle: "p", displayName: "Peer" }, content: "hi", createdAt: 1 } as never]]),
       },
     });
+    expect(w.find('[data-test="turn-agent-message"]').exists()).toBe(false);
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text())).toEqual(["answer"]);
+
+    await w.find('[data-test="trace-toggle"]').trigger("click");
     expect(w.find('[data-test="turn-agent-message"]').exists()).toBe(true);
     expect(w.find('[data-test="agent-message-card"]').text()).toContain("hi");
-    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
-    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text())).toEqual(["answer"]);
   });
 
   it("renders sub-second elapsed as <1s", () => {
@@ -139,6 +143,60 @@ describe("TurnParts trace collapse", () => {
       props: { parts: finishedTurn(), collapseTrace: true, traceKey: "t:6", traceElapsedMs: 400 },
     });
     expect(w.find('[data-test="trace-label"]').text()).toContain("Worked <1s");
+  });
+
+  it("folds interleaved narrative into the trace and leaves only the final answer", async () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "I'll inspect the implementation.\n\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "I found the likely cause.\n\n" },
+      { type: "reasoning", text: "checking another path" },
+      { type: "tool", step: tool("edit-1") },
+      { type: "text", text: "Fixed. The issue was caused by X." },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:process-text" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "Fixed. The issue was caused by X.",
+    ]);
+
+    // Expanding restores the full interleaved process + final reply in arrival order.
+    await w.find('[data-test="trace-toggle"]').trigger("click");
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "I'll inspect the implementation.",
+      "I found the likely cause.",
+      "Fixed. The issue was caused by X.",
+    ]);
+  });
+
+  it("collapses to only the summary header when a turn ends on a process item with no trailing text", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "running the checks" },
+      { type: "tool", step: tool("read-1") },
+      { type: "reasoning", text: "verifying" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:no-trailing" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
+  });
+
+  it("keeps reasoning-then-text turns to only the trailing text", () => {
+    const w = mount(TurnParts, {
+      props: {
+        parts: [
+          { type: "reasoning", text: "hmm" },
+          { type: "tool", step: tool("read-1") },
+          { type: "text", text: "final only" },
+        ] as TurnPartDto[],
+        collapseTrace: true,
+        traceKey: "t:reasoning-first",
+      },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual(["final only"]);
   });
 });
 

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -432,6 +432,72 @@ describe("TurnParts trace collapse", () => {
     ]);
     expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
   });
+
+  it("fails safe and shows header only when an active bold construct crosses a tool", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "I'll inspect **this " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "carefully**. Fixed." },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:bold-crosses-tool" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("fails safe and shows header only when an inline code span crosses a tool", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Use `foo " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "bar` now" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:code-crosses-tool" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("fails safe and shows header only when a markdown link label crosses a tool", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "See [the " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "docs](https://example.com)" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:link-crosses-tool" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("fails safe and shows header only when a tool is contained inside a heading", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "# Status " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "Fixed" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:heading-crosses-tool" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("allows safe paragraph slice when inline formatting precedes the tool but does not cross it", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Before **bold** after " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "final reply" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:inline-before-tool" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "final reply",
+    ]);
+  });
 });
 
 describe("MessageList convergence", () => {

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -198,6 +198,88 @@ describe("TurnParts trace collapse", () => {
     });
     expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual(["final only"]);
   });
+
+  it("keeps trailing final text when process and reply share one markdown block", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "I'll inspect this." },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "Fixed. The issue was X." },
+    ];
+    const w = mount(TurnParts, {
+      props: {
+        parts,
+        collapseTrace: true,
+        traceKey: "t:same-paragraph",
+      },
+    });
+    expect(
+      w.findAll('[data-test="turn-narrative"]')
+        .map((n) => n.text().trim()),
+    ).toEqual([
+      "Fixed. The issue was X.",
+    ]);
+    expect(
+      w.find('[data-test="tool-step-card"]').exists(),
+    ).toBe(false);
+  });
+
+  it("keeps only trailing text for text before -> reasoning -> final", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "I'm thinking about this." },
+      { type: "reasoning", text: "analyzing root cause" },
+      { type: "text", text: "Root cause identified." },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:text-reasoning-final" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "Root cause identified.",
+    ]);
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="trace-label"]').text()).toContain("1 thought");
+  });
+
+  it("keeps trailing text for tool -> final", () => {
+    const parts: TurnPartDto[] = [
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "Here is the result." },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:tool-final" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "Here is the result.",
+    ]);
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
+  });
+
+  it("concatenates consecutive trailing text chunks after the last process item", () => {
+    const parts: TurnPartDto[] = [
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "Result: " },
+      { type: "text", text: "success." },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:consecutive-text" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "Result: success.",
+    ]);
+  });
+
+  it("shows header only when turn has text -> tool with no trailing text", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Working on it..." },
+      { type: "tool", step: tool("read-1") },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:text-tool-no-trailing" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
+  });
 });
 
 describe("MessageList convergence", () => {

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -403,6 +403,35 @@ describe("TurnParts trace collapse", () => {
     expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
     expect(w.find("pre code").exists()).toBe(false);
   });
+
+  it("fails safe and shows header only when a turn ends inside a table lacking delimiter row with no reply", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "| name | value |\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "| foo | 1 |\n| bar | 2 |" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:table-no-delim-no-reply" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+    expect(w.find("table").exists()).toBe(false);
+  });
+
+  it("extracts trailing reply outside a table lacking delimiter row", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "| name | value |\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "| foo | 1 |\n| bar | 2 |\n\nafter" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:table-no-delim-after" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "after",
+    ]);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
+  });
 });
 
 describe("MessageList convergence", () => {

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -360,6 +360,49 @@ describe("TurnParts trace collapse", () => {
     expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
     expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
   });
+
+  it("fails safe and shows header only when a turn ends inside a code fence nested in a blockquote", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "> ```ts\n> const a = 1;\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "> const b = 2;\n> ```" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:bq-fence-no-after" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+    expect(w.find("pre code").exists()).toBe(false);
+  });
+
+  it("fails safe and shows header only when a turn ends inside a list nested in a blockquote", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "> 1. item one\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "> 2. item two\n" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:bq-list-no-after" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("preserves blockquote integrity and extracts trailing reply outside the blockquote", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "> ```ts\n> const a = 1;\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "> const b = 2;\n> ```\n\nafter blockquote" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:bq-fence-after" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "after blockquote",
+    ]);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
+    expect(w.find("pre code").exists()).toBe(false);
+  });
 });
 
 describe("MessageList convergence", () => {

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -498,6 +498,46 @@ describe("TurnParts trace collapse", () => {
       "final reply",
     ]);
   });
+
+  it("fails safe and shows header only when a link delimiter boundary [docs] | (url) is severed by a tool", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "See [docs]" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "(https://example.com) for details." },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:link-delimiter-tool" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("fails safe and shows header only when two hard-break trailing spaces are severed by a tool", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "foo " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: " \nbar" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:hardbreak-severed-tool" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("allows safe paragraph slice when a complete link precedes the tool without crossing it", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "See [docs](https://example.com) first. " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "Final answer." },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:link-before-tool" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "Final answer.",
+    ]);
+  });
 });
 
 describe("MessageList convergence", () => {

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -538,6 +538,46 @@ describe("TurnParts trace collapse", () => {
       "Final answer.",
     ]);
   });
+
+  it("fails safe and shows header only when an HTML entity is severed by a tool", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Result &" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "amp; done." },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:entity-severed-tool" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("fails safe and shows header only when a reference-style link is severed by a tool", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "See [docs]" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "[ref]\n\n[ref]: https://example.com" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:ref-link-severed-tool" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("allows safe paragraph slice when an uncrossed reference-style link is present in the reply", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Before.\n\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "See [docs][ref] now.\n\n[ref]: https://example.com" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:ref-link-uncrossed" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual([
+      "See docs now.",
+    ]);
+  });
 });
 
 describe("MessageList convergence", () => {

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -280,6 +280,86 @@ describe("TurnParts trace collapse", () => {
     expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
     expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
   });
+
+  it("preserves fenced code block integrity and extracts trailing reply outside the fence", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "```ts\nconst a = 1;\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "\nconst b = 2;\n```\n\nafter" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:fence-after" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual(["after"]);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
+    // Crucially: "after" must be a clean paragraph, NOT sucked into an unclosed code block
+    expect(w.find("pre code").exists()).toBe(false);
+  });
+
+  it("fails safe and shows header only when a turn ends inside a code fence with no reply", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "```ts\nconst a = 1;\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "\nconst b = 2;\n```" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:fence-no-after" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+    expect(w.find("pre code").exists()).toBe(false);
+  });
+
+  it("preserves table integrity and extracts trailing reply outside the table", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "| a | b |\n| - | - |\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "| 1 | 2 |\n\nafter" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:table-after" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual(["after"]);
+    expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
+  });
+
+  it("fails safe and shows header only when a turn ends inside a table with no reply", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "| a | b |\n| - | - |\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "| 1 | 2 |\n" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:table-no-after" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
+
+  it("extracts trailing reply after a markdown list", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "- one\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "\n- two\n\nafter" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:list-after" },
+    });
+    expect(w.findAll('[data-test="turn-narrative"]').map((n) => n.text().trim())).toEqual(["after"]);
+  });
+
+  it("fails safe and shows header only when tool is inside a list without trailing reply", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "- one\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "\n- two" },
+    ];
+    const w = mount(TurnParts, {
+      props: { parts, collapseTrace: true, traceKey: "t:list-no-after" },
+    });
+    expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
+    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+  });
 });
 
 describe("MessageList convergence", () => {

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -63,9 +63,23 @@ function traceElapsedOf(m: ChatMessage): number | null {
   return Number.isFinite(ms) && ms > 0 ? ms : null;
 }
 
+// Cache final-reply extraction by message object and parts reference to prevent
+// redundant markdown parses across MessageList (CopyButton) and TurnParts.
+const replyTextCache = new WeakMap<ChatMessage, { parts: TurnPartDto[]; text: string }>();
+
+function finalReplyTextOf(m: ChatMessage): string {
+  const parts = m.structured?.parts;
+  if (!parts?.length) return "";
+  const cached = replyTextCache.get(m);
+  if (cached && cached.parts === parts) return cached.text;
+  const text = extractFinalReplyText(parts);
+  replyTextCache.set(m, { parts, text });
+  return text;
+}
+
 function copyTextOf(m: ChatMessage): string {
   if (m.direction === "out" && m.structured?.parts?.length && !isFailedTurn(m) && hasTraceParts(m)) {
-    return extractFinalReplyText(m.structured.parts);
+    return finalReplyTextOf(m);
   }
   return m.text ?? "";
 }
@@ -591,7 +605,8 @@ watch(
                    Markdown narrative. Tool cards own their collapsed state. -->
               <div data-test="msg-content" class="space-y-2.5">
                 <TurnParts v-if="m.structured?.parts?.length" :parts="m.structured.parts" :ensure-full="ensureFullOf(m)" :sent-agent-messages="sentAgentMessageById"
-                           :collapse-trace="!isFailedTurn(m) && hasTraceParts(m)" :trace-key="traceKeyOf(m)" :trace-elapsed-ms="traceElapsedOf(m)" />
+                           :collapse-trace="!isFailedTurn(m) && hasTraceParts(m)" :trace-key="traceKeyOf(m)" :trace-elapsed-ms="traceElapsedOf(m)"
+                           :collapsed-reply-text="!isFailedTurn(m) && hasTraceParts(m) ? finalReplyTextOf(m) : undefined" />
                 <template v-else>
                   <ToolCallPanel v-if="m.structured?.toolSteps?.length" :steps="m.structured.toolSteps" :ensure-full="ensureFullOf(m)" />
                   <ReasoningPanel v-if="m.structured?.reasoning?.trim()" :reasoning="m.structured.reasoning" :default-open="false" />
@@ -599,7 +614,9 @@ watch(
                 </template>
               </div>
               <div data-test="msg-actions" class="flex items-center gap-1.5 pt-0.5 text-fg-muted">
-                <CopyButton v-if="copyTextOf(m)" :text="copyTextOf(m)" />
+                <template v-for="copyText in [copyTextOf(m)]" :key="0">
+                  <CopyButton v-if="copyText" :text="copyText" />
+                </template>
                 <span v-if="fmtTime(m.createdAt)" data-test="msg-time" class="font-mono text-[10.5px] tabular-nums">{{ fmtTime(m.createdAt) }}</span>
                 <span v-if="m.structured?.truncated" data-test="msg-truncated" class="inline-flex items-center gap-1 text-[11px] text-warn"><TriangleAlert :size="12" /> {{ $t("chat.truncated") }}</span>
                 <span v-if="m.status === 'cancelled'" data-test="msg-cancelled" class="inline-flex items-center gap-1 text-[11px] text-warn"><CircleStop :size="12" /> {{ $t("chat.stopped") }}</span>

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -12,7 +12,12 @@ import AgentMessageCard from "./AgentMessageCard.vue";
 import AgentIcon from "./AgentIcon.vue";
 import MessageAttachments from "./MessageAttachments.vue";
 import { fmtTime, fmtDateTime } from "../lib/format";
-import { anchoredAgentMessageIds, extractFinalReplyText } from "../lib/turn-presentation";
+import {
+  anchoredAgentMessageIds,
+  extractCollapsedTraceSummary,
+  extractFinalReplyText,
+  type CollapsedTraceSummary,
+} from "../lib/turn-presentation";
 const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; driver?: string | null; hasMoreOlder?: boolean; loadingOlder?: boolean; loadingHistory?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null; ensureFull?: (messageId: number) => Promise<void> }>();
 const emit = defineEmits<{ resend: [message: ChatMessage]; loadOlder: [] }>();
 
@@ -63,23 +68,25 @@ function traceElapsedOf(m: ChatMessage): number | null {
   return Number.isFinite(ms) && ms > 0 ? ms : null;
 }
 
-// Cache final-reply extraction by message object and parts reference to prevent
-// redundant markdown parses across MessageList (CopyButton) and TurnParts.
-const replyTextCache = new WeakMap<ChatMessage, { parts: TurnPartDto[]; text: string }>();
+// Cache collapsed trace metrics by message object and parts reference to prevent
+// redundant markdown parses and presentation derivations across MessageList and TurnParts.
+const traceSummaryCache = new WeakMap<ChatMessage, { parts: TurnPartDto[]; summary: CollapsedTraceSummary }>();
 
-function finalReplyTextOf(m: ChatMessage): string {
+function traceSummaryOf(m: ChatMessage): CollapsedTraceSummary {
   const parts = m.structured?.parts;
-  if (!parts?.length) return "";
-  const cached = replyTextCache.get(m);
-  if (cached && cached.parts === parts) return cached.text;
-  const text = extractFinalReplyText(parts);
-  replyTextCache.set(m, { parts, text });
-  return text;
+  if (!parts?.length) return { finalReplyText: "", toolCount: 0, thoughtCount: 0 };
+  const cached = traceSummaryCache.get(m);
+  if (cached && cached.parts === parts) return cached.summary;
+  const summary = extractCollapsedTraceSummary(parts, {
+    sentAgentMessageById: sentAgentMessageById.value,
+  });
+  traceSummaryCache.set(m, { parts, summary });
+  return summary;
 }
 
 function copyTextOf(m: ChatMessage): string {
   if (m.direction === "out" && m.structured?.parts?.length && !isFailedTurn(m) && hasTraceParts(m)) {
-    return finalReplyTextOf(m);
+    return traceSummaryOf(m).finalReplyText;
   }
   return m.text ?? "";
 }
@@ -606,7 +613,9 @@ watch(
               <div data-test="msg-content" class="space-y-2.5">
                 <TurnParts v-if="m.structured?.parts?.length" :parts="m.structured.parts" :ensure-full="ensureFullOf(m)" :sent-agent-messages="sentAgentMessageById"
                            :collapse-trace="!isFailedTurn(m) && hasTraceParts(m)" :trace-key="traceKeyOf(m)" :trace-elapsed-ms="traceElapsedOf(m)"
-                           :collapsed-reply-text="!isFailedTurn(m) && hasTraceParts(m) ? finalReplyTextOf(m) : undefined" />
+                           :collapsed-reply-text="!isFailedTurn(m) && hasTraceParts(m) ? traceSummaryOf(m).finalReplyText : undefined"
+                           :collapsed-tool-count="!isFailedTurn(m) && hasTraceParts(m) ? traceSummaryOf(m).toolCount : undefined"
+                           :collapsed-thought-count="!isFailedTurn(m) && hasTraceParts(m) ? traceSummaryOf(m).thoughtCount : undefined" />
                 <template v-else>
                   <ToolCallPanel v-if="m.structured?.toolSteps?.length" :steps="m.structured.toolSteps" :ensure-full="ensureFullOf(m)" />
                   <ReasoningPanel v-if="m.structured?.reasoning?.trim()" :reasoning="m.structured.reasoning" :default-open="false" />

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -12,8 +12,7 @@ import AgentMessageCard from "./AgentMessageCard.vue";
 import AgentIcon from "./AgentIcon.vue";
 import MessageAttachments from "./MessageAttachments.vue";
 import { fmtTime, fmtDateTime } from "../lib/format";
-import { anchoredAgentMessageIds } from "../lib/turn-presentation";
-
+import { anchoredAgentMessageIds, extractFinalReplyText } from "../lib/turn-presentation";
 const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; driver?: string | null; hasMoreOlder?: boolean; loadingOlder?: boolean; loadingHistory?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null; ensureFull?: (messageId: number) => Promise<void> }>();
 const emit = defineEmits<{ resend: [message: ChatMessage]; loadOlder: [] }>();
 
@@ -62,6 +61,13 @@ function traceElapsedOf(m: ChatMessage): number | null {
   if (m.startedAt === undefined) return null;
   const ms = Date.parse(m.createdAt) - m.startedAt;
   return Number.isFinite(ms) && ms > 0 ? ms : null;
+}
+
+function copyTextOf(m: ChatMessage): string {
+  if (m.direction === "out" && m.structured?.parts?.length && !isFailedTurn(m) && hasTraceParts(m)) {
+    return extractFinalReplyText(m.structured.parts);
+  }
+  return m.text ?? "";
 }
 
 // Presentation-only join (v0.3 spec §8): a SENT peer-message card anchors right after
@@ -593,7 +599,7 @@ watch(
                 </template>
               </div>
               <div data-test="msg-actions" class="flex items-center gap-1.5 pt-0.5 text-fg-muted">
-                <CopyButton v-if="m.text" :text="m.text" />
+                <CopyButton v-if="copyTextOf(m)" :text="copyTextOf(m)" />
                 <span v-if="fmtTime(m.createdAt)" data-test="msg-time" class="font-mono text-[10.5px] tabular-nums">{{ fmtTime(m.createdAt) }}</span>
                 <span v-if="m.structured?.truncated" data-test="msg-truncated" class="inline-flex items-center gap-1 text-[11px] text-warn"><TriangleAlert :size="12" /> {{ $t("chat.truncated") }}</span>
                 <span v-if="m.status === 'cancelled'" data-test="msg-cancelled" class="inline-flex items-center gap-1 text-[11px] text-warn"><CircleStop :size="12" /> {{ $t("chat.stopped") }}</span>

--- a/packages/relay-web/src/components/ReasoningPanel.vue
+++ b/packages/relay-web/src/components/ReasoningPanel.vue
@@ -1,26 +1,34 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { Brain, ChevronDown, ChevronRight } from "lucide-vue-next";
+
 const props = withDefaults(defineProps<{ reasoning: string; defaultOpen?: boolean; streaming?: boolean }>(), {
   defaultOpen: false,
   streaming: false,
 });
-// Reasoning is collapsed by default — the header (with a live shimmer while streaming)
-// signals it's there without burying the answer/tools below a wall of thought. The user
-// expands it on demand; their toggle is respected even mid-stream.
+
+// Reasoning is collapsed by default — de-cardified single line (zcode-style) with a
+// live shimmer while streaming. The user expands it on demand into an indented block.
 const localOpen = ref(props.defaultOpen ?? false);
 const open = computed(() => localOpen.value);
 </script>
 
 <template>
-  <div class="overflow-hidden rounded-lg border border-border bg-surface text-xs shadow-e1">
-    <button type="button" class="flex w-full items-center gap-1.5 px-3 py-2 text-left text-fg-muted" @click="localOpen = !localOpen">
-      <ChevronDown v-if="open" :size="13" class="shrink-0" />
-      <ChevronRight v-else :size="13" class="shrink-0" />
-      <Brain :size="13" :class="streaming ? 'text-accent' : ''" />
-      <span class="text-[12px] font-medium" :class="streaming ? 'shimmer-text' : ''">{{ streaming ? $t("reasoning.reasoningStreaming") : $t("reasoning.reasoning") }}</span>
-      <span v-if="streaming" data-test="reasoning-shimmer" class="ml-1 inline-block h-1.5 w-1.5 animate-pulse motion-reduce:animate-none rounded-full bg-fg-muted" aria-hidden="true" />
+  <div class="text-xs">
+    <button type="button"
+            class="group flex items-center gap-1.5 py-1 px-1.5 -mx-1.5 rounded-md text-left text-fg-muted hover:text-fg hover:bg-fg/5 transition-colors"
+            @click="localOpen = !localOpen">
+      <Brain :size="13" class="shrink-0 transition-colors"
+             :class="streaming ? 'text-accent' : 'text-fg-muted/80 group-hover:text-fg'" />
+      <span class="text-[12px] font-medium transition-colors"
+            :class="streaming ? 'shimmer-text text-accent' : ''">{{ streaming ? $t("reasoning.reasoningStreaming") : $t("reasoning.reasoning") }}</span>
+      <span v-if="streaming" data-test="reasoning-shimmer" class="ml-0.5 inline-block h-1.5 w-1.5 animate-pulse motion-reduce:animate-none rounded-full bg-accent" aria-hidden="true" />
+      <ChevronDown v-if="open" :size="12" class="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity" />
+      <ChevronRight v-else :size="12" class="shrink-0 opacity-40 group-hover:opacity-80 transition-opacity" />
     </button>
-    <p v-if="open" data-test="reasoning-body" class="whitespace-pre-wrap border-t border-border px-3 pb-2.5 pt-2 text-[12px] leading-relaxed text-fg-muted">{{ reasoning }}</p>
+    <p v-if="open" data-test="reasoning-body"
+       class="ml-2.5 my-1 border-l-2 border-border/60 pl-3 py-0.5 text-[12px] leading-relaxed text-fg-muted/85 whitespace-pre-wrap">
+      {{ reasoning }}
+    </p>
   </div>
 </template>

--- a/packages/relay-web/src/components/SubagentStepCard.vue
+++ b/packages/relay-web/src/components/SubagentStepCard.vue
@@ -194,7 +194,7 @@ onBeforeUnmount(() => {
         </p>
       </template>
       <button type="button" data-test="subagent-open-trace"
-              class="mt-2.5 inline-flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2.5 py-1.5 text-[10.5px] font-medium text-fg-muted transition-colors hover:border-accent/40 hover:text-accent"
+              class="inline-flex items-center gap-1.5 rounded-md px-1.5 py-1 text-[10.5px] font-medium text-accent transition-colors hover:bg-fg/5"
               @click="onOpenTrace">
         <ExternalLink :size="12" /> {{ $t("tools.viewFullTrace") }}
       </button>

--- a/packages/relay-web/src/components/SubagentStepCard.vue
+++ b/packages/relay-web/src/components/SubagentStepCard.vue
@@ -118,38 +118,29 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <article data-test="subagent-card"
-           class="overflow-hidden rounded-xl border bg-surface text-xs shadow-e1 transition-colors"
-           :class="status === 'error' ? 'border-danger/40' : status === 'running' ? 'border-accent/35' : 'border-border'"
+  <article data-test="subagent-card" class="text-xs"
            @mouseenter="paused = true" @mouseleave="paused = false" @focusin="paused = true" @focusout="paused = false">
     <button type="button" data-test="subagent-header"
-            class="group flex w-full items-center gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-bg/70"
+            class="group flex w-full items-center gap-1.5 py-1 px-1.5 -mx-1.5 rounded-md text-left text-fg-muted hover:text-fg hover:bg-fg/5 transition-colors"
             :aria-expanded="open" @click="onHeaderClick">
-      <ChevronDown v-if="open" :size="14" class="shrink-0 text-fg-muted" />
-      <ChevronRight v-else :size="14" class="shrink-0 text-fg-muted" />
-      <span class="relative grid h-7 w-7 shrink-0 place-items-center rounded-lg border border-accent/20 bg-accent/10 text-accent">
-        <Bot :size="15" />
-        <span v-if="status === 'running'" class="pulse-dot absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-run-bright" />
-      </span>
-      <span class="min-w-0 flex-1">
-        <span class="flex items-center gap-2">
-          <span class="shrink-0 whitespace-nowrap rounded-full bg-accent/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-accent">{{ $t("tools.subagent") }}</span>
-          <span class="truncate text-[12px] font-semibold text-fg">{{ step.title }}</span>
-        </span>
-        <span class="mt-0.5 block text-[10.5px] text-fg-muted">
+      <Bot :size="13" class="shrink-0 text-accent" />
+      <span class="shrink-0 font-medium text-[11.5px] text-accent">{{ $t("tools.subagent") }}</span>
+      <span class="min-w-0 truncate font-mono text-[11.5px] text-fg-muted group-hover:text-fg">{{ step.title }}</span>
+      <span class="ml-auto flex shrink-0 items-center gap-1.5">
+        <span class="font-mono text-[10.5px] text-fg-muted/70">
           <template v-if="hasTrace">{{ $t("tools.traceCount", { count: children.length }) }}</template>
           <template v-else-if="status === 'running'">{{ $t("tools.running") }} · {{ elapsedLabel }}</template>
           <template v-else>{{ status === "error" ? $t("tools.failed") : $t("tools.finished") }}</template>
         </span>
-      </span>
-      <span class="shrink-0">
-        <Loader2 v-if="status === 'running'" data-test="subagent-running" :size="14" class="animate-spin motion-reduce:animate-none text-accent" />
-        <AlertTriangle v-else-if="status === 'error'" data-test="subagent-error" :size="14" class="text-danger" />
-        <Check v-else data-test="subagent-success" :size="14" class="text-run" />
+        <Loader2 v-if="status === 'running'" data-test="subagent-running" :size="12" class="animate-spin motion-reduce:animate-none text-accent" />
+        <AlertTriangle v-else-if="status === 'error'" data-test="subagent-error" :size="12" class="text-danger" />
+        <Check v-else data-test="subagent-success" :size="12" class="text-run/70" />
+        <ChevronDown v-if="open" :size="12" class="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity" />
+        <ChevronRight v-else :size="12" class="shrink-0 opacity-40 group-hover:opacity-80 transition-opacity" />
       </span>
     </button>
 
-    <div v-if="!open" data-test="subagent-activity" class="border-t border-border/70 bg-bg/45 px-3 py-2">
+    <div v-if="!open" data-test="subagent-activity" class="ml-2.5 my-0.5 border-l-2 border-border/40 pl-3 py-0.5 text-[11px] text-fg-muted/80">
       <Transition v-if="hasTrace" name="activity-slide" mode="out-in">
         <div v-if="currentActivity" :key="currentActivity.toolCallId" class="flex min-w-0 items-center gap-2">
           <span class="h-1.5 w-1.5 shrink-0 rounded-full" :class="currentActivity.status === 'running' ? 'bg-accent' : currentActivity.status === 'error' ? 'bg-danger' : 'bg-run'" />
@@ -177,7 +168,7 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
-    <div v-else data-test="subagent-timeline" class="border-t border-border bg-bg/30 px-3 pb-3 pt-2.5">
+    <div v-else data-test="subagent-timeline" class="ml-2.5 my-1.5 border-l-2 border-border/50 pl-3 space-y-2">
       <ol v-if="hasTrace" class="relative ml-1 space-y-1.5 before:absolute before:bottom-2 before:left-[7px] before:top-2 before:w-px before:bg-border">
         <li v-for="child in children" :key="child.toolCallId" class="relative flex min-w-0 items-center gap-2 pl-5">
           <span class="absolute left-0 grid h-3.5 w-3.5 place-items-center rounded-full border border-border bg-surface">

--- a/packages/relay-web/src/components/ToolCallPanel.vue
+++ b/packages/relay-web/src/components/ToolCallPanel.vue
@@ -53,27 +53,30 @@ function fmtDuration(ms?: number): string {
 </script>
 
 <template>
-  <div class="overflow-hidden rounded-lg border border-border bg-surface text-xs shadow-e1">
+  <div data-test="tool-call-panel" class="text-xs">
     <button ref="header" type="button"
-            class="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-bg"
+            class="group flex w-full items-center gap-1.5 py-1 px-1.5 -mx-1.5 rounded-md text-left text-fg-muted hover:text-fg hover:bg-fg/5 transition-colors"
             :aria-expanded="open" @click="onHeaderClick">
-      <ChevronDown v-if="open" :size="13" class="shrink-0 text-fg-muted" />
-      <ChevronRight v-else :size="13" class="shrink-0 text-fg-muted" />
-      <span class="inline-flex items-center gap-1.5 text-[11.5px] font-semibold text-fg-muted"><Wrench :size="13" /> {{ $t("tools.toolSteps") }}</span>
+      <Wrench :size="13" class="shrink-0 text-fg-muted group-hover:text-fg" />
+      <span class="text-[11.5px] font-medium text-fg-muted group-hover:text-fg">{{ $t("tools.toolSteps") }}</span>
       <FueDot v-if="showFueDot" :pulsing="fue.status.value === 'unseen'" />
-      <span v-else data-test="tool-count" class="font-mono text-[10.5px] text-fg-muted">{{ steps.length }}</span>
-      <span data-test="tool-summary" class="ml-1 flex items-center gap-1.5 text-[10.5px] text-fg-muted">
+      <span v-else data-test="tool-count" class="font-mono text-[10.5px] text-fg-muted/70">{{ steps.length }}</span>
+      <span data-test="tool-summary" class="ml-1 flex items-center gap-1.5 text-[10.5px] text-fg-muted/70">
         <span v-for="k in summary.kinds" :key="'k' + k.label" :data-test="'sum-' + k.label"
               class="inline-flex items-center gap-0.5">
           <component :is="k.icon" :size="11" /><span class="tabular-nums">{{ k.count }}</span>
         </span>
-        <span v-if="summary.statuses.length" class="text-fg-muted">·</span>
+        <span v-if="summary.statuses.length" class="text-fg-muted/50">·</span>
         <span v-for="st in summary.statuses" :key="'s' + st.label" :data-test="'sum-' + st.label"
               class="inline-flex items-center gap-0.5"
               :class="st.label === 'success' ? 'text-run' : st.label === 'error' ? 'text-danger' : 'text-fg-muted'">
           <component :is="st.icon" :size="11"
                      :class="st.label === 'running' ? 'animate-spin motion-reduce:animate-none' : ''" /><span class="tabular-nums">{{ st.count }}</span>
         </span>
+      </span>
+      <span class="ml-auto flex shrink-0 items-center">
+        <ChevronDown v-if="open" :size="12" class="shrink-0 opacity-60 group-hover:opacity-100" />
+        <ChevronRight v-else :size="12" class="shrink-0 opacity-40 group-hover:opacity-80" />
       </span>
     </button>
     <FueCallout
@@ -83,20 +86,17 @@ function fmtDuration(ms?: number): string {
       :anchor="anchor"
       @dismiss="fue.dismiss()"
     />
-    <ul v-if="open" class="space-y-1 border-t border-border px-3 pb-2.5 pt-2">
+    <ul v-if="open" class="ml-2.5 my-1.5 border-l-2 border-border/50 pl-3 space-y-1">
       <li v-for="s in steps" :key="s.toolCallId">
-        <button type="button" data-test="tool-row" class="flex w-full items-center gap-2 rounded text-left text-[12px] hover:bg-fg/5" @click="toggleRow(s.toolCallId)">
-          <span class="grid h-4 w-4 shrink-0 place-items-center rounded-full"
-                :class="s.status === 'success' ? 'bg-run/15' : s.status === 'running' ? 'bg-accent/15' : 'bg-danger/15'">
-            <Check v-if="s.status === 'success'" data-test="step-status-success" :size="9" class="text-run" />
-            <Loader2 v-else-if="s.status === 'running'" data-test="step-status-running" :size="9" class="animate-spin motion-reduce:animate-none text-accent" />
-            <AlertTriangle v-else data-test="step-status-error" :size="9" class="text-danger" />
-          </span>
+        <button type="button" data-test="tool-row" class="flex w-full items-center gap-1.5 py-0.5 text-left text-[11.5px] text-fg-muted hover:text-fg transition-colors" @click="toggleRow(s.toolCallId)">
           <component :is="KIND_ICON[s.kind]" :size="12" class="shrink-0 text-fg-muted" />
-          <span class="truncate font-mono text-[11px] text-fg">{{ s.title }}</span>
-          <span v-if="s.durationMs !== undefined" class="ml-auto font-mono text-[10.5px] text-fg-muted">{{ fmtDuration(s.durationMs) }}</span>
+          <span class="truncate font-mono text-[11px]">{{ s.title }}</span>
+          <span v-if="s.durationMs !== undefined" class="ml-auto font-mono text-[10px] text-fg-muted/70">{{ fmtDuration(s.durationMs) }}</span>
+          <Check v-if="s.status === 'success'" data-test="step-status-success" :size="11" class="text-run/70" />
+          <Loader2 v-else-if="s.status === 'running'" data-test="step-status-running" :size="11" class="animate-spin motion-reduce:animate-none text-accent" />
+          <AlertTriangle v-else data-test="step-status-error" :size="11" class="text-danger" />
         </button>
-        <div v-if="expanded.has(s.toolCallId) && s.detail" class="px-2 pb-2 pt-1">
+        <div v-if="expanded.has(s.toolCallId) && s.detail" class="pl-3 py-1">
           <ToolDetail :detail="s.detail" />
         </div>
       </li>

--- a/packages/relay-web/src/components/ToolStepCard.vue
+++ b/packages/relay-web/src/components/ToolStepCard.vue
@@ -37,9 +37,14 @@ async function onHeaderClick(): Promise<void> {
   }
 }
 // Compute line additions and deletions for edit/diff steps (e.g. +4, −1).
+// Exclude inaccurate stats: naive fallback on huge inputs (d.exact === false)
+// and truncated inputs from connector cap (includes "…(truncated)").
 const diffStats = computed(() => {
   if (props.step.detail?.type !== "diff") return null;
-  const d = diffLines(props.step.detail.oldText, props.step.detail.newText);
+  const { oldText, newText } = props.step.detail;
+  if (oldText.includes("…(truncated)") || newText.includes("…(truncated)")) return null;
+  const d = diffLines(oldText, newText);
+  if (!d.exact) return null;
   if (d.add === 0 && d.del === 0) return null;
   return { add: d.add, del: d.del };
 });
@@ -99,16 +104,20 @@ function fmtDuration(ms?: number): string {
 
 <template>
   <div data-test="tool-step-card" class="text-xs">
-    <button type="button" data-test="tool-step-header"
-            class="group flex w-full items-center gap-1.5 py-1 px-1.5 -mx-1.5 rounded-md text-left text-fg-muted hover:text-fg hover:bg-fg/5 transition-colors"
-            :aria-expanded="hasDetail ? open : undefined"
-            :class="!hasDetail ? 'cursor-default' : ''"
-            @click="onHeaderClick">
+    <component :is="hasDetail ? 'button' : 'div'"
+               :type="hasDetail ? 'button' : undefined"
+               data-test="tool-step-header"
+               class="group flex w-full items-center gap-1.5 py-1 px-1.5 -mx-1.5 rounded-md text-left text-fg-muted"
+               :class="hasDetail ? 'hover:text-fg hover:bg-fg/5 transition-colors cursor-pointer' : 'cursor-default select-text'"
+               :aria-expanded="hasDetail ? open : undefined"
+               @click="hasDetail ? onHeaderClick() : undefined">
       <component :is="KIND_ICON[step.kind]" :size="13" class="shrink-0 transition-colors"
-                 :class="step.status === 'error' ? 'text-danger' : step.status === 'running' ? 'text-accent' : 'text-fg-muted/80 group-hover:text-fg'" />
-      <span class="shrink-0 font-medium text-[11.5px] text-fg-muted transition-colors group-hover:text-fg">{{ kindLabel }}</span>
+                 :class="step.status === 'error' ? 'text-danger' : step.status === 'running' ? 'text-accent' : hasDetail ? 'text-fg-muted/80 group-hover:text-fg' : 'text-fg-muted/80'" />
+      <span class="shrink-0 font-medium text-[11.5px] text-fg-muted transition-colors"
+            :class="hasDetail ? 'group-hover:text-fg' : ''">{{ kindLabel }}</span>
       <span v-if="fileExt" class="shrink-0 rounded bg-accent/10 px-1 py-0.5 text-[9px] font-semibold text-accent/80 font-mono leading-none">{{ fileExt }}</span>
-      <span class="min-w-0 truncate font-mono text-[11.5px] text-fg-muted/90 group-hover:text-fg">{{ step.title }}</span>
+      <span class="min-w-0 truncate font-mono text-[11.5px] text-fg-muted/90"
+            :class="hasDetail ? 'group-hover:text-fg' : ''">{{ step.title }}</span>
       <span class="ml-auto flex shrink-0 items-center gap-1.5">
         <span v-if="diffStats" data-test="step-diff-stats" class="flex items-center gap-1 font-mono text-[11px]">
           <span v-if="diffStats.add" class="text-run font-medium">+{{ diffStats.add }}</span>
@@ -121,7 +130,7 @@ function fmtDuration(ms?: number): string {
         <ChevronDown v-if="hasDetail && open" :size="12" class="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity" />
         <ChevronRight v-else-if="hasDetail" :size="12" class="shrink-0 opacity-40 group-hover:opacity-80 transition-opacity" />
       </span>
-    </button>
+    </component>
     <div v-if="hasDetail && open" data-test="tool-step-detail" class="ml-2.5 my-1.5 border-l-2 border-border/50 pl-3 space-y-1">
       <div v-if="hydrating" data-test="tool-step-hydrating" class="flex items-center gap-1.5 py-1 text-fg-muted">
         <Loader2 :size="13" class="animate-spin motion-reduce:animate-none" />

--- a/packages/relay-web/src/components/ToolStepCard.vue
+++ b/packages/relay-web/src/components/ToolStepCard.vue
@@ -67,14 +67,14 @@ const fileExt = computed(() => {
   const title = props.step.detail?.type === "diff" || props.step.detail?.type === "read"
     ? props.step.detail.path
     : props.step.title || "";
-  // Strip trailing line/query specifiers first, then isolate basename so dotted
-  // directory names (e.g. "src.v2/x", "a.b/c") or dotfiles (".gitignore") are not
-  // misidentified as extensions.
-  const cleanTitle = title.split(/[\s:#?]/)[0] ?? "";
-  const basename = cleanTitle.split(/[\\/]/).pop() ?? "";
-  const dot = basename.lastIndexOf(".");
-  if (dot <= 0 || dot === basename.length - 1) return "";
-  const raw = basename.slice(dot + 1).toUpperCase();
+  // Isolate basename first so Windows drive letters (C:\...) or scheme colons (file://...)
+  // are not stripped. Then strip trailing line/query specifiers so dotted directory
+  // names (e.g. "src.v2/x", "a.b/c") or dotfiles (".gitignore") are not misidentified.
+  const basename = title.split(/[\\/]/).pop() ?? "";
+  const cleanBasename = basename.split(/[\s:#?]/)[0] ?? "";
+  const dot = cleanBasename.lastIndexOf(".");
+  if (dot <= 0 || dot === cleanBasename.length - 1) return "";
+  const raw = cleanBasename.slice(dot + 1).toUpperCase();
   return raw.length <= 4 ? raw : "";
 });
 // The text the detail body already prints below (so we don't repeat it in the banner).
@@ -120,7 +120,7 @@ function fmtDuration(ms?: number): string {
                  :class="step.status === 'error' ? 'text-danger' : step.status === 'running' ? 'text-accent' : hasDetail ? 'text-fg-muted/80 group-hover:text-fg' : 'text-fg-muted/80'" />
       <span class="shrink-0 font-medium text-[11.5px] text-fg-muted transition-colors"
             :class="hasDetail ? 'group-hover:text-fg' : ''">{{ kindLabel }}</span>
-      <span v-if="fileExt" class="shrink-0 rounded bg-accent/10 px-1 py-0.5 text-[9px] font-semibold text-accent/80 font-mono leading-none">{{ fileExt }}</span>
+      <span v-if="fileExt" data-test="file-ext-badge" class="shrink-0 rounded bg-accent/10 px-1 py-0.5 text-[9px] font-semibold text-accent/80 font-mono leading-none">{{ fileExt }}</span>
       <span class="min-w-0 truncate font-mono text-[11.5px] text-fg-muted/90"
             :class="hasDetail ? 'group-hover:text-fg' : ''">{{ step.title }}</span>
       <span class="ml-auto flex shrink-0 items-center gap-1.5">

--- a/packages/relay-web/src/components/ToolStepCard.vue
+++ b/packages/relay-web/src/components/ToolStepCard.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import type { ToolStepDto } from "@ganglion/xacpx-relay-protocol";
 import { AlertTriangle, Check, ChevronDown, ChevronRight, Loader2 } from "lucide-vue-next";
 import ToolDetail from "./ToolDetail.vue";
 import { KIND_ICON } from "../lib/tool-summary";
+import { diffLines } from "../lib/line-diff";
 
 const props = defineProps<{ step: ToolStepDto; ensureFull?: () => Promise<void> }>();
+
+const { t } = useI18n();
 
 // Keep the tool's one-line summary visible without letting command output, diffs, and
 // file previews dominate the message list. Users can expand the detail on demand.
@@ -28,6 +32,44 @@ async function onHeaderClick(): Promise<void> {
     hydrating.value = false;
   }
 }
+
+// Compute line additions and deletions for edit/diff steps (e.g. +4, −1).
+const diffStats = computed(() => {
+  if (props.step.detail?.type !== "diff") return null;
+  const d = diffLines(props.step.detail.oldText, props.step.detail.newText);
+  if (d.add === 0 && d.del === 0) return null;
+  return { add: d.add, del: d.del };
+});
+
+const isWrite = computed(() => {
+  const name = (props.step.toolName || "").toLowerCase();
+  if (name.includes("write") || name.includes("create")) return true;
+  if (props.step.detail?.type === "diff" && props.step.detail.oldText === "") return true;
+  return false;
+});
+
+const kindLabel = computed(() => {
+  if (props.step.kind === "edit") {
+    return isWrite.value ? t("tools.kinds.write") : t("tools.kinds.edit");
+  }
+  return t("tools.kinds." + props.step.kind);
+});
+
+// File extension badge for file operations (e.g. TS, VUE, PY, JSON).
+const fileExt = computed(() => {
+  if (props.step.kind !== "read" && props.step.kind !== "edit") return "";
+  const title = props.step.detail?.type === "diff" || props.step.detail?.type === "read"
+    ? props.step.detail.path
+    : props.step.title || "";
+  const dot = title.lastIndexOf(".");
+  if (dot <= 0) return "";
+  const raw = title.slice(dot + 1).split(/[\s:#?]/)[0]?.toUpperCase() || "";
+  return raw.length <= 4 ? raw : "";
+});
+
+const hasDetail = computed(() => {
+  return props.step.detail !== undefined || props.step.error !== undefined || props.ensureFull !== undefined;
+});
 
 // The text the detail body already prints below (so we don't repeat it in the banner).
 const detailOutput = computed(() => {
@@ -60,33 +102,38 @@ function fmtDuration(ms?: number): string {
 </script>
 
 <template>
-  <div data-test="tool-step-card"
-       class="overflow-hidden rounded-lg border bg-surface text-xs shadow-e1"
-       :class="step.status === 'error' ? 'border-danger/40' : 'border-border'">
+  <div data-test="tool-step-card" class="text-xs">
     <button type="button" data-test="tool-step-header"
-            class="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-bg"
+            class="group flex w-full items-center gap-1.5 py-1 px-1.5 -mx-1.5 rounded-md text-left text-fg-muted hover:text-fg hover:bg-fg/5 transition-colors"
             :aria-expanded="open" @click="onHeaderClick">
-      <ChevronDown v-if="open" :size="13" class="shrink-0 text-fg-muted" />
-      <ChevronRight v-else :size="13" class="shrink-0 text-fg-muted" />
-      <component :is="KIND_ICON[step.kind]" :size="13" class="shrink-0 text-fg-muted" />
-      <span class="min-w-0 truncate font-mono text-[11.5px] text-fg">{{ step.title }}</span>
-      <span class="ml-auto flex shrink-0 items-center gap-2">
-        <span v-if="step.durationMs !== undefined" class="font-mono text-[10.5px] text-fg-muted">{{ fmtDuration(step.durationMs) }}</span>
-        <Check v-if="step.status === 'success'" data-test="step-status-success" :size="13" class="text-run" />
-        <Loader2 v-else-if="step.status === 'running'" data-test="step-status-running" :size="13" class="animate-spin motion-reduce:animate-none text-accent" />
-        <AlertTriangle v-else data-test="step-status-error" :size="13" class="text-danger" />
+      <component :is="KIND_ICON[step.kind]" :size="13" class="shrink-0 transition-colors"
+                 :class="step.status === 'error' ? 'text-danger' : step.status === 'running' ? 'text-accent' : 'text-fg-muted/80 group-hover:text-fg'" />
+      <span class="shrink-0 font-medium text-[11.5px] text-fg-muted transition-colors group-hover:text-fg">{{ kindLabel }}</span>
+      <span v-if="fileExt" class="shrink-0 rounded bg-accent/10 px-1 py-0.5 text-[9px] font-semibold text-accent/80 font-mono leading-none">{{ fileExt }}</span>
+      <span class="min-w-0 truncate font-mono text-[11.5px] text-fg-muted/90 group-hover:text-fg">{{ step.title }}</span>
+      <span class="ml-auto flex shrink-0 items-center gap-1.5">
+        <span v-if="diffStats" data-test="step-diff-stats" class="flex items-center gap-1 font-mono text-[11px]">
+          <span v-if="diffStats.add" class="text-run font-medium">+{{ diffStats.add }}</span>
+          <span v-if="diffStats.del" class="text-danger font-medium">−{{ diffStats.del }}</span>
+        </span>
+        <span v-if="step.durationMs !== undefined" class="font-mono text-[10.5px] text-fg-muted/70">{{ fmtDuration(step.durationMs) }}</span>
+        <Check v-if="step.status === 'success'" data-test="step-status-success" :size="12" class="text-run/70" />
+        <Loader2 v-else-if="step.status === 'running'" data-test="step-status-running" :size="12" class="animate-spin motion-reduce:animate-none text-accent" />
+        <AlertTriangle v-else data-test="step-status-error" :size="12" class="text-danger" />
+        <ChevronDown v-if="open" :size="12" class="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity" />
+        <ChevronRight v-else-if="hasDetail" :size="12" class="shrink-0 opacity-40 group-hover:opacity-80 transition-opacity" />
       </span>
     </button>
-    <div v-if="open" data-test="tool-step-detail" class="border-t border-border px-3 pb-2.5 pt-2">
+    <div v-if="open" data-test="tool-step-detail" class="ml-2.5 my-1.5 border-l-2 border-border/50 pl-3 space-y-1">
       <div v-if="hydrating" data-test="tool-step-hydrating" class="flex items-center gap-1.5 py-1 text-fg-muted">
         <Loader2 :size="13" class="animate-spin motion-reduce:animate-none" />
         <span>{{ $t("tools.loadingDetails") }}</span>
       </div>
       <template v-else>
         <div v-if="showErrorBanner" data-test="tool-step-error"
-             class="mb-1.5 flex items-start gap-1.5 rounded bg-danger/10 px-2 py-1.5 text-danger">
+             class="mb-1.5 flex items-start gap-1.5 rounded bg-danger/10 px-2 py-1.5 text-danger font-mono text-[11px]">
           <AlertTriangle :size="13" class="mt-0.5 shrink-0" />
-          <span class="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">{{ step.error }}</span>
+          <span class="whitespace-pre-wrap break-words leading-relaxed">{{ step.error }}</span>
         </div>
         <ToolDetail v-if="step.detail" :detail="step.detail" />
       </template>

--- a/packages/relay-web/src/components/ToolStepCard.vue
+++ b/packages/relay-web/src/components/ToolStepCard.vue
@@ -15,8 +15,12 @@ const { t } = useI18n();
 // file previews dominate the message list. Users can expand the detail on demand.
 const open = ref(false);
 const hydrating = ref(false);
+const hasDetail = computed(() => {
+  return props.step.detail !== undefined || props.step.error !== undefined || props.ensureFull !== undefined;
+});
 
 async function onHeaderClick(): Promise<void> {
+  if (!hasDetail.value) return;
   if (open.value) {
     open.value = false;
     return;
@@ -32,7 +36,6 @@ async function onHeaderClick(): Promise<void> {
     hydrating.value = false;
   }
 }
-
 // Compute line additions and deletions for edit/diff steps (e.g. +4, −1).
 const diffStats = computed(() => {
   if (props.step.detail?.type !== "diff") return null;
@@ -43,9 +46,7 @@ const diffStats = computed(() => {
 
 const isWrite = computed(() => {
   const name = (props.step.toolName || "").toLowerCase();
-  if (name.includes("write") || name.includes("create")) return true;
-  if (props.step.detail?.type === "diff" && props.step.detail.oldText === "") return true;
-  return false;
+  return name.includes("write") || name.includes("create");
 });
 
 const kindLabel = computed(() => {
@@ -66,11 +67,6 @@ const fileExt = computed(() => {
   const raw = title.slice(dot + 1).split(/[\s:#?]/)[0]?.toUpperCase() || "";
   return raw.length <= 4 ? raw : "";
 });
-
-const hasDetail = computed(() => {
-  return props.step.detail !== undefined || props.step.error !== undefined || props.ensureFull !== undefined;
-});
-
 // The text the detail body already prints below (so we don't repeat it in the banner).
 const detailOutput = computed(() => {
   const d = props.step.detail;
@@ -105,7 +101,9 @@ function fmtDuration(ms?: number): string {
   <div data-test="tool-step-card" class="text-xs">
     <button type="button" data-test="tool-step-header"
             class="group flex w-full items-center gap-1.5 py-1 px-1.5 -mx-1.5 rounded-md text-left text-fg-muted hover:text-fg hover:bg-fg/5 transition-colors"
-            :aria-expanded="open" @click="onHeaderClick">
+            :aria-expanded="hasDetail ? open : undefined"
+            :class="!hasDetail ? 'cursor-default' : ''"
+            @click="onHeaderClick">
       <component :is="KIND_ICON[step.kind]" :size="13" class="shrink-0 transition-colors"
                  :class="step.status === 'error' ? 'text-danger' : step.status === 'running' ? 'text-accent' : 'text-fg-muted/80 group-hover:text-fg'" />
       <span class="shrink-0 font-medium text-[11.5px] text-fg-muted transition-colors group-hover:text-fg">{{ kindLabel }}</span>
@@ -120,11 +118,11 @@ function fmtDuration(ms?: number): string {
         <Check v-if="step.status === 'success'" data-test="step-status-success" :size="12" class="text-run/70" />
         <Loader2 v-else-if="step.status === 'running'" data-test="step-status-running" :size="12" class="animate-spin motion-reduce:animate-none text-accent" />
         <AlertTriangle v-else data-test="step-status-error" :size="12" class="text-danger" />
-        <ChevronDown v-if="open" :size="12" class="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity" />
+        <ChevronDown v-if="hasDetail && open" :size="12" class="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity" />
         <ChevronRight v-else-if="hasDetail" :size="12" class="shrink-0 opacity-40 group-hover:opacity-80 transition-opacity" />
       </span>
     </button>
-    <div v-if="open" data-test="tool-step-detail" class="ml-2.5 my-1.5 border-l-2 border-border/50 pl-3 space-y-1">
+    <div v-if="hasDetail && open" data-test="tool-step-detail" class="ml-2.5 my-1.5 border-l-2 border-border/50 pl-3 space-y-1">
       <div v-if="hydrating" data-test="tool-step-hydrating" class="flex items-center gap-1.5 py-1 text-fg-muted">
         <Loader2 :size="13" class="animate-spin motion-reduce:animate-none" />
         <span>{{ $t("tools.loadingDetails") }}</span>

--- a/packages/relay-web/src/components/ToolStepCard.vue
+++ b/packages/relay-web/src/components/ToolStepCard.vue
@@ -67,9 +67,14 @@ const fileExt = computed(() => {
   const title = props.step.detail?.type === "diff" || props.step.detail?.type === "read"
     ? props.step.detail.path
     : props.step.title || "";
-  const dot = title.lastIndexOf(".");
-  if (dot <= 0) return "";
-  const raw = title.slice(dot + 1).split(/[\s:#?]/)[0]?.toUpperCase() || "";
+  // Strip trailing line/query specifiers first, then isolate basename so dotted
+  // directory names (e.g. "src.v2/x", "a.b/c") or dotfiles (".gitignore") are not
+  // misidentified as extensions.
+  const cleanTitle = title.split(/[\s:#?]/)[0] ?? "";
+  const basename = cleanTitle.split(/[\\/]/).pop() ?? "";
+  const dot = basename.lastIndexOf(".");
+  if (dot <= 0 || dot === basename.length - 1) return "";
+  const raw = basename.slice(dot + 1).toUpperCase();
   return raw.length <= 4 ? raw : "";
 });
 // The text the detail body already prints below (so we don't repeat it in the banner).

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -29,6 +29,9 @@ const props = defineProps<{
   traceKey?: string;
   /** Display-only turn duration (finished rows). Absent/non-positive → counts only. */
   traceElapsedMs?: number | null;
+  /** Precomputed final reply text (e.g. cached by parent MessageList). When provided,
+   *  extractFinalReplyText is bypassed on collapsed turns. */
+  collapsedReplyText?: string;
 }>();
 
 const { t, locale } = useI18n();
@@ -63,7 +66,9 @@ const expanded = computed(() => {
 });
 
 const finalReplyText = computed(() =>
-  extractFinalReplyText(props.parts, { presentation: presentation.value }),
+  props.collapsedReplyText !== undefined
+    ? props.collapsedReplyText
+    : extractFinalReplyText(props.parts, { presentation: presentation.value }),
 );
 
 // Collapsed view: directly construct a single text presentation item from the

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -97,21 +97,21 @@ function toggleTrace(): void {
 </script>
 
 <template>
-  <div class="space-y-1.5">
+  <div class="space-y-2">
     <!-- Collapsed-trace header (finished turns): one muted row summarizing the hidden
          activity; expanding re-renders the trace items inline below it. -->
     <button v-if="collapsible" type="button" data-test="trace-toggle"
-            class="flex w-full flex-wrap items-center gap-x-1.5 gap-y-0.5 py-0.5 text-left text-[11.5px] text-fg-muted transition-colors hover:text-fg"
+            class="group flex w-full flex-wrap items-center gap-x-1.5 gap-y-0.5 py-1 px-1.5 -mx-1.5 rounded-md text-left text-[11.5px] text-fg-muted transition-colors hover:text-fg hover:bg-fg/5"
             :aria-expanded="expanded" :aria-label="$t('turnTrace.toggleTrace')"
             :data-trace-key="traceKey ?? ''" @click="toggleTrace">
-      <ChevronDown v-if="expanded" :size="12" class="shrink-0" />
-      <ChevronRight v-else :size="12" class="shrink-0" />
+      <ChevronDown v-if="expanded" :size="12" class="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity" />
+      <ChevronRight v-else :size="12" class="shrink-0 opacity-40 group-hover:opacity-80 transition-opacity" />
       <span data-test="trace-label">{{ headerLabel }}</span>
     </button>
     <template v-for="item in visibleItems" :key="item.key">
       <StreamMarkdown v-if="item.type === 'text'" data-test="turn-narrative"
                       :text="item.text" :streaming="streaming === true && item.isLatest"
-                      class="text-[14px] leading-relaxed text-fg my-1"
+                      class="text-[14px] leading-relaxed text-fg"
                       :class="streaming === true && item.isLatest ? 'caret' : ''" />
       <ReasoningPanel v-else-if="item.type === 'reasoning'"
                       :reasoning="item.text"

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -97,7 +97,7 @@ function toggleTrace(): void {
 </script>
 
 <template>
-  <div class="space-y-2.5">
+  <div class="space-y-1.5">
     <!-- Collapsed-trace header (finished turns): one muted row summarizing the hidden
          activity; expanding re-renders the trace items inline below it. -->
     <button v-if="collapsible" type="button" data-test="trace-toggle"
@@ -111,7 +111,7 @@ function toggleTrace(): void {
     <template v-for="item in visibleItems" :key="item.key">
       <StreamMarkdown v-if="item.type === 'text'" data-test="turn-narrative"
                       :text="item.text" :streaming="streaming === true && item.isLatest"
-                      class="text-[14px] leading-relaxed text-fg"
+                      class="text-[14px] leading-relaxed text-fg my-1"
                       :class="streaming === true && item.isLatest ? 'caret' : ''" />
       <ReasoningPanel v-else-if="item.type === 'reasoning'"
                       :reasoning="item.text"

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -32,6 +32,11 @@ const props = defineProps<{
   /** Precomputed final reply text (e.g. cached by parent MessageList). When provided,
    *  extractFinalReplyText is bypassed on collapsed turns. */
   collapsedReplyText?: string;
+  /** Precomputed trace activity counts (e.g. cached by parent MessageList). When provided,
+   *  reading presentation is bypassed while collapsed so full layout derivation is deferred
+   *  until the user explicitly clicks to expand. */
+  collapsedToolCount?: number;
+  collapsedThoughtCount?: number;
 }>();
 
 const { t, locale } = useI18n();
@@ -88,9 +93,15 @@ const finalReplyText = computed(() =>
    ];
  });
 const toolCount = computed(() =>
-  presentation.value.filter((item) => item.type === "tool" || item.type === "subagent").length,
+  props.collapsedToolCount !== undefined
+    ? props.collapsedToolCount
+    : presentation.value.filter((item) => item.type === "tool" || item.type === "subagent").length,
 );
-const thoughtCount = computed(() => presentation.value.filter((item) => item.type === "reasoning").length);
+const thoughtCount = computed(() =>
+  props.collapsedThoughtCount !== undefined
+    ? props.collapsedThoughtCount
+    : presentation.value.filter((item) => item.type === "reasoning").length,
+);
 
 function formatElapsed(ms: number): string {
   if (ms < 1000) return locale.value.startsWith("zh") ? "<1秒" : "<1s";

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -8,7 +8,7 @@ import ReasoningPanel from "./ReasoningPanel.vue";
 import ToolStepCard from "./ToolStepCard.vue";
 import SubagentStepCard from "./SubagentStepCard.vue";
 import AgentMessageCard from "./AgentMessageCard.vue";
-import { deriveTurnPresentation } from "../lib/turn-presentation";
+import { deriveTurnPresentation, extractFinalReplyText } from "../lib/turn-presentation";
 import { expandedTraces } from "../lib/trace-expansion";
 
 // Wire parts preserve arrival order, but transport events are not necessarily safe
@@ -40,16 +40,9 @@ const presentation = computed(() =>
   ),
 );
 
-// The process trace boundary comes from props.parts (the raw event sequence),
-// NOT from presentation. presentation is a Markdown-safe layout model that
-// re-anchors activity to block boundaries. If interleaved process text and a
-// final reply share one Markdown block (e.g. streaming chunks without \n\n),
-// presentation emits the joined text before the activity, so slicing
-// presentation after the last non-text item drops the entire final reply.
-//
-// In the event sequence (props.parts), the semantic boundary is unambiguous:
-// the last visible process part (tool or non-empty reasoning). Everything
-// up through that part is process; any trailing text after it is the final reply.
+// A finished turn collapses everything up through its last process item (tool or
+// non-empty reasoning). The conversational final reply is extracted safely respecting
+// Markdown block boundaries via extractFinalReplyText.
 const lastProcessPartIndex = computed(() =>
   props.parts.findLastIndex(
     (part) =>
@@ -69,37 +62,26 @@ const expanded = computed(() => {
   return props.traceKey ? expandedTraces.has(props.traceKey) : localExpanded.value;
 });
 
-const collapsedReplyText = computed(() => {
-  const boundary = lastProcessPartIndex.value;
-  if (boundary < 0) {
-    return props.parts
-      .filter((part) => part.type === "text")
-      .map((part) => part.text)
-      .join("");
-  }
-  return props.parts
-    .slice(boundary + 1)
-    .filter((part) => part.type === "text")
-    .map((part) => part.text)
-    .join("");
-});
+const finalReplyText = computed(() =>
+  extractFinalReplyText(props.parts, { presentation: presentation.value }),
+);
 
 // Collapsed view: directly construct a single text presentation item from the
-// trailing reply text. When expanded (or when the turn has no process to fold),
-// deriveTurnPresentation provides the full Markdown-safe interleaved layout.
-const visibleItems = computed(() => {
-  if (expanded.value || !collapsible.value) return presentation.value;
-  const text = collapsedReplyText.value;
-  if (!text.trim()) return [];
-  return [
-    {
-      key: "collapsed-final-reply",
-      type: "text" as const,
-      text,
-      isLatest: false,
-    },
-  ];
-});
+// Markdown-safe trailing reply text. When expanded (or when the turn has no
+// process to fold), deriveTurnPresentation provides the full interleaved layout.
+ const visibleItems = computed(() => {
+   if (expanded.value || !collapsible.value) return presentation.value;
+  const text = finalReplyText.value;
+   if (!text.trim()) return [];
+   return [
+     {
+       key: "collapsed-final-reply",
+       type: "text" as const,
+       text,
+       isLatest: false,
+     },
+   ];
+ });
 const toolCount = computed(() =>
   presentation.value.filter((item) => item.type === "tool" || item.type === "subagent").length,
 );

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -40,15 +40,25 @@ const presentation = computed(() =>
   ),
 );
 
-// A finished turn collapses everything up through its LAST process item —
-// reasoning, tool, subagent, agent-message, AND the narrative text interleaved
-// between them all belongs to the process. Only trailing text after all process
-// activity is the final reply (deriveTurnPresentation already anchors activity in
-// arrival order, so "last non-text item" is the reliable process/reply boundary —
-// never m.text, which aggregates the whole turn's text).
-const hasTrace = computed(() =>
-  presentation.value.some((item) => item.type !== "text"),
+// The process trace boundary comes from props.parts (the raw event sequence),
+// NOT from presentation. presentation is a Markdown-safe layout model that
+// re-anchors activity to block boundaries. If interleaved process text and a
+// final reply share one Markdown block (e.g. streaming chunks without \n\n),
+// presentation emits the joined text before the activity, so slicing
+// presentation after the last non-text item drops the entire final reply.
+//
+// In the event sequence (props.parts), the semantic boundary is unambiguous:
+// the last visible process part (tool or non-empty reasoning). Everything
+// up through that part is process; any trailing text after it is the final reply.
+const lastProcessPartIndex = computed(() =>
+  props.parts.findLastIndex(
+    (part) =>
+      part.type === "tool"
+      || (part.type === "reasoning" && part.text.trim().length > 0),
+  ),
 );
+
+const hasTrace = computed(() => lastProcessPartIndex.value >= 0);
 const collapsible = computed(() => props.collapseTrace === true && hasTrace.value);
 // Keyed rows remember toggles in the module set (survives hub history convergence,
 // which replaces the message row and rebuilds this component); anonymous rows fall
@@ -58,14 +68,37 @@ const expanded = computed(() => {
   if (!collapsible.value) return false;
   return props.traceKey ? expandedTraces.has(props.traceKey) : localExpanded.value;
 });
-// Collapsed view: only the trailing text after the last process item (the final
-// reply). A pure-text turn keeps everything (no process to fold, no header).
+
+const collapsedReplyText = computed(() => {
+  const boundary = lastProcessPartIndex.value;
+  if (boundary < 0) {
+    return props.parts
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("");
+  }
+  return props.parts
+    .slice(boundary + 1)
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+});
+
+// Collapsed view: directly construct a single text presentation item from the
+// trailing reply text. When expanded (or when the turn has no process to fold),
+// deriveTurnPresentation provides the full Markdown-safe interleaved layout.
 const visibleItems = computed(() => {
   if (expanded.value || !collapsible.value) return presentation.value;
-  const items = presentation.value;
-  const lastProcessIndex = items.findLastIndex((item) => item.type !== "text");
-  if (lastProcessIndex < 0) return items;
-  return items.slice(lastProcessIndex + 1);
+  const text = collapsedReplyText.value;
+  if (!text.trim()) return [];
+  return [
+    {
+      key: "collapsed-final-reply",
+      type: "text" as const,
+      text,
+      isLatest: false,
+    },
+  ];
 });
 const toolCount = computed(() =>
   presentation.value.filter((item) => item.type === "tool" || item.type === "subagent").length,

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -40,10 +40,14 @@ const presentation = computed(() =>
   ),
 );
 
-// Trace = activity cards that fold away on turn end; text and agent-message cards
-// are the reply itself and never collapse.
+// A finished turn collapses everything up through its LAST process item —
+// reasoning, tool, subagent, agent-message, AND the narrative text interleaved
+// between them all belongs to the process. Only trailing text after all process
+// activity is the final reply (deriveTurnPresentation already anchors activity in
+// arrival order, so "last non-text item" is the reliable process/reply boundary —
+// never m.text, which aggregates the whole turn's text).
 const hasTrace = computed(() =>
-  presentation.value.some((item) => item.type !== "text" && item.type !== "agent-message"),
+  presentation.value.some((item) => item.type !== "text"),
 );
 const collapsible = computed(() => props.collapseTrace === true && hasTrace.value);
 // Keyed rows remember toggles in the module set (survives hub history convergence,
@@ -54,12 +58,15 @@ const expanded = computed(() => {
   if (!collapsible.value) return false;
   return props.traceKey ? expandedTraces.has(props.traceKey) : localExpanded.value;
 });
-// When collapsed, only reply-shaped items render; the header summarizes the hidden rest.
-const visibleItems = computed(() =>
-  expanded.value || !collapsible.value
-    ? presentation.value
-    : presentation.value.filter((item) => item.type === "text" || item.type === "agent-message"),
-);
+// Collapsed view: only the trailing text after the last process item (the final
+// reply). A pure-text turn keeps everything (no process to fold, no header).
+const visibleItems = computed(() => {
+  if (expanded.value || !collapsible.value) return presentation.value;
+  const items = presentation.value;
+  const lastProcessIndex = items.findLastIndex((item) => item.type !== "text");
+  if (lastProcessIndex < 0) return items;
+  return items.slice(lastProcessIndex + 1);
+});
 const toolCount = computed(() =>
   presentation.value.filter((item) => item.type === "tool" || item.type === "subagent").length,
 );

--- a/packages/relay-web/src/i18n/messages/en.ts
+++ b/packages/relay-web/src/i18n/messages/en.ts
@@ -482,6 +482,15 @@ export default {
     noRecordedActivity: "No recorded activity",
     viewFullTrace: "View full trace",
     loadingDetails: "Loading details…",
+    kinds: {
+      read: "Read",
+      search: "Search",
+      execute: "Terminal",
+      edit: "Edit",
+      write: "Write",
+      think: "Thinking",
+      other: "Tool",
+    },
   },
   plan: {
     title: "Plan",

--- a/packages/relay-web/src/i18n/messages/zh-CN.ts
+++ b/packages/relay-web/src/i18n/messages/zh-CN.ts
@@ -479,14 +479,23 @@ export default {
     noRecordedActivity: "暂无执行记录",
     viewFullTrace: "查看完整过程",
     loadingDetails: "正在加载详情…",
+    kinds: {
+      read: "查阅",
+      search: "搜索",
+      execute: "终端",
+      edit: "编辑",
+      write: "写入",
+      think: "思考",
+      other: "工具",
+    },
   },
   plan: {
     title: "计划",
     togglePlan: "切换计划",
   },
   reasoning: {
-    reasoning: "推理",
-    reasoningStreaming: "推理中…",
+    reasoning: "思考",
+    reasoningStreaming: "思考中…",
   },
   turnTrace: {
     worked: "已工作",

--- a/packages/relay-web/src/lib/line-diff.ts
+++ b/packages/relay-web/src/lib/line-diff.ts
@@ -21,7 +21,7 @@ function naiveDiff(oldLines: string[], newLines: string[]): ParsedDiff {
     rows.push({ type: "add", oldNo: null, newNo: newNo++, text });
     add++;
   }
-  return { rows, add, del };
+  return { rows, add, del, exact: false };
 }
 
 function splitLines(text: string): string[] {
@@ -85,5 +85,5 @@ export function diffLines(oldText: string, newText: string): ParsedDiff {
     rows.push({ type: "add", oldNo: null, newNo: newNo++, text: newLines[j++] });
     add++;
   }
-  return { rows, add, del };
+  return { rows, add, del, exact: true };
 }

--- a/packages/relay-web/src/lib/line-diff.ts
+++ b/packages/relay-web/src/lib/line-diff.ts
@@ -24,13 +24,22 @@ function naiveDiff(oldLines: string[], newLines: string[]): ParsedDiff {
   return { rows, add, del };
 }
 
+function splitLines(text: string): string[] {
+  if (!text) return [];
+  const lines = text.split("\n");
+  // A terminal newline terminates the final real line;
+  // the trailing split element is not an extra source line.
+  if (text.endsWith("\n")) {
+    lines.pop();
+  }
+  return lines;
+}
+
 /** Diff two independent text blobs at line granularity via classic LCS DP, then
  *  backtrack into renderable rows with old/new line numbers. */
 export function diffLines(oldText: string, newText: string): ParsedDiff {
-  // "".split("\n") returns [""], not []; treat an empty blob as zero lines so a
-  // new-file or full-delete edit doesn't emit a phantom empty row / miscount.
-  const oldLines = oldText ? oldText.split("\n") : [];
-  const newLines = newText ? newText.split("\n") : [];
+  const oldLines = splitLines(oldText);
+  const newLines = splitLines(newText);
   const n = oldLines.length;
   const m = newLines.length;
 

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -86,8 +86,15 @@ export function markdownBlockBoundaries(text: string): number[] {
   });
 }
 
-/** Return the markdown-it token type of the top-level block enclosing `offset`. */
-export function topLevelBlockTypeAt(text: string, offset: number): string | null {
+export interface TopLevelBlockInfo {
+  type: string;
+  startOffset: number;
+  endOffset: number;
+  source: string;
+}
+
+/** Return the top-level block enclosing `offset`, including its source slice. */
+export function topLevelBlockAt(text: string, offset: number): TopLevelBlockInfo | null {
   const lineStarts = [0];
   for (let i = 0; i < text.length; i += 1) {
     if (text[i] === "\n") lineStarts.push(i + 1);
@@ -98,10 +105,20 @@ export function topLevelBlockTypeAt(text: string, offset: number): string | null
     const startOffset = lineStarts[block.map![0]] ?? 0;
     const endOffset = lineStarts[block.map![1]] ?? text.length;
     if (offset >= startOffset && offset <= endOffset) {
-      return block.type;
+      return {
+        type: block.type,
+        startOffset,
+        endOffset,
+        source: text.slice(startOffset, endOffset),
+      };
     }
   }
   return null;
+}
+
+/** Return the markdown-it token type of the top-level block enclosing `offset`. */
+export function topLevelBlockTypeAt(text: string, offset: number): string | null {
+  return topLevelBlockAt(text, offset)?.type ?? null;
 }
 
 /** Render markdown to sanitized, XSS-safe HTML. */

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -86,6 +86,24 @@ export function markdownBlockBoundaries(text: string): number[] {
   });
 }
 
+/** Return the markdown-it token type of the top-level block enclosing `offset`. */
+export function topLevelBlockTypeAt(text: string, offset: number): string | null {
+  const lineStarts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "\n") lineStarts.push(i + 1);
+  }
+  const tokens = md.parse(text, {});
+  const blocks = tokens.filter((t) => t.level === 0 && t.map !== null);
+  for (const block of blocks) {
+    const startOffset = lineStarts[block.map![0]] ?? 0;
+    const endOffset = lineStarts[block.map![1]] ?? text.length;
+    if (offset >= startOffset && offset <= endOffset) {
+      return block.type;
+    }
+  }
+  return null;
+}
+
 /** Render markdown to sanitized, XSS-safe HTML. */
 export function renderMarkdown(text: string, options: RenderMarkdownOptions = {}): string {
   // Heal unterminated markup first (streaming), then run table normalization so it

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -93,13 +93,20 @@ export interface TopLevelBlockInfo {
   source: string;
 }
 
-/** Return the top-level block enclosing `offset`, including its source slice. */
-export function topLevelBlockAt(text: string, offset: number): TopLevelBlockInfo | null {
+/** Return the top-level block enclosing `offset`, including its source slice.
+ *  Accepts an optional markdown-it `env` object that collects document-level
+ *  metadata (such as reference link definitions) during the parse.
+ */
+export function topLevelBlockAt(
+  text: string,
+  offset: number,
+  env: Record<string, unknown> = {},
+): TopLevelBlockInfo | null {
   const lineStarts = [0];
   for (let i = 0; i < text.length; i += 1) {
     if (text[i] === "\n") lineStarts.push(i + 1);
   }
-  const tokens = md.parse(text, {});
+  const tokens = md.parse(text, env);
   const blocks = tokens.filter((t) => t.level === 0 && t.map !== null);
   for (const block of blocks) {
     const startOffset = lineStarts[block.map![0]] ?? 0;
@@ -115,48 +122,103 @@ export function topLevelBlockAt(text: string, offset: number): TopLevelBlockInfo
   }
   return null;
 }
-function getInlineSignature(source: string): string[] {
-  const tokens = md.parse(source, {});
+
+interface SemanticInlineToken {
+  type: string;
+  content: string;
+  attrs: string;
+  info: string;
+}
+
+function canonicalInlineTokens(source: string, env: Record<string, unknown>): SemanticInlineToken[] {
+  const tokens = md.parseInline(source, { ...env });
   const inline = tokens.find((t) => t.type === "inline");
   if (!inline || !inline.children) return [];
-  const sig: string[] = [];
+
+  const result: SemanticInlineToken[] = [];
   for (const c of inline.children) {
-    if (c.type === "text" || c.type === "softbreak") continue;
-    if (c.type === "link_open") {
-      sig.push(`link_open:${c.info || ""}:${JSON.stringify(c.attrs || [])}`);
-    } else if (c.type === "link_close") {
-      sig.push(`link_close:${c.info || ""}`);
-    } else if (c.type === "code_inline" || c.type === "image" || c.type === "html_inline") {
-      sig.push(`${c.type}:${c.content}:${JSON.stringify(c.attrs || [])}`);
-    } else {
-      sig.push(c.type);
+    if (c.type === "softbreak") {
+      if (result.length > 0 && result[result.length - 1]!.type === "text") {
+        result[result.length - 1]!.content += "\n";
+      } else {
+        result.push({ type: "text", content: "\n", attrs: "", info: "" });
+      }
+      continue;
+    }
+    if (c.type === "text") {
+      if (result.length > 0 && result[result.length - 1]!.type === "text") {
+        result[result.length - 1]!.content += c.content;
+      } else {
+        result.push({ type: "text", content: c.content, attrs: "", info: "" });
+      }
+      continue;
+    }
+    result.push({
+      type: c.type,
+      content: c.content || "",
+      attrs: c.attrs ? JSON.stringify(c.attrs) : "",
+      info: c.info || "",
+    });
+  }
+  return result;
+}
+
+function mergeTokenStreams(a: SemanticInlineToken[], b: SemanticInlineToken[]): SemanticInlineToken[] {
+  if (a.length === 0) return b;
+  if (b.length === 0) return a;
+  const merged = [...a];
+  const lastA = merged[merged.length - 1]!;
+  const firstB = b[0]!;
+  if (lastA.type === "text" && firstB.type === "text") {
+    merged[merged.length - 1] = {
+      ...lastA,
+      content: lastA.content + firstB.content,
+    };
+    merged.push(...b.slice(1));
+  } else {
+    merged.push(...b);
+  }
+  return merged;
+}
+
+function areSemanticTokensEqual(a: SemanticInlineToken[], b: SemanticInlineToken[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (
+      a[i]!.type !== b[i]!.type ||
+      a[i]!.content !== b[i]!.content ||
+      a[i]!.attrs !== b[i]!.attrs ||
+      a[i]!.info !== b[i]!.info
+    ) {
+      return false;
     }
   }
-  return sig;
+  return true;
 }
 
 /** Check whether `offsetInBlock` inside a paragraph block lands at a safe top-level
  *  text position rather than severing an active inline construct (code span,
- *  emphasis, strong, link label/delimiter, strikethrough, image, hardbreak, etc.).
- *  Compares the inline structural signature of the full block against the concatenated
- *  signatures of the prefix and suffix parsed independently; if any construct crosses
- *  the boundary, their structures diverge and this returns false.
+ *  emphasis, strong, link label/delimiter, reference link, HTML entity, hardbreak, etc.).
+ *  Compares the canonical inline semantic tokens of the full block against the concatenated
+ *  tokens of the prefix and suffix parsed independently within the same document env.
+ *  Adjacent text tokens across the slice boundary are merged so normal prose splits match;
+ *  if any inline construct or entity was severed, their token streams diverge and this returns false.
  */
-export function isSafeInlineParagraphOffset(paragraphSource: string, offsetInBlock: number): boolean {
+export function isSafeInlineParagraphOffset(
+  paragraphSource: string,
+  offsetInBlock: number,
+  env: Record<string, unknown> = {},
+): boolean {
   if (offsetInBlock < 0 || offsetInBlock > paragraphSource.length) return false;
   const prefix = paragraphSource.slice(0, offsetInBlock);
   const suffix = paragraphSource.slice(offsetInBlock);
 
-  const fullSig = getInlineSignature(paragraphSource);
-  const prefixSig = getInlineSignature(prefix);
-  const suffixSig = getInlineSignature(suffix);
-  const combinedSig = [...prefixSig, ...suffixSig];
+  const fullTokens = canonicalInlineTokens(paragraphSource, env);
+  const prefixTokens = canonicalInlineTokens(prefix, env);
+  const suffixTokens = canonicalInlineTokens(suffix, env);
+  const combinedTokens = mergeTokenStreams(prefixTokens, suffixTokens);
 
-  if (fullSig.length !== combinedSig.length) return false;
-  for (let i = 0; i < fullSig.length; i += 1) {
-    if (fullSig[i] !== combinedSig[i]) return false;
-  }
-  return true;
+  return areSemanticTokensEqual(fullTokens, combinedTokens);
 }
 
 /** Render markdown to sanitized, XSS-safe HTML. */

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -115,49 +115,48 @@ export function topLevelBlockAt(text: string, offset: number): TopLevelBlockInfo
   }
   return null;
 }
-const INLINE_SENTINEL = "\uFFF0";
-
-/** Check whether `offsetInBlock` inside a paragraph block lands at a safe top-level
- *  text position rather than severing an active inline construct (code_inline,
- *  emphasis, strong, link label, strikethrough, image, html_inline, etc.).
- */
-export function isSafeInlineParagraphOffset(paragraphSource: string, offsetInBlock: number): boolean {
-  if (paragraphSource.includes(INLINE_SENTINEL)) return false;
-  const before = paragraphSource.slice(0, offsetInBlock);
-  const after = paragraphSource.slice(offsetInBlock);
-  const withSentinel = before + INLINE_SENTINEL + after;
-
-  const tokens = md.parse(withSentinel, {});
+function getInlineSignature(source: string): string[] {
+  const tokens = md.parse(source, {});
   const inline = tokens.find((t) => t.type === "inline");
-  if (!inline || !inline.children) return false;
-
-  const stack: string[] = [];
-  let found = false;
-  let inConstruct: string | null = null;
-
-  for (const child of inline.children) {
-    if (child.type.endsWith("_open")) {
-      stack.push(child.type);
-    } else if (child.type.endsWith("_close")) {
-      stack.pop();
-    } else if (child.type === "code_inline" || child.type === "image" || child.type === "html_inline") {
-      if (child.content.includes(INLINE_SENTINEL)) {
-        found = true;
-        inConstruct = child.type;
-        break;
-      }
-    } else if (child.type === "text") {
-      if (child.content.includes(INLINE_SENTINEL)) {
-        found = true;
-        if (stack.length > 0) {
-          inConstruct = stack[stack.length - 1] ?? "nested_inline";
-        }
-        break;
-      }
+  if (!inline || !inline.children) return [];
+  const sig: string[] = [];
+  for (const c of inline.children) {
+    if (c.type === "text" || c.type === "softbreak") continue;
+    if (c.type === "link_open") {
+      sig.push(`link_open:${c.info || ""}:${JSON.stringify(c.attrs || [])}`);
+    } else if (c.type === "link_close") {
+      sig.push(`link_close:${c.info || ""}`);
+    } else if (c.type === "code_inline" || c.type === "image" || c.type === "html_inline") {
+      sig.push(`${c.type}:${c.content}:${JSON.stringify(c.attrs || [])}`);
+    } else {
+      sig.push(c.type);
     }
   }
+  return sig;
+}
 
-  return found && inConstruct === null && stack.length === 0;
+/** Check whether `offsetInBlock` inside a paragraph block lands at a safe top-level
+ *  text position rather than severing an active inline construct (code span,
+ *  emphasis, strong, link label/delimiter, strikethrough, image, hardbreak, etc.).
+ *  Compares the inline structural signature of the full block against the concatenated
+ *  signatures of the prefix and suffix parsed independently; if any construct crosses
+ *  the boundary, their structures diverge and this returns false.
+ */
+export function isSafeInlineParagraphOffset(paragraphSource: string, offsetInBlock: number): boolean {
+  if (offsetInBlock < 0 || offsetInBlock > paragraphSource.length) return false;
+  const prefix = paragraphSource.slice(0, offsetInBlock);
+  const suffix = paragraphSource.slice(offsetInBlock);
+
+  const fullSig = getInlineSignature(paragraphSource);
+  const prefixSig = getInlineSignature(prefix);
+  const suffixSig = getInlineSignature(suffix);
+  const combinedSig = [...prefixSig, ...suffixSig];
+
+  if (fullSig.length !== combinedSig.length) return false;
+  for (let i = 0; i < fullSig.length; i += 1) {
+    if (fullSig[i] !== combinedSig[i]) return false;
+  }
+  return true;
 }
 
 /** Render markdown to sanitized, XSS-safe HTML. */

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -115,10 +115,49 @@ export function topLevelBlockAt(text: string, offset: number): TopLevelBlockInfo
   }
   return null;
 }
+const INLINE_SENTINEL = "\uFFF0";
 
-/** Return the markdown-it token type of the top-level block enclosing `offset`. */
-export function topLevelBlockTypeAt(text: string, offset: number): string | null {
-  return topLevelBlockAt(text, offset)?.type ?? null;
+/** Check whether `offsetInBlock` inside a paragraph block lands at a safe top-level
+ *  text position rather than severing an active inline construct (code_inline,
+ *  emphasis, strong, link label, strikethrough, image, html_inline, etc.).
+ */
+export function isSafeInlineParagraphOffset(paragraphSource: string, offsetInBlock: number): boolean {
+  if (paragraphSource.includes(INLINE_SENTINEL)) return false;
+  const before = paragraphSource.slice(0, offsetInBlock);
+  const after = paragraphSource.slice(offsetInBlock);
+  const withSentinel = before + INLINE_SENTINEL + after;
+
+  const tokens = md.parse(withSentinel, {});
+  const inline = tokens.find((t) => t.type === "inline");
+  if (!inline || !inline.children) return false;
+
+  const stack: string[] = [];
+  let found = false;
+  let inConstruct: string | null = null;
+
+  for (const child of inline.children) {
+    if (child.type.endsWith("_open")) {
+      stack.push(child.type);
+    } else if (child.type.endsWith("_close")) {
+      stack.pop();
+    } else if (child.type === "code_inline" || child.type === "image" || child.type === "html_inline") {
+      if (child.content.includes(INLINE_SENTINEL)) {
+        found = true;
+        inConstruct = child.type;
+        break;
+      }
+    } else if (child.type === "text") {
+      if (child.content.includes(INLINE_SENTINEL)) {
+        found = true;
+        if (stack.length > 0) {
+          inConstruct = stack[stack.length - 1] ?? "nested_inline";
+        }
+        break;
+      }
+    }
+  }
+
+  return found && inConstruct === null && stack.length === 0;
 }
 
 /** Render markdown to sanitized, XSS-safe HTML. */

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -1,5 +1,5 @@
 import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
-import { markdownBlockBoundaries, topLevelBlockAt } from "./render-markdown";
+import { isSafeInlineParagraphOffset, markdownBlockBoundaries, topLevelBlockAt } from "./render-markdown";
 import { normalizeMarkdownTables } from "./normalize-markdown";
 import { hasToolStepAncestor, indexToolSteps } from "./subagent-trace";
 
@@ -189,13 +189,12 @@ export function deriveTurnPresentation(
 }
 
 /** Top-level block types that are strictly safe to slice mid-block across an activity.
- *  Containers (blockquotes, lists, tables) can be nested arbitrarily, and code blocks
- *  (fences) cannot be cleanly split. We fail-closed: only top-level paragraphs and
- *  headings permit extracting trailing text after a mid-block activity.
+ *  Containers (blockquotes, lists, tables, headings) can be nested arbitrarily or change
+ *  block semantics if split. We fail-closed: only top-level paragraphs permit extracting
+ *  trailing text after a mid-block activity.
  */
 const SAFE_SLICE_BLOCK_TYPES: Record<string, true> = {
   paragraph_open: true,
-  heading_open: true,
 };
 
 /** Extract the conversational final reply from a turn's wire parts.
@@ -268,6 +267,13 @@ export function extractFinalReplyText(
   // delimiterless tables recognized as a table during render but appearing as a paragraph
   // to raw markdown-it), fail-closed so we do not slice mid-table or synthesize corrupted tables.
   if (normalizeMarkdownTables(block.source) !== block.source) {
+    return "";
+  }
+  // Inline boundary guard: verify that the tool arrived at an unstyled top-level text
+  // boundary within the paragraph, rather than severing an active inline construct
+  // (code span, emphasis, bold, link label, strikethrough, image, html_inline, etc.).
+  const offsetInBlock = toolOffset - block.startOffset;
+  if (!isSafeInlineParagraphOffset(block.source, offsetInBlock)) {
     return "";
   }
   return trailing;

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -1,5 +1,5 @@
 import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
-import { markdownBlockBoundaries } from "./render-markdown";
+import { markdownBlockBoundaries, topLevelBlockTypeAt } from "./render-markdown";
 import { hasToolStepAncestor, indexToolSteps } from "./subagent-trace";
 
 export type TurnPresentationItem =
@@ -185,4 +185,78 @@ export function deriveTurnPresentation(
   }
 
   return result;
+}
+
+const UNSAFE_BLOCK_TYPES: Record<string, true> = {
+  fence: true,
+  code_block: true,
+  table_open: true,
+  bullet_list_open: true,
+  ordered_list_open: true,
+};
+
+/** Extract the conversational final reply from a turn's wire parts.
+ *
+ *  When a turn finishes with tool/reasoning activity:
+ *  1. If deriveTurnPresentation() produced text items after the last process item,
+ *     those items are already cleanly anchored at top-level Markdown block boundaries
+ *     (e.g. after a code fence or table closed). We join and return them.
+ *  2. If presentation placed the process item at the end, it was anchored at narrative end
+ *     because it arrived inside the final Markdown block. If that block is safe prose
+ *     (a paragraph), trailing text arriving after the process item is returned.
+ *  3. If the process item arrived inside an unsafe container (fence, table, list) that
+ *     never closed with a subsequent reply block, mid-block slicing would corrupt Markdown
+ *     (turning closing fences into unclosed opening fences, breaking table rows). The
+ *     fail-safe returns empty string (trace header only, no broken code block).
+ */
+export function extractFinalReplyText(
+  parts: TurnPartDto[],
+  opts?: { presentation?: TurnPresentationItem[] },
+): string {
+  const pres = opts?.presentation ?? deriveTurnPresentation(parts);
+  const lastProcessIndex = pres.findLastIndex((item) => item.type !== "text");
+
+  // Pure-text turn: no process items to fold
+  if (lastProcessIndex < 0) {
+    return parts
+      .filter((p): p is Extract<TurnPartDto, { type: "text" }> => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+  }
+
+  // deriveTurnPresentation already placed subsequent Markdown blocks after the activity
+  if (lastProcessIndex < pres.length - 1) {
+    return pres
+      .slice(lastProcessIndex + 1)
+      .filter((item): item is Extract<TurnPresentationItem, { type: "text" }> => item.type === "text")
+      .map((item) => item.text)
+      .join("");
+  }
+
+  // presentation ended on the process item (anchored at narrative.length).
+  const lastPartIdx = parts.findLastIndex(
+    (p) => p.type === "tool" || (p.type === "reasoning" && p.text.trim().length > 0),
+  );
+  if (lastPartIdx < 0) return "";
+  const trailing = parts
+    .slice(lastPartIdx + 1)
+    .filter((p): p is Extract<TurnPartDto, { type: "text" }> => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+  if (!trailing.trim()) return "";
+
+  // Check if the last activity was inside an unsafe Markdown block.
+  let narrative = "";
+  let toolOffset = 0;
+  for (let i = 0; i < parts.length; i += 1) {
+    if (i === lastPartIdx) toolOffset = narrative.length;
+    const part = parts[i]!;
+    if (part.type === "text") narrative += part.text;
+  }
+
+  const blockType = topLevelBlockTypeAt(narrative, toolOffset);
+  if (blockType && UNSAFE_BLOCK_TYPES[blockType]) {
+    return "";
+  }
+  return trailing;
 }

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -1,5 +1,6 @@
 import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
-import { markdownBlockBoundaries, topLevelBlockTypeAt } from "./render-markdown";
+import { markdownBlockBoundaries, topLevelBlockAt } from "./render-markdown";
+import { normalizeMarkdownTables } from "./normalize-markdown";
 import { hasToolStepAncestor, indexToolSteps } from "./subagent-trace";
 
 export type TurnPresentationItem =
@@ -258,9 +259,41 @@ export function extractFinalReplyText(
     if (part.type === "text") narrative += part.text;
   }
 
-  const blockType = topLevelBlockTypeAt(narrative, toolOffset);
-  if (!blockType || !SAFE_SLICE_BLOCK_TYPES[blockType]) {
+  const block = topLevelBlockAt(narrative, toolOffset);
+  if (!block || !SAFE_SLICE_BLOCK_TYPES[block.type]) {
+    return "";
+  }
+  // Normalization guard: the renderer runs normalizeMarkdownTables() before parsing.
+  // If the candidate block would be reshaped by table normalization (e.g. malformed
+  // delimiterless tables recognized as a table during render but appearing as a paragraph
+  // to raw markdown-it), fail-closed so we do not slice mid-table or synthesize corrupted tables.
+  if (normalizeMarkdownTables(block.source) !== block.source) {
     return "";
   }
   return trailing;
+}
+
+export interface CollapsedTraceSummary {
+  finalReplyText: string;
+  toolCount: number;
+  thoughtCount: number;
+}
+
+/** Extract all collapsed-trace header metrics in a single pass, sharing the
+ *  presentation derivation between the final conversational reply and the
+ *  activity counters so MessageList and TurnParts never perform duplicate Markdown parses.
+ */
+export interface CollapsedTraceSummaryOptions extends TurnPresentationOptions {
+  presentation?: TurnPresentationItem[];
+}
+
+export function extractCollapsedTraceSummary(
+  parts: TurnPartDto[],
+  opts?: CollapsedTraceSummaryOptions,
+): CollapsedTraceSummary {
+  const pres: TurnPresentationItem[] = opts?.presentation ?? deriveTurnPresentation(parts, opts);
+  const finalReplyText = extractFinalReplyText(parts, { presentation: pres });
+  const toolCount = pres.filter((item: TurnPresentationItem) => item.type === "tool" || item.type === "subagent").length;
+  const thoughtCount = pres.filter((item: TurnPresentationItem) => item.type === "reasoning").length;
+  return { finalReplyText, toolCount, thoughtCount };
 }

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -210,7 +210,7 @@ const SAFE_SLICE_BLOCK_TYPES: Record<string, true> = {
  *     blockquote) that never closed with a subsequent reply block, mid-block slicing would
  *     corrupt Markdown (turning closing fences into unclosed opening fences, breaking table
  *     rows, or severing nested blocks). The fail-safe is fail-closed: only explicitly safe
- *     top-level prose blocks (paragraph, heading) permit slicing trailing text; all other
+ *     top-level prose blocks (paragraph) permit slicing trailing text; all other
  *     block types (or missing blocks) return empty string (trace header only, no broken markdown).
  */
 export function extractFinalReplyText(
@@ -258,7 +258,8 @@ export function extractFinalReplyText(
     if (part.type === "text") narrative += part.text;
   }
 
-  const block = topLevelBlockAt(narrative, toolOffset);
+  const docEnv: Record<string, unknown> = {};
+  const block = topLevelBlockAt(narrative, toolOffset, docEnv);
   if (!block || !SAFE_SLICE_BLOCK_TYPES[block.type]) {
     return "";
   }
@@ -271,9 +272,9 @@ export function extractFinalReplyText(
   }
   // Inline boundary guard: verify that the tool arrived at an unstyled top-level text
   // boundary within the paragraph, rather than severing an active inline construct
-  // (code span, emphasis, bold, link label, strikethrough, image, html_inline, etc.).
+  // (code span, emphasis, bold, link label/delimiter, reference link, HTML entity, etc.).
   const offsetInBlock = toolOffset - block.startOffset;
-  if (!isSafeInlineParagraphOffset(block.source, offsetInBlock)) {
+  if (!isSafeInlineParagraphOffset(block.source, offsetInBlock, docEnv)) {
     return "";
   }
   return trailing;

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -187,12 +187,14 @@ export function deriveTurnPresentation(
   return result;
 }
 
-const UNSAFE_BLOCK_TYPES: Record<string, true> = {
-  fence: true,
-  code_block: true,
-  table_open: true,
-  bullet_list_open: true,
-  ordered_list_open: true,
+/** Top-level block types that are strictly safe to slice mid-block across an activity.
+ *  Containers (blockquotes, lists, tables) can be nested arbitrarily, and code blocks
+ *  (fences) cannot be cleanly split. We fail-closed: only top-level paragraphs and
+ *  headings permit extracting trailing text after a mid-block activity.
+ */
+const SAFE_SLICE_BLOCK_TYPES: Record<string, true> = {
+  paragraph_open: true,
+  heading_open: true,
 };
 
 /** Extract the conversational final reply from a turn's wire parts.
@@ -204,10 +206,12 @@ const UNSAFE_BLOCK_TYPES: Record<string, true> = {
  *  2. If presentation placed the process item at the end, it was anchored at narrative end
  *     because it arrived inside the final Markdown block. If that block is safe prose
  *     (a paragraph), trailing text arriving after the process item is returned.
- *  3. If the process item arrived inside an unsafe container (fence, table, list) that
- *     never closed with a subsequent reply block, mid-block slicing would corrupt Markdown
- *     (turning closing fences into unclosed opening fences, breaking table rows). The
- *     fail-safe returns empty string (trace header only, no broken code block).
+ *  3. If the process item arrived inside an unsafe or nested container (fence, table, list,
+ *     blockquote) that never closed with a subsequent reply block, mid-block slicing would
+ *     corrupt Markdown (turning closing fences into unclosed opening fences, breaking table
+ *     rows, or severing nested blocks). The fail-safe is fail-closed: only explicitly safe
+ *     top-level prose blocks (paragraph, heading) permit slicing trailing text; all other
+ *     block types (or missing blocks) return empty string (trace header only, no broken markdown).
  */
 export function extractFinalReplyText(
   parts: TurnPartDto[],
@@ -255,7 +259,7 @@ export function extractFinalReplyText(
   }
 
   const blockType = topLevelBlockTypeAt(narrative, toolOffset);
-  if (blockType && UNSAFE_BLOCK_TYPES[blockType]) {
+  if (!blockType || !SAFE_SLICE_BLOCK_TYPES[blockType]) {
     return "";
   }
   return trailing;

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -270,6 +270,13 @@ export function extractFinalReplyText(
   if (normalizeMarkdownTables(block.source) !== block.source) {
     return "";
   }
+  // Scope constraint: the fallback only applies when the trailing prose is strictly contained
+  // within the validated top-level block. Any unrendered Markdown metadata outside the block
+  // (such as trailing reference link definitions) must not leak as final reply.
+  const outsideBlock = narrative.slice(block.endOffset);
+  if (outsideBlock.trim().length > 0) {
+    return "";
+  }
   // Inline boundary guard: verify that the tool arrived at an unstyled top-level text
   // boundary within the paragraph, rather than severing an active inline construct
   // (code span, emphasis, bold, link label/delimiter, reference link, HTML entity, etc.).
@@ -277,7 +284,8 @@ export function extractFinalReplyText(
   if (!isSafeInlineParagraphOffset(block.source, offsetInBlock, docEnv)) {
     return "";
   }
-  return trailing;
+  const reply = narrative.slice(toolOffset, block.endOffset);
+  return reply.trim() ? reply : "";
 }
 
 export interface CollapsedTraceSummary {

--- a/packages/relay-web/src/lib/unified-diff.ts
+++ b/packages/relay-web/src/lib/unified-diff.ts
@@ -11,6 +11,7 @@ export interface ParsedDiff {
   rows: DiffRow[];
   add: number;
   del: number;
+  exact?: boolean;
 }
 
 const HUNK_RE = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)$/;


### PR DESCRIPTION
## 背景

PR #329 实现了回合结束后的 trace 折叠。但在回合进行中（streaming）以及展开中间过程时，各个推理和工具步骤依然以独立的厚重浮动卡片（`rounded-lg border border-border bg-surface shadow-e1`）呈现，在连续多次工具调用（连续读写文件、运行命令等）时数十个卡片层叠，视觉极其拥挤、噪音过大。

本 PR 彻底去除工具和推理卡片的外层框线、阴影和 surface 底色，实现 **zcode 风格的去卡片化（De-cardified）流式时间线**。

## 改动点

1. **`ReasoningPanel.vue` 去卡片化**：
   - 移除外层 `border`、`bg-surface`、`shadow-e1`。
   - 头部收敛为极简单行：`Brain` 图标 + `思考` / `思考中…` + streaming 脉冲点 + 微弱展开指示器。
   - 展开后的思考正文通过 `ml-2.5 my-1 border-l-2 border-border/60 pl-3 py-0.5` 左导向线缩进呈现，无框线包裹。

2. **`ToolStepCard.vue` 去卡片化与细节对齐**：
   - 移除外层卡片容器，转为平铺单行时间线。
   - 前置动作图标 + 操作动词标签（`终端` / `编辑` / `写入` / `查阅` / `搜索` / `工具`）。
   - 文件角标：先剥离 basename 再去除查询/行号后缀，准确提取文件名后缀（`TS`、`VUE`、`PY`、`JSON` 等）；兼容 Windows 盘符绝对路径（`C:\...`）与 URI scheme，安全忽略带点目录（`src.v2/x`、`a.b/c`）与 dotfiles。
   - 右侧统计：通过 `diffLines` 计算实时渲染行级 diff 差分统计（`+4` / `−1`，绿红配色）；超大输入 fallback（`exact: false`）或 connector 截断（`…(truncated)`）时隐藏，杜绝伪精确统计。
   - 无详情步骤降级为普通 `<div>`，移除按钮/tabindex/hover 样式。
   - 详情展开：以 `ml-2.5 my-1.5 border-l-2 border-border/50 pl-3` 左侧导向线缩进嵌套 `<ToolDetail>`（diff 视图片段、命令行输出等原生代码块）。

3. **`SubagentStepCard.vue` 与 `ToolCallPanel.vue` 同步对齐**：
   - 子代理步骤和旧历史聚合面板同样剥离卡片外壳，改为单行动作行 + 缩进式子步骤时间线。

4. **`TurnParts.vue` 节奏优化与折叠安全**：
   - 步骤与正文间距统一为 `space-y-2`（8px），使得密集的工具流与正文紧凑咬合。
   - Markdown 块完整性与 Fail-closed：`extractFinalReplyText()` 使用 `SAFE_SLICE_BLOCK_TYPES` 白名单（仅 `paragraph_open`），对 code fence、table、list、blockquote、heading 等容器嵌套一律 fail-closed 返回空串（仅保留 trace header），杜绝未闭合代码块/列表外泄或标题语义降级。
   - Table Normalization 防护：对候选段落执行 `normalizeMarkdownTables(block.source) === block.source` 校验；缺少 delimiter row 的表格即使被 raw markdown-it 误判为普通段落，只要会被渲染器 table normalizer 改写，一律 fail-closed 返回空串，杜绝表格行被错误提升为 header 或泄漏到回复中。
   - 文档环境感知与语义 Token 守卫（Document-Env & Semantic Token Guard）：通过从完整 narrative 一次解析收集 document-level `env`（跨规则引用链接），并使用 `md.parseInline(..., env)` 对 candidate paragraph 及其切分前后缀进行规范化 inline token 比较；保留解码后文本内容并在边界处合并相邻 text token，验证 HTML 实体（如 `&` | `amp;`）、转义字符、引用链接（`[docs]` | `[ref]`）、链接分界符（`[docs]` | `(url)`）、行内代码与硬换行未被跨 offset 切断。
   - 范围边界收敛（Scope Constraint）：fallback 提取严格收敛在当前校验通过的 top-level block 范围内部（`narrative.slice(toolOffset, block.endOffset)`）；若块外存在非空白未渲染元数据（如仅存后置引用链接定义 `[ref]: ...` 且无后续回复），fail-closed 返回空串，杜绝 Markdown metadata 泄露为回复。
   - 接收父级 precomputed `collapsedReplyText`、`collapsedToolCount`、`collapsedThoughtCount`，折叠态完全跳过 `presentation.value` 求值，将全量布局推导推迟至用户点击展开。

5. **`MessageList.vue` CopyButton 语义与推导共享**：
   - `copyTextOf()` 与 `TurnParts` 严格对齐，折叠回合仅复制最终回复，隐藏过程文本；失败回合保留完整文本；无回复正文时自动隐藏复制按钮。
   - 单次推导通过 `extractCollapsedTraceSummary()` 同时生成 final reply 与工具/思考计数，并在 `traceSummaryCache`（`WeakMap`）按 `(ChatMessage, parts)` 缓存，同时供给 `:collapsed-reply-text`、`:collapsed-tool-count`、`:collapsed-thought-count` 与 `CopyButton`，彻底消除挂载热路径上父子组件的重复 Markdown parse。

6. **i18n**：
   - 增补 `tools.kinds.*`（read, search, execute, edit, write, think, other），zh-CN 统一为思考/查阅/终端/编辑/写入等；两语言严格保持 key parity。

## 验证

- 新增测试覆盖：
  - 断言卡片外层无 `bg-surface` / `shadow-e1` / `border`。
  - 断言各类操作动词与文件扩展名角标正常渲染，兼容 Windows 绝对路径与带点目录。
  - 断言 diff stat（`+add` / `−del`）正确展示，超大/截断时隐藏。
  - 断言无详情步骤渲染为非交互 `div`。
  - 断言 code fence / table / list / blockquote 嵌套 fail-closed 块安全性。
  - 断言缺少 delimiter row 的表格在无 reply 时安全折叠为 header-only，有 reply 时提取外部回复。
  - 断言 inline 语法与语义守卫（HTML 实体、引用链接、普通链接分界符、代码跨度、加粗、硬换行跨越工具时 fail-closed，未跨越时安全切分）。
  - 断言末尾仅有引用定义（reference definition only）时 fail-closed 为 header-only，无 turn-narrative 且 CopyButton 不出现。
  - 断言 CopyButton 仅复制 final reply，并与 TurnParts 共享缓存推导与活动计数。
- 测试全绿：
  - `subagentstepcard.test.ts` (13/13)
  - `turnparts-collapse.test.ts` (44/44)
  - `toolstepcard.test.ts` (17/17)
  - `tooldetail.test.ts` (9/9)
  - `toolcallpanel.test.ts` (11/11)
  - `messagelist.test.ts` (67/67)
  - `i18n-parity.test.ts` (2/2)
  - Web 全套 131 文件 / **1465 测试全绿**；`vue-tsc` 与根 `tsc` 0 错误。

## 文档

- 设计 spec：`docs/superpowers/specs/2026-09-08-relay-web-decardify-tools-reasoning.md`
- 模块文档：`docs/relay-web-module.md` 更新组件描述与计算分工。
- 历史 spec：`docs/superpowers/specs/2026-09-07-relay-web-turn-trace-collapse.md` 标注已被 supersede 并同步最终契约。
