### PR TITLE
fix(runtime): keep MCP identity stable from session ensure

### DIFF
--- a/src/commands/transport-invoker.ts
+++ b/src/commands/transport-invoker.ts
@@ -156,10 +156,19 @@ export class TransportInvoker {
     reply?: (text: string) => Promise<void>,
     perfSpan?: PerfSpan,
   ): Promise<void> {
+    // Runtime workers treat MCP identity as immutable construction state. Bind
+    // the coordinator before the first ensure so the first prompt does not
+    // rotate an otherwise-empty agent session and then try to resume it. Keep
+    // the binding transport-local so it does not leak into logical session DTOs.
+    const ensuredSession: ResolvedSession = {
+      ...session,
+      mcpCoordinatorSession:
+        session.mcpCoordinatorSession ?? stableCoordinatorSession(session.transportSession),
+    };
     const attemptSession = (operation: string): Promise<void> => {
       const { handler, dispose } = this.createProgressHandler(session, reply);
       return this.measureTransportCall(operation, session, () =>
-        this.transport.ensureSession(session, handler),
+        this.transport.ensureSession(ensuredSession, handler),
       ).finally(dispose);
     };
 

--- a/src/commands/transport-invoker.ts
+++ b/src/commands/transport-invoker.ts
@@ -16,7 +16,7 @@ import {
   summarizeTransportNdjson,
 } from "./transport-diagnostics";
 import { t } from "../i18n";
-import { stableCoordinatorSession } from "../orchestration/coordinator-identity";
+import { withDefaultMcpIdentity } from "../orchestration/coordinator-identity";
 
 type AutoInstallFn = typeof defaultAutoInstall;
 type DiscoverPathsFn = typeof defaultDiscoverPaths;
@@ -160,11 +160,9 @@ export class TransportInvoker {
     // the coordinator before the first ensure so the first prompt does not
     // rotate an otherwise-empty agent session and then try to resume it. Keep
     // the binding transport-local so it does not leak into logical session DTOs.
-    const ensuredSession: ResolvedSession = {
-      ...session,
-      mcpCoordinatorSession:
-        session.mcpCoordinatorSession ?? stableCoordinatorSession(session.transportSession),
-    };
+    // Unconditional like the historical prompt binding (CLI queue owner relies
+    // on it); the bridge boundary gates direct reads on the runtime engine.
+    const ensuredSession: ResolvedSession = withDefaultMcpIdentity(session);
     const attemptSession = (operation: string): Promise<void> => {
       const { handler, dispose } = this.createProgressHandler(session, reply);
       return this.measureTransportCall(operation, session, () =>
@@ -220,7 +218,10 @@ export class TransportInvoker {
     onUsage?: (usage: PromptUsage) => void | Promise<void>,
     onCommands?: (commands: AgentCommand[]) => void | Promise<void>,
   ) {
-    session.mcpCoordinatorSession ??= stableCoordinatorSession(session.transportSession);
+    // Same invariant as ensure, kept transport-local: the bridge boundary is
+    // the authoritative default, but non-bridge transports (and the abort
+    // cancel below) must see the identical identity for this call.
+    const promptSession: ResolvedSession = withDefaultMcpIdentity(session);
     // `done` closes the race window between prompt resolving and the abort
     // listener firing: once we're in finally we suppress any late abort so
     // it can't cancel a *follow-up* prompt that happens to reuse this session.
@@ -231,7 +232,7 @@ export class TransportInvoker {
       abortRequested = true;
       if (done) return;
       try {
-        const result = this.transport.cancel(session);
+        const result = this.transport.cancel(promptSession);
         if (result && typeof (result as { catch?: unknown }).catch === "function") {
           (result as Promise<unknown>).catch(async (error) => {
             await this.logger.error("transport.cancel_on_abort_failed", "transport cancel triggered by abort signal failed", {
@@ -280,7 +281,7 @@ export class TransportInvoker {
         transportKind: this.config?.transport.type ?? inferTransportKind(this.transport),
       });
       return await this.measureTransportCall("prompt", session, () =>
-        this.transport.prompt(session, text, reply, replyContext, {
+        this.transport.prompt(promptSession, text, reply, replyContext, {
           ...(abortSignal ? { signal: abortSignal } : {}),
           ...(media ? { media } : {}),
           ...(reply ? { onSegment } : {}),
@@ -307,15 +308,17 @@ export class TransportInvoker {
   }
 
   async setModeTransportSession(session: ResolvedSession, modeId: string) {
-    return await this.measureTransportCall("set_mode", session, () => this.transport.setMode(session, modeId));
+    const bound = withDefaultMcpIdentity(session);
+    return await this.measureTransportCall("set_mode", session, () => this.transport.setMode(bound, modeId));
   }
 
   async setModelTransportSession(session: ResolvedSession, modelId: string) {
     if (!this.transport.setModel) {
       throw new Error("the active transport does not support switching models");
     }
+    const bound = withDefaultMcpIdentity(session);
     const setModel = this.transport.setModel.bind(this.transport);
-    return await this.measureTransportCall("set_model", session, () => setModel(session, modelId));
+    return await this.measureTransportCall("set_model", session, () => setModel(bound, modelId));
   }
 
   async getModelTransportSession(session: ResolvedSession): Promise<{ current?: string; available: string[] }> {
@@ -323,8 +326,9 @@ export class TransportInvoker {
       // Transport can't query acpx; fall back to the resolved model with no catalog.
       return { current: session.model, available: [] };
     }
+    const bound = withDefaultMcpIdentity(session);
     const getSessionModel = this.transport.getSessionModel.bind(this.transport);
-    return await this.measureTransportCall("get_model", session, () => getSessionModel(session));
+    return await this.measureTransportCall("get_model", session, () => getSessionModel(bound));
   }
 
   async cancelTransportSession(session: ResolvedSession) {

--- a/src/orchestration/coordinator-identity.ts
+++ b/src/orchestration/coordinator-identity.ts
@@ -17,6 +17,37 @@ export function stableCoordinatorSession(transportSession: string): string {
 }
 
 /**
+ * Unified transport-boundary default for the stable coordinator identity.
+ *
+ * Runtime workers treat `mcpCoordinatorSession + mcpSourceHandle` as immutable
+ * construction identity: `none -> coordinator` and `coordinator -> none` both
+ * rotate the worker. A plain logical session (no explicit worker binding) must
+ * therefore default to the stable coordinator identity on EVERY session-scoped
+ * operation — not only ensure/prompt, but also the model/effort reads that
+ * Relay Web fires in parallel right after create — otherwise a read carrying
+ * `none` rotates the fresh worker back and the next prompt rotates it again.
+ *
+ * Explicit worker bindings (`mcpCoordinatorSession` already set) win untouched.
+ * CLI sessions historically carry this binding too (it drives the MCP queue
+ * owner), so the default is unconditional: callers that must preserve the
+ * legacy CLI wire shape (bridge direct reads) gate on `transportEngine`
+ * themselves instead. Returns the input by reference when no default applies,
+ * so callers avoid needless allocation.
+ */
+export function withDefaultMcpIdentity<
+  T extends {
+    transportSession: string;
+    mcpCoordinatorSession?: string;
+  },
+>(session: T): T {
+  if (session.mcpCoordinatorSession !== undefined) return session;
+  return {
+    ...session,
+    mcpCoordinatorSession: stableCoordinatorSession(session.transportSession),
+  };
+}
+
+/**
  * The single chokepoint for asking "do these two transport names refer to the
  * same coordinator?". Both sides are reduced to their stable identity before
  * comparison, so it is robust to either side carrying a volatile

--- a/src/transport/acpx-bridge/acpx-bridge-transport.ts
+++ b/src/transport/acpx-bridge/acpx-bridge-transport.ts
@@ -19,6 +19,7 @@ import {
 } from "../quota-gated-reply-sink";
 import { createSerializedCallbackQueue } from "../serialized-callback-queue";
 import { resolveToolEventMode } from "../tool-event-mode.js";
+import { withDefaultMcpIdentity } from "../../orchestration/coordinator-identity";
 import type { BridgeEngineCapabilities, BridgeMethod } from "./acpx-bridge-protocol";
 import { decodeBridgeEngineCapabilities } from "./acpx-bridge-protocol";
 import type { BridgeEvent } from "./acpx-bridge-client";
@@ -316,6 +317,7 @@ export class AcpxBridgeTransport implements SessionTransport {
   }
 
   private toParams(session: ResolvedSession): Record<string, unknown> {
+    const transportEngine = session.transportEngine ?? "cli";
     return {
       agent: session.agent,
       driver: session.driver,
@@ -326,12 +328,21 @@ export class AcpxBridgeTransport implements SessionTransport {
       agentArgv: session.agentArgv,
       cwd: session.cwd,
       name: session.transportSession,
-      mcpCoordinatorSession: session.mcpCoordinatorSession,
+      // Every session-scoped Runtime operation may ensure/rotate a worker, not
+      // only prompt. Default at this shared bridge boundary so model/effort
+      // reads cannot move a fresh coordinator worker back to MCP=none. Gated
+      // on the runtime engine: CLI wire shape keeps `undefined` (the invoker
+      // already binds coordinator identity on its own paths for the queue
+      // owner), and explicit worker bindings ride through untouched.
+      mcpCoordinatorSession:
+        transportEngine === "runtime"
+          ? withDefaultMcpIdentity(session).mcpCoordinatorSession
+          : session.mcpCoordinatorSession,
       mcpSourceHandle: session.mcpSourceHandle,
       replyMode: session.effectiveReplyMode ?? session.replyMode ?? "verbose",
       // Stable worker-ownership identity + persisted engine affinity (plan §9.1/§48).
       logicalSessionId: session.logicalSessionId,
-      transportEngine: session.transportEngine ?? "cli",
+      transportEngine,
       ...(session.model?.trim() ? { model: session.model.trim() } : {}),
       ...(session.effort?.trim() ? { effort: session.effort.trim() } : {}),
     };

--- a/tests/unit/commands/transport-invoker-mcp.test.ts
+++ b/tests/unit/commands/transport-invoker-mcp.test.ts
@@ -1,7 +1,8 @@
-import { expect, test } from "bun:test";
+import { expect, mock, test } from "bun:test";
 
 import { TransportInvoker } from "../../../src/commands/transport-invoker";
 import { createNoopAppLogger } from "../../../src/logging/app-logger";
+import { AcpxBridgeTransport } from "../../../src/transport/acpx-bridge/acpx-bridge-transport";
 import type { ResolvedSession, SessionTransport } from "../../../src/transport/types";
 
 function makeInvoker(transport: SessionTransport): TransportInvoker {
@@ -40,6 +41,7 @@ test("a fresh session uses the same stable MCP identity for ensure and its first
     workspace: "repo",
     cwd: "/repo",
     transportSession: "repo:relay:demo:reset-123",
+    transportEngine: "runtime",
   };
 
   await invoker.ensureTransportSession(session);
@@ -74,4 +76,166 @@ test("ensure preserves an explicitly bound worker MCP identity", async () => {
   await invoker.ensureTransportSession(session);
 
   expect(seen).toEqual([["repo:coordinator", "repo:worker"]]);
+});
+
+test("bridge model and effort reads keep the fresh session's MCP identity stable before its first prompt", async () => {
+  const request = mock(async (method: string) => {
+    if (method === "getSessionModel") return { available: [] };
+    if (method === "getSessionEffort") return { available: [] };
+    if (method === "prompt") return { text: "ok" };
+    return {};
+  });
+  const transport = new AcpxBridgeTransport({ request });
+  const invoker = makeInvoker(transport);
+  const session: ResolvedSession = {
+    alias: "relay:demo",
+    agent: "codex",
+    workspace: "repo",
+    cwd: "/repo",
+    transportSession: "repo:relay:demo:reset-123",
+    transportEngine: "runtime",
+  };
+  await invoker.ensureTransportSession(session);
+  // Relay Web fires model/effort reads in parallel right after session select;
+  // both must carry the same stable identity as ensure and the first prompt.
+  await Promise.all([transport.getSessionModel(session), transport.getSessionEffort(session)]);
+  // Chat config paths warm the same worker: mode/model must not re-key it.
+  await invoker.setModeTransportSession(session, "ask");
+  await invoker.setModelTransportSession(session, "gpt-5");
+  await invoker.promptTransportSession(session, "hi");
+
+  expect(
+    request.mock.calls.map(([method, params]) => [
+      method,
+      params.mcpCoordinatorSession,
+      params.mcpSourceHandle,
+    ]),
+  ).toEqual([
+    ["ensureSession", "repo:relay:demo", undefined],
+    ["getSessionModel", "repo:relay:demo", undefined],
+    ["getSessionEffort", "repo:relay:demo", undefined],
+    ["setMode", "repo:relay:demo", undefined],
+    ["setModel", "repo:relay:demo", undefined],
+    ["prompt", "repo:relay:demo", undefined],
+  ]);
+  expect(session.mcpCoordinatorSession).toBeUndefined();
+});
+
+test("native resume keeps the same stable MCP identity across control reads to its first prompt", async () => {
+  const request = mock(async (method: string) => {
+    if (method === "getSessionModel") return { available: [] };
+    if (method === "getSessionEffort") return { available: [] };
+    if (method === "prompt") return { text: "ok" };
+    return {};
+  });
+  const transport = new AcpxBridgeTransport({ request });
+  const invoker = makeInvoker(transport);
+  // Web/chat native attach: bind an existing agent session, then the UI reads
+  // model/effort before the first prompt on the resumed worker.
+  const session: ResolvedSession = {
+    alias: "relay:attached",
+    agent: "codex",
+    workspace: "repo",
+    cwd: "/repo",
+    transportSession: "repo:relay:attached:reset-789",
+    transportEngine: "runtime",
+  };
+  await transport.resumeAgentSession(session, "acpx-record-1");
+  await Promise.all([transport.getSessionModel(session), transport.getSessionEffort(session)]);
+  await invoker.promptTransportSession(session, "hi");
+
+  expect(
+    request.mock.calls.map(([method, params]) => [
+      method,
+      params.mcpCoordinatorSession,
+      params.mcpSourceHandle,
+    ]),
+  ).toEqual([
+    ["resumeAgentSession", "repo:relay:attached", undefined],
+    ["getSessionModel", "repo:relay:attached", undefined],
+    ["getSessionEffort", "repo:relay:attached", undefined],
+    ["prompt", "repo:relay:attached", undefined],
+  ]);
+  expect(session.mcpCoordinatorSession).toBeUndefined();
+});
+
+test("bridge boundary preserves an explicitly bound worker MCP pair on every operation", async () => {
+  const request = mock(async (method: string) => {
+    if (method === "getSessionModel") return { available: [] };
+    if (method === "getSessionEffort") return { available: [] };
+    if (method === "prompt") return { text: "ok" };
+    return {};
+  });
+  const transport = new AcpxBridgeTransport({ request });
+  const invoker = makeInvoker(transport);
+  const session: ResolvedSession = {
+    alias: "worker",
+    agent: "codex",
+    workspace: "repo",
+    cwd: "/repo",
+    transportSession: "repo:worker",
+    transportEngine: "runtime",
+    mcpCoordinatorSession: "repo:coordinator",
+    mcpSourceHandle: "repo:worker",
+  };
+  await invoker.ensureTransportSession(session);
+  await transport.resumeAgentSession(session, "acpx-record-9");
+  await Promise.all([transport.getSessionModel(session), transport.getSessionEffort(session)]);
+  await invoker.setModeTransportSession(session, "ask");
+  await invoker.promptTransportSession(session, "hi");
+
+  expect(
+    request.mock.calls.map(([method, params]) => [
+      method,
+      params.mcpCoordinatorSession,
+      params.mcpSourceHandle,
+    ]),
+  ).toEqual([
+    ["ensureSession", "repo:coordinator", "repo:worker"],
+    ["resumeAgentSession", "repo:coordinator", "repo:worker"],
+    ["getSessionModel", "repo:coordinator", "repo:worker"],
+    ["getSessionEffort", "repo:coordinator", "repo:worker"],
+    ["setMode", "repo:coordinator", "repo:worker"],
+    ["prompt", "repo:coordinator", "repo:worker"],
+  ]);
+});
+
+test("cli sessions keep the invoker coordinator binding while direct bridge reads stay none", async () => {
+  const request = mock(async (method: string) => {
+    if (method === "getSessionModel") return { available: [] };
+    if (method === "getSessionEffort") return { available: [] };
+    if (method === "prompt") return { text: "ok" };
+    return {};
+  });
+  const transport = new AcpxBridgeTransport({ request });
+  const invoker = makeInvoker(transport);
+  const session: ResolvedSession = {
+    alias: "cli-demo",
+    agent: "codex",
+    workspace: "repo",
+    cwd: "/repo",
+    transportSession: "repo:cli-demo:reset-456",
+    transportEngine: "cli",
+  };
+
+  await invoker.ensureTransportSession(session);
+  await Promise.all([transport.getSessionModel(session), transport.getSessionEffort(session)]);
+  await invoker.promptTransportSession(session, "hi");
+
+  // Historical behavior: the invoker binds the stable coordinator identity on
+  // its own paths (drives the CLI MCP queue owner); direct bridge reads keep
+  // the legacy CLI `none` wire shape. CLI has no immutable worker identity,
+  // so this split cannot rotate anything.
+  expect(
+    request.mock.calls.map(([method, params]) => [
+      method,
+      params.mcpCoordinatorSession,
+    ]),
+  ).toEqual([
+    ["ensureSession", "repo:cli-demo"],
+    ["getSessionModel", undefined],
+    ["getSessionEffort", undefined],
+    ["prompt", "repo:cli-demo"],
+  ]);
+  expect(session.mcpCoordinatorSession).toBeUndefined();
 });

--- a/tests/unit/commands/transport-invoker-mcp.test.ts
+++ b/tests/unit/commands/transport-invoker-mcp.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+
+import { TransportInvoker } from "../../../src/commands/transport-invoker";
+import { createNoopAppLogger } from "../../../src/logging/app-logger";
+import type { ResolvedSession, SessionTransport } from "../../../src/transport/types";
+
+function makeInvoker(transport: SessionTransport): TransportInvoker {
+  return new TransportInvoker({
+    transport,
+    logger: createNoopAppLogger(),
+    sessions: {},
+    resolveSessionAgentCommand: async () => undefined,
+    autoInstall: async () => ({ ok: false, errors: [], logPath: "" }),
+    discoverPaths: async () => [],
+  } as never);
+}
+
+test("a fresh session uses the same stable MCP identity for ensure and its first prompt", async () => {
+  let ensuredMcpIdentity: string | undefined;
+  const seenMcpIdentities: Array<string | undefined> = [];
+  const transport = {
+    async ensureSession(session: ResolvedSession) {
+      ensuredMcpIdentity = session.mcpCoordinatorSession;
+      seenMcpIdentities.push(ensuredMcpIdentity);
+    },
+    async prompt(session: ResolvedSession) {
+      seenMcpIdentities.push(session.mcpCoordinatorSession);
+      if (!ensuredMcpIdentity || session.mcpCoordinatorSession !== ensuredMcpIdentity) {
+        throw new Error(
+          "Persistent ACP session fresh-acp-id could not be resumed: Internal error",
+        );
+      }
+      return { text: "ok" };
+    },
+  } as unknown as SessionTransport;
+  const invoker = makeInvoker(transport);
+  const session: ResolvedSession = {
+    alias: "relay:demo",
+    agent: "codex",
+    workspace: "repo",
+    cwd: "/repo",
+    transportSession: "repo:relay:demo:reset-123",
+  };
+
+  await invoker.ensureTransportSession(session);
+  expect(session.mcpCoordinatorSession).toBeUndefined();
+  await expect(invoker.promptTransportSession(session, "hi")).resolves.toEqual({
+    text: "ok",
+  });
+  expect(seenMcpIdentities).toEqual([
+    "repo:relay:demo",
+    "repo:relay:demo",
+  ]);
+});
+
+test("ensure preserves an explicitly bound worker MCP identity", async () => {
+  const seen: Array<[string | undefined, string | undefined]> = [];
+  const transport = {
+    async ensureSession(session: ResolvedSession) {
+      seen.push([session.mcpCoordinatorSession, session.mcpSourceHandle]);
+    },
+  } as unknown as SessionTransport;
+  const invoker = makeInvoker(transport);
+  const session: ResolvedSession = {
+    alias: "worker",
+    agent: "codex",
+    workspace: "repo",
+    cwd: "/repo",
+    transportSession: "repo:worker",
+    mcpCoordinatorSession: "repo:coordinator",
+    mcpSourceHandle: "repo:worker",
+  };
+
+  await invoker.ensureTransportSession(session);
+
+  expect(seen).toEqual([["repo:coordinator", "repo:worker"]]);
+});

--- a/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
+++ b/tests/unit/transport/acpx-bridge/acpx-bridge-transport.test.ts
@@ -940,7 +940,7 @@ test("bridge transport proxies primeRuntimeQueues mapping sessions to EngineSess
             agentArgv: undefined,
             cwd: "/tmp/backend",
             name: "backend:runtime-demo",
-            mcpCoordinatorSession: undefined,
+            mcpCoordinatorSession: "backend:runtime-demo",
             mcpSourceHandle: undefined,
             replyMode: "verbose",
             logicalSessionId: "log-sess-1",


### PR DESCRIPTION
## Summary

- bind the stable MCP coordinator identity before the initial transport ensure
- preserve explicit worker coordinator/source bindings and keep the derived identity transport-local
- add regression coverage for a fresh Codex session and an explicitly bound worker session

## Root cause

Relay Web created the Runtime session before a coordinator MCP identity was attached. The first prompt then added that identity, so Runtime treated the worker construction as stale, rotated the fresh worker, and attempted to resume an empty Codex ACP session that was not resumable yet. The prompt failed with: Persistent ACP session ... could not be resumed: Internal error.

## Testing

- targeted command/control/Runtime tests: 202 passed
- npx tsc --noEmit
- bun run build
- core unit suite passed during npm test
- bun run test:web: 131 files, 1465 tests passed

The aggregate npm test wrapper reached its fixed 180-second timeout while running test:web; the same Web suite completed successfully when run directly in about 288 seconds.