### PR TITLE
refactor(relay-web): add deterministic Markdown-aware turn layout

### DIFF
--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -121,6 +121,10 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   保持 atomic，内部 activity 延迟到块末。expanded 与 collapsed 均消费同一 plan，后者只取最后 activity 后的 Markdown
   nodes，不再二次拼接或重新解析 Markdown。子工具继续按 `parentToolCallId` 归入对应 Agent；旧历史里没有父子字段的工具
   仍按普通卡片渲染。
+- turn layout 有三层流式性能保护：无 activity 的 turn 直接走单个 Markdown render；activity geometry cache 只以
+  narrative、activity id/offset/wireIndex 和 streaming 几何为 key，因此 tool status/title/output 更新只替换卡片 payload，
+  不重跑 Markdown；同一 browser frame 内的 text delta 通过 `requestAnimationFrame` 合并。activity-bearing paragraph
+  超过 50,000 字符或 256 个 marker 时自动降级为 atomic block，降级只牺牲精确 interleave，不牺牲 Markdown 语义或顺序。
 - `SubagentStepCard.vue` 以 `children.length > 0` 判定是否具备真实 trace（provider 无关，仅看数据是否到达）。
   有 trace：默认折叠、运行中轮播当前活动步骤，展开后显示紧凑时间线与 `traceCount`。无 trace：折叠行显示 `detail.output`
   尾行（回退到 prompt）、运行时长与“{ago} 前更新”心跳；展开显示委派 prompt 折叠行 + 输出块（运行中为定高、贴底滚动的

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -126,8 +126,12 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   对应 Agent；旧历史里没有父子字段的工具仍按普通卡片渲染。
 - turn layout 有三层流式性能保护：无 activity 的 turn 直接走单个 Markdown render；全量 geometry cache 以
   narrative、activity id/offset/wireIndex 和 streaming 几何为 key，因此 tool status/title/output 更新只替换卡片 payload，
-  不重跑 Markdown；block 级 cache 以 block source、相对 activity 几何、streaming flag 和 reference fingerprint 为 key，
-  text streaming 追加时已沉降的头部 block 直接复用 marker plan 与 sanitized HTML/copy，只重算 tail block；同一
+  不重跑 Markdown；block 级 cache 以 block source、activity 几何、streaming flag 和 reference fingerprint 为 key，
+  text streaming 追加时已沉降的头部 block 直接复用 marker plan 与 sanitized HTML/copy，只重算 tail block——缓存只存
+  block-local 的 nodes 与 exact-inline/atomic disposition，slot 的绝对 sourceOffset 每帧按当前 boundary 重建，因此相邻
+  gap 收缩/扩张不会复活 stale slot；每帧按 live block key 剪枝，tail 历史版本不累积。`MessageList` 的 collapsed
+  summary cache 以 parts identity 加本 turn 实际 anchor 的 sent-message 条目为依赖（外加每 turn 独立的 layoutCache），
+  无关 transcript 行（普通 prompt、历史 prepend、receiver 行、未 anchor 的 sent 卡）不会让已有 trace 重做 layout；同一
   browser frame 内的 text delta 通过 `requestAnimationFrame` 合并。activity-bearing paragraph
   超过 50,000 字符或 256 个 marker 时自动降级为 atomic block，降级只牺牲精确 interleave，不牺牲 Markdown 语义或顺序。
   marker 抽取为单次线性扫描（`MARKER_OPEN → MARKER_CLOSE → Map`），不再按 encoding 逐个 `indexOf`。

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -119,12 +119,18 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   放置 activity（后来的 activity 永不超车）。顶层 paragraph 通过内部 marker 在同一 inline token tree 中拆出安全 HTML
   fragment，跨 `strong`/link label/inline code 时自动闭合并重开格式；list、table、blockquote、fence、heading 等结构块
   保持 atomic，内部 activity 延迟到块末。expanded 与 collapsed 均消费同一 plan，后者只取最后 activity 后的 Markdown
-  nodes，不再二次拼接或重新解析 Markdown。子工具继续按 `parentToolCallId` 归入对应 Agent；旧历史里没有父子字段的工具
-  仍按普通卡片渲染。
-- turn layout 有三层流式性能保护：无 activity 的 turn 直接走单个 Markdown render；activity geometry cache 只以
+  nodes，不再二次拼接或重新解析 Markdown。每个 Markdown node 同时携带 canonical raw `source`（geometry/debug 用）
+  与 plaintext `copyText`（clipboard 用）：`markdownTokensToPlainText`/`markdownSourceToPlainText` 是唯一的 Copy
+  contract——text/code 取内容、image 取 alt（空 alt 回退 URL）、link 取 label、break 取换行、reference definition
+  永不进入 token 流因此永不泄漏；heal 后的 block 按 healed HTML 的语义复制。子工具继续按 `parentToolCallId` 归入
+  对应 Agent；旧历史里没有父子字段的工具仍按普通卡片渲染。
+- turn layout 有三层流式性能保护：无 activity 的 turn 直接走单个 Markdown render；全量 geometry cache 以
   narrative、activity id/offset/wireIndex 和 streaming 几何为 key，因此 tool status/title/output 更新只替换卡片 payload，
-  不重跑 Markdown；同一 browser frame 内的 text delta 通过 `requestAnimationFrame` 合并。activity-bearing paragraph
+  不重跑 Markdown；block 级 cache 以 block source、相对 activity 几何、streaming flag 和 reference fingerprint 为 key，
+  text streaming 追加时已沉降的头部 block 直接复用 marker plan 与 sanitized HTML/copy，只重算 tail block；同一
+  browser frame 内的 text delta 通过 `requestAnimationFrame` 合并。activity-bearing paragraph
   超过 50,000 字符或 256 个 marker 时自动降级为 atomic block，降级只牺牲精确 interleave，不牺牲 Markdown 语义或顺序。
+  marker 抽取为单次线性扫描（`MARKER_OPEN → MARKER_CLOSE → Map`），不再按 encoding 逐个 `indexOf`。
 - `SubagentStepCard.vue` 以 `children.length > 0` 判定是否具备真实 trace（provider 无关，仅看数据是否到达）。
   有 trace：默认折叠、运行中轮播当前活动步骤，展开后显示紧凑时间线与 `traceCount`。无 trace：折叠行显示 `detail.output`
   尾行（回退到 prompt）、运行时长与“{ago} 前更新”心跳；展开显示委派 prompt 折叠行 + 输出块（运行中为定高、贴底滚动的

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -114,9 +114,13 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   `success`；失败通知会把父 Agent 及仍在运行的子步骤收敛为 `error`。实现入口是 provider-neutral 的
   `src/transport/background-followup.ts` 与 `background-followup-transport.ts`；为兼容既有日志查询，遥测事件 key
   暂时保留 `transport.claude_background_followup.*`。
-- `TurnParts.vue` 保留原始有序 parts，并通过 `turn-presentation` 把推理/工具锚定到事件到达时正在生成的
-  Markdown 顶层块末尾：同一段落、列表、表格或代码围栏内的 text part 会保持连续，显式块边界之间的活动仍与
-  文字穿插展示。子工具继续按 `parentToolCallId` 归入对应 Agent；旧历史里没有父子字段的工具仍按普通卡片渲染。
+- `TurnParts.vue` 保留原始有序 parts，并消费唯一的 `TurnPresentationPlan`：`turn-timeline` 只按 wire order
+  构造 narrative 与 activity offset，`turn-layout`/`markdown-layout` 对整份 Markdown 建立合法 slot，再线性、单调地
+  放置 activity（后来的 activity 永不超车）。顶层 paragraph 通过内部 marker 在同一 inline token tree 中拆出安全 HTML
+  fragment，跨 `strong`/link label/inline code 时自动闭合并重开格式；list、table、blockquote、fence、heading 等结构块
+  保持 atomic，内部 activity 延迟到块末。expanded 与 collapsed 均消费同一 plan，后者只取最后 activity 后的 Markdown
+  nodes，不再二次拼接或重新解析 Markdown。子工具继续按 `parentToolCallId` 归入对应 Agent；旧历史里没有父子字段的工具
+  仍按普通卡片渲染。
 - `SubagentStepCard.vue` 以 `children.length > 0` 判定是否具备真实 trace（provider 无关，仅看数据是否到达）。
   有 trace：默认折叠、运行中轮播当前活动步骤，展开后显示紧凑时间线与 `traceCount`。无 trace：折叠行显示 `detail.output`
   尾行（回退到 prompt）、运行时长与“{ago} 前更新”心跳；展开显示委派 prompt 折叠行 + 输出块（运行中为定高、贴底滚动的

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -119,7 +119,7 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   放置 activity（后来的 activity 永不超车）。顶层 paragraph 通过内部 marker 在同一 inline token tree 中拆出安全 HTML
   fragment，跨 `strong`/link label/inline code 时自动闭合并重开格式；list、table、blockquote、fence、heading 等结构块
   保持 atomic，内部 activity 延迟到块末。expanded 与 collapsed 均消费同一 plan，后者只取最后 activity 后的 Markdown
-- nodes，不再二次拼接或重新解析 Markdown。每个 Markdown node 同时携带 canonical raw `source`（geometry/debug 用）
+  nodes，不再二次拼接或重新解析 Markdown。每个 Markdown node 同时携带 canonical raw `source`（geometry/debug 用）
   与 plaintext `copyText`（clipboard 用）：`markdownTokensToPlainText`/`markdownSourceToPlainText` 是唯一的 Copy
   contract——text/code 取内容、image 取 alt（空 alt 回退 URL）、link 取 label、break 取换行、reference definition
   永不进入 token 流因此永不泄漏；heal 后的 block 按 healed HTML 的语义复制。copyText 是可组合的：各 block 的

--- a/docs/relay-web-module.md
+++ b/docs/relay-web-module.md
@@ -119,10 +119,12 @@ relay hub 的 Web 看板（阶段三 + 阶段四 + 阶段五）：登录后跨�
   放置 activity（后来的 activity 永不超车）。顶层 paragraph 通过内部 marker 在同一 inline token tree 中拆出安全 HTML
   fragment，跨 `strong`/link label/inline code 时自动闭合并重开格式；list、table、blockquote、fence、heading 等结构块
   保持 atomic，内部 activity 延迟到块末。expanded 与 collapsed 均消费同一 plan，后者只取最后 activity 后的 Markdown
-  nodes，不再二次拼接或重新解析 Markdown。每个 Markdown node 同时携带 canonical raw `source`（geometry/debug 用）
+- nodes，不再二次拼接或重新解析 Markdown。每个 Markdown node 同时携带 canonical raw `source`（geometry/debug 用）
   与 plaintext `copyText`（clipboard 用）：`markdownTokensToPlainText`/`markdownSourceToPlainText` 是唯一的 Copy
   contract——text/code 取内容、image 取 alt（空 alt 回退 URL）、link 取 label、break 取换行、reference definition
-  永不进入 token 流因此永不泄漏；heal 后的 block 按 healed HTML 的语义复制。子工具继续按 `parentToolCallId` 归入
+  永不进入 token 流因此永不泄漏；heal 后的 block 按 healed HTML 的语义复制。copyText 是可组合的：各 block 的
+  terminal newline 保留用于分隔相邻 block，任何 block-local trim 都禁止，只有最终 `finalReplyText` join 之后做一次
+  outer trimEnd。子工具继续按 `parentToolCallId` 归入
   对应 Agent；旧历史里没有父子字段的工具仍按普通卡片渲染。
 - turn layout 有三层流式性能保护：无 activity 的 turn 直接走单个 Markdown render；全量 geometry cache 以
   narrative、activity id/offset/wireIndex 和 streaming 几何为 key，因此 tool status/title/output 更新只替换卡片 payload，

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -184,10 +184,10 @@ export interface ToolStepDto {
   agentMessageId?: string;
 }
 
-/** One entry in a turn's ordered wire transcript, retained for transport and
- *  persistence. A presentation layer may move an activity to the end of the
- *  Markdown block that was in progress when it arrived, but must not globally
- *  bucket narrative and activity into separate lanes. */
+/** One entry in a turn's canonical ordered wire transcript, retained for transport,
+ *  persistence, and presentation timeline construction. Consecutive text may be
+ *  coalesced, but consumers must preserve the relative arrival order of text and
+ *  activity parts. */
 export type TurnPartDto =
   | { type: "text"; text: string }
   | { type: "reasoning"; text: string }

--- a/packages/relay-protocol/src/dtos.ts
+++ b/packages/relay-protocol/src/dtos.ts
@@ -186,8 +186,9 @@ export interface ToolStepDto {
 
 /** One entry in a turn's canonical ordered wire transcript, retained for transport,
  *  persistence, and presentation timeline construction. Consecutive text may be
- *  coalesced, but consumers must preserve the relative arrival order of text and
- *  activity parts. */
+ *  coalesced, but consumers must preserve canonical wire provenance: activities
+ *  never reorder against each other, and presentation may only delay an activity
+ *  to a legal Markdown slot — never move it earlier than its wire offset. */
 export type TurnPartDto =
   | { type: "text"; text: string }
   | { type: "reasoning"; text: string }

--- a/packages/relay-web/package.json
+++ b/packages/relay-web/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "generate-pwa-icons": "node scripts/generate-pwa-icons.mjs",
     "test": "vitest run",
+    "bench:turn-layout": "vitest bench src/__benchmarks__/turn-layout.bench.ts --run",
     "test:e2e": "playwright test",
     "test:e2e:desktop": "playwright test --project=chromium-desktop",
     "test:e2e:mobile": "playwright test --project=chromium-mobile"

--- a/packages/relay-web/src/__benchmarks__/turn-layout.bench.ts
+++ b/packages/relay-web/src/__benchmarks__/turn-layout.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from "vitest";
-import { planTurnLayout, type LayoutActivityGeometry } from "../lib/turn-layout";
+import { createTurnLayoutGeometryCache, planTurnLayout, type LayoutActivityGeometry } from "../lib/turn-layout";
 
 function trace(paragraphs: number): {
   narrative: string;
@@ -41,5 +41,13 @@ describe("turn layout", () => {
       activities.push({ id: `tool:${index}`, wireIndex: index, sourceOffset });
     }
     planTurnLayout(narrative, activities);
+  });
+
+  bench("streaming tail append with a warm block cache", () => {
+    const head = "settled paragraph one\n\nsettled paragraph two\n\n";
+    const tail = "streaming tail with **formatting** plus more text";
+    const cache = createTurnLayoutGeometryCache();
+    planTurnLayout(`${head}${tail}`, [], { streaming: true, latestVisibleIsText: true }, cache);
+    planTurnLayout(`${head}${tail}!`, [], { streaming: true, latestVisibleIsText: true }, cache);
   });
 });

--- a/packages/relay-web/src/__benchmarks__/turn-layout.bench.ts
+++ b/packages/relay-web/src/__benchmarks__/turn-layout.bench.ts
@@ -1,0 +1,33 @@
+import { bench, describe } from "vitest";
+import { planTurnLayout, type LayoutActivityGeometry } from "../lib/turn-layout";
+
+function trace(paragraphs: number): {
+  narrative: string;
+  activities: LayoutActivityGeometry[];
+} {
+  const chunks: string[] = [];
+  const activities: LayoutActivityGeometry[] = [];
+  let sourceOffset = 0;
+  for (let index = 0; index < paragraphs; index += 1) {
+    const prefix = `progress ${index} **before `;
+    const suffix = "after**\n\n";
+    chunks.push(prefix, suffix);
+    sourceOffset += prefix.length;
+    activities.push({ id: `tool:${index}`, wireIndex: index, sourceOffset });
+    sourceOffset += suffix.length;
+  }
+  return { narrative: chunks.join(""), activities };
+}
+
+describe("turn layout", () => {
+  const medium = trace(100);
+  const long = trace(500);
+
+  bench("100 marker-bearing paragraphs", () => {
+    planTurnLayout(medium.narrative, medium.activities);
+  });
+
+  bench("500 marker-bearing paragraphs", () => {
+    planTurnLayout(long.narrative, long.activities);
+  });
+});

--- a/packages/relay-web/src/__benchmarks__/turn-layout.bench.ts
+++ b/packages/relay-web/src/__benchmarks__/turn-layout.bench.ts
@@ -30,4 +30,16 @@ describe("turn layout", () => {
   bench("500 marker-bearing paragraphs", () => {
     planTurnLayout(long.narrative, long.activities);
   });
+
+  bench("one dense paragraph with 256 markers", () => {
+    const words = Array.from({ length: 257 }, (_, index) => `word${index}`);
+    const narrative = `${words.join(" ")} end`;
+    let sourceOffset = 0;
+    const activities: LayoutActivityGeometry[] = [];
+    for (let index = 0; index < 256; index += 1) {
+      sourceOffset += words[index]!.length + 1;
+      activities.push({ id: `tool:${index}`, wireIndex: index, sourceOffset });
+    }
+    planTurnLayout(narrative, activities);
+  });
 });

--- a/packages/relay-web/src/__benchmarks__/turn-layout.bench.ts
+++ b/packages/relay-web/src/__benchmarks__/turn-layout.bench.ts
@@ -43,11 +43,28 @@ describe("turn layout", () => {
     planTurnLayout(narrative, activities);
   });
 
+  // Steady-state streaming frame: the cache is warmed once outside the
+  // measured closure, then every iteration appends a slightly longer tail.
+  // The full-plan key always misses (new narrative) while the settled head
+  // blocks hit — so this measures one frame's incremental cost, not cold
+  // render plus one append. An activity in the settled head keeps the
+  // marker-plan reuse path in the measurement.
+  const warmHead = "settled paragraph one\n\nsettled paragraph two\n\n";
+  const warmTail = "streaming tail with **formatting** plus more text";
+  const warmActivities: LayoutActivityGeometry[] = [
+    { id: "tool:warm", wireIndex: 1, sourceOffset: "settled ".length },
+  ];
+  const warmOptions = { streaming: true, latestVisibleIsText: true } as const;
+  const warmCache = createTurnLayoutGeometryCache();
+  planTurnLayout(`${warmHead}${warmTail}`, warmActivities, warmOptions, warmCache);
+  let warmTick = 0;
   bench("streaming tail append with a warm block cache", () => {
-    const head = "settled paragraph one\n\nsettled paragraph two\n\n";
-    const tail = "streaming tail with **formatting** plus more text";
-    const cache = createTurnLayoutGeometryCache();
-    planTurnLayout(`${head}${tail}`, [], { streaming: true, latestVisibleIsText: true }, cache);
-    planTurnLayout(`${head}${tail}!`, [], { streaming: true, latestVisibleIsText: true }, cache);
+    warmTick += 1;
+    planTurnLayout(
+      `${warmHead}${warmTail}${".".repeat(warmTick % 8)}`,
+      warmActivities,
+      warmOptions,
+      warmCache,
+    );
   });
 });

--- a/packages/relay-web/src/__tests__/markdown-inline-markers.test.ts
+++ b/packages/relay-web/src/__tests__/markdown-inline-markers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { planInlineActivityMarkers } from "../lib/markdown-inline-markers";
+
+const planAt = (source: string, offset: number, streaming = false) =>
+  planInlineActivityMarkers(
+    source,
+    [{ id: "tool:read-1", offset }],
+    {},
+    { streaming },
+  );
+
+describe("planInlineActivityMarkers", () => {
+  it("closes and reopens strong formatting around an activity", () => {
+    const source = "Working **carefully now** done";
+    const plan = planAt(source, "Working **carefully ".length);
+
+    expect(plan?.activityIds).toEqual(["tool:read-1"]);
+    expect(plan?.fragments.map((fragment) => fragment.source)).toEqual([
+      "Working **carefully ",
+      "now** done",
+    ]);
+    expect(plan?.fragments[0]!.html).toContain("<strong>carefully </strong>");
+    expect(plan?.fragments[1]!.html).toContain("<strong>now</strong> done");
+  });
+
+  it("preserves markers while remend heals an incomplete streaming span", () => {
+    const source = "Working **carefully now";
+    const plan = planAt(source, "Working **carefully ".length, true);
+
+    expect(plan?.activityIds).toEqual(["tool:read-1"]);
+    expect(plan?.fragments[0]!.html).toContain("<strong>carefully </strong>");
+    expect(plan?.fragments[1]!.html).toContain("<strong>now</strong>");
+  });
+
+  it("duplicates a link wrapper when an activity lands in its label", () => {
+    const source = "[read the documentation](https://example.com)";
+    const plan = planAt(source, "[read the ".length);
+
+    expect(plan?.fragments[0]!.html).toContain('<a href="https://example.com"');
+    expect(plan?.fragments[0]!.html).toContain("read the </a>");
+    expect(plan?.fragments[1]!.html).toContain("documentation</a>");
+  });
+
+  it("splits inline code as code tokens instead of reparsing fragments", () => {
+    const source = "`alpha beta`";
+    const plan = planAt(source, "`alpha ".length);
+
+    expect(plan?.fragments[0]!.html).toContain("<code>alpha </code>");
+    expect(plan?.fragments[1]!.html).toContain("<code>beta</code>");
+  });
+
+  it("fails closed when marker injection changes syntax semantics", () => {
+    const linkDestination = "[docs](https://example.com)";
+    expect(planAt(linkDestination, "[docs](https://exa".length)).toBeNull();
+
+    const delimiter = "before **strong** after";
+    expect(planAt(delimiter, "before *".length)).toBeNull();
+
+    const imageLabel = "![alt text](image.png)";
+    expect(planAt(imageLabel, "![alt ".length)).toBeNull();
+  });
+
+  it("preserves marker and source order for multiple activities at one offset", () => {
+    const source = "before after";
+    const offset = "before ".length;
+    const plan = planInlineActivityMarkers(source, [
+      { id: "tool:a", offset },
+      { id: "tool:b", offset },
+      { id: "tool:c", offset },
+    ]);
+
+    expect(plan?.activityIds).toEqual(["tool:a", "tool:b", "tool:c"]);
+    expect(plan?.fragments.map((fragment) => fragment.source).join(""))
+      .toBe(source);
+  });
+});

--- a/packages/relay-web/src/__tests__/markdown-inline-markers.test.ts
+++ b/packages/relay-web/src/__tests__/markdown-inline-markers.test.ts
@@ -58,6 +58,12 @@ describe("planInlineActivityMarkers", () => {
 
     const imageLabel = "![alt text](image.png)";
     expect(planAt(imageLabel, "![alt ".length)).toBeNull();
+
+    const entity = "before &amp; after";
+    expect(planAt(entity, "before &am".length)).toBeNull();
+
+    const htmlLike = "before <span>text</span> after";
+    expect(planAt(htmlLike, "before <sp".length)).toBeNull();
   });
 
   it("preserves marker and source order for multiple activities at one offset", () => {

--- a/packages/relay-web/src/__tests__/markdown-inline-markers.test.ts
+++ b/packages/relay-web/src/__tests__/markdown-inline-markers.test.ts
@@ -21,6 +21,10 @@ describe("planInlineActivityMarkers", () => {
     ]);
     expect(plan?.fragments[0]!.html).toContain("<strong>carefully </strong>");
     expect(plan?.fragments[1]!.html).toContain("<strong>now</strong> done");
+    expect(plan?.fragments.map((fragment) => fragment.copyText)).toEqual([
+      "Working carefully ",
+      "now done",
+    ]);
   });
 
   it("preserves markers while remend heals an incomplete streaming span", () => {

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -235,9 +235,12 @@ describe("MessageList", () => {
 
     const turnParts = wrapper.findComponent(TurnParts);
     expect(turnParts.exists()).toBe(true);
-    expect(turnParts.props("collapsedReplyText")).toBe("Fixed. The issue was X.");
-    expect(turnParts.props("collapsedToolCount")).toBe(1);
-    expect(turnParts.props("collapsedThoughtCount")).toBe(0);
+    const presentation = turnParts.props("presentation");
+    if (!presentation) throw new Error("expected a precomputed presentation");
+    expect(presentation.finalReplyNodes.map((node: { source: string }) => node.source).join(""))
+      .toBe("Fixed. The issue was X.");
+    expect(presentation.toolCount).toBe(1);
+    expect(presentation.thoughtCount).toBe(0);
     const copy = wrapper.find('[data-test="msg-out"] [data-test="msg-actions"]').findComponent(CopyButton);
     expect(copy.exists()).toBe(true);
     expect(copy.props("text")).toBe("Fixed. The issue was X.");
@@ -378,17 +381,21 @@ describe("MessageList", () => {
     });
 
     const bubble = wrapper.find('[data-test="msg-streaming"]');
-    const narrative = bubble.find(".stream-md");
+    const narratives = bubble.findAll(".stream-md");
     const tool = bubble.find('[data-test="tool-step-header"]');
-    expect(bubble.findAll(".stream-md")).toHaveLength(1);
+    expect(narratives).toHaveLength(2);
     expect(bubble.find("table").exists()).toBe(false);
     expect(
-      narrative.element.compareDocumentPosition(tool.element)
+      narratives[0]!.element.compareDocumentPosition(tool.element)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      tool.element.compareDocumentPosition(narratives[1]!.element)
       & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 
-  it("keeps activity anchored after a streaming paragraph while remend heals it", async () => {
+  it("keeps activity inside a streaming strong span without changing wire order", async () => {
     const incompleteParts: LiveTurn["parts"] = [
       { type: "text", text: "Working **carefully " },
       {
@@ -408,12 +415,17 @@ describe("MessageList", () => {
     });
 
     let bubble = wrapper.find('[data-test="msg-streaming"]');
-    let narrative = bubble.find(".stream-md");
+    let narratives = bubble.findAll(".stream-md");
     let tool = bubble.find('[data-test="tool-step-header"]');
-    expect(bubble.findAll(".stream-md")).toHaveLength(1);
-    expect(narrative.html()).toContain("<strong>carefully now</strong>");
+    expect(narratives).toHaveLength(2);
+    expect(narratives[0]!.html()).toContain("<strong>carefully </strong>");
+    expect(narratives[1]!.html()).toContain("<strong>now</strong>");
     expect(
-      narrative.element.compareDocumentPosition(tool.element)
+      narratives[0]!.element.compareDocumentPosition(tool.element)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      tool.element.compareDocumentPosition(narratives[1]!.element)
       & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 
@@ -424,15 +436,20 @@ describe("MessageList", () => {
       ]),
     });
     await vi.waitFor(() => {
-      expect(wrapper.find('[data-test="msg-streaming"] .stream-md').html())
-        .toContain("<strong>carefully now</strong> done");
+      const updated = wrapper.findAll('[data-test="msg-streaming"] .stream-md');
+      expect(updated).toHaveLength(2);
+      expect(updated[0]!.html()).toContain("<strong>carefully </strong>");
+      expect(updated[1]!.html()).toContain("<strong>now</strong> done");
     });
     bubble = wrapper.find('[data-test="msg-streaming"]');
-    narrative = bubble.find(".stream-md");
+    narratives = bubble.findAll(".stream-md");
     tool = bubble.find('[data-test="tool-step-header"]');
-    expect(bubble.findAll(".stream-md")).toHaveLength(1);
     expect(
-      narrative.element.compareDocumentPosition(tool.element)
+      narratives[0]!.element.compareDocumentPosition(tool.element)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      tool.element.compareDocumentPosition(narratives[1]!.element)
       & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
@@ -994,7 +1011,7 @@ it("renders legacy persisted tool steps (no parts) in a collapsed panel", () => 
   expect(wrapper.find('[data-test="tool-row"]').exists()).toBe(false);
 });
 
-it("replays persisted activity after the Markdown block it interrupted", async () => {
+it("replays persisted activity inside marker-aware continuous prose", async () => {
   const wrapper = mount(MessageList, {
     props: {
       messages: [msg({
@@ -1014,19 +1031,25 @@ it("replays persisted activity after the Markdown block it interrupted", async (
   });
   await expandTrace(wrapper);
   const output = wrapper.find('[data-test="msg-out"]');
-  expect(output.findAll(".stream-md")).toHaveLength(1);
-  expect(output.find(".stream-md").html()).toContain("<strong>continuous prose</strong>");
+  const narratives = output.findAll(".stream-md");
+  expect(narratives).toHaveLength(2);
+  expect(narratives[0]!.html()).toContain("<strong>continuous</strong>");
+  expect(narratives[1]!.html()).toContain("<strong> prose</strong>");
   const tool = wrapper.findComponent(ToolStepCard);
   const reasoning = wrapper.findComponent({ name: "ReasoningPanel" });
   expect(tool.exists()).toBe(true);
   expect(wrapper.findComponent(ToolCallPanel).exists()).toBe(false);
   expect(reasoning.exists()).toBe(true);
   expect(
-    output.find(".stream-md").element.compareDocumentPosition(tool.element)
+    narratives[0]!.element.compareDocumentPosition(tool.element)
     & Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy();
   expect(
     tool.element.compareDocumentPosition(reasoning.element)
+    & Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+  expect(
+    reasoning.element.compareDocumentPosition(narratives[1]!.element)
     & Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy();
 });

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -366,7 +366,7 @@ describe("MessageList", () => {
     expect(narrative.find(":scope > hr:last-child").exists()).toBe(true);
   });
 
-  it("keeps one paragraph continuous and places its activity after the paragraph", () => {
+  it("keeps plain-text progress updates interleaved with activity", () => {
     const wrapper = mount(MessageList, {
       props: {
         messages: [],
@@ -389,20 +389,26 @@ describe("MessageList", () => {
     });
 
     const bubble = wrapper.find('[data-test="msg-streaming"]');
-    expect(bubble.findAll(".stream-md")).toHaveLength(1);
-    expect(bubble.find(".stream-md").text()).toBe(
-      "先检查这一层的 flex，再确认间接约束行高。",
-    );
+    const narratives = bubble.findAll(".stream-md");
+    expect(narratives).toHaveLength(2);
+    expect(narratives.map((item) => item.text())).toEqual([
+      "先检查这一层的 flex，",
+      "再确认间接约束行高。",
+    ]);
     const toolHeader = bubble.find('[data-test="tool-step-header"]');
     const reasoningPanel = bubble.findComponent({ name: "ReasoningPanel" });
     expect(toolHeader.exists()).toBe(true);
     expect(reasoningPanel.exists()).toBe(true);
     expect(
-      bubble.find(".stream-md").element.compareDocumentPosition(toolHeader.element)
+      narratives[0]!.element.compareDocumentPosition(toolHeader.element)
       & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
       toolHeader.element.compareDocumentPosition(reasoningPanel.element)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      reasoningPanel.element.compareDocumentPosition(narratives[1]!.element)
       & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -356,6 +356,87 @@ describe("MessageList", () => {
     expect(bubble.find(".stream-md.caret").exists()).toBe(true);
   });
 
+  it("does not create a table by splitting pipe prose around live activity", () => {
+    const wrapper = mount(MessageList, {
+      props: {
+        messages: [],
+        liveTurn: live([
+          { type: "text", text: "Progress: " },
+          {
+            type: "tool",
+            step: {
+              toolCallId: "read-1",
+              toolName: "Read",
+              kind: "read",
+              status: "success",
+              title: "index.css",
+            },
+          },
+          { type: "text", text: "| a | b |\n| 1 | 2 |" },
+        ]),
+      },
+    });
+
+    const bubble = wrapper.find('[data-test="msg-streaming"]');
+    const narrative = bubble.find(".stream-md");
+    const tool = bubble.find('[data-test="tool-step-header"]');
+    expect(bubble.findAll(".stream-md")).toHaveLength(1);
+    expect(bubble.find("table").exists()).toBe(false);
+    expect(
+      narrative.element.compareDocumentPosition(tool.element)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("keeps activity anchored after a streaming paragraph while remend heals it", async () => {
+    const incompleteParts: LiveTurn["parts"] = [
+      { type: "text", text: "Working **carefully " },
+      {
+        type: "tool",
+        step: {
+          toolCallId: "read-1",
+          toolName: "Read",
+          kind: "read",
+          status: "success",
+          title: "index.css",
+        },
+      },
+      { type: "text", text: "now" },
+    ];
+    const wrapper = mount(MessageList, {
+      props: { messages: [], liveTurn: live(incompleteParts) },
+    });
+
+    let bubble = wrapper.find('[data-test="msg-streaming"]');
+    let narrative = bubble.find(".stream-md");
+    let tool = bubble.find('[data-test="tool-step-header"]');
+    expect(bubble.findAll(".stream-md")).toHaveLength(1);
+    expect(narrative.html()).toContain("<strong>carefully now</strong>");
+    expect(
+      narrative.element.compareDocumentPosition(tool.element)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    await wrapper.setProps({
+      liveTurn: live([
+        ...incompleteParts.slice(0, -1),
+        { type: "text", text: "now** done" },
+      ]),
+    });
+    await vi.waitFor(() => {
+      expect(wrapper.find('[data-test="msg-streaming"] .stream-md').html())
+        .toContain("<strong>carefully now</strong> done");
+    });
+    bubble = wrapper.find('[data-test="msg-streaming"]');
+    narrative = bubble.find(".stream-md");
+    tool = bubble.find('[data-test="tool-step-header"]');
+    expect(bubble.findAll(".stream-md")).toHaveLength(1);
+    expect(
+      narrative.element.compareDocumentPosition(tool.element)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("keeps a caret host when streaming Markdown ends with a horizontal rule", () => {
     const wrapper = mount(MessageList, {
       props: { messages: [], liveTurn: live([{ type: "text", text: "---" }]) },

--- a/packages/relay-web/src/__tests__/messagelist.test.ts
+++ b/packages/relay-web/src/__tests__/messagelist.test.ts
@@ -243,7 +243,43 @@ describe("MessageList", () => {
     expect(presentation.thoughtCount).toBe(0);
     const copy = wrapper.find('[data-test="msg-out"] [data-test="msg-actions"]').findComponent(CopyButton);
     expect(copy.exists()).toBe(true);
-    expect(copy.props("text")).toBe("Fixed. The issue was X.");
+  });
+
+  it("keeps cached collapsed presentations when unrelated transcript rows arrive", async () => {
+    const messages = ["a", "b"].map((label) => msg({
+      direction: "out",
+      text: `${label} final.`,
+      status: "done",
+      structured: {
+        parts: [
+          { type: "text", text: `${label} working.` },
+          { type: "tool", step: sendStep(`read-${label}`) },
+          { type: "text", text: `${label} final.` },
+        ],
+      },
+    }));
+    const wrapper = mount(MessageList, {
+      props: { messages, liveTurn: null },
+    });
+    const before = wrapper.findAllComponents(TurnParts).map((parts) => parts.props("presentation"));
+    expect(before).toHaveLength(2);
+
+    // An unrelated user prompt plus an unrelated sent card rebuild the global
+    // sent-message map, but neither turn anchors the new id — both cached
+    // presentations (and their layouts) must survive untouched.
+    await wrapper.setProps({
+      messages: [
+        ...messages,
+        msg({ direction: "in", text: "unrelated question" }),
+        sentCard("unrelated-id"),
+      ],
+    });
+    const after = wrapper.findAllComponents(TurnParts).map((parts) => parts.props("presentation"));
+    for (const [index, presentation] of after.entries()) {
+      if (!presentation) throw new Error("expected a precomputed presentation");
+      expect(presentation).toBe(before[index]);
+      expect(presentation.layout).toBe(before[index]!.layout);
+    }
   });
 
   it("omits the assistant copy button when the turn ends on a process item with no final reply", () => {

--- a/packages/relay-web/src/__tests__/streammarkdown.test.ts
+++ b/packages/relay-web/src/__tests__/streammarkdown.test.ts
@@ -72,8 +72,8 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("StreamMarkdown streaming throttle", () => {
-  it("non-streaming: re-renders synchronously on every text change (no throttle)", async () => {
+describe("StreamMarkdown frame coalescing", () => {
+  it("non-streaming: re-renders synchronously on every text change", async () => {
     const w = mount(StreamMarkdown, { props: { text: "a", streaming: false } });
     expect(w.html()).toContain("<p>a</p>");
     await w.setProps({ text: "ab" });
@@ -87,28 +87,35 @@ describe("StreamMarkdown streaming throttle", () => {
   it("streaming: coalesces a burst of chunks into one trailing render with the full text", async () => {
     const w = mount(StreamMarkdown, { props: { text: "a", streaming: true } });
     expect(renderSpy).toHaveBeenCalledTimes(1); // initial mount render
-    // Rapid chunks well inside the throttle window: no immediate re-parse.
+    // Rapid chunks in one browser frame do not trigger repeated parsing.
     await w.setProps({ text: "ab" });
     await w.setProps({ text: "abc" });
     await w.setProps({ text: "abcd" });
     expect(renderSpy).toHaveBeenCalledTimes(1);
     expect(w.html()).toContain("<p>a</p>"); // still the last painted frame
-    // Trailing edge fires once and picks up the LATEST text.
-    vi.advanceTimersByTime(80);
+    // The next frame paints the latest text once.
+    vi.advanceTimersByTime(16);
     await nextTick();
     expect(renderSpy).toHaveBeenCalledTimes(2);
     expect(w.html()).toContain("<p>abcd</p>");
   });
 
-  it("streaming: a chunk arriving after the throttle window renders immediately", async () => {
+  it("streaming: starts a new render only in the next browser frame", async () => {
     const w = mount(StreamMarkdown, { props: { text: "a", streaming: true } });
-    vi.advanceTimersByTime(100); // let the window elapse with no pending chunk
     await w.setProps({ text: "ab" });
-    expect(renderSpy).toHaveBeenCalledTimes(2); // leading edge, no wait
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(16);
+    await nextTick();
+    expect(renderSpy).toHaveBeenCalledTimes(2);
     expect(w.html()).toContain("<p>ab</p>");
+    await w.setProps({ text: "abc" });
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(16);
+    await nextTick();
+    expect(renderSpy).toHaveBeenCalledTimes(3);
   });
 
-  it("streaming -> false renders the final full text immediately and drops the pending timer", async () => {
+  it("streaming -> false renders the final full text immediately and drops the pending frame", async () => {
     const w = mount(StreamMarkdown, { props: { text: "a", streaming: true } });
     await w.setProps({ text: "ab" }); // schedules a trailing render
     expect(vi.getTimerCount()).toBe(1);
@@ -120,7 +127,7 @@ describe("StreamMarkdown streaming throttle", () => {
     expect(renderSpy).toHaveBeenCalledTimes(calls);
   });
 
-  it("unmount clears a pending throttled render (no stray timer callback)", async () => {
+  it("unmount cancels a pending frame render", async () => {
     const w = mount(StreamMarkdown, { props: { text: "a", streaming: true } });
     await w.setProps({ text: "ab" });
     expect(vi.getTimerCount()).toBe(1);
@@ -129,6 +136,18 @@ describe("StreamMarkdown streaming throttle", () => {
     const calls = renderSpy.mock.calls.length;
     vi.advanceTimersByTime(200);
     expect(renderSpy).toHaveBeenCalledTimes(calls);
+  });
+
+  it("accepts pre-rendered layout HTML without parsing it again", async () => {
+    const w = mount(StreamMarkdown, {
+      props: { renderedHtml: "<p><strong>a</strong></p>", streaming: true },
+    });
+    expect(renderSpy).not.toHaveBeenCalled();
+    expect(w.html()).toContain("<strong>a</strong>");
+
+    await w.setProps({ renderedHtml: "<p><strong>ab</strong></p>" });
+    expect(renderSpy).not.toHaveBeenCalled();
+    expect(w.html()).toContain("<strong>ab</strong>");
   });
 });
 

--- a/packages/relay-web/src/__tests__/turn-layout.test.ts
+++ b/packages/relay-web/src/__tests__/turn-layout.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  placeActivitiesMonotonically,
+  type LayoutActivityGeometry,
+  type LayoutSlotCandidate,
+} from "../lib/turn-layout";
+
+const activities: LayoutActivityGeometry[] = [
+  { id: "a", wireIndex: 1, sourceOffset: 10 },
+  { id: "b", wireIndex: 3, sourceOffset: 20 },
+  { id: "c", wireIndex: 5, sourceOffset: 30 },
+];
+
+describe("placeActivitiesMonotonically", () => {
+  it("preserves wire order without sorting when an earlier activity is delayed", () => {
+    const candidates = new Map<string, LayoutSlotCandidate>([
+      ["a", { sourceOffset: 50, kind: "block-end", reason: "structural-block" }],
+      ["b", { sourceOffset: 20, kind: "exact-inline", reason: "exact" }],
+      ["c", { sourceOffset: 30, kind: "exact-inline", reason: "exact" }],
+    ]);
+
+    const placements = placeActivitiesMonotonically(
+      activities,
+      (activity) => candidates.get(activity.id)!,
+    );
+
+    expect([...placements]).toEqual([
+      ["a", {
+        sourceOffset: 10,
+        effectiveSlot: 50,
+        slotKind: "block-end",
+        reason: "structural-block",
+      }],
+      ["b", {
+        sourceOffset: 20,
+        effectiveSlot: 50,
+        slotKind: "exact-inline",
+        reason: "order-barrier",
+      }],
+      ["c", {
+        sourceOffset: 30,
+        effectiveSlot: 50,
+        slotKind: "exact-inline",
+        reason: "order-barrier",
+      }],
+    ]);
+  });
+
+  it("places every activity exactly once under generated candidate sequences", () => {
+    for (let sample = 0; sample < 200; sample += 1) {
+      const generated = Array.from({ length: 40 }, (_, index) => ({
+        id: `${sample}:${index}`,
+        wireIndex: index,
+        sourceOffset: index * 3,
+      }));
+      const placements = placeActivitiesMonotonically(generated, (activity) => ({
+        sourceOffset: activity.sourceOffset + ((sample + activity.wireIndex) % 7) * 5,
+        kind: "block-end",
+        reason: "structural-block",
+      }));
+
+      expect([...placements.keys()]).toEqual(generated.map((activity) => activity.id));
+      let previousSlot = 0;
+      for (const placement of placements.values()) {
+        expect(placement.effectiveSlot).toBeGreaterThanOrEqual(placement.sourceOffset);
+        expect(placement.effectiveSlot).toBeGreaterThanOrEqual(previousSlot);
+        previousSlot = placement.effectiveSlot;
+      }
+    }
+  });
+
+  it("rejects invalid callers instead of repairing their ordering", () => {
+    expect(() => placeActivitiesMonotonically(
+      [activities[1]!, activities[0]!],
+      (activity) => ({ sourceOffset: activity.sourceOffset, kind: "exact-inline", reason: "exact" }),
+    )).toThrow("strict wire order");
+
+    expect(() => placeActivitiesMonotonically(
+      activities,
+      (activity) => ({ sourceOffset: activity.sourceOffset - 1, kind: "exact-inline", reason: "exact" }),
+    )).toThrow("precedes its wire offset");
+  });
+});

--- a/packages/relay-web/src/__tests__/turn-layout.test.ts
+++ b/packages/relay-web/src/__tests__/turn-layout.test.ts
@@ -127,6 +127,31 @@ describe("planTurnLayout", () => {
     }
   });
 
+  it.each([
+    ["shrinks the blank gap", "[docs](https://example.com)\n\n\nNext", "[docs](https://example.com)\n\nNext"],
+    ["grows the blank gap", "[docs](https://example.com)\n\nNext", "[docs](https://example.com)\n\n\n\nNext"],
+  ])("matches a fresh layout when replacement %s around a marker-unsafe block", (_label, first, second) => {
+    const cache = createTurnLayoutGeometryCache();
+    const activity = [{ id: "tool:read-1", wireIndex: 1, sourceOffset: "[docs](https://exa".length }];
+    planTurnLayout(first, activity, {}, cache);
+    const cached = planTurnLayout(second, activity, {}, cache);
+    const fresh = planTurnLayout(second, activity, {});
+
+    expect(cached.nodes).toEqual(fresh.nodes);
+    expect([...cached.activityPlacements]).toEqual([...fresh.activityPlacements]);
+  });
+
+  it("matches a fresh layout when replacement shifts a structural block boundary", () => {
+    const cache = createTurnLayoutGeometryCache();
+    const activity = [{ id: "tool:read-1", wireIndex: 1, sourceOffset: "- one\n".length }];
+    planTurnLayout("- one\n\n- two\n\nafter", activity, {}, cache);
+    const cached = planTurnLayout("- one\n\n\n- two\n\nafter", activity, {}, cache);
+    const fresh = planTurnLayout("- one\n\n\n- two\n\nafter", activity, {});
+
+    expect(cached.nodes).toEqual(fresh.nodes);
+    expect([...cached.activityPlacements]).toEqual([...fresh.activityPlacements]);
+  });
+
   it("materializes marker-aware paragraph fragments in source order", () => {
     const narrative = "Working **carefully now** done";
     const offset = "Working **carefully ".length;

--- a/packages/relay-web/src/__tests__/turn-layout.test.ts
+++ b/packages/relay-web/src/__tests__/turn-layout.test.ts
@@ -98,6 +98,27 @@ describe("planTurnLayout", () => {
     expect(changed).not.toBe(first);
   });
 
+  it("reuses unchanged leading blocks when a streaming tail grows", () => {
+    const cache = createTurnLayoutGeometryCache();
+    const head = "settled paragraph one\n\nsettled paragraph two\n\n";
+    const firstHtml = (narrative: string) =>
+      planTurnLayout(narrative, [], { streaming: true, latestVisibleIsText: true }, cache).nodes
+        .filter((node) => node.type === "markdown")
+        .map((node) => node.html)
+        .join("");
+    const before = firstHtml(`${head}tail one`);
+    const settledKeys = [...cache.blocks.keys()].filter((key) => key !== "block:46:54");
+    const settledFingerprints = settledKeys.map((key) => cache.blocks.get(key)!.fingerprint);
+    const after = firstHtml(`${head}tail one plus more`);
+
+    expect(after).toContain(before.split("</p>")[0]!);
+    for (const key of settledKeys) {
+      expect(cache.blocks.get(key)!.fingerprint).toEqual(
+        settledFingerprints[settledKeys.indexOf(key)]!,
+      );
+    }
+  });
+
   it("materializes marker-aware paragraph fragments in source order", () => {
     const narrative = "Working **carefully now** done";
     const offset = "Working **carefully ".length;

--- a/packages/relay-web/src/__tests__/turn-layout.test.ts
+++ b/packages/relay-web/src/__tests__/turn-layout.test.ts
@@ -152,6 +152,20 @@ describe("planTurnLayout", () => {
     expect([...cached.activityPlacements]).toEqual([...fresh.activityPlacements]);
   });
 
+  it.each([
+    ["grows the inter-block gap", "Before\n\n\nAfter", "Before\n\n\n\nAfter"],
+    ["shrinks the inter-block gap", "Before\n\n\n\nAfter", "Before\n\n\nAfter"],
+  ])("matches a fresh layout when replacement %s around a tool in the gap", (_label, first, second) => {
+    const cache = createTurnLayoutGeometryCache();
+    const activity = [{ id: "tool:read-1", wireIndex: 1, sourceOffset: "Before\n\n".length }];
+    planTurnLayout(first, activity, {}, cache);
+    const cached = planTurnLayout(second, activity, {}, cache);
+    const fresh = planTurnLayout(second, activity, {});
+
+    expect(cached.nodes).toEqual(fresh.nodes);
+    expect([...cached.activityPlacements]).toEqual([...fresh.activityPlacements]);
+  });
+
   it("materializes marker-aware paragraph fragments in source order", () => {
     const narrative = "Working **carefully now** done";
     const offset = "Working **carefully ".length;

--- a/packages/relay-web/src/__tests__/turn-layout.test.ts
+++ b/packages/relay-web/src/__tests__/turn-layout.test.ts
@@ -101,21 +101,29 @@ describe("planTurnLayout", () => {
   it("reuses unchanged leading blocks when a streaming tail grows", () => {
     const cache = createTurnLayoutGeometryCache();
     const head = "settled paragraph one\n\nsettled paragraph two\n\n";
-    const firstHtml = (narrative: string) =>
+    const layoutHtml = (narrative: string) =>
       planTurnLayout(narrative, [], { streaming: true, latestVisibleIsText: true }, cache).nodes
         .filter((node) => node.type === "markdown")
         .map((node) => node.html)
         .join("");
-    const before = firstHtml(`${head}tail one`);
-    const settledKeys = [...cache.blocks.keys()].filter((key) => key !== "block:46:54");
-    const settledFingerprints = settledKeys.map((key) => cache.blocks.get(key)!.fingerprint);
-    const after = firstHtml(`${head}tail one plus more`);
+    const before = layoutHtml(`${head}tail one`);
+    const settledFingerprints = new Map(
+      [...cache.blocks.entries()]
+        .filter(([key]) => key !== "block:46:54")
+        .map(([key, entry]) => [key, entry.fingerprint] as const),
+    );
+    // Grow the tail in small increments the way streaming appends do: every
+    // frame mints a new tail range, but settled head entries must keep
+    // hitting and stale tail generations must not accumulate.
+    let after = before;
+    for (let index = 0; index < 60; index += 1) {
+      after = layoutHtml(`${head}tail one plus ${"more ".repeat(index + 1)}`);
+      expect(cache.blocks.size).toBeLessThanOrEqual(3);
+    }
 
     expect(after).toContain(before.split("</p>")[0]!);
-    for (const key of settledKeys) {
-      expect(cache.blocks.get(key)!.fingerprint).toEqual(
-        settledFingerprints[settledKeys.indexOf(key)]!,
-      );
+    for (const [key, fingerprint] of settledFingerprints) {
+      expect(cache.blocks.get(key)!.fingerprint).toEqual(fingerprint);
     }
   });
 

--- a/packages/relay-web/src/__tests__/turn-layout.test.ts
+++ b/packages/relay-web/src/__tests__/turn-layout.test.ts
@@ -173,6 +173,43 @@ describe("planTurnLayout", () => {
     }
   });
 
+  it("keeps a tool before the text when leading whitespace is trimmed from the paragraph", () => {
+    for (const leading of [" ", "  ", "   "]) {
+      const narrative = `${leading}hello`;
+      const plan = planTurnLayout(narrative, [
+        { id: "tool:read-1", wireIndex: 1, sourceOffset: leading.length },
+      ]);
+
+      // The tool slot coincides with the proven inline start, so the leading
+      // whitespace stays attached to the preceding empty node and the tool
+      // renders before the text — never spliced into the middle of "hello".
+      expect(plan.nodes.map((node) => node.type)).toEqual(["markdown", "activity", "markdown"]);
+      const markdownNodes = plan.nodes.filter((node) => node.type === "markdown");
+      expect(markdownNodes.map((node) => node.source).join("")).toBe(narrative);
+      expect(markdownNodes[0]!.source).toBe(leading);
+      expect(markdownNodes[0]!.html).toBe("");
+      expect(markdownNodes[1]!.source).toBe("hello");
+      expect(markdownNodes[1]!.html).toContain("<p>hello</p>");
+      expect(plan.activityPlacements.get("tool:read-1")).toEqual({
+        sourceOffset: leading.length,
+        effectiveSlot: leading.length,
+        slotKind: "exact-inline",
+        reason: "exact",
+      });
+    }
+  });
+
+  it("keeps every markdown source range on the raw projection it claims to consume", () => {
+    const narrative = "  hello\n\nsecond paragraph";
+    const plan = planTurnLayout(narrative, [
+      { id: "tool:read-1", wireIndex: 1, sourceOffset: 2 },
+    ]);
+    const markdown = plan.nodes.filter((node) => node.type === "markdown");
+    for (const node of markdown) {
+      expect(narrative.slice(node.sourceRange[0], node.sourceRange[1])).toBe(node.source);
+    }
+  });
+
   it("degrades an extreme activity-bearing paragraph to one atomic block", () => {
     const narrative = `${"a".repeat(50_001)} tail`;
     const plan = planTurnLayout(narrative, [

--- a/packages/relay-web/src/__tests__/turn-layout.test.ts
+++ b/packages/relay-web/src/__tests__/turn-layout.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  planTurnLayout,
   placeActivitiesMonotonically,
   type LayoutActivityGeometry,
   type LayoutSlotCandidate,
@@ -79,5 +80,82 @@ describe("placeActivitiesMonotonically", () => {
       activities,
       (activity) => ({ sourceOffset: activity.sourceOffset - 1, kind: "exact-inline", reason: "exact" }),
     )).toThrow("precedes its wire offset");
+  });
+});
+
+describe("planTurnLayout", () => {
+  it("materializes marker-aware paragraph fragments in source order", () => {
+    const narrative = "Working **carefully now** done";
+    const offset = "Working **carefully ".length;
+    const plan = planTurnLayout(narrative, [
+      { id: "tool:read-1", wireIndex: 1, sourceOffset: offset },
+    ]);
+
+    expect(plan.nodes.map((node) => node.type)).toEqual([
+      "markdown",
+      "activity",
+      "markdown",
+    ]);
+    const markdown = plan.nodes.filter((node) => node.type === "markdown");
+    expect(markdown.map((node) => node.source).join("")).toBe(narrative);
+    expect(markdown[0]!.html).toContain("<strong>carefully </strong>");
+    expect(markdown[1]!.html).toContain("<strong>now</strong> done");
+    expect(plan.activityPlacements.get("tool:read-1")).toEqual({
+      sourceOffset: offset,
+      effectiveSlot: offset,
+      slotKind: "exact-inline",
+      reason: "exact",
+    });
+  });
+
+  it("lifts activities out of structural Markdown blocks", () => {
+    const narrative = "- one\n\n- two\n\nafter";
+    const offset = "- one\n".length;
+    const plan = planTurnLayout(narrative, [
+      { id: "tool:read-1", wireIndex: 1, sourceOffset: offset },
+    ]);
+    const activityIndex = plan.nodes.findIndex((node) => node.type === "activity");
+    const afterIndex = plan.nodes.findIndex((node) =>
+      node.type === "markdown" && node.source.includes("after"),
+    );
+
+    expect(activityIndex).toBeGreaterThan(0);
+    expect(activityIndex).toBeLessThan(afterIndex);
+    expect(plan.activityPlacements.get("tool:read-1")?.reason)
+      .toBe("structural-block");
+  });
+
+  it("fails a whole paragraph closed when marker injection changes semantics", () => {
+    const narrative = "[docs](https://example.com)";
+    const offset = "[docs](https://exa".length;
+    const plan = planTurnLayout(narrative, [
+      { id: "tool:read-1", wireIndex: 1, sourceOffset: offset },
+    ]);
+
+    expect(plan.nodes.map((node) => node.type)).toEqual(["markdown", "activity"]);
+    expect(plan.activityPlacements.get("tool:read-1")?.reason).toBe("marker-unsafe");
+  });
+
+  it("covers narrative exactly once and emits every activity in wire order", () => {
+    const narrative = "alpha **beta gamma** omega\n\n- one\n- two\n\nend";
+    const layoutActivities = [
+      { id: "a", wireIndex: 1, sourceOffset: "alpha **beta ".length },
+      { id: "b", wireIndex: 3, sourceOffset: narrative.indexOf("- two") },
+      { id: "c", wireIndex: 5, sourceOffset: narrative.length },
+    ];
+    const plan = planTurnLayout(narrative, layoutActivities);
+    const markdown = plan.nodes.filter((node) => node.type === "markdown");
+    const renderedActivities = plan.nodes.filter((node) => node.type === "activity");
+
+    expect(markdown.map((node) => node.source).join("")).toBe(narrative);
+    expect(renderedActivities.map((node) => node.activityId))
+      .toEqual(layoutActivities.map((activity) => activity.id));
+    for (let index = 1; index < markdown.length; index += 1) {
+      expect(markdown[index - 1]!.sourceRange[1]).toBe(markdown[index]!.sourceRange[0]);
+    }
+    for (const activity of layoutActivities) {
+      expect(plan.activityPlacements.get(activity.id)!.effectiveSlot)
+        .toBeGreaterThanOrEqual(activity.sourceOffset);
+    }
   });
 });

--- a/packages/relay-web/src/__tests__/turn-layout.test.ts
+++ b/packages/relay-web/src/__tests__/turn-layout.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createTurnLayoutGeometryCache,
   planTurnLayout,
   placeActivitiesMonotonically,
   type LayoutActivityGeometry,
@@ -84,6 +85,19 @@ describe("placeActivitiesMonotonically", () => {
 });
 
 describe("planTurnLayout", () => {
+  it("reuses geometry when narrative and activity identity stay unchanged", () => {
+    const cache = createTurnLayoutGeometryCache();
+    const geometry = [{ id: "tool:read-1", wireIndex: 1, sourceOffset: 6 }];
+    const first = planTurnLayout("before after", geometry, {}, cache);
+    const second = planTurnLayout("before after", geometry, {}, cache);
+    const changed = planTurnLayout("before! after", [
+      { ...geometry[0]!, sourceOffset: 7 },
+    ], {}, cache);
+
+    expect(second).toBe(first);
+    expect(changed).not.toBe(first);
+  });
+
   it("materializes marker-aware paragraph fragments in source order", () => {
     const narrative = "Working **carefully now** done";
     const offset = "Working **carefully ".length;
@@ -157,5 +171,36 @@ describe("planTurnLayout", () => {
       expect(plan.activityPlacements.get(activity.id)!.effectiveSlot)
         .toBeGreaterThanOrEqual(activity.sourceOffset);
     }
+  });
+
+  it("degrades an extreme activity-bearing paragraph to one atomic block", () => {
+    const narrative = `${"a".repeat(50_001)} tail`;
+    const plan = planTurnLayout(narrative, [
+      { id: "tool:read-1", wireIndex: 1, sourceOffset: 25_000 },
+    ]);
+
+    expect(plan.nodes.map((node) => node.type)).toEqual(["markdown", "activity"]);
+    expect(plan.activityPlacements.get("tool:read-1")?.reason).toBe("marker-unsafe");
+  });
+
+  it("keeps a long mixed trace ordered and source-complete", () => {
+    const chunks: string[] = [];
+    const generated: LayoutActivityGeometry[] = [];
+    let sourceOffset = 0;
+    for (let index = 0; index < 120; index += 1) {
+      const prefix = `paragraph ${index} **before `;
+      const suffix = `after**\n\n`;
+      chunks.push(prefix, suffix);
+      sourceOffset += prefix.length;
+      generated.push({ id: `tool:${index}`, wireIndex: index, sourceOffset });
+      sourceOffset += suffix.length;
+    }
+    const narrative = chunks.join("");
+    const plan = planTurnLayout(narrative, generated);
+
+    expect(plan.nodes.filter((node) => node.type === "activity").map((node) => node.activityId))
+      .toEqual(generated.map((activity) => activity.id));
+    expect(plan.nodes.filter((node) => node.type === "markdown").map((node) => node.source).join(""))
+      .toBe(narrative);
   });
 });

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -39,6 +39,22 @@ describe("deriveTurnPresentation", () => {
     ]);
   });
 
+  it("keeps progress interleaved before a later Markdown result block", () => {
+    expect(visibleShape([
+      { type: "text", text: "plan A " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "plan B" },
+      { type: "tool", step: tool("read-2") },
+      { type: "text", text: "\n\n## Result\nDone" },
+    ])).toEqual([
+      { type: "text", text: "plan A " },
+      { type: "tool", id: "read-1" },
+      { type: "text", text: "plan B" },
+      { type: "tool", id: "read-2" },
+      { type: "text", text: "\n\n## Result\nDone" },
+    ]);
+  });
+
   it("keeps a tool event at a safe plain-text paragraph offset", () => {
     expect(visibleShape([
       { type: "text", text: "before " },
@@ -48,6 +64,28 @@ describe("deriveTurnPresentation", () => {
       { type: "text", text: "before " },
       { type: "tool", id: "read-1" },
       { type: "text", text: "after" },
+    ]);
+  });
+
+  it("does not split a paragraph when the suffix would become a standalone heading", () => {
+    expect(visibleShape([
+      { type: "text", text: "before " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "# not a heading" },
+    ])).toEqual([
+      { type: "text", text: "before # not a heading" },
+      { type: "tool", id: "read-1" },
+    ]);
+  });
+
+  it("does not split a paragraph that depends on a later reference definition", () => {
+    expect(visibleShape([
+      { type: "text", text: "See [docs][ref]" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "\n\n[ref]: https://example.com" },
+    ])).toEqual([
+      { type: "text", text: "See [docs][ref]\n\n[ref]: https://example.com" },
+      { type: "tool", id: "read-1" },
     ]);
   });
 

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -170,6 +170,34 @@ describe("deriveTurnPresentation", () => {
     expect(markdown?.type === "markdown" && markdown.html).toContain('href="https://example.com"');
   });
 
+  it("keeps a reference link alive when table normalization forces a block reparse", () => {
+    // The first paragraph needs table normalization (missing delimiter row),
+    // which forces renderAtomicBlock down the standalone-reparse path; without
+    // the document env the [docs][ref] link would render as literal text.
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "See [docs][ref]\n| a | b |\n| 1 | 2 |" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: " plus tail\n\n[ref]: https://example.com\n\nfinal" },
+    ];
+    const markdown = deriveTurnPresentation(parts).nodes
+      .filter((node) => node.type === "markdown");
+    expect(markdown.length).toBeGreaterThan(0);
+    expect(markdown.some((node) => node.type === "markdown" && node.html.includes('href="https://example.com"'))).toBe(true);
+  });
+
+  it("copies the displayed final reply instead of a raw broken fragment", () => {
+    const presentation = deriveTurnPresentation([
+      { type: "text", text: "I'll inspect **this " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "carefully**. Fixed." },
+    ]);
+    const hidden = presentation.nodes.filter((node) => node.type === "markdown");
+    expect(hidden.length).toBeGreaterThan(0);
+    expect(presentation.finalReplyNodes.map((node) => node.source).join("")).toContain("carefully**. Fixed.");
+    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).toBe("carefully. Fixed.");
+    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).not.toContain("**");
+  });
+
   it("never reorders activities across streaming Markdown prefixes", () => {
     const closing = "** done";
     for (let length = 0; length <= closing.length; length += 1) {

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -11,8 +11,8 @@ const tool = (id: string): ToolStepDto => ({
 });
 
 const visibleShape = (parts: TurnPartDto[], opts?: TurnPresentationOptions) =>
-  deriveTurnPresentation(parts, opts).map((item) => {
-    if (item.type === "text") return { type: item.type, text: item.text };
+  deriveTurnPresentation(parts, opts).nodes.map((item) => {
+    if (item.type === "markdown") return { type: "text", text: item.source };
     if (item.type === "reasoning") return { type: item.type, text: item.text };
     if (item.type === "agent-message") return { type: item.type, id: item.message.messageId, anchor: item.anchorToolCallId };
     return { type: item.type, id: item.step.toolCallId };
@@ -67,29 +67,31 @@ describe("deriveTurnPresentation", () => {
     ]);
   });
 
-  it("does not split a paragraph when the suffix would become a standalone heading", () => {
+  it("interleaves without reparsing a heading-like suffix", () => {
     expect(visibleShape([
       { type: "text", text: "before " },
       { type: "tool", step: tool("read-1") },
       { type: "text", text: "# not a heading" },
     ])).toEqual([
-      { type: "text", text: "before # not a heading" },
+      { type: "text", text: "before " },
       { type: "tool", id: "read-1" },
+      { type: "text", text: "# not a heading" },
     ]);
   });
 
-  it("does not split prose when the standalone suffix would normalize into a table", () => {
+  it("interleaves without normalizing a pipe-prose suffix into a table", () => {
     expect(visibleShape([
       { type: "text", text: "Progress: " },
       { type: "tool", step: tool("read-1") },
       { type: "text", text: "| a | b |\n| 1 | 2 |" },
     ])).toEqual([
-      { type: "text", text: "Progress: | a | b |\n| 1 | 2 |" },
+      { type: "text", text: "Progress: " },
       { type: "tool", id: "read-1" },
+      { type: "text", text: "| a | b |\n| 1 | 2 |" },
     ]);
   });
 
-  it("does not split a streaming paragraph while remend still needs to heal it", () => {
+  it("keeps streaming activity exact while marker-aware remend heals the paragraph", () => {
     const incomplete: TurnPartDto[] = [
       { type: "text", text: "Working **carefully " },
       { type: "tool", step: tool("read-1") },
@@ -100,25 +102,27 @@ describe("deriveTurnPresentation", () => {
       { type: "text", text: "now** done" },
     ];
     const expectedIncomplete = [
-      { type: "text", text: "Working **carefully now" },
+      { type: "text", text: "Working **carefully " },
       { type: "tool", id: "read-1" },
+      { type: "text", text: "now" },
     ];
     const expectedCompleted = [
-      { type: "text", text: "Working **carefully now** done" },
+      { type: "text", text: "Working **carefully " },
       { type: "tool", id: "read-1" },
+      { type: "text", text: "now** done" },
     ];
 
     expect(visibleShape(incomplete, { streaming: true })).toEqual(expectedIncomplete);
     expect(visibleShape(completed, { streaming: true })).toEqual(expectedCompleted);
   });
 
-  it("does not split a paragraph that depends on a later reference definition", () => {
+  it("renders a reference-dependent paragraph from the shared document env", () => {
     expect(visibleShape([
       { type: "text", text: "See [docs][ref]" },
       { type: "tool", step: tool("read-1") },
       { type: "text", text: "\n\n[ref]: https://example.com" },
     ])).toEqual([
-      { type: "text", text: "See [docs][ref]\n\n[ref]: https://example.com" },
+      { type: "text", text: "See [docs][ref]" },
       { type: "tool", id: "read-1" },
     ]);
   });
@@ -189,7 +193,7 @@ describe("deriveTurnPresentation", () => {
       { type: "text", text: "after" },
     ])).toEqual([
       { type: "tool", id: "read-1" },
-      { type: "text", text: " \nafter" },
+      { type: "text", text: "after" },
     ]);
   });
 
@@ -241,8 +245,8 @@ describe("deriveTurnPresentation", () => {
         { type: "text", text: "after" },
       ],
       { sentAgentMessageById: new Map([["m1", entry]]) },
-    );
-    expect(items.map((item) => item.type)).toEqual(["text", "tool", "agent-message", "text"]);
+    ).nodes;
+    expect(items.map((item) => item.type)).toEqual(["markdown", "tool", "agent-message", "markdown"]);
     const card = items[2]!;
     expect(card.type).toBe("agent-message");
     if (card.type === "agent-message") {

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -186,16 +186,21 @@ describe("deriveTurnPresentation", () => {
   });
 
   it("copies the displayed final reply instead of a raw broken fragment", () => {
-    const presentation = deriveTurnPresentation([
+    const parts: TurnPartDto[] = [
       { type: "text", text: "I'll inspect **this " },
       { type: "tool", step: tool("read-1") },
       { type: "text", text: "carefully**. Fixed." },
-    ]);
+    ];
+    const presentation = deriveTurnPresentation(parts);
     const hidden = presentation.nodes.filter((node) => node.type === "markdown");
     expect(hidden.length).toBeGreaterThan(0);
     expect(presentation.finalReplyNodes.map((node) => node.source).join("")).toContain("carefully**. Fixed.");
-    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).toBe("carefully. Fixed.");
-    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).not.toContain("**");
+    // Node copyText stays compositional (block terminator included); only the
+    // final joined reply is outer-trimmed.
+    expect(presentation.finalReplyNodes.map((node) => node.copyText).join(""))
+      .toBe("carefully. Fixed.\n\n");
+    expect(extractCollapsedTraceSummary(parts).finalReplyText).toBe("carefully. Fixed.");
+    expect(extractCollapsedTraceSummary(parts).finalReplyText).not.toContain("**");
   });
 
   it("copies an image-only final reply as its alt text instead of nothing", () => {
@@ -207,7 +212,7 @@ describe("deriveTurnPresentation", () => {
     const presentation = deriveTurnPresentation(parts);
     expect(presentation.finalReplyNodes.map((node) => node.source).join(""))
       .toBe("![plot](https://example.com/p.png)");
-    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).toBe("plot");
+    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).toBe("plot\n\n");
     expect(extractCollapsedTraceSummary(parts).finalReplyText).toBe("plot");
   });
 
@@ -218,7 +223,8 @@ describe("deriveTurnPresentation", () => {
       { type: "text", text: " now\n\n[ref]: https://example.com" },
     ];
     const presentation = deriveTurnPresentation(parts);
-    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).toBe(" now");
+    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).toBe(" now\n\n");
+    expect(extractCollapsedTraceSummary(parts).finalReplyText).toBe(" now");
     expect(extractCollapsedTraceSummary(parts).finalReplyText)
       .not.toContain("[ref]: https://example.com");
   });
@@ -232,6 +238,26 @@ describe("deriveTurnPresentation", () => {
     const text = extractCollapsedTraceSummary(parts).finalReplyText;
     expect(text).not.toContain("2After");
     expect(text).toMatch(/2\n+After/);
+  });
+
+  it("keeps a blank line between a split paragraph and the next paragraph when copying", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Before " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "after\n\nNext" },
+    ];
+    expect(extractCollapsedTraceSummary(parts).finalReplyText).toBe("after\n\nNext");
+  });
+
+  it("combines synthetic strong reopening with the block separator when copying", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Before **some " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "text**\n\nNext" },
+    ];
+    // "Before some " precedes the activity so it stays out of the final reply;
+    // the reply fragment carries no dangling "**" and still separates from Next.
+    expect(extractCollapsedTraceSummary(parts).finalReplyText).toBe("text\n\nNext");
   });
 
   it("never reorders activities across streaming Markdown prefixes", () => {

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -19,14 +19,35 @@ const visibleShape = (parts: TurnPartDto[], opts?: TurnPresentationOptions) =>
   });
 
 describe("deriveTurnPresentation", () => {
-  it("does not let a tool event split one narrative paragraph", () => {
+  it("keeps repeated plain-text progress updates interleaved with their tools", () => {
+    expect(visibleShape([
+      { type: "text", text: "plan: inspect the reap target" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "plan: inspect the reap target" },
+      { type: "tool", step: tool("read-2") },
+      { type: "text", text: "plan: inspect the reap target" },
+      { type: "tool", step: tool("edit-1") },
+      { type: "text", text: "High 修完，继续检查。" },
+    ])).toEqual([
+      { type: "text", text: "plan: inspect the reap target" },
+      { type: "tool", id: "read-1" },
+      { type: "text", text: "plan: inspect the reap target" },
+      { type: "tool", id: "read-2" },
+      { type: "text", text: "plan: inspect the reap target" },
+      { type: "tool", id: "edit-1" },
+      { type: "text", text: "High 修完，继续检查。" },
+    ]);
+  });
+
+  it("keeps a tool event at a safe plain-text paragraph offset", () => {
     expect(visibleShape([
       { type: "text", text: "before " },
       { type: "tool", step: tool("read-1") },
       { type: "text", text: "after" },
     ])).toEqual([
-      { type: "text", text: "before after" },
+      { type: "text", text: "before " },
       { type: "tool", id: "read-1" },
+      { type: "text", text: "after" },
     ]);
   });
 
@@ -77,14 +98,15 @@ describe("deriveTurnPresentation", () => {
     ]);
   });
 
-  it("treats a single line break as part of the same Markdown paragraph", () => {
+  it("keeps a tool event at a safe soft-break offset", () => {
     expect(visibleShape([
       { type: "text", text: "line one\n" },
       { type: "tool", step: tool("read-1") },
       { type: "text", text: "line two" },
     ])).toEqual([
-      { type: "text", text: "line one\nline two" },
+      { type: "text", text: "line one\n" },
       { type: "tool", id: "read-1" },
+      { type: "text", text: "line two" },
     ]);
   });
 

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
-import { deriveTurnPresentation, type TurnPresentationOptions } from "../lib/turn-presentation";
+import { deriveTurnPresentation, extractCollapsedTraceSummary, type TurnPresentationOptions } from "../lib/turn-presentation";
 import { createTurnLayoutGeometryCache } from "../lib/turn-layout";
 
 const tool = (id: string): ToolStepDto => ({
@@ -196,6 +196,31 @@ describe("deriveTurnPresentation", () => {
     expect(presentation.finalReplyNodes.map((node) => node.source).join("")).toContain("carefully**. Fixed.");
     expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).toBe("carefully. Fixed.");
     expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).not.toContain("**");
+  });
+
+  it("copies an image-only final reply as its alt text instead of nothing", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Before " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "![plot](https://example.com/p.png)" },
+    ];
+    const presentation = deriveTurnPresentation(parts);
+    expect(presentation.finalReplyNodes.map((node) => node.source).join(""))
+      .toBe("![plot](https://example.com/p.png)");
+    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).toBe("plot");
+    expect(extractCollapsedTraceSummary(parts).finalReplyText).toBe("plot");
+  });
+
+  it("copies a reference link label without leaking its definition", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "See [docs][ref]" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: " now\n\n[ref]: https://example.com" },
+    ];
+    const presentation = deriveTurnPresentation(parts);
+    expect(presentation.finalReplyNodes.map((node) => node.copyText).join("")).toBe(" now");
+    expect(extractCollapsedTraceSummary(parts).finalReplyText)
+      .not.toContain("[ref]: https://example.com");
   });
 
   it("never reorders activities across streaming Markdown prefixes", () => {

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -78,6 +78,40 @@ describe("deriveTurnPresentation", () => {
     ]);
   });
 
+  it("does not split prose when the standalone suffix would normalize into a table", () => {
+    expect(visibleShape([
+      { type: "text", text: "Progress: " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "| a | b |\n| 1 | 2 |" },
+    ])).toEqual([
+      { type: "text", text: "Progress: | a | b |\n| 1 | 2 |" },
+      { type: "tool", id: "read-1" },
+    ]);
+  });
+
+  it("does not split a streaming paragraph while remend still needs to heal it", () => {
+    const incomplete: TurnPartDto[] = [
+      { type: "text", text: "Working **carefully " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "now" },
+    ];
+    const completed: TurnPartDto[] = [
+      ...incomplete.slice(0, -1),
+      { type: "text", text: "now** done" },
+    ];
+    const expectedIncomplete = [
+      { type: "text", text: "Working **carefully now" },
+      { type: "tool", id: "read-1" },
+    ];
+    const expectedCompleted = [
+      { type: "text", text: "Working **carefully now** done" },
+      { type: "tool", id: "read-1" },
+    ];
+
+    expect(visibleShape(incomplete, { streaming: true })).toEqual(expectedIncomplete);
+    expect(visibleShape(completed, { streaming: true })).toEqual(expectedCompleted);
+  });
+
   it("does not split a paragraph that depends on a later reference definition", () => {
     expect(visibleShape([
       { type: "text", text: "See [docs][ref]" },

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -223,6 +223,17 @@ describe("deriveTurnPresentation", () => {
       .not.toContain("[ref]: https://example.com");
   });
 
+  it("keeps a newline between a healed table and the following paragraph when copying", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Working" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "\n\n| a | b |\n| 1 | 2 |\n\nAfter" },
+    ];
+    const text = extractCollapsedTraceSummary(parts).finalReplyText;
+    expect(text).not.toContain("2After");
+    expect(text).toMatch(/2\n+After/);
+  });
+
   it("never reorders activities across streaming Markdown prefixes", () => {
     const closing = "** done";
     for (let length = 0; length <= closing.length; length += 1) {

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
 import { deriveTurnPresentation, type TurnPresentationOptions } from "../lib/turn-presentation";
+import { createTurnLayoutGeometryCache } from "../lib/turn-layout";
 
 const tool = (id: string): ToolStepDto => ({
   toolCallId: id,
@@ -19,6 +20,40 @@ const visibleShape = (parts: TurnPartDto[], opts?: TurnPresentationOptions) =>
   });
 
 describe("deriveTurnPresentation", () => {
+  it("reuses layout geometry when only a tool payload changes", () => {
+    const layoutCache = createTurnLayoutGeometryCache();
+    const running = tool("read-1");
+    running.status = "running";
+    const success = { ...running, status: "success" as const };
+    const parts = (step: ToolStepDto): TurnPartDto[] => [
+      { type: "text", text: "before " },
+      { type: "tool", step },
+      { type: "text", text: "after" },
+    ];
+
+    const first = deriveTurnPresentation(parts(running), { layoutCache });
+    const second = deriveTurnPresentation(parts(success), { layoutCache });
+
+    expect(second.layout).toBe(first.layout);
+    const firstTool = first.nodes.find((node) => node.type === "tool");
+    const secondTool = second.nodes.find((node) => node.type === "tool");
+    expect(firstTool?.type === "tool" && firstTool.step.status).toBe("running");
+    expect(secondTool?.type === "tool" && secondTool.step.status).toBe("success");
+  });
+
+  it("uses a single Markdown node for the zero-activity fast path", () => {
+    const presentation = deriveTurnPresentation([
+      { type: "text", text: "first " },
+      { type: "text", text: "**second**" },
+    ]);
+
+    expect(presentation.layout.activityPlacements.size).toBe(0);
+    expect(presentation.nodes).toHaveLength(1);
+    expect(presentation.nodes[0]?.type).toBe("markdown");
+    expect(presentation.nodes[0]?.type === "markdown" && presentation.nodes[0].html)
+      .toContain("<strong>second</strong>");
+  });
+
   it("keeps repeated plain-text progress updates interleaved with their tools", () => {
     expect(visibleShape([
       { type: "text", text: "plan: inspect the reap target" },
@@ -68,15 +103,20 @@ describe("deriveTurnPresentation", () => {
   });
 
   it("interleaves without reparsing a heading-like suffix", () => {
-    expect(visibleShape([
+    const parts: TurnPartDto[] = [
       { type: "text", text: "before " },
       { type: "tool", step: tool("read-1") },
       { type: "text", text: "# not a heading" },
-    ])).toEqual([
+    ];
+    expect(visibleShape(parts)).toEqual([
       { type: "text", text: "before " },
       { type: "tool", id: "read-1" },
       { type: "text", text: "# not a heading" },
     ]);
+    const markdown = deriveTurnPresentation(parts).nodes
+      .filter((node) => node.type === "markdown");
+    expect(markdown[1]!.html).toContain("<p># not a heading</p>");
+    expect(markdown[1]!.html).not.toContain("<h1>");
   });
 
   it("interleaves without normalizing a pipe-prose suffix into a table", () => {
@@ -117,14 +157,35 @@ describe("deriveTurnPresentation", () => {
   });
 
   it("renders a reference-dependent paragraph from the shared document env", () => {
-    expect(visibleShape([
+    const parts: TurnPartDto[] = [
       { type: "text", text: "See [docs][ref]" },
       { type: "tool", step: tool("read-1") },
       { type: "text", text: "\n\n[ref]: https://example.com" },
-    ])).toEqual([
+    ];
+    expect(visibleShape(parts)).toEqual([
       { type: "text", text: "See [docs][ref]" },
       { type: "tool", id: "read-1" },
     ]);
+    const markdown = deriveTurnPresentation(parts).nodes.find((node) => node.type === "markdown");
+    expect(markdown?.type === "markdown" && markdown.html).toContain('href="https://example.com"');
+  });
+
+  it("never reorders activities across streaming Markdown prefixes", () => {
+    const closing = "** done";
+    for (let length = 0; length <= closing.length; length += 1) {
+      const presentation = deriveTurnPresentation([
+        { type: "text", text: "Working **carefully " },
+        { type: "tool", step: tool("read-1") },
+        { type: "text", text: "now" },
+        { type: "tool", step: tool("read-2") },
+        { type: "text", text: closing.slice(0, length) },
+      ], { streaming: true });
+      expect(presentation.nodes
+        .filter((node) => node.type === "tool")
+        .map((node) => node.step.toolCallId)).toEqual(["read-1", "read-2"]);
+      const placements = [...presentation.layout.activityPlacements.values()];
+      expect(placements[1]!.effectiveSlot).toBeGreaterThanOrEqual(placements[0]!.effectiveSlot);
+    }
   });
 
   it("places a tool at the semantic paragraph boundary inserted by the transport", () => {

--- a/packages/relay-web/src/__tests__/turn-presentation.test.ts
+++ b/packages/relay-web/src/__tests__/turn-presentation.test.ts
@@ -260,6 +260,15 @@ describe("deriveTurnPresentation", () => {
     expect(extractCollapsedTraceSummary(parts).finalReplyText).toBe("text\n\nNext");
   });
 
+  it("does not copy a split inter-block gap around a tool in the gap", () => {
+    const parts: TurnPartDto[] = [
+      { type: "text", text: "Before\n\n" },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "\nAfter" },
+    ];
+    expect(extractCollapsedTraceSummary(parts).finalReplyText).toBe("After");
+  });
+
   it("never reorders activities across streaming Markdown prefixes", () => {
     const closing = "** done";
     for (let length = 0; length <= closing.length; length += 1) {

--- a/packages/relay-web/src/__tests__/turn-timeline.test.ts
+++ b/packages/relay-web/src/__tests__/turn-timeline.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
+import { buildTurnTimeline } from "../lib/turn-timeline";
+
+const tool = (id: string, status: ToolStepDto["status"] = "running"): ToolStepDto => ({
+  toolCallId: id,
+  toolName: "Read",
+  kind: "read",
+  status,
+  title: `${id}.ts`,
+});
+
+describe("buildTurnTimeline", () => {
+  it("preserves narrative text and activity wire positions without Markdown knowledge", () => {
+    const timeline = buildTurnTimeline([
+      { type: "text", text: "Checking " },
+      { type: "tool", step: tool("read-1") },
+      { type: "text", text: "**config" },
+      { type: "reasoning", text: "compare defaults" },
+      { type: "tool", step: tool("read-2") },
+      { type: "text", text: "** now" },
+    ]);
+
+    expect(timeline.narrative).toBe("Checking **config** now");
+    expect(timeline.activities.map(({ kind, wireIndex, sourceOffset }) => ({
+      kind,
+      wireIndex,
+      sourceOffset,
+    }))).toEqual([
+      { kind: "tool", wireIndex: 1, sourceOffset: 9 },
+      { kind: "reasoning", wireIndex: 3, sourceOffset: 17 },
+      { kind: "tool", wireIndex: 4, sourceOffset: 17 },
+    ]);
+  });
+
+  it("keeps geometry identity stable when only a tool payload changes", () => {
+    const before = buildTurnTimeline([
+      { type: "text", text: "Checking" },
+      { type: "tool", step: tool("read-1", "running") },
+    ]);
+    const after = buildTurnTimeline([
+      { type: "text", text: "Checking" },
+      { type: "tool", step: tool("read-1", "success") },
+    ]);
+
+    const geometry = (timeline: ReturnType<typeof buildTurnTimeline>) => ({
+      narrative: timeline.narrative,
+      activities: timeline.activities.map(({ id, wireIndex, sourceOffset }) => ({
+        id,
+        wireIndex,
+        sourceOffset,
+      })),
+    });
+    expect(geometry(after)).toEqual(geometry(before));
+    expect(after.activities[0]!.payload).not.toEqual(before.activities[0]!.payload);
+  });
+
+  it("maintains offset and identity invariants for arbitrary wire sequences", () => {
+    let seed = 0x337;
+    const random = (): number => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed;
+    };
+
+    for (let sample = 0; sample < 200; sample += 1) {
+      const parts: TurnPartDto[] = [];
+      const length = 1 + (random() % 30);
+      for (let index = 0; index < length; index += 1) {
+        const choice = random() % 3;
+        if (choice === 0) parts.push({ type: "text", text: `t${random() % 100}` });
+        else if (choice === 1) parts.push({ type: "reasoning", text: `r${index}` });
+        else parts.push({ type: "tool", step: tool(`tool-${sample}-${index}`) });
+      }
+
+      const timeline = buildTurnTimeline(parts);
+      const expectedNarrative = parts
+        .filter((part): part is Extract<TurnPartDto, { type: "text" }> => part.type === "text")
+        .map((part) => part.text)
+        .join("");
+      expect(timeline.narrative).toBe(expectedNarrative);
+      expect(new Set(timeline.activities.map((activity) => activity.id)).size)
+        .toBe(timeline.activities.length);
+
+      let previousWireIndex = -1;
+      let previousOffset = 0;
+      for (const activity of timeline.activities) {
+        expect(activity.wireIndex).toBeGreaterThan(previousWireIndex);
+        expect(activity.sourceOffset).toBeGreaterThanOrEqual(previousOffset);
+        expect(activity.sourceOffset).toBeLessThanOrEqual(timeline.narrative.length);
+        previousWireIndex = activity.wireIndex;
+        previousOffset = activity.sourceOffset;
+      }
+    }
+  });
+});

--- a/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-collapse.test.ts
@@ -433,7 +433,7 @@ describe("TurnParts trace collapse", () => {
     expect(w.find('[data-test="tool-step-card"]').exists()).toBe(false);
   });
 
-  it("fails safe and shows header only when an active bold construct crosses a tool", () => {
+  it("uses the shared layout fragment when bold crosses a collapsed tool", () => {
     const parts: TurnPartDto[] = [
       { type: "text", text: "I'll inspect **this " },
       { type: "tool", step: tool("read-1") },
@@ -443,10 +443,11 @@ describe("TurnParts trace collapse", () => {
       props: { parts, collapseTrace: true, traceKey: "t:bold-crosses-tool" },
     });
     expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
-    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+    const narrative = w.find('[data-test="turn-narrative"]');
+    expect(narrative.html()).toContain("<strong>carefully</strong>. Fixed.");
   });
 
-  it("fails safe and shows header only when an inline code span crosses a tool", () => {
+  it("uses the shared layout fragment when inline code crosses a collapsed tool", () => {
     const parts: TurnPartDto[] = [
       { type: "text", text: "Use `foo " },
       { type: "tool", step: tool("read-1") },
@@ -456,10 +457,11 @@ describe("TurnParts trace collapse", () => {
       props: { parts, collapseTrace: true, traceKey: "t:code-crosses-tool" },
     });
     expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
-    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+    const narrative = w.find('[data-test="turn-narrative"]');
+    expect(narrative.html()).toContain("<code>bar</code> now");
   });
 
-  it("fails safe and shows header only when a markdown link label crosses a tool", () => {
+  it("uses the shared layout fragment when a link label crosses a collapsed tool", () => {
     const parts: TurnPartDto[] = [
       { type: "text", text: "See [the " },
       { type: "tool", step: tool("read-1") },
@@ -469,7 +471,9 @@ describe("TurnParts trace collapse", () => {
       props: { parts, collapseTrace: true, traceKey: "t:link-crosses-tool" },
     });
     expect(w.find('[data-test="trace-toggle"]').exists()).toBe(true);
-    expect(w.find('[data-test="turn-narrative"]').exists()).toBe(false);
+    const narrative = w.find('[data-test="turn-narrative"]');
+    expect(narrative.html()).toContain('<a href="https://example.com"');
+    expect(narrative.html()).toContain("docs</a>");
   });
 
   it("fails safe and shows header only when a tool is contained inside a heading", () => {

--- a/packages/relay-web/src/__tests__/turnparts-performance.test.ts
+++ b/packages/relay-web/src/__tests__/turnparts-performance.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { createPinia, setActivePinia } from "pinia";
+import type { ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
+import TurnParts from "../components/TurnParts.vue";
+
+const tool: ToolStepDto = {
+  toolCallId: "read-1",
+  toolName: "Read",
+  kind: "read",
+  status: "running",
+  title: "index.ts",
+};
+
+const parts = (suffix: string): TurnPartDto[] => [
+  { type: "text", text: "before " },
+  { type: "tool", step: tool },
+  { type: "text", text: suffix },
+];
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TurnParts streaming performance", () => {
+  it("coalesces multiple layout updates into one browser frame", async () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    const wrapper = mount(TurnParts, {
+      props: { parts: parts("one"), streaming: true },
+    });
+
+    await wrapper.setProps({ parts: parts("two") });
+    await wrapper.setProps({ parts: parts("three") });
+    await wrapper.setProps({ parts: parts("four") });
+    expect(frames).toHaveLength(1);
+    expect(wrapper.findAll('[data-test="turn-narrative"]')[1]!.text()).toBe("one");
+
+    frames[0]!(16);
+    await nextTick();
+    expect(wrapper.findAll('[data-test="turn-narrative"]')[1]!.text()).toBe("four");
+  });
+});

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -630,8 +630,8 @@ watch(
             </div>
             <div data-test="msg-out" class="min-w-0 flex-1 space-y-2.5"
                  :class="m.failed ? 'rounded-lg ring-1 ring-danger/40' : ''">
-              <!-- Structured transcript: activity cards stay grouped above one continuous
-                   Markdown narrative. Tool cards own their collapsed state. -->
+              <!-- Structured transcript: activity cards interleave with the Markdown
+                   narrative at wire-ordered slots. Tool cards own their collapsed state. -->
               <div data-test="msg-content" class="space-y-2.5">
                 <TurnParts v-if="m.structured?.parts?.length" :parts="m.structured.parts" :ensure-full="ensureFullOf(m)" :sent-agent-messages="sentAgentMessageById"
                            :collapse-trace="!isFailedTurn(m) && hasTraceParts(m)" :trace-key="traceKeyOf(m)" :trace-elapsed-ms="traceElapsedOf(m)"

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -17,6 +17,7 @@ import {
   extractCollapsedTraceSummary,
   type CollapsedTraceSummary,
 } from "../lib/turn-presentation";
+import { createTurnLayoutGeometryCache, type TurnLayoutGeometryCache } from "../lib/turn-layout";
 const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; driver?: string | null; hasMoreOlder?: boolean; loadingOlder?: boolean; loadingHistory?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null; ensureFull?: (messageId: number) => Promise<void> }>();
 const emit = defineEmits<{ resend: [message: ChatMessage]; loadOlder: [] }>();
 
@@ -67,28 +68,41 @@ function traceElapsedOf(m: ChatMessage): number | null {
   return Number.isFinite(ms) && ms > 0 ? ms : null;
 }
 
-// Cache collapsed trace metrics by message object and parts reference to prevent
-// redundant markdown parses and presentation derivations across MessageList and TurnParts.
+// Cache collapsed trace summaries per message row. The dependency is
+// per-turn, not per-transcript: only the parts array identity plus the
+// anchored sent-message entries this turn actually renders. An unrelated
+// transcript change (new prompt, history prepend, receiver row) rebuilds the
+// global sent-message map but leaves every untouched row's cache hit. Each
+// entry also owns a TurnLayoutGeometryCache, so even a genuine decoration
+// change reuses Markdown geometry instead of re-laying out.
 const traceSummaryCache = new WeakMap<ChatMessage, {
   parts: TurnPartDto[];
-  sentAgentMessages: Map<string, PeerMessageHistoryEntry>;
+  anchoredMessages: Array<[string, PeerMessageHistoryEntry | undefined]>;
+  layoutCache: TurnLayoutGeometryCache;
   summary: CollapsedTraceSummary;
 }>();
 
 function traceSummaryOf(m: ChatMessage): CollapsedTraceSummary {
   const parts = m.structured?.parts;
   if (!parts?.length) throw new Error("Trace summary requires structured turn parts");
-  const sentAgentMessages = sentAgentMessageById.value;
+  const byId = sentAgentMessageById.value;
+  const anchoredMessages = [...anchoredAgentMessageIds(parts)].map(
+    (id) => [id, byId.get(id)] as [string, PeerMessageHistoryEntry | undefined],
+  );
   const cached = traceSummaryCache.get(m);
+  const layoutCache = cached?.layoutCache ?? createTurnLayoutGeometryCache();
   if (
     cached
     && cached.parts === parts
-    && cached.sentAgentMessages === sentAgentMessages
+    && cached.anchoredMessages.length === anchoredMessages.length
+    && cached.anchoredMessages.every(([id, entry], index) =>
+      anchoredMessages[index]![0] === id && anchoredMessages[index]![1] === entry)
   ) return cached.summary;
   const summary = extractCollapsedTraceSummary(parts, {
-    sentAgentMessageById: sentAgentMessages,
+    sentAgentMessageById: byId,
+    layoutCache,
   });
-  traceSummaryCache.set(m, { parts, sentAgentMessages, summary });
+  traceSummaryCache.set(m, { parts, anchoredMessages, layoutCache, summary });
   return summary;
 }
 

--- a/packages/relay-web/src/components/MessageList.vue
+++ b/packages/relay-web/src/components/MessageList.vue
@@ -15,7 +15,6 @@ import { fmtTime, fmtDateTime } from "../lib/format";
 import {
   anchoredAgentMessageIds,
   extractCollapsedTraceSummary,
-  extractFinalReplyText,
   type CollapsedTraceSummary,
 } from "../lib/turn-presentation";
 const props = defineProps<{ messages: ChatMessage[]; liveTurn: LiveTurn | null; driver?: string | null; hasMoreOlder?: boolean; loadingOlder?: boolean; loadingHistory?: boolean; sessionKey?: string; scrollToScheduled?: { taskId: string; nonce: number } | null; ensureFull?: (messageId: number) => Promise<void> }>();
@@ -70,17 +69,26 @@ function traceElapsedOf(m: ChatMessage): number | null {
 
 // Cache collapsed trace metrics by message object and parts reference to prevent
 // redundant markdown parses and presentation derivations across MessageList and TurnParts.
-const traceSummaryCache = new WeakMap<ChatMessage, { parts: TurnPartDto[]; summary: CollapsedTraceSummary }>();
+const traceSummaryCache = new WeakMap<ChatMessage, {
+  parts: TurnPartDto[];
+  sentAgentMessages: Map<string, PeerMessageHistoryEntry>;
+  summary: CollapsedTraceSummary;
+}>();
 
 function traceSummaryOf(m: ChatMessage): CollapsedTraceSummary {
   const parts = m.structured?.parts;
-  if (!parts?.length) return { finalReplyText: "", toolCount: 0, thoughtCount: 0 };
+  if (!parts?.length) throw new Error("Trace summary requires structured turn parts");
+  const sentAgentMessages = sentAgentMessageById.value;
   const cached = traceSummaryCache.get(m);
-  if (cached && cached.parts === parts) return cached.summary;
+  if (
+    cached
+    && cached.parts === parts
+    && cached.sentAgentMessages === sentAgentMessages
+  ) return cached.summary;
   const summary = extractCollapsedTraceSummary(parts, {
-    sentAgentMessageById: sentAgentMessageById.value,
+    sentAgentMessageById: sentAgentMessages,
   });
-  traceSummaryCache.set(m, { parts, summary });
+  traceSummaryCache.set(m, { parts, sentAgentMessages, summary });
   return summary;
 }
 
@@ -613,9 +621,7 @@ watch(
               <div data-test="msg-content" class="space-y-2.5">
                 <TurnParts v-if="m.structured?.parts?.length" :parts="m.structured.parts" :ensure-full="ensureFullOf(m)" :sent-agent-messages="sentAgentMessageById"
                            :collapse-trace="!isFailedTurn(m) && hasTraceParts(m)" :trace-key="traceKeyOf(m)" :trace-elapsed-ms="traceElapsedOf(m)"
-                           :collapsed-reply-text="!isFailedTurn(m) && hasTraceParts(m) ? traceSummaryOf(m).finalReplyText : undefined"
-                           :collapsed-tool-count="!isFailedTurn(m) && hasTraceParts(m) ? traceSummaryOf(m).toolCount : undefined"
-                           :collapsed-thought-count="!isFailedTurn(m) && hasTraceParts(m) ? traceSummaryOf(m).thoughtCount : undefined" />
+                           :presentation="!isFailedTurn(m) && hasTraceParts(m) ? traceSummaryOf(m).presentation : undefined" />
                 <template v-else>
                   <ToolCallPanel v-if="m.structured?.toolSteps?.length" :steps="m.structured.toolSteps" :ensure-full="ensureFullOf(m)" />
                   <ReasoningPanel v-if="m.structured?.reasoning?.trim()" :reasoning="m.structured.reasoning" :default-open="false" />

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -12,7 +12,7 @@ defineOptions({ inheritAttrs: false });
 
 const { t } = useI18n();
 
-const props = defineProps<{ text: string; streaming?: boolean }>();
+const props = defineProps<{ text?: string; renderedHtml?: string; streaming?: boolean }>();
 
 // While streaming, every appended chunk grows `text`, and re-parsing the WHOLE buffer
 // (healing + markdown-it + DOMPurify) per chunk is O(n²) over the turn. Throttle the parse
@@ -157,7 +157,8 @@ function render(): void {
   // their listeners first so a plain (finalized) re-render doesn't strand them until the next
   // theme switch or unmount. The freshly rendered HTML gets its own enhancers after hydration.
   detachEnhancers();
-  html.value = renderMarkdown(props.text, { streaming: props.streaming });
+  html.value = props.renderedHtml
+    ?? renderMarkdown(props.text ?? "", { streaming: props.streaming });
   scheduleHydrate(false);
 }
 
@@ -168,7 +169,7 @@ onMounted(() => {
 });
 
 watch(
-  () => props.text,
+  () => [props.text, props.renderedHtml],
   () => {
     if (!props.streaming) {
       cancelTimer();

--- a/packages/relay-web/src/components/StreamMarkdown.vue
+++ b/packages/relay-web/src/components/StreamMarkdown.vue
@@ -14,24 +14,16 @@ const { t } = useI18n();
 
 const props = defineProps<{ text?: string; renderedHtml?: string; streaming?: boolean }>();
 
-// While streaming, every appended chunk grows `text`, and re-parsing the WHOLE buffer
-// (healing + markdown-it + DOMPurify) per chunk is O(n²) over the turn. Throttle the parse
-// to one render per THROTTLE_MS with a trailing call, so the last chunk always lands. The
-// non-streaming path renders synchronously on every change, exactly like the old computed.
-const THROTTLE_MS = 80;
-
 const theme = useThemeStore();
 const rootEl = ref<HTMLElement | null>(null);
 const html = ref("");
-let timer: ReturnType<typeof setTimeout> | null = null;
-let lastRenderAt = 0;
+let renderFrame: number | null = null;
 let disposed = false;
 
-function cancelTimer(): void {
-  if (timer !== null) {
-    clearTimeout(timer);
-    timer = null;
-  }
+function cancelRenderFrame(): void {
+  if (renderFrame === null) return;
+  cancelAnimationFrame(renderFrame);
+  renderFrame = null;
 }
 
 // Message images embedded in markdown (agent output like ![alt](data:...) or a
@@ -152,7 +144,6 @@ function scheduleHydrate(reset: boolean): void {
 }
 
 function render(): void {
-  lastRenderAt = Date.now();
   // Replacing v-html discards the current DOM, including any enhanced mermaid viewports; detach
   // their listeners first so a plain (finalized) re-render doesn't strand them until the next
   // theme switch or unmount. The freshly rendered HTML gets its own enhancers after hydration.
@@ -171,33 +162,29 @@ onMounted(() => {
 watch(
   () => [props.text, props.renderedHtml],
   () => {
-    if (!props.streaming) {
-      cancelTimer();
+    if (
+      props.renderedHtml !== undefined
+      || !props.streaming
+      || typeof requestAnimationFrame !== "function"
+    ) {
+      cancelRenderFrame();
       render();
       return;
     }
-    const elapsed = Date.now() - lastRenderAt;
-    if (elapsed >= THROTTLE_MS) {
-      cancelTimer();
+    if (renderFrame !== null) return;
+    renderFrame = requestAnimationFrame(() => {
+      renderFrame = null;
       render();
-      return;
-    }
-    // Trailing edge: one pending render picks up whatever `text` holds when it fires.
-    if (timer === null) {
-      timer = setTimeout(() => {
-        timer = null;
-        render();
-      }, THROTTLE_MS - elapsed);
-    }
+    });
   },
 );
 
-// Streaming ended (or toggled): drop any pending throttled render and paint the
+// Streaming ended (or toggled): drop any pending frame render and paint the
 // final full text immediately — the closing frame must never lag or be skipped.
 watch(
   () => props.streaming,
   () => {
-    cancelTimer();
+    cancelRenderFrame();
     render();
   },
 );
@@ -210,7 +197,7 @@ watch(
 
 onBeforeUnmount(() => {
   disposed = true;
-  cancelTimer();
+  cancelRenderFrame();
   detachEnhancers();
   rootEl.value?.removeEventListener("click", onRootClick);
 });

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -12,8 +12,8 @@ import { deriveTurnPresentation, extractFinalReplyText } from "../lib/turn-prese
 import { expandedTraces } from "../lib/trace-expansion";
 
 // Wire parts preserve arrival order, but transport events are not necessarily safe
-// Markdown boundaries. The presentation module anchors activity after the top-level
-// Markdown block that was in progress when the activity arrived.
+// Markdown boundaries. The presentation module keeps safe standalone prose splits in
+// place and otherwise anchors activity after the enclosing top-level Markdown block.
 const props = defineProps<{
   parts: TurnPartDto[];
   streaming?: boolean;
@@ -44,7 +44,10 @@ const { t, locale } = useI18n();
 const presentation = computed(() =>
   deriveTurnPresentation(
     props.parts,
-    props.sentAgentMessages ? { sentAgentMessageById: props.sentAgentMessages } : undefined,
+    {
+      streaming: props.streaming === true,
+      ...(props.sentAgentMessages ? { sentAgentMessageById: props.sentAgentMessages } : {}),
+    },
   ),
 );
 

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onBeforeUnmount, ref, shallowRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { ChevronDown, ChevronRight } from "lucide-vue-next";
 import type { PeerMessageHistoryEntry, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
@@ -12,6 +12,7 @@ import {
   deriveTurnPresentation,
   type TurnPresentationPlan,
 } from "../lib/turn-presentation";
+import { createTurnLayoutGeometryCache } from "../lib/turn-layout";
 import { expandedTraces } from "../lib/trace-expansion";
 
 const props = defineProps<{
@@ -34,15 +35,51 @@ const props = defineProps<{
 
 const { t, locale } = useI18n();
 
-const presentation = computed(() =>
+const layoutCache = createTurnLayoutGeometryCache();
+const derivePresentation = (): TurnPresentationPlan =>
   props.presentation ?? deriveTurnPresentation(
     props.parts,
     {
       streaming: props.streaming === true,
+      layoutCache,
       ...(props.sentAgentMessages ? { sentAgentMessageById: props.sentAgentMessages } : {}),
     },
-  ),
+  );
+const presentation = shallowRef(derivePresentation());
+let presentationFrame: number | null = null;
+
+function cancelPresentationFrame(): void {
+  if (presentationFrame === null) return;
+  cancelAnimationFrame(presentationFrame);
+  presentationFrame = null;
+}
+
+function refreshPresentation(): void {
+  presentation.value = derivePresentation();
+}
+
+watch(
+  () => [props.parts, props.presentation, props.sentAgentMessages, props.streaming],
+  () => {
+    if (
+      props.presentation
+      || props.streaming !== true
+      || typeof requestAnimationFrame !== "function"
+    ) {
+      cancelPresentationFrame();
+      refreshPresentation();
+      return;
+    }
+    if (presentationFrame !== null) return;
+    presentationFrame = requestAnimationFrame(() => {
+      presentationFrame = null;
+      refreshPresentation();
+    });
+  },
+  { deep: true },
 );
+
+onBeforeUnmount(cancelPresentationFrame);
 
 const lastProcessPartIndex = computed(() =>
   props.parts.findLastIndex(

--- a/packages/relay-web/src/components/TurnParts.vue
+++ b/packages/relay-web/src/components/TurnParts.vue
@@ -8,12 +8,12 @@ import ReasoningPanel from "./ReasoningPanel.vue";
 import ToolStepCard from "./ToolStepCard.vue";
 import SubagentStepCard from "./SubagentStepCard.vue";
 import AgentMessageCard from "./AgentMessageCard.vue";
-import { deriveTurnPresentation, extractFinalReplyText } from "../lib/turn-presentation";
+import {
+  deriveTurnPresentation,
+  type TurnPresentationPlan,
+} from "../lib/turn-presentation";
 import { expandedTraces } from "../lib/trace-expansion";
 
-// Wire parts preserve arrival order, but transport events are not necessarily safe
-// Markdown boundaries. The presentation module keeps safe standalone prose splits in
-// place and otherwise anchors activity after the enclosing top-level Markdown block.
 const props = defineProps<{
   parts: TurnPartDto[];
   streaming?: boolean;
@@ -29,20 +29,13 @@ const props = defineProps<{
   traceKey?: string;
   /** Display-only turn duration (finished rows). Absent/non-positive → counts only. */
   traceElapsedMs?: number | null;
-  /** Precomputed final reply text (e.g. cached by parent MessageList). When provided,
-   *  extractFinalReplyText is bypassed on collapsed turns. */
-  collapsedReplyText?: string;
-  /** Precomputed trace activity counts (e.g. cached by parent MessageList). When provided,
-   *  reading presentation is bypassed while collapsed so full layout derivation is deferred
-   *  until the user explicitly clicks to expand. */
-  collapsedToolCount?: number;
-  collapsedThoughtCount?: number;
+  presentation?: TurnPresentationPlan;
 }>();
 
 const { t, locale } = useI18n();
 
 const presentation = computed(() =>
-  deriveTurnPresentation(
+  props.presentation ?? deriveTurnPresentation(
     props.parts,
     {
       streaming: props.streaming === true,
@@ -51,9 +44,6 @@ const presentation = computed(() =>
   ),
 );
 
-// A finished turn collapses everything up through its last process item (tool or
-// non-empty reasoning). The conversational final reply is extracted safely respecting
-// Markdown block boundaries via extractFinalReplyText.
 const lastProcessPartIndex = computed(() =>
   props.parts.findLastIndex(
     (part) =>
@@ -73,38 +63,13 @@ const expanded = computed(() => {
   return props.traceKey ? expandedTraces.has(props.traceKey) : localExpanded.value;
 });
 
-const finalReplyText = computed(() =>
-  props.collapsedReplyText !== undefined
-    ? props.collapsedReplyText
-    : extractFinalReplyText(props.parts, { presentation: presentation.value }),
+const visibleItems = computed(() =>
+  expanded.value || !collapsible.value
+    ? presentation.value.nodes
+    : presentation.value.finalReplyNodes,
 );
-
-// Collapsed view: directly construct a single text presentation item from the
-// Markdown-safe trailing reply text. When expanded (or when the turn has no
-// process to fold), deriveTurnPresentation provides the full interleaved layout.
- const visibleItems = computed(() => {
-   if (expanded.value || !collapsible.value) return presentation.value;
-  const text = finalReplyText.value;
-   if (!text.trim()) return [];
-   return [
-     {
-       key: "collapsed-final-reply",
-       type: "text" as const,
-       text,
-       isLatest: false,
-     },
-   ];
- });
-const toolCount = computed(() =>
-  props.collapsedToolCount !== undefined
-    ? props.collapsedToolCount
-    : presentation.value.filter((item) => item.type === "tool" || item.type === "subagent").length,
-);
-const thoughtCount = computed(() =>
-  props.collapsedThoughtCount !== undefined
-    ? props.collapsedThoughtCount
-    : presentation.value.filter((item) => item.type === "reasoning").length,
-);
+const toolCount = computed(() => presentation.value.toolCount);
+const thoughtCount = computed(() => presentation.value.thoughtCount);
 
 function formatElapsed(ms: number): string {
   if (ms < 1000) return locale.value.startsWith("zh") ? "<1秒" : "<1s";
@@ -150,8 +115,8 @@ function toggleTrace(): void {
       <span data-test="trace-label">{{ headerLabel }}</span>
     </button>
     <template v-for="item in visibleItems" :key="item.key">
-      <StreamMarkdown v-if="item.type === 'text'" data-test="turn-narrative"
-                      :text="item.text" :streaming="streaming === true && item.isLatest"
+      <StreamMarkdown v-if="item.type === 'markdown'" data-test="turn-narrative"
+                      :rendered-html="item.html" :streaming="streaming === true && item.isLatest"
                       class="text-[14px] leading-relaxed text-fg"
                       :class="streaming === true && item.isLatest ? 'caret' : ''" />
       <ReasoningPanel v-else-if="item.type === 'reasoning'"
@@ -164,7 +129,7 @@ function toggleTrace(): void {
       <div v-else-if="item.type === 'agent-message'" data-test="turn-agent-message">
         <AgentMessageCard :message="item.message" anchored />
       </div>
-      <SubagentStepCard v-else :step="item.step" :children="item.children" :ensure-full="ensureFull" />
+      <SubagentStepCard v-else-if="item.type === 'subagent'" :step="item.step" :children="item.children" :ensure-full="ensureFull" />
     </template>
   </div>
 </template>

--- a/packages/relay-web/src/lib/markdown-inline-markers.ts
+++ b/packages/relay-web/src/lib/markdown-inline-markers.ts
@@ -240,7 +240,12 @@ function splitAndRender(
     if (token.type === "turn_activity_marker") {
       const marker = markersById.get(token.content);
       if (!marker) return null;
-      fragmentTokens.push(...openStack.toReversed().map(syntheticClose));
+      // Reverse-index loop, not toReversed(): the latter needs Chrome 110+ /
+      // Firefox 115+ / Safari 16+, while the codebase baseline (findLast)
+      // only requires Chrome 97+ / Firefox 104+ / Safari 15.4+.
+      for (let index = openStack.length - 1; index >= 0; index -= 1) {
+        fragmentTokens.push(syntheticClose(openStack[index]!));
+      }
       pushFragment(marker.offset);
       activityIds.push(marker.id);
       fragmentStart = marker.offset;

--- a/packages/relay-web/src/lib/markdown-inline-markers.ts
+++ b/packages/relay-web/src/lib/markdown-inline-markers.ts
@@ -1,0 +1,283 @@
+import type Token from "markdown-it/lib/token.mjs";
+import {
+  parseMarkdownInline,
+  preprocessMarkdownSource,
+  renderMarkdownInlineFragment,
+  type RenderMarkdownOptions,
+} from "./render-markdown";
+
+const MARKER_OPEN = "\uE000";
+const MARKER_CLOSE = "\uE001";
+let nextMarkerNonce = 0;
+
+export interface InlineActivityMarker {
+  id: string;
+  offset: number;
+}
+
+export interface InlineMarkdownFragment {
+  sourceRange: [number, number];
+  source: string;
+  html: string;
+}
+
+export interface InlineMarkerPlan {
+  fragments: InlineMarkdownFragment[];
+  activityIds: string[];
+}
+
+interface EncodedMarker extends InlineActivityMarker {
+  encoded: string;
+}
+
+interface SemanticToken {
+  type: string;
+  tag: string;
+  nesting: number;
+  content: string;
+  attrs: string;
+  markup: string;
+  info: string;
+}
+
+function cloneToken(token: Token, overrides: Partial<Token> = {}): Token {
+  return Object.assign(
+    Object.create(Object.getPrototypeOf(token)) as Token,
+    token,
+    {
+      attrs: token.attrs?.map(([name, value]) => [name, value] as [string, string]) ?? null,
+      children: token.children ? [...token.children] : null,
+    },
+    overrides,
+  );
+}
+
+function encodeMarkers(markers: readonly InlineActivityMarker[]): EncodedMarker[] | null {
+  const seen = new Set<string>();
+  let previousOffset = -1;
+  for (const marker of markers) {
+    if (marker.offset < previousOffset || seen.has(marker.id)) return null;
+    previousOffset = marker.offset;
+    seen.add(marker.id);
+  }
+  const nonce = (nextMarkerNonce++).toString(36);
+  return markers.map((marker, index) => ({
+    ...marker,
+    encoded: `${MARKER_OPEN}${nonce}.${index.toString(36)}${MARKER_CLOSE}`,
+  }));
+}
+
+function injectMarkers(source: string, markers: readonly EncodedMarker[]): string | null {
+  if (source.includes(MARKER_OPEN) || source.includes(MARKER_CLOSE)) return null;
+  let result = "";
+  let cursor = 0;
+  for (const marker of markers) {
+    if (marker.offset < 0 || marker.offset > source.length) return null;
+    result += source.slice(cursor, marker.offset);
+    result += marker.encoded;
+    cursor = marker.offset;
+  }
+  return result + source.slice(cursor);
+}
+
+function markerToken(token: Token, marker: EncodedMarker): Token {
+  return cloneToken(token, {
+    type: "turn_activity_marker",
+    tag: "",
+    nesting: 0,
+    content: marker.id,
+    markup: "",
+    info: "",
+    attrs: null,
+    children: null,
+    meta: { activityId: marker.id, sourceOffset: marker.offset },
+  });
+}
+
+function extractMarkerTokens(
+  tokens: readonly Token[],
+  markers: readonly EncodedMarker[],
+): { tokens: Token[]; activityIds: string[] } {
+  const byEncoding = new Map(markers.map((marker) => [marker.encoded, marker]));
+  const encodings = markers.map((marker) => marker.encoded);
+  const result: Token[] = [];
+  const activityIds: string[] = [];
+
+  for (const token of tokens) {
+    if (token.type !== "text" && token.type !== "code_inline") {
+      result.push(token);
+      continue;
+    }
+    let cursor = 0;
+    let found = false;
+    while (cursor < token.content.length) {
+      let nextIndex = -1;
+      let nextEncoding = "";
+      for (const encoding of encodings) {
+        const index = token.content.indexOf(encoding, cursor);
+        if (index >= 0 && (nextIndex < 0 || index < nextIndex)) {
+          nextIndex = index;
+          nextEncoding = encoding;
+        }
+      }
+      if (nextIndex < 0) break;
+      found = true;
+      if (nextIndex > cursor) {
+        result.push(cloneToken(token, { content: token.content.slice(cursor, nextIndex) }));
+      }
+      const marker = byEncoding.get(nextEncoding)!;
+      result.push(markerToken(token, marker));
+      activityIds.push(marker.id);
+      cursor = nextIndex + nextEncoding.length;
+    }
+    if (!found) {
+      result.push(token);
+    } else if (cursor < token.content.length) {
+      result.push(cloneToken(token, { content: token.content.slice(cursor) }));
+    }
+  }
+
+  return { tokens: result, activityIds };
+}
+
+function semanticTokens(tokens: readonly Token[]): SemanticToken[] {
+  const result: SemanticToken[] = [];
+  for (const token of tokens) {
+    if (token.type === "turn_activity_marker") continue;
+    const semantic: SemanticToken = {
+      type: token.type,
+      tag: token.tag,
+      nesting: token.nesting,
+      content: token.content,
+      attrs: token.attrs ? JSON.stringify(token.attrs) : "",
+      markup: token.markup,
+      info: token.info,
+    };
+    const previous = result[result.length - 1];
+    if (
+      previous
+      && (semantic.type === "text" || semantic.type === "code_inline")
+      && previous.type === semantic.type
+      && previous.tag === semantic.tag
+      && previous.nesting === semantic.nesting
+      && previous.attrs === semantic.attrs
+      && previous.markup === semantic.markup
+      && previous.info === semantic.info
+    ) {
+      previous.content += semantic.content;
+    } else {
+      result.push(semantic);
+    }
+  }
+  return result;
+}
+
+function semanticTokensEqual(left: readonly Token[], right: readonly Token[]): boolean {
+  return JSON.stringify(semanticTokens(left)) === JSON.stringify(semanticTokens(right));
+}
+
+function syntheticClose(open: Token): Token {
+  return cloneToken(open, {
+    type: open.type.endsWith("_open")
+      ? `${open.type.slice(0, -5)}_close`
+      : open.type,
+    nesting: -1,
+    attrs: null,
+  });
+}
+
+function hasRenderableContent(tokens: readonly Token[]): boolean {
+  return tokens.some((token) =>
+    token.nesting === 0
+    && (token.type !== "text" || token.content.trim().length > 0),
+  );
+}
+
+function splitAndRender(
+  source: string,
+  tokens: readonly Token[],
+  markersById: ReadonlyMap<string, EncodedMarker>,
+  env: Record<string, unknown>,
+): InlineMarkerPlan | null {
+  const fragments: InlineMarkdownFragment[] = [];
+  const activityIds: string[] = [];
+  const openStack: Token[] = [];
+  let fragmentTokens: Token[] = [];
+  let fragmentStart = 0;
+
+  const pushFragment = (end: number): void => {
+    if (end <= fragmentStart) return;
+    const sourceFragment = source.slice(fragmentStart, end);
+    fragments.push({
+      sourceRange: [fragmentStart, end],
+      source: sourceFragment,
+      html: hasRenderableContent(fragmentTokens)
+        ? renderMarkdownInlineFragment(fragmentTokens, env)
+        : "",
+    });
+  };
+
+  for (const token of tokens) {
+    if (token.type === "turn_activity_marker") {
+      const marker = markersById.get(token.content);
+      if (!marker) return null;
+      fragmentTokens.push(...openStack.toReversed().map(syntheticClose));
+      pushFragment(marker.offset);
+      activityIds.push(marker.id);
+      fragmentStart = marker.offset;
+      fragmentTokens = openStack.map((open) => cloneToken(open));
+      continue;
+    }
+
+    fragmentTokens.push(token);
+    if (token.nesting === 1) {
+      openStack.push(token);
+    } else if (token.nesting === -1) {
+      const open = openStack.pop();
+      if (!open || open.tag !== token.tag) return null;
+    }
+  }
+
+  if (openStack.length !== 0) return null;
+  pushFragment(source.length);
+  return { fragments, activityIds };
+}
+
+/**
+ * Parse a complete paragraph with zero-width activity markers, prove that removing
+ * those markers preserves the original semantic token stream, then materialize
+ * independently valid HTML fragments by closing and reopening the active inline stack.
+ */
+export function planInlineActivityMarkers(
+  paragraphSource: string,
+  markers: readonly InlineActivityMarker[],
+  documentEnv: Record<string, unknown> = {},
+  options: RenderMarkdownOptions = {},
+): InlineMarkerPlan | null {
+  if (markers.length === 0) return null;
+  const encodedMarkers = encodeMarkers(markers);
+  if (!encodedMarkers) return null;
+  const markedSource = injectMarkers(paragraphSource, encodedMarkers);
+  if (markedSource === null) return null;
+
+  const originalPrepared = preprocessMarkdownSource(paragraphSource, options);
+  const markedPrepared = preprocessMarkdownSource(markedSource, options);
+  const originalTokens = parseMarkdownInline(originalPrepared, { ...documentEnv });
+  const markedTokens = parseMarkdownInline(markedPrepared, { ...documentEnv });
+  const extracted = extractMarkerTokens(markedTokens, encodedMarkers);
+  const expectedIds = markers.map((marker) => marker.id);
+  if (
+    extracted.activityIds.length !== expectedIds.length
+    || extracted.activityIds.some((id, index) => id !== expectedIds[index])
+    || !semanticTokensEqual(originalTokens, extracted.tokens)
+  ) {
+    return null;
+  }
+
+  return splitAndRender(
+    paragraphSource,
+    extracted.tokens,
+    new Map(encodedMarkers.map((marker) => [marker.id, marker])),
+    documentEnv,
+  );
+}

--- a/packages/relay-web/src/lib/markdown-inline-markers.ts
+++ b/packages/relay-web/src/lib/markdown-inline-markers.ts
@@ -19,6 +19,13 @@ export interface InlineMarkdownFragment {
   sourceRange: [number, number];
   source: string;
   html: string;
+  /**
+   * Standalone copy representation derived from the fragment's own inline
+   * tokens (text/code content, breaks as newlines, markup delimiters dropped),
+   * so copying a fragment cut out of an inline construct never ships a
+   * dangling `**`, backtick, or link destination.
+   */
+  copyText: string;
 }
 
 export interface InlineMarkerPlan {
@@ -199,6 +206,22 @@ function hasRenderableContent(tokens: readonly Token[]): boolean {
   );
 }
 
+function fragmentCopyText(tokens: readonly Token[]): string {
+  // Tokens here are the fragment's own inline stream (already synthetic-closed
+  // and reopened by splitAndRender): text/code content is user-visible,
+  // softbreaks/hardbreaks are line breaks, everything else (strong/link/code
+  // delimiters, markers) is markup, not copyable content.
+  const parts: string[] = [];
+  for (const token of tokens) {
+    if (token.type === "text" || token.type === "code_inline") {
+      parts.push(token.content);
+    } else if (token.type === "softbreak" || token.type === "hardbreak") {
+      parts.push("\n");
+    }
+  }
+  return parts.join("");
+}
+
 function splitAndRender(
   source: string,
   tokens: readonly Token[],
@@ -220,6 +243,7 @@ function splitAndRender(
       html: hasRenderableContent(fragmentTokens)
         ? renderMarkdownInlineFragment(fragmentTokens, env)
         : "",
+      copyText: fragmentCopyText(fragmentTokens),
     });
   };
 

--- a/packages/relay-web/src/lib/markdown-inline-markers.ts
+++ b/packages/relay-web/src/lib/markdown-inline-markers.ts
@@ -1,5 +1,6 @@
 import type Token from "markdown-it/lib/token.mjs";
 import {
+  markdownTokensToPlainText,
   parseMarkdownInline,
   preprocessMarkdownSource,
   renderMarkdownInlineFragment,
@@ -92,7 +93,6 @@ function isInsideHtmlLikeSyntax(source: string, offset: number): boolean {
   const close = source.lastIndexOf(">", Math.max(0, offset - 1));
   return open > close && source.indexOf(">", offset) >= 0;
 }
-
 function markerToken(token: Token, marker: EncodedMarker): Token {
   return cloneToken(token, {
     type: "turn_activity_marker",
@@ -111,8 +111,11 @@ function extractMarkerTokens(
   tokens: readonly Token[],
   markers: readonly EncodedMarker[],
 ): { tokens: Token[]; activityIds: string[] } {
+  // Single linear scan: every encoded marker starts with MARKER_OPEN and ends
+  // at the next MARKER_CLOSE, so one indexOf pair per occurrence finds the
+  // next candidate and a Map lookup validates it. The previous version probed
+  // every encoding at every position (O(markers) indexOf calls per hit).
   const byEncoding = new Map(markers.map((marker) => [marker.encoded, marker]));
-  const encodings = markers.map((marker) => marker.encoded);
   const result: Token[] = [];
   const activityIds: string[] = [];
 
@@ -124,24 +127,20 @@ function extractMarkerTokens(
     let cursor = 0;
     let found = false;
     while (cursor < token.content.length) {
-      let nextIndex = -1;
-      let nextEncoding = "";
-      for (const encoding of encodings) {
-        const index = token.content.indexOf(encoding, cursor);
-        if (index >= 0 && (nextIndex < 0 || index < nextIndex)) {
-          nextIndex = index;
-          nextEncoding = encoding;
-        }
-      }
-      if (nextIndex < 0) break;
+      const openIndex = token.content.indexOf(MARKER_OPEN, cursor);
+      if (openIndex < 0) break;
+      const closeIndex = token.content.indexOf(MARKER_CLOSE, openIndex + MARKER_OPEN.length);
+      if (closeIndex < 0) break;
+      const candidate = token.content.slice(openIndex, closeIndex + MARKER_CLOSE.length);
+      const marker = byEncoding.get(candidate);
+      if (!marker) break;
       found = true;
-      if (nextIndex > cursor) {
-        result.push(cloneToken(token, { content: token.content.slice(cursor, nextIndex) }));
+      if (openIndex > cursor) {
+        result.push(cloneToken(token, { content: token.content.slice(cursor, openIndex) }));
       }
-      const marker = byEncoding.get(nextEncoding)!;
       result.push(markerToken(token, marker));
       activityIds.push(marker.id);
-      cursor = nextIndex + nextEncoding.length;
+      cursor = openIndex + candidate.length;
     }
     if (!found) {
       result.push(token);
@@ -207,19 +206,9 @@ function hasRenderableContent(tokens: readonly Token[]): boolean {
 }
 
 function fragmentCopyText(tokens: readonly Token[]): string {
-  // Tokens here are the fragment's own inline stream (already synthetic-closed
-  // and reopened by splitAndRender): text/code content is user-visible,
-  // softbreaks/hardbreaks are line breaks, everything else (strong/link/code
-  // delimiters, markers) is markup, not copyable content.
-  const parts: string[] = [];
-  for (const token of tokens) {
-    if (token.type === "text" || token.type === "code_inline") {
-      parts.push(token.content);
-    } else if (token.type === "softbreak" || token.type === "hardbreak") {
-      parts.push("\n");
-    }
-  }
-  return parts.join("");
+  // Fragments reuse the single Copy contract: the fragment's own inline
+  // stream (already synthetic-closed/reopened) serialized as plaintext.
+  return markdownTokensToPlainText(tokens);
 }
 
 function splitAndRender(

--- a/packages/relay-web/src/lib/markdown-inline-markers.ts
+++ b/packages/relay-web/src/lib/markdown-inline-markers.ts
@@ -80,6 +80,12 @@ function injectMarkers(source: string, markers: readonly EncodedMarker[]): strin
   return result + source.slice(cursor);
 }
 
+function isInsideHtmlLikeSyntax(source: string, offset: number): boolean {
+  const open = source.lastIndexOf("<", Math.max(0, offset - 1));
+  const close = source.lastIndexOf(">", Math.max(0, offset - 1));
+  return open > close && source.indexOf(">", offset) >= 0;
+}
+
 function markerToken(token: Token, marker: EncodedMarker): Token {
   return cloneToken(token, {
     type: "turn_activity_marker",
@@ -255,6 +261,9 @@ export function planInlineActivityMarkers(
   options: RenderMarkdownOptions = {},
 ): InlineMarkerPlan | null {
   if (markers.length === 0) return null;
+  if (markers.some((marker) => isInsideHtmlLikeSyntax(paragraphSource, marker.offset))) {
+    return null;
+  }
   const encodedMarkers = encodeMarkers(markers);
   if (!encodedMarkers) return null;
   const markedSource = injectMarkers(paragraphSource, encodedMarkers);

--- a/packages/relay-web/src/lib/markdown-layout.ts
+++ b/packages/relay-web/src/lib/markdown-layout.ts
@@ -185,6 +185,7 @@ function renderLayoutBlock(
 
   if (markerPlan && inlineStart !== null) {
     pushMarkdownNode(nodes, narrative, block.startOffset, inlineStart, "", "");
+    const firstFragmentIndex = nodes.length;
     for (const fragment of markerPlan.fragments) {
       pushMarkdownNode(
         nodes,
@@ -194,6 +195,20 @@ function renderLayoutBlock(
         fragment.html,
         fragment.copyText,
       );
+    }
+    // Marker fragments serialize inline tokens only, so they never see the
+    // block-level terminator (paragraph_close → "\n\n"). Reattach it to the
+    // last fragment from the block's own tokens, but only when proven: the
+    // fragment join must be an exact prefix of the whole-block serialization
+    // (under streaming healing it may not be — then keep today's behavior
+    // and append nothing; layout is never affected, only this copy suffix).
+    if (nodes.length > firstFragmentIndex) {
+      const fragmentCopy = markerPlan.fragments.map((fragment) => fragment.copyText).join("");
+      const wholeCopy = markdownTokensToPlainText(block.tokens);
+      if (wholeCopy.startsWith(fragmentCopy) && wholeCopy.length > fragmentCopy.length) {
+        const last = nodes[nodes.length - 1]!;
+        last.copyText += wholeCopy.slice(fragmentCopy.length);
+      }
     }
     const inlineEnd = inlineStart + inlineSource!.length;
     pushMarkdownNode(nodes, narrative, inlineEnd, block.endOffset, "", "");

--- a/packages/relay-web/src/lib/markdown-layout.ts
+++ b/packages/relay-web/src/lib/markdown-layout.ts
@@ -1,0 +1,194 @@
+import { planInlineActivityMarkers } from "./markdown-inline-markers";
+import { normalizeMarkdownTables } from "./normalize-markdown";
+import {
+  analyzeMarkdownDocument,
+  preprocessMarkdownSource,
+  renderMarkdown,
+  renderMarkdownTokens,
+  type RenderMarkdownOptions,
+  type TopLevelBlockInfo,
+} from "./render-markdown";
+import type {
+  LayoutActivityGeometry,
+  LayoutSlotCandidate,
+  MarkdownLayoutNode,
+} from "./turn-layout";
+
+export interface MarkdownLayoutOptions extends RenderMarkdownOptions {
+  latestVisibleIsText?: boolean;
+}
+
+export interface MarkdownLayoutGeometry {
+  markdownNodes: MarkdownLayoutNode[];
+  candidates: Map<string, LayoutSlotCandidate>;
+}
+
+function renderAtomicBlock(
+  block: TopLevelBlockInfo,
+  env: Record<string, unknown>,
+  streaming: boolean,
+): string {
+  return preprocessMarkdownSource(block.source, { streaming }) === block.source
+    ? renderMarkdownTokens(block.tokens, env)
+    : renderMarkdown(block.source, { streaming });
+}
+
+function pushMarkdownNode(
+  nodes: MarkdownLayoutNode[],
+  narrative: string,
+  start: number,
+  end: number,
+  html: string,
+): void {
+  if (end <= start) return;
+  nodes.push({
+    type: "markdown",
+    key: `markdown:${start}:${end}`,
+    sourceRange: [start, end],
+    source: narrative.slice(start, end),
+    html,
+    isLatest: false,
+  });
+}
+
+function activitiesInside(
+  activities: readonly LayoutActivityGeometry[],
+  start: number,
+  end: number,
+): LayoutActivityGeometry[] {
+  return activities.filter((activity) =>
+    activity.sourceOffset > start && activity.sourceOffset < end,
+  );
+}
+
+/**
+ * Analyze Markdown once, derive legal slots, and pre-render a complete source-range
+ * partition. Only top-level paragraphs may contain exact inline activity markers;
+ * every structural block remains atomic.
+ */
+export function deriveMarkdownLayout(
+  narrative: string,
+  activities: readonly LayoutActivityGeometry[],
+  options: MarkdownLayoutOptions = {},
+): MarkdownLayoutGeometry {
+  const document = analyzeMarkdownDocument(narrative);
+  const candidates = new Map<string, LayoutSlotCandidate>();
+  const markdownNodes: MarkdownLayoutNode[] = [];
+  let cursor = 0;
+
+  document.blocks.forEach((block, blockIndex) => {
+    pushMarkdownNode(markdownNodes, narrative, cursor, block.startOffset, "");
+    const internalActivities = activitiesInside(
+      activities,
+      block.startOffset,
+      block.endOffset,
+    );
+    const trailingSource = narrative.slice(block.endOffset);
+    const streamingBlock = options.streaming === true
+      && options.latestVisibleIsText === true
+      && trailingSource.trim().length === 0;
+    const normalized = normalizeMarkdownTables(block.source) !== block.source;
+    const inlineSource = block.type === "paragraph_open" && !normalized
+      ? block.inlineSource
+      : null;
+    const markers = inlineSource === null
+      ? []
+      : internalActivities
+        .filter((activity) => activity.sourceOffset - block.startOffset <= inlineSource.length)
+        .map((activity) => ({
+          id: activity.id,
+          offset: activity.sourceOffset - block.startOffset,
+        }));
+    const markerPlan = markers.length === internalActivities.length && markers.length > 0
+      ? planInlineActivityMarkers(inlineSource!, markers, document.env, {
+        streaming: streamingBlock,
+      })
+      : null;
+
+    if (markerPlan) {
+      for (const fragment of markerPlan.fragments) {
+        pushMarkdownNode(
+          markdownNodes,
+          narrative,
+          block.startOffset + fragment.sourceRange[0],
+          block.startOffset + fragment.sourceRange[1],
+          fragment.html,
+        );
+      }
+      const inlineEnd = block.startOffset + inlineSource!.length;
+      pushMarkdownNode(markdownNodes, narrative, inlineEnd, block.endOffset, "");
+      for (const activity of internalActivities) {
+        candidates.set(activity.id, {
+          sourceOffset: activity.sourceOffset,
+          kind: "exact-inline",
+          reason: "exact",
+        });
+      }
+    } else {
+      pushMarkdownNode(
+        markdownNodes,
+        narrative,
+        block.startOffset,
+        block.endOffset,
+        renderAtomicBlock(block, document.env, streamingBlock),
+      );
+      const boundary = document.boundaries[blockIndex] ?? block.endOffset;
+      for (const activity of internalActivities) {
+        candidates.set(activity.id, {
+          sourceOffset: boundary,
+          kind: "block-end",
+          reason: inlineSource !== null && !normalized
+            ? "marker-unsafe"
+            : "structural-block",
+        });
+      }
+    }
+    cursor = block.endOffset;
+  });
+  pushMarkdownNode(markdownNodes, narrative, cursor, narrative.length, "");
+
+  for (const activity of activities) {
+    if (candidates.has(activity.id)) continue;
+    if (activity.sourceOffset === 0) {
+      candidates.set(activity.id, {
+        sourceOffset: 0,
+        kind: "document-start",
+        reason: "exact",
+      });
+      continue;
+    }
+    if (activity.sourceOffset === narrative.length) {
+      candidates.set(activity.id, {
+        sourceOffset: narrative.length,
+        kind: "document-end",
+        reason: "exact",
+      });
+      continue;
+    }
+    const gap = markdownNodes.find((node) =>
+      activity.sourceOffset >= node.sourceRange[0]
+      && activity.sourceOffset <= node.sourceRange[1]
+      && node.html === ""
+      && node.source.trim().length === 0,
+    );
+    if (gap) {
+      candidates.set(activity.id, {
+        sourceOffset: activity.sourceOffset,
+        kind: "block-end",
+        reason: "exact",
+      });
+      continue;
+    }
+    candidates.set(activity.id, {
+      sourceOffset: narrative.length,
+      kind: "document-end",
+      reason: "structural-block",
+    });
+  }
+
+  const latestMarkdown = markdownNodes.findLast((node) => node.html.trim().length > 0);
+  if (latestMarkdown && options.streaming && options.latestVisibleIsText) {
+    latestMarkdown.isLatest = true;
+  }
+  return { markdownNodes, candidates };
+}

--- a/packages/relay-web/src/lib/markdown-layout.ts
+++ b/packages/relay-web/src/lib/markdown-layout.ts
@@ -30,19 +30,30 @@ export interface MarkdownLayoutGeometry {
  * Fingerprint of the document-wide reference universe: reference definitions
  * live outside any single block but change what every link block renders, so
  * a block cache entry is only reusable while this fingerprint is unchanged.
+ * JSON-encoded so hrefs/titles containing `#`, `|`, or `=` cannot collide.
  */
 export function referenceEnvFingerprint(env: Record<string, unknown>): string {
   const references = env["references"];
-  if (!references || typeof references !== "object") return "";
+  if (!references || typeof references !== "object") return "[]";
   const table = references as Record<string, { href?: unknown; title?: unknown }>;
-  return Object.keys(table).sort()
-    .map((label) => {
-      const entry = table[label];
-      const href = typeof entry?.href === "string" ? entry.href : "";
-      const title = typeof entry?.title === "string" ? entry.title : "";
-      return `${label}=${href}#${title}`;
-    })
-    .join("|");
+  return JSON.stringify(Object.keys(table).sort().map((label) => {
+    const entry = table[label];
+    return [
+      label,
+      typeof entry?.href === "string" ? entry.href : "",
+      typeof entry?.title === "string" ? entry.title : "",
+    ];
+  }));
+}
+
+/**
+ * Fingerprint of a block's activity geometry. JSON-encoded so provider
+ * toolCallIds containing `@` or `,` cannot collide across splits.
+ */
+export function activityGeometryFingerprint(
+  activities: readonly LayoutActivityGeometry[],
+): string {
+  return JSON.stringify(activities.map((activity) => [activity.id, activity.sourceOffset]));
 }
 
 const MAX_INLINE_PARAGRAPH_CHARS = 50_000;
@@ -198,6 +209,7 @@ export function deriveMarkdownLayout(
   const references = referenceEnvFingerprint(document.env);
   const candidates = new Map<string, LayoutSlotCandidate>();
   const markdownNodes: MarkdownLayoutNode[] = [];
+  const liveBlockKeys = new Set<string>();
   const activitiesByBlock = document.blocks.map((): LayoutActivityGeometry[] => []);
   let activityBlockIndex = 0;
   for (const activity of activities) {
@@ -235,10 +247,11 @@ export function deriveMarkdownLayout(
     // entry — node sourceRanges and candidate slots are absolute. Sharing
     // only happens for the same block across frames (streaming appends).
     const cacheKey = blockCache ? `block:${block.startOffset}:${block.endOffset}` : null;
+    if (cacheKey) liveBlockKeys.add(cacheKey);
     const fingerprint: TurnLayoutBlockFingerprint | null = blockCache
       ? {
         source: block.source,
-        activityIds: internalActivities.map((activity) => `${activity.id}@${activity.sourceOffset}`).join(","),
+        activityIds: activityGeometryFingerprint(internalActivities),
         streaming: streamingBlock,
         references,
       }
@@ -284,6 +297,15 @@ export function deriveMarkdownLayout(
     cursor = block.endOffset;
   });
   pushMarkdownNode(markdownNodes, narrative, cursor, narrative.length, "", "");
+  if (blockCache) {
+    // A growing streaming tail mints a new `block:start:end` key every frame;
+    // without pruning, every historical tail length (with its full html/copy
+    // strings) would accumulate for the component's lifetime. The cache may
+    // only hold this frame's blocks.
+    for (const key of [...blockCache.keys()]) {
+      if (!liveBlockKeys.has(key)) blockCache.delete(key);
+    }
+  }
 
   const markdownBoundaries = new Set<number>([0, narrative.length]);
   for (const node of markdownNodes) {

--- a/packages/relay-web/src/lib/markdown-layout.ts
+++ b/packages/relay-web/src/lib/markdown-layout.ts
@@ -3,8 +3,8 @@ import { normalizeMarkdownTables } from "./normalize-markdown";
 import {
   analyzeMarkdownDocument,
   preprocessMarkdownSource,
-  renderMarkdown,
   renderMarkdownTokens,
+  renderMarkdownWithEnv,
   type RenderMarkdownOptions,
   type TopLevelBlockInfo,
 } from "./render-markdown";
@@ -31,9 +31,10 @@ function renderAtomicBlock(
   env: Record<string, unknown>,
   streaming: boolean,
 ): string {
-  return preprocessMarkdownSource(block.source, { streaming }) === block.source
-    ? renderMarkdownTokens(block.tokens, env)
-    : renderMarkdown(block.source, { streaming });
+  if (preprocessMarkdownSource(block.source, { streaming }) === block.source) {
+    return renderMarkdownTokens(block.tokens, env);
+  }
+  return renderMarkdownWithEnv(block.source, { streaming }, env);
 }
 
 function pushMarkdownNode(
@@ -42,14 +43,17 @@ function pushMarkdownNode(
   start: number,
   end: number,
   html: string,
+  copyText?: string,
 ): void {
   if (end <= start) return;
+  const source = narrative.slice(start, end);
   nodes.push({
     type: "markdown",
     key: `markdown:${start}:${end}`,
     sourceRange: [start, end],
-    source: narrative.slice(start, end),
+    source,
     html,
+    copyText: copyText ?? source,
     isLatest: false,
   });
 }
@@ -101,36 +105,46 @@ export function deriveMarkdownLayout(
       && options.latestVisibleIsText === true
       && block.endOffset >= lastNonWhitespaceOffset;
     const normalized = normalizeMarkdownTables(block.source) !== block.source;
+    // The marker planner only understands proven inline coordinates: an
+    // unprovable projection (null) or any activity in the trimmed edge gap
+    // stays atomic instead of guessing a coordinate.
     const inlineSource = block.type === "paragraph_open" && !normalized
+      && block.inlineSource !== null
+      && block.inlineStartOffset !== null
       ? block.inlineSource
       : null;
-    const markers = inlineSource === null
+    const inlineStart = inlineSource === null ? null : block.inlineStartOffset;
+    const markers = inlineSource === null || inlineStart === null
       ? []
       : internalActivities
-        .filter((activity) => activity.sourceOffset - block.startOffset <= inlineSource.length)
+        .filter((activity) => activity.sourceOffset >= inlineStart
+          && activity.sourceOffset - inlineStart <= inlineSource.length)
         .map((activity) => ({
           id: activity.id,
-          offset: activity.sourceOffset - block.startOffset,
+          offset: activity.sourceOffset - inlineStart,
         }));
     const markerPlan = markers.length === internalActivities.length && markers.length > 0
-      && inlineSource!.length <= MAX_INLINE_PARAGRAPH_CHARS
+      && inlineSource !== null && inlineStart !== null
+      && inlineSource.length <= MAX_INLINE_PARAGRAPH_CHARS
       && markers.length <= MAX_INLINE_MARKERS_PER_PARAGRAPH
-      ? planInlineActivityMarkers(inlineSource!, markers, document.env, {
+      ? planInlineActivityMarkers(inlineSource, markers, document.env, {
         streaming: streamingBlock,
       })
       : null;
 
-    if (markerPlan) {
+    if (markerPlan && inlineStart !== null) {
+      pushMarkdownNode(markdownNodes, narrative, block.startOffset, inlineStart, "");
       for (const fragment of markerPlan.fragments) {
         pushMarkdownNode(
           markdownNodes,
           narrative,
-          block.startOffset + fragment.sourceRange[0],
-          block.startOffset + fragment.sourceRange[1],
+          inlineStart + fragment.sourceRange[0],
+          inlineStart + fragment.sourceRange[1],
           fragment.html,
+          fragment.copyText,
         );
       }
-      const inlineEnd = block.startOffset + inlineSource!.length;
+      const inlineEnd = inlineStart + inlineSource!.length;
       pushMarkdownNode(markdownNodes, narrative, inlineEnd, block.endOffset, "");
       for (const activity of internalActivities) {
         candidates.set(activity.id, {

--- a/packages/relay-web/src/lib/markdown-layout.ts
+++ b/packages/relay-web/src/lib/markdown-layout.ts
@@ -23,6 +23,9 @@ export interface MarkdownLayoutGeometry {
   candidates: Map<string, LayoutSlotCandidate>;
 }
 
+const MAX_INLINE_PARAGRAPH_CHARS = 50_000;
+const MAX_INLINE_MARKERS_PER_PARAGRAPH = 256;
+
 function renderAtomicBlock(
   block: TopLevelBlockInfo,
   env: Record<string, unknown>,
@@ -51,16 +54,6 @@ function pushMarkdownNode(
   });
 }
 
-function activitiesInside(
-  activities: readonly LayoutActivityGeometry[],
-  start: number,
-  end: number,
-): LayoutActivityGeometry[] {
-  return activities.filter((activity) =>
-    activity.sourceOffset > start && activity.sourceOffset < end,
-  );
-}
-
 /**
  * Analyze Markdown once, derive legal slots, and pre-render a complete source-range
  * partition. Only top-level paragraphs may contain exact inline activity markers;
@@ -74,19 +67,39 @@ export function deriveMarkdownLayout(
   const document = analyzeMarkdownDocument(narrative);
   const candidates = new Map<string, LayoutSlotCandidate>();
   const markdownNodes: MarkdownLayoutNode[] = [];
+  const activitiesByBlock = document.blocks.map((): LayoutActivityGeometry[] => []);
+  let activityBlockIndex = 0;
+  for (const activity of activities) {
+    while (
+      activityBlockIndex < document.blocks.length
+      && activity.sourceOffset >= document.blocks[activityBlockIndex]!.endOffset
+    ) {
+      activityBlockIndex += 1;
+    }
+    const block = document.blocks[activityBlockIndex];
+    if (
+      block
+      && activity.sourceOffset > block.startOffset
+      && activity.sourceOffset < block.endOffset
+    ) {
+      activitiesByBlock[activityBlockIndex]!.push(activity);
+    }
+  }
   let cursor = 0;
+  let lastNonWhitespaceOffset = narrative.length;
+  while (
+    lastNonWhitespaceOffset > 0
+    && /\s/.test(narrative[lastNonWhitespaceOffset - 1]!)
+  ) {
+    lastNonWhitespaceOffset -= 1;
+  }
 
   document.blocks.forEach((block, blockIndex) => {
     pushMarkdownNode(markdownNodes, narrative, cursor, block.startOffset, "");
-    const internalActivities = activitiesInside(
-      activities,
-      block.startOffset,
-      block.endOffset,
-    );
-    const trailingSource = narrative.slice(block.endOffset);
+    const internalActivities = activitiesByBlock[blockIndex]!;
     const streamingBlock = options.streaming === true
       && options.latestVisibleIsText === true
-      && trailingSource.trim().length === 0;
+      && block.endOffset >= lastNonWhitespaceOffset;
     const normalized = normalizeMarkdownTables(block.source) !== block.source;
     const inlineSource = block.type === "paragraph_open" && !normalized
       ? block.inlineSource
@@ -100,6 +113,8 @@ export function deriveMarkdownLayout(
           offset: activity.sourceOffset - block.startOffset,
         }));
     const markerPlan = markers.length === internalActivities.length && markers.length > 0
+      && inlineSource!.length <= MAX_INLINE_PARAGRAPH_CHARS
+      && markers.length <= MAX_INLINE_MARKERS_PER_PARAGRAPH
       ? planInlineActivityMarkers(inlineSource!, markers, document.env, {
         streaming: streamingBlock,
       })
@@ -147,6 +162,12 @@ export function deriveMarkdownLayout(
   });
   pushMarkdownNode(markdownNodes, narrative, cursor, narrative.length, "");
 
+  const markdownBoundaries = new Set<number>([0, narrative.length]);
+  for (const node of markdownNodes) {
+    markdownBoundaries.add(node.sourceRange[0]);
+    markdownBoundaries.add(node.sourceRange[1]);
+  }
+  let markdownNodeIndex = 0;
   for (const activity of activities) {
     if (candidates.has(activity.id)) continue;
     if (activity.sourceOffset === 0) {
@@ -165,13 +186,28 @@ export function deriveMarkdownLayout(
       });
       continue;
     }
-    const gap = markdownNodes.find((node) =>
-      activity.sourceOffset >= node.sourceRange[0]
-      && activity.sourceOffset <= node.sourceRange[1]
-      && node.html === ""
-      && node.source.trim().length === 0,
-    );
-    if (gap) {
+    if (markdownBoundaries.has(activity.sourceOffset)) {
+      candidates.set(activity.id, {
+        sourceOffset: activity.sourceOffset,
+        kind: "block-end",
+        reason: "exact",
+      });
+      continue;
+    }
+    while (
+      markdownNodeIndex < markdownNodes.length
+      && activity.sourceOffset > markdownNodes[markdownNodeIndex]!.sourceRange[1]
+    ) {
+      markdownNodeIndex += 1;
+    }
+    const gap = markdownNodes[markdownNodeIndex];
+    if (
+      gap
+      && activity.sourceOffset > gap.sourceRange[0]
+      && activity.sourceOffset < gap.sourceRange[1]
+      && gap.html === ""
+      && gap.source.trim().length === 0
+    ) {
       candidates.set(activity.id, {
         sourceOffset: activity.sourceOffset,
         kind: "block-end",

--- a/packages/relay-web/src/lib/markdown-layout.ts
+++ b/packages/relay-web/src/lib/markdown-layout.ts
@@ -11,6 +11,7 @@ import {
   type TopLevelBlockInfo,
 } from "./render-markdown";
 import type {
+  BlockActivityDisposition,
   LayoutActivityGeometry,
   LayoutSlotCandidate,
   MarkdownLayoutNode,
@@ -100,12 +101,41 @@ function pushMarkdownNode(
     isLatest: false,
   });
 }
-
 interface BlockRenderInput {
   block: TopLevelBlockInfo;
-  boundary: number;
   internalActivities: readonly LayoutActivityGeometry[];
   streamingBlock: boolean;
+}
+
+/**
+ * Rebuild a block's slot candidates from its cached-or-fresh disposition.
+ * Runs on every frame for every block: `exact-inline` resolves to the
+ * activity's current wire offset, `block-end` to the block's *current*
+ * boundary. Absolute slots are never read back from the cache, so a
+ * neighboring gap shrink/grow cannot resurrect a stale slot.
+ */
+function placeBlockActivities(
+  candidates: Map<string, LayoutSlotCandidate>,
+  internalActivities: readonly LayoutActivityGeometry[],
+  boundary: number,
+  dispositions: ReadonlyArray<{ id: string; disposition: BlockActivityDisposition }>,
+): void {
+  const byId = new Map(internalActivities.map((activity) => [activity.id, activity]));
+  for (const { id, disposition } of dispositions) {
+    if (disposition.kind === "exact-inline") {
+      candidates.set(id, {
+        sourceOffset: byId.get(id)!.sourceOffset,
+        kind: "exact-inline",
+        reason: "exact",
+      });
+      continue;
+    }
+    candidates.set(id, {
+      sourceOffset: boundary,
+      kind: "block-end",
+      reason: disposition.reason,
+    });
+  }
 }
 
 /**
@@ -119,10 +149,10 @@ function renderLayoutBlock(
   narrative: string,
   documentEnv: Record<string, unknown>,
   input: BlockRenderInput,
-): { nodes: MarkdownLayoutNode[]; candidates: Array<[string, LayoutSlotCandidate]> } {
+): { nodes: MarkdownLayoutNode[]; activities: Array<{ id: string; disposition: BlockActivityDisposition }> } {
   const nodes: MarkdownLayoutNode[] = [];
-  const candidates: Array<[string, LayoutSlotCandidate]> = [];
-  const { block, boundary, internalActivities, streamingBlock } = input;
+  const activities: Array<{ id: string; disposition: BlockActivityDisposition }> = [];
+  const { block, internalActivities, streamingBlock } = input;
   const normalized = normalizeMarkdownTables(block.source) !== block.source;
   // The marker planner only understands proven inline coordinates: an
   // unprovable projection (null) or any activity in the trimmed edge gap
@@ -166,13 +196,9 @@ function renderLayoutBlock(
     const inlineEnd = inlineStart + inlineSource!.length;
     pushMarkdownNode(nodes, narrative, inlineEnd, block.endOffset, "", "");
     for (const activity of internalActivities) {
-      candidates.push([activity.id, {
-        sourceOffset: activity.sourceOffset,
-        kind: "exact-inline",
-        reason: "exact",
-      }]);
+      activities.push({ id: activity.id, disposition: { kind: "exact-inline" } });
     }
-    return { nodes, candidates };
+    return { nodes, activities };
   }
   const rendered = renderAtomicBlock(block, documentEnv, streamingBlock);
   pushMarkdownNode(
@@ -184,15 +210,17 @@ function renderLayoutBlock(
     rendered.copyText,
   );
   for (const activity of internalActivities) {
-    candidates.push([activity.id, {
-      sourceOffset: boundary,
-      kind: "block-end",
-      reason: inlineSource !== null && !normalized
-        ? "marker-unsafe"
-        : "structural-block",
-    }]);
+    activities.push({
+      id: activity.id,
+      disposition: {
+        kind: "block-end",
+        reason: inlineSource !== null && !normalized
+          ? "marker-unsafe"
+          : "structural-block",
+      },
+    });
   }
-  return { nodes, candidates };
+  return { nodes, activities };
 }
 /**
  * Analyze Markdown once, derive legal slots, and pre-render a complete source-range
@@ -244,8 +272,9 @@ export function deriveMarkdownLayout(
       && options.latestVisibleIsText === true
       && block.endOffset >= lastNonWhitespaceOffset;
     // Positional key: identical text at different offsets must NOT share an
-    // entry — node sourceRanges and candidate slots are absolute. Sharing
-    // only happens for the same block across frames (streaming appends).
+    // entry — node sourceRanges are absolute. Slot candidates are rebuilt
+    // from dispositions every frame, so they never go stale. Sharing only
+    // happens for the same block across frames (streaming appends).
     const cacheKey = blockCache ? `block:${block.startOffset}:${block.endOffset}` : null;
     if (cacheKey) liveBlockKeys.add(cacheKey);
     const fingerprint: TurnLayoutBlockFingerprint | null = blockCache
@@ -271,27 +300,25 @@ export function deriveMarkdownLayout(
           sourceRange: [node.sourceRange[0], node.sourceRange[1]],
         });
       }
-      for (const [id, candidate] of cached.candidates) candidates.set(id, candidate);
+      placeBlockActivities(candidates, internalActivities, document.boundaries[blockIndex] ?? block.endOffset, cached.activities);
       cursor = block.endOffset;
       return;
     }
     const rendered = renderLayoutBlock(narrative, document.env, {
       block,
-      boundary: document.boundaries[blockIndex] ?? block.endOffset,
       internalActivities,
       streamingBlock,
     });
     for (const node of rendered.nodes) markdownNodes.push(node);
-    for (const [id, candidate] of rendered.candidates) candidates.set(id, candidate);
+    placeBlockActivities(candidates, internalActivities, document.boundaries[blockIndex] ?? block.endOffset, rendered.activities);
     if (cacheKey && fingerprint && blockCache) {
       blockCache.set(cacheKey, {
         fingerprint,
-        baseStart: block.startOffset,
         nodes: rendered.nodes.map((node) => ({
           ...node,
           sourceRange: [node.sourceRange[0], node.sourceRange[1]] as [number, number],
         })),
-        candidates: rendered.candidates,
+        activities: rendered.activities,
       });
     }
     cursor = block.endOffset;

--- a/packages/relay-web/src/lib/markdown-layout.ts
+++ b/packages/relay-web/src/lib/markdown-layout.ts
@@ -2,6 +2,8 @@ import { planInlineActivityMarkers } from "./markdown-inline-markers";
 import { normalizeMarkdownTables } from "./normalize-markdown";
 import {
   analyzeMarkdownDocument,
+  markdownSourceToPlainText,
+  markdownTokensToPlainText,
   preprocessMarkdownSource,
   renderMarkdownTokens,
   renderMarkdownWithEnv,
@@ -12,8 +14,9 @@ import type {
   LayoutActivityGeometry,
   LayoutSlotCandidate,
   MarkdownLayoutNode,
+  TurnLayoutBlockCacheEntry,
+  TurnLayoutBlockFingerprint,
 } from "./turn-layout";
-
 export interface MarkdownLayoutOptions extends RenderMarkdownOptions {
   latestVisibleIsText?: boolean;
 }
@@ -23,6 +26,25 @@ export interface MarkdownLayoutGeometry {
   candidates: Map<string, LayoutSlotCandidate>;
 }
 
+/**
+ * Fingerprint of the document-wide reference universe: reference definitions
+ * live outside any single block but change what every link block renders, so
+ * a block cache entry is only reusable while this fingerprint is unchanged.
+ */
+export function referenceEnvFingerprint(env: Record<string, unknown>): string {
+  const references = env["references"];
+  if (!references || typeof references !== "object") return "";
+  const table = references as Record<string, { href?: unknown; title?: unknown }>;
+  return Object.keys(table).sort()
+    .map((label) => {
+      const entry = table[label];
+      const href = typeof entry?.href === "string" ? entry.href : "";
+      const title = typeof entry?.title === "string" ? entry.title : "";
+      return `${label}=${href}#${title}`;
+    })
+    .join("|");
+}
+
 const MAX_INLINE_PARAGRAPH_CHARS = 50_000;
 const MAX_INLINE_MARKERS_PER_PARAGRAPH = 256;
 
@@ -30,11 +52,21 @@ function renderAtomicBlock(
   block: TopLevelBlockInfo,
   env: Record<string, unknown>,
   streaming: boolean,
-): string {
+): { html: string; copyText: string } {
   if (preprocessMarkdownSource(block.source, { streaming }) === block.source) {
-    return renderMarkdownTokens(block.tokens, env);
+    return {
+      html: renderMarkdownTokens(block.tokens, env),
+      copyText: markdownTokensToPlainText(block.tokens),
+    };
   }
-  return renderMarkdownWithEnv(block.source, { streaming }, env);
+  // A preprocessing rewrite heals display (remend/table fix) through a
+  // standalone reparse, and Copy must describe the healed output — not the
+  // raw pre-heal tokens. Reference definitions still resolve from the full
+  // document env, never from the standalone block alone.
+  return {
+    html: renderMarkdownWithEnv(block.source, { streaming }, env),
+    copyText: markdownSourceToPlainText(block.source, { streaming }, env).trim(),
+  };
 }
 
 function pushMarkdownNode(
@@ -43,7 +75,7 @@ function pushMarkdownNode(
   start: number,
   end: number,
   html: string,
-  copyText?: string,
+  copyText: string,
 ): void {
   if (end <= start) return;
   const source = narrative.slice(start, end);
@@ -53,11 +85,104 @@ function pushMarkdownNode(
     sourceRange: [start, end],
     source,
     html,
-    copyText: copyText ?? source,
+    copyText,
     isLatest: false,
   });
 }
 
+interface BlockRenderInput {
+  block: TopLevelBlockInfo;
+  boundary: number;
+  internalActivities: readonly LayoutActivityGeometry[];
+  streamingBlock: boolean;
+}
+
+/**
+ * Render one top-level block in isolation: the unit of work the streaming
+ * cache reuses. Pure in its inputs — same block source, same relative
+ * activity geometry, same streaming flag, same reference fingerprint — so a
+ * cache hit reproduces exactly what a fresh render would. The inter-block gap
+ * prefix stays with the caller: it depends on cursor position, not the block.
+ */
+function renderLayoutBlock(
+  narrative: string,
+  documentEnv: Record<string, unknown>,
+  input: BlockRenderInput,
+): { nodes: MarkdownLayoutNode[]; candidates: Array<[string, LayoutSlotCandidate]> } {
+  const nodes: MarkdownLayoutNode[] = [];
+  const candidates: Array<[string, LayoutSlotCandidate]> = [];
+  const { block, boundary, internalActivities, streamingBlock } = input;
+  const normalized = normalizeMarkdownTables(block.source) !== block.source;
+  // The marker planner only understands proven inline coordinates: an
+  // unprovable projection (null) or any activity in the trimmed edge gap
+  // stays atomic instead of guessing a coordinate.
+  const inlineSource = block.type === "paragraph_open" && !normalized
+    && block.inlineSource !== null
+    && block.inlineStartOffset !== null
+    ? block.inlineSource
+    : null;
+  const inlineStart = inlineSource === null ? null : block.inlineStartOffset;
+  const markers = inlineSource === null || inlineStart === null
+    ? []
+    : internalActivities
+      .filter((activity) => activity.sourceOffset >= inlineStart
+        && activity.sourceOffset - inlineStart <= inlineSource.length)
+      .map((activity) => ({
+        id: activity.id,
+        offset: activity.sourceOffset - inlineStart,
+      }));
+  const markerPlan = markers.length === internalActivities.length && markers.length > 0
+    && inlineSource !== null && inlineStart !== null
+    && inlineSource.length <= MAX_INLINE_PARAGRAPH_CHARS
+    && markers.length <= MAX_INLINE_MARKERS_PER_PARAGRAPH
+    ? planInlineActivityMarkers(inlineSource, markers, documentEnv, {
+      streaming: streamingBlock,
+    })
+    : null;
+
+  if (markerPlan && inlineStart !== null) {
+    pushMarkdownNode(nodes, narrative, block.startOffset, inlineStart, "", "");
+    for (const fragment of markerPlan.fragments) {
+      pushMarkdownNode(
+        nodes,
+        narrative,
+        inlineStart + fragment.sourceRange[0],
+        inlineStart + fragment.sourceRange[1],
+        fragment.html,
+        fragment.copyText,
+      );
+    }
+    const inlineEnd = inlineStart + inlineSource!.length;
+    pushMarkdownNode(nodes, narrative, inlineEnd, block.endOffset, "", "");
+    for (const activity of internalActivities) {
+      candidates.push([activity.id, {
+        sourceOffset: activity.sourceOffset,
+        kind: "exact-inline",
+        reason: "exact",
+      }]);
+    }
+    return { nodes, candidates };
+  }
+  const rendered = renderAtomicBlock(block, documentEnv, streamingBlock);
+  pushMarkdownNode(
+    nodes,
+    narrative,
+    block.startOffset,
+    block.endOffset,
+    rendered.html,
+    rendered.copyText,
+  );
+  for (const activity of internalActivities) {
+    candidates.push([activity.id, {
+      sourceOffset: boundary,
+      kind: "block-end",
+      reason: inlineSource !== null && !normalized
+        ? "marker-unsafe"
+        : "structural-block",
+    }]);
+  }
+  return { nodes, candidates };
+}
 /**
  * Analyze Markdown once, derive legal slots, and pre-render a complete source-range
  * partition. Only top-level paragraphs may contain exact inline activity markers;
@@ -67,8 +192,10 @@ export function deriveMarkdownLayout(
   narrative: string,
   activities: readonly LayoutActivityGeometry[],
   options: MarkdownLayoutOptions = {},
+  blockCache?: Map<string, TurnLayoutBlockCacheEntry>,
 ): MarkdownLayoutGeometry {
   const document = analyzeMarkdownDocument(narrative);
+  const references = referenceEnvFingerprint(document.env);
   const candidates = new Map<string, LayoutSlotCandidate>();
   const markdownNodes: MarkdownLayoutNode[] = [];
   const activitiesByBlock = document.blocks.map((): LayoutActivityGeometry[] => []);
@@ -99,82 +226,64 @@ export function deriveMarkdownLayout(
   }
 
   document.blocks.forEach((block, blockIndex) => {
-    pushMarkdownNode(markdownNodes, narrative, cursor, block.startOffset, "");
+    pushMarkdownNode(markdownNodes, narrative, cursor, block.startOffset, "", "");
     const internalActivities = activitiesByBlock[blockIndex]!;
     const streamingBlock = options.streaming === true
       && options.latestVisibleIsText === true
       && block.endOffset >= lastNonWhitespaceOffset;
-    const normalized = normalizeMarkdownTables(block.source) !== block.source;
-    // The marker planner only understands proven inline coordinates: an
-    // unprovable projection (null) or any activity in the trimmed edge gap
-    // stays atomic instead of guessing a coordinate.
-    const inlineSource = block.type === "paragraph_open" && !normalized
-      && block.inlineSource !== null
-      && block.inlineStartOffset !== null
-      ? block.inlineSource
-      : null;
-    const inlineStart = inlineSource === null ? null : block.inlineStartOffset;
-    const markers = inlineSource === null || inlineStart === null
-      ? []
-      : internalActivities
-        .filter((activity) => activity.sourceOffset >= inlineStart
-          && activity.sourceOffset - inlineStart <= inlineSource.length)
-        .map((activity) => ({
-          id: activity.id,
-          offset: activity.sourceOffset - inlineStart,
-        }));
-    const markerPlan = markers.length === internalActivities.length && markers.length > 0
-      && inlineSource !== null && inlineStart !== null
-      && inlineSource.length <= MAX_INLINE_PARAGRAPH_CHARS
-      && markers.length <= MAX_INLINE_MARKERS_PER_PARAGRAPH
-      ? planInlineActivityMarkers(inlineSource, markers, document.env, {
+    // Positional key: identical text at different offsets must NOT share an
+    // entry — node sourceRanges and candidate slots are absolute. Sharing
+    // only happens for the same block across frames (streaming appends).
+    const cacheKey = blockCache ? `block:${block.startOffset}:${block.endOffset}` : null;
+    const fingerprint: TurnLayoutBlockFingerprint | null = blockCache
+      ? {
+        source: block.source,
+        activityIds: internalActivities.map((activity) => `${activity.id}@${activity.sourceOffset}`).join(","),
         streaming: streamingBlock,
-      })
+        references,
+      }
       : null;
-
-    if (markerPlan && inlineStart !== null) {
-      pushMarkdownNode(markdownNodes, narrative, block.startOffset, inlineStart, "");
-      for (const fragment of markerPlan.fragments) {
-        pushMarkdownNode(
-          markdownNodes,
-          narrative,
-          inlineStart + fragment.sourceRange[0],
-          inlineStart + fragment.sourceRange[1],
-          fragment.html,
-          fragment.copyText,
-        );
-      }
-      const inlineEnd = inlineStart + inlineSource!.length;
-      pushMarkdownNode(markdownNodes, narrative, inlineEnd, block.endOffset, "");
-      for (const activity of internalActivities) {
-        candidates.set(activity.id, {
-          sourceOffset: activity.sourceOffset,
-          kind: "exact-inline",
-          reason: "exact",
+    const cached = cacheKey && fingerprint && blockCache ? blockCache.get(cacheKey) : undefined;
+    const hit = cached
+      && fingerprint
+      && cached.fingerprint.source === fingerprint.source
+      && cached.fingerprint.activityIds === fingerprint.activityIds
+      && cached.fingerprint.streaming === fingerprint.streaming
+      && cached.fingerprint.references === fingerprint.references;
+    if (hit) {
+      // Fresh copies: callers mutate isLatest on the returned nodes.
+      for (const node of cached.nodes) {
+        markdownNodes.push({
+          ...node,
+          sourceRange: [node.sourceRange[0], node.sourceRange[1]],
         });
       }
-    } else {
-      pushMarkdownNode(
-        markdownNodes,
-        narrative,
-        block.startOffset,
-        block.endOffset,
-        renderAtomicBlock(block, document.env, streamingBlock),
-      );
-      const boundary = document.boundaries[blockIndex] ?? block.endOffset;
-      for (const activity of internalActivities) {
-        candidates.set(activity.id, {
-          sourceOffset: boundary,
-          kind: "block-end",
-          reason: inlineSource !== null && !normalized
-            ? "marker-unsafe"
-            : "structural-block",
-        });
-      }
+      for (const [id, candidate] of cached.candidates) candidates.set(id, candidate);
+      cursor = block.endOffset;
+      return;
+    }
+    const rendered = renderLayoutBlock(narrative, document.env, {
+      block,
+      boundary: document.boundaries[blockIndex] ?? block.endOffset,
+      internalActivities,
+      streamingBlock,
+    });
+    for (const node of rendered.nodes) markdownNodes.push(node);
+    for (const [id, candidate] of rendered.candidates) candidates.set(id, candidate);
+    if (cacheKey && fingerprint && blockCache) {
+      blockCache.set(cacheKey, {
+        fingerprint,
+        baseStart: block.startOffset,
+        nodes: rendered.nodes.map((node) => ({
+          ...node,
+          sourceRange: [node.sourceRange[0], node.sourceRange[1]] as [number, number],
+        })),
+        candidates: rendered.candidates,
+      });
     }
     cursor = block.endOffset;
   });
-  pushMarkdownNode(markdownNodes, narrative, cursor, narrative.length, "");
+  pushMarkdownNode(markdownNodes, narrative, cursor, narrative.length, "", "");
 
   const markdownBoundaries = new Set<number>([0, narrative.length]);
   for (const node of markdownNodes) {

--- a/packages/relay-web/src/lib/markdown-layout.ts
+++ b/packages/relay-web/src/lib/markdown-layout.ts
@@ -74,10 +74,12 @@ function renderAtomicBlock(
   // A preprocessing rewrite heals display (remend/table fix) through a
   // standalone reparse, and Copy must describe the healed output — not the
   // raw pre-heal tokens. Reference definitions still resolve from the full
-  // document env, never from the standalone block alone.
+  // document env, never from the standalone block alone. No trimming here:
+  // copyText is compositional, and the block's terminal newline separates it
+  // from the next block; the single outer trim happens at the final join.
   return {
     html: renderMarkdownWithEnv(block.source, { streaming }, env),
-    copyText: markdownSourceToPlainText(block.source, { streaming }, env).trim(),
+    copyText: markdownSourceToPlainText(block.source, { streaming }, env),
   };
 }
 

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -90,6 +90,14 @@ export interface TopLevelBlockInfo {
   endOffset: number;
   source: string;
   inlineSource: string | null;
+  /**
+   * Raw-narrative offset where `inlineSource` begins, or null when it cannot be
+   * proven. markdown-it derives paragraph inline content via `asciiTrim` (plus
+   * at most an indent-strip on continuation lines), so `inlineSource` is NOT in
+   * general a view of `source` at a raw offset. Marker planning must only use
+   * this proven projection; anything else stays atomic.
+   */
+  inlineStartOffset: number | null;
   tokens: Token[];
 }
 
@@ -97,6 +105,42 @@ export interface MarkdownDocumentAnalysis {
   boundaries: number[];
   blocks: TopLevelBlockInfo[];
   env: Record<string, unknown>;
+}
+
+/**
+ * Prove the raw-narrative projection of a top-level paragraph's inline content.
+ * markdown-it builds paragraph inline content with `getLines(...)` (which strips
+ * at most the block indent, never content) followed by a leading/trailing ASCII
+ * trim, so the proof is exact: find the largest leading run and smallest trailing
+ * run of ASCII-trimmable characters whose removal reproduces `inlineSource`, then
+ * verify the middle slice byte-for-byte. Returns the raw start offset of the
+ * inline content, or null when no such projection exists (indented-code-looking
+ * blocks, list/quote/heading wrappers, tabs expanded by getLines, ...). Callers
+ * must treat null as "marker path unprovable, stay atomic".
+ */
+export function locateInlineProjection(
+  source: string,
+  startOffset: number,
+  inlineSource: string,
+): number | null {
+  if (inlineSource.length === 0) return null;
+  // markdown-it trims only ASCII space/tab/LF/CR at block edges; anything else
+  // (unicode spaces, content) must match byte-for-byte below.
+  let leading = 0;
+  while (leading < source.length) {
+    const code = source.charCodeAt(leading)!;
+    if (code !== 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) break;
+    leading += 1;
+  }
+  let trailing = 0;
+  while (trailing < source.length - leading) {
+    const code = source.charCodeAt(source.length - 1 - trailing)!;
+    if (code !== 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) break;
+    trailing += 1;
+  }
+  const candidate = source.slice(leading, source.length - trailing);
+  if (candidate !== inlineSource) return null;
+  return startOffset + leading;
 }
 
 /** Parse a Markdown document once and retain all top-level block ranges plus the
@@ -125,16 +169,22 @@ export function analyzeMarkdownDocument(
   const blocks = topLevelEntries.map(({ token, tokenIndex }, index): TopLevelBlockInfo => {
     const startOffset = lineStarts[token.map![0]] ?? 0;
     const endOffset = lineStarts[token.map![1]] ?? text.length;
+    const blockSource = text.slice(startOffset, endOffset);
     const blockTokens = tokens.slice(
       tokenIndex,
       topLevelEntries[index + 1]?.tokenIndex ?? tokens.length,
     );
+    const inlineSource = blockTokens.find((blockToken) => blockToken.type === "inline")?.content ?? null;
+    const inlineStartOffset = token.type === "paragraph_open" && inlineSource !== null
+      ? locateInlineProjection(blockSource, startOffset, inlineSource)
+      : null;
     return {
       type: token.type,
       startOffset,
       endOffset,
-      source: text.slice(startOffset, endOffset),
-      inlineSource: blockTokens.find((blockToken) => blockToken.type === "inline")?.content ?? null,
+      source: blockSource,
+      inlineSource,
+      inlineStartOffset,
       tokens: blockTokens,
     };
   });
@@ -158,7 +208,21 @@ export function renderMarkdownTokens(
 
 /** Render markdown to sanitized, XSS-safe HTML. */
 export function renderMarkdown(text: string, options: RenderMarkdownOptions = {}): string {
+  return renderMarkdownWithEnv(text, options, {});
+}
+
+/**
+ * Render markdown reusing a previously parsed document env, so reference-style
+ * links keep resolving even when preprocessing rewrites the block source and
+ * forces a standalone reparse. The env is shallow-copied: definitions already
+ * collected by the full document parse win over anything the reparse sees.
+ */
+export function renderMarkdownWithEnv(
+  text: string,
+  options: RenderMarkdownOptions = {},
+  env: Record<string, unknown> = {},
+): string {
   const source = preprocessMarkdownSource(text, options);
-  const rawHtml = md.render(source);
+  const rawHtml = md.render(source, { ...env });
   return DOMPurify.sanitize(rawHtml);
 }

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -56,41 +56,69 @@ export interface RenderMarkdownOptions {
   streaming?: boolean;
 }
 
-/**
- * Return source offsets where a top-level Markdown block can safely hand over to
- * non-Markdown turn activity. Gaps between blocks stay attached to the preceding
- * block, so an activity observed after "\n\n" lands before the next block. Parsing
- * the raw source is intentionally conservative: normalization may recognize more
- * constructs, but it must never create an unsafe split inside the original source.
- */
-export function markdownBlockBoundaries(text: string): number[] {
-  const lineStarts = [0];
-  for (let i = 0; i < text.length; i += 1) {
-    if (text[i] === "\n") lineStarts.push(i + 1);
-  }
-
-  const ranges = md
-    .parse(text, {})
-    .filter((token) => token.level === 0 && token.map !== null)
-    .map((token) => token.map!)
-    .filter((range, index, all) =>
-      index === 0 || range[0] !== all[index - 1]![0] || range[1] !== all[index - 1]![1],
-    );
-
-  if (ranges.length === 0) return [text.length];
-  return ranges.map((_, index) => {
-    const nextStartLine = ranges[index + 1]?.[0];
-    return nextStartLine === undefined
-      ? text.length
-      : (lineStarts[nextStartLine] ?? text.length);
-  });
-}
-
 export interface TopLevelBlockInfo {
   type: string;
   startOffset: number;
   endOffset: number;
   source: string;
+}
+
+export interface MarkdownDocumentAnalysis {
+  boundaries: number[];
+  blocks: TopLevelBlockInfo[];
+  env: Record<string, unknown>;
+}
+
+/** Parse a Markdown document once and retain all top-level block ranges plus the
+ * document env populated by markdown-it (notably reference link definitions).
+ * Gaps between blocks stay attached to the preceding boundary, so activity after
+ * "\n\n" lands before the next block.
+ */
+export function analyzeMarkdownDocument(
+  text: string,
+  env: Record<string, unknown> = {},
+): MarkdownDocumentAnalysis {
+  const lineStarts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "\n") lineStarts.push(i + 1);
+  }
+
+  const topLevelTokens = md
+    .parse(text, env)
+    .filter((token) => token.level === 0 && token.map !== null)
+    .filter((token, index, all) =>
+      index === 0
+      || token.map![0] !== all[index - 1]!.map![0]
+      || token.map![1] !== all[index - 1]!.map![1],
+    );
+  const blocks = topLevelTokens.map((token): TopLevelBlockInfo => {
+    const startOffset = lineStarts[token.map![0]] ?? 0;
+    const endOffset = lineStarts[token.map![1]] ?? text.length;
+    return {
+      type: token.type,
+      startOffset,
+      endOffset,
+      source: text.slice(startOffset, endOffset),
+    };
+  });
+  const boundaries = blocks.length === 0 ? [text.length] : blocks.map((_, index) => {
+    const nextStartLine = topLevelTokens[index + 1]?.map![0];
+    return nextStartLine === undefined
+      ? text.length
+      : (lineStarts[nextStartLine] ?? text.length);
+  });
+
+  return { boundaries, blocks, env };
+}
+
+/**
+ * Return source offsets where a top-level Markdown block can safely hand over to
+ * non-Markdown turn activity. Parsing the raw source is intentionally conservative:
+ * normalization may recognize more constructs, but it must never create an unsafe
+ * split inside the original source.
+ */
+export function markdownBlockBoundaries(text: string): number[] {
+  return analyzeMarkdownDocument(text).boundaries;
 }
 
 /** Return the top-level block enclosing `offset`, including its source slice.
@@ -102,25 +130,9 @@ export function topLevelBlockAt(
   offset: number,
   env: Record<string, unknown> = {},
 ): TopLevelBlockInfo | null {
-  const lineStarts = [0];
-  for (let i = 0; i < text.length; i += 1) {
-    if (text[i] === "\n") lineStarts.push(i + 1);
-  }
-  const tokens = md.parse(text, env);
-  const blocks = tokens.filter((t) => t.level === 0 && t.map !== null);
-  for (const block of blocks) {
-    const startOffset = lineStarts[block.map![0]] ?? 0;
-    const endOffset = lineStarts[block.map![1]] ?? text.length;
-    if (offset >= startOffset && offset <= endOffset) {
-      return {
-        type: block.type,
-        startOffset,
-        endOffset,
-        source: text.slice(startOffset, endOffset),
-      };
-    }
-  }
-  return null;
+  return analyzeMarkdownDocument(text, env).blocks.find(
+    (block) => offset >= block.startOffset && offset <= block.endOffset,
+  ) ?? null;
 }
 
 interface SemanticInlineToken {
@@ -196,6 +208,14 @@ function areSemanticTokensEqual(a: SemanticInlineToken[], b: SemanticInlineToken
   return true;
 }
 
+function isStandaloneParagraph(source: string): boolean {
+  if (!source.trim()) return true;
+  const blocks = md
+    .parse(source, {})
+    .filter((token) => token.level === 0 && token.map !== null);
+  return blocks.length === 1 && blocks[0]!.type === "paragraph_open";
+}
+
 /** Check whether `offsetInBlock` inside a paragraph block lands at a safe top-level
  *  text position rather than severing an active inline construct (code span,
  *  emphasis, strong, link label/delimiter, reference link, HTML entity, hardbreak, etc.).
@@ -216,6 +236,30 @@ export function isSafeInlineParagraphOffset(
   const fullTokens = canonicalInlineTokens(paragraphSource, env);
   const prefixTokens = canonicalInlineTokens(prefix, env);
   const suffixTokens = canonicalInlineTokens(suffix, env);
+  const combinedTokens = mergeTokenStreams(prefixTokens, suffixTokens);
+
+  return areSemanticTokensEqual(fullTokens, combinedTokens);
+}
+
+/** Check a paragraph split as it will actually render in TurnParts: the full
+ * paragraph resolves against its document env, while the prefix and suffix are
+ * parsed by separate StreamMarkdown instances with isolated env objects. This
+ * rejects document-context dependencies such as reference-style links while still
+ * allowing ordinary prose in an earlier block to interleave with activity.
+ */
+export function isSafeStandaloneInlineParagraphOffset(
+  paragraphSource: string,
+  offsetInBlock: number,
+  documentEnv: Record<string, unknown> = {},
+): boolean {
+  if (offsetInBlock < 0 || offsetInBlock > paragraphSource.length) return false;
+  const prefix = paragraphSource.slice(0, offsetInBlock);
+  const suffix = paragraphSource.slice(offsetInBlock);
+  if (!isStandaloneParagraph(prefix) || !isStandaloneParagraph(suffix)) return false;
+
+  const fullTokens = canonicalInlineTokens(paragraphSource, documentEnv);
+  const prefixTokens = canonicalInlineTokens(prefix, {});
+  const suffixTokens = canonicalInlineTokens(suffix, {});
   const combinedTokens = mergeTokenStreams(prefixTokens, suffixTokens);
 
   return areSemanticTokensEqual(fullTokens, combinedTokens);

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from "markdown-it";
+import type Token from "markdown-it/lib/token.mjs";
 import DOMPurify from "dompurify";
 import remend from "remend";
 import { normalizeMarkdownTables } from "./normalize-markdown";
@@ -63,6 +64,24 @@ export function preprocessMarkdownSource(
 ): string {
   const healed = options.streaming ? remend(text) : text;
   return normalizeMarkdownTables(healed);
+}
+
+/** Parse one inline Markdown stream with the same parser and document env as full rendering. */
+export function parseMarkdownInline(
+  source: string,
+  env: Record<string, unknown> = {},
+): Token[] {
+  const inline = md.parseInline(source, env).find((token) => token.type === "inline");
+  return inline?.children ?? [];
+}
+
+/** Render a token fragment as one paragraph through the shared sanitizer. */
+export function renderMarkdownInlineFragment(
+  tokens: Token[],
+  env: Record<string, unknown> = {},
+): string {
+  const inner = md.renderer.renderInline(tokens, md.options, env);
+  return DOMPurify.sanitize(`<p>${inner}</p>`);
 }
 
 export interface TopLevelBlockInfo {

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -84,6 +84,79 @@ export function renderMarkdownInlineFragment(
   return DOMPurify.sanitize(`<p>${inner}</p>`);
 }
 
+/**
+ * Plaintext projection of already-parsed Markdown tokens: the single Copy
+ * contract for every layout node. Text and inline code contribute their
+ * visible content, fenced/indented code contributes its source, images
+ * contribute their alt text (falling back to the URL when alt is empty, so a
+ * visible image never copies as nothing), links contribute their label (never
+ * the destination), and soft/hard breaks become newlines. Table cells are
+ * separated by spaces and rows by newlines; paragraphs and headings are
+ * separated by blank lines. Block containers contribute their inline
+ * children; everything else — emphasis/link delimiters, fences metadata,
+ * thematic breaks — contributes nothing. Reference definitions are invisible
+ * by construction: md.parse drops them from the token stream, so they can
+ * never leak into the clipboard.
+ */
+export function markdownTokensToPlainText(tokens: readonly Token[]): string {
+  const parts: string[] = [];
+  const visit = (token: Token): void => {
+    switch (token.type) {
+      case "text":
+      case "code_inline":
+        parts.push(token.content);
+        return;
+      case "softbreak":
+      case "hardbreak":
+        parts.push("\n");
+        return;
+      case "image": {
+        const alt = token.children?.map((child) => child.content).join("") ?? token.content;
+        parts.push(alt || token.attrs?.find(([name]) => name === "src")?.[1] || "");
+        return;
+      }
+      case "fence":
+      case "code_block":
+      case "html_block":
+        parts.push(token.content);
+        return;
+      case "th_close":
+      case "td_close":
+        parts.push(" ");
+        return;
+      case "tr_close":
+        parts.push("\n");
+        return;
+      case "paragraph_close":
+      case "heading_close":
+        parts.push("\n\n");
+        return;
+      default:
+        if (token.children) {
+          for (const child of token.children) visit(child);
+        }
+    }
+  };
+  for (const token of tokens) visit(token);
+  return parts.join("").replace(/[ \t]+\n/g, "\n");
+}
+
+/**
+ * Plaintext projection of a Markdown source string through the exact
+ * preprocessing used for rendering, so Copy always describes what the healed
+ * HTML shows rather than the raw pre-heal source. The env is shallow-copied
+ * so document reference definitions resolve exactly as in the display parse.
+ */
+export function markdownSourceToPlainText(
+  text: string,
+  options: RenderMarkdownOptions = {},
+  env: Record<string, unknown> = {},
+): string {
+  const source = preprocessMarkdownSource(text, options);
+  if (!source.trim()) return "";
+  return markdownTokensToPlainText(md.parse(source, { ...env }));
+}
+
 export interface TopLevelBlockInfo {
   type: string;
   startOffset: number;

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -125,7 +125,11 @@ export function markdownTokensToPlainText(tokens: readonly Token[]): string {
         parts.push(" ");
         return;
       case "tr_close":
-        parts.push("\n");
+        // Drop only the synthetic separator the cell close just added, so a
+        // table row ends cleanly without touching real trailing spaces inside
+        // fenced/indented code content elsewhere in the parts.
+        if (parts[parts.length - 1] === " ") parts[parts.length - 1] = "\n";
+        else parts.push("\n");
         return;
       case "paragraph_close":
       case "heading_close":
@@ -138,7 +142,7 @@ export function markdownTokensToPlainText(tokens: readonly Token[]): string {
     }
   };
   for (const token of tokens) visit(token);
-  return parts.join("").replace(/[ \t]+\n/g, "\n");
+  return parts.join("");
 }
 
 /**

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -89,6 +89,8 @@ export interface TopLevelBlockInfo {
   startOffset: number;
   endOffset: number;
   source: string;
+  inlineSource: string | null;
+  tokens: Token[];
 }
 
 export interface MarkdownDocumentAnalysis {
@@ -111,26 +113,33 @@ export function analyzeMarkdownDocument(
     if (text[i] === "\n") lineStarts.push(i + 1);
   }
 
-  const topLevelTokens = md
-    .parse(text, env)
-    .filter((token) => token.level === 0 && token.map !== null)
-    .filter((token, index, all) =>
+  const tokens = md.parse(text, env);
+  const topLevelEntries = tokens
+    .map((token, tokenIndex) => ({ token, tokenIndex }))
+    .filter(({ token }) => token.level === 0 && token.map !== null)
+    .filter(({ token }, index, all) =>
       index === 0
-      || token.map![0] !== all[index - 1]!.map![0]
-      || token.map![1] !== all[index - 1]!.map![1],
+      || token.map![0] !== all[index - 1]!.token.map![0]
+      || token.map![1] !== all[index - 1]!.token.map![1],
     );
-  const blocks = topLevelTokens.map((token): TopLevelBlockInfo => {
+  const blocks = topLevelEntries.map(({ token, tokenIndex }, index): TopLevelBlockInfo => {
     const startOffset = lineStarts[token.map![0]] ?? 0;
     const endOffset = lineStarts[token.map![1]] ?? text.length;
+    const blockTokens = tokens.slice(
+      tokenIndex,
+      topLevelEntries[index + 1]?.tokenIndex ?? tokens.length,
+    );
     return {
       type: token.type,
       startOffset,
       endOffset,
       source: text.slice(startOffset, endOffset),
+      inlineSource: blockTokens.find((blockToken) => blockToken.type === "inline")?.content ?? null,
+      tokens: blockTokens,
     };
   });
   const boundaries = blocks.length === 0 ? [text.length] : blocks.map((_, index) => {
-    const nextStartLine = topLevelTokens[index + 1]?.map![0];
+    const nextStartLine = topLevelEntries[index + 1]?.token.map![0];
     return nextStartLine === undefined
       ? text.length
       : (lineStarts[nextStartLine] ?? text.length);
@@ -139,170 +148,12 @@ export function analyzeMarkdownDocument(
   return { boundaries, blocks, env };
 }
 
-/**
- * Return source offsets where a top-level Markdown block can safely hand over to
- * non-Markdown turn activity. Parsing the raw source is intentionally conservative:
- * normalization may recognize more constructs, but it must never create an unsafe
- * split inside the original source.
- */
-export function markdownBlockBoundaries(text: string): number[] {
-  return analyzeMarkdownDocument(text).boundaries;
-}
-
-/** Return the top-level block enclosing `offset`, including its source slice.
- *  Accepts an optional markdown-it `env` object that collects document-level
- *  metadata (such as reference link definitions) during the parse.
- */
-export function topLevelBlockAt(
-  text: string,
-  offset: number,
+/** Render already-parsed block tokens in their original document environment. */
+export function renderMarkdownTokens(
+  tokens: Token[],
   env: Record<string, unknown> = {},
-): TopLevelBlockInfo | null {
-  return analyzeMarkdownDocument(text, env).blocks.find(
-    (block) => offset >= block.startOffset && offset <= block.endOffset,
-  ) ?? null;
-}
-
-interface SemanticInlineToken {
-  type: string;
-  content: string;
-  attrs: string;
-  info: string;
-}
-
-function canonicalInlineTokens(source: string, env: Record<string, unknown>): SemanticInlineToken[] {
-  const tokens = md.parseInline(source, { ...env });
-  const inline = tokens.find((t) => t.type === "inline");
-  if (!inline || !inline.children) return [];
-
-  const result: SemanticInlineToken[] = [];
-  for (const c of inline.children) {
-    if (c.type === "softbreak") {
-      if (result.length > 0 && result[result.length - 1]!.type === "text") {
-        result[result.length - 1]!.content += "\n";
-      } else {
-        result.push({ type: "text", content: "\n", attrs: "", info: "" });
-      }
-      continue;
-    }
-    if (c.type === "text") {
-      if (result.length > 0 && result[result.length - 1]!.type === "text") {
-        result[result.length - 1]!.content += c.content;
-      } else {
-        result.push({ type: "text", content: c.content, attrs: "", info: "" });
-      }
-      continue;
-    }
-    result.push({
-      type: c.type,
-      content: c.content || "",
-      attrs: c.attrs ? JSON.stringify(c.attrs) : "",
-      info: c.info || "",
-    });
-  }
-  return result;
-}
-
-function mergeTokenStreams(a: SemanticInlineToken[], b: SemanticInlineToken[]): SemanticInlineToken[] {
-  if (a.length === 0) return b;
-  if (b.length === 0) return a;
-  const merged = [...a];
-  const lastA = merged[merged.length - 1]!;
-  const firstB = b[0]!;
-  if (lastA.type === "text" && firstB.type === "text") {
-    merged[merged.length - 1] = {
-      ...lastA,
-      content: lastA.content + firstB.content,
-    };
-    merged.push(...b.slice(1));
-  } else {
-    merged.push(...b);
-  }
-  return merged;
-}
-
-function areSemanticTokensEqual(a: SemanticInlineToken[], b: SemanticInlineToken[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i += 1) {
-    if (
-      a[i]!.type !== b[i]!.type ||
-      a[i]!.content !== b[i]!.content ||
-      a[i]!.attrs !== b[i]!.attrs ||
-      a[i]!.info !== b[i]!.info
-    ) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function isStandaloneParagraph(source: string): boolean {
-  if (!source.trim()) return true;
-  const blocks = md
-    .parse(source, {})
-    .filter((token) => token.level === 0 && token.map !== null);
-  return blocks.length === 1 && blocks[0]!.type === "paragraph_open";
-}
-
-function preprocessingPreservesSource(source: string, streaming: boolean): boolean {
-  if (preprocessMarkdownSource(source) !== source) return false;
-  return !streaming || preprocessMarkdownSource(source, { streaming: true }) === source;
-}
-
-/** Check whether `offsetInBlock` inside a paragraph block lands at a safe top-level
- *  text position rather than severing an active inline construct (code span,
- *  emphasis, strong, link label/delimiter, reference link, HTML entity, hardbreak, etc.).
- *  Compares the canonical inline semantic tokens of the full block against the concatenated
- *  tokens of the prefix and suffix parsed independently within the same document env.
- *  Adjacent text tokens across the slice boundary are merged so normal prose splits match;
- *  if any inline construct or entity was severed, their token streams diverge and this returns false.
- */
-export function isSafeInlineParagraphOffset(
-  paragraphSource: string,
-  offsetInBlock: number,
-  env: Record<string, unknown> = {},
-): boolean {
-  if (offsetInBlock < 0 || offsetInBlock > paragraphSource.length) return false;
-  const prefix = paragraphSource.slice(0, offsetInBlock);
-  const suffix = paragraphSource.slice(offsetInBlock);
-
-  const fullTokens = canonicalInlineTokens(paragraphSource, env);
-  const prefixTokens = canonicalInlineTokens(prefix, env);
-  const suffixTokens = canonicalInlineTokens(suffix, env);
-  const combinedTokens = mergeTokenStreams(prefixTokens, suffixTokens);
-
-  return areSemanticTokensEqual(fullTokens, combinedTokens);
-}
-
-/** Check a paragraph split as it will actually render in TurnParts: preprocessing
- * must preserve the full paragraph and both standalone fragments, the full paragraph
- * resolves against its document env, and the fragments parse with isolated env objects.
- * This rejects preprocessing-created block semantics and document-context dependencies
- * while still allowing ordinary prose in an earlier block to interleave with activity.
- */
-export function isSafeStandaloneParagraphOffset(
-  paragraphSource: string,
-  offsetInBlock: number,
-  documentEnv: Record<string, unknown> = {},
-  options: RenderMarkdownOptions = {},
-): boolean {
-  if (offsetInBlock < 0 || offsetInBlock > paragraphSource.length) return false;
-  const prefix = paragraphSource.slice(0, offsetInBlock);
-  const suffix = paragraphSource.slice(offsetInBlock);
-  const streaming = options.streaming === true;
-  if (
-    !preprocessingPreservesSource(paragraphSource, streaming)
-    || !preprocessingPreservesSource(prefix, streaming)
-    || !preprocessingPreservesSource(suffix, streaming)
-  ) return false;
-  if (!isStandaloneParagraph(prefix) || !isStandaloneParagraph(suffix)) return false;
-
-  const fullTokens = canonicalInlineTokens(paragraphSource, documentEnv);
-  const prefixTokens = canonicalInlineTokens(prefix, {});
-  const suffixTokens = canonicalInlineTokens(suffix, {});
-  const combinedTokens = mergeTokenStreams(prefixTokens, suffixTokens);
-
-  return areSemanticTokensEqual(fullTokens, combinedTokens);
+): string {
+  return DOMPurify.sanitize(md.renderer.render(tokens, md.options, env));
 }
 
 /** Render markdown to sanitized, XSS-safe HTML. */

--- a/packages/relay-web/src/lib/render-markdown.ts
+++ b/packages/relay-web/src/lib/render-markdown.ts
@@ -56,6 +56,15 @@ export interface RenderMarkdownOptions {
   streaming?: boolean;
 }
 
+/** Apply the exact source preprocessing used before every markdown-it render. */
+export function preprocessMarkdownSource(
+  text: string,
+  options: RenderMarkdownOptions = {},
+): string {
+  const healed = options.streaming ? remend(text) : text;
+  return normalizeMarkdownTables(healed);
+}
+
 export interface TopLevelBlockInfo {
   type: string;
   startOffset: number;
@@ -216,6 +225,11 @@ function isStandaloneParagraph(source: string): boolean {
   return blocks.length === 1 && blocks[0]!.type === "paragraph_open";
 }
 
+function preprocessingPreservesSource(source: string, streaming: boolean): boolean {
+  if (preprocessMarkdownSource(source) !== source) return false;
+  return !streaming || preprocessMarkdownSource(source, { streaming: true }) === source;
+}
+
 /** Check whether `offsetInBlock` inside a paragraph block lands at a safe top-level
  *  text position rather than severing an active inline construct (code span,
  *  emphasis, strong, link label/delimiter, reference link, HTML entity, hardbreak, etc.).
@@ -241,20 +255,27 @@ export function isSafeInlineParagraphOffset(
   return areSemanticTokensEqual(fullTokens, combinedTokens);
 }
 
-/** Check a paragraph split as it will actually render in TurnParts: the full
- * paragraph resolves against its document env, while the prefix and suffix are
- * parsed by separate StreamMarkdown instances with isolated env objects. This
- * rejects document-context dependencies such as reference-style links while still
- * allowing ordinary prose in an earlier block to interleave with activity.
+/** Check a paragraph split as it will actually render in TurnParts: preprocessing
+ * must preserve the full paragraph and both standalone fragments, the full paragraph
+ * resolves against its document env, and the fragments parse with isolated env objects.
+ * This rejects preprocessing-created block semantics and document-context dependencies
+ * while still allowing ordinary prose in an earlier block to interleave with activity.
  */
-export function isSafeStandaloneInlineParagraphOffset(
+export function isSafeStandaloneParagraphOffset(
   paragraphSource: string,
   offsetInBlock: number,
   documentEnv: Record<string, unknown> = {},
+  options: RenderMarkdownOptions = {},
 ): boolean {
   if (offsetInBlock < 0 || offsetInBlock > paragraphSource.length) return false;
   const prefix = paragraphSource.slice(0, offsetInBlock);
   const suffix = paragraphSource.slice(offsetInBlock);
+  const streaming = options.streaming === true;
+  if (
+    !preprocessingPreservesSource(paragraphSource, streaming)
+    || !preprocessingPreservesSource(prefix, streaming)
+    || !preprocessingPreservesSource(suffix, streaming)
+  ) return false;
   if (!isStandaloneParagraph(prefix) || !isStandaloneParagraph(suffix)) return false;
 
   const fullTokens = canonicalInlineTokens(paragraphSource, documentEnv);
@@ -267,10 +288,7 @@ export function isSafeStandaloneInlineParagraphOffset(
 
 /** Render markdown to sanitized, XSS-safe HTML. */
 export function renderMarkdown(text: string, options: RenderMarkdownOptions = {}): string {
-  // Heal unterminated markup first (streaming), then run table normalization so it
-  // sees correct fence state, then parse.
-  const healed = options.streaming ? remend(text) : text;
-  const source = normalizeMarkdownTables(healed);
+  const source = preprocessMarkdownSource(text, options);
   const rawHtml = md.render(source);
   return DOMPurify.sanitize(rawHtml);
 }

--- a/packages/relay-web/src/lib/turn-layout.ts
+++ b/packages/relay-web/src/lib/turn-layout.ts
@@ -1,3 +1,5 @@
+import { deriveMarkdownLayout, type MarkdownLayoutOptions } from "./markdown-layout";
+
 export type LayoutSlotKind =
   | "exact-inline"
   | "block-end"
@@ -92,4 +94,114 @@ export function placeActivitiesMonotonically(
   }
 
   return placements;
+}
+
+function splitEmptyMarkdownNode(
+  node: MarkdownLayoutNode,
+  splitOffset: number,
+): [MarkdownLayoutNode, MarkdownLayoutNode] {
+  const [start, end] = node.sourceRange;
+  const relative = splitOffset - start;
+  return [
+    {
+      ...node,
+      key: `markdown:${start}:${splitOffset}`,
+      sourceRange: [start, splitOffset],
+      source: node.source.slice(0, relative),
+    },
+    {
+      ...node,
+      key: `markdown:${splitOffset}:${end}`,
+      sourceRange: [splitOffset, end],
+      source: node.source.slice(relative),
+    },
+  ];
+}
+
+function ensureSlotBoundaries(
+  markdownNodes: readonly MarkdownLayoutNode[],
+  placements: ReadonlyMap<string, ActivityPlacement>,
+): MarkdownLayoutNode[] {
+  const result = [...markdownNodes];
+  for (const placement of placements.values()) {
+    const containingIndex = result.findIndex((node) =>
+      placement.effectiveSlot > node.sourceRange[0]
+      && placement.effectiveSlot < node.sourceRange[1],
+    );
+    if (containingIndex < 0) continue;
+    const containing = result[containingIndex]!;
+    if (containing.html !== "" || containing.source.trim().length > 0) {
+      throw new Error("A legal activity slot must coincide with a Markdown node boundary");
+    }
+    result.splice(
+      containingIndex,
+      1,
+      ...splitEmptyMarkdownNode(containing, placement.effectiveSlot),
+    );
+  }
+  return result.filter((node) => node.sourceRange[1] > node.sourceRange[0]);
+}
+
+/** Build the render-safe turn layout from ordered activity geometry. */
+export function planTurnLayout(
+  narrative: string,
+  activities: readonly LayoutActivityGeometry[],
+  options: MarkdownLayoutOptions = {},
+): TurnLayoutPlan {
+  const markdown = deriveMarkdownLayout(narrative, activities, options);
+  const activityPlacements = placeActivitiesMonotonically(
+    activities,
+    (activity) => markdown.candidates.get(activity.id)!,
+  );
+  const markdownNodes = ensureSlotBoundaries(markdown.markdownNodes, activityPlacements);
+  const nodes: TurnLayoutNode[] = [];
+  let activityIndex = 0;
+
+  const pushMarkdown = (node: MarkdownLayoutNode): void => {
+    const previous = nodes[nodes.length - 1];
+    if (previous?.type === "markdown" && previous.sourceRange[1] === node.sourceRange[0]) {
+      previous.key = `markdown:${previous.sourceRange[0]}:${node.sourceRange[1]}`;
+      previous.sourceRange = [previous.sourceRange[0], node.sourceRange[1]];
+      previous.source += node.source;
+      previous.html += node.html;
+      previous.isLatest ||= node.isLatest;
+      return;
+    }
+    nodes.push({ ...node, sourceRange: [...node.sourceRange] });
+  };
+
+  const pushActivitiesAt = (slot: number): void => {
+    while (activityIndex < activities.length) {
+      const activity = activities[activityIndex]!;
+      const placement = activityPlacements.get(activity.id)!;
+      if (placement.effectiveSlot !== slot) break;
+      nodes.push({
+        type: "activity",
+        key: `activity:${activity.id}`,
+        activityId: activity.id,
+        wireIndex: activity.wireIndex,
+      });
+      activityIndex += 1;
+    }
+  };
+
+  pushActivitiesAt(0);
+  for (const markdownNode of markdownNodes) {
+    const [start, end] = markdownNode.sourceRange;
+    const nextActivity = activities[activityIndex];
+    if (nextActivity) {
+      const slot = activityPlacements.get(nextActivity.id)!.effectiveSlot;
+      if (slot > start && slot < end) {
+        throw new Error("Activity slot was not materialized as a Markdown boundary");
+      }
+    }
+    pushMarkdown(markdownNode);
+    pushActivitiesAt(end);
+  }
+  pushActivitiesAt(narrative.length);
+  if (activityIndex !== activities.length) {
+    throw new Error("Every layout activity must be materialized exactly once");
+  }
+
+  return { nodes, activityPlacements };
 }

--- a/packages/relay-web/src/lib/turn-layout.ts
+++ b/packages/relay-web/src/lib/turn-layout.ts
@@ -157,15 +157,23 @@ function sliceEmptyMarkdownNode(
 ): MarkdownLayoutNode {
   const relativeStart = start - node.sourceRange[0];
   const relativeEnd = end - node.sourceRange[0];
-  // Empty-HTML whitespace splits carry no rendered content, so slicing the raw
-  // source slice is exact here; copyText only diverges on marker-aware fragments
-  // which already sit on node boundaries and never enter this path with content.
+  // copyText is compositional (a node may carry a block terminator beyond its
+  // source span), so source-relative slicing is only valid when the copy has
+  // the same length as the source — true for "" gaps and whitespace fragments
+  // (whitespace serializes to itself). Anything else falls back to the source
+  // slice, which for the empty-html nodes reaching a partial split here is
+  // whitespace or "".
+  const copyText = start === node.sourceRange[0] && end === node.sourceRange[1]
+    ? node.copyText
+    : node.copyText.length === node.source.length
+      ? node.copyText.slice(relativeStart, relativeEnd)
+      : node.source.slice(relativeStart, relativeEnd);
   return {
     ...node,
     key: `markdown:${start}:${end}`,
     sourceRange: [start, end],
     source: node.source.slice(relativeStart, relativeEnd),
-    copyText: node.copyText.slice(relativeStart, relativeEnd),
+    copyText,
   };
 }
 

--- a/packages/relay-web/src/lib/turn-layout.ts
+++ b/packages/relay-web/src/lib/turn-layout.ts
@@ -1,0 +1,95 @@
+export type LayoutSlotKind =
+  | "exact-inline"
+  | "block-end"
+  | "document-start"
+  | "document-end";
+
+export type ActivityPlacementReason =
+  | "exact"
+  | "structural-block"
+  | "marker-unsafe"
+  | "order-barrier";
+
+export interface LayoutActivityGeometry {
+  id: string;
+  wireIndex: number;
+  sourceOffset: number;
+}
+
+export interface LayoutSlotCandidate {
+  sourceOffset: number;
+  kind: LayoutSlotKind;
+  reason: Exclude<ActivityPlacementReason, "order-barrier">;
+}
+
+export interface ActivityPlacement {
+  sourceOffset: number;
+  effectiveSlot: number;
+  slotKind: LayoutSlotKind;
+  reason: ActivityPlacementReason;
+}
+
+export interface MarkdownLayoutNode {
+  type: "markdown";
+  key: string;
+  sourceRange: [number, number];
+  source: string;
+  html: string;
+  isLatest: boolean;
+}
+
+export interface ActivityLayoutNode {
+  type: "activity";
+  key: string;
+  activityId: string;
+  wireIndex: number;
+}
+
+export type TurnLayoutNode = MarkdownLayoutNode | ActivityLayoutNode;
+
+export interface TurnLayoutPlan {
+  nodes: TurnLayoutNode[];
+  activityPlacements: Map<string, ActivityPlacement>;
+}
+
+/**
+ * Place activities in canonical wire order. A delayed activity becomes an order
+ * barrier for everything after it, so presentation order is a construction
+ * invariant rather than a consequence of a later sort.
+ */
+export function placeActivitiesMonotonically(
+  activities: readonly LayoutActivityGeometry[],
+  candidateFor: (activity: LayoutActivityGeometry) => LayoutSlotCandidate,
+): Map<string, ActivityPlacement> {
+  const placements = new Map<string, ActivityPlacement>();
+  let previousWireIndex = -1;
+  let previousEffectiveSlot = 0;
+
+  for (const activity of activities) {
+    if (activity.wireIndex <= previousWireIndex) {
+      throw new Error("Layout activities must be provided in strict wire order");
+    }
+    if (placements.has(activity.id)) {
+      throw new Error(`Duplicate layout activity id: ${activity.id}`);
+    }
+
+    const candidate = candidateFor(activity);
+    if (candidate.sourceOffset < activity.sourceOffset) {
+      throw new Error(`Layout candidate for ${activity.id} precedes its wire offset`);
+    }
+    const blockedByOrder = candidate.sourceOffset < previousEffectiveSlot;
+    const effectiveSlot = blockedByOrder
+      ? previousEffectiveSlot
+      : candidate.sourceOffset;
+    placements.set(activity.id, {
+      sourceOffset: activity.sourceOffset,
+      effectiveSlot,
+      slotKind: candidate.kind,
+      reason: blockedByOrder ? "order-barrier" : candidate.reason,
+    });
+    previousWireIndex = activity.wireIndex;
+    previousEffectiveSlot = effectiveSlot;
+  }
+
+  return placements;
+}

--- a/packages/relay-web/src/lib/turn-layout.ts
+++ b/packages/relay-web/src/lib/turn-layout.ts
@@ -159,15 +159,16 @@ function sliceEmptyMarkdownNode(
   const relativeEnd = end - node.sourceRange[0];
   // copyText is compositional (a node may carry a block terminator beyond its
   // source span), so source-relative slicing is only valid when the copy has
-  // the same length as the source — true for "" gaps and whitespace fragments
-  // (whitespace serializes to itself). Anything else falls back to the source
-  // slice, which for the empty-html nodes reaching a partial split here is
-  // whitespace or "".
-  const copyText = start === node.sourceRange[0] && end === node.sourceRange[1]
-    ? node.copyText
-    : node.copyText.length === node.source.length
-      ? node.copyText.slice(relativeStart, relativeEnd)
-      : node.source.slice(relativeStart, relativeEnd);
+  // the same length as the source — true for whitespace fragments, which
+  // serialize to themselves. Whole-node passthrough keeps the full semantic
+  // copy. A partial split with no 1:1 projection (notably the "" inter-block
+  // gaps) keeps "" instead of inventing clipboard text from raw geometry.
+  const whole = start === node.sourceRange[0] && end === node.sourceRange[1];
+  let copyText: string;
+  if (whole) copyText = node.copyText;
+  else if (node.copyText.length === node.source.length) {
+    copyText = node.copyText.slice(relativeStart, relativeEnd);
+  } else copyText = "";
   return {
     ...node,
     key: `markdown:${start}:${end}`,

--- a/packages/relay-web/src/lib/turn-layout.ts
+++ b/packages/relay-web/src/lib/turn-layout.ts
@@ -61,13 +61,28 @@ export interface TurnLayoutPlan {
   activityPlacements: Map<string, ActivityPlacement>;
 }
 
+export interface TurnLayoutBlockFingerprint {
+  source: string;
+  activityIds: string;
+  streaming: boolean;
+  references: string;
+}
+
+export interface TurnLayoutBlockCacheEntry {
+  fingerprint: TurnLayoutBlockFingerprint;
+  baseStart: number;
+  nodes: MarkdownLayoutNode[];
+  candidates: Array<[string, LayoutSlotCandidate]>;
+}
+
 export interface TurnLayoutGeometryCache {
   key: string | null;
   plan: TurnLayoutPlan | null;
+  blocks: Map<string, TurnLayoutBlockCacheEntry>;
 }
 
 export function createTurnLayoutGeometryCache(): TurnLayoutGeometryCache {
-  return { key: null, plan: null };
+  return { key: null, plan: null, blocks: new Map() };
 }
 
 function layoutGeometryKey(
@@ -184,7 +199,7 @@ export function planTurnLayout(
 ): TurnLayoutPlan {
   const cacheKey = cache ? layoutGeometryKey(narrative, activities, options) : null;
   if (cache && cache.key === cacheKey && cache.plan) return cache.plan;
-  const markdown = deriveMarkdownLayout(narrative, activities, options);
+  const markdown = deriveMarkdownLayout(narrative, activities, options, cache?.blocks);
   const activityPlacements = placeActivitiesMonotonically(
     activities,
     (activity) => markdown.candidates.get(activity.id)!,

--- a/packages/relay-web/src/lib/turn-layout.ts
+++ b/packages/relay-web/src/lib/turn-layout.ts
@@ -68,11 +68,21 @@ export interface TurnLayoutBlockFingerprint {
   references: string;
 }
 
+/**
+ * A block's verdict on its internal activities, without any absolute
+ * document geometry. `exact-inline` slots resolve to the activity's own
+ * wire offset; `block-end` slots resolve to the block's *current* boundary,
+ * which depends on the neighboring gap — so the boundary is rebound on every
+ * frame, never read back from the cache.
+ */
+export type BlockActivityDisposition =
+  | { kind: "exact-inline" }
+  | { kind: "block-end"; reason: Exclude<ActivityPlacementReason, "order-barrier"> };
+
 export interface TurnLayoutBlockCacheEntry {
   fingerprint: TurnLayoutBlockFingerprint;
-  baseStart: number;
   nodes: MarkdownLayoutNode[];
-  candidates: Array<[string, LayoutSlotCandidate]>;
+  activities: Array<{ id: string; disposition: BlockActivityDisposition }>;
 }
 
 export interface TurnLayoutGeometryCache {

--- a/packages/relay-web/src/lib/turn-layout.ts
+++ b/packages/relay-web/src/lib/turn-layout.ts
@@ -54,6 +54,28 @@ export interface TurnLayoutPlan {
   activityPlacements: Map<string, ActivityPlacement>;
 }
 
+export interface TurnLayoutGeometryCache {
+  key: string | null;
+  plan: TurnLayoutPlan | null;
+}
+
+export function createTurnLayoutGeometryCache(): TurnLayoutGeometryCache {
+  return { key: null, plan: null };
+}
+
+function layoutGeometryKey(
+  narrative: string,
+  activities: readonly LayoutActivityGeometry[],
+  options: MarkdownLayoutOptions,
+): string {
+  return JSON.stringify([
+    narrative,
+    options.streaming === true,
+    options.latestVisibleIsText === true,
+    activities.map(({ id, wireIndex, sourceOffset }) => [id, wireIndex, sourceOffset]),
+  ]);
+}
+
 /**
  * Place activities in canonical wire order. A delayed activity becomes an order
  * barrier for everything after it, so presentation order is a construction
@@ -96,50 +118,50 @@ export function placeActivitiesMonotonically(
   return placements;
 }
 
-function splitEmptyMarkdownNode(
+function sliceEmptyMarkdownNode(
   node: MarkdownLayoutNode,
-  splitOffset: number,
-): [MarkdownLayoutNode, MarkdownLayoutNode] {
-  const [start, end] = node.sourceRange;
-  const relative = splitOffset - start;
-  return [
-    {
-      ...node,
-      key: `markdown:${start}:${splitOffset}`,
-      sourceRange: [start, splitOffset],
-      source: node.source.slice(0, relative),
-    },
-    {
-      ...node,
-      key: `markdown:${splitOffset}:${end}`,
-      sourceRange: [splitOffset, end],
-      source: node.source.slice(relative),
-    },
-  ];
+  start: number,
+  end: number,
+): MarkdownLayoutNode {
+  const relativeStart = start - node.sourceRange[0];
+  const relativeEnd = end - node.sourceRange[0];
+  return {
+    ...node,
+    key: `markdown:${start}:${end}`,
+    sourceRange: [start, end],
+    source: node.source.slice(relativeStart, relativeEnd),
+  };
 }
 
 function ensureSlotBoundaries(
   markdownNodes: readonly MarkdownLayoutNode[],
   placements: ReadonlyMap<string, ActivityPlacement>,
 ): MarkdownLayoutNode[] {
-  const result = [...markdownNodes];
-  for (const placement of placements.values()) {
-    const containingIndex = result.findIndex((node) =>
-      placement.effectiveSlot > node.sourceRange[0]
-      && placement.effectiveSlot < node.sourceRange[1],
-    );
-    if (containingIndex < 0) continue;
-    const containing = result[containingIndex]!;
-    if (containing.html !== "" || containing.source.trim().length > 0) {
-      throw new Error("A legal activity slot must coincide with a Markdown node boundary");
+  const result: MarkdownLayoutNode[] = [];
+  const effectiveSlots = [...placements.values()].map((placement) => placement.effectiveSlot);
+  let slotIndex = 0;
+  for (const node of markdownNodes) {
+    const [nodeStart, nodeEnd] = node.sourceRange;
+    while (effectiveSlots[slotIndex] !== undefined && effectiveSlots[slotIndex]! <= nodeStart) {
+      slotIndex += 1;
     }
-    result.splice(
-      containingIndex,
-      1,
-      ...splitEmptyMarkdownNode(containing, placement.effectiveSlot),
-    );
+    let segmentStart = nodeStart;
+    while (effectiveSlots[slotIndex] !== undefined && effectiveSlots[slotIndex]! < nodeEnd) {
+      const slot = effectiveSlots[slotIndex]!;
+      if (node.html !== "" || node.source.trim().length > 0) {
+        throw new Error("A legal activity slot must coincide with a Markdown node boundary");
+      }
+      if (slot > segmentStart) {
+        result.push(sliceEmptyMarkdownNode(node, segmentStart, slot));
+        segmentStart = slot;
+      }
+      while (effectiveSlots[slotIndex] === slot) slotIndex += 1;
+    }
+    if (nodeEnd > segmentStart) {
+      result.push(sliceEmptyMarkdownNode(node, segmentStart, nodeEnd));
+    }
   }
-  return result.filter((node) => node.sourceRange[1] > node.sourceRange[0]);
+  return result;
 }
 
 /** Build the render-safe turn layout from ordered activity geometry. */
@@ -147,7 +169,10 @@ export function planTurnLayout(
   narrative: string,
   activities: readonly LayoutActivityGeometry[],
   options: MarkdownLayoutOptions = {},
+  cache?: TurnLayoutGeometryCache,
 ): TurnLayoutPlan {
+  const cacheKey = cache ? layoutGeometryKey(narrative, activities, options) : null;
+  if (cache && cache.key === cacheKey && cache.plan) return cache.plan;
   const markdown = deriveMarkdownLayout(narrative, activities, options);
   const activityPlacements = placeActivitiesMonotonically(
     activities,
@@ -203,5 +228,10 @@ export function planTurnLayout(
     throw new Error("Every layout activity must be materialized exactly once");
   }
 
-  return { nodes, activityPlacements };
+  const plan = { nodes, activityPlacements };
+  if (cache) {
+    cache.key = cacheKey;
+    cache.plan = plan;
+  }
+  return plan;
 }

--- a/packages/relay-web/src/lib/turn-layout.ts
+++ b/packages/relay-web/src/lib/turn-layout.ts
@@ -37,6 +37,13 @@ export interface MarkdownLayoutNode {
   sourceRange: [number, number];
   source: string;
   html: string;
+  /**
+   * Standalone copy representation. `source` stays the canonical raw slice for
+   * geometry/debug/reconstruction; this field is what the clipboard should get
+   * so a fragment cut out of the middle of an inline construct never ships a
+   * dangling `**`, backtick, or link destination.
+   */
+  copyText: string;
   isLatest: boolean;
 }
 
@@ -125,11 +132,15 @@ function sliceEmptyMarkdownNode(
 ): MarkdownLayoutNode {
   const relativeStart = start - node.sourceRange[0];
   const relativeEnd = end - node.sourceRange[0];
+  // Empty-HTML whitespace splits carry no rendered content, so slicing the raw
+  // source slice is exact here; copyText only diverges on marker-aware fragments
+  // which already sit on node boundaries and never enter this path with content.
   return {
     ...node,
     key: `markdown:${start}:${end}`,
     sourceRange: [start, end],
     source: node.source.slice(relativeStart, relativeEnd),
+    copyText: node.copyText.slice(relativeStart, relativeEnd),
   };
 }
 
@@ -188,6 +199,7 @@ export function planTurnLayout(
       previous.key = `markdown:${previous.sourceRange[0]}:${node.sourceRange[1]}`;
       previous.sourceRange = [previous.sourceRange[0], node.sourceRange[1]];
       previous.source += node.source;
+      previous.copyText += node.copyText;
       previous.html += node.html;
       previous.isLatest ||= node.isLatest;
       return;

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -175,6 +175,7 @@ export function deriveTurnPresentation(
         sourceRange: [0, timeline.narrative.length],
         source: timeline.narrative,
         html,
+        copyText: timeline.narrative,
         isLatest: options.streaming === true && latestVisibleIsText,
       }
       : null;
@@ -292,7 +293,7 @@ export function extractCollapsedTraceSummary(
 ): CollapsedTraceSummary {
   const presentation = deriveTurnPresentation(parts, options);
   return {
-    finalReplyText: presentation.finalReplyNodes.map((node) => node.source).join(""),
+    finalReplyText: presentation.finalReplyNodes.map((node) => node.copyText).join(""),
     toolCount: presentation.toolCount,
     thoughtCount: presentation.thoughtCount,
     presentation,

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -97,12 +97,26 @@ export function deriveTurnPresentation(
   });
 
   const boundaries = markdownBlockBoundaries(narrative);
+  const documentEnv: Record<string, unknown> = {};
+
+  const safeNarrativeAnchor = (offset: number): number | null => {
+    const block = topLevelBlockAt(narrative, offset, documentEnv);
+    if (!block || block.type !== "paragraph_open") return null;
+    if (normalizeMarkdownTables(block.source) !== block.source) return null;
+    if (narrative.slice(block.endOffset).trim().length > 0) return null;
+    const offsetInBlock = offset - block.startOffset;
+    return isSafeInlineParagraphOffset(block.source, offsetInBlock, documentEnv)
+      ? offset
+      : null;
+  };
 
   const anchored = new Map<number, typeof activities>();
   for (const activity of activities) {
     const anchor = narrative.slice(0, activity.offset).trim().length === 0
       ? 0
-      : (boundaries.find((boundary) => boundary >= activity.offset) ?? narrative.length);
+      : (safeNarrativeAnchor(activity.offset)
+        ?? boundaries.find((boundary) => boundary >= activity.offset)
+        ?? narrative.length);
     const group = anchored.get(anchor) ?? [];
     group.push(activity);
     anchored.set(anchor, group);

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -1,5 +1,5 @@
 import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
-import { renderMarkdown } from "./render-markdown";
+import { markdownSourceToPlainText, renderMarkdown } from "./render-markdown";
 import {
   planTurnLayout,
   type MarkdownLayoutNode,
@@ -175,7 +175,11 @@ export function deriveTurnPresentation(
         sourceRange: [0, timeline.narrative.length],
         source: timeline.narrative,
         html,
-        copyText: timeline.narrative,
+        copyText: html.trim()
+          ? markdownSourceToPlainText(timeline.narrative, {
+            streaming: options.streaming === true && latestVisibleIsText,
+          }).trim()
+          : "",
         isLatest: options.streaming === true && latestVisibleIsText,
       }
       : null;

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -1,16 +1,12 @@
 import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
-import {
-  analyzeMarkdownDocument,
-  isSafeInlineParagraphOffset,
-  isSafeStandaloneParagraphOffset,
-  topLevelBlockAt,
-  type TopLevelBlockInfo,
-} from "./render-markdown";
-import { normalizeMarkdownTables } from "./normalize-markdown";
+import { planTurnLayout, type MarkdownLayoutNode, type TurnLayoutPlan } from "./turn-layout";
+import { buildTurnTimeline, type TimelineActivity } from "./turn-timeline";
 import { hasToolStepAncestor, indexToolSteps } from "./subagent-trace";
 
+export type TurnPresentationMarkdownItem = MarkdownLayoutNode;
+
 export type TurnPresentationItem =
-  | { key: string; type: "text"; text: string; isLatest: boolean }
+  | TurnPresentationMarkdownItem
   | { key: string; type: "reasoning"; text: string; isLatest: boolean }
   | { key: string; type: "tool"; step: ToolStepDto; isLatest: boolean }
   | {
@@ -28,24 +24,43 @@ export type TurnPresentationItem =
       isLatest: boolean;
     };
 
-/** Optional composition inputs. `sentAgentMessageById` keys SENT peer-message
- *  history entries by messageId so the sent card can be joined — presentation-only —
- *  to the exact agent_send tool step whose structured receipt carries that id.
- *  The persisted rows stay the canonical record; nothing here mutates them. */
+export interface TurnPresentationPlan {
+  nodes: TurnPresentationItem[];
+  finalReplyNodes: TurnPresentationMarkdownItem[];
+  layout: TurnLayoutPlan;
+  toolCount: number;
+  thoughtCount: number;
+}
+
 export interface TurnPresentationOptions {
   sentAgentMessageById?: Map<string, PeerMessageHistoryEntry>;
-  /** Mirror StreamMarkdown's live preprocessing so unsafe temporary splits fail closed. */
   streaming?: boolean;
 }
 
-type ActivityPart =
-  | Exclude<TurnPartDto, { type: "text" }>
-  | { type: "subagent"; step: ToolStepDto; children: ToolStepDto[] };
+type DecoratedActivity =
+  | {
+      id: string;
+      wireIndex: number;
+      sourceOffset: number;
+      type: "reasoning";
+      text: string;
+    }
+  | {
+      id: string;
+      wireIndex: number;
+      sourceOffset: number;
+      type: "tool";
+      step: ToolStepDto;
+    }
+  | {
+      id: string;
+      wireIndex: number;
+      sourceOffset: number;
+      type: "subagent";
+      step: ToolStepDto;
+      children: ToolStepDto[];
+    };
 
-/** MessageIds these parts can anchor a sent card to: every tool step's
- *  `agentMessageId`, including steps folded into subagent activities. Mirrors the
- *  anchoring deriveTurnPresentation performs, so a caller can suppress a standalone
- *  card row exactly when the card renders inside a turn. */
 export function anchoredAgentMessageIds(parts: TurnPartDto[]): Set<string> {
   const ids = new Set<string>();
   for (const part of parts) {
@@ -54,117 +69,97 @@ export function anchoredAgentMessageIds(parts: TurnPartDto[]): Set<string> {
   return ids;
 }
 
-export function deriveTurnPresentation(
-  parts: TurnPartDto[],
-  opts?: TurnPresentationOptions,
-): TurnPresentationItem[] {
-  const latestVisibleIndex = parts.findLastIndex((part) =>
-    part.type === "tool" || part.text.trim().length > 0,
-  );
-  const toolSteps = parts
-    .filter((part): part is Extract<TurnPartDto, { type: "tool" }> => part.type === "tool")
-    .map((part) => part.step);
+function decorateActivities(
+  timelineActivities: readonly TimelineActivity[],
+): DecoratedActivity[] {
+  const toolSteps = timelineActivities
+    .filter((activity): activity is TimelineActivity & {
+      payload: Extract<TurnPartDto, { type: "tool" }>;
+    } => activity.payload.type === "tool")
+    .map((activity) => activity.payload.step);
   const stepsById = indexToolSteps(toolSteps);
   const subagentIds = new Set(
     toolSteps.filter((step) => step.isSubagent === true).map((step) => step.toolCallId),
   );
-  const descendantsOf = (parentToolCallId: string) =>
-    toolSteps.filter((step) =>
-      hasToolStepAncestor(step, stepsById, (ancestorId) => ancestorId === parentToolCallId),
+  const descendantsByParent = new Map<string, ToolStepDto[]>();
+  for (const parentId of subagentIds) {
+    descendantsByParent.set(
+      parentId,
+      toolSteps.filter((step) =>
+        hasToolStepAncestor(step, stepsById, (ancestorId) => ancestorId === parentId),
+      ),
     );
-  let narrative = "";
-  const activities: Array<{
-    offset: number;
-    index: number;
-    part: ActivityPart;
-  }> = [];
-
-  parts.forEach((part, index) => {
-    if (part.type === "text") {
-      narrative += part.text;
-      return;
-    }
-    if (part.type === "reasoning" && !part.text.trim()) return;
-    if (
-      part.type === "tool"
-      && hasToolStepAncestor(part.step, stepsById, (ancestorId) => subagentIds.has(ancestorId))
-    ) return;
-    if (part.type === "tool" && part.step.isSubagent) {
-      activities.push({
-        offset: narrative.length,
-        index,
-        part: {
-          type: "subagent",
-          step: part.step,
-          children: descendantsOf(part.step.toolCallId),
-        },
-      });
-      return;
-    }
-    activities.push({ offset: narrative.length, index, part });
-  });
-
-  const markdown = analyzeMarkdownDocument(narrative);
-
-  const blockAtOffset = (offset: number): TopLevelBlockInfo | null => {
-    let low = 0;
-    let high = markdown.blocks.length;
-    while (low < high) {
-      const middle = Math.floor((low + high) / 2);
-      if (markdown.blocks[middle]!.endOffset < offset) low = middle + 1;
-      else high = middle;
-    }
-    const block = markdown.blocks[low];
-    return block && offset >= block.startOffset ? block : null;
-  };
-
-  const boundaryAtOrAfter = (offset: number): number | null => {
-    let low = 0;
-    let high = markdown.boundaries.length;
-    while (low < high) {
-      const middle = Math.floor((low + high) / 2);
-      if (markdown.boundaries[middle]! < offset) low = middle + 1;
-      else high = middle;
-    }
-    return markdown.boundaries[low] ?? null;
-  };
-
-  const safeNarrativeAnchor = (offset: number): number | null => {
-    const block = blockAtOffset(offset);
-    if (!block || block.type !== "paragraph_open") return null;
-    const offsetInBlock = offset - block.startOffset;
-    return isSafeStandaloneParagraphOffset(
-      block.source,
-      offsetInBlock,
-      markdown.env,
-      { streaming: opts?.streaming === true },
-    )
-      ? offset
-      : null;
-  };
-
-  const anchored = new Map<number, typeof activities>();
-  for (const activity of activities) {
-    const anchor = narrative.slice(0, activity.offset).trim().length === 0
-      ? 0
-      : (safeNarrativeAnchor(activity.offset)
-        ?? boundaryAtOrAfter(activity.offset)
-        ?? narrative.length);
-    const group = anchored.get(anchor) ?? [];
-    group.push(activity);
-    anchored.set(anchor, group);
   }
 
-  const result: TurnPresentationItem[] = [];
-  let cursor = 0;
+  const result: DecoratedActivity[] = [];
+  for (const activity of timelineActivities) {
+    if (activity.payload.type === "reasoning") {
+      if (!activity.payload.text.trim()) continue;
+      result.push({
+        id: activity.id,
+        wireIndex: activity.wireIndex,
+        sourceOffset: activity.sourceOffset,
+        type: "reasoning",
+        text: activity.payload.text,
+      });
+      continue;
+    }
+    const step = activity.payload.step;
+    if (hasToolStepAncestor(step, stepsById, (ancestorId) => subagentIds.has(ancestorId))) {
+      continue;
+    }
+    if (step.isSubagent) {
+      result.push({
+        id: activity.id,
+        wireIndex: activity.wireIndex,
+        sourceOffset: activity.sourceOffset,
+        type: "subagent",
+        step,
+        children: descendantsByParent.get(step.toolCallId) ?? [],
+      });
+      continue;
+    }
+    result.push({
+      id: activity.id,
+      wireIndex: activity.wireIndex,
+      sourceOffset: activity.sourceOffset,
+      type: "tool",
+      step,
+    });
+  }
+  return result;
+}
 
-  // Sent cards join right after the exact tool step that produced them (a send made
-  // inside a subagent anchors after the whole subagent activity). Each messageId
-  // anchors at most once; receiver-direction entries never join — those stay
-  // standalone timeline rows.
+export function deriveTurnPresentation(
+  parts: TurnPartDto[],
+  options: TurnPresentationOptions = {},
+): TurnPresentationPlan {
+  const timeline = buildTurnTimeline(parts);
+  const activities = decorateActivities(timeline.activities);
+  const latestVisibleWireIndex = parts.findLastIndex((part) =>
+    part.type === "tool" || part.text.trim().length > 0,
+  );
+  const latestVisibleIsText = latestVisibleWireIndex >= 0
+    && parts[latestVisibleWireIndex]?.type === "text";
+  const layout = planTurnLayout(
+    timeline.narrative,
+    activities.map(({ id, wireIndex, sourceOffset }) => ({
+      id,
+      wireIndex,
+      sourceOffset,
+    })),
+    {
+      streaming: options.streaming === true,
+      latestVisibleIsText,
+    },
+  );
+  const activityById = new Map(activities.map((activity) => [activity.id, activity]));
+  const nodes: TurnPresentationItem[] = [];
+  const markdownByKey = new Map<string, TurnPresentationMarkdownItem>();
   const anchoredMessageIds = new Set<string>();
-  const pushAgentMessages = (steps: ToolStepDto[]): void => {
-    const byId = opts?.sentAgentMessageById;
+
+  const pushAgentMessages = (steps: readonly ToolStepDto[]): void => {
+    const byId = options.sentAgentMessageById;
     if (!byId || byId.size === 0) return;
     for (const step of steps) {
       const id = step.agentMessageId;
@@ -172,7 +167,7 @@ export function deriveTurnPresentation(
       const message = byId.get(id);
       if (!message || message.direction !== "sent") continue;
       anchoredMessageIds.add(id);
-      result.push({
+      nodes.push({
         key: `agent-message:${id}`,
         type: "agent-message",
         message,
@@ -182,180 +177,74 @@ export function deriveTurnPresentation(
     }
   };
 
-  const pushText = (end: number) => {
-    const text = narrative.slice(cursor, end);
-    if (text.trim()) {
-      result.push({
-        key: `text:${cursor}`,
-        type: "text",
-        text,
-        isLatest: false,
+  for (const node of layout.nodes) {
+    if (node.type === "markdown") {
+      if (!node.html.trim()) continue;
+      nodes.push(node);
+      markdownByKey.set(node.key, node);
+      continue;
+    }
+    const activity = activityById.get(node.activityId);
+    if (!activity) throw new Error(`Missing presentation activity: ${node.activityId}`);
+    const isLatest = activity.wireIndex === latestVisibleWireIndex;
+    if (activity.type === "reasoning") {
+      nodes.push({
+        key: `reasoning:${activity.id}`,
+        type: "reasoning",
+        text: activity.text,
+        isLatest,
       });
+    } else if (activity.type === "tool") {
+      nodes.push({
+        key: `tool:${activity.step.toolCallId}`,
+        type: "tool",
+        step: activity.step,
+        isLatest,
+      });
+      pushAgentMessages([activity.step]);
+    } else {
+      nodes.push({
+        key: `subagent:${activity.step.toolCallId}`,
+        type: "subagent",
+        step: activity.step,
+        children: activity.children,
+        isLatest,
+      });
+      pushAgentMessages([activity.step, ...activity.children]);
     }
-    cursor = end;
+  }
+
+  const lastLayoutActivityIndex = layout.nodes.findLastIndex((node) => node.type === "activity");
+  const finalReplyNodes = layout.nodes
+    .slice(lastLayoutActivityIndex + 1)
+    .filter((node): node is MarkdownLayoutNode => node.type === "markdown" && node.html.trim().length > 0)
+    .map((node) => markdownByKey.get(node.key) ?? node);
+
+  return {
+    nodes,
+    finalReplyNodes,
+    layout,
+    toolCount: nodes.filter((node) => node.type === "tool" || node.type === "subagent").length,
+    thoughtCount: nodes.filter((node) => node.type === "reasoning").length,
   };
-
-  for (const [anchor, group] of [...anchored.entries()].sort(([a], [b]) => a - b)) {
-    pushText(anchor);
-    for (const activity of group) {
-      if (activity.part.type === "reasoning") {
-        result.push({
-          key: `reasoning:${activity.index}`,
-          type: "reasoning",
-          text: activity.part.text,
-          isLatest: activity.index === latestVisibleIndex,
-        });
-      } else if (activity.part.type === "tool") {
-        result.push({
-          key: `tool:${activity.part.step.toolCallId}`,
-          type: "tool",
-          step: activity.part.step,
-          isLatest: activity.index === latestVisibleIndex,
-        });
-        pushAgentMessages([activity.part.step]);
-      } else {
-        result.push({
-          key: `subagent:${activity.part.step.toolCallId}`,
-          type: "subagent",
-          step: activity.part.step,
-          children: activity.part.children,
-          isLatest: activity.index === latestVisibleIndex,
-        });
-        pushAgentMessages([activity.part.step, ...activity.part.children]);
-      }
-    }
-  }
-  pushText(narrative.length);
-
-  if (latestVisibleIndex >= 0 && parts[latestVisibleIndex]?.type === "text") {
-    const latestText = result.findLast((item) => item.type === "text");
-    if (latestText) latestText.isLatest = true;
-  }
-
-  return result;
-}
-
-/** Top-level block types that are strictly safe to slice mid-block across an activity.
- *  Containers (blockquotes, lists, tables, headings) can be nested arbitrarily or change
- *  block semantics if split. We fail-closed: only top-level paragraphs permit extracting
- *  trailing text after a mid-block activity.
- */
-const SAFE_SLICE_BLOCK_TYPES: Record<string, true> = {
-  paragraph_open: true,
-};
-
-/** Extract the conversational final reply from a turn's wire parts.
- *
- *  When a turn finishes with tool/reasoning activity:
- *  1. If deriveTurnPresentation() produced text items after the last process item,
- *     those items are already cleanly anchored at top-level Markdown block boundaries
- *     (e.g. after a code fence or table closed). We join and return them.
- *  2. If presentation placed the process item at the end, it was anchored at narrative end
- *     because it arrived inside the final Markdown block. If that block is safe prose
- *     (a paragraph), trailing text arriving after the process item is returned.
- *  3. If the process item arrived inside an unsafe or nested container (fence, table, list,
- *     blockquote) that never closed with a subsequent reply block, mid-block slicing would
- *     corrupt Markdown (turning closing fences into unclosed opening fences, breaking table
- *     rows, or severing nested blocks). The fail-safe is fail-closed: only explicitly safe
- *     top-level prose blocks (paragraph) permit slicing trailing text; all other
- *     block types (or missing blocks) return empty string (trace header only, no broken markdown).
- */
-export function extractFinalReplyText(
-  parts: TurnPartDto[],
-  opts?: { presentation?: TurnPresentationItem[] },
-): string {
-  const pres = opts?.presentation ?? deriveTurnPresentation(parts);
-  const lastProcessIndex = pres.findLastIndex((item) => item.type !== "text");
-
-  // Pure-text turn: no process items to fold
-  if (lastProcessIndex < 0) {
-    return parts
-      .filter((p): p is Extract<TurnPartDto, { type: "text" }> => p.type === "text")
-      .map((p) => p.text)
-      .join("");
-  }
-
-  // deriveTurnPresentation already placed subsequent Markdown blocks after the activity
-  if (lastProcessIndex < pres.length - 1) {
-    return pres
-      .slice(lastProcessIndex + 1)
-      .filter((item): item is Extract<TurnPresentationItem, { type: "text" }> => item.type === "text")
-      .map((item) => item.text)
-      .join("");
-  }
-
-  // presentation ended on the process item (anchored at narrative.length).
-  const lastPartIdx = parts.findLastIndex(
-    (p) => p.type === "tool" || (p.type === "reasoning" && p.text.trim().length > 0),
-  );
-  if (lastPartIdx < 0) return "";
-  const trailing = parts
-    .slice(lastPartIdx + 1)
-    .filter((p): p is Extract<TurnPartDto, { type: "text" }> => p.type === "text")
-    .map((p) => p.text)
-    .join("");
-  if (!trailing.trim()) return "";
-
-  // Check if the last activity was inside an unsafe Markdown block.
-  let narrative = "";
-  let toolOffset = 0;
-  for (let i = 0; i < parts.length; i += 1) {
-    if (i === lastPartIdx) toolOffset = narrative.length;
-    const part = parts[i]!;
-    if (part.type === "text") narrative += part.text;
-  }
-
-  const docEnv: Record<string, unknown> = {};
-  const block = topLevelBlockAt(narrative, toolOffset, docEnv);
-  if (!block || !SAFE_SLICE_BLOCK_TYPES[block.type]) {
-    return "";
-  }
-  // Normalization guard: the renderer runs normalizeMarkdownTables() before parsing.
-  // If the candidate block would be reshaped by table normalization (e.g. malformed
-  // delimiterless tables recognized as a table during render but appearing as a paragraph
-  // to raw markdown-it), fail-closed so we do not slice mid-table or synthesize corrupted tables.
-  if (normalizeMarkdownTables(block.source) !== block.source) {
-    return "";
-  }
-  // Scope constraint: the fallback only applies when the trailing prose is strictly contained
-  // within the validated top-level block. Any unrendered Markdown metadata outside the block
-  // (such as trailing reference link definitions) must not leak as final reply.
-  const outsideBlock = narrative.slice(block.endOffset);
-  if (outsideBlock.trim().length > 0) {
-    return "";
-  }
-  // Inline boundary guard: verify that the tool arrived at an unstyled top-level text
-  // boundary within the paragraph, rather than severing an active inline construct
-  // (code span, emphasis, bold, link label/delimiter, reference link, HTML entity, etc.).
-  const offsetInBlock = toolOffset - block.startOffset;
-  if (!isSafeInlineParagraphOffset(block.source, offsetInBlock, docEnv)) {
-    return "";
-  }
-  const reply = narrative.slice(toolOffset, block.endOffset);
-  return reply.trim() ? reply : "";
 }
 
 export interface CollapsedTraceSummary {
   finalReplyText: string;
   toolCount: number;
   thoughtCount: number;
-}
-
-/** Extract all collapsed-trace header metrics in a single pass, sharing the
- *  presentation derivation between the final conversational reply and the
- *  activity counters so MessageList and TurnParts never perform duplicate Markdown parses.
- */
-export interface CollapsedTraceSummaryOptions extends TurnPresentationOptions {
-  presentation?: TurnPresentationItem[];
+  presentation: TurnPresentationPlan;
 }
 
 export function extractCollapsedTraceSummary(
   parts: TurnPartDto[],
-  opts?: CollapsedTraceSummaryOptions,
+  options: TurnPresentationOptions = {},
 ): CollapsedTraceSummary {
-  const pres: TurnPresentationItem[] = opts?.presentation ?? deriveTurnPresentation(parts, opts);
-  const finalReplyText = extractFinalReplyText(parts, { presentation: pres });
-  const toolCount = pres.filter((item: TurnPresentationItem) => item.type === "tool" || item.type === "subagent").length;
-  const thoughtCount = pres.filter((item: TurnPresentationItem) => item.type === "reasoning").length;
-  return { finalReplyText, toolCount, thoughtCount };
+  const presentation = deriveTurnPresentation(parts, options);
+  return {
+    finalReplyText: presentation.finalReplyNodes.map((node) => node.source).join(""),
+    toolCount: presentation.toolCount,
+    thoughtCount: presentation.thoughtCount,
+    presentation,
+  };
 }

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -1,7 +1,13 @@
 import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
-import { planTurnLayout, type MarkdownLayoutNode, type TurnLayoutPlan } from "./turn-layout";
+import { renderMarkdown } from "./render-markdown";
+import {
+  planTurnLayout,
+  type MarkdownLayoutNode,
+  type TurnLayoutGeometryCache,
+  type TurnLayoutPlan,
+} from "./turn-layout";
 import { buildTurnTimeline, type TimelineActivity } from "./turn-timeline";
-import { hasToolStepAncestor, indexToolSteps } from "./subagent-trace";
+import { indexToolSteps } from "./subagent-trace";
 
 export type TurnPresentationMarkdownItem = MarkdownLayoutNode;
 
@@ -35,6 +41,7 @@ export interface TurnPresentationPlan {
 export interface TurnPresentationOptions {
   sentAgentMessageById?: Map<string, PeerMessageHistoryEntry>;
   streaming?: boolean;
+  layoutCache?: TurnLayoutGeometryCache;
 }
 
 type DecoratedActivity =
@@ -81,14 +88,28 @@ function decorateActivities(
   const subagentIds = new Set(
     toolSteps.filter((step) => step.isSubagent === true).map((step) => step.toolCallId),
   );
+  const rootSubagentByStep = new Map<string, string | null>();
+  const resolvingSubagents = new Set<string>();
+  const rootSubagentOf = (step: ToolStepDto): string | null => {
+    const cached = rootSubagentByStep.get(step.toolCallId);
+    if (cached !== undefined) return cached;
+    if (resolvingSubagents.has(step.toolCallId)) return null;
+    resolvingSubagents.add(step.toolCallId);
+    const parentId = step.parentToolCallId;
+    const parent = parentId ? stepsById.get(parentId) : undefined;
+    const parentRoot = parent ? rootSubagentOf(parent) : null;
+    const rootSubagentId = parentRoot ?? (parentId && subagentIds.has(parentId) ? parentId : null);
+    resolvingSubagents.delete(step.toolCallId);
+    rootSubagentByStep.set(step.toolCallId, rootSubagentId);
+    return rootSubagentId;
+  };
   const descendantsByParent = new Map<string, ToolStepDto[]>();
-  for (const parentId of subagentIds) {
-    descendantsByParent.set(
-      parentId,
-      toolSteps.filter((step) =>
-        hasToolStepAncestor(step, stepsById, (ancestorId) => ancestorId === parentId),
-      ),
-    );
+  for (const step of toolSteps) {
+    const rootSubagentId = rootSubagentOf(step);
+    if (!rootSubagentId) continue;
+    const descendants = descendantsByParent.get(rootSubagentId) ?? [];
+    descendants.push(step);
+    descendantsByParent.set(rootSubagentId, descendants);
   }
 
   const result: DecoratedActivity[] = [];
@@ -105,7 +126,7 @@ function decorateActivities(
       continue;
     }
     const step = activity.payload.step;
-    if (hasToolStepAncestor(step, stepsById, (ancestorId) => subagentIds.has(ancestorId))) {
+    if (rootSubagentOf(step)) {
       continue;
     }
     if (step.isSubagent) {
@@ -141,6 +162,34 @@ export function deriveTurnPresentation(
   );
   const latestVisibleIsText = latestVisibleWireIndex >= 0
     && parts[latestVisibleWireIndex]?.type === "text";
+  if (activities.length === 0) {
+    const html = timeline.narrative.trim()
+      ? renderMarkdown(timeline.narrative, {
+        streaming: options.streaming === true && latestVisibleIsText,
+      })
+      : "";
+    const markdownNode: MarkdownLayoutNode | null = timeline.narrative.length > 0
+      ? {
+        type: "markdown",
+        key: `markdown:0:${timeline.narrative.length}`,
+        sourceRange: [0, timeline.narrative.length],
+        source: timeline.narrative,
+        html,
+        isLatest: options.streaming === true && latestVisibleIsText,
+      }
+      : null;
+    const layout: TurnLayoutPlan = {
+      nodes: markdownNode ? [markdownNode] : [],
+      activityPlacements: new Map(),
+    };
+    return {
+      nodes: markdownNode && html.trim() ? [markdownNode] : [],
+      finalReplyNodes: markdownNode && html.trim() ? [markdownNode] : [],
+      layout,
+      toolCount: 0,
+      thoughtCount: 0,
+    };
+  }
   const layout = planTurnLayout(
     timeline.narrative,
     activities.map(({ id, wireIndex, sourceOffset }) => ({
@@ -152,6 +201,7 @@ export function deriveTurnPresentation(
       streaming: options.streaming === true,
       latestVisibleIsText,
     },
+    options.layoutCache,
   );
   const activityById = new Map(activities.map((activity) => [activity.id, activity]));
   const nodes: TurnPresentationItem[] = [];

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -1,5 +1,11 @@
 import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglion/xacpx-relay-protocol";
-import { isSafeInlineParagraphOffset, markdownBlockBoundaries, topLevelBlockAt } from "./render-markdown";
+import {
+  analyzeMarkdownDocument,
+  isSafeInlineParagraphOffset,
+  isSafeStandaloneInlineParagraphOffset,
+  topLevelBlockAt,
+  type TopLevelBlockInfo,
+} from "./render-markdown";
 import { normalizeMarkdownTables } from "./normalize-markdown";
 import { hasToolStepAncestor, indexToolSteps } from "./subagent-trace";
 
@@ -96,16 +102,37 @@ export function deriveTurnPresentation(
     activities.push({ offset: narrative.length, index, part });
   });
 
-  const boundaries = markdownBlockBoundaries(narrative);
-  const documentEnv: Record<string, unknown> = {};
+  const markdown = analyzeMarkdownDocument(narrative);
+
+  const blockAtOffset = (offset: number): TopLevelBlockInfo | null => {
+    let low = 0;
+    let high = markdown.blocks.length;
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (markdown.blocks[middle]!.endOffset < offset) low = middle + 1;
+      else high = middle;
+    }
+    const block = markdown.blocks[low];
+    return block && offset >= block.startOffset ? block : null;
+  };
+
+  const boundaryAtOrAfter = (offset: number): number | null => {
+    let low = 0;
+    let high = markdown.boundaries.length;
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (markdown.boundaries[middle]! < offset) low = middle + 1;
+      else high = middle;
+    }
+    return markdown.boundaries[low] ?? null;
+  };
 
   const safeNarrativeAnchor = (offset: number): number | null => {
-    const block = topLevelBlockAt(narrative, offset, documentEnv);
+    const block = blockAtOffset(offset);
     if (!block || block.type !== "paragraph_open") return null;
     if (normalizeMarkdownTables(block.source) !== block.source) return null;
-    if (narrative.slice(block.endOffset).trim().length > 0) return null;
     const offsetInBlock = offset - block.startOffset;
-    return isSafeInlineParagraphOffset(block.source, offsetInBlock, documentEnv)
+    return isSafeStandaloneInlineParagraphOffset(block.source, offsetInBlock, markdown.env)
       ? offset
       : null;
   };
@@ -115,7 +142,7 @@ export function deriveTurnPresentation(
     const anchor = narrative.slice(0, activity.offset).trim().length === 0
       ? 0
       : (safeNarrativeAnchor(activity.offset)
-        ?? boundaries.find((boundary) => boundary >= activity.offset)
+        ?? boundaryAtOrAfter(activity.offset)
         ?? narrative.length);
     const group = anchored.get(anchor) ?? [];
     group.push(activity);

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -2,7 +2,7 @@ import type { PeerMessageHistoryEntry, ToolStepDto, TurnPartDto } from "@ganglio
 import {
   analyzeMarkdownDocument,
   isSafeInlineParagraphOffset,
-  isSafeStandaloneInlineParagraphOffset,
+  isSafeStandaloneParagraphOffset,
   topLevelBlockAt,
   type TopLevelBlockInfo,
 } from "./render-markdown";
@@ -34,6 +34,8 @@ export type TurnPresentationItem =
  *  The persisted rows stay the canonical record; nothing here mutates them. */
 export interface TurnPresentationOptions {
   sentAgentMessageById?: Map<string, PeerMessageHistoryEntry>;
+  /** Mirror StreamMarkdown's live preprocessing so unsafe temporary splits fail closed. */
+  streaming?: boolean;
 }
 
 type ActivityPart =
@@ -130,9 +132,13 @@ export function deriveTurnPresentation(
   const safeNarrativeAnchor = (offset: number): number | null => {
     const block = blockAtOffset(offset);
     if (!block || block.type !== "paragraph_open") return null;
-    if (normalizeMarkdownTables(block.source) !== block.source) return null;
     const offsetInBlock = offset - block.startOffset;
-    return isSafeStandaloneInlineParagraphOffset(block.source, offsetInBlock, markdown.env)
+    return isSafeStandaloneParagraphOffset(
+      block.source,
+      offsetInBlock,
+      markdown.env,
+      { streaming: opts?.streaming === true },
+    )
       ? offset
       : null;
   };

--- a/packages/relay-web/src/lib/turn-presentation.ts
+++ b/packages/relay-web/src/lib/turn-presentation.ts
@@ -178,7 +178,7 @@ export function deriveTurnPresentation(
         copyText: html.trim()
           ? markdownSourceToPlainText(timeline.narrative, {
             streaming: options.streaming === true && latestVisibleIsText,
-          }).trim()
+          })
           : "",
         isLatest: options.streaming === true && latestVisibleIsText,
       }
@@ -297,7 +297,10 @@ export function extractCollapsedTraceSummary(
 ): CollapsedTraceSummary {
   const presentation = deriveTurnPresentation(parts, options);
   return {
-    finalReplyText: presentation.finalReplyNodes.map((node) => node.copyText).join(""),
+    // Single outer normalization: per-node copyText stays compositional
+    // (block terminal newlines separate neighbors), so only the reply tail
+    // is trimmed here.
+    finalReplyText: presentation.finalReplyNodes.map((node) => node.copyText).join("").trimEnd(),
     toolCount: presentation.toolCount,
     thoughtCount: presentation.thoughtCount,
     presentation,

--- a/packages/relay-web/src/lib/turn-timeline.ts
+++ b/packages/relay-web/src/lib/turn-timeline.ts
@@ -1,0 +1,49 @@
+import type { TurnPartDto } from "@ganglion/xacpx-relay-protocol";
+
+export type TimelineActivityPart = Exclude<TurnPartDto, { type: "text" }>;
+
+export interface TimelineActivity {
+  id: string;
+  wireIndex: number;
+  sourceOffset: number;
+  kind: TimelineActivityPart["type"];
+  payload: TimelineActivityPart;
+}
+
+export interface TurnTimeline {
+  narrative: string;
+  activities: TimelineActivity[];
+}
+
+function activityId(part: TimelineActivityPart, wireIndex: number): string {
+  return part.type === "tool"
+    ? `tool:${part.step.toolCallId}:${wireIndex}`
+    : `reasoning:${wireIndex}`;
+}
+
+/** Build the canonical turn timeline without interpreting Markdown or changing wire order. */
+export function buildTurnTimeline(parts: TurnPartDto[]): TurnTimeline {
+  const narrativeChunks: string[] = [];
+  const activities: TimelineActivity[] = [];
+  let sourceOffset = 0;
+
+  parts.forEach((part, wireIndex) => {
+    if (part.type === "text") {
+      narrativeChunks.push(part.text);
+      sourceOffset += part.text.length;
+      return;
+    }
+    activities.push({
+      id: activityId(part, wireIndex),
+      wireIndex,
+      sourceOffset,
+      kind: part.type,
+      payload: part,
+    });
+  });
+
+  return {
+    narrative: narrativeChunks.join(""),
+    activities,
+  };
+}


### PR DESCRIPTION
## Summary

- introduce a canonical turn timeline that preserves wire order and source offsets without interpreting Markdown
- replace per-activity anchors, standalone fragment reparsing, and anchor sorting with ordered legal layout slots and monotonic placement
- render activity-bearing paragraphs from one semantic inline token tree using zero-width markers, closing and reopening formatting around tool/reasoning cards
- keep headings, lists, blockquotes, tables, fences, Mermaid, and other structural Markdown atomic
- make expanded and collapsed views consume one `TurnPresentationPlan`; remove the second collapsed Markdown safety path
- cache layout geometry across tool payload-only updates, coalesce live layout work per animation frame, and degrade extreme paragraphs to atomic blocks

## Architecture

```text
TurnPartDto[]
  -> TurnTimeline (canonical wire order)
  -> Markdown layout analysis + legal slots
  -> marker-aware inline paragraph fragments
  -> monotonic activity placement
  -> TurnLayoutPlan
  -> presentation decoration + DOM
```

Markdown text is no longer split into standalone Markdown documents to insert activity. Paragraph markers are parsed in the original document environment and accepted only when removing them preserves the original semantic token stream. Unsupported marker positions fail closed to the enclosing block end.

## Invariants

- activity output order always equals wire order
- every visible activity is emitted exactly once
- Markdown source ranges are ordered, non-overlapping, and reconstruct the original narrative
- activity placement never precedes its source offset
- expanded and collapsed rendering share the same layout proof
- tool status/title/output-only updates reuse layout geometry

## Validation

- `bun run test` — 135 files, 1514 tests passed
- `bun run build` — production typecheck and Vite/PWA build passed
- `bun run test:e2e` — 33 passed, 3 conditional skips
- `bun run bench:turn-layout` — 500 marker-bearing paragraphs averaged ~359 ms; 5× the 100-paragraph input took ~4.11× the time